### PR TITLE
LTG-386 - Modify the Notification Lambda to send texts

### DIFF
--- a/ci/terraform/aws/sqs.tf
+++ b/ci/terraform/aws/sqs.tf
@@ -133,9 +133,10 @@ resource "aws_lambda_function" "email_sqs_lambda" {
   }
   environment {
     variables = {
-      VERIFY_EMAIL_TEMPLATE_ID = "b7dbb02f-941b-4d72-ad64-84cbe5d77c2e"
-      NOTIFY_API_KEY           = var.notify_api_key
-      NOTIFY_URL               = var.notify_url
+      VERIFY_EMAIL_TEMPLATE_ID        = "b7dbb02f-941b-4d72-ad64-84cbe5d77c2e"
+      VERIFY_PHONE_NUMBER_TEMPLATE_ID = "7dd388f1-e029-4fe7-92ff-18496dcb53e9"
+      NOTIFY_API_KEY                  = var.notify_api_key
+      NOTIFY_URL                      = var.notify_url
     }
   }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/SendEmailNotificationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/SendEmailNotificationIntegrationTest.java
@@ -3,6 +3,7 @@ package uk.gov.di.authentication.queuehandlers;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.authentication.helpers.httpstub.HttpStubExtension;
@@ -17,41 +18,25 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static uk.gov.di.entity.NotificationType.VERIFY_EMAIL;
+import static uk.gov.di.entity.NotificationType.VERIFY_PHONE_NUMBER;
 
 public class SendEmailNotificationIntegrationTest {
 
+    private static final String TEST_PHONE_NUMBER = "01234567811";
     private static final String TEST_EMAIL_ADDRESS = "joe.bloggs@example.com";
     private static final int VERIFICATION_CODE_LENGTH = 6;
 
     @RegisterExtension
-    public final HttpStubExtension notifyStub =
-            new HttpStubExtension(8888) {
-                {
-                    register(
-                            "/v2/notifications/email",
-                            201,
-                            "application/json",
-                            "{"
-                                    + "  \"id\": \"740e5834-3a29-46b4-9a6f-16142fde533a\","
-                                    + "  \"reference\": \"STRING\","
-                                    + "  \"content\": {"
-                                    + "    \"subject\": \"SUBJECT TEXT\","
-                                    + "    \"body\": \"MESSAGE TEXT\",\n"
-                                    + "    \"from_email\": \"SENDER EMAIL\""
-                                    + "  },"
-                                    + "  \"uri\": \"http://localhost:8888/v2/notifications/a-message-id\","
-                                    + "  \"template\": {"
-                                    + "    \"id\": \"740e5834-3a29-46b4-9a6f-16142fde533a\","
-                                    + "    \"version\": 1,"
-                                    + "    \"uri\": \"http://localhost:8888/v2/template/f33517ff-2a88-4f6e-b855-c550268ce08a\""
-                                    + "  }"
-                                    + "}");
-                }
-            };
+    public static final HttpStubExtension notifyStub = new HttpStubExtension(8888);
+
+    @AfterEach
+    public void resetStub() {
+        notifyStub.reset();
+    }
 
     @Test
-    void shouldCallNotifyWhenValidRequestIsAddedToQueue()
-            throws JsonProcessingException, InterruptedException {
+    void shouldCallNotifyWhenValidEmailRequestIsAddedToQueue() throws JsonProcessingException {
+        registerEmail();
         NotifyRequest notifyRequest = new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL, "162534");
 
         AwsSqsClient client =
@@ -72,5 +57,74 @@ public class SendEmailNotificationIntegrationTest {
         assertEquals(TEST_EMAIL_ADDRESS, personalisation.get("email-address").asText());
         assertEquals(
                 VERIFICATION_CODE_LENGTH, personalisation.get("validation-code").asText().length());
+    }
+
+    @Test
+    void shouldCallNotifyWhenValidPhoneNumberRequestIsAddedToQueue()
+            throws JsonProcessingException {
+        registerText();
+        NotifyRequest notifyRequest =
+                new NotifyRequest(TEST_PHONE_NUMBER, VERIFY_PHONE_NUMBER, "162534");
+
+        AwsSqsClient client =
+                new AwsSqsClient(
+                        "eu-west-2",
+                        "http://localhost:45678/123456789012/local-email-notification-queue",
+                        Optional.of("http://localhost:45678/"));
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        client.send(objectMapper.writeValueAsString(notifyRequest));
+
+        await().atMost(1, MINUTES)
+                .untilAsserted(() -> assertThat(notifyStub.getCountOfRequests(), equalTo(1)));
+
+        JsonNode request = objectMapper.readTree(notifyStub.getLastRequest().getEntity());
+        JsonNode personalisation = request.get("personalisation");
+        assertEquals(TEST_PHONE_NUMBER, request.get("phone_number").asText());
+        assertEquals(
+                VERIFICATION_CODE_LENGTH, personalisation.get("validation-code").asText().length());
+    }
+
+    private void registerEmail() {
+        notifyStub.register(
+                "/v2/notifications/email",
+                201,
+                "application/json",
+                "{"
+                        + "  \"id\": \"740e5834-3a29-46b4-9a6f-16142fde533a\","
+                        + "  \"reference\": \"STRING\","
+                        + "  \"content\": {"
+                        + "    \"subject\": \"SUBJECT TEXT\","
+                        + "    \"body\": \"MESSAGE TEXT\",\n"
+                        + "    \"from_email\": \"SENDER EMAIL\""
+                        + "  },"
+                        + "  \"uri\": \"http://localhost:8888/v2/notifications/a-message-id\","
+                        + "  \"template\": {"
+                        + "    \"id\": \"f33517ff-2a88-4f6e-b855-c550268ce08a\","
+                        + "    \"version\": 1,"
+                        + "    \"uri\": \"http://localhost:8888/v2/template/f33517ff-2a88-4f6e-b855-c550268ce08a\""
+                        + "  }"
+                        + "}");
+    }
+
+    private void registerText() {
+        notifyStub.register(
+                "/v2/notifications/sms",
+                201,
+                "application/json",
+                "{"
+                        + "  \"id\": \"740e5834-3a29-46b4-9a6f-16142fde533a\","
+                        + "  \"reference\": \"STRING\","
+                        + "  \"content\": {"
+                        + "    \"body\": \"MESSAGE TEXT\",\n"
+                        + "    \"from_number\": \"SENDER\""
+                        + "  },"
+                        + "  \"uri\": \"http://localhost:8888/v2/notifications/a-message-id\","
+                        + "  \"template\": {"
+                        + "    \"id\": \"f33517ff-2a88-4f6e-b855-c550268ce08a\","
+                        + "    \"version\": 1,"
+                        + "    \"uri\": \"http://localhost:8888/v2/template/f33517ff-2a88-4f6e-b855-c550268ce08a\""
+                        + "  }"
+                        + "}");
     }
 }

--- a/serverless/lambda/src/main/java/uk/gov/di/services/ConfigurationService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/ConfigurationService.java
@@ -51,6 +51,8 @@ public class ConfigurationService {
         switch (notificationType) {
             case VERIFY_EMAIL:
                 return System.getenv("VERIFY_EMAIL_TEMPLATE_ID");
+            case VERIFY_PHONE_NUMBER:
+                return System.getenv("VERIFY_PHONE_NUMBER_TEMPLATE_ID");
             default:
                 throw new RuntimeException("NotificationType template ID does not exist");
         }

--- a/serverless/lambda/src/main/java/uk/gov/di/services/NotificationService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/NotificationService.java
@@ -22,6 +22,11 @@ public class NotificationService {
         notifyClient.sendEmail(templateId, email, personalisation, "");
     }
 
+    public void sendText(String phoneNumber, Map<String, Object> personalisation, String templateId)
+            throws NotificationClientException {
+        notifyClient.sendSms(templateId, phoneNumber, personalisation, "");
+    }
+
     public boolean validateCode(String email, String code) {
         if (!validationCode.containsKey(email)) {
             return false;

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/NotificationHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/NotificationHandlerTest.java
@@ -23,10 +23,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.entity.NotificationType.VERIFY_EMAIL;
+import static uk.gov.di.entity.NotificationType.VERIFY_PHONE_NUMBER;
 
 public class NotificationHandlerTest {
 
     private static final String TEST_EMAIL_ADDRESS = "joe.bloggs@digital.cabinet-office.gov.uk";
+    private static final String TEST_PHONE_NUMBER = "01234567891";
     private static final String TEMPLATE_ID = "fdsfdssd";
     private static final String CODE = "123456";
     private final Context context = mock(Context.class);
@@ -41,7 +43,7 @@ public class NotificationHandlerTest {
     }
 
     @Test
-    public void shouldSuccessfullyProcessMessageFromSQSQueue()
+    public void shouldSuccessfullyProcessEmailMessageFromSQSQueue()
             throws JsonProcessingException, NotificationClientException {
         when(configService.getNotificationTemplateId(VERIFY_EMAIL)).thenReturn(TEMPLATE_ID);
 
@@ -56,6 +58,25 @@ public class NotificationHandlerTest {
         personalisation.put("email-address", notifyRequest.getDestination());
 
         verify(notificationService).sendEmail(TEST_EMAIL_ADDRESS, personalisation, TEMPLATE_ID);
+    }
+
+    @Test
+    public void shouldSuccessfullyProcessPhoneMessageFromSQSQueue()
+            throws JsonProcessingException, NotificationClientException {
+        when(configService.getNotificationTemplateId(VERIFY_PHONE_NUMBER)).thenReturn(TEMPLATE_ID);
+
+        NotifyRequest notifyRequest =
+                new NotifyRequest(TEST_PHONE_NUMBER, VERIFY_PHONE_NUMBER, "654321");
+        String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
+        SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
+
+        handler.handleRequest(sqsEvent, context);
+
+        Map<String, Object> personalisation = new HashMap<>();
+        personalisation.put("validation-code", "654321");
+
+        verify(notificationService)
+                .sendText(notifyRequest.getDestination(), personalisation, TEMPLATE_ID);
     }
 
     @Test
@@ -94,7 +115,36 @@ public class NotificationHandlerTest {
                         () -> handler.handleRequest(sqsEvent, context),
                         "Expected to throw exception");
 
-        assertEquals("Error when sending email via Notify", exception.getMessage());
+        assertEquals(
+                "Error sending with Notify using NotificationType: VERIFY_EMAIL",
+                exception.getMessage());
+    }
+
+    @Test
+    public void shouldThrowExceptionIfNotifyIsUnableToSendText()
+            throws JsonProcessingException, NotificationClientException {
+        when(configService.getNotificationTemplateId(VERIFY_PHONE_NUMBER)).thenReturn(TEMPLATE_ID);
+
+        NotifyRequest notifyRequest =
+                new NotifyRequest(TEST_PHONE_NUMBER, VERIFY_PHONE_NUMBER, "654321");
+        String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
+        SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
+
+        Map<String, Object> personalisation = new HashMap<>();
+        personalisation.put("validation-code", "654321");
+        doThrow(NotificationClientException.class)
+                .when(notificationService)
+                .sendText(TEST_PHONE_NUMBER, personalisation, TEMPLATE_ID);
+
+        RuntimeException exception =
+                assertThrows(
+                        RuntimeException.class,
+                        () -> handler.handleRequest(sqsEvent, context),
+                        "Expected to throw exception");
+
+        assertEquals(
+                "Error sending with Notify using NotificationType: VERIFY_PHONE_NUMBER",
+                exception.getMessage());
     }
 
     private SQSEvent generateSQSEvent(String messageBody) {


### PR DESCRIPTION
## What?

- Check for the VERIFY_PHONE_NUMBER notificationType in the notification Lambda and use Notify to send a text message using the number supplied in the destination.
- Add a new template ID to the sqs.tf which will be used to send to notify so it can use the template we have created for text messages.

## Why?

- So we can use Notify to send text messages so a user can confirm there phone number
