### PR TITLE
LTG-397 - Write terraform for Login apigateway and lambda

### DIFF
--- a/ci/terraform/aws/login.tf
+++ b/ci/terraform/aws/login.tf
@@ -1,0 +1,22 @@
+module "login" {
+  source = "../modules/endpoint-module"
+
+  endpoint_name   = "login"
+  endpoint_method = "POST"
+  handler_environment_variables = {
+    BASE_URL = var.api_base_url
+    REDIS_HOST     = aws_elasticache_replication_group.sessions_store.primary_endpoint_address
+    REDIS_PORT     = aws_elasticache_replication_group.sessions_store.port
+    REDIS_PASSWORD = random_password.redis_password.result
+    REDIS_TLS      = "true"
+  }
+  handler_function_name = "uk.gov.di.lambdas.LoginHandler::handleRequest"
+
+  rest_api_id               = module.api_gateway_root.di_authentication_api_id
+  root_resource_id          = module.api_gateway_root.root_resource_id
+  execution_arn             = module.api_gateway_root.execution_arn
+  api_deployment_stage_name = var.api_deployment_stage_name
+  lambda_zip_file           = var.lambda_zip_file
+  security_group_id         = aws_vpc.authentication.default_security_group_id
+  subnet_id                 = aws_subnet.authentication.*.id
+}

--- a/ci/terraform/aws/outputs.tf
+++ b/ci/terraform/aws/outputs.tf
@@ -14,6 +14,10 @@ output "jwks_url" {
   value = module.jwks.base_url
 }
 
+output "login_url" {
+  value = module.login.base_url
+}
+
 output "signup_url" {
   value = module.signup.base_url
 }

--- a/ci/terraform/localstack/localstack.tf
+++ b/ci/terraform/localstack/localstack.tf
@@ -72,6 +72,28 @@ module "jwks" {
   subnet_id                 = aws_subnet.authentication.*.id
 }
 
+module "login" {
+  source = "../modules/endpoint-module"
+  providers = {
+    aws = aws.localstack
+  }
+
+  endpoint_name   = "login"
+  endpoint_method = "POST"
+  handler_environment_variables = {
+    BASE_URL = var.api_base_url
+  }
+  handler_function_name = "uk.gov.di.lambdas.LoginHandler::handleRequest"
+
+  rest_api_id               = module.api_gateway_root.di_authentication_api_id
+  root_resource_id          = module.api_gateway_root.root_resource_id
+  execution_arn             = module.api_gateway_root.execution_arn
+  api_deployment_stage_name = var.api_deployment_stage_name
+  lambda_zip_file           = var.lambda_zip_file
+  security_group_id         = aws_vpc.authentication.default_security_group_id
+  subnet_id                 = aws_subnet.authentication.*.id
+}
+
 module "token" {
   source = "../modules/endpoint-module"
   providers = {

--- a/ci/terraform/localstack/outputs.tf
+++ b/ci/terraform/localstack/outputs.tf
@@ -14,6 +14,10 @@ output "openid_configuration_discovery_url" {
   value = "http://localhost:45678/restapis/${module.api_gateway_root.di_authentication_api_id}/${var.environment}/_user_request_/.well-known/openid-configuration"
 }
 
+output "login" {
+  value = "http://localhost:45678/restapis/${module.api_gateway_root.di_authentication_api_id}/${var.environment}/_user_request_/login"
+}
+
 output "jwks" {
   value = "http://localhost:45678/restapis/${module.api_gateway_root.di_authentication_api_id}/${var.environment}/_user_request_/.well-known/jwks.json"
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
@@ -12,30 +12,30 @@ import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.helpers.SessionHelper;
-import uk.gov.di.entity.SignupRequest;
-import uk.gov.di.entity.SignupResponse;
+import uk.gov.di.entity.LoginRequest;
+import uk.gov.di.entity.LoginResponse;
 
 import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static uk.gov.di.entity.SessionState.TWO_FACTOR_REQUIRED;
+import static uk.gov.di.entity.SessionState.AUTHENTICATED;
 
-public class SignupIntegrationTest extends IntegrationTestEndpoints {
+public class LoginIntegrationTest extends IntegrationTestEndpoints {
 
-    private static final String SIGNUP_ENDPOINT = "/signup";
+    private static final String LOGIN_ENDPOINT = "/login";
     private ObjectMapper objectMapper = new ObjectMapper();
 
     @Test
-    public void shouldCallSignupEndpointAndReturn200() throws IOException {
+    public void shouldCallLoginEndpointAndReturn200() throws IOException {
         Client client = ClientBuilder.newClient();
-        WebTarget webTarget = client.target(ROOT_RESOURCE_URL + SIGNUP_ENDPOINT);
+        WebTarget webTarget = client.target(ROOT_RESOURCE_URL + LOGIN_ENDPOINT);
         String sessionId = SessionHelper.createSession();
         Invocation.Builder invocationBuilder = webTarget.request(MediaType.APPLICATION_JSON);
         MultivaluedMap headers = new MultivaluedHashMap();
         headers.add("Session-Id", sessionId);
 
-        SignupRequest request =
-                new SignupRequest("joe.bloggs@digital.cabinet-office.gov.uk", "1-valid-password");
+        LoginRequest request =
+                new LoginRequest("joe.bloggs@digital.cabinet-office.gov.uk", "password");
 
         Response response =
                 invocationBuilder
@@ -45,8 +45,7 @@ public class SignupIntegrationTest extends IntegrationTestEndpoints {
         assertEquals(200, response.getStatus());
 
         String responseString = response.readEntity(String.class);
-        SignupResponse signupResponse =
-                objectMapper.readValue(responseString, SignupResponse.class);
-        assertEquals(TWO_FACTOR_REQUIRED, signupResponse.getSessionState());
+        LoginResponse loginResponse = objectMapper.readValue(responseString, LoginResponse.class);
+        assertEquals(AUTHENTICATED, loginResponse.getSessionState());
     }
 }


### PR DESCRIPTION
## What?

 - Write terraform for Login apigateway and lambda
 - Write integration test for the Login endpoint

## Why?

- Add terraform to create a api gateway using the 'login' endpoint name which will forward a request to the LoginHandler lambda function.
- Add a happy path integration test to ensure we can call the Login endpoint and get a successful response
- Rename the SignupIntegrationTest

## Related PRs

Please include links to PRs in other repositories relevant to this PR.
Delete this section if not needed.