### PR TITLE
LTG-300: Spotless and missing environment variables

### DIFF
--- a/ci/terraform/aws/send_notification.tf
+++ b/ci/terraform/aws/send_notification.tf
@@ -5,6 +5,10 @@ module "send_notification" {
   endpoint_method = "POST"
   handler_environment_variables = {
     EMAIL_QUEUE_URL = module.email_notification_sqs_queue.queue_url
+    REDIS_HOST     = aws_elasticache_replication_group.sessions_store.primary_endpoint_address
+    REDIS_PORT     = aws_elasticache_replication_group.sessions_store.port
+    REDIS_PASSWORD = random_password.redis_password.result
+    REDIS_TLS      = "true"
   }
   handler_function_name = "uk.gov.di.lambdas.SendNotificationHandler::handleRequest"
 

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/SendNotificationHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/SendNotificationHandler.java
@@ -36,7 +36,8 @@ public class SendNotificationHandler
     public SendNotificationHandler(
             ConfigurationService configurationService,
             ValidationService validationService,
-            AwsSqsClient sqsClient, SessionService sessionService) {
+            AwsSqsClient sqsClient,
+            SessionService sessionService) {
         this.configurationService = configurationService;
         this.validationService = validationService;
         this.sqsClient = sqsClient;

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/SendNotificationHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/SendNotificationHandlerTest.java
@@ -46,7 +46,8 @@ class SendNotificationHandlerTest {
     private final SessionService sessionService = mock(SessionService.class);
     private final Context context = mock(Context.class);
     private final SendNotificationHandler handler =
-            new SendNotificationHandler(configurationService, validationService, awsSqsClient, sessionService);
+            new SendNotificationHandler(
+                    configurationService, validationService, awsSqsClient, sessionService);
 
     @BeforeEach
     void setup() {
@@ -78,7 +79,7 @@ class SendNotificationHandlerTest {
                                 (session) ->
                                         session.getState().equals(VERIFY_EMAIL_CODE_SENT)
                                                 && session.getEmailAddress()
-                                                .equals(TEST_EMAIL_ADDRESS)));
+                                                        .equals(TEST_EMAIL_ADDRESS)));
     }
 
     @Test
@@ -104,7 +105,7 @@ class SendNotificationHandlerTest {
                                 (session) ->
                                         session.getState().equals(VERIFY_EMAIL_CODE_SENT)
                                                 && session.getEmailAddress()
-                                                .equals(TEST_EMAIL_ADDRESS)));
+                                                        .equals(TEST_EMAIL_ADDRESS)));
     }
 
     @Test


### PR DESCRIPTION
## What?

- Run Spotless on previous PR
- Add environment variables required for Redis connection to the SendNotification handler Terraform

## Why?

Require connection to Redis to validate session

## Related PRs

#74 