### PR TITLE
LTG-374 - Retrieve email code expiry time from config

### DIFF
--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/SendNotificationHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/SendNotificationHandler.java
@@ -98,7 +98,10 @@ public class SendNotificationHandler
                                     sendNotificationRequest.getEmail(),
                                     sendNotificationRequest.getNotificationType(),
                                     code);
-                    codeStorageService.saveEmailCode(sendNotificationRequest.getEmail(), code, 900);
+                    codeStorageService.saveEmailCode(
+                            sendNotificationRequest.getEmail(),
+                            code,
+                            configurationService.getEmailCodeExpiry());
                     sessionService.save(session.get().setState(VERIFY_EMAIL_CODE_SENT));
                     sqsClient.send(serialiseRequest(notifyRequest));
                     return generateApiGatewayProxyResponse(200, "OK");

--- a/serverless/lambda/src/main/java/uk/gov/di/services/ConfigurationService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/ConfigurationService.java
@@ -39,6 +39,10 @@ public class ConfigurationService {
         return System.getenv("NOTIFY_API_KEY");
     }
 
+    public long getEmailCodeExpiry() {
+        return Long.parseLong(System.getenv().getOrDefault("EMAIL_CODE_EXPIRY", "900"));
+    }
+
     public String getNotificationTemplateId(NotificationType notificationType) {
         switch (notificationType) {
             case VERIFY_EMAIL:

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/SendNotificationHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/SendNotificationHandlerTest.java
@@ -65,6 +65,7 @@ class SendNotificationHandlerTest {
     @BeforeEach
     void setup() {
         when(context.getLogger()).thenReturn(mock(LambdaLogger.class));
+        when(configurationService.getEmailCodeExpiry()).thenReturn(CODE_EXPIRY_TIME);
         when(codeGeneratorService.sixDigitCode()).thenReturn(TEST_SIX_DIGIT_CODE);
     }
 


### PR DESCRIPTION
## What?

-  Retrieve email code expiry time from config and give it a default value of 15 minutes if the env var is not set
- We may want to make this config value more generic if we want to reuse the value for others codes as well. 


## Why?

- So it can be dynamic 