### PR TITLE
LTG-315 - Refactor and rename verify-email lambda

### DIFF
--- a/ci/terraform/aws/outputs.tf
+++ b/ci/terraform/aws/outputs.tf
@@ -30,6 +30,6 @@ output "openid_configuration_discovery_url" {
   value = "http://localhost:45678/restapis/${module.api_gateway_root.di_authentication_api_id}/${var.environment}/_user_request_/.wellknown/openid-configuration"
 }
 
-output "verify_email_url" {
-  value = module.verify_email.base_url
+output "send_notification_url" {
+  value = module.send_notification.base_url
 }

--- a/ci/terraform/aws/send_notification.tf
+++ b/ci/terraform/aws/send_notification.tf
@@ -1,12 +1,12 @@
-module "verify_email" {
+module "send_notification" {
   source = "../modules/endpoint-module"
 
-  endpoint_name   = "verify-email"
+  endpoint_name   = "send-notification"
   endpoint_method = "POST"
   handler_environment_variables = {
     EMAIL_QUEUE_URL = module.email_notification_sqs_queue.queue_url
   }
-  handler_function_name = "uk.gov.di.lambdas.SendUserEmailHandler::handleRequest"
+  handler_function_name = "uk.gov.di.lambdas.SendNotificationHandler::handleRequest"
 
   rest_api_id               = module.api_gateway_root.di_authentication_api_id
   root_resource_id          = module.api_gateway_root.root_resource_id

--- a/ci/terraform/aws/sqs.tf
+++ b/ci/terraform/aws/sqs.tf
@@ -3,7 +3,7 @@ module "email_notification_sqs_queue" {
 
   environment = var.environment
   name = "email-notification"
-  sender_principal_arns = [module.verify_email.lambda_iam_role_arn]
+  sender_principal_arns = [module.send_notification.lambda_iam_role_arn]
 
   handler_environment_variables = {
     VERIFY_EMAIL_TEMPLATE_ID = "b7dbb02f-941b-4d72-ad64-84cbe5d77c2e"

--- a/ci/terraform/localstack/localstack.tf
+++ b/ci/terraform/localstack/localstack.tf
@@ -182,19 +182,19 @@ module "userexists" {
   subnet_id                 = aws_subnet.authentication.*.id
 }
 
-module "verify_email" {
+module "send_notification" {
   source = "../modules/endpoint-module"
   providers = {
     aws = aws.localstack
   }
 
-  endpoint_name   = "verify-email"
+  endpoint_name   = "send-notification"
   endpoint_method = "POST"
   handler_environment_variables = {
     EMAIL_QUEUE_URL = module.email_notification_sqs_queue.queue_url
     SQS_ENDPOINT = var.localstack_endpoint
   }
-  handler_function_name = "uk.gov.di.lambdas.SendUserEmailHandler::handleRequest"
+  handler_function_name = "uk.gov.di.lambdas.SendNotificationHandler::handleRequest"
 
   rest_api_id               = module.api_gateway_root.di_authentication_api_id
   root_resource_id          = module.api_gateway_root.root_resource_id

--- a/ci/terraform/localstack/outputs.tf
+++ b/ci/terraform/localstack/outputs.tf
@@ -30,8 +30,8 @@ output "userexists_url" {
   value = "http://localhost:45678/restapis/${module.api_gateway_root.di_authentication_api_id}/${var.environment}/_user_request_/userexists"
 }
 
-output "verify_email_url" {
-  value = "http://localhost:45678/restapis/${module.api_gateway_root.di_authentication_api_id}/${var.environment}/_user_request_/verify-email"
+output "send_notification_url" {
+  value = "http://localhost:45678/restapis/${module.api_gateway_root.di_authentication_api_id}/${var.environment}/_user_request_/send-notification"
 }
 
 output "api_gateway_root_id" {


### PR DESCRIPTION
## What?

- Update the VerifyEmail Lambda so it can handle all requests that need to use Notify.
- Rename verify-email api endpoint to send-notification

## Why?

- The Lambda behind this endpoint will handle all notifications so we need to give it a more generic name
