### PR TITLE
LTG-403 - Hook up UserExist lambda to DynamoDB

### DIFF
--- a/ci/terraform/aws/userexists.tf
+++ b/ci/terraform/aws/userexists.tf
@@ -6,11 +6,13 @@ module "userexists" {
   environment     = var.environment
 
   handler_environment_variables = {
+    ENVIRONMENT = var.environment
     BASE_URL = var.api_base_url
     REDIS_HOST     = var.use_localstack ? var.external_redis_host : aws_elasticache_replication_group.sessions_store[0].primary_endpoint_address
     REDIS_PORT     = var.use_localstack ? var.external_redis_port : aws_elasticache_replication_group.sessions_store[0].port
     REDIS_PASSWORD = var.use_localstack ? var.external_redis_password : random_password.redis_password.result
     REDIS_TLS      = var.redis_use_tls
+    DYNAMO_ENDPOINT = var.use_localstack ? var.lambda_dynamo_endpoint : null
   }
   handler_function_name = "uk.gov.di.lambdas.CheckUserExistsHandler::handleRequest"
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserExistsIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserExistsIntegrationTest.java
@@ -11,6 +11,7 @@ import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.helpers.DynamoHelper;
 import uk.gov.di.authentication.helpers.SessionHelper;
 import uk.gov.di.entity.CheckUserExistsResponse;
 import uk.gov.di.entity.UserWithEmailRequest;
@@ -18,36 +19,64 @@ import uk.gov.di.entity.UserWithEmailRequest;
 import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.entity.SessionState.AUTHENTICATION_REQUIRED;
+import static uk.gov.di.entity.SessionState.USER_NOT_FOUND;
 
 public class UserExistsIntegrationTest extends IntegrationTestEndpoints {
 
     private static final String USEREXISTS_ENDPOINT = "/user-exists";
-    private ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Test
-    public void shouldCallUserExistsResourceAndReturn200() throws IOException {
-        Client client = ClientBuilder.newClient();
-        WebTarget webTarget = client.target(ROOT_RESOURCE_URL + USEREXISTS_ENDPOINT);
+    public void shouldCallUserExistsEndpointAndReturnAuthenticationRequestStateWhenUserExists()
+            throws IOException {
+        String emailAddress = "joe.bloggs+1@digital.cabinet-office.gov.uk";
         String sessionId = SessionHelper.createSession();
-        Invocation.Builder invocationBuilder = webTarget.request(MediaType.APPLICATION_JSON);
+        DynamoHelper.signUp(emailAddress, "password-1");
         MultivaluedMap headers = new MultivaluedHashMap();
         headers.add("Session-Id", sessionId);
-
-        UserWithEmailRequest request =
-                new UserWithEmailRequest("joe.bloggs@digital.cabinet-office.gov.uk");
-
-        Response response =
-                invocationBuilder
-                        .headers(headers)
-                        .post(Entity.entity(request, MediaType.APPLICATION_JSON));
+        UserWithEmailRequest request = new UserWithEmailRequest(emailAddress);
+        Response response = sendRequest(sessionId, request);
 
         assertEquals(200, response.getStatus());
-
         String responseString = response.readEntity(String.class);
         CheckUserExistsResponse checkUserExistsResponse =
                 objectMapper.readValue(responseString, CheckUserExistsResponse.class);
         assertEquals(request.getEmail(), checkUserExistsResponse.getEmail());
         assertEquals(AUTHENTICATION_REQUIRED, checkUserExistsResponse.getSessionState());
+        assertTrue(checkUserExistsResponse.doesUserExist());
+    }
+
+    @Test
+    public void shouldCallUserExistsEndpointAndReturnUserNotFoundStateWhenUserDoesNotExist()
+            throws IOException {
+        String emailAddress = "joe.bloggs+2@digital.cabinet-office.gov.uk";
+        String sessionId = SessionHelper.createSession();
+        MultivaluedMap headers = new MultivaluedHashMap();
+        headers.add("Session-Id", sessionId);
+        UserWithEmailRequest request = new UserWithEmailRequest(emailAddress);
+        Response response = sendRequest(sessionId, request);
+
+        assertEquals(200, response.getStatus());
+        String responseString = response.readEntity(String.class);
+        CheckUserExistsResponse checkUserExistsResponse =
+                objectMapper.readValue(responseString, CheckUserExistsResponse.class);
+        assertEquals(request.getEmail(), checkUserExistsResponse.getEmail());
+        assertEquals(USER_NOT_FOUND, checkUserExistsResponse.getSessionState());
+        assertFalse(checkUserExistsResponse.doesUserExist());
+    }
+
+    private Response sendRequest(String sessionId, UserWithEmailRequest request) {
+        Client client = ClientBuilder.newClient();
+        WebTarget webTarget = client.target(ROOT_RESOURCE_URL + USEREXISTS_ENDPOINT);
+        Invocation.Builder invocationBuilder = webTarget.request(MediaType.APPLICATION_JSON);
+        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
+        headers.add("Session-Id", sessionId);
+
+        return invocationBuilder
+                .headers(headers)
+                .post(Entity.entity(request, MediaType.APPLICATION_JSON));
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/helpers/DynamoHelper.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/helpers/DynamoHelper.java
@@ -16,4 +16,8 @@ public class DynamoHelper {
     public static boolean userExists(String email) {
         return DYNAMO_SERVICE.userExists(email);
     }
+
+    public static void signUp(String email, String password) {
+        DYNAMO_SERVICE.signUp(email, password);
+    }
 }

--- a/serverless/lambda/src/main/java/uk/gov/di/entity/ErrorResponse.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/entity/ErrorResponse.java
@@ -13,7 +13,8 @@ public enum ErrorResponse {
     ERROR_1005(1005, "Password is empty"),
     ERROR_1006(1006, "Password must be at least 8 characters"),
     ERROR_1007(1007, "Password must contain a number"),
-    ERROR_1008(1008, "Invalid login credentials");
+    ERROR_1008(1008, "Invalid login credentials"),
+    ERROR_1009(1009, "An account with this email address already exists");
 
     @JsonProperty("code")
     private int code;

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/CheckUserExistsHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/CheckUserExistsHandler.java
@@ -12,8 +12,8 @@ import uk.gov.di.entity.Session;
 import uk.gov.di.entity.UserWithEmailRequest;
 import uk.gov.di.services.AuthenticationService;
 import uk.gov.di.services.ConfigurationService;
+import uk.gov.di.services.DynamoService;
 import uk.gov.di.services.SessionService;
-import uk.gov.di.services.UserService;
 import uk.gov.di.services.ValidationService;
 
 import java.util.Optional;
@@ -41,9 +41,14 @@ public class CheckUserExistsHandler
     }
 
     public CheckUserExistsHandler() {
+        ConfigurationService configurationService = new ConfigurationService();
         this.validationService = new ValidationService();
-        this.authenticationService = new UserService();
-        this.sessionService = new SessionService(new ConfigurationService());
+        this.sessionService = new SessionService(configurationService);
+        this.authenticationService =
+                new DynamoService(
+                        configurationService.getAwsRegion(),
+                        configurationService.getEnvironment(),
+                        configurationService.getDynamoEndpointUri());
     }
 
     @Override

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/SignUpHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/SignUpHandler.java
@@ -69,6 +69,9 @@ public class SignUpHandler
                     validationService.validatePassword(signupRequest.getPassword());
 
             if (passwordValidationErrors.isEmpty()) {
+                if (authenticationService.userExists(signupRequest.getEmail())) {
+                    return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1009);
+                }
                 authenticationService.signUp(signupRequest.getEmail(), signupRequest.getPassword());
 
                 sessionService.save(

--- a/serverless/lambda/src/main/java/uk/gov/di/services/AuthenticationService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/AuthenticationService.java
@@ -5,7 +5,7 @@ import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 public interface AuthenticationService {
     public boolean userExists(String email);
 
-    public boolean signUp(String email, String password);
+    public void signUp(String email, String password);
 
     public boolean verifyAccessCode(String username, String code);
 

--- a/serverless/lambda/src/main/java/uk/gov/di/services/DynamoService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/DynamoService.java
@@ -60,7 +60,7 @@ public class DynamoService implements AuthenticationService {
     }
 
     @Override
-    public boolean signUp(String email, String password) {
+    public void signUp(String email, String password) {
         String dateTime = LocalDateTime.now().toString();
         Subject subject = new Subject();
         UserCredentials userCredentials =
@@ -79,7 +79,6 @@ public class DynamoService implements AuthenticationService {
                         .setUpdated(dateTime);
         userCredentialsMapper.save(userCredentials);
         userProfileMapper.save(userProfile);
-        return true;
     }
 
     @Override

--- a/serverless/lambda/src/main/java/uk/gov/di/services/UserService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/UserService.java
@@ -29,12 +29,11 @@ public class UserService implements AuthenticationService {
     }
 
     @Override
-    public boolean signUp(String email, String password) {
+    public void signUp(String email, String password) {
         credentialsMap.put(email, password);
         UserInfo userInfo = new UserInfo(new Subject());
         userInfo.setEmailAddress(email);
         userInfoMap.put(email, userInfo);
-        return true;
     }
 
     @Override

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/SignUpHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/SignUpHandlerTest.java
@@ -119,8 +119,7 @@ class SignUpHandlerTest {
     @Test
     public void shouldReturn400IfUserAlreadyExists() throws JsonProcessingException {
         String password = "computer-1";
-        when(validationService.validatePassword(eq(password)))
-                .thenReturn(Optional.empty());
+        when(validationService.validatePassword(eq(password))).thenReturn(Optional.empty());
         when(authenticationService.userExists(eq("joe.bloggs@test.com"))).thenReturn(true);
 
         usingValidSession();

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/SignUpHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/SignUpHandlerTest.java
@@ -10,8 +10,8 @@ import org.junit.jupiter.api.Test;
 import uk.gov.di.entity.ErrorResponse;
 import uk.gov.di.entity.Session;
 import uk.gov.di.entity.SignupResponse;
+import uk.gov.di.services.AuthenticationService;
 import uk.gov.di.services.SessionService;
-import uk.gov.di.services.UserService;
 import uk.gov.di.services.ValidationService;
 
 import java.util.Map;
@@ -32,27 +32,28 @@ import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 class SignUpHandlerTest {
 
     private final Context context = mock(Context.class);
-    private final UserService userService = mock(UserService.class);
+    private final AuthenticationService authenticationService = mock(AuthenticationService.class);
     private final ValidationService validationService = mock(ValidationService.class);
     private final SessionService sessionService = mock(SessionService.class);
     private SignUpHandler handler;
 
     @BeforeEach
     public void setUp() {
-        handler = new SignUpHandler(userService, validationService, sessionService);
+        handler = new SignUpHandler(authenticationService, validationService, sessionService);
     }
 
     @Test
     public void shouldReturn200IfSignUpIsSuccessful() throws JsonProcessingException {
         String password = "computer-1";
         when(validationService.validatePassword(eq(password))).thenReturn(Optional.empty());
+        when(authenticationService.userExists(eq("joe.bloggs@test.com"))).thenReturn(false);
         usingValidSession();
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setHeaders(Map.of("Session-Id", "a-session-id"));
         event.setBody("{ \"password\": \"computer-1\", \"email\": \"joe.bloggs@test.com\" }");
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
-        verify(userService).signUp(eq("joe.bloggs@test.com"), eq(password));
+        verify(authenticationService).signUp(eq("joe.bloggs@test.com"), eq(password));
         verify(sessionService)
                 .save(
                         argThat(
@@ -111,6 +112,26 @@ class SignUpHandlerTest {
         assertThat(result, hasStatus(400));
 
         String expectedResponse = new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1007);
+
+        assertThat(result, hasBody(expectedResponse));
+    }
+
+    @Test
+    public void shouldReturn400IfUserAlreadyExists() throws JsonProcessingException {
+        String password = "computer-1";
+        when(validationService.validatePassword(eq(password)))
+                .thenReturn(Optional.empty());
+        when(authenticationService.userExists(eq("joe.bloggs@test.com"))).thenReturn(true);
+
+        usingValidSession();
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        event.setHeaders(Map.of("Session-Id", "a-session-id"));
+        event.setBody("{ \"password\": \"computer\", \"email\": \"joe.bloggs@test.com\" }");
+        APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
+
+        assertThat(result, hasStatus(400));
+
+        String expectedResponse = new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1009);
 
         assertThat(result, hasBody(expectedResponse));
     }


### PR DESCRIPTION
## What?

- Check if user exists before calling signup
- Change the return type of SignUp to void
- Hook up the UserExist lambda to Dynamo

## Why?

- So we can use Dynamo to check if a user exist rather than checking in memory
- Before signing up a user we should double check to make sure that user doesn't exist. Although this should not happen it will prevent any edge cases of trying to sign up a user who already has an account.
- We don't return anything from the SignUp method so it can just be void.
