### PR TITLE
Ltg 313 create sqs queue

### DIFF
--- a/ci/terraform/aws/sqs.tf
+++ b/ci/terraform/aws/sqs.tf
@@ -1,8 +1,6 @@
 module "email_notification_sqs_queue" {
   source = "../modules/sqs-queue"
-  providers = {
-    aws = aws.localstack
-  }
+
   environment = var.environment
   queue_name = "email-notification"
   principals_arns = [module.userexists.lambda_iam_role_arn]

--- a/ci/terraform/localstack/site.tf
+++ b/ci/terraform/localstack/site.tf
@@ -26,5 +26,6 @@ provider "aws" {
     lambda     = "http://localhost:45678"
     s3         = "http://localhost:45678"
     ec2        = "http://localhost:45678"
+    sqs        = "http://localhost:45678"
   }
 }

--- a/ci/terraform/localstack/sqs.tf
+++ b/ci/terraform/localstack/sqs.tf
@@ -1,0 +1,10 @@
+module "email_notification_sqs_queue" {
+  source = "../modules/sqs-queue"
+  providers = {
+    aws = aws.localstack
+  }
+
+  account_id = "123456789012"
+  environment = var.environment
+  queue_name = "email-notification"
+}

--- a/ci/terraform/modules/endpoint-module/outputs.tf
+++ b/ci/terraform/modules/endpoint-module/outputs.tf
@@ -1,3 +1,7 @@
 output "base_url" {
   value = aws_api_gateway_deployment.endpoint_deployment.invoke_url
 }
+
+output "lambda_iam_role_arn" {
+  value = aws_iam_role.lambda_iam_role.arn
+}

--- a/ci/terraform/modules/sqs-queue/sqs.tf
+++ b/ci/terraform/modules/sqs-queue/sqs.tf
@@ -1,0 +1,35 @@
+resource "aws_sqs_queue" "queue" {
+  name                      = "${var.environment}-${var.queue_name}-queue"
+  delay_seconds             = 10
+  max_message_size          = 2048
+  message_retention_seconds = 1209600
+  receive_wait_time_seconds = 10
+}
+
+data "aws_iam_policy_document" "queue_policy_document" {
+  statement {
+    sid    = "SendAndReceive"
+    effect = "Allow"
+
+    principals {
+      type = "AWS"
+
+      identifiers = ["arn:aws:iam::${var.account_id}:root"]
+    }
+
+    actions = [
+      "sqs:SendMessage",
+      "sqs:ReceiveMessage",
+      "sqs:ChangeMessageVisibility",
+      "sqs:DeleteMessage",
+      "sqs:GetQueueAttributes",
+    ]
+
+    resources = [aws_sqs_queue.queue.arn]
+  }
+}
+
+resource "aws_sqs_queue_policy" "event" {
+  queue_url = aws_sqs_queue.queue.id
+  policy    = data.aws_iam_policy_document.queue_policy_document.json
+}

--- a/ci/terraform/modules/sqs-queue/sqs.tf
+++ b/ci/terraform/modules/sqs-queue/sqs.tf
@@ -14,7 +14,7 @@ data "aws_iam_policy_document" "queue_policy_document" {
     principals {
       type = "AWS"
 
-      identifiers = ["arn:aws:iam::${var.account_id}:root"]
+      identifiers = var.principals_arns
     }
 
     actions = [

--- a/ci/terraform/modules/sqs-queue/variables.tf
+++ b/ci/terraform/modules/sqs-queue/variables.tf
@@ -1,0 +1,11 @@
+variable "queue_name" {
+  type    = string
+}
+
+variable "environment" {
+  type    = string
+}
+
+variable "account_id" {
+  type    = string
+}

--- a/ci/terraform/modules/sqs-queue/variables.tf
+++ b/ci/terraform/modules/sqs-queue/variables.tf
@@ -6,6 +6,6 @@ variable "environment" {
   type    = string
 }
 
-variable "account_id" {
-  type    = string
+variable "principals_arns" {
+  type = list(string)
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: docker
       dockerfile: localstack.Dockerfile
     environment:
-      SERVICES: lambda, apigateway, iam, ec2
+      SERVICES: lambda, apigateway, iam, ec2, sqs
       EDGE_PORT: "45678"
       EXTERNAL_HOSTNAME: ${AWS_HOSTNAME:-localhost}
       DEFAULT_REGION: eu-west-2


### PR DESCRIPTION
## What?

- Create an SQS queue module to build a queue and related policies
- Add module to localstack Terraform
- Enable SQS in localstack
- Enable SQS in AWS 
- Restrict access to the SQS queue for a specific Lambda. It is currently the userexists Lambda as the Lambdas which will talk to it haven't been built yet.


## Why?

- So it can be used by the Lambda to put messages on the queue for when a user doesn't have an account. Another Lambda will read from the queue and be responsible for using Notify to send an email. 