### PR TITLE
LTG-409 - Validate phone number

### DIFF
--- a/serverless/lambda/build.gradle
+++ b/serverless/lambda/build.gradle
@@ -21,7 +21,8 @@ dependencies {
             "com.fasterxml.jackson.core:jackson-annotations:2.12.3",
             "io.lettuce:lettuce-core:6.1.3.RELEASE",
             "uk.gov.service.notify:notifications-java-client:3.17.2-RELEASE",
-            "org.bouncycastle:bcprov-jdk15on:1.69"
+            "org.bouncycastle:bcprov-jdk15on:1.69",
+            "com.googlecode.libphonenumber:libphonenumber:8.12.26"
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.2',
             'com.amazonaws:aws-lambda-java-tests:1.0.2',
             'org.mockito:mockito-core:3.11.2',

--- a/serverless/lambda/src/main/java/uk/gov/di/entity/ErrorResponse.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/entity/ErrorResponse.java
@@ -16,7 +16,8 @@ public enum ErrorResponse {
     ERROR_1008(1008, "Invalid login credentials"),
     ERROR_1009(1009, "An account with this email address already exists"),
     ERROR_1010(1010, "An account with this email address does not exist"),
-    ERROR_1011(1011, "Phone number is missing");
+    ERROR_1011(1011, "Phone number is missing"),
+    ERROR_1012(1011, "Phone number is invalid");
 
     @JsonProperty("code")
     private int code;

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/SendNotificationHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/SendNotificationHandler.java
@@ -100,8 +100,16 @@ public class SendNotificationHandler
                     if (sendNotificationRequest.getPhoneNumber() == null) {
                         return generateApiGatewayProxyResponse(400, ErrorResponse.ERROR_1011);
                     }
+                    String phoneNumber =
+                            removeWhitespaceFromPhoneNumber(
+                                    sendNotificationRequest.getPhoneNumber());
+                    Optional<ErrorResponse> errorResponse =
+                            validationService.validatePhoneNumber(phoneNumber);
+                    if (errorResponse.isPresent()) {
+                        return generateApiGatewayProxyErrorResponse(400, errorResponse.get());
+                    }
                     return handleNotificationRequest(
-                            sendNotificationRequest.getPhoneNumber(),
+                            phoneNumber,
                             sendNotificationRequest.getNotificationType(),
                             session.get());
             }
@@ -113,6 +121,10 @@ public class SendNotificationHandler
             logger.log("Error parsing request: " + e.getMessage());
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
         }
+    }
+
+    private String removeWhitespaceFromPhoneNumber(String phoneNumber) {
+        return phoneNumber.replaceAll("\\s+", "");
     }
 
     private APIGatewayProxyResponseEvent handleNotificationRequest(

--- a/serverless/lambda/src/main/java/uk/gov/di/services/ValidationService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/ValidationService.java
@@ -1,5 +1,7 @@
 package uk.gov.di.services;
 
+import com.google.i18n.phonenumbers.NumberParseException;
+import com.google.i18n.phonenumbers.PhoneNumberUtil;
 import uk.gov.di.entity.ErrorResponse;
 
 import java.util.Optional;
@@ -31,5 +33,21 @@ public class ValidationService {
             return Optional.of(ErrorResponse.ERROR_1007);
         }
         return Optional.empty();
+    }
+
+    public Optional<ErrorResponse> validatePhoneNumber(String phoneNumberInput) {
+        if ((!phoneNumberInput.matches("[0-9]+")) || (phoneNumberInput.length() < 10)) {
+            return Optional.of(ErrorResponse.ERROR_1012);
+        }
+        PhoneNumberUtil phoneUtil = PhoneNumberUtil.getInstance();
+        try {
+            var phoneNumber = phoneUtil.parse(phoneNumberInput, "GB");
+            if (phoneUtil.isValidNumber(phoneNumber)) {
+                return Optional.empty();
+            }
+            return Optional.of(ErrorResponse.ERROR_1012);
+        } catch (NumberParseException e) {
+            return Optional.of(ErrorResponse.ERROR_1012);
+        }
     }
 }

--- a/serverless/lambda/src/test/java/uk/gov/di/services/ValidationServiceTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/services/ValidationServiceTest.java
@@ -3,6 +3,8 @@ package uk.gov.di.services;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.entity.ErrorResponse;
 
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -12,7 +14,8 @@ public class ValidationServiceTest {
 
     @Test
     public void shouldRejectEmptyEmail() {
-        assertEquals(ErrorResponse.ERROR_1003, validationService.validateEmailAddress("").get());
+        assertEquals(
+                Optional.of(ErrorResponse.ERROR_1003), validationService.validateEmailAddress(""));
     }
 
     @Test
@@ -22,13 +25,14 @@ public class ValidationServiceTest {
         var newlinesEmail = System.lineSeparator() + System.lineSeparator();
 
         assertEquals(
-                ErrorResponse.ERROR_1003,
-                validationService.validateEmailAddress(spacesEmail).get());
+                Optional.of(ErrorResponse.ERROR_1003),
+                validationService.validateEmailAddress(spacesEmail));
         assertEquals(
-                ErrorResponse.ERROR_1003, validationService.validateEmailAddress(tabsEmail).get());
+                Optional.of(ErrorResponse.ERROR_1003),
+                validationService.validateEmailAddress(tabsEmail));
         assertEquals(
-                ErrorResponse.ERROR_1003,
-                validationService.validateEmailAddress(newlinesEmail).get());
+                Optional.of(ErrorResponse.ERROR_1003),
+                validationService.validateEmailAddress(newlinesEmail));
     }
 
     @Test
@@ -38,13 +42,14 @@ public class ValidationServiceTest {
         var noDotsEmail = "test@examplegovuk";
 
         assertEquals(
-                ErrorResponse.ERROR_1004, validationService.validateEmailAddress(noAtsEmail).get());
+                Optional.of(ErrorResponse.ERROR_1004),
+                validationService.validateEmailAddress(noAtsEmail));
         assertEquals(
-                ErrorResponse.ERROR_1004,
-                validationService.validateEmailAddress(multipleAtsEmail).get());
+                Optional.of(ErrorResponse.ERROR_1004),
+                validationService.validateEmailAddress(multipleAtsEmail));
         assertEquals(
-                ErrorResponse.ERROR_1004,
-                validationService.validateEmailAddress(noDotsEmail).get());
+                Optional.of(ErrorResponse.ERROR_1004),
+                validationService.validateEmailAddress(noDotsEmail));
     }
 
     @Test
@@ -59,16 +64,51 @@ public class ValidationServiceTest {
         var shortPassword = "passw0r";
 
         assertEquals(
-                ErrorResponse.ERROR_1006, validationService.validatePassword(shortPassword).get());
+                Optional.of(ErrorResponse.ERROR_1006),
+                validationService.validatePassword(shortPassword));
     }
 
     @Test
     public void shouldRejectEmptyPassword() {
-        assertEquals(ErrorResponse.ERROR_1005, validationService.validatePassword("").get());
+        assertEquals(Optional.of(ErrorResponse.ERROR_1005), validationService.validatePassword(""));
     }
 
     @Test
     public void shouldNotThrowNullPointerIfPasswordInputsAreNull() {
-        assertEquals(ErrorResponse.ERROR_1005, validationService.validatePassword(null).get());
+        assertEquals(
+                Optional.of(ErrorResponse.ERROR_1005), validationService.validatePassword(null));
+    }
+
+    @Test
+    public void shouldReturnErrorIsPhoneNumberContainsLetter() {
+        assertEquals(
+                Optional.of(ErrorResponse.ERROR_1012),
+                validationService.validatePhoneNumber("0123456789A"));
+    }
+
+    @Test
+    public void shouldReturnErrorIsPhoneNumberIsLessThan10Characters() {
+        assertEquals(
+                Optional.of(ErrorResponse.ERROR_1012),
+                validationService.validatePhoneNumber("0123456789"));
+    }
+
+    @Test
+    public void shouldReturnErrorIsPhoneNumberIsTooLong() {
+        assertEquals(
+                Optional.of(ErrorResponse.ERROR_1012),
+                validationService.validatePhoneNumber("012345678999"));
+    }
+
+    @Test
+    public void shouldNotReturnErrorIsPhoneNumberIsValid() {
+        assertEquals(Optional.empty(), validationService.validatePhoneNumber("01234567891"));
+    }
+
+    @Test
+    public void shouldReturnErrorIsPhoneNumberContainsNonnumericCharacters() {
+        assertEquals(
+                Optional.of(ErrorResponse.ERROR_1012),
+                validationService.validatePhoneNumber("202-456-1111"));
     }
 }


### PR DESCRIPTION
## What?

- We must check that any phone number is a valid British number before we send it over to Notify.
- We can use the https://github.com/google/libphonenumber lib to do some checking but before we use it, explicitly check that there is at least 10 characters that consist of all numbers.
- Notify strip any whitespace when validating the number.
- When a phone number is invalid we will send the appropriate Error response back.

## Why?

- To ensure that anything we put on the SQS queue is a valid number. This will ensure we only ever send valid numbers to Notify.