### PR TITLE
LTG-275: add basic integration test to run locally

### DIFF
--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -137,7 +137,7 @@ jobs:
             - -euc
             - |
               cd di-authentication-api
-              gradle --no-daemon build
+              gradle --no-daemon build -x integration-tests:test
               cp build/distributions/di-authentication-api.zip ../di-authentication-api-zip/
     - put: di-authentication-api-upload
       params:

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -1,0 +1,28 @@
+plugins {
+    id 'java'
+}
+
+group 'uk.gov.di'
+version 'unspecified'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.0',
+            'org.glassfish.jersey.core:jersey-client:3.0.2',
+            'org.glassfish.jersey.inject:jersey-hk2:3.0.2',
+            'org.glassfish.jersey.media:jersey-media-json-jackson:3.0.2'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
+}
+
+test {
+    useJUnitPlatform()
+    filter {
+        includeTestsMatching "*"
+    }
+    testLogging {
+        showStandardStreams = false
+    }
+}

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenResourceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenResourceIntegrationTest.java
@@ -1,0 +1,34 @@
+package uk.gov.di.authentication.api;
+
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.Invocation;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TokenResourceIntegrationTest {
+
+    private static final String localTokenEndpointFormat = "http://localhost:45678/restapis/%s/local/_user_request_/token";
+    private final static String localApiGatewayId = Optional.ofNullable(System.getenv().get("API_GATEWAY_ID")).orElse("");
+    private final static String rootResourceUrl =
+            Optional.ofNullable(System.getenv().get("ROOT_RESOURCE_URL")).orElse(String.format(localTokenEndpointFormat, localApiGatewayId));
+
+    @Test
+    public void shouldCallTokenResourceAndReturn200() {
+        Client client = ClientBuilder.newClient();
+        WebTarget webTarget = client.target(rootResourceUrl);
+
+        Invocation.Builder invocationBuilder = webTarget.request(MediaType.TEXT_PLAIN);
+        Response response = invocationBuilder
+                .post(Entity.entity("code=123456789&client_id=test-id&client_secret=test-secret", MediaType.TEXT_PLAIN));
+
+        assertEquals(200, response.getStatus());
+    }
+}

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -5,7 +5,7 @@ source ./scripts/test-api.sh
 
 printf "\nRunning build and unit tests...\n"
 
-./gradlew clean build
+./gradlew clean build -x integration-tests:test
 
 build_and_test_exit_code=$?
 if [ ${build_and_test_exit_code} -ne 0 ]; then
@@ -14,7 +14,8 @@ if [ ${build_and_test_exit_code} -ne 0 ]; then
 fi
 
 startup
-test-api
+
+run-integration-tests
 
 build_and_test_exit_code=$?
 

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -72,3 +72,10 @@ startup() {
   run_terraform ci/terraform/localstack
   funky_started
 }
+
+run-integration-tests() {
+  pushd ci/terraform/localstack >/dev/null
+  export API_GATEWAY_ID="$(terraform output -raw api-gateway-root-id)"
+  popd >/dev/null
+  ./gradlew integration-tests:test
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,3 +2,5 @@ include 'serverless'
 include 'serverless:lambda'
 findProject(':serverless:lambda')?.name = 'lambda'
 rootProject.name = 'di-authentication-api'
+include 'integration-tests'
+


### PR DESCRIPTION
## What

Add basic integration test to run locally.
Create integration-tests module.
Run integration tests from pre-commit.
Exclude from running in the build pipeline pending work to add into the build.

## Why

Ability to write tests calling the api in API Gateway connected to the Lambda functions.
