### PR TITLE
LTG-267: update lambda.zip path in the build

### DIFF
--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -88,7 +88,7 @@ jobs:
                 cd di-authentication-api/ci/terraform/aws
                 terraform init -input=false -backend-config "role_arn=${DEPLOYER_ROLE_ARN}"
                 terraform plan \
-                  -var 'lambda-zip-file=../../../lambda-zip/lambda.zip' \
+                  -var 'lambda-zip-file=../../../../lambda-zip/lambda.zip' \
                   -var "deployer-role-arn=${DEPLOYER_ROLE_ARN}" \
                   -out=../../../terraform-plan/terraform.plan
 


### PR DESCRIPTION
## What

update lambda.zip path in the build

## Why

relative path has changed due to terraform modules

## Related

#6 
#8 