### PR TITLE
BAU: Integrate Hamcrest and create custom Matchers

### DIFF
--- a/serverless/lambda/build.gradle
+++ b/serverless/lambda/build.gradle
@@ -19,7 +19,8 @@ dependencies {
             "com.fasterxml.jackson.core:jackson-annotations:2.12.3"
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.0',
                         'com.amazonaws:aws-lambda-java-tests:1.0.0',
-                        'org.mockito:mockito-core:3.9.0'
+                        'org.mockito:mockito-core:3.9.0',
+                        'org.hamcrest:hamcrest:2.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
 }
 

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/AuthorisationHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/AuthorisationHandlerTest.java
@@ -29,6 +29,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.matchers.APIGatewayProxyResponseEventStatusMatcher.hasStatus;
 
 class AuthorisationHandlerTest {
 
@@ -80,7 +81,7 @@ class AuthorisationHandlerTest {
         URI uri = URI.create(response.getHeaders().get("Location"));
         Map<String, String> requestParams = RequestBodyHelper.PARSE_REQUEST_BODY(uri.getQuery());
 
-        assertEquals(302, response.getStatusCode());
+        assertThat(response, hasStatus(302));
         assertEquals(loginUrl.getAuthority(), uri.getAuthority());
 
         assertThat(requestParams, hasEntry("session-id", session.getSessionId()));
@@ -103,7 +104,7 @@ class AuthorisationHandlerTest {
 
         APIGatewayProxyResponseEvent response = handler.handleRequest(event, CONTEXT);
 
-        assertEquals(400, response.getStatusCode());
+        assertThat(response, hasStatus(400));
         assertEquals("Cannot parse authentication request", response.getBody());
     }
 
@@ -123,7 +124,7 @@ class AuthorisationHandlerTest {
 
         APIGatewayProxyResponseEvent response = handler.handleRequest(event, CONTEXT);
 
-        assertEquals(302, response.getStatusCode());
+        assertThat(response, hasStatus(302));
         assertEquals(
                 "http://localhost:8080?error=invalid_scope&error_description=Invalid%2C+unknown+or+malformed+scope",
                 response.getHeaders().get("Location")

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/AuthorisationHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/AuthorisationHandlerTest.java
@@ -21,12 +21,14 @@ import java.net.URI;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class AuthorisationHandlerTest {
 
@@ -80,7 +82,9 @@ class AuthorisationHandlerTest {
 
         assertEquals(302, response.getStatusCode());
         assertEquals(loginUrl.getAuthority(), uri.getAuthority());
-        assertEquals(session.getSessionId(), requestParams.get("session-id"));
+
+        assertThat(requestParams, hasEntry("session-id", session.getSessionId()));
+
         verify(SESSION_SERVICE).save(eq(session));
     }
 

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/ClientRegistrationHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/ClientRegistrationHandlerTest.java
@@ -13,9 +13,11 @@ import uk.gov.di.services.ClientService;
 import java.util.List;
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.matchers.APIGatewayProxyResponseEventStatusMatcher.hasStatus;
 
 class ClientRegistrationHandlerTest {
 
@@ -43,7 +45,7 @@ class ClientRegistrationHandlerTest {
         event.setBody("{ \"client_name\": \"test-client\", \"redirect_uris\": [\"http://localhost:8080/redirect-uri\"], \"contacts\": [\"joe.bloggs@test.com\"] }");
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, CONTEXT);
 
-        assertEquals(200, result.getStatusCode());
+        assertThat(result, hasStatus(200));
         Client clientResult = objectMapper.readValue(result.getBody(), Client.class);
         assertEquals(client.getClientId(), clientResult.getClientId());
     }
@@ -54,7 +56,7 @@ class ClientRegistrationHandlerTest {
         event.setBody("{\"redirect_uris\": [\"http://localhost:8080/redirect-uri\"], \"contacts\": [\"joe.bloggs@test.com\"] }");
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, CONTEXT);
 
-        assertEquals(400, result.getStatusCode());
+        assertThat(result, hasStatus(400));
         assertEquals("Request is missing parameters", result.getBody());
     }
 }

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/JwksHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/JwksHandlerTest.java
@@ -13,9 +13,11 @@ import uk.gov.di.services.TokenService;
 
 import java.util.UUID;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.matchers.APIGatewayProxyResponseEventStatusMatcher.hasStatus;
 
 class JwksHandlerTest {
 
@@ -38,7 +40,7 @@ class JwksHandlerTest {
 
         JWKSet expectedJWKSet = new JWKSet(signingKey);
 
-        assertEquals(200, result.getStatusCode());
+        assertThat(result, hasStatus(200));
         assertEquals(expectedJWKSet.toString(true), result.getBody());
     }
 
@@ -49,7 +51,7 @@ class JwksHandlerTest {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, CONTEXT);
 
-        assertEquals(500, result.getStatusCode());
+        assertThat(result, hasStatus(500));
         assertEquals("Signing key is not present", result.getBody());
     }
 }

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/SignUpHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/SignUpHandlerTest.java
@@ -11,12 +11,14 @@ import uk.gov.di.services.ValidationService;
 import java.util.Collections;
 import java.util.Set;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.matchers.APIGatewayProxyResponseEventStatusMatcher.hasStatus;
 import static uk.gov.di.validation.PasswordValidation.NO_NUMBER_INCLUDED;
 
 class SignUpHandlerTest {
@@ -41,7 +43,7 @@ class SignUpHandlerTest {
 
         verify(USER_SERVICE).signUp(eq("joe.bloggs@test.com"), eq(password));
 
-        assertEquals(200, result.getStatusCode());
+        assertThat(result, hasStatus(200));
     }
 
     @Test
@@ -50,7 +52,7 @@ class SignUpHandlerTest {
         event.setBody("{ \"email\": \"joe.bloggs@test.com\" }");
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, CONTEXT);
 
-        assertEquals(400, result.getStatusCode());
+        assertThat(result, hasStatus(400));
         assertEquals("Request is missing parameters", result.getBody());
     }
 
@@ -63,7 +65,7 @@ class SignUpHandlerTest {
         event.setBody("{ \"password\": \"computer\", \"email\": \"joe.bloggs@test.com\" }");
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, CONTEXT);
 
-        assertEquals(400, result.getStatusCode());
+        assertThat(result, hasStatus(400));
         assertTrue(result.getBody().contains(NO_NUMBER_INCLUDED.toString()));
     }
 }

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/TokenHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/TokenHandlerTest.java
@@ -9,14 +9,20 @@ import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import uk.gov.di.services.*;
+import uk.gov.di.services.AuthorizationCodeService;
+import uk.gov.di.services.ClientService;
+import uk.gov.di.services.InMemoryClientService;
+import uk.gov.di.services.TokenService;
+import uk.gov.di.services.UserService;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.matchers.APIGatewayProxyResponseEventStatusMatcher.hasStatus;
 
 public class TokenHandlerTest {
 
@@ -48,7 +54,7 @@ public class TokenHandlerTest {
         event.setBody("code=343242&client_id=test-id&client_secret=test-secret");
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, CONTEXT);
 
-        assertEquals(200, result.getStatusCode());
+        assertThat(result, hasStatus(200));
         assertTrue(result.getBody().contains(accessToken.getValue()));
     }
 

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/UserInfoHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/UserInfoHandlerTest.java
@@ -16,11 +16,13 @@ import uk.gov.di.services.UserInfoService;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.matchers.APIGatewayProxyResponseEventStatusMatcher.hasStatus;
 
 public class UserInfoHandlerTest {
 
@@ -46,7 +48,7 @@ public class UserInfoHandlerTest {
         when(CONTEXT.getLogger()).thenReturn(mock(LambdaLogger.class));
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, CONTEXT);
 
-        assertEquals(200, result.getStatusCode());
+        assertThat(result, hasStatus(200));
         UserInfo parse = UserInfo.parse(result.getBody());
         assertEquals(EMAIL_ADDRESS.get(), parse.getEmailAddress());
     }
@@ -58,7 +60,7 @@ public class UserInfoHandlerTest {
         when(CONTEXT.getLogger()).thenReturn(mock(LambdaLogger.class));
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, CONTEXT);
 
-        assertEquals(401, result.getStatusCode());
+        assertThat(result, hasStatus(401));
         assertEquals("Access Token Not Parsable", result.getBody());
     }
 
@@ -68,7 +70,7 @@ public class UserInfoHandlerTest {
         when(CONTEXT.getLogger()).thenReturn(mock(LambdaLogger.class));
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, CONTEXT);
 
-        assertEquals(401, result.getStatusCode());
+        assertThat(result, hasStatus(401));
         assertEquals("No access token present", result.getBody());
     }
 
@@ -81,7 +83,7 @@ public class UserInfoHandlerTest {
         when(CONTEXT.getLogger()).thenReturn(mock(LambdaLogger.class));
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, CONTEXT);
 
-        assertEquals(401, result.getStatusCode());
+        assertThat(result, hasStatus(401));
         assertEquals("Access Token Invalid", result.getBody());
     }
 

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/WellknownHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/WellknownHandlerTest.java
@@ -15,9 +15,11 @@ import java.net.URI;
 import java.util.List;
 import java.util.Optional;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.matchers.APIGatewayProxyResponseEventStatusMatcher.hasStatus;
 
 class WellknownHandlerTest {
     private final Context CONTEXT = mock(Context.class);
@@ -38,7 +40,7 @@ class WellknownHandlerTest {
 
         URI expectedRegistrationURI = URI.create("http://localhost:8080/connect/register");
 
-        assertEquals(200, result.getStatusCode());
+        assertThat(result, hasStatus(200));
         assertEquals(List.of(GrantType.AUTHORIZATION_CODE), OIDCProviderMetadata.parse(result.getBody()).getGrantTypes());
         assertEquals(List.of(ClaimType.NORMAL), OIDCProviderMetadata.parse(result.getBody()).getClaimTypes());
         assertEquals(expectedRegistrationURI, OIDCProviderMetadata.parse(result.getBody()).getRegistrationEndpointURI());
@@ -51,7 +53,7 @@ class WellknownHandlerTest {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, CONTEXT);
 
-        assertEquals(500, result.getStatusCode());
+        assertThat(result, hasStatus(500));
         assertEquals("Service not configured", result.getBody());
     }
 }

--- a/serverless/lambda/src/test/java/uk/gov/di/matchers/APIGatewayProxyResponseEventStatusMatcher.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/matchers/APIGatewayProxyResponseEventStatusMatcher.java
@@ -1,0 +1,38 @@
+package uk.gov.di.matchers;
+
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+public class APIGatewayProxyResponseEventStatusMatcher extends TypeSafeDiagnosingMatcher<APIGatewayProxyResponseEvent> {
+
+    private final int statusCode;
+
+    public APIGatewayProxyResponseEventStatusMatcher(int statusCode) {
+        this.statusCode = statusCode;
+    }
+
+    @Override
+    protected boolean matchesSafely(APIGatewayProxyResponseEvent item, Description mismatchDescription) {
+        boolean matched = item.getStatusCode() == statusCode;
+
+        if (!matched) {
+            mismatchDescription.appendText(descriptionWith(item.getStatusCode()));
+        }
+
+        return matched;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText(descriptionWith(statusCode));
+    }
+
+    public static APIGatewayProxyResponseEventStatusMatcher hasStatus(int statusCode) {
+        return new APIGatewayProxyResponseEventStatusMatcher(statusCode);
+    }
+
+    private String descriptionWith(Integer statusCode) {
+        return "an APIGatewayProxyResponseEvent with status code " + statusCode;
+    }
+}


### PR DESCRIPTION
This PR pulls in Hamcrest 2.2 (latest) to improve the way we write our test assertions.

Additionally, this PR includes an example custom Matcher for APIGatewayProxyResponseEvent, as we'll be asserting on this _a lot_ in our tests.
