### PR TITLE
LTG-386: Generate six-digit code in API Gateway handler

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/SendEmailNotificationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/SendEmailNotificationIntegrationTest.java
@@ -52,7 +52,7 @@ public class SendEmailNotificationIntegrationTest {
     @Test
     void shouldCallNotifyWhenValidRequestIsAddedToQueue()
             throws JsonProcessingException, InterruptedException {
-        NotifyRequest notifyRequest = new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL);
+        NotifyRequest notifyRequest = new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL, null);
 
         AwsSqsClient client =
                 new AwsSqsClient(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/SendEmailNotificationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/SendEmailNotificationIntegrationTest.java
@@ -52,7 +52,7 @@ public class SendEmailNotificationIntegrationTest {
     @Test
     void shouldCallNotifyWhenValidRequestIsAddedToQueue()
             throws JsonProcessingException, InterruptedException {
-        NotifyRequest notifyRequest = new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL, null);
+        NotifyRequest notifyRequest = new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL, "162534");
 
         AwsSqsClient client =
                 new AwsSqsClient(

--- a/serverless/lambda/src/main/java/uk/gov/di/entity/NotifyRequest.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/entity/NotifyRequest.java
@@ -8,12 +8,16 @@ public class NotifyRequest {
 
     @JsonProperty private String destination;
 
+    @JsonProperty private String code;
+
     public NotifyRequest(
             @JsonProperty(required = true, value = "destination") String destination,
             @JsonProperty(required = true, value = "notificationType")
-                    NotificationType notificationType) {
+                    NotificationType notificationType,
+            @JsonProperty(value = "code") String code) {
         this.destination = destination;
         this.notificationType = notificationType;
+        this.code = code;
     }
 
     public NotificationType getNotificationType() {
@@ -22,5 +26,9 @@ public class NotifyRequest {
 
     public String getDestination() {
         return destination;
+    }
+
+    public String getCode() {
+        return code;
     }
 }

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/NotificationHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/NotificationHandler.java
@@ -48,9 +48,8 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                         objectMapper.readValue(msg.getBody(), NotifyRequest.class);
                 switch (notifyRequest.getNotificationType()) {
                     case VERIFY_EMAIL:
-                        String code = notificationService.generateSixDigitCode();
                         Map<String, Object> personalisation = new HashMap<>();
-                        personalisation.put("validation-code", code);
+                        personalisation.put("validation-code", notifyRequest.getCode());
                         personalisation.put("email-address", notifyRequest.getDestination());
                         notificationService.sendEmail(
                                 notifyRequest.getDestination(),

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/SendNotificationHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/SendNotificationHandler.java
@@ -87,7 +87,7 @@ public class SendNotificationHandler
                             new NotifyRequest(
                                     sendNotificationRequest.getEmail(),
                                     sendNotificationRequest.getNotificationType(),
-                                    null);
+                                    codeGeneratorService.sixDigitCode());
                     sessionService.save(session.get().setState(VERIFY_EMAIL_CODE_SENT));
                     sqsClient.send(serialiseRequest(notifyRequest));
                     return generateApiGatewayProxyResponse(200, "OK");

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/SendNotificationHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/SendNotificationHandler.java
@@ -12,6 +12,7 @@ import uk.gov.di.entity.NotifyRequest;
 import uk.gov.di.entity.SendNotificationRequest;
 import uk.gov.di.entity.Session;
 import uk.gov.di.services.AwsSqsClient;
+import uk.gov.di.services.CodeGeneratorService;
 import uk.gov.di.services.ConfigurationService;
 import uk.gov.di.services.SessionService;
 import uk.gov.di.services.ValidationService;
@@ -31,17 +32,20 @@ public class SendNotificationHandler
     private final ValidationService validationService;
     private final AwsSqsClient sqsClient;
     private final SessionService sessionService;
+    private final CodeGeneratorService codeGeneratorService;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     public SendNotificationHandler(
             ConfigurationService configurationService,
             ValidationService validationService,
             AwsSqsClient sqsClient,
-            SessionService sessionService) {
+            SessionService sessionService,
+            CodeGeneratorService codeGeneratorService) {
         this.configurationService = configurationService;
         this.validationService = validationService;
         this.sqsClient = sqsClient;
         this.sessionService = sessionService;
+        this.codeGeneratorService = codeGeneratorService;
     }
 
     public SendNotificationHandler() {
@@ -53,6 +57,7 @@ public class SendNotificationHandler
                         configurationService.getSqsEndpointUri());
         this.validationService = new ValidationService();
         sessionService = new SessionService(configurationService);
+        this.codeGeneratorService = new CodeGeneratorService();
     }
 
     @Override

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/SendNotificationHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/SendNotificationHandler.java
@@ -81,7 +81,8 @@ public class SendNotificationHandler
                     NotifyRequest notifyRequest =
                             new NotifyRequest(
                                     sendNotificationRequest.getEmail(),
-                                    sendNotificationRequest.getNotificationType());
+                                    sendNotificationRequest.getNotificationType(),
+                                    null);
                     sessionService.save(session.get().setState(VERIFY_EMAIL_CODE_SENT));
                     sqsClient.send(serialiseRequest(notifyRequest));
                     return generateApiGatewayProxyResponse(200, "OK");

--- a/serverless/lambda/src/main/java/uk/gov/di/services/CodeGeneratorService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/CodeGeneratorService.java
@@ -1,0 +1,14 @@
+package uk.gov.di.services;
+
+import java.security.SecureRandom;
+
+import static java.lang.String.format;
+
+public class CodeGeneratorService {
+
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    public String sixDigitCode() {
+        return format("%06d", RANDOM.nextInt(999999));
+    }
+}

--- a/serverless/lambda/src/main/java/uk/gov/di/services/NotificationService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/NotificationService.java
@@ -6,9 +6,6 @@ import uk.gov.service.notify.NotificationClientException;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Random;
-
-import static java.lang.String.format;
 
 public class NotificationService {
 
@@ -23,12 +20,6 @@ public class NotificationService {
     public void sendEmail(String email, Map<String, Object> personalisation, String templateId)
             throws NotificationClientException {
         notifyClient.sendEmail(templateId, email, personalisation, "");
-    }
-
-    public String generateSixDigitCode() {
-        Random rnd = new Random();
-        String code = format("%06d", rnd.nextInt(999999));
-        return code;
     }
 
     public boolean validateCode(String email, String code) {

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/NotificationHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/NotificationHandlerTest.java
@@ -46,7 +46,7 @@ public class NotificationHandlerTest {
         when(configService.getNotificationTemplateId(VERIFY_EMAIL)).thenReturn(TEMPLATE_ID);
         when(notificationService.generateSixDigitCode()).thenReturn(CODE);
 
-        NotifyRequest notifyRequest = new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL);
+        NotifyRequest notifyRequest = new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL, null);
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
 
@@ -79,7 +79,7 @@ public class NotificationHandlerTest {
         when(configService.getNotificationTemplateId(VERIFY_EMAIL)).thenReturn(TEMPLATE_ID);
         when(notificationService.generateSixDigitCode()).thenReturn(CODE);
 
-        NotifyRequest notifyRequest = new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL);
+        NotifyRequest notifyRequest = new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL, null);
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
 

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/NotificationHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/NotificationHandlerTest.java
@@ -44,16 +44,15 @@ public class NotificationHandlerTest {
     public void shouldSuccessfullyProcessMessageFromSQSQueue()
             throws JsonProcessingException, NotificationClientException {
         when(configService.getNotificationTemplateId(VERIFY_EMAIL)).thenReturn(TEMPLATE_ID);
-        when(notificationService.generateSixDigitCode()).thenReturn(CODE);
 
-        NotifyRequest notifyRequest = new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL, null);
+        NotifyRequest notifyRequest = new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL, "654321");
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
 
         handler.handleRequest(sqsEvent, context);
 
         Map<String, Object> personalisation = new HashMap<>();
-        personalisation.put("validation-code", CODE);
+        personalisation.put("validation-code", "654321");
         personalisation.put("email-address", notifyRequest.getDestination());
 
         verify(notificationService).sendEmail(TEST_EMAIL_ADDRESS, personalisation, TEMPLATE_ID);
@@ -77,14 +76,13 @@ public class NotificationHandlerTest {
     public void shouldThrowExceptionIfNotifyIsUnableToSendEmail()
             throws JsonProcessingException, NotificationClientException {
         when(configService.getNotificationTemplateId(VERIFY_EMAIL)).thenReturn(TEMPLATE_ID);
-        when(notificationService.generateSixDigitCode()).thenReturn(CODE);
 
-        NotifyRequest notifyRequest = new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL, null);
+        NotifyRequest notifyRequest = new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL, "654321");
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
 
         Map<String, Object> personalisation = new HashMap<>();
-        personalisation.put("validation-code", CODE);
+        personalisation.put("validation-code", "654321");
         personalisation.put("email-address", notifyRequest.getDestination());
         doThrow(NotificationClientException.class)
                 .when(notificationService)

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/SendNotificationHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/SendNotificationHandlerTest.java
@@ -58,12 +58,13 @@ class SendNotificationHandlerTest {
     @BeforeEach
     void setup() {
         when(context.getLogger()).thenReturn(mock(LambdaLogger.class));
+        when(codeGeneratorService.sixDigitCode()).thenReturn("123456");
     }
 
     @Test
     void shouldReturn200AndPutMessageOnQueueForAValidRequest() throws JsonProcessingException {
         when(validationService.validateEmailAddress(eq(TEST_EMAIL_ADDRESS))).thenReturn(Set.of());
-        NotifyRequest notifyRequest = new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL, null);
+        NotifyRequest notifyRequest = new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL, "123456");
         ObjectMapper objectMapper = new ObjectMapper();
         String serialisedRequest = objectMapper.writeValueAsString(notifyRequest);
 
@@ -147,7 +148,7 @@ class SendNotificationHandlerTest {
     @Test
     public void shouldReturn500IfMessageCannotBeSentToQueue() throws JsonProcessingException {
         when(validationService.validateEmailAddress(eq(TEST_EMAIL_ADDRESS))).thenReturn(Set.of());
-        NotifyRequest notifyRequest = new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL, null);
+        NotifyRequest notifyRequest = new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL, "123456");
         ObjectMapper objectMapper = new ObjectMapper();
         String serialisedRequest = objectMapper.writeValueAsString(notifyRequest);
         doThrow(SdkClientException.class).when(awsSqsClient).send(eq(serialisedRequest));

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/SendNotificationHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/SendNotificationHandlerTest.java
@@ -57,7 +57,7 @@ class SendNotificationHandlerTest {
     @Test
     void shouldReturn200AndPutMessageOnQueueForAValidRequest() throws JsonProcessingException {
         when(validationService.validateEmailAddress(eq(TEST_EMAIL_ADDRESS))).thenReturn(Set.of());
-        NotifyRequest notifyRequest = new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL);
+        NotifyRequest notifyRequest = new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL, null);
         ObjectMapper objectMapper = new ObjectMapper();
         String serialisedRequest = objectMapper.writeValueAsString(notifyRequest);
 
@@ -85,7 +85,7 @@ class SendNotificationHandlerTest {
     @Test
     void shouldReturn400IfInvalidSessionProvided() throws JsonProcessingException {
         when(validationService.validateEmailAddress(eq(TEST_EMAIL_ADDRESS))).thenReturn(Set.of());
-        NotifyRequest notifyRequest = new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL);
+        NotifyRequest notifyRequest = new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL, null);
         ObjectMapper objectMapper = new ObjectMapper();
         String serialisedRequest = objectMapper.writeValueAsString(notifyRequest);
 
@@ -141,7 +141,7 @@ class SendNotificationHandlerTest {
     @Test
     public void shouldReturn500IfMessageCannotBeSentToQueue() throws JsonProcessingException {
         when(validationService.validateEmailAddress(eq(TEST_EMAIL_ADDRESS))).thenReturn(Set.of());
-        NotifyRequest notifyRequest = new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL);
+        NotifyRequest notifyRequest = new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL, null);
         ObjectMapper objectMapper = new ObjectMapper();
         String serialisedRequest = objectMapper.writeValueAsString(notifyRequest);
         doThrow(SdkClientException.class).when(awsSqsClient).send(eq(serialisedRequest));
@@ -162,7 +162,7 @@ class SendNotificationHandlerTest {
     @Test
     public void shouldReturn400WhenInvalidNotificationType() throws JsonProcessingException {
         when(validationService.validateEmailAddress(eq(TEST_EMAIL_ADDRESS))).thenReturn(Set.of());
-        NotifyRequest notifyRequest = new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL);
+        NotifyRequest notifyRequest = new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL, null);
         ObjectMapper objectMapper = new ObjectMapper();
         String serialisedRequest = objectMapper.writeValueAsString(notifyRequest);
 

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/SendNotificationHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/SendNotificationHandlerTest.java
@@ -12,6 +12,7 @@ import software.amazon.awssdk.core.exception.SdkClientException;
 import uk.gov.di.entity.NotifyRequest;
 import uk.gov.di.entity.Session;
 import uk.gov.di.services.AwsSqsClient;
+import uk.gov.di.services.CodeGeneratorService;
 import uk.gov.di.services.ConfigurationService;
 import uk.gov.di.services.SessionService;
 import uk.gov.di.services.ValidationService;
@@ -44,10 +45,15 @@ class SendNotificationHandlerTest {
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final AwsSqsClient awsSqsClient = mock(AwsSqsClient.class);
     private final SessionService sessionService = mock(SessionService.class);
+    private final CodeGeneratorService codeGeneratorService = mock(CodeGeneratorService.class);
     private final Context context = mock(Context.class);
     private final SendNotificationHandler handler =
             new SendNotificationHandler(
-                    configurationService, validationService, awsSqsClient, sessionService);
+                    configurationService,
+                    validationService,
+                    awsSqsClient,
+                    sessionService,
+                    codeGeneratorService);
 
     @BeforeEach
     void setup() {


### PR DESCRIPTION
## What?

This PR moves the six-digit code generation from taking place in the SQS-receive lambda to taking place in the `SendNotificationRequest` handler in the API Gateway

## Why?

We want to store and validate against this code but the SQS lambda (rightly) has no access to any of the storage.
