### PR TITLE
LTG-35: scope on auth redirect

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorizationAPIResourceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorizationAPIResourceIntegrationTest.java
@@ -1,0 +1,13 @@
+package uk.gov.di.authentication.api;
+
+import java.util.Optional;
+
+public class AuthorizationAPIResourceIntegrationTest {
+    protected static final String LOCAL_ENDPOINT_FORMAT =
+            "http://localhost:45678/restapis/%s/local/_user_request_";
+    protected static final String LOCAL_API_GATEWAY_ID =
+            Optional.ofNullable(System.getenv().get("API_GATEWAY_ID")).orElse("");
+    protected static final String ROOT_RESOURCE_URL =
+            Optional.ofNullable(System.getenv().get("ROOT_RESOURCE_URL"))
+                    .orElse(String.format(LOCAL_ENDPOINT_FORMAT, LOCAL_API_GATEWAY_ID));
+}

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenResourceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenResourceIntegrationTest.java
@@ -9,19 +9,9 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
 
-import java.util.Optional;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class TokenResourceIntegrationTest {
-
-    private static final String LOCAL_TOKEN_ENDPOINT_FORMAT =
-            "http://localhost:45678/restapis/%s/local/_user_request_";
-    private static final String LOCAL_API_GATEWAY_ID =
-            Optional.ofNullable(System.getenv().get("API_GATEWAY_ID")).orElse("");
-    private static final String ROOT_RESOURCE_URL =
-            Optional.ofNullable(System.getenv().get("ROOT_RESOURCE_URL"))
-                    .orElse(String.format(LOCAL_TOKEN_ENDPOINT_FORMAT, LOCAL_API_GATEWAY_ID));
+public class TokenResourceIntegrationTest extends AuthorizationAPIResourceIntegrationTest {
 
     private static final String TOKEN_RESOURCE = "/token";
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserExistsResourceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserExistsResourceIntegrationTest.java
@@ -15,20 +15,11 @@ import org.junit.jupiter.api.Test;
 import uk.gov.di.entity.CheckUserExistsRequest;
 import uk.gov.di.entity.CheckUserExistsResponse;
 
-import java.util.Optional;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class UserExistsResourceIntegrationTest {
-
-    private static final String LOCAL_ENDPOINT_FORMAT =
-            "http://localhost:45678/restapis/%s/local/_user_request_";
-    private static final String LOCAL_API_GATEWAY_ID =
-            Optional.ofNullable(System.getenv().get("API_GATEWAY_ID")).orElse("");
-    private static final String ROOT_RESOURCE_URL =
-            Optional.ofNullable(System.getenv().get("ROOT_RESOURCE_URL"))
-                    .orElse(String.format(LOCAL_ENDPOINT_FORMAT, LOCAL_API_GATEWAY_ID));
+public class UserExistsResourceIntegrationTest extends AuthorizationAPIResourceIntegrationTest {
 
     private static final String USEREXISTS_RESOURCE = "/userexists";
     private ObjectMapper objectMapper = new ObjectMapper();


### PR DESCRIPTION
## What?

Add scope to /authorize redirect.
Refactoring of existing integration test to reduce duplication of variables.
Integration test not provided as we don't currently have a local Redis which is making the test fail.

## Why?

So that the scope can be stored in a client session.