### PR TITLE
Ltg 313 - Create lambda to populate queue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ build
 **/.project
 **/.settings
 **/bin
+.java-version

--- a/ci/terraform/aws/outputs.tf
+++ b/ci/terraform/aws/outputs.tf
@@ -29,3 +29,7 @@ output "userexists_url" {
 output "openid_configuration_discovery_url" {
   value = "http://localhost:45678/restapis/${module.api_gateway_root.di_authentication_api_id}/${var.environment}/_user_request_/.wellknown/openid-configuration"
 }
+
+output "verify_email_url" {
+  value = module.verify_email.base_url
+}

--- a/ci/terraform/aws/sqs.tf
+++ b/ci/terraform/aws/sqs.tf
@@ -3,7 +3,7 @@ module "email_notification_sqs_queue" {
 
   environment = var.environment
   name = "email-notification"
-  sender_principal_arns = [module.userexists.lambda_iam_role_arn]
+  sender_principal_arns = [module.verify_email.lambda_iam_role_arn]
 
   handler_environment_variables = {
     VERIFY_EMAIL_TEMPLATE_ID = "b7dbb02f-941b-4d72-ad64-84cbe5d77c2e"

--- a/ci/terraform/aws/verify_email.tf
+++ b/ci/terraform/aws/verify_email.tf
@@ -1,0 +1,18 @@
+module "verify_email" {
+  source = "../modules/endpoint-module"
+
+  endpoint_name   = "verify-email"
+  endpoint_method = "POST"
+  handler_environment_variables = {
+    SQS_EMAIL = module.email_notification_sqs_queue.queue_name
+  }
+  handler_function_name = "uk.gov.di.lambdas.SendUserEmailHandler::handleRequest"
+
+  rest_api_id               = module.api_gateway_root.di_authentication_api_id
+  root_resource_id          = module.api_gateway_root.root_resource_id
+  execution_arn             = module.api_gateway_root.execution_arn
+  api_deployment_stage_name = var.api_deployment_stage_name
+  lambda_zip_file           = var.lambda_zip_file
+  security_group_id         = aws_vpc.authentication.default_security_group_id
+  subnet_id                 = aws_subnet.authentication.*.id
+}

--- a/ci/terraform/localstack/localstack.tf
+++ b/ci/terraform/localstack/localstack.tf
@@ -181,3 +181,26 @@ module "userexists" {
   security_group_id         = aws_vpc.authentication.default_security_group_id
   subnet_id                 = aws_subnet.authentication.*.id
 }
+
+module "verify_email" {
+  source = "../modules/endpoint-module"
+  providers = {
+    aws = aws.localstack
+  }
+
+  endpoint_name   = "verify-email"
+  endpoint_method = "POST"
+  handler_environment_variables = {
+    SQS_EMAIL = module.email_notification_sqs_queue.queue_name
+    SQS_ENDPOINT = var.localstack_endpoint
+  }
+  handler_function_name = "uk.gov.di.lambdas.SendUserEmailHandler::handleRequest"
+
+  rest_api_id               = module.api_gateway_root.di_authentication_api_id
+  root_resource_id          = module.api_gateway_root.root_resource_id
+  execution_arn             = module.api_gateway_root.execution_arn
+  api_deployment_stage_name = var.api_deployment_stage_name
+  lambda_zip_file           = var.lambda_zip_file
+  security_group_id         = aws_vpc.authentication.default_security_group_id
+  subnet_id                 = aws_subnet.authentication.*.id
+}

--- a/ci/terraform/localstack/outputs.tf
+++ b/ci/terraform/localstack/outputs.tf
@@ -30,6 +30,10 @@ output "userexists_url" {
   value = "http://localhost:45678/restapis/${module.api_gateway_root.di_authentication_api_id}/${var.environment}/_user_request_/userexists"
 }
 
+output "verify_email_url" {
+  value = "http://localhost:45678/restapis/${module.api_gateway_root.di_authentication_api_id}/${var.environment}/_user_request_/verify-email"
+}
+
 output "api_gateway_root_id" {
   value = module.api_gateway_root.di_authentication_api_id
 }

--- a/ci/terraform/localstack/site.tf
+++ b/ci/terraform/localstack/site.tf
@@ -20,12 +20,12 @@ provider "aws" {
   skip_requesting_account_id  = true
 
   endpoints {
-    apigateway = "http://localhost:45678"
-    ecr        = "http://localhost:45678"
-    iam        = "http://localhost:45678"
-    lambda     = "http://localhost:45678"
-    s3         = "http://localhost:45678"
-    ec2        = "http://localhost:45678"
-    sqs        = "http://localhost:45678"
+    apigateway = var.localstack_endpoint
+    ecr        = var.localstack_endpoint
+    iam        = var.localstack_endpoint
+    lambda     = var.localstack_endpoint
+    s3         = var.localstack_endpoint
+    ec2        = var.localstack_endpoint
+    sqs        = var.localstack_endpoint
   }
 }

--- a/ci/terraform/localstack/variables.tf
+++ b/ci/terraform/localstack/variables.tf
@@ -18,3 +18,8 @@ variable "api_base_url" {
   type    = string
   default = "http://localhost:8080"
 }
+
+variable "localstack_endpoint" {
+  type = string
+  default = "http://localhost:45678"
+}

--- a/ci/terraform/modules/sqs-queue/outputs.tf
+++ b/ci/terraform/modules/sqs-queue/outputs.tf
@@ -1,3 +1,7 @@
 output "queue_arn" {
   value = aws_sqs_queue.queue.arn
 }
+
+output "queue_name" {
+  value = aws_sqs_queue.queue.name
+}

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserExistsResourceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserExistsResourceIntegrationTest.java
@@ -12,8 +12,8 @@ import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
-import uk.gov.di.entity.CheckUserExistsRequest;
 import uk.gov.di.entity.CheckUserExistsResponse;
+import uk.gov.di.entity.UserWithEmailRequest;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -42,8 +42,8 @@ public class UserExistsResourceIntegrationTest {
         MultivaluedMap headers = new MultivaluedHashMap();
         headers.add("Session-Id", UUID.randomUUID().toString());
 
-        CheckUserExistsRequest request =
-                new CheckUserExistsRequest("joe.bloggs@digital.cabinet-office.gov.uk");
+        UserWithEmailRequest request =
+                new UserWithEmailRequest("joe.bloggs@digital.cabinet-office.gov.uk");
 
         Response response =
                 invocationBuilder

--- a/serverless/lambda/build.gradle
+++ b/serverless/lambda/build.gradle
@@ -12,6 +12,7 @@ repositories {
 dependencies {
     implementation "com.amazonaws:aws-lambda-java-core:1.2.1",
             "com.amazonaws:aws-lambda-java-events:2.2.5",
+            "software.amazon.awssdk:sqs:2.16.78",
             "com.nimbusds:oauth2-oidc-sdk:9.3.1",
             "com.nimbusds:nimbus-jose-jwt:9.8.1",
             "com.fasterxml.jackson.core:jackson-core:2.12.3",

--- a/serverless/lambda/src/main/java/uk/gov/di/entity/NotificationType.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/entity/NotificationType.java
@@ -1,6 +1,5 @@
 package uk.gov.di.entity;
 
 public enum NotificationType {
-
     VERIFY_EMAIL
 }

--- a/serverless/lambda/src/main/java/uk/gov/di/entity/NotifyRequest.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/entity/NotifyRequest.java
@@ -4,14 +4,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class NotifyRequest {
 
-    @JsonProperty
-    private NotificationType notificationType;
+    @JsonProperty private NotificationType notificationType;
 
-    @JsonProperty
-    private String destination;
+    @JsonProperty private String destination;
 
-    public NotifyRequest(@JsonProperty(required = true, value = "destination")  String destination,
-                         @JsonProperty(required = true, value= "notificationType") NotificationType notificationType) {
+    public NotifyRequest(
+            @JsonProperty(required = true, value = "destination") String destination,
+            @JsonProperty(required = true, value = "notificationType")
+                    NotificationType notificationType) {
         this.destination = destination;
         this.notificationType = notificationType;
     }

--- a/serverless/lambda/src/main/java/uk/gov/di/entity/UserWithEmailRequest.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/entity/UserWithEmailRequest.java
@@ -2,11 +2,11 @@ package uk.gov.di.entity;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class CheckUserExistsRequest {
+public class UserWithEmailRequest {
 
     private String email;
 
-    public CheckUserExistsRequest(@JsonProperty(required = true, value = "email") String email) {
+    public UserWithEmailRequest(@JsonProperty(required = true, value = "email") String email) {
         this.email = email;
     }
 

--- a/serverless/lambda/src/main/java/uk/gov/di/helpers/ApiGatewayResponseHelper.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/helpers/ApiGatewayResponseHelper.java
@@ -1,0 +1,14 @@
+package uk.gov.di.helpers;
+
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+
+public class ApiGatewayResponseHelper {
+    public static APIGatewayProxyResponseEvent generateApiGatewayProxyResponse(
+            int statusCode, String body) {
+        APIGatewayProxyResponseEvent apiGatewayProxyResponseEvent =
+                new APIGatewayProxyResponseEvent();
+        apiGatewayProxyResponseEvent.setStatusCode(statusCode);
+        apiGatewayProxyResponseEvent.setBody(body);
+        return apiGatewayProxyResponseEvent;
+    }
+}

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/CheckUserExistsHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/CheckUserExistsHandler.java
@@ -6,8 +6,8 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import uk.gov.di.entity.CheckUserExistsRequest;
 import uk.gov.di.entity.CheckUserExistsResponse;
+import uk.gov.di.entity.UserWithEmailRequest;
 import uk.gov.di.services.AuthenticationService;
 import uk.gov.di.services.UserService;
 import uk.gov.di.services.ValidationService;
@@ -16,6 +16,8 @@ import uk.gov.di.validation.EmailValidation;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+
+import static uk.gov.di.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 
 public class CheckUserExistsHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -44,8 +46,8 @@ public class CheckUserExistsHandler
                 return generateApiGatewayProxyResponse(400, "Session-Id is missing");
             }
 
-            CheckUserExistsRequest userExistsRequest =
-                    objectMapper.readValue(input.getBody(), CheckUserExistsRequest.class);
+            UserWithEmailRequest userExistsRequest =
+                    objectMapper.readValue(input.getBody(), UserWithEmailRequest.class);
             Set<EmailValidation> emailErrors =
                     validationService.validateEmailAddress(userExistsRequest.getEmail());
             if (!emailErrors.isEmpty()) {
@@ -68,14 +70,5 @@ public class CheckUserExistsHandler
         } catch (JsonProcessingException e) {
             return generateApiGatewayProxyResponse(400, "Request is missing parameters");
         }
-    }
-
-    private APIGatewayProxyResponseEvent generateApiGatewayProxyResponse(
-            int statusCode, String body) {
-        APIGatewayProxyResponseEvent apiGatewayProxyResponseEvent =
-                new APIGatewayProxyResponseEvent();
-        apiGatewayProxyResponseEvent.setStatusCode(statusCode);
-        apiGatewayProxyResponseEvent.setBody(body);
-        return apiGatewayProxyResponseEvent;
     }
 }

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/NotificationHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/NotificationHandler.java
@@ -22,9 +22,11 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
     private NotificationService notificationService;
     private ObjectMapper objectMapper = new ObjectMapper();
     private ConfigurationService configService;
-    private NotificationClient client = new NotificationClient(new ConfigurationService().getNotifyApiKey());
+    private NotificationClient client =
+            new NotificationClient(new ConfigurationService().getNotifyApiKey());
 
-    public NotificationHandler(NotificationService notificationService, ConfigurationService configService) {
+    public NotificationHandler(
+            NotificationService notificationService, ConfigurationService configService) {
         this.notificationService = notificationService;
         this.configService = configService;
     }
@@ -37,26 +39,27 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
     @Override
     public Void handleRequest(SQSEvent event, Context context) {
 
-            for(SQSMessage msg : event.getRecords()){
-                try {
-                    NotifyRequest notifyRequest = objectMapper.readValue(msg.getBody(), NotifyRequest.class);
-                    switch (notifyRequest.getNotificationType()) {
-                        case VERIFY_EMAIL:
-                            Random rnd = new Random();
-                            String number = Integer.toString(rnd.nextInt(999999));
-                            Map<String, Object> personalisation = new HashMap<>();
-                            personalisation.put("validation-code", number);
-                            personalisation.put("email-address", notifyRequest.getDestination());
-                            notificationService.sendEmail(
-                                    notifyRequest.getDestination(),
-                                    personalisation,
-                                    configService.getNotificationTemplateId(VERIFY_EMAIL));
-                            break;
-                    }
-                } catch (JsonProcessingException e) {
-                    throw new RuntimeException(e);
+        for (SQSMessage msg : event.getRecords()) {
+            try {
+                NotifyRequest notifyRequest =
+                        objectMapper.readValue(msg.getBody(), NotifyRequest.class);
+                switch (notifyRequest.getNotificationType()) {
+                    case VERIFY_EMAIL:
+                        Random rnd = new Random();
+                        String number = Integer.toString(rnd.nextInt(999999));
+                        Map<String, Object> personalisation = new HashMap<>();
+                        personalisation.put("validation-code", number);
+                        personalisation.put("email-address", notifyRequest.getDestination());
+                        notificationService.sendEmail(
+                                notifyRequest.getDestination(),
+                                personalisation,
+                                configService.getNotificationTemplateId(VERIFY_EMAIL));
+                        break;
                 }
+            } catch (JsonProcessingException e) {
+                throw new RuntimeException(e);
             }
-            return null;
+        }
+        return null;
     }
 }

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/SendUserEmailHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/SendUserEmailHandler.java
@@ -1,0 +1,80 @@
+package uk.gov.di.lambdas;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.LambdaLogger;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import uk.gov.di.entity.NotificationType;
+import uk.gov.di.entity.NotifyRequest;
+import uk.gov.di.entity.UserWithEmailRequest;
+import uk.gov.di.services.AwsSqsClient;
+import uk.gov.di.services.ConfigurationService;
+import uk.gov.di.services.ValidationService;
+import uk.gov.di.validation.EmailValidation;
+
+import java.util.Set;
+
+import static uk.gov.di.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
+
+public class SendUserEmailHandler
+        implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+
+    private final ConfigurationService configurationService;
+    private final ValidationService validationService;
+    private final AwsSqsClient sqsClient;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public SendUserEmailHandler(
+            ConfigurationService configurationService,
+            ValidationService validationService,
+            AwsSqsClient sqsClient) {
+        this.configurationService = configurationService;
+        this.validationService = validationService;
+        this.sqsClient = sqsClient;
+    }
+
+    public SendUserEmailHandler() {
+        this.configurationService = new ConfigurationService();
+        this.sqsClient =
+                new AwsSqsClient(
+                        configurationService.getAwsRegion(),
+                        configurationService.getEmailQueueUri(),
+                        configurationService.getSqsEndpointUri());
+        this.validationService = new ValidationService();
+    }
+
+    @Override
+    public APIGatewayProxyResponseEvent handleRequest(
+            APIGatewayProxyRequestEvent input, Context context) {
+        LambdaLogger logger = context.getLogger();
+
+        try {
+            UserWithEmailRequest userRequest =
+                    objectMapper.readValue(input.getBody(), UserWithEmailRequest.class);
+            Set<EmailValidation> emailErrors =
+                    validationService.validateEmailAddress(userRequest.getEmail());
+            if (!emailErrors.isEmpty()) {
+                return generateApiGatewayProxyResponse(400, emailErrors.toString());
+            }
+
+            NotifyRequest notifyRequest =
+                    new NotifyRequest(userRequest.getEmail(), NotificationType.VERIFY_EMAIL);
+            sqsClient.send(serialiseRequest(notifyRequest));
+            return generateApiGatewayProxyResponse(200, "");
+        } catch (SdkClientException ex) {
+            logger.log("Error sending message to queue: " + ex.getMessage());
+            return generateApiGatewayProxyResponse(500, "Error sending message to queue");
+        } catch (JsonProcessingException e) {
+            logger.log("Error parsing request: " + e.getMessage());
+            return generateApiGatewayProxyResponse(400, "Request is missing parameters");
+        }
+    }
+
+    private String serialiseRequest(Object request) throws JsonProcessingException {
+        return objectMapper.writeValueAsString(request);
+    }
+}

--- a/serverless/lambda/src/main/java/uk/gov/di/services/AwsSqsClient.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/AwsSqsClient.java
@@ -1,0 +1,44 @@
+package uk.gov.di.services;
+
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.SqsClientBuilder;
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
+
+import java.net.URI;
+import java.util.Optional;
+
+public class AwsSqsClient {
+
+    private final SqsClient client;
+    private final String queueUrl;
+
+    public AwsSqsClient(String region, String queueUrl, Optional<String> sqsEndpoint) {
+        SqsClientBuilder amazonSqsBuilder =
+                SqsClient.builder().region(Region.of(region));
+
+        if (sqsEndpoint.isPresent()) {
+            amazonSqsBuilder
+                .endpointOverride(URI.create(sqsEndpoint.get()))
+                .credentialsProvider(
+                    StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(
+                            "FAKEACCESSKEY",
+                            "FAKESECRETKEY")
+                    )
+                );
+        }
+        this.client = amazonSqsBuilder.build();
+        this.queueUrl = queueUrl;
+    }
+
+    public void send(final String event) throws SdkClientException {
+        SendMessageRequest messageRequest =
+                SendMessageRequest.builder().queueUrl(queueUrl).messageBody(event).build();
+
+        client.sendMessage(messageRequest);
+    }
+}

--- a/serverless/lambda/src/main/java/uk/gov/di/services/AwsSqsClient.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/AwsSqsClient.java
@@ -17,19 +17,14 @@ public class AwsSqsClient {
     private final String queueUrl;
 
     public AwsSqsClient(String region, String queueUrl, Optional<String> sqsEndpoint) {
-        SqsClientBuilder amazonSqsBuilder =
-                SqsClient.builder().region(Region.of(region));
+        SqsClientBuilder amazonSqsBuilder = SqsClient.builder().region(Region.of(region));
 
         if (sqsEndpoint.isPresent()) {
             amazonSqsBuilder
-                .endpointOverride(URI.create(sqsEndpoint.get()))
-                .credentialsProvider(
-                    StaticCredentialsProvider.create(
-                        AwsBasicCredentials.create(
-                            "FAKEACCESSKEY",
-                            "FAKESECRETKEY")
-                    )
-                );
+                    .endpointOverride(URI.create(sqsEndpoint.get()))
+                    .credentialsProvider(
+                            StaticCredentialsProvider.create(
+                                    AwsBasicCredentials.create("FAKEACCESSKEY", "FAKESECRETKEY")));
         }
         this.client = amazonSqsBuilder.build();
         this.queueUrl = queueUrl;

--- a/serverless/lambda/src/main/java/uk/gov/di/services/ConfigurationService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/ConfigurationService.java
@@ -36,7 +36,7 @@ public class ConfigurationService {
     }
 
     public String getNotificationTemplateId(NotificationType notificationType) {
-        switch(notificationType) {
+        switch (notificationType) {
             case VERIFY_EMAIL:
                 return System.getenv("VERIFY_EMAIL_TEMPLATE_ID");
             default:
@@ -44,10 +44,15 @@ public class ConfigurationService {
         }
     }
 
-    public String getEmailQueueUri() { return System.getenv("SQS_EMAIL"); }
+    public String getEmailQueueUri() {
+        return System.getenv("SQS_EMAIL");
+    }
 
-    public String getAwsRegion() { return System.getenv("AWS_REGION"); }
+    public String getAwsRegion() {
+        return System.getenv("AWS_REGION");
+    }
 
-    public Optional<String> getSqsEndpointUri() { return Optional.of(System.getenv("SQS_ENDPOINT")); }
-
+    public Optional<String> getSqsEndpointUri() {
+        return Optional.of(System.getenv("SQS_ENDPOINT"));
+    }
 }

--- a/serverless/lambda/src/main/java/uk/gov/di/services/ConfigurationService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/ConfigurationService.java
@@ -43,4 +43,11 @@ public class ConfigurationService {
                 throw new RuntimeException("NotificationType template ID does not exist");
         }
     }
+
+    public String getEmailQueueUri() { return System.getenv("SQS_EMAIL"); }
+
+    public String getAwsRegion() { return System.getenv("AWS_REGION"); }
+
+    public Optional<String> getSqsEndpointUri() { return Optional.of(System.getenv("SQS_ENDPOINT")); }
+
 }

--- a/serverless/lambda/src/main/java/uk/gov/di/services/NotificationService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/NotificationService.java
@@ -19,11 +19,7 @@ public class NotificationService {
 
     public void sendEmail(String email, Map<String, Object> personalisation, String templateId) {
         try {
-            notifyClient.sendEmail(
-                    templateId,
-                    email,
-                    personalisation,
-                    "");
+            notifyClient.sendEmail(templateId, email, personalisation, "");
         } catch (NotificationClientException e) {
             throw new RuntimeException(e);
         }
@@ -34,7 +30,10 @@ public class NotificationService {
             return false;
         } else if (!validationCode.get(email).getCode().equals(code)) {
             return false;
-        } else if (validationCode.get(email).getTimeOfIssue().isAfter(validationCode.get(email).getTimeOfIssue().plusMinutes(15))) {
+        } else if (validationCode
+                .get(email)
+                .getTimeOfIssue()
+                .isAfter(validationCode.get(email).getTimeOfIssue().plusMinutes(15))) {
             validationCode.remove(email);
             return false;
         } else {

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/SendUserEmailHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/SendUserEmailHandlerTest.java
@@ -1,0 +1,101 @@
+package uk.gov.di.lambdas;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.LambdaLogger;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import uk.gov.di.entity.NotificationType;
+import uk.gov.di.entity.NotifyRequest;
+import uk.gov.di.services.AwsSqsClient;
+import uk.gov.di.services.ConfigurationService;
+import uk.gov.di.services.ValidationService;
+import uk.gov.di.validation.EmailValidation;
+
+import java.util.Set;
+
+import static java.lang.String.format;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class SendUserEmailHandlerTest {
+
+    private static final String TEST_EMAIL_ADDRESS = "joe.bloggs@digital.cabinet-office.gov.uk";
+
+    private final ValidationService validationService = mock(ValidationService.class);
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private final AwsSqsClient awsSqsClient = mock(AwsSqsClient.class);
+    private final Context context = mock(Context.class);
+    private final SendUserEmailHandler handler =
+            new SendUserEmailHandler(configurationService, validationService, awsSqsClient);
+
+    @BeforeEach
+    void setup() {
+        when(context.getLogger()).thenReturn(mock(LambdaLogger.class));
+    }
+
+    @Test
+    void shouldReturn200AndPutMessageOnQueueForAValidRequest() throws JsonProcessingException {
+        when(validationService.validateEmailAddress(eq(TEST_EMAIL_ADDRESS))).thenReturn(Set.of());
+        NotifyRequest notifyRequest =
+                new NotifyRequest(TEST_EMAIL_ADDRESS, NotificationType.VERIFY_EMAIL);
+        ObjectMapper objectMapper = new ObjectMapper();
+        String serialisedRequest = objectMapper.writeValueAsString(notifyRequest);
+
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        event.setBody(format("{ \"email\": \"%s\" }", TEST_EMAIL_ADDRESS));
+        APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
+
+        assertEquals(200, result.getStatusCode());
+
+        verify(awsSqsClient).send(serialisedRequest);
+    }
+
+    @Test
+    public void shouldReturn400IfRequestIsMissingEmail() {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        event.setBody("{ }");
+        APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
+
+        assertEquals(400, result.getStatusCode());
+        assertEquals("Request is missing parameters", result.getBody());
+    }
+
+    @Test
+    public void shouldReturn400IfEmailAddressIsInvalid() {
+        when(validationService.validateEmailAddress(eq("joe.bloggs")))
+                .thenReturn(Set.of(EmailValidation.INCORRECT_FORMAT));
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        event.setBody("{ \"email\": \"joe.bloggs\" }");
+        APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
+
+        assertEquals(400, result.getStatusCode());
+        assertTrue(result.getBody().contains(EmailValidation.INCORRECT_FORMAT.toString()));
+    }
+
+    @Test
+    public void shouldReturn500IfMessageCannotBeSentToQueue() throws JsonProcessingException {
+        when(validationService.validateEmailAddress(eq(TEST_EMAIL_ADDRESS))).thenReturn(Set.of());
+        NotifyRequest notifyRequest =
+                new NotifyRequest(TEST_EMAIL_ADDRESS, NotificationType.VERIFY_EMAIL);
+        ObjectMapper objectMapper = new ObjectMapper();
+        String serialisedRequest = objectMapper.writeValueAsString(notifyRequest);
+        doThrow(SdkClientException.class).when(awsSqsClient).send(eq(serialisedRequest));
+
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        event.setBody(format("{ \"email\": \"%s\" }", TEST_EMAIL_ADDRESS));
+        APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
+
+        assertEquals(500, result.getStatusCode());
+        assertTrue(result.getBody().contains("Error sending message to queue"));
+    }
+}


### PR DESCRIPTION
## What?

- Add a simple lambda to put a message on the queue. Lambda accepts e-mail in body of request and passes on to queue. No validation against session at this time.
- Write terraform to create verify-email lambda. This terraform will create a lambda which can be accessed via api-gateway using the 'verify-email' path. The verify-email uses the SendUserEmailHandler to put a message on the SQS queue.

## Why?

- So we have a Lambda to put messages onto a queue 