### PR TITLE
BAU: Refactor `RedisConnectionService`

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/helpers/SessionHelper.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/helpers/SessionHelper.java
@@ -21,7 +21,8 @@ public class SessionHelper {
         try (RedisConnectionService redis =
                 new RedisConnectionService(REDIS_HOST, 6379, false, REDIS_PASSWORD, 1800)) {
             Session session = new Session(IdGenerator.generate());
-            redis.saveSession(session);
+            redis.saveWithExpiry(
+                    session.getSessionId(), new ObjectMapper().writeValueAsString(session), 1800);
             return session.getSessionId();
         }
     }
@@ -32,7 +33,8 @@ public class SessionHelper {
             Session session =
                     new ObjectMapper().readValue(redis.getValue(sessionId), Session.class);
             session.setEmailAddress(emailAddress);
-            redis.saveSession(session);
+            redis.saveWithExpiry(
+                    session.getSessionId(), new ObjectMapper().writeValueAsString(session), 1800);
 
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/helpers/SessionHelper.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/helpers/SessionHelper.java
@@ -1,5 +1,6 @@
 package uk.gov.di.authentication.helpers;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import uk.gov.di.entity.Session;
 import uk.gov.di.helpers.IdGenerator;
 import uk.gov.di.services.CodeGeneratorService;
@@ -28,7 +29,8 @@ public class SessionHelper {
     public static void addEmailToSession(String sessionId, String emailAddress) {
         try (RedisConnectionService redis =
                 new RedisConnectionService(REDIS_HOST, 6379, false, REDIS_PASSWORD, 1800)) {
-            Session session = redis.loadSession(sessionId);
+            Session session =
+                    new ObjectMapper().readValue(redis.getValue(sessionId), Session.class);
             session.setEmailAddress(emailAddress);
             redis.saveSession(session);
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/helpers/SessionHelper.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/helpers/SessionHelper.java
@@ -19,7 +19,7 @@ public class SessionHelper {
 
     public static String createSession() throws IOException {
         try (RedisConnectionService redis =
-                new RedisConnectionService(REDIS_HOST, 6379, false, REDIS_PASSWORD, 1800)) {
+                new RedisConnectionService(REDIS_HOST, 6379, false, REDIS_PASSWORD)) {
             Session session = new Session(IdGenerator.generate());
             redis.saveWithExpiry(
                     session.getSessionId(), new ObjectMapper().writeValueAsString(session), 1800);
@@ -29,7 +29,7 @@ public class SessionHelper {
 
     public static void addEmailToSession(String sessionId, String emailAddress) {
         try (RedisConnectionService redis =
-                new RedisConnectionService(REDIS_HOST, 6379, false, REDIS_PASSWORD, 1800)) {
+                new RedisConnectionService(REDIS_HOST, 6379, false, REDIS_PASSWORD)) {
             Session session =
                     new ObjectMapper().readValue(redis.getValue(sessionId), Session.class);
             session.setEmailAddress(emailAddress);
@@ -43,7 +43,7 @@ public class SessionHelper {
 
     public static String generateAndSaveEmailCode(String email, long codeExpiryTime) {
         try (RedisConnectionService redis =
-                new RedisConnectionService(REDIS_HOST, 6379, false, REDIS_PASSWORD, 1800)) {
+                new RedisConnectionService(REDIS_HOST, 6379, false, REDIS_PASSWORD)) {
 
             var code = new CodeGeneratorService().sixDigitCode();
             new CodeStorageService(redis).saveEmailCode(email, code, codeExpiryTime);

--- a/serverless/lambda/src/main/java/uk/gov/di/services/CodeStorageService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/CodeStorageService.java
@@ -17,7 +17,7 @@ public class CodeStorageService {
         String encodedhash = HashHelper.hashSha256String(email);
         String key = EMAIL_KEY_PREFIX + encodedhash;
         try (RedisConnectionService redis = redisConnectionService) {
-            redis.saveCodeWithExpiry(key, code, codeExpiryTime);
+            redis.saveWithExpiry(key, code, codeExpiryTime);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/serverless/lambda/src/main/java/uk/gov/di/services/RedisConnectionService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/RedisConnectionService.java
@@ -32,9 +32,9 @@ public class RedisConnectionService implements AutoCloseable {
         }
     }
 
-    public boolean sessionExists(String sessionId) {
+    public boolean keyExists(String key) {
         try (StatefulRedisConnection<String, String> connection = client.connect()) {
-            return (connection.sync().exists(sessionId) == 1);
+            return (connection.sync().exists(key) == 1);
         }
     }
 

--- a/serverless/lambda/src/main/java/uk/gov/di/services/RedisConnectionService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/RedisConnectionService.java
@@ -38,10 +38,6 @@ public class RedisConnectionService implements AutoCloseable {
                 session.getSessionId(), objectMapper.writeValueAsString(session), sessionExpiry);
     }
 
-    public void saveCodeWithExpiry(String key, String value, long expiry) {
-        saveWithExpiry(key, value, expiry);
-    }
-
     public void saveWithExpiry(String key, String value, long expiry) {
         try (StatefulRedisConnection<String, String> connection = client.connect()) {
             connection.sync().setex(key, expiry, value);

--- a/serverless/lambda/src/main/java/uk/gov/di/services/RedisConnectionService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/RedisConnectionService.java
@@ -44,13 +44,6 @@ public class RedisConnectionService implements AutoCloseable {
         }
     }
 
-    public Session loadSession(String sessionId) throws IOException {
-        try (StatefulRedisConnection<String, String> connection = client.connect()) {
-            String result = connection.sync().get(sessionId);
-            return objectMapper.readValue(result, Session.class);
-        }
-    }
-
     public boolean sessionExists(String sessionId) {
         try (StatefulRedisConnection<String, String> connection = client.connect()) {
             return (connection.sync().exists(sessionId) == 1);

--- a/serverless/lambda/src/main/java/uk/gov/di/services/RedisConnectionService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/RedisConnectionService.java
@@ -4,9 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.api.StatefulRedisConnection;
-import uk.gov.di.entity.Session;
 
-import java.io.IOException;
 import java.util.Optional;
 
 public class RedisConnectionService implements AutoCloseable {
@@ -31,11 +29,6 @@ public class RedisConnectionService implements AutoCloseable {
                 configurationService.getUseRedisTLS(),
                 configurationService.getRedisPassword(),
                 configurationService.getSessionExpiry());
-    }
-
-    public void saveSession(Session session) throws IOException {
-        saveWithExpiry(
-                session.getSessionId(), objectMapper.writeValueAsString(session), sessionExpiry);
     }
 
     public void saveWithExpiry(String key, String value, long expiry) {

--- a/serverless/lambda/src/main/java/uk/gov/di/services/RedisConnectionService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/RedisConnectionService.java
@@ -34,17 +34,15 @@ public class RedisConnectionService implements AutoCloseable {
     }
 
     public void saveSession(Session session) throws IOException {
-        try (StatefulRedisConnection<String, String> connection = client.connect()) {
-            connection
-                    .sync()
-                    .setex(
-                            session.getSessionId(),
-                            sessionExpiry,
-                            objectMapper.writeValueAsString(session));
-        }
+        saveWithExpiry(
+                session.getSessionId(), objectMapper.writeValueAsString(session), sessionExpiry);
     }
 
     public void saveCodeWithExpiry(String key, String value, long expiry) {
+        saveWithExpiry(key, value, expiry);
+    }
+
+    public void saveWithExpiry(String key, String value, long expiry) {
         try (StatefulRedisConnection<String, String> connection = client.connect()) {
             connection.sync().setex(key, expiry, value);
         }

--- a/serverless/lambda/src/main/java/uk/gov/di/services/RedisConnectionService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/RedisConnectionService.java
@@ -1,6 +1,5 @@
 package uk.gov.di.services;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.api.StatefulRedisConnection;
@@ -9,17 +8,14 @@ import java.util.Optional;
 
 public class RedisConnectionService implements AutoCloseable {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
     private final RedisClient client;
-    private final long sessionExpiry;
 
     public RedisConnectionService(
-            String host, int port, boolean useSsl, Optional<String> password, long sessionExpiry) {
+            String host, int port, boolean useSsl, Optional<String> password) {
         RedisURI.Builder builder = RedisURI.builder().withHost(host).withPort(port).withSsl(useSsl);
         if (password.isPresent()) builder.withPassword(password.get().toCharArray());
         RedisURI redisURI = builder.build();
         this.client = RedisClient.create(redisURI);
-        this.sessionExpiry = sessionExpiry;
     }
 
     public RedisConnectionService(ConfigurationService configurationService) {
@@ -27,8 +23,7 @@ public class RedisConnectionService implements AutoCloseable {
                 configurationService.getRedisHost(),
                 configurationService.getRedisPort(),
                 configurationService.getUseRedisTLS(),
-                configurationService.getRedisPassword(),
-                configurationService.getSessionExpiry());
+                configurationService.getRedisPassword());
     }
 
     public void saveWithExpiry(String key, String value, long expiry) {

--- a/serverless/lambda/src/main/java/uk/gov/di/services/SessionService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/SessionService.java
@@ -39,7 +39,7 @@ public class SessionService {
         }
         try (RedisConnectionService redis = getRedisConnection()) {
             String sessionId = headers.get(SESSION_ID_HEADER);
-            if (redis.sessionExists(sessionId)) {
+            if (redis.keyExists(sessionId)) {
                 return Optional.of(
                         OBJECT_MAPPER.readValue(redis.getValue(sessionId), Session.class));
             }

--- a/serverless/lambda/src/main/java/uk/gov/di/services/SessionService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/SessionService.java
@@ -54,7 +54,6 @@ public class SessionService {
                 configurationService.getRedisHost(),
                 configurationService.getRedisPort(),
                 configurationService.getUseRedisTLS(),
-                configurationService.getRedisPassword(),
-                configurationService.getSessionExpiry());
+                configurationService.getRedisPassword());
     }
 }

--- a/serverless/lambda/src/main/java/uk/gov/di/services/SessionService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/SessionService.java
@@ -24,7 +24,10 @@ public class SessionService {
 
     public void save(Session session) {
         try (RedisConnectionService redis = getRedisConnection()) {
-            redis.saveSession(session);
+            redis.saveWithExpiry(
+                    session.getSessionId(),
+                    OBJECT_MAPPER.writeValueAsString(session),
+                    configurationService.getSessionExpiry());
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/serverless/lambda/src/main/java/uk/gov/di/services/SessionService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/SessionService.java
@@ -1,5 +1,6 @@
 package uk.gov.di.services;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import uk.gov.di.entity.Session;
 import uk.gov.di.helpers.IdGenerator;
 
@@ -9,6 +10,7 @@ import java.util.Optional;
 public class SessionService {
 
     private static final String SESSION_ID_HEADER = "Session-Id";
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private final ConfigurationService configurationService;
 
@@ -35,7 +37,8 @@ public class SessionService {
         try (RedisConnectionService redis = getRedisConnection()) {
             String sessionId = headers.get(SESSION_ID_HEADER);
             if (redis.sessionExists(sessionId)) {
-                return Optional.of(redis.loadSession(sessionId));
+                return Optional.of(
+                        OBJECT_MAPPER.readValue(redis.getValue(sessionId), Session.class));
             }
             return Optional.empty();
         } catch (Exception e) {

--- a/serverless/lambda/src/test/java/uk/gov/di/services/CodeStorageServiceTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/services/CodeStorageServiceTest.java
@@ -27,7 +27,7 @@ class CodeStorageServiceTest {
                 EMAIL_KEY_PREFIX
                         + "f660ab912ec121d1b1e928a0bb4bc61b15f5ad44d5efdc4e1c92a25e99b8e44a";
 
-        verify(redisConnectionService).saveCodeWithExpiry(redisEmailKey, code, CODE_EXPIRY_TIME);
+        verify(redisConnectionService).saveWithExpiry(redisEmailKey, code, CODE_EXPIRY_TIME);
     }
 
     @Test


### PR DESCRIPTION
## What?

This removes all non-Redis logic and configuration from the `RedisConnectionService`


## Why?

It knew too much.

...

That is to say, logic specific to session storage and code storage belongs in their respective services, not within this one. The sole responsibility of the `RedisConnectionService` is handling API calls to Redis

