### PR TITLE
LTG-313: Pass full queue URL to lambda

### DIFF
--- a/ci/terraform/aws/verify_email.tf
+++ b/ci/terraform/aws/verify_email.tf
@@ -4,7 +4,7 @@ module "verify_email" {
   endpoint_name   = "verify-email"
   endpoint_method = "POST"
   handler_environment_variables = {
-    SQS_EMAIL = module.email_notification_sqs_queue.queue_name
+    EMAIL_QUEUE_URL = module.email_notification_sqs_queue.queue_url
   }
   handler_function_name = "uk.gov.di.lambdas.SendUserEmailHandler::handleRequest"
 

--- a/ci/terraform/localstack/localstack.tf
+++ b/ci/terraform/localstack/localstack.tf
@@ -191,7 +191,7 @@ module "verify_email" {
   endpoint_name   = "verify-email"
   endpoint_method = "POST"
   handler_environment_variables = {
-    SQS_EMAIL = module.email_notification_sqs_queue.queue_name
+    EMAIL_QUEUE_URL = module.email_notification_sqs_queue.queue_url
     SQS_ENDPOINT = var.localstack_endpoint
   }
   handler_function_name = "uk.gov.di.lambdas.SendUserEmailHandler::handleRequest"

--- a/ci/terraform/modules/sqs-queue/outputs.tf
+++ b/ci/terraform/modules/sqs-queue/outputs.tf
@@ -5,3 +5,7 @@ output "queue_arn" {
 output "queue_name" {
   value = aws_sqs_queue.queue.name
 }
+
+output "queue_url" {
+  value = aws_sqs_queue.queue.id
+}

--- a/serverless/lambda/src/main/java/uk/gov/di/services/ConfigurationService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/ConfigurationService.java
@@ -45,7 +45,7 @@ public class ConfigurationService {
     }
 
     public String getEmailQueueUri() {
-        return System.getenv("SQS_EMAIL");
+        return System.getenv("EMAIL_QUEUE_URL");
     }
 
     public String getAwsRegion() {


### PR DESCRIPTION
## What?

- Pass the queue URL (Terraform `id`) to lambda rather than just the name.
- Rename the environment variable for the queue URL to acurately represent what it contains.

## Why?

Lambda is failing to connect to the queue to send messages.
