### PR TITLE
BAU - Create a new IAM role that has permissions to Dynamo and SQS

### DIFF
--- a/ci/terraform/aws/dynamodb.tf
+++ b/ci/terraform/aws/dynamodb.tf
@@ -126,3 +126,9 @@ resource "aws_iam_role_policy_attachment" "lambda_dynamo" {
   role       = aws_iam_role.lambda_iam_role.name
   policy_arn = aws_iam_policy.lambda_dynamo_policy[0].arn
 }
+
+resource "aws_iam_role_policy_attachment" "lambda_sqs_dynamo" {
+  count      = var.use_localstack ? 0 : 1
+  role       = aws_iam_role.dynamo_sqs_lambda_iam_role.arn
+  policy_arn = aws_iam_policy.lambda_dynamo_policy[0].arn
+}

--- a/ci/terraform/aws/lambda-roles.tf
+++ b/ci/terraform/aws/lambda-roles.tf
@@ -84,3 +84,22 @@ resource "aws_iam_role_policy_attachment" "sqs_lambda_networking" {
   role       = aws_iam_role.sqs_lambda_iam_role.name
   policy_arn = aws_iam_policy.endpoint_networking_policy.arn
 }
+
+resource "aws_iam_role" "dynamo_sqs_lambda_iam_role" {
+  name = "${var.environment}-dynamo-sqs-lambda-role"
+
+  assume_role_policy = var.lambda_iam_policy
+  tags = {
+    environment = var.environment
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "dynamo_sqs_lambda_logs" {
+  role       = aws_iam_role.dynamo_sqs_lambda_iam_role.name
+  policy_arn = aws_iam_policy.endpoint_logging_policy.arn
+}
+
+resource "aws_iam_role_policy_attachment" "dynamo_sqs_lambda_networking" {
+  role       = aws_iam_role.dynamo_sqs_lambda_iam_role.name
+  policy_arn = aws_iam_policy.endpoint_networking_policy.arn
+}

--- a/ci/terraform/aws/mfa.tf
+++ b/ci/terraform/aws/mfa.tf
@@ -23,7 +23,7 @@ module "mfa" {
   lambda_zip_file           = var.lambda_zip_file
   security_group_id         = aws_vpc.authentication.default_security_group_id
   subnet_id                 = aws_subnet.authentication.*.id
-  lambda_role_arn           = aws_iam_role.sqs_lambda_iam_role.arn
+  lambda_role_arn           = aws_iam_role.dynamo_sqs_lambda_iam_role.arn
 
   depends_on = [
     aws_api_gateway_rest_api.di_authentication_api,

--- a/ci/terraform/aws/sqs.tf
+++ b/ci/terraform/aws/sqs.tf
@@ -54,7 +54,7 @@ data "aws_iam_policy_document" "email_queue_policy_document" {
 
     principals {
       type        = "AWS"
-      identifiers = [aws_iam_role.sqs_lambda_iam_role.arn]
+      identifiers = [aws_iam_role.sqs_lambda_iam_role.arn, aws_iam_role.dynamo_sqs_lambda_iam_role.arn]
     }
 
     actions = [
@@ -92,6 +92,7 @@ data "aws_iam_policy_document" "email_queue_policy_document" {
     time_sleep.wait_60_seconds,
     aws_iam_role.email_lambda_iam_role,
     aws_iam_role.sqs_lambda_iam_role,
+    aws_iam_role.dynamo_sqs_lambda_iam_role,
   ]
 }
 


### PR DESCRIPTION
## What?

- Create a new IAM role which has permissions for Dynamo and SQS and assign it to the MFA lambda.

## Why?

- The MFA lambda needs permissions to talk to Dynamo and SQS. We currently don't have an IAM role that does it and want to keep the existing IAM roles limited to the permissions that they require.