### PR TITLE
LTG-300: Add session handling to `SignupHandler`

### DIFF
--- a/ci/terraform/aws/signup.tf
+++ b/ci/terraform/aws/signup.tf
@@ -5,6 +5,10 @@ module "signup" {
   endpoint_method = "POST"
   handler_environment_variables = {
     BASE_URL = var.api_base_url
+    REDIS_HOST     = aws_elasticache_replication_group.sessions_store.primary_endpoint_address
+    REDIS_PORT     = aws_elasticache_replication_group.sessions_store.port
+    REDIS_PASSWORD = random_password.redis_password.result
+    REDIS_TLS      = "true"
   }
   handler_function_name = "uk.gov.di.lambdas.SignUpHandler::handleRequest"
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/SignupResourceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/SignupResourceIntegrationTest.java
@@ -1,0 +1,52 @@
+package uk.gov.di.authentication.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.Invocation;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.helpers.SessionHelper;
+import uk.gov.di.entity.SignupRequest;
+import uk.gov.di.entity.SignupResponse;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static uk.gov.di.entity.SessionState.TWO_FACTOR_REQUIRED;
+
+public class SignupResourceIntegrationTest extends AuthorizationAPIResourceIntegrationTest {
+
+    private static final String SIGNUP_RESOURCE = "/signup";
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    public void shouldCallUserExistsResourceAndReturn200() throws IOException {
+        Client client = ClientBuilder.newClient();
+        WebTarget webTarget = client.target(ROOT_RESOURCE_URL + SIGNUP_RESOURCE);
+        String sessionId = SessionHelper.createSession();
+        Invocation.Builder invocationBuilder = webTarget.request(MediaType.APPLICATION_JSON);
+        MultivaluedMap headers = new MultivaluedHashMap();
+        headers.add("Session-Id", sessionId);
+
+        SignupRequest request =
+                new SignupRequest("joe.bloggs@digital.cabinet-office.gov.uk", "1-valid-password");
+
+        Response response =
+                invocationBuilder
+                        .headers(headers)
+                        .post(Entity.entity(request, MediaType.APPLICATION_JSON));
+
+        assertEquals(200, response.getStatus());
+
+        String responseString = response.readEntity(String.class);
+        SignupResponse signupResponse =
+                objectMapper.readValue(responseString, SignupResponse.class);
+        assertEquals(TWO_FACTOR_REQUIRED, signupResponse.getSessionState());
+    }
+}

--- a/serverless/lambda/src/main/java/uk/gov/di/Messages.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/Messages.java
@@ -1,0 +1,6 @@
+package uk.gov.di;
+
+public class Messages {
+    public static final String ERROR_INVALID_SESSION_ID = "Session-Id is missing or invalid";
+    public static final String ERROR_MISSING_REQUEST_PARAMETERS = "Request is missing parameters";
+}

--- a/serverless/lambda/src/main/java/uk/gov/di/entity/SignupResponse.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/entity/SignupResponse.java
@@ -1,0 +1,9 @@
+package uk.gov.di.entity;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class SignupResponse extends BaseAPIResponse {
+    public SignupResponse(@JsonProperty("sessionState") SessionState sessionState) {
+        super(sessionState);
+    }
+}

--- a/serverless/lambda/src/main/java/uk/gov/di/helpers/ApiGatewayResponseHelper.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/helpers/ApiGatewayResponseHelper.java
@@ -1,8 +1,17 @@
 package uk.gov.di.helpers;
 
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class ApiGatewayResponseHelper {
+
+    public static <T> APIGatewayProxyResponseEvent generateApiGatewayProxyResponse(
+            int statusCode, T body) throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        return generateApiGatewayProxyResponse(statusCode, objectMapper.writeValueAsString(body));
+    }
+
     public static APIGatewayProxyResponseEvent generateApiGatewayProxyResponse(
             int statusCode, String body) {
         APIGatewayProxyResponseEvent apiGatewayProxyResponseEvent =

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/CheckUserExistsHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/CheckUserExistsHandler.java
@@ -19,6 +19,8 @@ import uk.gov.di.validation.EmailValidation;
 import java.util.Optional;
 import java.util.Set;
 
+import static uk.gov.di.Messages.ERROR_INVALID_SESSION_ID;
+import static uk.gov.di.Messages.ERROR_MISSING_REQUEST_PARAMETERS;
 import static uk.gov.di.entity.SessionState.AUTHENTICATION_REQUIRED;
 import static uk.gov.di.entity.SessionState.USER_NOT_FOUND;
 import static uk.gov.di.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
@@ -76,9 +78,9 @@ public class CheckUserExistsHandler
 
                 return generateApiGatewayProxyResponse(200, checkUserExistsResponseString);
             }
-            return generateApiGatewayProxyResponse(400, "Session-Id is missing or invalid");
+            return generateApiGatewayProxyResponse(400, ERROR_INVALID_SESSION_ID);
         } catch (JsonProcessingException e) {
-            return generateApiGatewayProxyResponse(400, "Request is missing parameters");
+            return generateApiGatewayProxyResponse(400, ERROR_MISSING_REQUEST_PARAMETERS);
         }
     }
 }

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/CheckUserExistsHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/CheckUserExistsHandlerTest.java
@@ -26,6 +26,8 @@ import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.Messages.ERROR_INVALID_SESSION_ID;
+import static uk.gov.di.Messages.ERROR_MISSING_REQUEST_PARAMETERS;
 import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
 
 class CheckUserExistsHandlerTest {
@@ -93,7 +95,7 @@ class CheckUserExistsHandlerTest {
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertEquals(400, result.getStatusCode());
-        assertThat(result, hasBody("Request is missing parameters"));
+        assertThat(result, hasBody(ERROR_MISSING_REQUEST_PARAMETERS));
     }
 
     @Test
@@ -104,7 +106,7 @@ class CheckUserExistsHandlerTest {
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertEquals(400, result.getStatusCode());
-        assertThat(result, hasBody("Session-Id is missing or invalid"));
+        assertThat(result, hasBody(ERROR_INVALID_SESSION_ID));
     }
 
     @Test

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/SignUpHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/SignUpHandlerTest.java
@@ -3,20 +3,33 @@ package uk.gov.di.lambdas;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.entity.Session;
+import uk.gov.di.entity.SignupResponse;
+import uk.gov.di.services.SessionService;
 import uk.gov.di.services.UserService;
 import uk.gov.di.services.ValidationService;
 
 import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.Messages.ERROR_INVALID_SESSION_ID;
+import static uk.gov.di.Messages.ERROR_MISSING_REQUEST_PARAMETERS;
+import static uk.gov.di.entity.SessionState.TWO_FACTOR_REQUIRED;
 import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
 import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 import static uk.gov.di.validation.PasswordValidation.NO_NUMBER_INCLUDED;
@@ -26,34 +39,62 @@ class SignUpHandlerTest {
     private final Context context = mock(Context.class);
     private final UserService userService = mock(UserService.class);
     private final ValidationService validationService = mock(ValidationService.class);
+    private final SessionService sessionService = mock(SessionService.class);
     private SignUpHandler handler;
 
     @BeforeEach
     public void setUp() {
-        handler = new SignUpHandler(userService, validationService);
+        handler = new SignUpHandler(userService, validationService, sessionService);
     }
 
     @Test
-    public void shouldReturn200IfSignUpIsSuccessful() {
+    public void shouldReturn200IfSignUpIsSuccessful() throws JsonProcessingException {
         String password = "computer-1";
         when(validationService.validatePassword(eq(password))).thenReturn(Collections.EMPTY_SET);
+        usingValidSession();
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        event.setHeaders(Map.of("Session-Id", "a-session-id"));
         event.setBody("{ \"password\": \"computer-1\", \"email\": \"joe.bloggs@test.com\" }");
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         verify(userService).signUp(eq("joe.bloggs@test.com"), eq(password));
+        verify(sessionService)
+                .save(
+                        argThat(
+                                (session) ->
+                                        session.getState().equals(TWO_FACTOR_REQUIRED)
+                                                && session.getEmailAddress()
+                                                        .equals("joe.bloggs@test.com")));
 
         assertThat(result, hasStatus(200));
+        SignupResponse response =
+                new ObjectMapper().readValue(result.getBody(), SignupResponse.class);
+        assertThat(response.getSessionState(), equalTo(TWO_FACTOR_REQUIRED));
+    }
+
+    @Test
+    public void shouldReturn400IfSessionIdMissing() throws JsonProcessingException {
+        String password = "computer-1";
+        when(validationService.validatePassword(eq(password))).thenReturn(Collections.EMPTY_SET);
+
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        event.setBody("{ \"password\": \"computer-1\", \"email\": \"joe.bloggs@test.com\" }");
+        APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
+
+        assertThat(result, hasStatus(400));
+        assertThat(result, hasBody(ERROR_INVALID_SESSION_ID));
     }
 
     @Test
     public void shouldReturn400IfAnyRequestParametersAreMissing() {
+        usingValidSession();
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        event.setHeaders(Map.of("Session-Id", "a-session-id"));
         event.setBody("{ \"email\": \"joe.bloggs@test.com\" }");
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(400));
-        assertThat(result, hasBody("Request is missing parameters"));
+        assertThat(result, hasBody(ERROR_MISSING_REQUEST_PARAMETERS));
     }
 
     @Test
@@ -62,11 +103,18 @@ class SignUpHandlerTest {
         when(validationService.validatePassword(eq(password)))
                 .thenReturn(Set.of(NO_NUMBER_INCLUDED));
 
+        usingValidSession();
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        event.setHeaders(Map.of("Session-Id", "a-session-id"));
         event.setBody("{ \"password\": \"computer\", \"email\": \"joe.bloggs@test.com\" }");
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(400));
         assertTrue(result.getBody().contains(NO_NUMBER_INCLUDED.toString()));
+    }
+
+    private void usingValidSession() {
+        when(sessionService.getSessionFromRequestHeaders(anyMap()))
+                .thenReturn(Optional.of(new Session()));
     }
 }


### PR DESCRIPTION
## What?

- Validate session exists before attempting to create user
- Update session with relevant state and username before returning success
- Add integration test
- Create constants for repeated text strings.

## Why?

We need to validate that we are in a valid session before we create a user.
