### PR TITLE
LTG-274 - Fix ErrorObject json response

### DIFF
--- a/serverless/lambda/src/main/java/uk/gov/di/entity/ErrorResponse.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/entity/ErrorResponse.java
@@ -1,7 +1,9 @@
 package uk.gov.di.entity;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public enum ErrorResponse {
     ERROR_1000(1000, "Session-Id is missing or invalid"),
     ERROR_1001(1001, "Request is missing parameters"),
@@ -20,7 +22,10 @@ public enum ErrorResponse {
 
     ErrorResponse(
             @JsonProperty(required = true, value = "code") int code,
-            @JsonProperty(required = true, value = "message") String message) {}
+            @JsonProperty(required = true, value = "message") String message) {
+        this.code = code;
+        this.message = message;
+    }
 
     public int getCode() {
         return code;


### PR DESCRIPTION
## What?

- By default Jackson will represent Java Enums as String and just return the value of the enum. I.E - ERROR_1000.
- We want to ensure that the error object is returned to display the code and message so we need to add the @JsonFormat(shape = JsonFormat.Shape.OBJECT) annotation for this to happen.


## Why?

- So it is returned as {"code": 1000, "message": "Session-Id is missing or invalid"} instead of just ERROR_1000