### PR TITLE
BAU: Fix minor Terraform issues

### DIFF
--- a/ci/terraform/aws/redis.tf
+++ b/ci/terraform/aws/redis.tf
@@ -5,6 +5,7 @@ resource "aws_elasticache_subnet_group" "sessions_store" {
 
 resource "random_password" "redis_password" {
   length = 32
+  override_special = "!#$%&"
 }
 
 resource "aws_elasticache_replication_group" "sessions_store" {

--- a/ci/terraform/aws/site.tf
+++ b/ci/terraform/aws/site.tf
@@ -10,7 +10,7 @@ terraform {
 
   backend "s3" {
     bucket  = "digital-identity-dev-tfstate"
-    key     = "spike-terraform.tfstate"
+    key     = "test-terraform.tfstate"
     encrypt = true
     region  = "eu-west-2"
   }

--- a/ci/terraform/aws/vpc.tf
+++ b/ci/terraform/aws/vpc.tf
@@ -28,9 +28,7 @@ resource "aws_vpc_endpoint" "sqs" {
   vpc_id            = aws_vpc.authentication.id
   service_name      = data.aws_vpc_endpoint_service.sqs.service_name
 
-  subnet_ids = [
-    aws_subnet.authentication.*.id
-  ]
+  subnet_ids = aws_subnet.authentication.*.id
 
   security_group_ids = [
     aws_vpc.authentication.default_security_group_id


### PR DESCRIPTION
## What?

- Change VPC endpoint subnet to a list (originally this was incorrectly a list of lists)
- Reduce the number of special characters that can be used as the Redis password (Redis doesn't like @, " or \)
- Change name of state file in S3 to reflect environment name.

## Why?

We had to re-create the environment and ran into the above issues.