### PR TITLE
LTG-403 - Hook up Login lambda with DynamoDB

### DIFF
--- a/ci/terraform/aws/login.tf
+++ b/ci/terraform/aws/login.tf
@@ -4,11 +4,13 @@ module "login" {
   endpoint_name   = "login"
   endpoint_method = "POST"
   handler_environment_variables = {
+    ENVIRONMENT = var.environment
     BASE_URL = var.api_base_url
     REDIS_HOST     = var.use_localstack ? var.external_redis_host : aws_elasticache_replication_group.sessions_store[0].primary_endpoint_address
     REDIS_PORT     = var.use_localstack ? var.external_redis_port : aws_elasticache_replication_group.sessions_store[0].port
     REDIS_PASSWORD = var.use_localstack ? var.external_redis_password : random_password.redis_password.result
     REDIS_TLS      = var.redis_use_tls
+    DYNAMO_ENDPOINT = var.use_localstack ? var.lambda_dynamo_endpoint : null
   }
   handler_function_name = "uk.gov.di.lambdas.LoginHandler::handleRequest"
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
@@ -11,6 +11,7 @@ import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.helpers.DynamoHelper;
 import uk.gov.di.authentication.helpers.SessionHelper;
 import uk.gov.di.entity.LoginRequest;
 import uk.gov.di.entity.LoginResponse;
@@ -23,10 +24,13 @@ import static uk.gov.di.entity.SessionState.AUTHENTICATED;
 public class LoginIntegrationTest extends IntegrationTestEndpoints {
 
     private static final String LOGIN_ENDPOINT = "/login";
-    private ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Test
-    public void shouldCallLoginEndpointAndReturn200() throws IOException {
+    public void shouldCallLoginEndpointAndReturn200WhenLoginIsSuccessful() throws IOException {
+        String email = "joe.bloggs+3@digital.cabinet-office.gov.uk";
+        String password = "password-1";
+        DynamoHelper.signUp(email, password);
         Client client = ClientBuilder.newClient();
         WebTarget webTarget = client.target(ROOT_RESOURCE_URL + LOGIN_ENDPOINT);
         String sessionId = SessionHelper.createSession();
@@ -34,8 +38,7 @@ public class LoginIntegrationTest extends IntegrationTestEndpoints {
         MultivaluedMap headers = new MultivaluedHashMap();
         headers.add("Session-Id", sessionId);
 
-        LoginRequest request =
-                new LoginRequest("joe.bloggs@digital.cabinet-office.gov.uk", "password");
+        LoginRequest request = new LoginRequest(email, password);
 
         Response response =
                 invocationBuilder
@@ -47,5 +50,27 @@ public class LoginIntegrationTest extends IntegrationTestEndpoints {
         String responseString = response.readEntity(String.class);
         LoginResponse loginResponse = objectMapper.readValue(responseString, LoginResponse.class);
         assertEquals(AUTHENTICATED, loginResponse.getSessionState());
+    }
+
+    @Test
+    public void shouldCallLoginEndpointAndReturn401henUserHasInvalidCredentials()
+            throws IOException {
+        String email = "joe.bloggs+4@digital.cabinet-office.gov.uk";
+        String password = "password-1";
+        DynamoHelper.signUp(email, "wrong-password");
+        Client client = ClientBuilder.newClient();
+        WebTarget webTarget = client.target(ROOT_RESOURCE_URL + LOGIN_ENDPOINT);
+        String sessionId = SessionHelper.createSession();
+        Invocation.Builder invocationBuilder = webTarget.request(MediaType.APPLICATION_JSON);
+        MultivaluedMap headers = new MultivaluedHashMap();
+        headers.add("Session-Id", sessionId);
+
+        LoginRequest request = new LoginRequest(email, password);
+        Response response =
+                invocationBuilder
+                        .headers(headers)
+                        .post(Entity.entity(request, MediaType.APPLICATION_JSON));
+
+        assertEquals(401, response.getStatus());
     }
 }

--- a/serverless/lambda/src/main/java/uk/gov/di/entity/ErrorResponse.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/entity/ErrorResponse.java
@@ -14,7 +14,8 @@ public enum ErrorResponse {
     ERROR_1006(1006, "Password must be at least 8 characters"),
     ERROR_1007(1007, "Password must contain a number"),
     ERROR_1008(1008, "Invalid login credentials"),
-    ERROR_1009(1009, "An account with this email address already exists");
+    ERROR_1009(1009, "An account with this email address already exists"),
+    ERROR_1010(1010, "An account with this email address does not exist");
 
     @JsonProperty("code")
     private int code;

--- a/serverless/lambda/src/main/java/uk/gov/di/services/DynamoService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/DynamoService.java
@@ -88,7 +88,8 @@ public class DynamoService implements AuthenticationService {
 
     @Override
     public boolean login(String email, String password) {
-        return false;
+        UserCredentials userCredentials = userCredentialsMapper.load(UserCredentials.class, email);
+        return userCredentials.getPassword().equals(password);
     }
 
     @Override

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/LoginHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/LoginHandlerTest.java
@@ -10,8 +10,8 @@ import org.junit.jupiter.api.Test;
 import uk.gov.di.entity.ErrorResponse;
 import uk.gov.di.entity.LoginResponse;
 import uk.gov.di.entity.Session;
+import uk.gov.di.services.AuthenticationService;
 import uk.gov.di.services.SessionService;
-import uk.gov.di.services.UserService;
 
 import java.util.Map;
 import java.util.Optional;
@@ -32,17 +32,18 @@ class LoginHandlerTest {
     private static final String PASSWORD = "joe.bloggs@test.com";
     private LoginHandler handler;
     private final Context context = mock(Context.class);
-    private final UserService userService = mock(UserService.class);
+    private final AuthenticationService authenticationService = mock(AuthenticationService.class);
     private final SessionService sessionService = mock(SessionService.class);
 
     @BeforeEach
     public void setUp() {
-        handler = new LoginHandler(sessionService, userService);
+        handler = new LoginHandler(sessionService, authenticationService);
     }
 
     @Test
     public void shouldReturn200IfLoginIsSuccessful() throws JsonProcessingException {
-        when(userService.login(EMAIL, PASSWORD)).thenReturn(true);
+        when(authenticationService.userExists(EMAIL)).thenReturn(true);
+        when(authenticationService.login(EMAIL, PASSWORD)).thenReturn(true);
         usingValidSession();
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setHeaders(Map.of("Session-Id", "a-session-id"));
@@ -58,10 +59,11 @@ class LoginHandlerTest {
 
     @Test
     public void shouldReturn401IfUserHasInvalidCredentials() throws JsonProcessingException {
+        when(authenticationService.userExists(EMAIL)).thenReturn(true);
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setHeaders(Map.of("Session-Id", "a-session-id"));
         event.setBody(format("{ \"password\": \"%s\", \"email\": \"%s\" }", PASSWORD, EMAIL));
-        when(userService.login(EMAIL, PASSWORD)).thenReturn(false);
+        when(authenticationService.login(EMAIL, PASSWORD)).thenReturn(false);
         usingValidSession();
 
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
@@ -77,7 +79,7 @@ class LoginHandlerTest {
         event.setHeaders(Map.of("Session-Id", "a-session-id"));
         event.setBody(format("{ \"password\": \"%s\"}", PASSWORD));
 
-        when(userService.login(EMAIL, PASSWORD)).thenReturn(false);
+        when(authenticationService.login(EMAIL, PASSWORD)).thenReturn(false);
         usingValidSession();
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
@@ -92,7 +94,7 @@ class LoginHandlerTest {
         event.setHeaders(Map.of("Session-Id", "a-session-id"));
         event.setBody(format("{ \"password\": \"%s\"}", PASSWORD));
 
-        when(userService.login(EMAIL, PASSWORD)).thenReturn(false);
+        when(authenticationService.login(EMAIL, PASSWORD)).thenReturn(false);
         when(sessionService.getSessionFromRequestHeaders(event.getHeaders()))
                 .thenReturn(Optional.empty());
 
@@ -100,6 +102,22 @@ class LoginHandlerTest {
 
         assertThat(result, hasStatus(400));
         String expectedResponse = new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1000);
+        assertThat(result, hasBody(expectedResponse));
+    }
+
+    @Test
+    public void shouldReturn400IfUserDoesNotHaveAnAccount() throws JsonProcessingException {
+        when(authenticationService.userExists(EMAIL)).thenReturn(false);
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        event.setHeaders(Map.of("Session-Id", "a-session-id"));
+        event.setBody(format("{ \"password\": \"%s\", \"email\": \"%s\" }", PASSWORD, EMAIL));
+        when(authenticationService.login(EMAIL, PASSWORD)).thenReturn(false);
+        usingValidSession();
+
+        APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
+
+        assertThat(result, hasStatus(400));
+        String expectedResponse = new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1010);
         assertThat(result, hasBody(expectedResponse));
     }
 


### PR DESCRIPTION
## What?

- Switch the Login lambda to use the DynamoService rather than the in memory UserService.
- Check if a user has an account before attempting to login 

## Why?

- Because we need to use a database than rely on in-memory storage 
-  So we can send back a more accurate error message