### PR TITLE
BAU: change userexists endpoint to user-exists

### DIFF
--- a/ci/terraform/aws/userexists.tf
+++ b/ci/terraform/aws/userexists.tf
@@ -1,7 +1,7 @@
 module "userexists" {
   source = "../modules/endpoint-module"
 
-  endpoint_name   = "userexists"
+  endpoint_name   = "user-exists"
   endpoint_method = "POST"
   handler_environment_variables = {
     BASE_URL = var.api_base_url

--- a/ci/terraform/localstack/localstack.tf
+++ b/ci/terraform/localstack/localstack.tf
@@ -166,7 +166,7 @@ module "userexists" {
     aws = aws.localstack
   }
 
-  endpoint_name   = "userexists"
+  endpoint_name   = "user-exists"
   endpoint_method = "POST"
   handler_environment_variables = {
     BASE_URL = var.api_base_url

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserExistsIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserExistsIntegrationTest.java
@@ -22,7 +22,7 @@ import static uk.gov.di.entity.SessionState.AUTHENTICATION_REQUIRED;
 
 public class UserExistsIntegrationTest extends IntegrationTestEndpoints {
 
-    private static final String USEREXISTS_ENDPOINT = "/userexists";
+    private static final String USEREXISTS_ENDPOINT = "/user-exists";
     private ObjectMapper objectMapper = new ObjectMapper();
 
     @Test


### PR DESCRIPTION
## What?

Change 'userexists' endpoint to user-exists.

## Why?

Keep API resource path names consistent.

## Related

https://github.com/alphagov/di-authentication-frontend/pull/58