### PR TITLE
BAU - Update in memory client redirect URIs

### DIFF
--- a/serverless/lambda/src/main/java/uk/gov/di/services/InMemoryClientService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/InMemoryClientService.java
@@ -26,7 +26,7 @@ public class InMemoryClientService implements ClientService {
                                     "test-id",
                                     "test-secret",
                                     List.of("code"),
-                                    List.of("http://localhost:8080"),
+                                    List.of("http://localhost:8080", "https://di-auth-stub-relying-party-build.london.cloudapps.digital"),
                                     List.of("contact@example.com")));
                 }
             };


### PR DESCRIPTION
## What?

- Update in memory client redirect URIs

## Why?

- So that the Stub RP in the Build PaaS space is configured to talk to it

