### PR TITLE
GOVSI-494: add additional session cookie attributes

### DIFF
--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/AuthorisationHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/AuthorisationHandler.java
@@ -118,7 +118,10 @@ public class AuthorisationHandler
                                 ResponseHeaders.LOCATION,
                                 buildLocationString(scope, session),
                                 ResponseHeaders.SET_COOKIE,
-                                buildCookieString(session)));
+                                buildCookieString(
+                                        session,
+                                        configurationService.getSessionCookieMaxAge(),
+                                        configurationService.getSessionCookieAttributes())));
     }
 
     private APIGatewayProxyResponseEvent errorResponse(
@@ -143,18 +146,13 @@ public class AuthorisationHandler
         return format(
                 "%s?%s&%s",
                 configurationService.getLoginURI(),
-                buildEncodedParam(
-                        ResponseParameters.SESSION_ID,
-                        session.getSessionId()),
-                buildEncodedParam(
-                        ResponseParameters.SCOPE, scope.toString()));
+                buildEncodedParam(ResponseParameters.SESSION_ID, session.getSessionId()),
+                buildEncodedParam(ResponseParameters.SCOPE, scope.toString()));
     }
 
-    private String buildCookieString(Session session) {
+    private String buildCookieString(Session session, Integer maxAge, String attributes) {
         return format(
-                "%s=%s.%s",
-                "gs",
-                session.getSessionId(),
-                session.getClientSessionId());
+                "%s=%s.%s; Max-Age=%d; %s",
+                "gs", session.getSessionId(), session.getClientSessionId(), maxAge, attributes);
     }
 }

--- a/serverless/lambda/src/main/java/uk/gov/di/services/ConfigurationService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/ConfigurationService.java
@@ -83,4 +83,13 @@ public class ConfigurationService {
     public int getCodeMaxRetries() {
         return Integer.parseInt(System.getenv().getOrDefault("CODE_MAX_RETRIES", "5"));
     }
+
+    public int getSessionCookieMaxAge() {
+        return Integer.parseInt(System.getenv().getOrDefault("SESSION_COOKIE_MAX_AGE", "1800"));
+    }
+
+    public String getSessionCookieAttributes() {
+        return Optional.ofNullable(System.getenv("SESSION_COOKIE_ATTRIBUTES"))
+                .orElse("Secure; HttpOnly;");
+    }
 }

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/AuthorisationHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/AuthorisationHandlerTest.java
@@ -55,6 +55,8 @@ class AuthorisationHandlerTest {
                 .thenReturn(Optional.empty());
         when(configService.getLoginURI()).thenReturn(loginUrl);
         when(sessionService.createSession()).thenReturn(session);
+        when(configService.getSessionCookieAttributes()).thenReturn("Secure; HttpOnly;");
+        when(configService.getSessionCookieMaxAge()).thenReturn(1800);
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setQueryStringParameters(
@@ -68,7 +70,8 @@ class AuthorisationHandlerTest {
         URI uri = URI.create(response.getHeaders().get("Location"));
         Map<String, String> requestParams = RequestBodyHelper.PARSE_REQUEST_BODY(uri.getQuery());
 
-        final String expectedCookieString = "gs=a-session-id.client-session-id";
+        final String expectedCookieString =
+                "gs=a-session-id.client-session-id; Max-Age=1800; Secure; HttpOnly;";
 
         assertThat(response, hasStatus(302));
         assertEquals(loginUrl.getAuthority(), uri.getAuthority());

--- a/serverless/lambda/src/test/java/uk/gov/di/services/ConfigurationServiceTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/services/ConfigurationServiceTest.java
@@ -1,0 +1,20 @@
+package uk.gov.di.services;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ConfigurationServiceTest {
+
+    @Test
+    void sessionCookieMaxAgeShouldEqualDefaultWhenEnvVarUnset() {
+        ConfigurationService configurationService = new ConfigurationService();
+        assertEquals(1800, configurationService.getSessionCookieMaxAge());
+    }
+
+    @Test
+    void getSessionCookieAttributesShouldEqualDefaultWhenEnvVarUnset() {
+        ConfigurationService configurationService = new ConfigurationService();
+        assertEquals("Secure; HttpOnly;", configurationService.getSessionCookieAttributes());
+    }
+}


### PR DESCRIPTION
## What?

Add additional session cookie attributes.

## Why?

Attributes required for increased security.
The attributes must be configurable because they will not work in the current dev and test environments where the application is split across different domains.