### PR TITLE
GOVSI-445 - Add PrivateKey JWT auth on the token endpoint

### DIFF
--- a/ci/terraform/aws/api-gateway.tf
+++ b/ci/terraform/aws/api-gateway.tf
@@ -18,6 +18,13 @@ resource "aws_api_gateway_resource" "connect_resource" {
   path_part   = "connect"
 }
 
+data "aws_region" "current"{
+}
+
+locals {
+  api_base_url = var.use_localstack ? "${var.aws_endpoint}/restapis/${aws_api_gateway_rest_api.di_authentication_api.id}/${var.api_deployment_stage_name}/_user_request_" : "https://${aws_api_gateway_rest_api.di_authentication_api.id}.execute-api.${data.aws_region.current.name}.amazonaws.com/${var.api_deployment_stage_name}"
+}
+
 resource "aws_api_gateway_deployment" "deployment" {
   rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
 

--- a/ci/terraform/aws/authorize.tf
+++ b/ci/terraform/aws/authorize.tf
@@ -6,7 +6,7 @@ module "authorize" {
   environment     = var.environment
 
   handler_environment_variables = {
-    BASE_URL       = var.api_base_url
+    BASE_URL       = local.api_base_url
     LOGIN_URI      = "https://di-authentication-frontend.london.cloudapps.digital/"
     REDIS_HOST     = var.use_localstack ? var.external_redis_host : aws_elasticache_replication_group.sessions_store[0].primary_endpoint_address
     REDIS_PORT     = var.use_localstack ? var.external_redis_port : aws_elasticache_replication_group.sessions_store[0].port

--- a/ci/terraform/aws/jwks.tf
+++ b/ci/terraform/aws/jwks.tf
@@ -6,7 +6,7 @@ module "jwks" {
   environment     = var.environment
 
   handler_environment_variables = {
-    BASE_URL = var.api_base_url
+    BASE_URL = local.api_base_url
   }
   handler_function_name = "uk.gov.di.lambdas.JwksHandler::handleRequest"
 

--- a/ci/terraform/aws/login.tf
+++ b/ci/terraform/aws/login.tf
@@ -5,7 +5,7 @@ module "login" {
   endpoint_method = "POST"
   handler_environment_variables = {
     ENVIRONMENT = var.environment
-    BASE_URL = var.api_base_url
+    BASE_URL = local.api_base_url
     REDIS_HOST     = var.use_localstack ? var.external_redis_host : aws_elasticache_replication_group.sessions_store[0].primary_endpoint_address
     REDIS_PORT     = var.use_localstack ? var.external_redis_port : aws_elasticache_replication_group.sessions_store[0].port
     REDIS_PASSWORD = var.use_localstack ? var.external_redis_password : random_password.redis_password.result

--- a/ci/terraform/aws/outputs.tf
+++ b/ci/terraform/aws/outputs.tf
@@ -1,5 +1,5 @@
 output "base_url" {
-  value = var.use_localstack ? "${var.aws_endpoint}/restapis/${aws_api_gateway_rest_api.di_authentication_api.id}/${var.api_deployment_stage_name}/_user_request_" : aws_api_gateway_stage.endpoint_stage.invoke_url
+  value = local.api_base_url
 }
 
 output "api_gateway_root_id" {

--- a/ci/terraform/aws/register.tf
+++ b/ci/terraform/aws/register.tf
@@ -6,7 +6,7 @@ module "register" {
 
   handler_environment_variables = {
     ENVIRONMENT = var.environment
-    BASE_URL = var.api_base_url
+    BASE_URL = local.api_base_url
     DYNAMO_ENDPOINT = var.use_localstack ? var.lambda_dynamo_endpoint : null
   }
   handler_function_name = "uk.gov.di.lambdas.ClientRegistrationHandler::handleRequest"

--- a/ci/terraform/aws/signup.tf
+++ b/ci/terraform/aws/signup.tf
@@ -7,7 +7,7 @@ module "signup" {
 
   handler_environment_variables = {
     ENVIRONMENT = var.environment
-    BASE_URL = var.api_base_url
+    BASE_URL = local.api_base_url
     REDIS_HOST     = var.use_localstack ? var.external_redis_host : aws_elasticache_replication_group.sessions_store[0].primary_endpoint_address
     REDIS_PORT     = var.use_localstack ? var.external_redis_port : aws_elasticache_replication_group.sessions_store[0].port
     REDIS_PASSWORD = var.use_localstack ? var.external_redis_password : random_password.redis_password.result

--- a/ci/terraform/aws/token.tf
+++ b/ci/terraform/aws/token.tf
@@ -7,7 +7,7 @@ module "token" {
 
   handler_environment_variables = {
     ENVIRONMENT = var.environment
-    BASE_URL = var.api_base_url
+    BASE_URL = var.use_localstack ? "${var.aws_endpoint}/restapis/${aws_api_gateway_rest_api.di_authentication_api.id}/${var.api_deployment_stage_name}/_user_request_/token" : "${var.aws_endpoint}/token"
     DYNAMO_ENDPOINT = var.use_localstack ? var.lambda_dynamo_endpoint : null
   }
   handler_function_name = "uk.gov.di.lambdas.TokenHandler::handleRequest"

--- a/ci/terraform/aws/token.tf
+++ b/ci/terraform/aws/token.tf
@@ -7,7 +7,7 @@ module "token" {
 
   handler_environment_variables = {
     ENVIRONMENT = var.environment
-    BASE_URL = var.use_localstack ? "${var.aws_endpoint}/restapis/${aws_api_gateway_rest_api.di_authentication_api.id}/${var.api_deployment_stage_name}/_user_request_/token" : "${var.aws_endpoint}/token"
+    BASE_URL = "${local.api_base_url}/token"
     DYNAMO_ENDPOINT = var.use_localstack ? var.lambda_dynamo_endpoint : null
   }
   handler_function_name = "uk.gov.di.lambdas.TokenHandler::handleRequest"

--- a/ci/terraform/aws/userexists.tf
+++ b/ci/terraform/aws/userexists.tf
@@ -7,7 +7,7 @@ module "userexists" {
 
   handler_environment_variables = {
     ENVIRONMENT = var.environment
-    BASE_URL = var.api_base_url
+    BASE_URL = local.api_base_url
     REDIS_HOST     = var.use_localstack ? var.external_redis_host : aws_elasticache_replication_group.sessions_store[0].primary_endpoint_address
     REDIS_PORT     = var.use_localstack ? var.external_redis_port : aws_elasticache_replication_group.sessions_store[0].port
     REDIS_PASSWORD = var.use_localstack ? var.external_redis_password : random_password.redis_password.result

--- a/ci/terraform/aws/userinfo.tf
+++ b/ci/terraform/aws/userinfo.tf
@@ -6,7 +6,7 @@ module "userinfo" {
   environment     = var.environment
 
   handler_environment_variables = {
-    BASE_URL = var.api_base_url
+    BASE_URL = local.api_base_url
   }
   handler_function_name = "uk.gov.di.lambdas.UserInfoHandler::handleRequest"
 

--- a/ci/terraform/aws/verify_code.tf
+++ b/ci/terraform/aws/verify_code.tf
@@ -7,7 +7,7 @@ module "verify_code" {
 
   handler_environment_variables = {
     ENVIRONMENT = var.environment
-    BASE_URL = var.api_base_url
+    BASE_URL = local.api_base_url
     REDIS_HOST     = var.use_localstack ? var.external_redis_host : aws_elasticache_replication_group.sessions_store[0].primary_endpoint_address
     REDIS_PORT     = var.use_localstack ? var.external_redis_port : aws_elasticache_replication_group.sessions_store[0].port
     REDIS_PASSWORD = var.use_localstack ? var.external_redis_password : random_password.redis_password.result

--- a/ci/terraform/aws/wellknown.tf
+++ b/ci/terraform/aws/wellknown.tf
@@ -6,7 +6,7 @@ module "openid_configuration_discovery" {
   environment     = var.environment
 
   handler_environment_variables = {
-    BASE_URL = var.api_base_url
+    BASE_URL = local.api_base_url
   }
   handler_function_name = "uk.gov.di.lambdas.WellknownHandler::handleRequest"
 

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -11,6 +11,8 @@ repositories {
 
 dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.2',
+            'com.nimbusds:nimbus-jose-jwt:9.11',
+            'com.nimbusds:oauth2-oidc-sdk:9.9.1',
             'org.glassfish.jersey.core:jersey-client:3.0.2',
             'org.glassfish.jersey.inject:jersey-hk2:3.0.2',
             'org.glassfish.jersey.media:jersey-media-json-jackson:3.0.2',

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
@@ -1,5 +1,11 @@
 package uk.gov.di.authentication.api;
 
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import com.nimbusds.oauth2.sdk.auth.PrivateKeyJWT;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.util.URLUtils;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.client.Entity;
@@ -10,7 +16,18 @@ import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.helpers.DynamoHelper;
 
-import static java.lang.String.format;
+import java.net.URI;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.interfaces.RSAPrivateKey;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -19,25 +36,55 @@ public class TokenIntegrationTest extends IntegrationTestEndpoints {
     private static final String TOKEN_ENDPOINT = "/token";
 
     @Test
-    public void shouldCallTokenResourceAndReturn200() {
+    public void shouldCallTokenResourceAndReturn200() throws JOSEException {
         String clientID = "test-id";
+        KeyPair keyPair = generateRsaKeyPair();
+        setUpDynamo(keyPair, clientID);
+        PrivateKey privateKey = keyPair.getPrivate();
+        PrivateKeyJWT privateKeyJWT =
+                new PrivateKeyJWT(
+                        new ClientID(clientID),
+                        URI.create(ROOT_RESOURCE_URL + TOKEN_ENDPOINT),
+                        JWSAlgorithm.RS256,
+                        (RSAPrivateKey) privateKey,
+                        null,
+                        null);
+        Map<String, List<String>> customParams = new HashMap<>();
+        customParams.put("grant_type", Collections.singletonList("authorization_code"));
+        customParams.put("client_id", Collections.singletonList(clientID));
+        customParams.put("code", Collections.singletonList(new AuthorizationCode().toString()));
+        customParams.put("redirect_uri", Collections.singletonList("http://localhost/redirect"));
+        Map<String, List<String>> privateKeyParams = privateKeyJWT.toParameters();
+        privateKeyParams.putAll(customParams);
         Client client = ClientBuilder.newClient();
+        WebTarget webTarget = client.target(ROOT_RESOURCE_URL + TOKEN_ENDPOINT);
+        Invocation.Builder invocationBuilder = webTarget.request(MediaType.TEXT_PLAIN);
+        String requestParams = URLUtils.serializeParameters(privateKeyParams);
+        Response response =
+                invocationBuilder.post(Entity.entity(requestParams, MediaType.TEXT_PLAIN));
+
+        assertEquals(200, response.getStatus());
+    }
+
+    private void setUpDynamo(KeyPair keyPair, String clientID) {
         DynamoHelper.registerClient(
                 clientID,
                 "test-client",
                 singletonList("http://localhost/redirect"),
                 singletonList("joe.bloggs@digital.cabinet-office.gov.uk"),
                 singletonList("openid"),
-                "public-key");
-        WebTarget webTarget = client.target(ROOT_RESOURCE_URL + TOKEN_ENDPOINT);
+                Base64.getMimeEncoder().encodeToString(keyPair.getPublic().getEncoded()));
         DynamoHelper.signUp("joe.bloggs@digital.cabinet-office.gov.uk", "password-1");
-        Invocation.Builder invocationBuilder = webTarget.request(MediaType.TEXT_PLAIN);
-        Response response =
-                invocationBuilder.post(
-                        Entity.entity(
-                                format("code=123456789&client_id=%s", clientID),
-                                MediaType.TEXT_PLAIN));
+    }
 
-        assertEquals(200, response.getStatus());
+    private KeyPair generateRsaKeyPair() {
+        KeyPairGenerator kpg;
+        try {
+            kpg = KeyPairGenerator.getInstance("RSA");
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException();
+        }
+        kpg.initialize(2048);
+        return kpg.generateKeyPair();
     }
 }

--- a/serverless/lambda/src/main/java/uk/gov/di/entity/ErrorResponse.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/entity/ErrorResponse.java
@@ -19,7 +19,9 @@ public enum ErrorResponse {
     ERROR_1011(1011, "Phone number is missing"),
     ERROR_1012(1012, "Phone number is invalid"),
     ERROR_1013(1013, "Update profile type is invalid"),
-    ERROR_1014(1014, "Phone number is not registered");
+    ERROR_1014(1014, "Phone number is not registered"),
+    ERROR_1015(1015, "Unable to Verify Signature of Private Key JWT"),
+    ERROR_1016(1016, "Client not found");
 
     @JsonProperty("code")
     private int code;

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/TokenHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/TokenHandler.java
@@ -1,16 +1,26 @@
 package uk.gov.di.lambdas;
 
 import com.amazonaws.services.lambda.runtime.Context;
-import com.amazonaws.services.lambda.runtime.LambdaLogger;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jwt.SignedJWT;
-import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod;
+import com.nimbusds.oauth2.sdk.auth.PrivateKeyJWT;
+import com.nimbusds.oauth2.sdk.auth.Secret;
+import com.nimbusds.oauth2.sdk.auth.verifier.ClientAuthenticationVerifier;
+import com.nimbusds.oauth2.sdk.auth.verifier.ClientCredentialsSelector;
+import com.nimbusds.oauth2.sdk.auth.verifier.InvalidClientException;
+import com.nimbusds.oauth2.sdk.id.Audience;
+import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.openid.connect.sdk.OIDCTokenResponse;
 import com.nimbusds.openid.connect.sdk.token.OIDCTokens;
+import uk.gov.di.entity.ClientRegistry;
 import uk.gov.di.entity.ErrorResponse;
 import uk.gov.di.services.AuthenticationService;
 import uk.gov.di.services.AuthorizationCodeService;
@@ -20,7 +30,16 @@ import uk.gov.di.services.DynamoClientService;
 import uk.gov.di.services.DynamoService;
 import uk.gov.di.services.TokenService;
 
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static uk.gov.di.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
@@ -67,19 +86,36 @@ public class TokenHandler
     @Override
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
-        LambdaLogger logger = context.getLogger();
         Map<String, String> requestBody = PARSE_REQUEST_BODY(input.getBody());
 
-        if (!requestBody.containsKey("code") || !requestBody.containsKey("client_id")) {
+        if (!requestBody.containsKey("code")
+                || !requestBody.containsKey("client_id")
+                || !requestBody.containsKey("grant_type")
+                || !requestBody.containsKey("redirect_uri")) {
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
         }
-
-        AuthorizationCode code = new AuthorizationCode(requestBody.get("code"));
-        String clientID = requestBody.get("client_id");
-
-        if (!clientService.isValidClient(clientID)) {
+        PrivateKeyJWT privateKeyJWT;
+        try {
+            privateKeyJWT = PrivateKeyJWT.parse(input.getBody());
+        } catch (ParseException e) {
+            return generateApiGatewayProxyResponse(400, "Invalid PrivateKeyJWT");
+        }
+        String clientID = privateKeyJWT.getClientID().toString();
+        Optional<ClientRegistry> client = clientService.getClient(clientID);
+        if (client.isEmpty()) {
             return generateApiGatewayProxyResponse(403, "client is not valid");
         }
+        ClientAuthenticationVerifier<?> authenticationVerifier =
+                new ClientAuthenticationVerifier<>(
+                        generateClientCredentialsSelector(client.get()),
+                        Collections.singleton(
+                                new Audience(configurationService.getBaseURL().orElseThrow())));
+        try {
+            authenticationVerifier.verify(privateKeyJWT, null, null);
+        } catch (InvalidClientException | JOSEException e) {
+            return generateApiGatewayProxyResponse(403, "Unable to Verify PrivateKeyJWT");
+        }
+
         //        String email = authorizationCodeService.getEmailForCode(code);
         String email = "joe.bloggs@digital.cabinet-office.gov.uk";
 
@@ -95,5 +131,37 @@ public class TokenHandler
         OIDCTokenResponse tokenResponse = new OIDCTokenResponse(oidcTokens);
 
         return generateApiGatewayProxyResponse(200, tokenResponse.toJSONObject().toJSONString());
+    }
+
+    private ClientCredentialsSelector<?> generateClientCredentialsSelector(
+            ClientRegistry clientRegistry) {
+        return new ClientCredentialsSelector<>() {
+            @Override
+            public List<Secret> selectClientSecrets(
+                    ClientID claimedClientID,
+                    ClientAuthenticationMethod authMethod,
+                    com.nimbusds.oauth2.sdk.auth.verifier.Context context) {
+                return null;
+            }
+
+            @Override
+            public List<PublicKey> selectPublicKeys(
+                    ClientID claimedClientID,
+                    ClientAuthenticationMethod authMethod,
+                    JWSHeader jwsHeader,
+                    boolean forceRefresh,
+                    com.nimbusds.oauth2.sdk.auth.verifier.Context context) {
+
+                String publicKey = clientRegistry.getPublicKey();
+                byte[] decodedKey = Base64.getMimeDecoder().decode(publicKey);
+                try {
+                    X509EncodedKeySpec x509publicKey = new X509EncodedKeySpec(decodedKey);
+                    KeyFactory kf = KeyFactory.getInstance("RSA");
+                    return Collections.singletonList(kf.generatePublic(x509publicKey));
+                } catch (InvalidKeySpecException | NoSuchAlgorithmException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
     }
 }

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/TokenHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/TokenHandler.java
@@ -98,12 +98,12 @@ public class TokenHandler
         try {
             privateKeyJWT = PrivateKeyJWT.parse(input.getBody());
         } catch (ParseException e) {
-            return generateApiGatewayProxyResponse(400, "Invalid PrivateKeyJWT");
+            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
         }
         String clientID = privateKeyJWT.getClientID().toString();
         Optional<ClientRegistry> client = clientService.getClient(clientID);
         if (client.isEmpty()) {
-            return generateApiGatewayProxyResponse(403, "client is not valid");
+            return generateApiGatewayProxyErrorResponse(403, ErrorResponse.ERROR_1016);
         }
         ClientAuthenticationVerifier<?> authenticationVerifier =
                 new ClientAuthenticationVerifier<>(
@@ -113,7 +113,7 @@ public class TokenHandler
         try {
             authenticationVerifier.verify(privateKeyJWT, null, null);
         } catch (InvalidClientException | JOSEException e) {
-            return generateApiGatewayProxyResponse(403, "Unable to Verify PrivateKeyJWT");
+            return generateApiGatewayProxyErrorResponse(403, ErrorResponse.ERROR_1015);
         }
 
         //        String email = authorizationCodeService.getEmailForCode(code);

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/TokenHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/TokenHandlerTest.java
@@ -5,11 +5,18 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import com.nimbusds.oauth2.sdk.auth.PrivateKeyJWT;
+import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
+import com.nimbusds.oauth2.sdk.util.URLUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.entity.ClientRegistry;
 import uk.gov.di.entity.ErrorResponse;
 import uk.gov.di.services.AuthenticationService;
 import uk.gov.di.services.AuthorizationCodeService;
@@ -17,6 +24,20 @@ import uk.gov.di.services.ClientService;
 import uk.gov.di.services.ConfigurationService;
 import uk.gov.di.services.TokenService;
 
+import java.net.URI;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.interfaces.RSAPrivateKey;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -29,6 +50,7 @@ import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class TokenHandlerTest {
 
+    private static final String TEST_EMAIL = "joe.bloggs@digital.cabinet-office.gov.uk";
     private final Context context = mock(Context.class);
     private final SignedJWT signedJWT = mock(SignedJWT.class);
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
@@ -51,31 +73,40 @@ public class TokenHandlerTest {
     }
 
     @Test
-    public void shouldReturn200IfSuccessfulRequest() {
+    public void shouldReturn200IfSuccessfulRequest() throws JOSEException {
+        KeyPair keyPair = generateRsaKeyPair();
+        ClientRegistry clientRegistry =
+                new ClientRegistry()
+                        .setClientID("test-id")
+                        .setClientName("test-client")
+                        .setRedirectUrls(singletonList("http://localhost/redirect"))
+                        .setScopes(singletonList("openid"))
+                        .setContacts(singletonList(TEST_EMAIL))
+                        .setPublicKey(
+                                Base64.getMimeEncoder()
+                                        .encodeToString(keyPair.getPublic().getEncoded()));
         Subject subject = new Subject();
         BearerAccessToken accessToken = new BearerAccessToken();
-        when(clientService.isValidClient(eq("test-id"))).thenReturn(true);
-        when(tokenService.issueToken(eq("joe.bloggs@digital.cabinet-office.gov.uk")))
-                .thenReturn(accessToken);
-        when(authenticationService.getSubjectFromEmail(
-                        eq("joe.bloggs@digital.cabinet-office.gov.uk")))
-                .thenReturn(subject);
+        when(configurationService.getBaseURL()).thenReturn(Optional.of("http://localhost/token"));
+        when(clientService.getClient(eq("test-id"))).thenReturn(Optional.of(clientRegistry));
+        when(tokenService.issueToken(eq(TEST_EMAIL))).thenReturn(accessToken);
+        when(authenticationService.getSubjectFromEmail(eq(TEST_EMAIL))).thenReturn(subject);
         when(tokenService.generateIDToken(eq("test-id"), any(Subject.class))).thenReturn(signedJWT);
 
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        event.setBody("code=343242&client_id=test-id");
-        APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
+        APIGatewayProxyResponseEvent result =
+                generateApiGatewayRequest(keyPair.getPrivate(), "test-id");
 
         assertThat(result, hasStatus(200));
         assertTrue(result.getBody().contains(accessToken.getValue()));
     }
 
     @Test
-    public void shouldReturn403IfClientIsNotValid() {
-        when(clientService.isValidClient(eq("invalid-id"))).thenReturn(false);
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        event.setBody("code=343242&client_id=invalid-id");
-        APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
+    public void shouldReturn403IfClientIsNotValid() throws JOSEException {
+        when(clientService.getClient(eq("invalid-id"))).thenReturn(Optional.empty());
+        KeyPair keyPair = generateRsaKeyPair();
+
+        APIGatewayProxyResponseEvent result =
+                generateApiGatewayRequest(keyPair.getPrivate(), "invalid-id");
 
         assertEquals(403, result.getStatusCode());
         assertThat(result, hasBody("client is not valid"));
@@ -90,5 +121,62 @@ public class TokenHandlerTest {
         assertEquals(400, result.getStatusCode());
         String expectedResponse = new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1001);
         assertThat(result, hasBody(expectedResponse));
+    }
+
+    @Test
+    public void shouldReturn403IfSignatureOfPrivateKeyJWTCantBeVerified() throws JOSEException {
+        KeyPair keyPairOne = generateRsaKeyPair();
+        KeyPair keyPairTwo = generateRsaKeyPair();
+        ClientRegistry clientRegistry =
+                new ClientRegistry()
+                        .setClientID("test-id")
+                        .setClientName("test-client")
+                        .setRedirectUrls(singletonList("http://localhost/redirect"))
+                        .setScopes(singletonList("openid"))
+                        .setContacts(singletonList(TEST_EMAIL))
+                        .setPublicKey(
+                                Base64.getMimeEncoder()
+                                        .encodeToString(keyPairTwo.getPublic().getEncoded()));
+        when(configurationService.getBaseURL()).thenReturn(Optional.of("http://localhost/token"));
+        when(clientService.getClient(eq("test-id"))).thenReturn(Optional.of(clientRegistry));
+
+        APIGatewayProxyResponseEvent result =
+                generateApiGatewayRequest(keyPairOne.getPrivate(), "test-id");
+
+        assertThat(result, hasStatus(403));
+    }
+
+    private APIGatewayProxyResponseEvent generateApiGatewayRequest(
+            PrivateKey privateKey, String clientID) throws JOSEException {
+        PrivateKeyJWT privateKeyJWT =
+                new PrivateKeyJWT(
+                        new ClientID(clientID),
+                        URI.create("http://localhost/token"),
+                        JWSAlgorithm.RS256,
+                        (RSAPrivateKey) privateKey,
+                        null,
+                        null);
+        Map<String, List<String>> customParams = new HashMap<>();
+        customParams.put("grant_type", Collections.singletonList("authorization_code"));
+        customParams.put("client_id", Collections.singletonList(clientID));
+        customParams.put("code", Collections.singletonList(new AuthorizationCode().toString()));
+        customParams.put("redirect_uri", Collections.singletonList("http://localhost/redirect"));
+        Map<String, List<String>> privateKeyParams = privateKeyJWT.toParameters();
+        privateKeyParams.putAll(customParams);
+        String requestParams = URLUtils.serializeParameters(privateKeyParams);
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        event.setBody(requestParams);
+        return handler.handleRequest(event, context);
+    }
+
+    private KeyPair generateRsaKeyPair() {
+        KeyPairGenerator kpg;
+        try {
+            kpg = KeyPairGenerator.getInstance("RSA");
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException();
+        }
+        kpg.initialize(2048);
+        return kpg.generateKeyPair();
     }
 }

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/TokenHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/TokenHandlerTest.java
@@ -101,7 +101,7 @@ public class TokenHandlerTest {
     }
 
     @Test
-    public void shouldReturn403IfClientIsNotValid() throws JOSEException {
+    public void shouldReturn403IfClientIsNotValid() throws JOSEException, JsonProcessingException {
         when(clientService.getClient(eq("invalid-id"))).thenReturn(Optional.empty());
         KeyPair keyPair = generateRsaKeyPair();
 
@@ -109,7 +109,8 @@ public class TokenHandlerTest {
                 generateApiGatewayRequest(keyPair.getPrivate(), "invalid-id");
 
         assertEquals(403, result.getStatusCode());
-        assertThat(result, hasBody("client is not valid"));
+        String expectedResponse = new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1016);
+        assertThat(result, hasBody(expectedResponse));
     }
 
     @Test
@@ -124,7 +125,7 @@ public class TokenHandlerTest {
     }
 
     @Test
-    public void shouldReturn403IfSignatureOfPrivateKeyJWTCantBeVerified() throws JOSEException {
+    public void shouldReturn403IfSignatureOfPrivateKeyJWTCantBeVerified() throws JOSEException, JsonProcessingException {
         KeyPair keyPairOne = generateRsaKeyPair();
         KeyPair keyPairTwo = generateRsaKeyPair();
         ClientRegistry clientRegistry =
@@ -144,6 +145,8 @@ public class TokenHandlerTest {
                 generateApiGatewayRequest(keyPairOne.getPrivate(), "test-id");
 
         assertThat(result, hasStatus(403));
+        String expectedResponse = new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1015);
+        assertThat(result, hasBody(expectedResponse));
     }
 
     private APIGatewayProxyResponseEvent generateApiGatewayRequest(

--- a/serverless/lambda/src/test/java/uk/gov/di/services/TokenServiceTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/services/TokenServiceTest.java
@@ -1,14 +1,25 @@
 package uk.gov.di.services;
 
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.auth.PrivateKeyJWT;
+import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
 import org.junit.jupiter.api.Test;
 
+import java.net.URI;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.RSAPrivateKey;
 import java.text.ParseException;
+import java.util.Base64;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -36,5 +47,33 @@ public class TokenServiceTest {
 
         assertEquals(BASE_URL, signedJWT.getJWTClaimsSet().getIssuer());
         assertEquals(SUBJECT.getValue(), signedJWT.getJWTClaimsSet().getClaim("sub"));
+    }
+
+    @Test
+    public void shouldSuccessfullyValidatePrivateKeyJWTSignature() throws JOSEException {
+        KeyPair keyPair = generateRsaKeyPair();
+        PrivateKeyJWT privateKeyJWT =
+                new PrivateKeyJWT(
+                        new ClientID("client-id"),
+                        URI.create("http://localhost/token"),
+                        JWSAlgorithm.RS256,
+                        (RSAPrivateKey) keyPair.getPrivate(),
+                        null,
+                        null);
+        String publicKey = Base64.getMimeEncoder().encodeToString(keyPair.getPublic().getEncoded());
+        assertTrue(
+                tokenService.validatePrivateKeyJWTSignature(
+                        publicKey, privateKeyJWT, "http://localhost/token"));
+    }
+
+    private KeyPair generateRsaKeyPair() {
+        KeyPairGenerator kpg;
+        try {
+            kpg = KeyPairGenerator.getInstance("RSA");
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException();
+        }
+        kpg.initialize(2048);
+        return kpg.generateKeyPair();
     }
 }


### PR DESCRIPTION
## What?

- Add PrivateKeyAuthentication to the token endpoint and use Nimbus libraries to Verify that the PrivateKeyJWT contains the required attributes.
- Construct the Base URL in terraform
- Return ErrorResponses from Token endpoint
- Retrieve the Public Key from Dynamo to then Verify the signature of the Private Key JWT

## Why?

- Private Key JWT Client authentication is used by clients to authenticate to the authorization server when using the token endpoint
- We need the application to read the BaseURL so it can validate the audience
