### PR TITLE
GOVSI-493: Re-factor Session class

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/helpers/RedisHelper.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/helpers/RedisHelper.java
@@ -23,7 +23,7 @@ public class RedisHelper {
     public static String createSession() throws IOException {
         try (RedisConnectionService redis =
                 new RedisConnectionService(REDIS_HOST, 6379, false, REDIS_PASSWORD)) {
-            Session session = new Session(IdGenerator.generate());
+            Session session = new Session(IdGenerator.generate(), IdGenerator.generate());
             redis.saveWithExpiry(
                     session.getSessionId(), new ObjectMapper().writeValueAsString(session), 1800);
             return session.getSessionId();

--- a/serverless/lambda/src/main/java/uk/gov/di/entity/Session.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/entity/Session.java
@@ -3,6 +3,7 @@ package uk.gov.di.entity;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -13,8 +14,11 @@ public class Session {
     @JsonProperty("session_id")
     private String sessionId;
 
-    @JsonProperty("authentication_request")
-    private Map<String, List<String>> authenticationRequest;
+    @JsonProperty("client_session_id")
+    private String clientSessionId;
+
+    @JsonProperty("authentication_requests")
+    private Map<String, Map<String, List<String>>> authenticationRequests;
 
     @JsonProperty("state")
     private SessionState state;
@@ -25,19 +29,24 @@ public class Session {
     @JsonProperty("retry_count")
     private int retryCount;
 
-    public Session(String sessionId) {
+    public Session(String sessionId, String clientSessionId) {
         this.sessionId = sessionId;
+        this.clientSessionId = clientSessionId;
         this.state = NEW;
+        this.authenticationRequests = new HashMap<>();
     }
 
     @JsonCreator
     public Session(
             @JsonProperty("session_id") String sessionId,
-            @JsonProperty("authentication_request") Map<String, List<String>> authenticationRequest,
+            @JsonProperty("client_session_id") String clientSessionId,
+            @JsonProperty("authentication_requests")
+                    Map<String, Map<String, List<String>>> authenticationRequests,
             @JsonProperty("state") SessionState state,
             @JsonProperty("email_address") String emailAddress) {
         this.sessionId = sessionId;
-        this.authenticationRequest = authenticationRequest;
+        this.clientSessionId = clientSessionId;
+        this.authenticationRequests = authenticationRequests;
         this.state = state;
         this.emailAddress = emailAddress;
     }
@@ -46,12 +55,17 @@ public class Session {
         return sessionId;
     }
 
-    public Map<String, List<String>> getAuthenticationRequest() {
-        return authenticationRequest;
+    public String getClientSessionId() {
+        return clientSessionId;
     }
 
-    public Session setAuthenticationRequest(Map<String, List<String>> authenticationRequest) {
-        this.authenticationRequest = authenticationRequest;
+    public Map<String, Map<String, List<String>>> getAuthenticationRequests() {
+        return authenticationRequests;
+    }
+
+    public Session addClientSessionAuthorisationRequest(
+            String clientSessionId, Map<String, List<String>> authRequest) {
+        authenticationRequests.put(clientSessionId, authRequest);
         return this;
     }
 

--- a/serverless/lambda/src/main/java/uk/gov/di/services/SessionService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/SessionService.java
@@ -33,7 +33,7 @@ public class SessionService {
     }
 
     public Session createSession() {
-        return new Session(IdGenerator.generate());
+        return new Session(IdGenerator.generate(), IdGenerator.generate());
     }
 
     public void save(Session session) {

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/AuthorisationHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/AuthorisationHandlerTest.java
@@ -49,7 +49,7 @@ class AuthorisationHandlerTest {
     void shouldRedirectToLoginOnSuccess() {
         AuthorizationCode authCode = new AuthorizationCode();
         final URI loginUrl = URI.create("http://example.com");
-        final Session session = new Session("a-session-id");
+        final Session session = new Session("a-session-id", "client-session-id");
 
         when(clientService.getErrorForAuthorizationRequest(any(AuthorizationRequest.class)))
                 .thenReturn(Optional.empty());

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/CheckUserExistsHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/CheckUserExistsHandlerTest.java
@@ -132,6 +132,6 @@ class CheckUserExistsHandlerTest {
 
     private void usingValidSession() {
         when(sessionService.getSessionFromRequestHeaders(anyMap()))
-                .thenReturn(Optional.of(new Session("a-session-id")));
+                .thenReturn(Optional.of(new Session("a-session-id", "client-session-id")));
     }
 }

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/LoginHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/LoginHandlerTest.java
@@ -123,6 +123,6 @@ class LoginHandlerTest {
 
     private void usingValidSession() {
         when(sessionService.getSessionFromRequestHeaders(anyMap()))
-                .thenReturn(Optional.of(new Session("a-session-id")));
+                .thenReturn(Optional.of(new Session("a-session-id", "client-session-id")));
     }
 }

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/MfaHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/MfaHandlerTest.java
@@ -105,6 +105,9 @@ public class MfaHandlerTest {
 
     private void usingValidSession(String email) {
         when(sessionService.getSessionFromRequestHeaders(anyMap()))
-                .thenReturn(Optional.of(new Session("a-session-id").setEmailAddress(email)));
+                .thenReturn(
+                        Optional.of(
+                                new Session("a-session-id", "client-session-id")
+                                        .setEmailAddress(email)));
     }
 }

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/SendNotificationHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/SendNotificationHandlerTest.java
@@ -143,7 +143,10 @@ class SendNotificationHandlerTest {
         when(validationService.validateEmailAddress(eq("joe.bloggs")))
                 .thenReturn(Optional.of(ErrorResponse.ERROR_1004));
         when(sessionService.getSessionFromRequestHeaders(anyMap()))
-                .thenReturn(Optional.of(new Session("a-session-id").setEmailAddress("joe.bloggs")));
+                .thenReturn(
+                        Optional.of(
+                                new Session("a-session-id", "client-session-id")
+                                        .setEmailAddress("joe.bloggs")));
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setHeaders(Map.of("Session-Id", "a-session-id"));
         event.setBody(
@@ -263,7 +266,8 @@ class SendNotificationHandlerTest {
         when(sessionService.getSessionFromRequestHeaders(anyMap()))
                 .thenReturn(
                         Optional.of(
-                                new Session("a-session-id").setEmailAddress(TEST_EMAIL_ADDRESS)));
+                                new Session("a-session-id", "client-session-id")
+                                        .setEmailAddress(TEST_EMAIL_ADDRESS)));
     }
 
     private boolean isSessionWithEmailSent(Session session) {

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/SignUpHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/SignUpHandlerTest.java
@@ -137,6 +137,6 @@ class SignUpHandlerTest {
 
     private void usingValidSession() {
         when(sessionService.getSessionFromRequestHeaders(anyMap()))
-                .thenReturn(Optional.of(new Session("a-session-id")));
+                .thenReturn(Optional.of(new Session("a-session-id", "client-session-id")));
     }
 }

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/UpdateProfileHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/UpdateProfileHandlerTest.java
@@ -82,6 +82,7 @@ class UpdateProfileHandlerTest {
         when(sessionService.getSessionFromRequestHeaders(anyMap()))
                 .thenReturn(
                         Optional.of(
-                                new Session("a-session-id").setEmailAddress(TEST_EMAIL_ADDRESS)));
+                                new Session("a-session-id", "client-session-id")
+                                        .setEmailAddress(TEST_EMAIL_ADDRESS)));
     }
 }

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/VerifyCodeRequestHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/VerifyCodeRequestHandlerTest.java
@@ -53,7 +53,8 @@ class VerifyCodeRequestHandlerTest {
     private final DynamoService dynamoService = mock(DynamoService.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final ValidationService validationService = mock(ValidationService.class);
-    private final Session session = new Session("session-id").setEmailAddress(TEST_EMAIL_ADDRESS);
+    private final Session session =
+            new Session("session-id", "client-session-id").setEmailAddress(TEST_EMAIL_ADDRESS);
     private VerifyCodeHandler handler;
 
     @BeforeEach


### PR DESCRIPTION
## What?

- Session should now include an active clientSessionId field
- Authentication requests should be stored as map using clientSessionId as the key

## Why?

We need to re-structure the session object in order to support SSO (logging into additional services without needing to re-authenticate)
