### PR TITLE
LTG-300: Serialise the session object

### DIFF
--- a/serverless/lambda/src/main/java/uk/gov/di/services/RedisConnectionService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/RedisConnectionService.java
@@ -34,7 +34,7 @@ public class RedisConnectionService implements AutoCloseable {
             logger.log("Opening Redis Connection");
             connection = client.connect();
             RedisStringCommands<String, String> sync = connection.sync();
-            sync.set(session.getSessionId(), objectMapper.writeValueAsString(this));
+            sync.set(session.getSessionId(), objectMapper.writeValueAsString(session));
             logger.log("Closing connection");
         } finally {
             if (connection!=null && connection.isOpen()) {


### PR DESCRIPTION
## What?

- A copy and paste error meant we were serialising the wrong object.

## Why?

The lambda is not executing due to a serialisation error.

## Related PRs

#51 