### PR TITLE
LTG-313 - Make the SQS_ENDPOINT config Optional.ofNullable

### DIFF
--- a/serverless/lambda/src/main/java/uk/gov/di/services/ConfigurationService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/ConfigurationService.java
@@ -53,6 +53,6 @@ public class ConfigurationService {
     }
 
     public Optional<String> getSqsEndpointUri() {
-        return Optional.of(System.getenv("SQS_ENDPOINT"));
+        return Optional.ofNullable(System.getenv("SQS_ENDPOINT"));
     }
 }


### PR DESCRIPTION


## What?

- We only need the SQS_ENDPOINT set if we are using localstack so it is fine to be null when running in AWS.

## Why?

- So we don't get a null pointer when running in AWS
