### PR TITLE
LTG-300: Improve error handling in session save

### DIFF
--- a/serverless/lambda/src/main/java/uk/gov/di/services/SessionService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/SessionService.java
@@ -13,7 +13,8 @@ public class SessionService {
         try (RedisConnectionService redis = new RedisConnectionService(logger)) {
             redis.saveSession(session);
         } catch (Exception e) {
-            e.printStackTrace();
+            logger.log("Redis error: " + e.getMessage());
+            throw new RuntimeException(e);
         }
     }
 }


### PR DESCRIPTION
## What?

Change the error handling to log and re-throw rather than default print stack trace which was inadvertently left in.

## Why?

Correct error handling is a good thing.