### PR TITLE
LTG-300: Inject Redis configuration into userexists lambda

### DIFF
--- a/ci/terraform/aws/userexists.tf
+++ b/ci/terraform/aws/userexists.tf
@@ -5,6 +5,10 @@ module "userexists" {
   endpoint_method = "POST"
   handler_environment_variables = {
     BASE_URL = var.api_base_url
+    REDIS_HOST     = aws_elasticache_replication_group.sessions_store.primary_endpoint_address
+    REDIS_PORT     = aws_elasticache_replication_group.sessions_store.port
+    REDIS_PASSWORD = random_password.redis_password.result
+    REDIS_TLS      = "true"
   }
   handler_function_name = "uk.gov.di.lambdas.CheckUserExistsHandler::handleRequest"
 


### PR DESCRIPTION
## What?

- Add the required environment variables to allow the lambda to connect to Redis

## Why?

In previous PR we omitted to add the configuration to the `userexists` lambda.

## Related PRs

#70 