### PR TITLE
LTG-300: Re-factor session ID generation

### DIFF
--- a/serverless/lambda/src/main/java/uk/gov/di/entity/Session.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/entity/Session.java
@@ -4,8 +4,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 
-import java.util.UUID;
-
 import static uk.gov.di.entity.SessionState.NEW;
 
 public class Session {
@@ -18,8 +16,8 @@ public class Session {
 
     @JsonProperty private String emailAddress;
 
-    public Session() {
-        this.sessionId = UUID.randomUUID().toString();
+    public Session(String sessionId) {
+        this.sessionId = sessionId;
         this.state = NEW;
     }
 

--- a/serverless/lambda/src/main/java/uk/gov/di/helpers/IdGenerator.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/helpers/IdGenerator.java
@@ -1,0 +1,16 @@
+package uk.gov.di.helpers;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+
+public class IdGenerator {
+    private static final int ENTROPY_BYTES = 20;
+    private static final SecureRandom RANDOM = new SecureRandom();
+    private static final Base64.Encoder ENCODER = Base64.getUrlEncoder().withoutPadding();
+
+    public static String generate() {
+        byte[] buffer = new byte[ENTROPY_BYTES];
+        RANDOM.nextBytes(buffer);
+        return ENCODER.encodeToString(buffer);
+    }
+}

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/AuthorisationHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/AuthorisationHandler.java
@@ -33,7 +33,7 @@ public class AuthorisationHandler
     private final SessionService sessionService;
 
     private interface ResponseParameters {
-        String SESSION_ID = "session-id";
+        String SESSION_ID = "id";
         String SCOPE = "scope";
     }
 

--- a/serverless/lambda/src/main/java/uk/gov/di/services/SessionService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/SessionService.java
@@ -1,6 +1,7 @@
 package uk.gov.di.services;
 
 import uk.gov.di.entity.Session;
+import uk.gov.di.helpers.IdGenerator;
 
 import java.util.Map;
 import java.util.Optional;
@@ -16,7 +17,7 @@ public class SessionService {
     }
 
     public Session createSession() {
-        return new Session();
+        return new Session(IdGenerator.generate());
     }
 
     public void save(Session session) {

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/AuthorisationHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/AuthorisationHandlerTest.java
@@ -88,7 +88,7 @@ class AuthorisationHandlerTest {
         assertThat(response, hasStatus(302));
         assertEquals(loginUrl.getAuthority(), uri.getAuthority());
 
-        assertThat(requestParams, hasEntry("session-id", session.getSessionId()));
+        assertThat(requestParams, hasEntry("id", session.getSessionId()));
 
         verify(sessionService).save(eq(session));
     }

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/AuthorisationHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/AuthorisationHandlerTest.java
@@ -62,7 +62,7 @@ class AuthorisationHandlerTest {
                         null);
 
         final URI loginUrl = URI.create("http://example.com");
-        final Session session = new Session();
+        final Session session = new Session("a-session-id");
 
         when(clientService.getErrorForAuthorizationRequest(any(AuthorizationRequest.class)))
                 .thenReturn(Optional.empty());

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/CheckUserExistsHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/CheckUserExistsHandlerTest.java
@@ -126,6 +126,6 @@ class CheckUserExistsHandlerTest {
 
     private void usingValidSession() {
         when(sessionService.getSessionFromRequestHeaders(anyMap()))
-                .thenReturn(Optional.of(new Session()));
+                .thenReturn(Optional.of(new Session("a-session-id")));
     }
 }

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/SendNotificationHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/SendNotificationHandlerTest.java
@@ -183,6 +183,8 @@ class SendNotificationHandlerTest {
 
     private void usingValidSession() {
         when(sessionService.getSessionFromRequestHeaders(anyMap()))
-                .thenReturn(Optional.of(new Session().setEmailAddress(TEST_EMAIL_ADDRESS)));
+                .thenReturn(
+                        Optional.of(
+                                new Session("a-session-id").setEmailAddress(TEST_EMAIL_ADDRESS)));
     }
 }

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/SignUpHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/SignUpHandlerTest.java
@@ -115,6 +115,6 @@ class SignUpHandlerTest {
 
     private void usingValidSession() {
         when(sessionService.getSessionFromRequestHeaders(anyMap()))
-                .thenReturn(Optional.of(new Session()));
+                .thenReturn(Optional.of(new Session("a-session-id")));
     }
 }


### PR DESCRIPTION
## What?

- Change the query variable name used to pass the session ID to the frontend
- Use a session ID generator better with more entropy than a UUID
- Refactor Session constructor

## Why?

More randomness should be used for generating session IDs to reduce the chances of a rogue actor guessing and manipulating session.
