### PR TITLE
LTG-257 - Use the non-deprecated way of accepting query params

### DIFF
--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/AuthorisationHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/AuthorisationHandler.java
@@ -14,8 +14,10 @@ import uk.gov.di.services.AuthorizationCodeService;
 import uk.gov.di.services.ClientService;
 import uk.gov.di.services.InMemoryClientService;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class AuthorisationHandler implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
@@ -33,7 +35,15 @@ public class AuthorisationHandler implements RequestHandler<APIGatewayProxyReque
     public APIGatewayProxyResponseEvent handleRequest(APIGatewayProxyRequestEvent input, Context context) {
 
         try {
-            var authRequest = AuthenticationRequest.parse(input.getMultiValueQueryStringParameters());
+            Map<String, List<String>> queryStringMultiValuedMap = input.getQueryStringParameters().entrySet()
+                    .stream()
+                    .collect(
+                            Collectors.toMap(
+                                    entry -> entry.getKey(),
+                                    entry -> List.of(entry.getValue())
+                            )
+                    );
+            var authRequest = AuthenticationRequest.parse(queryStringMultiValuedMap);
 
             Optional<ErrorObject> error = clientService.getErrorForAuthorizationRequest(authRequest);
 

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/AuthorisationHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/AuthorisationHandlerTest.java
@@ -98,12 +98,12 @@ class AuthorisationHandlerTest {
         when(CLIENT_SERVICE.getErrorForAuthorizationRequest(any(AuthorizationRequest.class)))
                 .thenReturn(Optional.of(OAuth2Error.INVALID_SCOPE));
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        event.setMultiValueQueryStringParameters(
+        event.setQueryStringParameters(
                 Map.of(
-                        "client_id", List.of("test-id"),
-                        "redirect_uri", List.of("http://localhost:8080"),
-                        "scope", List.of("email,openid,profile,non-existent-scope"),
-                        "response_type", List.of("code")
+                        "client_id", "test-id",
+                        "redirect_uri", "http://localhost:8080",
+                        "scope", "email,openid,profile,non-existent-scope",
+                        "response_type", "code"
                 )
         );
 


### PR DESCRIPTION
- AWS lambda has deprecated the use of accepting multiValueQueryStringParameters so therefore refactor to accept query string params.
- https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html