### PR TITLE
LTG-342: Integration tests for SQS & Notify

### DIFF
--- a/ci/terraform/localstack/sqs.tf
+++ b/ci/terraform/localstack/sqs.tf
@@ -8,7 +8,7 @@ module "email_notification_sqs_queue" {
   sender_principal_arns = [module.userexists.lambda_iam_role_arn]
   handler_environment_variables = {
     VERIFY_EMAIL_TEMPLATE_ID = "b7dbb02f-941b-4d72-ad64-84cbe5d77c2e"
-    NOTIFY_API_KEY = "some-api-key"
+    NOTIFY_API_KEY = "a988d9fca677c75b3677e878b259bedf03846afa23d8f5ad1e3b1d55a53558bbab0fca6affc841546846ca2be0afeb91ee24b8b4dc9e9a2e3f1dd56c043d8068"
   }
   handler_function_name = "uk.gov.di.lambdas.NotificationHandler::handleRequest"
   lambda_zip_file = var.lambda_zip_file

--- a/ci/terraform/localstack/sqs.tf
+++ b/ci/terraform/localstack/sqs.tf
@@ -8,7 +8,8 @@ module "email_notification_sqs_queue" {
   sender_principal_arns = [module.userexists.lambda_iam_role_arn]
   handler_environment_variables = {
     VERIFY_EMAIL_TEMPLATE_ID = "b7dbb02f-941b-4d72-ad64-84cbe5d77c2e"
-    NOTIFY_API_KEY = "a988d9fca677c75b3677e878b259bedf03846afa23d8f5ad1e3b1d55a53558bbab0fca6affc841546846ca2be0afeb91ee24b8b4dc9e9a2e3f1dd56c043d8068"
+    NOTIFY_URL     = var.notify_url
+    NOTIFY_API_KEY = var.notify_api_key
   }
   handler_function_name = "uk.gov.di.lambdas.NotificationHandler::handleRequest"
   lambda_zip_file = var.lambda_zip_file

--- a/ci/terraform/localstack/variables.tf
+++ b/ci/terraform/localstack/variables.tf
@@ -23,3 +23,11 @@ variable "localstack_endpoint" {
   type = string
   default = "http://localhost:45678"
 }
+
+variable "notify_url" {
+  type = string
+}
+
+variable "notify_api_key" {
+  type = string
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,8 @@ services:
       DEFAULT_REGION: eu-west-2
       TEST_AWS_ACCOUNT_ID: 123456789012
       DEBUG: "1"
-      NOTIFY_URL: "http://host.docker.internal:8888"
+    extra_hosts:
+      - "notify.internal:host-gateway"
     networks:
       - di-authentication-api-net
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       DEFAULT_REGION: eu-west-2
       TEST_AWS_ACCOUNT_ID: 123456789012
       DEBUG: "1"
+      NOTIFY_URL: "http://host.docker.internal:8888"
     networks:
       - di-authentication-api-net
     volumes:

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -14,6 +14,7 @@ dependencies {
             'org.glassfish.jersey.core:jersey-client:3.0.2',
             'org.glassfish.jersey.inject:jersey-hk2:3.0.2',
             'org.glassfish.jersey.media:jersey-media-json-jackson:3.0.2',
+            'org.eclipse.jetty:jetty-server:11.0.5',
             project(":serverless:lambda")
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
 }

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -15,6 +15,7 @@ dependencies {
             'org.glassfish.jersey.inject:jersey-hk2:3.0.2',
             'org.glassfish.jersey.media:jersey-media-json-jackson:3.0.2',
             'org.eclipse.jetty:jetty-server:11.0.5',
+            "software.amazon.awssdk:sqs:2.16.78",
             project(":serverless:lambda")
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
 }

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -16,6 +16,7 @@ dependencies {
             'org.glassfish.jersey.media:jersey-media-json-jackson:3.0.2',
             'org.eclipse.jetty:jetty-server:11.0.5',
             "software.amazon.awssdk:sqs:2.16.78",
+            "org.awaitility:awaitility:4.1.0",
             project(":serverless:lambda")
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/helpers/httpstub/HttpProxyExtension.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/helpers/httpstub/HttpProxyExtension.java
@@ -1,0 +1,40 @@
+package uk.gov.di.authentication.helpers.httpstub;
+
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.util.Optional;
+
+public class HttpProxyExtension extends HttpStubExtension implements BeforeAllCallback {
+    private String currentHost;
+    private String currentPort;
+    private String currentNonProxyHosts;
+
+    private void disableProxy() throws Exception {
+        System.setProperty("http.proxyHost", currentHost);
+        System.setProperty("http.proxyPort", currentPort);
+        System.setProperty("http.nonProxyHosts", currentNonProxyHosts);
+    }
+
+    private void enableProxy() {
+        currentHost = Optional.ofNullable(System.getProperty("http.proxyHost")).orElse("");
+        currentPort = Optional.ofNullable(System.getProperty("http.proxyPort")).orElse("");
+        currentNonProxyHosts =
+                Optional.ofNullable(System.getProperty("http.nonProxyHosts")).orElse("");
+
+        System.setProperty("http.proxyHost", "localhost");
+        System.setProperty("http.proxyPort", String.valueOf(super.getHttpPort()));
+        System.setProperty("http.nonProxyHosts", "localhost"); // NOT 127.0.0.1
+    }
+
+    @Override
+    public void afterAll(ExtensionContext context) throws Exception {
+        disableProxy();
+        super.afterAll(context);
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+        enableProxy();
+    }
+}

--- a/integration-tests/src/test/java/uk/gov/di/authentication/helpers/httpstub/HttpStub.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/helpers/httpstub/HttpStub.java
@@ -31,7 +31,7 @@ class HttpStub {
         this(RANDOM_PORT, keyStorePath, keyStorePassword);
     }
 
-    private HttpStub(int port, String keyStorePath, String keyStorePassword) {
+    public HttpStub(int port, String keyStorePath, String keyStorePassword) {
         this(port, false, keyStorePath, keyStorePassword, null, null);
     }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/helpers/httpstub/HttpStub.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/helpers/httpstub/HttpStub.java
@@ -1,0 +1,182 @@
+package uk.gov.di.authentication.helpers.httpstub;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.security.KeyStore;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
+
+class HttpStub {
+
+    private static final int RANDOM_PORT = 0;
+    private Server server;
+    private ConcurrentMap<String, RegisteredResponse> registeredResponses =
+            new ConcurrentHashMap<>();
+    private List<RecordedRequest> recordedRequests = new CopyOnWriteArrayList<>();
+
+    public HttpStub(String keyStorePath, String keyStorePassword) {
+        this(RANDOM_PORT, keyStorePath, keyStorePassword);
+    }
+
+    private HttpStub(int port, String keyStorePath, String keyStorePassword) {
+        this(port, false, keyStorePath, keyStorePassword, null, null);
+    }
+
+    public HttpStub(
+            String keyStorePath,
+            String keyStorePassword,
+            String trustStorePath,
+            String trustStorePassword) {
+        this(
+                RANDOM_PORT,
+                false,
+                keyStorePath,
+                keyStorePassword,
+                trustStorePath,
+                trustStorePassword);
+    }
+
+    public HttpStub(
+            boolean needSSL,
+            String keyStorePath,
+            String keyStorePassword,
+            String trustStorePath,
+            String trustStorePassword) {
+        this(
+                RANDOM_PORT,
+                needSSL,
+                keyStorePath,
+                keyStorePassword,
+                trustStorePath,
+                trustStorePassword);
+    }
+
+    private HttpStub(
+            int port,
+            boolean needSSL,
+            String keyStorePath,
+            String keyStorePassword,
+            String trustStorePath,
+            String trustStorePassword) {
+        server = new Server(port);
+        if (keyStorePath != null) {
+            File file = new File(keyStorePath);
+            char[] password = keyStorePassword.toCharArray();
+            KeyStore keyStore = unchecked(() -> KeyStore.getInstance(file, password));
+            SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
+            if (trustStorePath != null) {
+
+                KeyStore trustStore =
+                        unchecked(
+                                () ->
+                                        KeyStore.getInstance(
+                                                new File(trustStorePath),
+                                                trustStorePassword.toCharArray()));
+                sslContextFactory.setTrustStore(trustStore);
+                sslContextFactory.setTrustStorePassword(trustStorePassword);
+            } else {
+                sslContextFactory.setTrustStore(keyStore);
+                sslContextFactory.setTrustStorePassword(keyStorePassword);
+            }
+
+            sslContextFactory.setNeedClientAuth(needSSL);
+            sslContextFactory.setKeyStore(keyStore);
+            sslContextFactory.setKeyStorePassword(keyStorePassword);
+
+            ServerConnector serverConnector = new ServerConnector(server, sslContextFactory);
+
+            server.addConnector(serverConnector);
+        }
+        server.setHandler(new Handler());
+    }
+
+    public void start() {
+        try {
+            server.start();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void stop() throws Exception {
+        server.setStopTimeout(0);
+        server.stop();
+    }
+
+    public int getHttpPort() {
+        return ((ServerConnector) server.getConnectors()[0]).getLocalPort();
+    }
+
+    public int getHttpsPort() {
+        return ((ServerConnector) server.getConnectors()[1]).getLocalPort();
+    }
+
+    public void reset() {
+        registeredResponses.clear();
+        recordedRequests.clear();
+    }
+
+    public void register(String path, int responseStatus, String contentType, String responseBody) {
+        if (path.isBlank()) path = "/";
+        registeredResponses.put(
+                path, new RegisteredResponse(responseStatus, contentType, responseBody));
+    }
+
+    public int getCountOfRequestsTo(final String path) {
+        return recordedRequests.stream()
+                .filter(input -> input.getPath().equals(path))
+                .collect(Collectors.toList())
+                .size();
+    }
+
+    public RecordedRequest getLastRequest() {
+        return recordedRequests.get(recordedRequests.size() - 1);
+    }
+
+    public int getCountOfRequests() {
+        return recordedRequests.size();
+    }
+
+    public static <T> T unchecked(Callable<T> callable) {
+        try {
+            return callable.call();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private class Handler extends AbstractHandler {
+        @Override
+        public void handle(
+                String target,
+                Request baseRequest,
+                HttpServletRequest request,
+                HttpServletResponse response)
+                throws IOException, ServletException {
+            recordedRequests.add(new RecordedRequest(baseRequest));
+
+            RegisteredResponse registeredResponse =
+                    registeredResponses.get(baseRequest.getRequestURI());
+
+            if (registeredResponse != null) {
+                response.setStatus(registeredResponse.getStatus());
+                response.setContentType(registeredResponse.getContentType());
+                response.getWriter().append(registeredResponse.getBody());
+                baseRequest.setHandled(true);
+            }
+        }
+    }
+}

--- a/integration-tests/src/test/java/uk/gov/di/authentication/helpers/httpstub/HttpStubExtension.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/helpers/httpstub/HttpStubExtension.java
@@ -1,0 +1,113 @@
+package uk.gov.di.authentication.helpers.httpstub;
+
+import jakarta.ws.rs.core.UriBuilder;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.net.URI;
+
+public class HttpStubExtension implements AfterAllCallback {
+
+    protected final HttpStub httpStub;
+
+    public HttpStubExtension() {
+        this(null, null);
+    }
+
+    public HttpStubExtension(int port) {
+        httpStub = new HttpStub(null, null);
+        httpStub.start();
+    }
+
+    public HttpStubExtension(String keyStorePath, String keyStorePassword) {
+        httpStub = new HttpStub(keyStorePath, keyStorePassword);
+        httpStub.start();
+    }
+
+    public HttpStubExtension(
+            String keyStorePath,
+            String keyStorePassword,
+            String trustStorePath,
+            String trustStorePassword) {
+        httpStub = new HttpStub(keyStorePath, keyStorePassword, trustStorePath, trustStorePassword);
+        httpStub.start();
+    }
+
+    public HttpStubExtension(
+            boolean needSsl,
+            String keyStorePath,
+            String keyStorePassword,
+            String trustStorePath,
+            String trustStorePassword) {
+        httpStub =
+                new HttpStub(
+                        needSsl,
+                        keyStorePath,
+                        keyStorePassword,
+                        trustStorePath,
+                        trustStorePassword);
+        httpStub.start();
+    }
+
+    public static HttpStubExtension httpStubExtensionWithValidSslCert() {
+        return new HttpStubExtension("deploy/keys/server_auth.ks", "puppet");
+    }
+
+    public static HttpStubExtension httpStubExtensionWithClientAuth() {
+        return new HttpStubExtension(
+                true,
+                "deploy/keys/server_auth.ks",
+                "puppet",
+                "deploy/keys/server_auth.ks",
+                "puppet");
+    }
+
+    public static HttpStubExtension httpStubExtensionWithInvalidSslCert() {
+        return new HttpStubExtension("deploy/keys/invalid_server_ssl_auth.ks", "puppet");
+    }
+
+    public int getHttpPort() {
+        return httpStub.getHttpPort();
+    }
+
+    public int getHttpsPort() {
+        return httpStub.getHttpsPort();
+    }
+
+    public void reset() {
+        httpStub.reset();
+    }
+
+    public void register(String path, int responseStatus) {
+        httpStub.register(path, responseStatus, null, "");
+    }
+
+    public void register(String path, int responseStatus, String contentType, String responseBody) {
+        httpStub.register(path, responseStatus, contentType, responseBody);
+    }
+
+    public int getCountOfRequestsTo(final String path) {
+        return httpStub.getCountOfRequestsTo(path);
+    }
+
+    public int getCountOfRequests() {
+        return httpStub.getCountOfRequests();
+    }
+
+    public RecordedRequest getLastRequest() {
+        return httpStub.getLastRequest();
+    }
+
+    public URI uri(String path) {
+        return baseUri().path(path).build();
+    }
+
+    private UriBuilder baseUri() {
+        return UriBuilder.fromUri("http://localhost").port(getHttpPort());
+    }
+
+    @Override
+    public void afterAll(ExtensionContext context) throws Exception {
+        httpStub.stop();
+    }
+}

--- a/integration-tests/src/test/java/uk/gov/di/authentication/helpers/httpstub/HttpStubExtension.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/helpers/httpstub/HttpStubExtension.java
@@ -15,7 +15,7 @@ public class HttpStubExtension implements AfterAllCallback {
     }
 
     public HttpStubExtension(int port) {
-        httpStub = new HttpStub(null, null);
+        httpStub = new HttpStub(port, null, null);
         httpStub.start();
     }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/helpers/httpstub/RecordedRequest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/helpers/httpstub/RecordedRequest.java
@@ -1,11 +1,9 @@
 package uk.gov.di.authentication.helpers.httpstub;
 
-import com.google.common.collect.Iterables;
-import org.apache.commons.io.IOUtils;
 import org.eclipse.jetty.server.Request;
 
+import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.Reader;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -50,12 +48,12 @@ public class RecordedRequest {
 
     public String getHeader(String name) {
         List<String> values = headers.get(name.toLowerCase());
-        return values == null ? null : Iterables.getFirst(values, null);
+        return values == null ? null : values.get(0);
     }
 
     private static String readEntity(Request request) {
-        try (Reader in = request.getReader()) {
-            return IOUtils.toString(in);
+        try (BufferedReader in = request.getReader()) {
+            return in.lines().collect(Collectors.joining());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/helpers/httpstub/RecordedRequest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/helpers/httpstub/RecordedRequest.java
@@ -1,0 +1,71 @@
+package uk.gov.di.authentication.helpers.httpstub;
+
+import com.google.common.collect.Iterables;
+import org.apache.commons.io.IOUtils;
+import org.eclipse.jetty.server.Request;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class RecordedRequest {
+    private final String requestURI;
+    private final Map<String, List<String>> headers;
+    private final String querystring;
+    private final String method;
+    private final String url;
+    private String entity;
+
+    public RecordedRequest(Request request) {
+        this.method = request.getMethod();
+        this.requestURI = request.getRequestURI();
+        this.querystring = request.getQueryString();
+        this.headers = getHeaders(request);
+        this.entity = readEntity(request);
+        this.url = request.getRequestURL().toString();
+    }
+
+    public String getQuerystring() {
+        return querystring;
+    }
+
+    public String getMethod() {
+        return method;
+    }
+
+    public String getEntity() {
+        return entity;
+    }
+
+    public String getPath() {
+        return requestURI;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public String getHeader(String name) {
+        List<String> values = headers.get(name.toLowerCase());
+        return values == null ? null : Iterables.getFirst(values, null);
+    }
+
+    private static String readEntity(Request request) {
+        try (Reader in = request.getReader()) {
+            return IOUtils.toString(in);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static Map<String, List<String>> getHeaders(Request request) {
+        return Collections.list(request.getHeaderNames()).stream()
+                .collect(
+                        Collectors.toUnmodifiableMap(
+                                String::toLowerCase,
+                                n -> List.copyOf(Collections.list(request.getHeaders(n)))));
+    }
+}

--- a/integration-tests/src/test/java/uk/gov/di/authentication/helpers/httpstub/RegisteredResponse.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/helpers/httpstub/RegisteredResponse.java
@@ -1,0 +1,25 @@
+package uk.gov.di.authentication.helpers.httpstub;
+
+class RegisteredResponse {
+    private final int status;
+    private final String contentType;
+    private final String body;
+
+    public RegisteredResponse(int status, String contentType, String body) {
+        this.status = status;
+        this.contentType = contentType;
+        this.body = body;
+    }
+
+    public int getStatus() {
+        return status;
+    }
+
+    public String getContentType() {
+        return contentType;
+    }
+
+    public String getBody() {
+        return body;
+    }
+}

--- a/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/SendEmailNotificationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/SendEmailNotificationIntegrationTest.java
@@ -1,16 +1,74 @@
 package uk.gov.di.authentication.queuehandlers;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.authentication.helpers.httpstub.HttpStubExtension;
+import uk.gov.di.entity.NotifyRequest;
+import uk.gov.di.services.AwsSqsClient;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static uk.gov.di.entity.NotificationType.VERIFY_EMAIL;
 
 public class SendEmailNotificationIntegrationTest {
 
+    private static final String TEST_EMAIL_ADDRESS = "joe.bloggs@example.com";
+    private static final int VERIFICATION_CODE_LENGTH = 6;
+
     @RegisterExtension
-    private final HttpStubExtension notifyStub = new HttpStubExtension();
+    public final HttpStubExtension notifyStub =
+            new HttpStubExtension(8888) {
+                {
+                    register(
+                            "/v2/notifications/email",
+                            201,
+                            "application/json",
+                            "{"
+                                    + "  \"id\": \"740e5834-3a29-46b4-9a6f-16142fde533a\","
+                                    + "  \"reference\": \"STRING\","
+                                    + "  \"content\": {"
+                                    + "    \"subject\": \"SUBJECT TEXT\","
+                                    + "    \"body\": \"MESSAGE TEXT\",\n"
+                                    + "    \"from_email\": \"SENDER EMAIL\""
+                                    + "  },"
+                                    + "  \"uri\": \"http://localhost:8888/v2/notifications/a-message-id\","
+                                    + "  \"template\": {"
+                                    + "    \"id\": \"740e5834-3a29-46b4-9a6f-16142fde533a\","
+                                    + "    \"version\": 1,"
+                                    + "    \"uri\": \"http://localhost:8888/v2/template/f33517ff-2a88-4f6e-b855-c550268ce08a\""
+                                    + "  }"
+                                    + "}");
+                }
+            };
 
     @Test
-    void shouldCallNotifyWhenValidRequestIsAddedToQueue () {
+    @Timeout(60)
+    void shouldCallNotifyWhenValidRequestIsAddedToQueue()
+            throws JsonProcessingException, InterruptedException {
+        NotifyRequest notifyRequest = new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL);
 
+        AwsSqsClient client =
+                new AwsSqsClient(
+                        "eu-west-2",
+                        "http://localhost:45678/123456789012/local-email-notification-queue",
+                        Optional.of("http://localhost:45678/"));
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        client.send(objectMapper.writeValueAsString(notifyRequest));
+
+        while (notifyStub.getCountOfRequests() == 0) {
+            Thread.sleep(500);
+        }
+        JsonNode request = objectMapper.readTree(notifyStub.getLastRequest().getEntity());
+        JsonNode personalisation = request.get("personalisation");
+        assertEquals(TEST_EMAIL_ADDRESS, request.get("email_address").asText());
+        assertEquals(TEST_EMAIL_ADDRESS, personalisation.get("email-address").asText());
+        assertEquals(
+                VERIFICATION_CODE_LENGTH, personalisation.get("validation-code").asText().length());
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/SendEmailNotificationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/SendEmailNotificationIntegrationTest.java
@@ -1,0 +1,16 @@
+package uk.gov.di.authentication.queuehandlers;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.di.authentication.helpers.httpstub.HttpStubExtension;
+
+public class SendEmailNotificationIntegrationTest {
+
+    @RegisterExtension
+    private final HttpStubExtension notifyStub = new HttpStubExtension();
+
+    @Test
+    void shouldCallNotifyWhenValidRequestIsAddedToQueue () {
+
+    }
+}

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -48,9 +48,10 @@ done
 if [[ ${RUN_UNIT} -eq 1 ]]; then
   printf "\nRunning build and unit tests...\n"
 
+  set +e
   ./gradlew clean build -x integration-tests:test
-
   build_and_test_exit_code=$?
+  set -e
   if [ ${build_and_test_exit_code} -ne 0 ]; then
     printf "\nBuild and test failed.\n"
     exit 1
@@ -62,9 +63,10 @@ if [[ ${RUN_INTEGRATION} -eq 1 ]]; then
   export TF_VAR_notify_api_key="my_test_key-$(uuidgen)-$(uuidgen)"
   startup
 
+  set +e
   run-integration-tests
-
   build_and_test_exit_code=$?
+  set -e
 
   stop_docker_services aws redis
 fi

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -58,6 +58,8 @@ if [[ ${RUN_UNIT} -eq 1 ]]; then
 fi
 
 if [[ ${RUN_INTEGRATION} -eq 1 ]]; then
+  export TF_VAR_notify_url="http://notify.internal:8888"
+  export TF_VAR_notify_api_key="my_test_key-$(uuidgen)-$(uuidgen)"
   startup
 
   run-integration-tests

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -42,8 +42,10 @@ function run_terraform() {
   rm -f terraform.tfstate.backup
   terraform init
   printf "\nRunning terraform apply (quietly - output redirected to terraform.log)...\n"
+  set +e
   terraform apply -auto-approve > terraform.log
   tf_exit_code=$?
+  set -e
   if [ ${tf_exit_code} -eq 0 ]; then
     printf "\nTerraform succeeded.\n"
   else

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/NotificationHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/NotificationHandler.java
@@ -31,7 +31,11 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
 
     public NotificationHandler() {
         this.configService = new ConfigurationService();
-        NotificationClient client = new NotificationClient(configService.getNotifyApiKey());
+        NotificationClient client =
+                configService
+                        .getNotifyApiUrl()
+                        .map(url -> new NotificationClient(configService.getNotifyApiKey(), url))
+                        .orElse(new NotificationClient(configService.getNotifyApiKey()));
         this.notificationService = new NotificationService(client);
     }
 

--- a/serverless/lambda/src/main/java/uk/gov/di/services/ConfigurationService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/ConfigurationService.java
@@ -48,6 +48,10 @@ public class ConfigurationService {
         }
     }
 
+    public Optional<String> getNotifyApiUrl() {
+        return Optional.ofNullable(System.getenv("NOTIFY_URL"));
+    }
+
     public String getEmailQueueUri() {
         return System.getenv("EMAIL_QUEUE_URL");
     }

--- a/serverless/lambda/src/main/java/uk/gov/di/services/NotificationService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/NotificationService.java
@@ -8,6 +8,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 
+import static java.lang.String.format;
+
 public class NotificationService {
 
     private NotificationClient notifyClient;
@@ -25,7 +27,7 @@ public class NotificationService {
 
     public String generateSixDigitCode() {
         Random rnd = new Random();
-        String code = Integer.toString(rnd.nextInt(999999));
+        String code = format("%06d", rnd.nextInt(999999));
         return code;
     }
 


### PR DESCRIPTION
## What?

- Add the HttpStub extension (this was originally developed for the doc-checking project).
- Use HttpStubExtension to listen for a GOV.UK Notify request from the Lambda
- Allow passing in of Notify API URL, to override the default in tests, via environment variables.
- Wait for Lambda to call (the fake) Notify and verify the payload.
- Pad generated code with zeros to fix the test case when generated code is < 100000.

## Why?

We wish to test that the lambda is correctly calling Notify with the correct parameters.
