### PR TITLE
LTG-284 - Migrate dynamic client endpoint to Lambda

### DIFF
--- a/ci/terraform/aws/outputs.tf
+++ b/ci/terraform/aws/outputs.tf
@@ -18,6 +18,10 @@ output "signup_url" {
   value = module.signup.base_url
 }
 
+output "register_url" {
+  value = module.register.base_url
+}
+
 
 
 output "openid_configuration_discovery_url" {

--- a/ci/terraform/aws/register.tf
+++ b/ci/terraform/aws/register.tf
@@ -1,0 +1,16 @@
+module "register" {
+  source = "../modules/endpoint-module"
+
+  endpoint_name   = "register"
+  endpoint_method = "POST"
+  handler_environment_variables = {
+    BASE_URL = var.api_base_url
+  }
+  handler_function_name = "uk.gov.di.lambdas.ClientRegistrationHandler::handleRequest"
+
+  rest_api_id               = module.api_gateway_root.di_authentication_api_id
+  root_resource_id          = module.api_gateway_root.connect_resource_id
+  execution_arn             = module.api_gateway_root.execution_arn
+  api_deployment_stage_name = var.api_deployment_stage_name
+  lambda_zip_file           = var.lambda_zip_file
+}

--- a/ci/terraform/localstack/localstack.tf
+++ b/ci/terraform/localstack/localstack.tf
@@ -86,6 +86,26 @@ module "token" {
   lambda_zip_file           = var.lambda_zip_file
 }
 
+module "register" {
+  source = "../modules/endpoint-module"
+  providers = {
+    aws = aws.localstack
+  }
+
+  endpoint_name   = "register"
+  endpoint_method = "POST"
+  handler_environment_variables = {
+    BASE_URL = var.api_base_url
+  }
+  handler_function_name = "uk.gov.di.lambdas.ClientRegistrationHandler::handleRequest"
+
+  rest_api_id               = module.api_gateway_root.di_authentication_api_id
+  root_resource_id          = module.api_gateway_root.connect_resource_id
+  execution_arn             = module.api_gateway_root.execution_arn
+  api_deployment_stage_name = var.api_deployment_stage_name
+  lambda_zip_file           = var.lambda_zip_file
+}
+
 module "signup" {
   source = "../modules/endpoint-module"
   providers = {

--- a/ci/terraform/localstack/outputs.tf
+++ b/ci/terraform/localstack/outputs.tf
@@ -22,6 +22,10 @@ output "signup" {
   value = "http://localhost:45678/restapis/${module.api_gateway_root.di_authentication_api_id}/${var.environment}/_user_request_/signup"
 }
 
+output "register" {
+  value = "http://localhost:45678/restapis/${module.api_gateway_root.di_authentication_api_id}/${var.environment}/_user_request_/connect/register"
+}
+
 output "api_gateway_root_id" {
   value = module.api_gateway_root.di_authentication_api_id
 }

--- a/ci/terraform/modules/api-gateway-root/api-gateway-root.tf
+++ b/ci/terraform/modules/api-gateway-root/api-gateway-root.tf
@@ -7,3 +7,9 @@ resource "aws_api_gateway_resource" "wellknown_resource" {
   parent_id   = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
   path_part   = ".well-known"
 }
+
+resource "aws_api_gateway_resource" "connect_resource" {
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
+  parent_id   = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
+  path_part   = "connect"
+}

--- a/ci/terraform/modules/api-gateway-root/outputs.tf
+++ b/ci/terraform/modules/api-gateway-root/outputs.tf
@@ -12,6 +12,11 @@ output "wellknown_resource_id" {
   sensitive = true
 }
 
+output "connect_resource_id" {
+  value     = aws_api_gateway_resource.connect_resource.id
+  sensitive = true
+}
+
 output "execution_arn" {
   value     = aws_api_gateway_rest_api.di_authentication_api.execution_arn
   sensitive = true

--- a/serverless/lambda/src/main/java/uk/gov/di/entity/Client.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/entity/Client.java
@@ -1,25 +1,40 @@
 package uk.gov.di.entity;
 
-import java.util.List;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.List;
 
 public class Client {
 
+    @JsonProperty("client_name")
     private String clientName;
+
+    @JsonProperty("client_id")
     private String clientId;
+
+    @JsonProperty("client_secret")
     private String clientSecret;
-    private List<String> scopes;
+
+    @JsonProperty("response_types")
     private List<String> allowedResponseTypes;
-    private List<String> redirectUrls;
+
+    @JsonProperty("redirect_uris")
+    private List<String> redirectUris;
+
+    @JsonProperty("contacts")
     private List<String> contacts;
 
-    public Client(String clientName, String clientId, String clientSecret, List<String> scopes, List<String> allowedResponseTypes, List<String> redirectUrls, List<String> contacts) {
+    public Client(@JsonProperty(required = true, value = "client_name") String clientName,
+                  @JsonProperty(required = true, value = "client_id") String clientId,
+                  @JsonProperty(required = true, value = "client_secret") String clientSecret,
+                  @JsonProperty(required = true, value = "response_types") List<String> allowedResponseTypes,
+                  @JsonProperty(required = true, value = "redirect_uris") List<String> redirectUris,
+                  @JsonProperty(required = true, value = "contacts") List<String> contacts) {
         this.clientName = clientName;
         this.clientId = clientId;
         this.clientSecret = clientSecret;
-        this.scopes = scopes;
         this.allowedResponseTypes = allowedResponseTypes;
-        this.redirectUrls = redirectUrls;
+        this.redirectUris = redirectUris;
         this.contacts = contacts;
     }
 
@@ -35,16 +50,12 @@ public class Client {
         return clientSecret;
     }
 
-    public List<String> getScopes() {
-        return scopes;
-    }
-
     public List<String> getAllowedResponseTypes() {
         return allowedResponseTypes;
     }
 
-    public List<String> getRedirectUrls() {
-        return redirectUrls;
+    public List<String> getRedirectUris() {
+        return redirectUris;
     }
 
     public List<String> getContacts() {

--- a/serverless/lambda/src/main/java/uk/gov/di/entity/ClientRegistrationRequest.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/entity/ClientRegistrationRequest.java
@@ -1,0 +1,35 @@
+package uk.gov.di.entity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class ClientRegistrationRequest {
+
+    private String clientName;
+    private List<String> redirectUris;
+    private List<String> contacts;
+
+    @JsonCreator
+    public ClientRegistrationRequest(
+            @JsonProperty(required = true, value = "client_name") String clientName,
+            @JsonProperty(required = true, value = "redirect_uris")List<String> redirectUris,
+            @JsonProperty(required = true, value = "contacts") List<String> contacts) {
+        this.clientName = clientName;
+        this.redirectUris = redirectUris;
+        this.contacts = contacts;
+    }
+
+    public String getClientName() {
+        return clientName;
+    }
+
+    public List<String> getRedirectUris() {
+        return redirectUris;
+    }
+
+    public List<String> getContacts() {
+        return contacts;
+    }
+}

--- a/serverless/lambda/src/main/java/uk/gov/di/entity/SignupRequest.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/entity/SignupRequest.java
@@ -1,6 +1,5 @@
 package uk.gov.di.entity;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 
@@ -9,7 +8,6 @@ public class SignupRequest {
     private String email;
     private String password;
 
-    @JsonCreator
     public SignupRequest(
             @JsonProperty(required = true, value = "email") String email,
             @JsonProperty(required = true, value = "password") String password) {

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/ClientRegistrationHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/ClientRegistrationHandler.java
@@ -1,0 +1,48 @@
+package uk.gov.di.lambdas;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import uk.gov.di.entity.Client;
+import uk.gov.di.entity.ClientRegistrationRequest;
+import uk.gov.di.services.AuthorizationCodeService;
+import uk.gov.di.services.ClientService;
+import uk.gov.di.services.InMemoryClientService;
+
+public class ClientRegistrationHandler implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+
+    private ClientService clientService;
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    public ClientRegistrationHandler(ClientService clientService) {
+        this.clientService = clientService;
+    }
+
+    public ClientRegistrationHandler() {
+        this.clientService = new InMemoryClientService(new AuthorizationCodeService());
+    }
+
+    @Override
+    public APIGatewayProxyResponseEvent handleRequest(APIGatewayProxyRequestEvent input, Context context) {
+        APIGatewayProxyResponseEvent response = new APIGatewayProxyResponseEvent();
+
+        try {
+            ClientRegistrationRequest clientRegistrationRequest = objectMapper.readValue(input.getBody(), ClientRegistrationRequest.class);
+            Client client = clientService.addClient(
+                    clientRegistrationRequest.getClientName(),
+                    clientRegistrationRequest.getRedirectUris(),
+                    clientRegistrationRequest.getContacts());
+            String clientString = objectMapper.writeValueAsString(client);
+            response.setBody(clientString);
+            response.setStatusCode(200);
+            return response;
+        } catch (JsonProcessingException e) {
+            response.setStatusCode(400);
+            response.setBody("Request is missing parameters");
+            return response;
+        }
+    }
+}

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/SignUpHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/SignUpHandler.java
@@ -13,10 +13,7 @@ import uk.gov.di.services.UserService;
 import uk.gov.di.services.ValidationService;
 import uk.gov.di.validation.PasswordValidation;
 
-import java.util.Map;
 import java.util.Set;
-
-import static uk.gov.di.helpers.RequestBodyHelper.PARSE_REQUEST_BODY;
 
 public class SignUpHandler implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 

--- a/serverless/lambda/src/main/java/uk/gov/di/services/InMemoryClientService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/InMemoryClientService.java
@@ -21,7 +21,6 @@ public class InMemoryClientService implements ClientService {
                     "client-name",
                             "test-id",
                             "test-secret",
-                    List.of("email", "openid", "profile"),
                     List.of("code"),
                             List.of("http://localhost:8080"),
                             List.of("contact@example.com")));
@@ -42,16 +41,12 @@ public class InMemoryClientService implements ClientService {
 
         var client = clientMaybe.get();
 
-        if (!client.getRedirectUrls().contains(authRequest.getRedirectionURI().toString())) {
+        if (!client.getRedirectUris().contains(authRequest.getRedirectionURI().toString())) {
             return Optional.of(OAuth2Error.INVALID_REQUEST_URI);
         }
 
         if (!client.getAllowedResponseTypes().contains(authRequest.getResponseType().toString())) {
             return Optional.of(OAuth2Error.UNSUPPORTED_RESPONSE_TYPE);
-        }
-
-        if (!client.getScopes().containsAll(authRequest.getScope().toStringList())) {
-            return Optional.of(OAuth2Error.INVALID_SCOPE);
         }
 
         return Optional.empty();
@@ -76,11 +71,7 @@ public class InMemoryClientService implements ClientService {
 
         String clientId = UUID.randomUUID().toString();
         String clientSecret = UUID.randomUUID().toString();
-        Client client = new Client(clientName, clientId, clientSecret, List.of(
-                "openid",
-                "email",
-                "profile"
-        ), List.of("code"), redirectUris, contacts);
+        Client client = new Client(clientName, clientId, clientSecret, List.of("code"), redirectUris, contacts);
         clients.add(client);
         return client;
     }

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/ClientRegistrationHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/ClientRegistrationHandlerTest.java
@@ -1,0 +1,60 @@
+package uk.gov.di.lambdas;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.entity.Client;
+import uk.gov.di.services.ClientService;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ClientRegistrationHandlerTest {
+
+    private final Context CONTEXT = mock(Context.class);
+    private ClientRegistrationHandler handler;
+    private final ClientService CLIENT_SERVICE = mock(ClientService.class);
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    public void setup() {
+        handler = new ClientRegistrationHandler(CLIENT_SERVICE);
+    }
+
+    @Test
+    public void shouldReturn200IfClientRegistrationRequestIsSuccessful() throws JsonProcessingException {
+        String clientName = "test-client";
+        List<String> redirectUris = List.of("http://localhost:8080/redirect-uri");
+        List<String> contacts = List.of("joe.bloggs@test.com");
+        String clientId = UUID.randomUUID().toString();
+        String clientSecret = UUID.randomUUID().toString();
+        Client client = new Client(clientName, clientId, clientSecret, List.of("code"), redirectUris, contacts);
+        when(CLIENT_SERVICE.addClient(clientName, redirectUris, contacts)).thenReturn(client);
+
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        event.setBody("{ \"client_name\": \"test-client\", \"redirect_uris\": [\"http://localhost:8080/redirect-uri\"], \"contacts\": [\"joe.bloggs@test.com\"] }");
+        APIGatewayProxyResponseEvent result = handler.handleRequest(event, CONTEXT);
+
+        assertEquals(200, result.getStatusCode());
+        Client clientResult = objectMapper.readValue(result.getBody(), Client.class);
+        assertEquals(client.getClientId(), clientResult.getClientId());
+    }
+
+    @Test
+    public void shouldReturn400IfAnyRequestParametersAreMissing() {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        event.setBody("{\"redirect_uris\": [\"http://localhost:8080/redirect-uri\"], \"contacts\": [\"joe.bloggs@test.com\"] }");
+        APIGatewayProxyResponseEvent result = handler.handleRequest(event, CONTEXT);
+
+        assertEquals(400, result.getStatusCode());
+        assertEquals("Request is missing parameters", result.getBody());
+    }
+}


### PR DESCRIPTION
- Create a new Lambda handler which will handle POST requests when a Client is registering their software
- Remove Scopes for the Client class as it is not part of the Dynamic Client Registration spec https://openid.net/specs/openid-connect-registration-1_0.html
- Add the ability to serialize and deserialize the Client class
- Write terraform for API Gateway and Lambda for Dynamic Client reg