### PR TITLE
LTG-315: Don't expose NotifyRequest to API

### DIFF
--- a/serverless/lambda/src/main/java/uk/gov/di/entity/SendNotificationRequest.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/entity/SendNotificationRequest.java
@@ -1,0 +1,29 @@
+package uk.gov.di.entity;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import static java.lang.String.format;
+
+public class SendNotificationRequest extends UserWithEmailRequest {
+
+    private final NotificationType notificationType;
+
+    public SendNotificationRequest(
+            @JsonProperty(required = true, value = "email") String email,
+            @JsonProperty(required = true, value = "notificationType")
+                    NotificationType notificationType) {
+        super(email);
+        this.notificationType = notificationType;
+    }
+
+    public NotificationType getNotificationType() {
+        return notificationType;
+    }
+
+    @Override
+    public String toString() {
+        return format(
+                "SendNotificationRequest{ email='%s', notificationType = '%s' }",
+                email, notificationType);
+    }
+}

--- a/serverless/lambda/src/main/java/uk/gov/di/entity/UserWithEmailRequest.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/entity/UserWithEmailRequest.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class UserWithEmailRequest {
 
-    private String email;
+    protected String email;
 
     public UserWithEmailRequest(@JsonProperty(required = true, value = "email") String email) {
         this.email = email;

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/SendNotificationHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/SendNotificationHandlerTest.java
@@ -53,7 +53,7 @@ class SendNotificationHandlerTest {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setBody(
                 format(
-                        "{ \"destination\": \"%s\", \"notificationType\": \"%s\" }",
+                        "{ \"email\": \"%s\", \"notificationType\": \"%s\" }",
                         TEST_EMAIL_ADDRESS, VERIFY_EMAIL));
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
@@ -79,7 +79,7 @@ class SendNotificationHandlerTest {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setBody(
                 format(
-                        "{ \"destination\": \"%s\", \"notificationType\": \"%s\" }",
+                        "{ \"email\": \"%s\", \"notificationType\": \"%s\" }",
                         "joe.bloggs", VERIFY_EMAIL));
 
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
@@ -99,7 +99,7 @@ class SendNotificationHandlerTest {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setBody(
                 format(
-                        "{ \"destination\": \"%s\", \"notificationType\": \"%s\" }",
+                        "{ \"email\": \"%s\", \"notificationType\": \"%s\" }",
                         TEST_EMAIL_ADDRESS, VERIFY_EMAIL));
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
@@ -117,7 +117,7 @@ class SendNotificationHandlerTest {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setBody(
                 format(
-                        "{ \"destination\": \"%s\", \"notificationType\": \"%s\" }",
+                        "{ \"email\": \"%s\", \"notificationType\": \"%s\" }",
                         TEST_EMAIL_ADDRESS, "VERIFY_PASSWORD"));
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 


### PR DESCRIPTION
## What?

- Create a new `SendNotificationRequest` object which contains e-mail address and notification type.

## Why?

The `NotifyRequest` object has the concept of `destination` which can be either an email address or a telephone number. This won't be known by the frontend. The frontend will know the session ID (which it provides as a header) and the e-mail address, which is used to validate against the session ID provided. The actual email address and/or phone number for notifications will be pulled from the user storage before passing onto SQS to deliver to Notify.

## Related PRs

#68 