### PR TITLE
LTG-402: Create DynamoDb Tables

### DIFF
--- a/ci/terraform/aws/dynamodb.tf
+++ b/ci/terraform/aws/dynamodb.tf
@@ -23,4 +23,39 @@ resource "aws_dynamodb_table" "user_credentials_table" {
     projection_type    = "INCLUDE"
     non_key_attributes = ["Email"]
   }
+
+  server_side_encryption {
+    enabled = true
+  }
+}
+
+resource "aws_dynamodb_table" "user_profile_table" {
+  name           = "${var.environment}-user-profile"
+  billing_mode   = "PROVISIONED"
+  write_capacity = 5
+  read_capacity  = 5
+  hash_key       = "Email"
+
+  attribute {
+    name = "Email"
+    type = "S"
+  }
+
+  attribute {
+    name = "SubjectID"
+    type = "S"
+  }
+
+  global_secondary_index {
+    name               = "SubjectIDIndex"
+    hash_key           = "SubjectID"
+    write_capacity     = 5
+    read_capacity      = 5
+    projection_type    = "INCLUDE"
+    non_key_attributes = ["Email"]
+  }
+
+  server_side_encryption {
+    enabled = true
+  }
 }

--- a/ci/terraform/aws/dynamodb.tf
+++ b/ci/terraform/aws/dynamodb.tf
@@ -1,0 +1,26 @@
+resource "aws_dynamodb_table" "user_credentials_table" {
+  name           = "${var.environment}-user-credentials"
+  billing_mode   = "PROVISIONED"
+  write_capacity = 5
+  read_capacity  = 5
+  hash_key       = "Email"
+
+  attribute {
+    name = "Email"
+    type = "S"
+  }
+
+  attribute {
+    name = "SubjectID"
+    type = "S"
+  }
+
+  global_secondary_index {
+    name               = "SubjectIDIndex"
+    hash_key           = "SubjectID"
+    write_capacity     = 5
+    read_capacity      = 5
+    projection_type    = "INCLUDE"
+    non_key_attributes = ["Email"]
+  }
+}

--- a/ci/terraform/aws/vpc.tf
+++ b/ci/terraform/aws/vpc.tf
@@ -36,6 +36,23 @@ resource "aws_vpc_endpoint" "sqs" {
   private_dns_enabled = true
 }
 
+data "aws_vpc_endpoint_service" "dyanmodb" {
+  service = "dynamodb"
+}
+
+resource "aws_vpc_endpoint" "dyanmodb" {
+  vpc_endpoint_type = "Gateway"
+  vpc_id            = aws_vpc.authentication.id
+  service_name      = data.aws_vpc_endpoint_service.dyanmodb.service_name
+}
+
+resource "aws_vpc_endpoint_route_table_association" "dynamodb" {
+  vpc_endpoint_id = aws_vpc_endpoint.dyanmodb.id
+  count = length(data.aws_availability_zones.available.names)
+
+  route_table_id         = aws_route_table.private_route_table[count.index].id
+}
+
 resource "aws_subnet" "authentication_public" {
   count             = length(data.aws_availability_zones.available.names)
   vpc_id            = aws_vpc.authentication.id


### PR DESCRIPTION
## What?

- Create a new DynamoDB table resource to create a User Credentials table with the Email being the partition key.
- Make the SubjectID a global_secondary_index on user credentials to allow the application to find a user using the SubjectID.
- Create a VPC endpoint and route table entries so that we can access DynamoDB from our VPC.
- Create a new DynamoDB table resource to create a User Profile table with the Email being the partition key.
- Make the SubjectID a global_secondary_index on user profile table to allow the application to find a user using the SubjectID.

## Why?

We need to store the users data so once they've registered they can come back and re-use their account.