### PR TITLE
LTG-342 - Read the Notify API key from the concourse pipeline

### DIFF
--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -59,6 +59,7 @@ jobs:
               tag: 0.14.10
           params:
             DEPLOYER_ROLE_ARN: ((deployer-role-arn))
+            BUILD_NOTIFY_API_KEY: ((build-notify-api-key))
           inputs:
             - name: lambda-zip
             - name: di-authentication-api
@@ -74,6 +75,7 @@ jobs:
                 terraform plan \
                   -var 'lambda_zip_file=../../../../lambda-zip/lambda.zip' \
                   -var "deployer_role_arn=${DEPLOYER_ROLE_ARN}" \
+                  -var "notify_api_key=${BUILD_NOTIFY_API_KEY}" \
                   -out=../../../../terraform-plan/terraform.plan
 
       - task: terraform-apply

--- a/ci/terraform/aws/sqs.tf
+++ b/ci/terraform/aws/sqs.tf
@@ -7,6 +7,7 @@ module "email_notification_sqs_queue" {
 
   handler_environment_variables = {
     VERIFY_EMAIL_TEMPLATE_ID = "b7dbb02f-941b-4d72-ad64-84cbe5d77c2e"
+    NOTIFY_API_KEY = var.notify_api_key
   }
   handler_function_name = "uk.gov.di.lambdas.NotificationHandler::handleRequest"
 

--- a/ci/terraform/aws/variables.tf
+++ b/ci/terraform/aws/variables.tf
@@ -10,6 +10,11 @@ variable "deployer_role_arn" {
   type        = string
 }
 
+variable "notify_api_key" {
+  description = "The API key required to communicate with Notify"
+  type        = string
+}
+
 variable "environment" {
   type    = string
   default = "test"

--- a/ci/terraform/localstack/sqs.tf
+++ b/ci/terraform/localstack/sqs.tf
@@ -8,6 +8,7 @@ module "email_notification_sqs_queue" {
   sender_principal_arns = [module.userexists.lambda_iam_role_arn]
   handler_environment_variables = {
     VERIFY_EMAIL_TEMPLATE_ID = "b7dbb02f-941b-4d72-ad64-84cbe5d77c2e"
+    NOTIFY_API_KEY = "some-api-key"
   }
   handler_function_name = "uk.gov.di.lambdas.NotificationHandler::handleRequest"
   lambda_zip_file = var.lambda_zip_file


### PR DESCRIPTION
## What?

- Read the API key from parameter store when deploying the lambda and assign it to a terraform variable.
- Read the terraform variable in sqs.tf so it can be assigned to the variable in the config service and then used by the Notification Lambda.

## Why?

- So we can make the Notification Lambda use Notify to generate an Email