### PR TITLE
LTG-301: stop deploying api app

### DIFF
--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -1,9 +1,3 @@
-resource_types:
-  - name: cf-cli
-    type: docker-image
-    source:
-      repository: nulldriver/cf-cli-resource
-
 resources:
   - name: di-authentication-api
     type: git
@@ -22,16 +16,6 @@ resources:
       paths:
         - ci/pipeline.yaml
       branch: main
-
-  - name: di-authentication-api-upload
-    type: cf-cli
-    icon: cloud-upload
-    source:
-      api: https://api.london.cloud.service.gov.uk
-      username: ((cf-username))
-      password: ((cf-password))
-      org: gds-digital-identity-authentication
-      space: build
 
 jobs:
   - name: update-pipeline
@@ -161,33 +145,3 @@ jobs:
                 export ROOT_RESOURCE_URL=$(< terraform-outputs/token_url.txt)
                 cd di-authentication-api
                 gradle --no-daemon integration-tests:test
-
-  - name: deploy-app
-    plan:
-    - get: di-authentication-api
-      trigger: true
-    - task: build
-      config:
-        platform: linux
-        image_resource:
-          type: registry-image
-          source:
-            repository: gradle
-            tag: 7.0.2-jdk16
-        inputs:
-          - name: di-authentication-api
-        outputs:
-          - name: di-authentication-api-zip
-        run:
-          path: /bin/bash
-          args:
-            - -euc
-            - |
-              cd di-authentication-api
-              gradle --no-daemon build -x integration-tests:test
-              cp build/distributions/di-authentication-api.zip ../di-authentication-api-zip/
-    - put: di-authentication-api-upload
-      params:
-        command: push
-        manifest: di-authentication-api/manifest.yml
-        path: di-authentication-api-zip/di-authentication-api.zip


### PR DESCRIPTION
## What

Remove app deployment from the pipeline.

## Why

The api is no longer an app but is built on API Gateway and Lambda.