### PR TITLE
LTG-265 - Add terraform to create wellknown lambda

### DIFF
--- a/ci/terraform/aws/wellknown.tf
+++ b/ci/terraform/aws/wellknown.tf
@@ -1,0 +1,9 @@
+module "wellknown" {
+  source = "../modules/wellknown"
+
+  rest_api_id = module.api-gateway-root.di-authentication-api-id
+  root_resource_id = module.api-gateway-root.root_resource_id
+  execution_arn = module.api-gateway-root.execution_arn
+  api-deployment-stage-name = var.api-deployment-stage-name
+  lambda-zip-file = var.lambda-zip-file
+}

--- a/ci/terraform/localstack/localstack.tf
+++ b/ci/terraform/localstack/localstack.tf
@@ -41,3 +41,15 @@ module "authorize" {
   api-deployment-stage-name = var.api-deployment-stage-name
   lambda-zip-file = var.lambda-zip-file
 }
+
+module "wellknown" {
+  source = "../modules/wellknown"
+  providers = {
+    aws = aws.localstack
+  }
+  rest_api_id = module.api-gateway-root.di-authentication-api-id
+  root_resource_id = module.api-gateway-root.root_resource_id
+  execution_arn = module.api-gateway-root.execution_arn
+  api-deployment-stage-name = var.api-deployment-stage-name
+  lambda-zip-file = var.lambda-zip-file
+}

--- a/ci/terraform/modules/wellknown/api-gateway-token.tf
+++ b/ci/terraform/modules/wellknown/api-gateway-token.tf
@@ -1,0 +1,46 @@
+resource "aws_api_gateway_resource" "proxyWellknown" {
+  rest_api_id = var.rest_api_id
+  parent_id = var.root_resource_id
+  path_part = ".well-known/openid-configuration"
+}
+
+resource "aws_api_gateway_method" "proxyMethodWellknown" {
+  rest_api_id = var.rest_api_id
+  resource_id = aws_api_gateway_resource.proxyWellknown.id
+  http_method = "GET"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_integration" "lambdaWellknown" {
+  rest_api_id = var.rest_api_id
+  resource_id = aws_api_gateway_method.proxyMethodWellknown.resource_id
+  http_method = aws_api_gateway_method.proxyMethodWellknown.http_method
+
+  integration_http_method = "POST"
+  type = "AWS_PROXY"
+  uri = aws_lambda_function.wellknown_lambda.invoke_arn
+}
+
+resource "aws_api_gateway_deployment" "apideployWellknown" {
+  depends_on = [
+    aws_api_gateway_integration.lambdaWellknown,
+  ]
+
+  rest_api_id = var.rest_api_id
+  stage_name = var.api-deployment-stage-name
+}
+
+resource "aws_lambda_permission" "apigwWellknown" {
+  statement_id = "AllowAPIGatewayInvoke"
+  action = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.wellknown_lambda.function_name
+  principal = "apigateway.amazonaws.com"
+
+  # The "/*/*" portion grants access from any method on any resource
+  # within the API Gateway REST API.
+  source_arn = "${var.execution_arn}/*/*"
+}
+
+output "base_url_wellknown" {
+  value = aws_api_gateway_deployment.apideployWellknown.invoke_url
+}

--- a/ci/terraform/modules/wellknown/lambda.tf
+++ b/ci/terraform/modules/wellknown/lambda.tf
@@ -1,0 +1,65 @@
+resource "aws_iam_role" "iam_for_wellknown_lambda" {
+  name = "iam_for_wellknown_lambda"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_lambda_function" "wellknown_lambda" {
+  filename = var.lambda-zip-file
+  function_name = "WellknownLambda"
+  role = aws_iam_role.iam_for_wellknown_lambda.arn
+  handler = "uk.gov.di.lambdas.WellknownHandler::handleRequest"
+
+  source_code_hash = filebase64sha256(var.lambda-zip-file)
+
+  environment {
+    variables = {
+      BASE_URL = "http://some-base-url"
+    }
+  }
+
+  runtime = "java11"
+}
+
+resource "aws_iam_policy" "wellknown_lambda_logging" {
+  name        = "wellknown_lambda_logging"
+  path        = "/"
+  description = "IAM policy for logging from a lambda"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents",
+        "logs:CreateLogGroup"
+      ],
+      "Resource": "arn:aws:logs:*:*:*",
+      "Effect": "Allow"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_logs" {
+  role       = aws_iam_role.iam_for_wellknown_lambda.name
+  policy_arn = aws_iam_policy.wellknown_lambda_logging.arn
+}

--- a/ci/terraform/modules/wellknown/variables.tf
+++ b/ci/terraform/modules/wellknown/variables.tf
@@ -1,0 +1,25 @@
+variable "lambda-zip-file" {
+  type        = string
+}
+
+variable "rest_api_id" {
+  type = string
+}
+
+variable "root_resource_id" {
+  type = string
+}
+
+variable "execution_arn" {
+  type = string
+}
+
+variable "environment" {
+  type = string
+  default = "test"
+}
+
+variable "api-deployment-stage-name" {
+  type = string
+  default = "test"
+}

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/WellknownHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/WellknownHandler.java
@@ -13,6 +13,7 @@ import com.nimbusds.oauth2.sdk.id.Issuer;
 import com.nimbusds.openid.connect.sdk.SubjectType;
 import com.nimbusds.openid.connect.sdk.claims.ClaimType;
 import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata;
+import uk.gov.di.services.ConfigurationService;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -22,11 +23,21 @@ import java.util.Optional;
 
 public class WellknownHandler implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
+    private ConfigurationService configService;
+
+    public WellknownHandler(ConfigurationService configService) {
+        this.configService = configService;
+    }
+
+    public WellknownHandler() {
+        this.configService = new ConfigurationService();
+    }
+
     @Override
     public APIGatewayProxyResponseEvent handleRequest(APIGatewayProxyRequestEvent input, Context context) {
         APIGatewayProxyResponseEvent apiGatewayProxyResponseEvent = new APIGatewayProxyResponseEvent();
         try {
-            Optional<String> baseUrl = Optional.ofNullable(context.getClientContext().getEnvironment().get("BASE_URL"));
+            Optional<String> baseUrl = configService.getBaseURL();
 
             var providerMetadata = new OIDCProviderMetadata(new Issuer(baseUrl.orElseThrow()),
                     List.of(SubjectType.PUBLIC), buildURI(".well-known/jwks.json", baseUrl.get()));

--- a/serverless/lambda/src/main/java/uk/gov/di/services/ConfigurationService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/ConfigurationService.java
@@ -1,0 +1,10 @@
+package uk.gov.di.services;
+
+import java.util.Optional;
+
+public class ConfigurationService {
+
+    public Optional<String> getBaseURL() {
+        return Optional.ofNullable(System.getenv("BASE_URL"));
+    }
+}

--- a/serverless/lambda/src/main/java/uk/gov/di/services/TokenService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/TokenService.java
@@ -29,9 +29,10 @@ public class TokenService {
     private final Issuer issuer;
 
     private final Map<AccessToken, String> tokensMap = new HashMap<>();
+    private final ConfigurationService configService = new ConfigurationService();
 
     public TokenService() {
-        this.issuer = new Issuer(System.getenv("BASE_URL"));
+        this.issuer = new Issuer(configService.getBaseURL().get());
         try {
             signingKey = new RSAKeyGenerator(2048).keyID(UUID.randomUUID().toString()).generate();
             signer = new RSASSASigner(signingKey);

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/WellknownHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/WellknownHandlerTest.java
@@ -1,6 +1,5 @@
 package uk.gov.di.lambdas;
 
-import com.amazonaws.services.lambda.runtime.ClientContext;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
@@ -10,10 +9,12 @@ import com.nimbusds.openid.connect.sdk.claims.ClaimType;
 import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.services.ConfigurationService;
 
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -21,18 +22,17 @@ import static org.mockito.Mockito.when;
 
 class WellknownHandlerTest {
     private final Context CONTEXT = mock(Context.class);
-    private final ClientContext clientContext = mock(ClientContext.class);
+    private final ConfigurationService CONFIG_SERVICE = mock(ConfigurationService.class);
     private WellknownHandler handler;
 
     @BeforeEach
     public void setUp() {
-        handler = new WellknownHandler();
-        when(CONTEXT.getClientContext()).thenReturn(clientContext);
+        handler = new WellknownHandler(CONFIG_SERVICE);
     }
 
     @Test
     public void shouldReturn200WhenRequestIsSuccessful() throws ParseException {
-        when(CONTEXT.getClientContext().getEnvironment()).thenReturn(Map.of("BASE_URL", "http://localhost:8080/"));
+        when(CONFIG_SERVICE.getBaseURL()).thenReturn(Optional.of("http://localhost:8080/"));
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, CONTEXT);
@@ -47,7 +47,7 @@ class WellknownHandlerTest {
 
     @Test
     public void shouldReturn500WhenConfigIsMissing() {
-        when(CONTEXT.getClientContext().getEnvironment()).thenReturn(Map.of());
+        when(CONFIG_SERVICE.getBaseURL()).thenReturn(Optional.empty());
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, CONTEXT);


### PR DESCRIPTION
- Get the BASE_URL environment variable by using System.getenv and move this to a separate configuration service
- Add the required terraform for the wellknown lambda and apigateway
- Amend the unit tests to mock out the configuration service