### PR TITLE
LTG-300 - Connect authorize lambda to Redis

### DIFF
--- a/ci/terraform/aws/authorize.tf
+++ b/ci/terraform/aws/authorize.tf
@@ -4,7 +4,9 @@ module "authorize" {
   endpoint_name   = "authorize"
   endpoint_method = "GET"
   handler_environment_variables = {
-    BASE_URL = var.api_base_url
+    BASE_URL  = var.api_base_url
+    LOGIN_URI = "https://di-authentication-frontend.london.cloudapps.digital/"
+    REDIS_URL = aws_elasticache_replication_group.sessions_store.primary_endpoint_address
   }
   handler_function_name = "uk.gov.di.lambdas.AuthorisationHandler::handleRequest"
 
@@ -13,6 +15,6 @@ module "authorize" {
   execution_arn             = module.api_gateway_root.execution_arn
   api_deployment_stage_name = var.api_deployment_stage_name
   lambda_zip_file           = var.lambda_zip_file
-  security_group_id         = aws_security_group.elasticache_security_group.id
+  security_group_id         = aws_vpc.authentication.default_security_group_id
   subnet_id                 = aws_subnet.authentication.*.id
 }

--- a/ci/terraform/aws/jwks.tf
+++ b/ci/terraform/aws/jwks.tf
@@ -13,6 +13,6 @@ module "jwks" {
   execution_arn             = module.api_gateway_root.execution_arn
   api_deployment_stage_name = var.api_deployment_stage_name
   lambda_zip_file           = var.lambda_zip_file
-  security_group_id         = aws_security_group.elasticache_security_group.id
+  security_group_id         = aws_vpc.authentication.default_security_group_id
   subnet_id                 = aws_subnet.authentication.*.id
 }

--- a/ci/terraform/aws/redis.tf
+++ b/ci/terraform/aws/redis.tf
@@ -16,5 +16,5 @@ resource "aws_elasticache_replication_group" "sessions_store" {
   port                          = 6379
 
   subnet_group_name    = aws_elasticache_subnet_group.sessions_store.name
-  security_group_ids   = [aws_security_group.elasticache_security_group.id]
+  security_group_ids   = [aws_vpc.authentication.default_security_group_id]
 }

--- a/ci/terraform/aws/register.tf
+++ b/ci/terraform/aws/register.tf
@@ -13,6 +13,6 @@ module "register" {
   execution_arn             = module.api_gateway_root.execution_arn
   api_deployment_stage_name = var.api_deployment_stage_name
   lambda_zip_file           = var.lambda_zip_file
-  security_group_id         = aws_security_group.elasticache_security_group.id
+  security_group_id         = aws_vpc.authentication.default_security_group_id
   subnet_id                 = aws_subnet.authentication.*.id
 }

--- a/ci/terraform/aws/signup.tf
+++ b/ci/terraform/aws/signup.tf
@@ -13,6 +13,6 @@ module "signup" {
   execution_arn             = module.api_gateway_root.execution_arn
   api_deployment_stage_name = var.api_deployment_stage_name
   lambda_zip_file           = var.lambda_zip_file
-  security_group_id         = aws_security_group.elasticache_security_group.id
+  security_group_id         = aws_vpc.authentication.default_security_group_id
   subnet_id                 = aws_subnet.authentication.*.id
 }

--- a/ci/terraform/aws/token.tf
+++ b/ci/terraform/aws/token.tf
@@ -13,6 +13,6 @@ module "token" {
   execution_arn             = module.api_gateway_root.execution_arn
   api_deployment_stage_name = var.api_deployment_stage_name
   lambda_zip_file           = var.lambda_zip_file
-  security_group_id         = aws_security_group.elasticache_security_group.id
+  security_group_id         = aws_vpc.authentication.default_security_group_id
   subnet_id                 = aws_subnet.authentication.*.id
 }

--- a/ci/terraform/aws/userexists.tf
+++ b/ci/terraform/aws/userexists.tf
@@ -13,6 +13,6 @@ module "userexists" {
   execution_arn             = module.api_gateway_root.execution_arn
   api_deployment_stage_name = var.api_deployment_stage_name
   lambda_zip_file           = var.lambda_zip_file
-  security_group_id         = aws_security_group.elasticache_security_group.id
+  security_group_id         = aws_vpc.authentication.default_security_group_id
   subnet_id                 = aws_subnet.authentication.*.id
 }

--- a/ci/terraform/aws/userinfo.tf
+++ b/ci/terraform/aws/userinfo.tf
@@ -13,6 +13,6 @@ module "userinfo" {
   execution_arn             = module.api_gateway_root.execution_arn
   api_deployment_stage_name = var.api_deployment_stage_name
   lambda_zip_file           = var.lambda_zip_file
-  security_group_id         = aws_security_group.elasticache_security_group.id
+  security_group_id         = aws_vpc.authentication.default_security_group_id
   subnet_id                 = aws_subnet.authentication.*.id
 }

--- a/ci/terraform/aws/vpc.tf
+++ b/ci/terraform/aws/vpc.tf
@@ -4,12 +4,6 @@ resource "aws_vpc" "authentication" {
   enable_dns_support   = true
 }
 
-resource "aws_security_group" "elasticache_security_group" {
-  name        = "${var.environment}-elasticache-security-group"
-  vpc_id      = aws_vpc.authentication.id
-  description = "Security group to allow access to Redis"
-}
-
 data "aws_availability_zones" "available" {}
 
 resource "aws_subnet" "authentication" {
@@ -17,4 +11,10 @@ resource "aws_subnet" "authentication" {
   vpc_id            = aws_vpc.authentication.id
   cidr_block        = "10.0.${count.index}.0/24"
   availability_zone = data.aws_availability_zones.available.names[count.index]
+}
+
+resource "aws_route_table_association" "private" {
+  count          = length(data.aws_availability_zones.available.names)
+  subnet_id      = element(aws_subnet.authentication.*.id,count.index)
+  route_table_id = aws_vpc.authentication.default_route_table_id
 }

--- a/ci/terraform/aws/wellknown.tf
+++ b/ci/terraform/aws/wellknown.tf
@@ -13,6 +13,6 @@ module "openid_configuration_discovery" {
   execution_arn             = module.api_gateway_root.execution_arn
   api_deployment_stage_name = var.api_deployment_stage_name
   lambda_zip_file           = var.lambda_zip_file
-  security_group_id         = aws_security_group.elasticache_security_group.id
+  security_group_id         = aws_vpc.authentication.default_security_group_id
   subnet_id                 = aws_subnet.authentication.*.id
 }

--- a/ci/terraform/localstack/localstack.tf
+++ b/ci/terraform/localstack/localstack.tf
@@ -24,7 +24,7 @@ module "authorize" {
   execution_arn             = module.api_gateway_root.execution_arn
   api_deployment_stage_name = var.api_deployment_stage_name
   lambda_zip_file           = var.lambda_zip_file
-  security_group_id         = aws_security_group.elasticache_security_group.id
+  security_group_id         = aws_vpc.authentication.default_security_group_id
   subnet_id                 = aws_subnet.authentication.*.id
 }
 
@@ -46,7 +46,7 @@ module "openid_configuration_discovery" {
   execution_arn             = module.api_gateway_root.execution_arn
   api_deployment_stage_name = var.api_deployment_stage_name
   lambda_zip_file           = var.lambda_zip_file
-  security_group_id         = aws_security_group.elasticache_security_group.id
+  security_group_id         = aws_vpc.authentication.default_security_group_id
   subnet_id                 = aws_subnet.authentication.*.id
 }
 
@@ -68,7 +68,7 @@ module "jwks" {
   execution_arn             = module.api_gateway_root.execution_arn
   api_deployment_stage_name = var.api_deployment_stage_name
   lambda_zip_file           = var.lambda_zip_file
-  security_group_id         = aws_security_group.elasticache_security_group.id
+  security_group_id         = aws_vpc.authentication.default_security_group_id
   subnet_id                 = aws_subnet.authentication.*.id
 }
 
@@ -90,7 +90,7 @@ module "token" {
   execution_arn             = module.api_gateway_root.execution_arn
   api_deployment_stage_name = var.api_deployment_stage_name
   lambda_zip_file           = var.lambda_zip_file
-  security_group_id         = aws_security_group.elasticache_security_group.id
+  security_group_id         = aws_vpc.authentication.default_security_group_id
   subnet_id                 = aws_subnet.authentication.*.id
 }
 
@@ -112,7 +112,7 @@ module "register" {
   execution_arn             = module.api_gateway_root.execution_arn
   api_deployment_stage_name = var.api_deployment_stage_name
   lambda_zip_file           = var.lambda_zip_file
-  security_group_id         = aws_security_group.elasticache_security_group.id
+  security_group_id         = aws_vpc.authentication.default_security_group_id
   subnet_id                 = aws_subnet.authentication.*.id
 }
 
@@ -134,7 +134,7 @@ module "signup" {
   execution_arn             = module.api_gateway_root.execution_arn
   api_deployment_stage_name = var.api_deployment_stage_name
   lambda_zip_file           = var.lambda_zip_file
-  security_group_id         = aws_security_group.elasticache_security_group.id
+  security_group_id         = aws_vpc.authentication.default_security_group_id
   subnet_id                 = aws_subnet.authentication.*.id
 }
 
@@ -156,7 +156,7 @@ module "userinfo" {
   execution_arn             = module.api_gateway_root.execution_arn
   api_deployment_stage_name = var.api_deployment_stage_name
   lambda_zip_file           = var.lambda_zip_file
-  security_group_id         = aws_security_group.elasticache_security_group.id
+  security_group_id         = aws_vpc.authentication.default_security_group_id
   subnet_id                 = aws_subnet.authentication.*.id
 }
 
@@ -178,6 +178,6 @@ module "userexists" {
   execution_arn             = module.api_gateway_root.execution_arn
   api_deployment_stage_name = var.api_deployment_stage_name
   lambda_zip_file           = var.lambda_zip_file
-  security_group_id         = aws_security_group.elasticache_security_group.id
+  security_group_id         = aws_vpc.authentication.default_security_group_id
   subnet_id                 = aws_subnet.authentication.*.id
 }

--- a/ci/terraform/modules/endpoint-module/lambda.tf
+++ b/ci/terraform/modules/endpoint-module/lambda.tf
@@ -9,6 +9,8 @@ resource "aws_lambda_function" "endpoint_lambda" {
   function_name = replace("${var.endpoint_name}-${var.environment}-lambda", ".", "")
   role          = aws_iam_role.lambda_iam_role.arn
   handler       = var.handler_function_name
+  timeout       = 30
+  memory_size = 512
 
   source_code_hash = filebase64sha256(var.lambda_zip_file)
   vpc_config {

--- a/serverless/lambda/src/main/java/uk/gov/di/services/ConfigurationService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/ConfigurationService.java
@@ -12,4 +12,8 @@ public class ConfigurationService {
     public URI getLoginURI() {
         return URI.create(System.getenv("LOGIN_URI"));
     }
+
+    public String getRedisURL() {
+        return System.getenv("REDIS_URL");
+    }
 }

--- a/serverless/lambda/src/main/java/uk/gov/di/services/SessionService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/SessionService.java
@@ -1,19 +1,38 @@
 package uk.gov.di.services;
 
+import com.amazonaws.services.lambda.runtime.LambdaLogger;
+
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.api.sync.RedisStringCommands;
 import uk.gov.di.entity.Session;
 
 public class SessionService {
+
+    private final ConfigurationService configService = new ConfigurationService();
+
     public Session createSession() {
         return new Session();
     }
 
-    public void save(Session session) {
-        RedisClient client = RedisClient.create("redis://test-sessions-store.rixhjg.ng.0001.euw2.cache.amazonaws.com:6379");
-        StatefulRedisConnection<String, String> connection = client.connect();
-        RedisStringCommands<String, String> sync = connection.sync();
-        sync.set(session.getSessionId(), "???");
+    public void save(Session session, LambdaLogger logger) {
+        logger.log("Creating Redis Client");
+        RedisClient client = RedisClient.create(configService.getRedisURL());
+        try {
+            logger.log("Opening Redis Connection");
+            StatefulRedisConnection<String, String> connection = client.connect();
+            logger.log("Creating command");
+            RedisStringCommands<String, String> sync = connection.sync();
+            logger.log("Executing set command");
+            String result = sync.set(session.getSessionId(), "xyz");
+            logger.log("Command result: " + result);
+            logger.log("Closing connection");
+            connection.close();
+        } catch (Exception e) {
+            logger.log("An error occurred: " + e.getMessage());
+        } finally {
+            logger.log("Shutting down client");
+            client.shutdown();
+        }
     }
 }

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/AuthorisationHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/AuthorisationHandlerTest.java
@@ -1,6 +1,7 @@
 package uk.gov.di.lambdas;
 
 import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.LambdaLogger;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
@@ -44,6 +45,7 @@ class AuthorisationHandlerTest {
     @BeforeEach
     public void setUp() {
         handler = new AuthorisationHandler(CLIENT_SERVICE, CONFIGURATION_SERVICE, SESSION_SERVICE);
+        when(CONTEXT.getLogger()).thenReturn(mock(LambdaLogger.class));
     }
 
     @Test
@@ -86,7 +88,7 @@ class AuthorisationHandlerTest {
 
         assertThat(requestParams, hasEntry("session-id", session.getSessionId()));
 
-        verify(SESSION_SERVICE).save(eq(session));
+        verify(SESSION_SERVICE).save(eq(session), any(LambdaLogger.class));
     }
 
     @Test


### PR DESCRIPTION
- Set all Lambdas to use the default security group for the VPC
- Set timeout of the Lambdas to 30 seconds
- Increase the memory of the lambdas from default to 512. We were unable to connect to Redis with 128 mb.
- Configure the LOGIN_URI to the frontend client which runs in PaaS
- Add environment variable for Redis endpoint by using the primary endpoint address