### PR TITLE
LTG-374 - Delete email code after it has been used

### DIFF
--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/VerifyCodeHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/VerifyCodeHandler.java
@@ -66,7 +66,7 @@ public class VerifyCodeHandler
                     if (code.isEmpty() || !code.get().equals(codeRequest.getCode())) {
                         return generateApiGatewayProxyResponse(400, ERROR_MISMATCHED_EMAIL_CODE);
                     }
-
+                    codeStorageService.deleteCodeForEmail(session.get().getEmailAddress());
                     sessionService.save(session.get().setState(EMAIL_CODE_VERIFIED));
                     return generateApiGatewayProxyResponse(
                             200, new VerifyCodeResponse(session.get().getState()));

--- a/serverless/lambda/src/main/java/uk/gov/di/services/CodeStorageService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/CodeStorageService.java
@@ -1,10 +1,14 @@
 package uk.gov.di.services;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import uk.gov.di.helpers.HashHelper;
 
 import java.util.Optional;
 
 public class CodeStorageService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CodeStorageService.class);
 
     private final RedisConnectionService redisConnectionService;
     private static final String EMAIL_KEY_PREFIX = "email-code:";
@@ -27,5 +31,15 @@ public class CodeStorageService {
         return Optional.ofNullable(
                 redisConnectionService.getValue(
                         EMAIL_KEY_PREFIX + HashHelper.hashSha256String(emailAddress)));
+    }
+
+    public void deleteCodeForEmail(String emailAddress) {
+        long numberOfKeysRemoved =
+                redisConnectionService.deleteValue(
+                        EMAIL_KEY_PREFIX + HashHelper.hashSha256String(emailAddress));
+
+        if (numberOfKeysRemoved == 0) {
+            LOGGER.info("No key was deleted for: " + emailAddress);
+        }
     }
 }

--- a/serverless/lambda/src/main/java/uk/gov/di/services/RedisConnectionService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/RedisConnectionService.java
@@ -44,6 +44,12 @@ public class RedisConnectionService implements AutoCloseable {
         }
     }
 
+    public long deleteValue(String key) {
+        try (StatefulRedisConnection<String, String> connection = client.connect()) {
+            return connection.sync().del(key);
+        }
+    }
+
     @Override
     public void close() {
         client.shutdown();

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/VerifyCodeRequestHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/VerifyCodeRequestHandlerTest.java
@@ -20,6 +20,7 @@ import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.Messages.ERROR_INVALID_SESSION_ID;
 import static uk.gov.di.Messages.ERROR_MISMATCHED_EMAIL_CODE;
@@ -53,8 +54,8 @@ class VerifyCodeRequestHandlerTest {
         when(sessionService.getSessionFromRequestHeaders(event.getHeaders()))
                 .thenReturn(Optional.of(SESSION));
         when(codeStorageService.getCodeForEmail("test@test.com")).thenReturn(Optional.of("123456"));
-
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
+        verify(codeStorageService).deleteCodeForEmail("test@test.com");
         assertThat(result, hasStatus(200));
         VerifyCodeResponse codeResponse =
                 new ObjectMapper().readValue(result.getBody(), VerifyCodeResponse.class);

--- a/serverless/lambda/src/test/java/uk/gov/di/services/CodeStorageServiceTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/services/CodeStorageServiceTest.java
@@ -49,4 +49,13 @@ class CodeStorageServiceTest {
 
         assertTrue(codeStorageService.getCodeForEmail("test@test.com").isEmpty());
     }
+
+    @Test
+    public void shouldCallRedisToDeleteCodeWithHashedEmail() {
+        codeStorageService.deleteCodeForEmail("test@test.com");
+
+        verify(redisConnectionService)
+                .deleteValue(
+                        "email-code:f660ab912ec121d1b1e928a0bb4bc61b15f5ad44d5efdc4e1c92a25e99b8e44a");
+    }
 }

--- a/serverless/lambda/src/test/java/uk/gov/di/services/SessionServiceTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/services/SessionServiceTest.java
@@ -72,7 +72,8 @@ class SessionServiceTest {
     public void shouldNotRetrieveSessionIfNotPresentInRedis() {
         when(redis.keyExists("session-id")).thenReturn(false);
 
-        var session = sessionService.getSessionFromRequestHeaders(Map.of("Session-Id", "session-id"));
+        var session =
+                sessionService.getSessionFromRequestHeaders(Map.of("Session-Id", "session-id"));
 
         assertTrue(session.isEmpty());
     }


### PR DESCRIPTION
## What?

-  Delete email code after it has been used
- The code is a one time code so once it has been used successfully we should delete it from redis.
- If the code fails to delete we don't want to the user to fail as the code will disappear after a certain time period but we should be aware when it does fail to delete so log out a message for now.
- Add an integration test to ensure that a code can't be used again by a user
- Refactor the VerifyCodeIntegrationTest to reduce a lot of duplication


## Why?

- The code is a one time code so once it has been used successfully we should delete it from redis.

