### PR TITLE
LTG-300: Fix Redis deployment engine version

### DIFF
--- a/ci/terraform/aws/redis.tf
+++ b/ci/terraform/aws/redis.tf
@@ -11,7 +11,7 @@ resource "aws_elasticache_replication_group" "sessions_store" {
   node_type                     = "cache.t2.micro"
   number_cache_clusters         = length(data.aws_availability_zones.available.names)
   engine                        = "redis"
-  engine_version                = "6.x"
+  engine_version                = "6.0.5"
   parameter_group_name          = "default.redis6.x"
   port                          = 6379
 


### PR DESCRIPTION
## What

- Need to lock in version 6.0.5 rather than "6.x" or Terraform will try and re-create.

## Why

We are getting failures in the pipeline.
