### PR TITLE
LTG-282 - Create terraform for verify-code lambda and api-gateway

### DIFF
--- a/ci/terraform/aws/outputs.tf
+++ b/ci/terraform/aws/outputs.tf
@@ -33,3 +33,7 @@ output "openid_configuration_discovery_url" {
 output "send_notification_url" {
   value = module.send_notification.base_url
 }
+
+output "verify_code_url" {
+  value = module.verify_code.base_url
+}

--- a/ci/terraform/aws/verify_code.tf
+++ b/ci/terraform/aws/verify_code.tf
@@ -1,0 +1,22 @@
+module "verify_code" {
+  source = "../modules/endpoint-module"
+
+  endpoint_name   = "verify-code"
+  endpoint_method = "POST"
+  handler_environment_variables = {
+    BASE_URL = var.api_base_url
+    REDIS_HOST     = aws_elasticache_replication_group.sessions_store.primary_endpoint_address
+    REDIS_PORT     = aws_elasticache_replication_group.sessions_store.port
+    REDIS_PASSWORD = random_password.redis_password.result
+    REDIS_TLS      = "true"
+  }
+  handler_function_name = "uk.gov.di.lambdas.VerifyCodeHandler::handleRequest"
+
+  rest_api_id               = module.api_gateway_root.di_authentication_api_id
+  root_resource_id          = module.api_gateway_root.root_resource_id
+  execution_arn             = module.api_gateway_root.execution_arn
+  api_deployment_stage_name = var.api_deployment_stage_name
+  lambda_zip_file           = var.lambda_zip_file
+  security_group_id         = aws_vpc.authentication.default_security_group_id
+  subnet_id                 = aws_subnet.authentication.*.id
+}

--- a/ci/terraform/localstack/localstack.tf
+++ b/ci/terraform/localstack/localstack.tf
@@ -204,3 +204,25 @@ module "send_notification" {
   security_group_id         = aws_vpc.authentication.default_security_group_id
   subnet_id                 = aws_subnet.authentication.*.id
 }
+
+module "verify_code" {
+  source = "../modules/endpoint-module"
+  providers = {
+    aws = aws.localstack
+  }
+
+  endpoint_name   = "verify-code"
+  endpoint_method = "POST"
+  handler_environment_variables = {
+    BASE_URL = var.api_base_url
+  }
+  handler_function_name = "uk.gov.di.lambdas.VerifyCodeHandler::handleRequest"
+
+  rest_api_id               = module.api_gateway_root.di_authentication_api_id
+  root_resource_id          = module.api_gateway_root.root_resource_id
+  execution_arn             = module.api_gateway_root.execution_arn
+  api_deployment_stage_name = var.api_deployment_stage_name
+  lambda_zip_file           = var.lambda_zip_file
+  security_group_id         = aws_vpc.authentication.default_security_group_id
+  subnet_id                 = aws_subnet.authentication.*.id
+}

--- a/ci/terraform/localstack/outputs.tf
+++ b/ci/terraform/localstack/outputs.tf
@@ -34,6 +34,10 @@ output "send_notification_url" {
   value = "http://localhost:45678/restapis/${module.api_gateway_root.di_authentication_api_id}/${var.environment}/_user_request_/send-notification"
 }
 
+output "verify_code_url" {
+  value = "http://localhost:45678/restapis/${module.api_gateway_root.di_authentication_api_id}/${var.environment}/_user_request_/verify-code"
+}
+
 output "api_gateway_root_id" {
   value = module.api_gateway_root.di_authentication_api_id
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IntegrationTestEndpoints.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IntegrationTestEndpoints.java
@@ -2,7 +2,7 @@ package uk.gov.di.authentication.api;
 
 import java.util.Optional;
 
-public class AuthorizationAPIResourceIntegrationTest {
+public class IntegrationTestEndpoints {
     protected static final String LOCAL_ENDPOINT_FORMAT =
             "http://localhost:45678/restapis/%s/local/_user_request_";
     protected static final String LOCAL_API_GATEWAY_ID =

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/SignupIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/SignupIntegrationTest.java
@@ -20,15 +20,15 @@ import java.io.IOException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static uk.gov.di.entity.SessionState.TWO_FACTOR_REQUIRED;
 
-public class SignupResourceIntegrationTest extends AuthorizationAPIResourceIntegrationTest {
+public class SignupIntegrationTest extends IntegrationTestEndpoints {
 
-    private static final String SIGNUP_RESOURCE = "/signup";
+    private static final String SIGNUP_ENDPOINT = "/signup";
     private ObjectMapper objectMapper = new ObjectMapper();
 
     @Test
     public void shouldCallUserExistsResourceAndReturn200() throws IOException {
         Client client = ClientBuilder.newClient();
-        WebTarget webTarget = client.target(ROOT_RESOURCE_URL + SIGNUP_RESOURCE);
+        WebTarget webTarget = client.target(ROOT_RESOURCE_URL + SIGNUP_ENDPOINT);
         String sessionId = SessionHelper.createSession();
         Invocation.Builder invocationBuilder = webTarget.request(MediaType.APPLICATION_JSON);
         MultivaluedMap headers = new MultivaluedHashMap();

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
@@ -11,14 +11,14 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class TokenResourceIntegrationTest extends AuthorizationAPIResourceIntegrationTest {
+public class TokenIntegrationTest extends IntegrationTestEndpoints {
 
-    private static final String TOKEN_RESOURCE = "/token";
+    private static final String TOKEN_ENDPOINT = "/token";
 
     @Test
     public void shouldCallTokenResourceAndReturn200() {
         Client client = ClientBuilder.newClient();
-        WebTarget webTarget = client.target(ROOT_RESOURCE_URL + TOKEN_RESOURCE);
+        WebTarget webTarget = client.target(ROOT_RESOURCE_URL + TOKEN_ENDPOINT);
 
         Invocation.Builder invocationBuilder = webTarget.request(MediaType.TEXT_PLAIN);
         Response response =

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserExistsIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserExistsIntegrationTest.java
@@ -20,15 +20,15 @@ import java.io.IOException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static uk.gov.di.entity.SessionState.AUTHENTICATION_REQUIRED;
 
-public class UserExistsResourceIntegrationTest extends AuthorizationAPIResourceIntegrationTest {
+public class UserExistsIntegrationTest extends IntegrationTestEndpoints {
 
-    private static final String USEREXISTS_RESOURCE = "/userexists";
+    private static final String USEREXISTS_ENDPOINT = "/userexists";
     private ObjectMapper objectMapper = new ObjectMapper();
 
     @Test
     public void shouldCallUserExistsResourceAndReturn200() throws IOException {
         Client client = ClientBuilder.newClient();
-        WebTarget webTarget = client.target(ROOT_RESOURCE_URL + USEREXISTS_RESOURCE);
+        WebTarget webTarget = client.target(ROOT_RESOURCE_URL + USEREXISTS_ENDPOINT);
         String sessionId = SessionHelper.createSession();
         Invocation.Builder invocationBuilder = webTarget.request(MediaType.APPLICATION_JSON);
         MultivaluedMap headers = new MultivaluedHashMap();

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
@@ -1,0 +1,45 @@
+package uk.gov.di.authentication.api;
+
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.Invocation;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.helpers.SessionHelper;
+import uk.gov.di.entity.NotificationType;
+import uk.gov.di.entity.VerifyCodeRequest;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static uk.gov.di.authentication.api.AuthorizationAPIResourceIntegrationTest.ROOT_RESOURCE_URL;
+
+public class VerifyCodeIntegrationTest {
+
+    private static final String VERIFY_CODE_ENDPOINT = "/verify-code";
+
+    @Test
+    public void shouldCallVerifyCodeEndpointToVerifyEmailAndReturn200() throws IOException {
+        Client client = ClientBuilder.newClient();
+        WebTarget webTarget = client.target(ROOT_RESOURCE_URL + VERIFY_CODE_ENDPOINT);
+        String sessionId = SessionHelper.createSession();
+        Invocation.Builder invocationBuilder = webTarget.request(MediaType.APPLICATION_JSON);
+        MultivaluedMap headers = new MultivaluedHashMap();
+        headers.add("Session-Id", sessionId);
+
+        VerifyCodeRequest codeRequest =
+                new VerifyCodeRequest(NotificationType.VERIFY_EMAIL, "123456");
+
+        Response response =
+                invocationBuilder
+                        .headers(headers)
+                        .post(Entity.entity(codeRequest, MediaType.APPLICATION_JSON));
+
+        assertEquals(200, response.getStatus());
+    }
+}

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
@@ -17,9 +17,8 @@ import uk.gov.di.entity.VerifyCodeRequest;
 import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static uk.gov.di.authentication.api.AuthorizationAPIResourceIntegrationTest.ROOT_RESOURCE_URL;
 
-public class VerifyCodeIntegrationTest {
+public class VerifyCodeIntegrationTest extends IntegrationTestEndpoints {
 
     private static final String VERIFY_CODE_ENDPOINT = "/verify-code";
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/SendEmailNotificationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/SendEmailNotificationIntegrationTest.java
@@ -65,7 +65,7 @@ public class SendEmailNotificationIntegrationTest {
 
         await().atMost(1, MINUTES)
                 .untilAsserted(() -> assertThat(notifyStub.getCountOfRequests(), equalTo(1)));
-        
+
         JsonNode request = objectMapper.readTree(notifyStub.getLastRequest().getEntity());
         JsonNode personalisation = request.get("personalisation");
         assertEquals(TEST_EMAIL_ADDRESS, request.get("email_address").asText());

--- a/serverless/lambda/src/main/java/uk/gov/di/entity/VerifyCodeRequest.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/entity/VerifyCodeRequest.java
@@ -9,7 +9,8 @@ public class VerifyCodeRequest {
     @JsonProperty private String code;
 
     public VerifyCodeRequest(
-            @JsonProperty(required = true, value = "notificationType") NotificationType notificationType,
+            @JsonProperty(required = true, value = "notificationType")
+                    NotificationType notificationType,
             @JsonProperty(required = true, value = "code") String code) {
         this.notificationType = notificationType;
         this.code = code;

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/VerifyCodeHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/VerifyCodeHandler.java
@@ -16,7 +16,8 @@ import java.util.Optional;
 import static uk.gov.di.Messages.ERROR_MISSING_REQUEST_PARAMETERS;
 import static uk.gov.di.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 
-public class VerifyCodeHandler implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+public class VerifyCodeHandler
+        implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final SessionService sessionService;
@@ -33,12 +34,14 @@ public class VerifyCodeHandler implements RequestHandler<APIGatewayProxyRequestE
     }
 
     @Override
-    public APIGatewayProxyResponseEvent handleRequest(APIGatewayProxyRequestEvent input, Context context) {
+    public APIGatewayProxyResponseEvent handleRequest(
+            APIGatewayProxyRequestEvent input, Context context) {
 
         Optional<Session> session = sessionService.getSessionFromRequestHeaders(input.getHeaders());
 
         try {
-            VerifyCodeRequest codeRequest = objectMapper.readValue(input.getBody(), VerifyCodeRequest.class);
+            VerifyCodeRequest codeRequest =
+                    objectMapper.readValue(input.getBody(), VerifyCodeRequest.class);
         } catch (JsonProcessingException e) {
             return generateApiGatewayProxyResponse(400, ERROR_MISSING_REQUEST_PARAMETERS);
         }

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/VerifyCodeRequestHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/VerifyCodeRequestHandlerTest.java
@@ -35,9 +35,7 @@ class VerifyCodeRequestHandlerTest {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setHeaders(Map.of("Session-Id", "a-session-id"));
         event.setBody(
-                format(
-                        "{ \"code\": \"123456\", \"notificationType\": \"%s\" }",
-                        VERIFY_EMAIL));
+                format("{ \"code\": \"123456\", \"notificationType\": \"%s\" }", VERIFY_EMAIL));
 
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
         assertThat(result, hasStatus(200));
@@ -48,10 +46,7 @@ class VerifyCodeRequestHandlerTest {
     public void shouldReturn400IfRequestIsMissingNotificationType() {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setHeaders(Map.of("Session-Id", "a-session-id"));
-        event.setBody(
-                format(
-                        "{ \"code\": \"123456\"}",
-                        VERIFY_EMAIL));
+        event.setBody(format("{ \"code\": \"123456\"}", VERIFY_EMAIL));
 
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
         assertThat(result, hasStatus(400));


### PR DESCRIPTION
## What?

- Write terraform for verify-code lambda and api gateway
- Add integration test for verify-code endpoint
- Refactor Integration tests

## Why?

- To create an api-gateway endpoint called 'verify-code' which calls the VerifyCodeHandler, for both localstack and aws 
- Add an integration test for the verify-code endpoint so we can be confident that the endpoint is working as required 
- To make the naming consistent and clear for the Integration tests 