### PR TITLE
LTG-282 - Create Lambda for validating code

### DIFF
--- a/serverless/lambda/src/main/java/uk/gov/di/entity/VerifyCodeRequest.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/entity/VerifyCodeRequest.java
@@ -1,0 +1,25 @@
+package uk.gov.di.entity;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class VerifyCodeRequest {
+
+    @JsonProperty private NotificationType notificationType;
+
+    @JsonProperty private String code;
+
+    public VerifyCodeRequest(
+            @JsonProperty(required = true, value = "notificationType") NotificationType notificationType,
+            @JsonProperty(required = true, value = "code") String code) {
+        this.notificationType = notificationType;
+        this.code = code;
+    }
+
+    public NotificationType getNotificationType() {
+        return notificationType;
+    }
+
+    public String getCode() {
+        return code;
+    }
+}

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/VerifyCodeHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/VerifyCodeHandler.java
@@ -1,0 +1,48 @@
+package uk.gov.di.lambdas;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import uk.gov.di.entity.Session;
+import uk.gov.di.entity.VerifyCodeRequest;
+import uk.gov.di.services.ConfigurationService;
+import uk.gov.di.services.SessionService;
+
+import java.util.Optional;
+
+import static uk.gov.di.Messages.ERROR_MISSING_REQUEST_PARAMETERS;
+import static uk.gov.di.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
+
+public class VerifyCodeHandler implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final SessionService sessionService;
+    private final ConfigurationService configService;
+
+    public VerifyCodeHandler(SessionService sessionService, ConfigurationService configService) {
+        this.sessionService = sessionService;
+        this.configService = configService;
+    }
+
+    public VerifyCodeHandler() {
+        this.configService = new ConfigurationService();
+        this.sessionService = new SessionService(configService);
+    }
+
+    @Override
+    public APIGatewayProxyResponseEvent handleRequest(APIGatewayProxyRequestEvent input, Context context) {
+
+        Optional<Session> session = sessionService.getSessionFromRequestHeaders(input.getHeaders());
+
+        try {
+            VerifyCodeRequest codeRequest = objectMapper.readValue(input.getBody(), VerifyCodeRequest.class);
+        } catch (JsonProcessingException e) {
+            return generateApiGatewayProxyResponse(400, ERROR_MISSING_REQUEST_PARAMETERS);
+        }
+
+        return generateApiGatewayProxyResponse(200, "OK");
+    }
+}

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/VerifyCodeRequestHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/VerifyCodeRequestHandlerTest.java
@@ -1,0 +1,60 @@
+package uk.gov.di.lambdas;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.services.ConfigurationService;
+import uk.gov.di.services.SessionService;
+
+import java.util.Map;
+
+import static java.lang.String.format;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static uk.gov.di.Messages.ERROR_MISSING_REQUEST_PARAMETERS;
+import static uk.gov.di.entity.NotificationType.VERIFY_EMAIL;
+import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
+import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
+
+class VerifyCodeRequestHandlerTest {
+
+    private final Context context = mock(Context.class);
+    private final SessionService sessionService = mock(SessionService.class);
+    private final ConfigurationService configService = mock(ConfigurationService.class);
+    private VerifyCodeHandler handler;
+
+    @BeforeEach
+    public void setup() {
+        handler = new VerifyCodeHandler(sessionService, configService);
+    }
+
+    @Test
+    public void shouldReturn200ForValidRequest() {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        event.setHeaders(Map.of("Session-Id", "a-session-id"));
+        event.setBody(
+                format(
+                        "{ \"code\": \"123456\", \"notificationType\": \"%s\" }",
+                        VERIFY_EMAIL));
+
+        APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
+        assertThat(result, hasStatus(200));
+        assertThat(result, hasBody("OK"));
+    }
+
+    @Test
+    public void shouldReturn400IfRequestIsMissingNotificationType() {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        event.setHeaders(Map.of("Session-Id", "a-session-id"));
+        event.setBody(
+                format(
+                        "{ \"code\": \"123456\"}",
+                        VERIFY_EMAIL));
+
+        APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
+        assertThat(result, hasStatus(400));
+        assertThat(result, hasBody(ERROR_MISSING_REQUEST_PARAMETERS));
+    }
+}


### PR DESCRIPTION
## What?

- Create a generic Lambda which will expect a notificationType and a code. This will allow this lambda to be used for multiple purposes including verify-email and verify-2fa.
- Eventually this Lambda will be responsible for validating the code.
- Add some tests to test a happy and sad path until more functionality is added.

## Why?

- So we can validate the code which is sent to the user via Notify