### PR TITLE
LTG-267: add url outputs to the top level

### DIFF
--- a/ci/terraform/aws/outputs.tf
+++ b/ci/terraform/aws/outputs.tf
@@ -1,0 +1,7 @@
+output "base_url_token" {
+  value = module.token.base_url_token
+}
+
+output "base_url_userinfo" {
+  value = module.userinfo.base_url_userinfo
+}


### PR DESCRIPTION
## What

add url outputs to the top level

## Why

outputs from modules not being displayed