### PR TITLE
LTG-267: update relative path for terraform plan

### DIFF
--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -90,7 +90,7 @@ jobs:
                 terraform plan \
                   -var 'lambda-zip-file=../../../../lambda-zip/lambda.zip' \
                   -var "deployer-role-arn=${DEPLOYER_ROLE_ARN}" \
-                  -out=../../../terraform-plan/terraform.plan
+                  -out=../../../../terraform-plan/terraform.plan
 
       - task: terraform-apply
         config:
@@ -113,7 +113,7 @@ jobs:
               - |
                 cd di-authentication-api/ci/terraform/aws
                 terraform init -input=false -backend-config "role_arn=${DEPLOYER_ROLE_ARN}"
-                terraform apply -auto-approve ../../../terraform-plan/terraform.plan
+                terraform apply -auto-approve ../../../../terraform-plan/terraform.plan
 
   - name: deploy-app
     plan:


### PR DESCRIPTION
## What

update relative path for terraform plan

## Why
 
root module has moved so relative path to plan file has moved too

## Related

#9 
