### PR TITLE
LTG-191: Add Lambdas and Elasticache to Security Groups

### DIFF
--- a/ci/terraform/aws/authorize.tf
+++ b/ci/terraform/aws/authorize.tf
@@ -13,4 +13,5 @@ module "authorize" {
   execution_arn             = module.api_gateway_root.execution_arn
   api_deployment_stage_name = var.api_deployment_stage_name
   lambda_zip_file           = var.lambda_zip_file
+  security_group_id         = aws_security_group.elasticache_security_group.id
 }

--- a/ci/terraform/aws/jwks.tf
+++ b/ci/terraform/aws/jwks.tf
@@ -13,4 +13,5 @@ module "jwks" {
   execution_arn             = module.api_gateway_root.execution_arn
   api_deployment_stage_name = var.api_deployment_stage_name
   lambda_zip_file           = var.lambda_zip_file
+  security_group_id         = aws_security_group.elasticache_security_group.id
 }

--- a/ci/terraform/aws/redis.tf
+++ b/ci/terraform/aws/redis.tf
@@ -6,5 +6,7 @@ resource "aws_elasticache_cluster" "sessions_store" {
   parameter_group_name = "default.redis6.x"
   engine_version       = "6.x"
   port                 = 6379
-
+  security_group_ids = [
+    aws_security_group.elasticache_security_group.id
+  ]
 }

--- a/ci/terraform/aws/register.tf
+++ b/ci/terraform/aws/register.tf
@@ -13,4 +13,5 @@ module "register" {
   execution_arn             = module.api_gateway_root.execution_arn
   api_deployment_stage_name = var.api_deployment_stage_name
   lambda_zip_file           = var.lambda_zip_file
+  security_group_id         = aws_security_group.elasticache_security_group.id
 }

--- a/ci/terraform/aws/signup.tf
+++ b/ci/terraform/aws/signup.tf
@@ -13,4 +13,5 @@ module "signup" {
   execution_arn             = module.api_gateway_root.execution_arn
   api_deployment_stage_name = var.api_deployment_stage_name
   lambda_zip_file           = var.lambda_zip_file
+  security_group_id         = aws_security_group.elasticache_security_group.id
 }

--- a/ci/terraform/aws/token.tf
+++ b/ci/terraform/aws/token.tf
@@ -13,4 +13,5 @@ module "token" {
   execution_arn             = module.api_gateway_root.execution_arn
   api_deployment_stage_name = var.api_deployment_stage_name
   lambda_zip_file           = var.lambda_zip_file
+  security_group_id         = aws_security_group.elasticache_security_group.id
 }

--- a/ci/terraform/aws/userinfo.tf
+++ b/ci/terraform/aws/userinfo.tf
@@ -13,4 +13,5 @@ module "userinfo" {
   execution_arn             = module.api_gateway_root.execution_arn
   api_deployment_stage_name = var.api_deployment_stage_name
   lambda_zip_file           = var.lambda_zip_file
+  security_group_id         = aws_security_group.elasticache_security_group.id
 }

--- a/ci/terraform/aws/wellknown.tf
+++ b/ci/terraform/aws/wellknown.tf
@@ -13,4 +13,5 @@ module "openid_configuration_discovery" {
   execution_arn             = module.api_gateway_root.execution_arn
   api_deployment_stage_name = var.api_deployment_stage_name
   lambda_zip_file           = var.lambda_zip_file
+  security_group_id         = aws_security_group.elasticache_security_group.id
 }

--- a/ci/terraform/localstack/localstack.tf
+++ b/ci/terraform/localstack/localstack.tf
@@ -24,6 +24,7 @@ module "authorize" {
   execution_arn             = module.api_gateway_root.execution_arn
   api_deployment_stage_name = var.api_deployment_stage_name
   lambda_zip_file           = var.lambda_zip_file
+  security_group_id         = aws_security_group.elasticache_security_group.id
 }
 
 module "openid_configuration_discovery" {
@@ -44,6 +45,7 @@ module "openid_configuration_discovery" {
   execution_arn             = module.api_gateway_root.execution_arn
   api_deployment_stage_name = var.api_deployment_stage_name
   lambda_zip_file           = var.lambda_zip_file
+  security_group_id         = aws_security_group.elasticache_security_group.id
 }
 
 module "jwks" {
@@ -64,6 +66,7 @@ module "jwks" {
   execution_arn             = module.api_gateway_root.execution_arn
   api_deployment_stage_name = var.api_deployment_stage_name
   lambda_zip_file           = var.lambda_zip_file
+  security_group_id         = aws_security_group.elasticache_security_group.id
 }
 
 module "token" {
@@ -84,6 +87,7 @@ module "token" {
   execution_arn             = module.api_gateway_root.execution_arn
   api_deployment_stage_name = var.api_deployment_stage_name
   lambda_zip_file           = var.lambda_zip_file
+  security_group_id         = aws_security_group.elasticache_security_group.id
 }
 
 module "register" {
@@ -104,6 +108,7 @@ module "register" {
   execution_arn             = module.api_gateway_root.execution_arn
   api_deployment_stage_name = var.api_deployment_stage_name
   lambda_zip_file           = var.lambda_zip_file
+  security_group_id         = aws_security_group.elasticache_security_group.id
 }
 
 module "signup" {
@@ -124,6 +129,7 @@ module "signup" {
   execution_arn             = module.api_gateway_root.execution_arn
   api_deployment_stage_name = var.api_deployment_stage_name
   lambda_zip_file           = var.lambda_zip_file
+  security_group_id         = aws_security_group.elasticache_security_group.id
 }
 
 module "userinfo" {
@@ -144,4 +150,5 @@ module "userinfo" {
   execution_arn             = module.api_gateway_root.execution_arn
   api_deployment_stage_name = var.api_deployment_stage_name
   lambda_zip_file           = var.lambda_zip_file
+  security_group_id         = aws_security_group.elasticache_security_group.id
 }

--- a/ci/terraform/localstack/vpc.tf
+++ b/ci/terraform/localstack/vpc.tf
@@ -1,0 +1,11 @@
+resource "aws_vpc" "authentication" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+}
+
+resource "aws_security_group" "elasticache_security_group" {
+  name        = "${var.environment}-elasticache-security-group"
+  vpc_id      = aws_vpc.authentication.id
+  description = "Security group to allow access to Redis"
+}

--- a/ci/terraform/modules/endpoint-module/lambda.tf
+++ b/ci/terraform/modules/endpoint-module/lambda.tf
@@ -11,7 +11,10 @@ resource "aws_lambda_function" "endpoint_lambda" {
   handler       = var.handler_function_name
 
   source_code_hash = filebase64sha256(var.lambda_zip_file)
-
+  vpc_config {
+    security_group_ids = [var.security_group_id]
+    subnet_ids = []
+  }
   environment {
     variables = var.handler_environment_variables
   }

--- a/ci/terraform/modules/endpoint-module/variables.tf
+++ b/ci/terraform/modules/endpoint-module/variables.tf
@@ -63,3 +63,8 @@ variable "lambda_iam_policy" {
 }
 EOF
 }
+
+variable "security_group_id" {
+  type = string
+  description = "The id of the security for the lambda"
+}


### PR DESCRIPTION
## What

In previous PR we created a VPC and security group for Elasticache, lets now associate our lamdas and Elasticache with it.

## Why

We want to secure access to the session data in the Redis cluster.