### PR TITLE
LTG-403: Add DynamoDB to Docker Compose

### DIFF
--- a/ci/terraform/aws/dynamodb.tf
+++ b/ci/terraform/aws/dynamodb.tf
@@ -1,6 +1,4 @@
 resource "aws_dynamodb_table" "user_credentials_table" {
-  count = var.use_localstack ? 0 : 1
-
   name           = "${var.environment}-user-credentials"
   billing_mode   = "PROVISIONED"
   write_capacity = 5
@@ -32,8 +30,6 @@ resource "aws_dynamodb_table" "user_credentials_table" {
 }
 
 resource "aws_dynamodb_table" "user_profile_table" {
-  count = var.use_localstack ? 0 : 1
-
   name           = "${var.environment}-user-profile"
   billing_mode   = "PROVISIONED"
   write_capacity = 5
@@ -82,8 +78,8 @@ data "aws_iam_policy_document" "dynamo_policy_document" {
       "dynamodb:PutItem",
     ]
     resources = [
-      aws_dynamodb_table.user_credentials_table[0].arn,
-      aws_dynamodb_table.user_profile_table[0].arn
+      aws_dynamodb_table.user_credentials_table.arn,
+      aws_dynamodb_table.user_profile_table.arn
     ]
   }
 }

--- a/ci/terraform/aws/localstack.tfvars
+++ b/ci/terraform/aws/localstack.tfvars
@@ -1,5 +1,6 @@
 environment               = "local"
 aws_endpoint              = "http://localhost:45678"
+aws_dynamodb_endpoint     = "http://localhost:8000"
 use_localstack            = true
 redis_use_tls             = "false"
 external_redis_password   = "redis"

--- a/ci/terraform/aws/site.tf
+++ b/ci/terraform/aws/site.tf
@@ -44,5 +44,6 @@ provider "aws" {
     sqs         = var.aws_endpoint
     sts         = var.aws_endpoint
     elasticache = var.aws_endpoint
+    dynamodb    = var.aws_dynamodb_endpoint
   }
 }

--- a/ci/terraform/aws/variables.tf
+++ b/ci/terraform/aws/variables.tf
@@ -59,6 +59,11 @@ variable "aws_endpoint" {
   default = null
 }
 
+variable "aws_dynamodb_endpoint" {
+  type    = string
+  default = null
+}
+
 variable "use_localstack" {
   type    = bool
   default = false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,5 +41,18 @@ services:
     networks:
       - di-authentication-api-net
 
+  dynamodb:
+    command: "-jar DynamoDBLocal.jar -sharedDb -optimizeDbBeforeStartup -dbPath ."
+    working_dir: /home/dynamodblocal
+    image: amazon/dynamodb-local:latest
+    healthcheck:
+      test: curl http://localhost:8000
+      interval: 5s
+      timeout: 1m
+    ports:
+      - 8000:8000
+    networks:
+      - di-authentication-api-net
+
 networks:
   di-authentication-api-net:

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -70,7 +70,7 @@ if [[ ${RUN_INTEGRATION} -eq 1 ]]; then
   build_and_test_exit_code=$?
   set -e
 
-  stop_docker_services aws redis
+  stop_docker_services aws redis dynamodb
 fi
 
 if [[ ${IN_GITHUB_ACTIONS} -eq 0 ]]; then

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -69,11 +69,11 @@ function funky_started() {
 }
 
 startup() {
-  stop_docker_services aws redis
+  stop_docker_services aws redis dynamodb
   printf "\nStarting di-authentication-api...\n"
   ./gradlew clean build -x test
   printf "\nStarting Docker services...\n"
-  startup_docker aws redis
+  startup_docker aws redis dynamodb
   run_terraform ci/terraform/aws
   if [[ ${IN_GITHUB_ACTIONS} -eq 0 ]]; then
     funky_started


### PR DESCRIPTION
## What?

- Add the AWS provided DynamoDB image to Docker Compose
- Enable DynamoDB Terraform when using Localstack pointing it at the local DynamoDB endpoint.

## Why?

We need to be able to test DynamoDB functionality locally

## Related PRs

#120 
#117 