### PR TITLE
LTG-300: Add subnets and convert Redis instance to cluster

### DIFF
--- a/ci/terraform/aws/authorize.tf
+++ b/ci/terraform/aws/authorize.tf
@@ -14,4 +14,5 @@ module "authorize" {
   api_deployment_stage_name = var.api_deployment_stage_name
   lambda_zip_file           = var.lambda_zip_file
   security_group_id         = aws_security_group.elasticache_security_group.id
+  subnet_id                 = aws_subnet.authentication.*.id
 }

--- a/ci/terraform/aws/jwks.tf
+++ b/ci/terraform/aws/jwks.tf
@@ -14,4 +14,6 @@ module "jwks" {
   api_deployment_stage_name = var.api_deployment_stage_name
   lambda_zip_file           = var.lambda_zip_file
   security_group_id         = aws_security_group.elasticache_security_group.id
+  subnet_id                 = aws_subnet.authentication.*.id
+
 }

--- a/ci/terraform/aws/jwks.tf
+++ b/ci/terraform/aws/jwks.tf
@@ -15,5 +15,4 @@ module "jwks" {
   lambda_zip_file           = var.lambda_zip_file
   security_group_id         = aws_security_group.elasticache_security_group.id
   subnet_id                 = aws_subnet.authentication.*.id
-
 }

--- a/ci/terraform/aws/redis.tf
+++ b/ci/terraform/aws/redis.tf
@@ -1,12 +1,20 @@
-resource "aws_elasticache_cluster" "sessions_store" {
-  cluster_id           = "sessions-store"
-  engine               = "redis"
-  node_type            = "cache.t2.micro"
-  num_cache_nodes      = 1
-  parameter_group_name = "default.redis6.x"
-  engine_version       = "6.x"
-  port                 = 6379
-  security_group_ids = [
-    aws_security_group.elasticache_security_group.id
-  ]
+resource "aws_elasticache_subnet_group" "sessions_store" {
+  name       = "${var.environment}-session-store-cache-subnet"
+  subnet_ids = aws_subnet.authentication.*.id
+}
+
+resource "aws_elasticache_replication_group" "sessions_store" {
+  automatic_failover_enabled    = true
+  availability_zones            = data.aws_availability_zones.available.names
+  replication_group_id          = "${var.environment}-sessions-store"
+  replication_group_description = "A Redis cluster for storing user session data"
+  node_type                     = "cache.t2.micro"
+  number_cache_clusters         = length(data.aws_availability_zones.available.names)
+  engine                        = "redis"
+  engine_version                = "6.x"
+  parameter_group_name          = "default.redis6.x"
+  port                          = 6379
+
+  subnet_group_name    = aws_elasticache_subnet_group.sessions_store.name
+  security_group_ids   = [aws_security_group.elasticache_security_group.id]
 }

--- a/ci/terraform/aws/register.tf
+++ b/ci/terraform/aws/register.tf
@@ -14,4 +14,5 @@ module "register" {
   api_deployment_stage_name = var.api_deployment_stage_name
   lambda_zip_file           = var.lambda_zip_file
   security_group_id         = aws_security_group.elasticache_security_group.id
+  subnet_id                 = aws_subnet.authentication.*.id
 }

--- a/ci/terraform/aws/signup.tf
+++ b/ci/terraform/aws/signup.tf
@@ -14,4 +14,6 @@ module "signup" {
   api_deployment_stage_name = var.api_deployment_stage_name
   lambda_zip_file           = var.lambda_zip_file
   security_group_id         = aws_security_group.elasticache_security_group.id
+  subnet_id                 = aws_subnet.authentication.*.id
+
 }

--- a/ci/terraform/aws/signup.tf
+++ b/ci/terraform/aws/signup.tf
@@ -15,5 +15,4 @@ module "signup" {
   lambda_zip_file           = var.lambda_zip_file
   security_group_id         = aws_security_group.elasticache_security_group.id
   subnet_id                 = aws_subnet.authentication.*.id
-
 }

--- a/ci/terraform/aws/token.tf
+++ b/ci/terraform/aws/token.tf
@@ -14,4 +14,6 @@ module "token" {
   api_deployment_stage_name = var.api_deployment_stage_name
   lambda_zip_file           = var.lambda_zip_file
   security_group_id         = aws_security_group.elasticache_security_group.id
+  subnet_id                 = aws_subnet.authentication.*.id
+
 }

--- a/ci/terraform/aws/token.tf
+++ b/ci/terraform/aws/token.tf
@@ -15,5 +15,4 @@ module "token" {
   lambda_zip_file           = var.lambda_zip_file
   security_group_id         = aws_security_group.elasticache_security_group.id
   subnet_id                 = aws_subnet.authentication.*.id
-
 }

--- a/ci/terraform/aws/userinfo.tf
+++ b/ci/terraform/aws/userinfo.tf
@@ -14,4 +14,6 @@ module "userinfo" {
   api_deployment_stage_name = var.api_deployment_stage_name
   lambda_zip_file           = var.lambda_zip_file
   security_group_id         = aws_security_group.elasticache_security_group.id
+  subnet_id                 = aws_subnet.authentication.*.id
+
 }

--- a/ci/terraform/aws/userinfo.tf
+++ b/ci/terraform/aws/userinfo.tf
@@ -15,5 +15,4 @@ module "userinfo" {
   lambda_zip_file           = var.lambda_zip_file
   security_group_id         = aws_security_group.elasticache_security_group.id
   subnet_id                 = aws_subnet.authentication.*.id
-
 }

--- a/ci/terraform/aws/vpc.tf
+++ b/ci/terraform/aws/vpc.tf
@@ -9,3 +9,12 @@ resource "aws_security_group" "elasticache_security_group" {
   vpc_id      = aws_vpc.authentication.id
   description = "Security group to allow access to Redis"
 }
+
+data "aws_availability_zones" "available" {}
+
+resource "aws_subnet" "authentication" {
+  count             = length(data.aws_availability_zones.available.names)
+  vpc_id            = aws_vpc.authentication.id
+  cidr_block        = "10.0.${count.index}.0/24"
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+}

--- a/ci/terraform/aws/wellknown.tf
+++ b/ci/terraform/aws/wellknown.tf
@@ -14,4 +14,5 @@ module "openid_configuration_discovery" {
   api_deployment_stage_name = var.api_deployment_stage_name
   lambda_zip_file           = var.lambda_zip_file
   security_group_id         = aws_security_group.elasticache_security_group.id
+  subnet_id                 = aws_subnet.authentication.*.id
 }

--- a/ci/terraform/localstack/localstack.tf
+++ b/ci/terraform/localstack/localstack.tf
@@ -25,6 +25,7 @@ module "authorize" {
   api_deployment_stage_name = var.api_deployment_stage_name
   lambda_zip_file           = var.lambda_zip_file
   security_group_id         = aws_security_group.elasticache_security_group.id
+  subnet_id                 = aws_subnet.authentication.*.id
 }
 
 module "openid_configuration_discovery" {
@@ -46,6 +47,7 @@ module "openid_configuration_discovery" {
   api_deployment_stage_name = var.api_deployment_stage_name
   lambda_zip_file           = var.lambda_zip_file
   security_group_id         = aws_security_group.elasticache_security_group.id
+  subnet_id                 = aws_subnet.authentication.*.id
 }
 
 module "jwks" {
@@ -67,6 +69,7 @@ module "jwks" {
   api_deployment_stage_name = var.api_deployment_stage_name
   lambda_zip_file           = var.lambda_zip_file
   security_group_id         = aws_security_group.elasticache_security_group.id
+  subnet_id                 = aws_subnet.authentication.*.id
 }
 
 module "token" {
@@ -88,6 +91,7 @@ module "token" {
   api_deployment_stage_name = var.api_deployment_stage_name
   lambda_zip_file           = var.lambda_zip_file
   security_group_id         = aws_security_group.elasticache_security_group.id
+  subnet_id                 = aws_subnet.authentication.*.id
 }
 
 module "register" {
@@ -109,6 +113,7 @@ module "register" {
   api_deployment_stage_name = var.api_deployment_stage_name
   lambda_zip_file           = var.lambda_zip_file
   security_group_id         = aws_security_group.elasticache_security_group.id
+  subnet_id                 = aws_subnet.authentication.*.id
 }
 
 module "signup" {
@@ -130,6 +135,7 @@ module "signup" {
   api_deployment_stage_name = var.api_deployment_stage_name
   lambda_zip_file           = var.lambda_zip_file
   security_group_id         = aws_security_group.elasticache_security_group.id
+  subnet_id                 = aws_subnet.authentication.*.id
 }
 
 module "userinfo" {
@@ -151,4 +157,5 @@ module "userinfo" {
   api_deployment_stage_name = var.api_deployment_stage_name
   lambda_zip_file           = var.lambda_zip_file
   security_group_id         = aws_security_group.elasticache_security_group.id
+  subnet_id                 = aws_subnet.authentication.*.id
 }

--- a/ci/terraform/localstack/site.tf
+++ b/ci/terraform/localstack/site.tf
@@ -25,5 +25,6 @@ provider "aws" {
     iam        = "http://localhost:45678"
     lambda     = "http://localhost:45678"
     s3         = "http://localhost:45678"
+    ec2        = "http://localhost:45678"
   }
 }

--- a/ci/terraform/localstack/vpc.tf
+++ b/ci/terraform/localstack/vpc.tf
@@ -1,11 +1,36 @@
+locals {
+  availability_zones = [
+    "eu-west-2a",
+    "eu-west-2b",
+    "eu-west-2c"
+  ]
+}
+
 resource "aws_vpc" "authentication" {
+  provider = "aws.localstack"
+
   cidr_block           = "10.0.0.0/16"
   enable_dns_hostnames = true
   enable_dns_support   = true
 }
 
 resource "aws_security_group" "elasticache_security_group" {
+  provider = "aws.localstack"
+
   name        = "${var.environment}-elasticache-security-group"
   vpc_id      = aws_vpc.authentication.id
   description = "Security group to allow access to Redis"
+}
+
+data "aws_availability_zones" "available" {
+  provider = "aws.localstack"
+}
+
+resource "aws_subnet" "authentication" {
+  provider = "aws.localstack"
+
+  count             = length(data.aws_availability_zones.available.names)
+  vpc_id            = aws_vpc.authentication.id
+  cidr_block        = "10.0.${count.index}.0/24"
+  availability_zone = data.aws_availability_zones.available.names[count.index]
 }

--- a/ci/terraform/modules/endpoint-module/lambda.tf
+++ b/ci/terraform/modules/endpoint-module/lambda.tf
@@ -13,7 +13,7 @@ resource "aws_lambda_function" "endpoint_lambda" {
   source_code_hash = filebase64sha256(var.lambda_zip_file)
   vpc_config {
     security_group_ids = [var.security_group_id]
-    subnet_ids = []
+    subnet_ids = var.subnet_id
   }
   environment {
     variables = var.handler_environment_variables
@@ -49,4 +49,34 @@ EOF
 resource "aws_iam_role_policy_attachment" "lambda_logs" {
   role       = aws_iam_role.lambda_iam_role.name
   policy_arn = aws_iam_policy.endpoint_logging_policy.arn
+}
+
+resource "aws_iam_policy" "endpoint_networking_policy" {
+  name        = "${var.endpoint_name}_lambda_networking"
+  path        = "/"
+  description = "IAM policy for managing VPC connection for a lambda"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DescribeNetworkInterfaces",
+        "ec2:CreateNetworkInterface",
+        "ec2:DeleteNetworkInterface",
+        "ec2:DescribeInstances",
+        "ec2:AttachNetworkInterface"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_networking" {
+  role       = aws_iam_role.lambda_iam_role.name
+  policy_arn = aws_iam_policy.endpoint_networking_policy.arn
 }

--- a/ci/terraform/modules/endpoint-module/variables.tf
+++ b/ci/terraform/modules/endpoint-module/variables.tf
@@ -68,3 +68,8 @@ variable "security_group_id" {
   type = string
   description = "The id of the security for the lambda"
 }
+
+variable "subnet_id" {
+  type = list(string)
+  description = "The id of the subnets for the lambda"
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: docker
       dockerfile: localstack.Dockerfile
     environment:
-      SERVICES: lambda, apigateway, iam
+      SERVICES: lambda, apigateway, iam, ec2
       EDGE_PORT: "45678"
       EXTERNAL_HOSTNAME: ${AWS_HOSTNAME:-localhost}
       DEFAULT_REGION: eu-west-2


### PR DESCRIPTION
## What

- Add subnets, one per AZ, to the VPC
- Allow the lambda function to use these subnets
- Convert the Redis instance to a cluster with replicas in each AZ/subnet.
- Ensure VPCs are created using "localstack" aws provider
- Enable EC2 service in localstack to enable use of VPCs and subnets

## Why

To provide access to Redis by Lambdas and to provide fault tolerance
