### PR TITLE
LTG-374 - Return validation errors as a standard ErrorResponse

### DIFF
--- a/serverless/lambda/src/main/java/uk/gov/di/entity/ErrorResponse.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/entity/ErrorResponse.java
@@ -5,7 +5,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public enum ErrorResponse {
     ERROR_1000(1000, "Session-Id is missing or invalid"),
     ERROR_1001(1001, "Request is missing parameters"),
-    ERROR_1002(1002, "Notification type is invalid");
+    ERROR_1002(1002, "Notification type is invalid"),
+    ERROR_1003(1003, "Email address is empty"),
+    ERROR_1004(1004, "Email address is in an incorrect format"),
+    ERROR_1005(1005, "Password is empty"),
+    ERROR_1006(1006, "Password must be at least 8 characters"),
+    ERROR_1007(1007, "Password must contain a number");
 
     @JsonProperty("code")
     private int code;

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/CheckUserExistsHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/CheckUserExistsHandler.java
@@ -15,10 +15,8 @@ import uk.gov.di.services.ConfigurationService;
 import uk.gov.di.services.SessionService;
 import uk.gov.di.services.UserService;
 import uk.gov.di.services.ValidationService;
-import uk.gov.di.validation.EmailValidation;
 
 import java.util.Optional;
-import java.util.Set;
 
 import static uk.gov.di.entity.SessionState.AUTHENTICATION_REQUIRED;
 import static uk.gov.di.entity.SessionState.USER_NOT_FOUND;
@@ -59,10 +57,10 @@ public class CheckUserExistsHandler
                 UserWithEmailRequest userExistsRequest =
                         objectMapper.readValue(input.getBody(), UserWithEmailRequest.class);
                 String emailAddress = userExistsRequest.getEmail();
-                Set<EmailValidation> emailErrors =
+                Optional<ErrorResponse> errorResponse =
                         validationService.validateEmailAddress(emailAddress);
-                if (!emailErrors.isEmpty()) {
-                    return generateApiGatewayProxyResponse(400, emailErrors.toString());
+                if (!errorResponse.isEmpty()) {
+                    return generateApiGatewayProxyErrorResponse(400, errorResponse.get());
                 }
                 boolean userExists = authenticationService.userExists(emailAddress);
                 session.get().setEmailAddress(emailAddress);

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/ClientRegistrationHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/ClientRegistrationHandler.java
@@ -8,10 +8,12 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import uk.gov.di.entity.Client;
 import uk.gov.di.entity.ClientRegistrationRequest;
+import uk.gov.di.entity.ErrorResponse;
 import uk.gov.di.services.AuthorizationCodeService;
 import uk.gov.di.services.ClientService;
 import uk.gov.di.services.InMemoryClientService;
 
+import static uk.gov.di.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 
 public class ClientRegistrationHandler
@@ -42,7 +44,7 @@ public class ClientRegistrationHandler
             String clientString = objectMapper.writeValueAsString(client);
             return generateApiGatewayProxyResponse(200, clientString);
         } catch (JsonProcessingException e) {
-            return generateApiGatewayProxyResponse(400, "Request is missing parameters");
+            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
         }
     }
 }

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/SignUpHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/SignUpHandler.java
@@ -16,10 +16,8 @@ import uk.gov.di.services.ConfigurationService;
 import uk.gov.di.services.SessionService;
 import uk.gov.di.services.UserService;
 import uk.gov.di.services.ValidationService;
-import uk.gov.di.validation.PasswordValidation;
 
 import java.util.Optional;
-import java.util.Set;
 
 import static uk.gov.di.entity.SessionState.TWO_FACTOR_REQUIRED;
 import static uk.gov.di.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
@@ -62,7 +60,7 @@ public class SignUpHandler
             SignupRequest signupRequest =
                     objectMapper.readValue(input.getBody(), SignupRequest.class);
 
-            Set<PasswordValidation> passwordValidationErrors =
+            Optional<ErrorResponse> passwordValidationErrors =
                     validationService.validatePassword(signupRequest.getPassword());
 
             if (passwordValidationErrors.isEmpty()) {
@@ -75,7 +73,7 @@ public class SignUpHandler
                 return generateApiGatewayProxyResponse(
                         200, new SignupResponse(session.get().getState()));
             } else {
-                return generateApiGatewayProxyResponse(400, passwordValidationErrors.toString());
+                return generateApiGatewayProxyErrorResponse(400, passwordValidationErrors.get());
             }
         } catch (JsonProcessingException e) {
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/TokenHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/TokenHandler.java
@@ -11,6 +11,7 @@ import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.openid.connect.sdk.OIDCTokenResponse;
 import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import com.nimbusds.openid.connect.sdk.token.OIDCTokens;
+import uk.gov.di.entity.ErrorResponse;
 import uk.gov.di.services.AuthenticationService;
 import uk.gov.di.services.AuthorizationCodeService;
 import uk.gov.di.services.ClientService;
@@ -21,6 +22,7 @@ import uk.gov.di.services.UserService;
 
 import java.util.Map;
 
+import static uk.gov.di.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.helpers.RequestBodyHelper.PARSE_REQUEST_BODY;
 
@@ -63,7 +65,7 @@ public class TokenHandler
         if (!requestBody.containsKey("code")
                 || !requestBody.containsKey("client_id")
                 || !requestBody.containsKey("client_secret")) {
-            return generateApiGatewayProxyResponse(400, "Request is missing parameters");
+            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
         }
 
         AuthorizationCode code = new AuthorizationCode(requestBody.get("code"));

--- a/serverless/lambda/src/main/java/uk/gov/di/services/ValidationService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/ValidationService.java
@@ -1,10 +1,8 @@
 package uk.gov.di.services;
 
-import uk.gov.di.validation.EmailValidation;
-import uk.gov.di.validation.PasswordValidation;
+import uk.gov.di.entity.ErrorResponse;
 
-import java.util.EnumSet;
-import java.util.Set;
+import java.util.Optional;
 import java.util.regex.Pattern;
 
 public class ValidationService {
@@ -12,30 +10,26 @@ public class ValidationService {
     private static final Pattern EMAIL_REGEX = Pattern.compile("[^@]+@[^@]+\\.[^@]*");
     private static final Pattern PASSWORD_REGEX = Pattern.compile(".*\\d.*");
 
-    public Set<EmailValidation> validateEmailAddress(String email) {
-        Set<EmailValidation> emailErrors = EnumSet.noneOf(EmailValidation.class);
+    public Optional<ErrorResponse> validateEmailAddress(String email) {
         if (email.isBlank()) {
-            emailErrors.add(EmailValidation.EMPTY_EMAIL);
+            return Optional.of(ErrorResponse.ERROR_1003);
         }
         if (!email.isBlank() && !EMAIL_REGEX.matcher(email).matches()) {
-            emailErrors.add(EmailValidation.INCORRECT_FORMAT);
+            return Optional.of(ErrorResponse.ERROR_1004);
         }
-        return emailErrors;
+        return Optional.empty();
     }
 
-    public Set<PasswordValidation> validatePassword(String password) {
-        Set<PasswordValidation> passwordErrors = EnumSet.noneOf(PasswordValidation.class);
-        boolean passwordIsEmpty = false;
+    public Optional<ErrorResponse> validatePassword(String password) {
         if (password == null || password.isBlank()) {
-            passwordErrors.add(PasswordValidation.EMPTY_PASSWORD_FIELD);
-            passwordIsEmpty = true;
+            return Optional.of(ErrorResponse.ERROR_1005);
         }
-        if (!passwordIsEmpty && password.length() < 8) {
-            passwordErrors.add(PasswordValidation.PASSWORD_TOO_SHORT);
+        if (password.length() < 8) {
+            return Optional.of(ErrorResponse.ERROR_1006);
         }
-        if (!passwordIsEmpty && !PASSWORD_REGEX.matcher(password).matches()) {
-            passwordErrors.add(PasswordValidation.NO_NUMBER_INCLUDED);
+        if (!PASSWORD_REGEX.matcher(password).matches()) {
+            return Optional.of(ErrorResponse.ERROR_1007);
         }
-        return passwordErrors;
+        return Optional.empty();
     }
 }

--- a/serverless/lambda/src/main/java/uk/gov/di/validation/EmailValidation.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/validation/EmailValidation.java
@@ -1,6 +1,0 @@
-package uk.gov.di.validation;
-
-public enum EmailValidation {
-    EMPTY_EMAIL,
-    INCORRECT_FORMAT
-}

--- a/serverless/lambda/src/main/java/uk/gov/di/validation/PasswordValidation.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/validation/PasswordValidation.java
@@ -1,7 +1,0 @@
-package uk.gov.di.validation;
-
-public enum PasswordValidation {
-    EMPTY_PASSWORD_FIELD,
-    PASSWORD_TOO_SHORT,
-    NO_NUMBER_INCLUDED
-}

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/ClientRegistrationHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/ClientRegistrationHandlerTest.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.entity.Client;
+import uk.gov.di.entity.ErrorResponse;
 import uk.gov.di.services.ClientService;
 
 import java.util.List;
@@ -61,13 +62,14 @@ class ClientRegistrationHandlerTest {
     }
 
     @Test
-    public void shouldReturn400IfAnyRequestParametersAreMissing() {
+    public void shouldReturn400IfAnyRequestParametersAreMissing() throws JsonProcessingException {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setBody(
                 "{\"redirect_uris\": [\"http://localhost:8080/redirect-uri\"], \"contacts\": [\"joe.bloggs@test.com\"] }");
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(400));
-        assertThat(result, hasBody("Request is missing parameters"));
+        String expectedResponse = new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1001);
+        assertThat(result, hasBody(expectedResponse));
     }
 }

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/TokenHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/TokenHandlerTest.java
@@ -3,12 +3,15 @@ package uk.gov.di.lambdas;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.entity.ErrorResponse;
 import uk.gov.di.services.AuthorizationCodeService;
 import uk.gov.di.services.ClientService;
 import uk.gov.di.services.ConfigurationService;
@@ -81,12 +84,13 @@ public class TokenHandlerTest {
     }
 
     @Test
-    public void shouldReturn400IfAnyRequestParametersAreMissing() {
+    public void shouldReturn400IfAnyRequestParametersAreMissing() throws JsonProcessingException {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setBody("code=343242&client_id=invalid-id");
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertEquals(400, result.getStatusCode());
-        assertThat(result, hasBody("Request is missing parameters"));
+        String expectedResponse = new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1001);
+        assertThat(result, hasBody(expectedResponse));
     }
 }

--- a/serverless/lambda/src/test/java/uk/gov/di/services/ValidationServiceTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/services/ValidationServiceTest.java
@@ -1,10 +1,7 @@
 package uk.gov.di.services;
 
 import org.junit.jupiter.api.Test;
-import uk.gov.di.validation.EmailValidation;
-import uk.gov.di.validation.PasswordValidation;
-
-import java.util.Set;
+import uk.gov.di.entity.ErrorResponse;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -15,8 +12,7 @@ public class ValidationServiceTest {
 
     @Test
     public void shouldRejectEmptyEmail() {
-        assertEquals(
-                Set.of(EmailValidation.EMPTY_EMAIL), validationService.validateEmailAddress(""));
+        assertEquals(ErrorResponse.ERROR_1003, validationService.validateEmailAddress("").get());
     }
 
     @Test
@@ -26,14 +22,13 @@ public class ValidationServiceTest {
         var newlinesEmail = System.lineSeparator() + System.lineSeparator();
 
         assertEquals(
-                Set.of(EmailValidation.EMPTY_EMAIL),
-                validationService.validateEmailAddress(spacesEmail));
+                ErrorResponse.ERROR_1003,
+                validationService.validateEmailAddress(spacesEmail).get());
         assertEquals(
-                Set.of(EmailValidation.EMPTY_EMAIL),
-                validationService.validateEmailAddress(tabsEmail));
+                ErrorResponse.ERROR_1003, validationService.validateEmailAddress(tabsEmail).get());
         assertEquals(
-                Set.of(EmailValidation.EMPTY_EMAIL),
-                validationService.validateEmailAddress(newlinesEmail));
+                ErrorResponse.ERROR_1003,
+                validationService.validateEmailAddress(newlinesEmail).get());
     }
 
     @Test
@@ -43,14 +38,13 @@ public class ValidationServiceTest {
         var noDotsEmail = "test@examplegovuk";
 
         assertEquals(
-                Set.of(EmailValidation.INCORRECT_FORMAT),
-                validationService.validateEmailAddress(noAtsEmail));
+                ErrorResponse.ERROR_1004, validationService.validateEmailAddress(noAtsEmail).get());
         assertEquals(
-                Set.of(EmailValidation.INCORRECT_FORMAT),
-                validationService.validateEmailAddress(multipleAtsEmail));
+                ErrorResponse.ERROR_1004,
+                validationService.validateEmailAddress(multipleAtsEmail).get());
         assertEquals(
-                Set.of(EmailValidation.INCORRECT_FORMAT),
-                validationService.validateEmailAddress(noDotsEmail));
+                ErrorResponse.ERROR_1004,
+                validationService.validateEmailAddress(noDotsEmail).get());
     }
 
     @Test
@@ -65,32 +59,16 @@ public class ValidationServiceTest {
         var shortPassword = "passw0r";
 
         assertEquals(
-                Set.of(PasswordValidation.PASSWORD_TOO_SHORT),
-                validationService.validatePassword(shortPassword));
+                ErrorResponse.ERROR_1006, validationService.validatePassword(shortPassword).get());
     }
 
     @Test
     public void shouldRejectEmptyPassword() {
-        assertEquals(
-                Set.of(PasswordValidation.EMPTY_PASSWORD_FIELD),
-                validationService.validatePassword(""));
-    }
-
-    @Test
-    public void shouldGiveMultipleErrorsForShortPasswordWithNoNumbers() {
-        var shortPasswordWithNoNumbers = "pass";
-
-        assertEquals(
-                Set.of(
-                        PasswordValidation.NO_NUMBER_INCLUDED,
-                        PasswordValidation.PASSWORD_TOO_SHORT),
-                validationService.validatePassword(shortPasswordWithNoNumbers));
+        assertEquals(ErrorResponse.ERROR_1005, validationService.validatePassword("").get());
     }
 
     @Test
     public void shouldNotThrowNullPointerIfPasswordInputsAreNull() {
-        assertEquals(
-                Set.of(PasswordValidation.EMPTY_PASSWORD_FIELD),
-                validationService.validatePassword(null));
+        assertEquals(ErrorResponse.ERROR_1005, validationService.validatePassword(null).get());
     }
 }


### PR DESCRIPTION
## What?

- Add the relevant validation errors to the ErrorResponse so validation errors will be generated the same as all other errors
- Make the validateEmail and validatePassword methods return an Optional<ErrorResponse>
- Refactor other error responses to use the generateApiGatewayProxyErrorResponse method.
- Delete the PasswordValidation and EmailValidation enums as these errors are no in ErrorResponse


## Why?

- So we have a standard way of returning errors to the client 
