### PR TITLE
LGT-267: add omitted terraform module for api-gateway-root

### DIFF
--- a/ci/terraform/modules/api-gateway-root/api-gateway-root.tf
+++ b/ci/terraform/modules/api-gateway-root/api-gateway-root.tf
@@ -1,0 +1,18 @@
+resource "aws_api_gateway_rest_api" "di-authentication-api" {
+  name = "di-authentication-api-${var.environment}"
+}
+
+output "di-authentication-api-id" {
+  value = aws_api_gateway_rest_api.di-authentication-api.id
+  sensitive = true
+}
+
+output "root_resource_id" {
+  value = aws_api_gateway_rest_api.di-authentication-api.root_resource_id
+  sensitive = true
+}
+
+output "execution_arn" {
+  value = aws_api_gateway_rest_api.di-authentication-api.execution_arn
+  sensitive = true
+}

--- a/ci/terraform/modules/api-gateway-root/variables.tf
+++ b/ci/terraform/modules/api-gateway-root/variables.tf
@@ -1,0 +1,4 @@
+variable "environment" {
+  type = string
+  default = "test"
+}


### PR DESCRIPTION
## What

add omitted terraform module for api-gateway-root

## Why

fix broken build

## Related

#6 