### PR TITLE
LTG-300: Secure Redis Cluster

### DIFF
--- a/ci/terraform/aws/authorize.tf
+++ b/ci/terraform/aws/authorize.tf
@@ -6,8 +6,10 @@ module "authorize" {
   handler_environment_variables = {
     BASE_URL       = var.api_base_url
     LOGIN_URI      = "https://di-authentication-frontend.london.cloudapps.digital/"
-    REDIS_URL      = "rediss://${aws_elasticache_replication_group.sessions_store.primary_endpoint_address}:${aws_elasticache_replication_group.sessions_store.port}"
+    REDIS_HOST     = aws_elasticache_replication_group.sessions_store.primary_endpoint_address
+    REDIS_PORT     = aws_elasticache_replication_group.sessions_store.port
     REDIS_PASSWORD = random_password.redis_password.result
+    REDIS_TLS      = "true"
   }
   handler_function_name = "uk.gov.di.lambdas.AuthorisationHandler::handleRequest"
 

--- a/ci/terraform/aws/authorize.tf
+++ b/ci/terraform/aws/authorize.tf
@@ -4,9 +4,10 @@ module "authorize" {
   endpoint_name   = "authorize"
   endpoint_method = "GET"
   handler_environment_variables = {
-    BASE_URL  = var.api_base_url
-    LOGIN_URI = "https://di-authentication-frontend.london.cloudapps.digital/"
-    REDIS_URL = "redis://${aws_elasticache_replication_group.sessions_store.primary_endpoint_address}:${aws_elasticache_replication_group.sessions_store.port}"
+    BASE_URL       = var.api_base_url
+    LOGIN_URI      = "https://di-authentication-frontend.london.cloudapps.digital/"
+    REDIS_URL      = "rediss://${aws_elasticache_replication_group.sessions_store.primary_endpoint_address}:${aws_elasticache_replication_group.sessions_store.port}"
+    REDIS_PASSWORD = random_password.redis_password.result
   }
   handler_function_name = "uk.gov.di.lambdas.AuthorisationHandler::handleRequest"
 

--- a/ci/terraform/aws/redis.tf
+++ b/ci/terraform/aws/redis.tf
@@ -3,6 +3,10 @@ resource "aws_elasticache_subnet_group" "sessions_store" {
   subnet_ids = aws_subnet.authentication.*.id
 }
 
+resource "random_password" "redis_password" {
+  length = 32
+}
+
 resource "aws_elasticache_replication_group" "sessions_store" {
   automatic_failover_enabled    = true
   availability_zones            = data.aws_availability_zones.available.names
@@ -11,10 +15,21 @@ resource "aws_elasticache_replication_group" "sessions_store" {
   node_type                     = "cache.t2.micro"
   number_cache_clusters         = length(data.aws_availability_zones.available.names)
   engine                        = "redis"
-  engine_version                = "6.0.5"
+  engine_version                = "6.x"
   parameter_group_name          = "default.redis6.x"
   port                          = 6379
 
+  at_rest_encryption_enabled = true
+  transit_encryption_enabled = true
+  auth_token                 = random_password.redis_password.result
+  apply_immediately          = true
+
   subnet_group_name    = aws_elasticache_subnet_group.sessions_store.name
   security_group_ids   = [aws_vpc.authentication.default_security_group_id]
+
+  lifecycle {
+    ignore_changes = [
+      engine_version
+    ]
+  }
 }

--- a/serverless/lambda/src/main/java/uk/gov/di/services/ConfigurationService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/ConfigurationService.java
@@ -13,7 +13,19 @@ public class ConfigurationService {
         return URI.create(System.getenv("LOGIN_URI"));
     }
 
-    public String getRedisURL() {
-        return System.getenv("REDIS_URL");
+    public String getRedisHost() {
+        return System.getenv("REDIS_HOST");
+    }
+
+    public int getRedisPort() {
+        return Integer.parseInt(System.getenv().getOrDefault("REDIS_PORT", "6379"));
+    }
+
+    public boolean getUseRedisTLS() {
+        return Boolean.parseBoolean(System.getenv().getOrDefault("REDIS_TLS", "false"));
+    }
+
+    public String getRedisPassword() {
+        return System.getenv("REDIS_PASSWORD");
     }
 }

--- a/serverless/lambda/src/main/java/uk/gov/di/services/RedisConnectionService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/RedisConnectionService.java
@@ -1,0 +1,51 @@
+package uk.gov.di.services;
+
+import com.amazonaws.services.lambda.runtime.LambdaLogger;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.RedisURI;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.sync.RedisStringCommands;
+import uk.gov.di.entity.Session;
+
+import java.io.IOException;
+
+public class RedisConnectionService implements AutoCloseable {
+
+    private final ConfigurationService configService = new ConfigurationService();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final RedisClient client;
+    private final LambdaLogger logger;
+
+    public RedisConnectionService(LambdaLogger logger) {
+        this.logger = logger;
+        RedisURI redisURI = RedisURI.builder()
+                .withHost(configService.getRedisHost())
+                .withPort(configService.getRedisPort())
+                .withSsl(configService.getUseRedisTLS())
+                .withPassword(configService.getRedisPassword().toCharArray())
+                .build();
+        client = RedisClient.create(redisURI);
+    }
+
+    public void saveSession(Session session) throws IOException {
+        StatefulRedisConnection<String, String> connection = null;
+        try {
+            logger.log("Opening Redis Connection");
+            connection = client.connect();
+            RedisStringCommands<String, String> sync = connection.sync();
+            sync.set(session.getSessionId(), objectMapper.writeValueAsString(this));
+            logger.log("Closing connection");
+        } finally {
+            if (connection!=null && connection.isOpen()) {
+                connection.close();
+            }
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        logger.log("Shutting down client");
+        client.shutdown();
+    }
+}

--- a/serverless/lambda/src/main/java/uk/gov/di/services/SessionService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/SessionService.java
@@ -1,46 +1,19 @@
 package uk.gov.di.services;
 
 import com.amazonaws.services.lambda.runtime.LambdaLogger;
-
-import io.lettuce.core.RedisClient;
-import io.lettuce.core.RedisURI;
-import io.lettuce.core.api.StatefulRedisConnection;
-import io.lettuce.core.api.sync.RedisStringCommands;
 import uk.gov.di.entity.Session;
 
 public class SessionService {
-
-    private final ConfigurationService configService = new ConfigurationService();
 
     public Session createSession() {
         return new Session();
     }
 
     public void save(Session session, LambdaLogger logger) {
-
-        RedisURI redisURI = RedisURI.builder()
-                .withHost(configService.getRedisHost())
-                .withPort(configService.getRedisPort())
-                .withSsl(configService.getUseRedisTLS())
-                .withPassword(configService.getRedisPassword().toCharArray())
-                .build();
-        logger.log("Creating Redis Client");
-        RedisClient client = RedisClient.create(redisURI);
-        try {
-            logger.log("Opening Redis Connection");
-            StatefulRedisConnection<String, String> connection = client.connect();
-            logger.log("Creating command");
-            RedisStringCommands<String, String> sync = connection.sync();
-            logger.log("Executing set command");
-            String result = sync.set(session.getSessionId(), "xyz");
-            logger.log("Command result: " + result);
-            logger.log("Closing connection");
-            connection.close();
+        try (RedisConnectionService redis = new RedisConnectionService(logger)) {
+            redis.saveSession(session);
         } catch (Exception e) {
-            logger.log("An error occurred: " + e.getMessage());
-        } finally {
-            logger.log("Shutting down client");
-            client.shutdown();
+            e.printStackTrace();
         }
     }
 }

--- a/serverless/lambda/src/main/java/uk/gov/di/services/SessionService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/SessionService.java
@@ -3,6 +3,7 @@ package uk.gov.di.services;
 import com.amazonaws.services.lambda.runtime.LambdaLogger;
 
 import io.lettuce.core.RedisClient;
+import io.lettuce.core.RedisURI;
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.api.sync.RedisStringCommands;
 import uk.gov.di.entity.Session;
@@ -16,8 +17,15 @@ public class SessionService {
     }
 
     public void save(Session session, LambdaLogger logger) {
+
+        RedisURI redisURI = RedisURI.builder()
+                .withHost(configService.getRedisHost())
+                .withPort(configService.getRedisPort())
+                .withSsl(configService.getUseRedisTLS())
+                .withPassword(configService.getRedisPassword().toCharArray())
+                .build();
         logger.log("Creating Redis Client");
-        RedisClient client = RedisClient.create(configService.getRedisURL());
+        RedisClient client = RedisClient.create(redisURI);
         try {
             logger.log("Opening Redis Connection");
             StatefulRedisConnection<String, String> connection = client.connect();


### PR DESCRIPTION
## What?

- Add encryption to Redis cluster
- Use "6.x" as engine version and ignore changes to work around Terraform provider issue.
- Open secure connection to Redis from Lambda
- Refactor Redis connection 

## Why?

To provide secure connection and storage in Redis
