### PR TITLE
LTG-354: Bump Terraform image version to 1.0

### DIFF
--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -57,7 +57,7 @@ jobs:
             type: registry-image
             source:
               repository: hashicorp/terraform
-              tag: 0.14.10
+              tag: 1.0.0
           params:
             DEPLOYER_ROLE_ARN: ((deployer-role-arn))
             BUILD_NOTIFY_API_KEY: ((build-notify-api-key))
@@ -94,7 +94,7 @@ jobs:
             type: registry-image
             source:
               repository: hashicorp/terraform
-              tag: 0.14.10
+              tag: 1.0.0
           params:
             DEPLOYER_ROLE_ARN: ((deployer-role-arn))
             DEPLOY_ENVIRONMENT: test


### PR DESCRIPTION
## What?

- The Terraform now requires at least v1.0 of Terraform, we forgot to bump it in the pipeline.

## Why?

The pipeline is failing to execute the Terraform

## Related PRs

#118 