### PR TITLE
GOVSI-468 - Modify NotificationHandler to send MFA SMS messages

### DIFF
--- a/ci/terraform/aws/sqs.tf
+++ b/ci/terraform/aws/sqs.tf
@@ -135,6 +135,7 @@ resource "aws_lambda_function" "email_sqs_lambda" {
     variables = {
       VERIFY_EMAIL_TEMPLATE_ID        = "b7dbb02f-941b-4d72-ad64-84cbe5d77c2e"
       VERIFY_PHONE_NUMBER_TEMPLATE_ID = "7dd388f1-e029-4fe7-92ff-18496dcb53e9"
+      MFA_SMS_TEMPLATE_ID             = "7dd388f1-e029-4fe7-92ff-18496dcb53e9"
       NOTIFY_API_KEY                  = var.notify_api_key
       NOTIFY_URL                      = var.notify_url
     }

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/NotificationHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/NotificationHandler.java
@@ -16,6 +16,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static java.lang.String.format;
+import static uk.gov.di.entity.NotificationType.MFA_SMS;
 import static uk.gov.di.entity.NotificationType.VERIFY_EMAIL;
 import static uk.gov.di.entity.NotificationType.VERIFY_PHONE_NUMBER;
 
@@ -67,6 +68,14 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                                     notifyRequest.getDestination(),
                                     textPersonalisation,
                                     configService.getNotificationTemplateId(VERIFY_PHONE_NUMBER));
+                            break;
+                        case MFA_SMS:
+                            Map<String, Object> mfaPersonalisation = new HashMap<>();
+                            mfaPersonalisation.put("validation-code", notifyRequest.getCode());
+                            notificationService.sendText(
+                                    notifyRequest.getDestination(),
+                                    mfaPersonalisation,
+                                    configService.getNotificationTemplateId(MFA_SMS));
                             break;
                     }
                 } catch (NotificationClientException e) {

--- a/serverless/lambda/src/main/java/uk/gov/di/services/ConfigurationService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/ConfigurationService.java
@@ -53,6 +53,8 @@ public class ConfigurationService {
                 return System.getenv("VERIFY_EMAIL_TEMPLATE_ID");
             case VERIFY_PHONE_NUMBER:
                 return System.getenv("VERIFY_PHONE_NUMBER_TEMPLATE_ID");
+            case MFA_SMS:
+                return System.getenv("MFA_SMS_TEMPLATE_ID");
             default:
                 throw new RuntimeException("NotificationType template ID does not exist");
         }


### PR DESCRIPTION
## What?

- Modify NotificationHandler to send MFA SMS messages

## Why?

- We have a new NotificationType for handling MFA SMS so modify the NotificationHandler to send an SMS via Notify when a message with that NotificationType is pulled of the que.
