### PR TITLE
LTG-266 - Create Lambda for /jwks.json endpoint

### DIFF
--- a/ci/terraform/aws/jwks.tf
+++ b/ci/terraform/aws/jwks.tf
@@ -1,0 +1,16 @@
+module "jwks" {
+  source = "../modules/endpoint-module"
+
+  endpoint_name   = "jwks.json"
+  endpoint_method = "GET"
+  handler_environment_variables = {
+    BASE_URL = var.api_base_url
+  }
+  handler_function_name = "uk.gov.di.lambdas.JwksHandler::handleRequest"
+
+  rest_api_id               = module.api_gateway_root.di_authentication_api_id
+  root_resource_id          = module.api_gateway_root.wellknown_resource_id
+  execution_arn             = module.api_gateway_root.execution_arn
+  api_deployment_stage_name = var.api_deployment_stage_name
+  lambda_zip_file           = var.lambda_zip_file
+}

--- a/ci/terraform/aws/outputs.tf
+++ b/ci/terraform/aws/outputs.tf
@@ -6,6 +6,16 @@ output "userinfo_url" {
   value = module.userinfo.base_url
 }
 
+output "authorise_url" {
+  value = module.authorize.base_url
+}
+
+output "jwks_url" {
+  value = module.jwks.base_url
+}
+
+
+
 output "openid_configuration_discovery_url" {
   value = "http://localhost:45678/restapis/${module.api_gateway_root.di_authentication_api_id}/${var.environment}/_user_request_/.wellknown/openid-configuration"
 }

--- a/ci/terraform/localstack/localstack.tf
+++ b/ci/terraform/localstack/localstack.tf
@@ -44,7 +44,26 @@ module "openid_configuration_discovery" {
   execution_arn             = module.api_gateway_root.execution_arn
   api_deployment_stage_name = var.api_deployment_stage_name
   lambda_zip_file           = var.lambda_zip_file
+}
 
+module "jwks" {
+  source = "../modules/endpoint-module"
+  providers = {
+    aws = aws.localstack
+  }
+
+  endpoint_name   = "jwk.json"
+  endpoint_method = "GET"
+  handler_environment_variables = {
+    BASE_URL = var.api_base_url
+  }
+  handler_function_name = "uk.gov.di.lambdas.JwksHandler::handleRequest"
+
+  rest_api_id               = module.api_gateway_root.di_authentication_api_id
+  root_resource_id          = module.api_gateway_root.wellknown_resource_id
+  execution_arn             = module.api_gateway_root.execution_arn
+  api_deployment_stage_name = var.api_deployment_stage_name
+  lambda_zip_file           = var.lambda_zip_file
 }
 
 module "token" {

--- a/ci/terraform/localstack/outputs.tf
+++ b/ci/terraform/localstack/outputs.tf
@@ -14,6 +14,10 @@ output "openid_configuration_discovery_url" {
   value = "http://localhost:45678/restapis/${module.api_gateway_root.di_authentication_api_id}/${var.environment}/_user_request_/.well-known/openid-configuration"
 }
 
+output "jwks" {
+  value = "http://localhost:45678/restapis/${module.api_gateway_root.di_authentication_api_id}/${var.environment}/_user_request_/.well-known/jwks.json"
+}
+
 output "api_gateway_root_id" {
   value = module.api_gateway_root.di_authentication_api_id
 }

--- a/ci/terraform/modules/endpoint-module/lambda.tf
+++ b/ci/terraform/modules/endpoint-module/lambda.tf
@@ -6,7 +6,7 @@ resource "aws_iam_role" "lambda_iam_role" {
 
 resource "aws_lambda_function" "endpoint_lambda" {
   filename      = var.lambda_zip_file
-  function_name = "${var.endpoint_name}-${var.environment}-lambda"
+  function_name = replace("${var.endpoint_name}-${var.environment}-lambda", ".", "")
   role          = aws_iam_role.lambda_iam_role.arn
   handler       = var.handler_function_name
 

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -75,7 +75,7 @@ startup() {
 
 run-integration-tests() {
   pushd ci/terraform/localstack >/dev/null
-  export API_GATEWAY_ID="$(terraform output -raw api-gateway-root-id)"
+  export API_GATEWAY_ID="$(terraform output -raw api_gateway_root_id)"
   popd >/dev/null
   ./gradlew integration-tests:test
 }

--- a/scripts/test-api.sh
+++ b/scripts/test-api.sh
@@ -5,7 +5,7 @@ test-api() {
   printf "\n\nRunning api tests...\n"
 
   pushd ci/terraform/localstack > /dev/null
-  apigatewayid="$(terraform output -raw api-gateway-root-id)"
+  apigatewayid="$(terraform output -raw api_gateway_root_id)"
   popd > /dev/null
 
   url="http://localhost:45678/restapis/${apigatewayid}/local/_user_request_/token"

--- a/scripts/test-api.sh
+++ b/scripts/test-api.sh
@@ -5,10 +5,8 @@ test-api() {
   printf "\n\nRunning api tests...\n"
 
   pushd ci/terraform/localstack > /dev/null
-  apigatewayid="$(terraform output -raw api_gateway_root_id)"
+  url="$(terraform output -raw token_url)"
   popd > /dev/null
-
-  url="http://localhost:45678/restapis/${apigatewayid}/local/_user_request_/token"
 
   curl -i --location --request POST "${url}" \
     --header 'Content-Type: application/x-www-form-urlencoded' \

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/JwksHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/JwksHandler.java
@@ -1,0 +1,39 @@
+package uk.gov.di.lambdas;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.nimbusds.jose.jwk.JWKSet;
+import uk.gov.di.services.TokenService;
+
+public class JwksHandler implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+
+    private TokenService tokenService;
+
+    public JwksHandler(TokenService tokenService) {
+        this.tokenService = tokenService;
+    }
+
+    public JwksHandler() {
+        this.tokenService = new TokenService();
+    }
+
+    @Override
+    public APIGatewayProxyResponseEvent handleRequest(APIGatewayProxyRequestEvent input, Context context) {
+        APIGatewayProxyResponseEvent apiGatewayProxyResponseEvent = new APIGatewayProxyResponseEvent();
+
+        JWKSet jwkSet;
+        try {
+            jwkSet = new JWKSet(tokenService.getSigningKey());
+        } catch (IllegalArgumentException e) {
+            apiGatewayProxyResponseEvent.setBody("Signing key is not present");
+            apiGatewayProxyResponseEvent.setStatusCode(500);
+            return apiGatewayProxyResponseEvent;
+        }
+
+        apiGatewayProxyResponseEvent.setBody(jwkSet.toString(true));
+        apiGatewayProxyResponseEvent.setStatusCode(200);
+        return apiGatewayProxyResponseEvent;
+    }
+}

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/WellknownHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/WellknownHandler.java
@@ -19,7 +19,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.Optional;
 
 public class WellknownHandler implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/JwksHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/JwksHandlerTest.java
@@ -1,0 +1,55 @@
+package uk.gov.di.lambdas;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.services.TokenService;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class JwksHandlerTest {
+
+    private final Context CONTEXT = mock(Context.class);
+    private JwksHandler handler;
+    private final TokenService TOKEN_SERVICE = mock(TokenService.class);
+
+    @BeforeEach
+    public void setUp() {
+        handler = new JwksHandler(TOKEN_SERVICE);
+    }
+
+    @Test
+    public void shouldReturn200WhenRequestIsSuccessful() throws JOSEException {
+        JWK signingKey = new RSAKeyGenerator(2048).keyID(UUID.randomUUID().toString()).generate();
+        when(TOKEN_SERVICE.getSigningKey()).thenReturn(signingKey);
+
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        APIGatewayProxyResponseEvent result = handler.handleRequest(event, CONTEXT);
+
+        JWKSet expectedJWKSet = new JWKSet(signingKey);
+
+        assertEquals(200, result.getStatusCode());
+        assertEquals(expectedJWKSet.toString(true), result.getBody());
+    }
+
+    @Test
+    public void shouldReturn500WhenSigningKeyIsNotPresent() {
+        when(TOKEN_SERVICE.getSigningKey()).thenReturn(null);
+
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        APIGatewayProxyResponseEvent result = handler.handleRequest(event, CONTEXT);
+
+        assertEquals(500, result.getStatusCode());
+        assertEquals("Signing key is not present", result.getBody());
+    }
+}

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/WellknownHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/WellknownHandlerTest.java
@@ -13,7 +13,6 @@ import uk.gov.di.services.ConfigurationService;
 
 import java.net.URI;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;


### PR DESCRIPTION
- Some client libraries require this endpoint when integrating so we need to have this run as a lambda function.
- The signing key is currently generated on the fly in the token service but eventually this will be swapped out with something more permanent
- Add terraform for jwks lambda and api gateway
- The jwks endpoint will use the well-known base path
- Amend the api_gateway_root_id to use snake case and fix the integration tests
- When constructing the lambda function_name remove any full stops. This is because we are currently using the endpoint name and the jwks endpoint is 'jwks.json' which terraform will not like.
- Rather than constructing the URL manually for the integration tests we can use the URL generated from outputs.tf