### PR TITLE
BAU: Refactor out `RequestHelper` in integration tests

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
@@ -4,18 +4,11 @@ import com.nimbusds.oauth2.sdk.AuthorizationRequest;
 import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.id.State;
-import jakarta.ws.rs.client.Client;
-import jakarta.ws.rs.client.ClientBuilder;
-import jakarta.ws.rs.client.Entity;
-import jakarta.ws.rs.client.Invocation;
-import jakarta.ws.rs.client.WebTarget;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.MultivaluedHashMap;
-import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.helpers.DynamoHelper;
 import uk.gov.di.authentication.helpers.RedisHelper;
+import uk.gov.di.authentication.helpers.RequestHelper;
 import uk.gov.di.entity.AuthCodeRequest;
 
 import java.io.IOException;
@@ -46,15 +39,8 @@ public class AuthCodeIntegrationTest extends IntegrationTestEndpoints {
                 clientSessionId, sessionId, generateAuthRequest().toParameters());
         setUpDynamo(keyPair);
 
-        Client client = ClientBuilder.newClient();
-        WebTarget webTarget = client.target(ROOT_RESOURCE_URL + AUTH_CODE_ENDPOINT);
-        Invocation.Builder invocationBuilder = webTarget.request(MediaType.APPLICATION_JSON);
-        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
-        headers.add("Session-Id", sessionId);
         Response response =
-                invocationBuilder
-                        .headers(headers)
-                        .post(Entity.entity(authCodeRequest, MediaType.APPLICATION_JSON));
+                RequestHelper.requestWithSession(AUTH_CODE_ENDPOINT, authCodeRequest, sessionId);
 
         assertEquals(302, response.getStatus());
     }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientRegistrationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientRegistrationIntegrationTest.java
@@ -2,14 +2,10 @@ package uk.gov.di.authentication.api;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.client.Entity;
-import jakarta.ws.rs.client.Invocation;
-import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.MultivaluedHashMap;
-import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.helpers.DynamoHelper;
@@ -34,23 +30,19 @@ public class ClientRegistrationIntegrationTest extends IntegrationTestEndpoints 
                         singletonList("test-client@test.com"),
                         "public-key",
                         singletonList("openid"));
-        Response response = sendRequest(clientRequest);
+
+        Response response =
+                ClientBuilder.newClient()
+                        .target(ROOT_RESOURCE_URL + REGISTER_ENDPOINT)
+                        .request(MediaType.APPLICATION_JSON)
+                        .headers(new MultivaluedHashMap<>())
+                        .post(Entity.entity(clientRequest, MediaType.APPLICATION_JSON));
+
         ClientRegistrationResponse clientResponse =
                 objectMapper.readValue(
                         response.readEntity(String.class), ClientRegistrationResponse.class);
 
         assertEquals(200, response.getStatus());
         assertTrue(DynamoHelper.clientExists(clientResponse.getClientId()));
-    }
-
-    private Response sendRequest(ClientRegistrationRequest clientRequest) {
-        Client client = ClientBuilder.newClient();
-        WebTarget webTarget = client.target(ROOT_RESOURCE_URL + REGISTER_ENDPOINT);
-        Invocation.Builder invocationBuilder = webTarget.request(MediaType.APPLICATION_JSON);
-        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
-
-        return invocationBuilder
-                .headers(headers)
-                .post(Entity.entity(clientRequest, MediaType.APPLICATION_JSON));
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IntegrationTestEndpoints.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IntegrationTestEndpoints.java
@@ -7,7 +7,7 @@ public class IntegrationTestEndpoints {
             "http://localhost:45678/restapis/%s/local/_user_request_";
     protected static final String LOCAL_API_GATEWAY_ID =
             Optional.ofNullable(System.getenv().get("API_GATEWAY_ID")).orElse("");
-    protected static final String ROOT_RESOURCE_URL =
+    public static final String ROOT_RESOURCE_URL =
             Optional.ofNullable(System.getenv().get("ROOT_RESOURCE_URL"))
                     .orElse(String.format(LOCAL_ENDPOINT_FORMAT, LOCAL_API_GATEWAY_ID));
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
@@ -1,18 +1,11 @@
 package uk.gov.di.authentication.api;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.ws.rs.client.Client;
-import jakarta.ws.rs.client.ClientBuilder;
-import jakarta.ws.rs.client.Entity;
-import jakarta.ws.rs.client.Invocation;
-import jakarta.ws.rs.client.WebTarget;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.MultivaluedHashMap;
-import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.helpers.DynamoHelper;
 import uk.gov.di.authentication.helpers.RedisHelper;
+import uk.gov.di.authentication.helpers.RequestHelper;
 import uk.gov.di.entity.LoginRequest;
 import uk.gov.di.entity.LoginResponse;
 
@@ -33,19 +26,11 @@ public class LoginIntegrationTest extends IntegrationTestEndpoints {
         String phoneNumber = "01234567890";
         DynamoHelper.signUp(email, password);
         DynamoHelper.addPhoneNumber(email, phoneNumber);
-        Client client = ClientBuilder.newClient();
-        WebTarget webTarget = client.target(ROOT_RESOURCE_URL + LOGIN_ENDPOINT);
         String sessionId = RedisHelper.createSession();
-        Invocation.Builder invocationBuilder = webTarget.request(MediaType.APPLICATION_JSON);
-        MultivaluedMap headers = new MultivaluedHashMap();
-        headers.add("Session-Id", sessionId);
-
-        LoginRequest request = new LoginRequest(email, password);
 
         Response response =
-                invocationBuilder
-                        .headers(headers)
-                        .post(Entity.entity(request, MediaType.APPLICATION_JSON));
+                RequestHelper.requestWithSession(
+                        LOGIN_ENDPOINT, new LoginRequest(email, password), sessionId);
 
         assertEquals(200, response.getStatus());
 
@@ -60,18 +45,11 @@ public class LoginIntegrationTest extends IntegrationTestEndpoints {
         String email = "joe.bloggs+4@digital.cabinet-office.gov.uk";
         String password = "password-1";
         DynamoHelper.signUp(email, "wrong-password");
-        Client client = ClientBuilder.newClient();
-        WebTarget webTarget = client.target(ROOT_RESOURCE_URL + LOGIN_ENDPOINT);
         String sessionId = RedisHelper.createSession();
-        Invocation.Builder invocationBuilder = webTarget.request(MediaType.APPLICATION_JSON);
-        MultivaluedMap headers = new MultivaluedHashMap();
-        headers.add("Session-Id", sessionId);
 
-        LoginRequest request = new LoginRequest(email, password);
         Response response =
-                invocationBuilder
-                        .headers(headers)
-                        .post(Entity.entity(request, MediaType.APPLICATION_JSON));
+                RequestHelper.requestWithSession(
+                        LOGIN_ENDPOINT, new LoginRequest(email, password), sessionId);
 
         assertEquals(401, response.getStatus());
     }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/SignupIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/SignupIntegrationTest.java
@@ -1,18 +1,11 @@
 package uk.gov.di.authentication.api;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.ws.rs.client.Client;
-import jakarta.ws.rs.client.ClientBuilder;
-import jakarta.ws.rs.client.Entity;
-import jakarta.ws.rs.client.Invocation;
-import jakarta.ws.rs.client.WebTarget;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.MultivaluedHashMap;
-import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.helpers.DynamoHelper;
 import uk.gov.di.authentication.helpers.RedisHelper;
+import uk.gov.di.authentication.helpers.RequestHelper;
 import uk.gov.di.entity.BaseAPIResponse;
 import uk.gov.di.entity.SignupRequest;
 
@@ -29,20 +22,12 @@ public class SignupIntegrationTest extends IntegrationTestEndpoints {
 
     @Test
     public void shouldCallSignupEndpointAndReturn200() throws IOException {
-        Client client = ClientBuilder.newClient();
-        WebTarget webTarget = client.target(ROOT_RESOURCE_URL + SIGNUP_ENDPOINT);
         String sessionId = RedisHelper.createSession();
-        Invocation.Builder invocationBuilder = webTarget.request(MediaType.APPLICATION_JSON);
-        MultivaluedMap headers = new MultivaluedHashMap();
-        headers.add("Session-Id", sessionId);
 
         SignupRequest request =
                 new SignupRequest("joe.bloggs+5@digital.cabinet-office.gov.uk", "password-1");
 
-        Response response =
-                invocationBuilder
-                        .headers(headers)
-                        .post(Entity.entity(request, MediaType.APPLICATION_JSON));
+        Response response = RequestHelper.requestWithSession(SIGNUP_ENDPOINT, request, sessionId);
 
         assertEquals(200, response.getStatus());
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateProfileIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateProfileIntegrationTest.java
@@ -1,13 +1,5 @@
 package uk.gov.di.authentication.api;
 
-import jakarta.ws.rs.client.Client;
-import jakarta.ws.rs.client.ClientBuilder;
-import jakarta.ws.rs.client.Entity;
-import jakarta.ws.rs.client.Invocation;
-import jakarta.ws.rs.client.WebTarget;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.MultivaluedHashMap;
-import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.helpers.DynamoHelper;
@@ -17,6 +9,7 @@ import uk.gov.di.entity.UpdateProfileRequest;
 import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static uk.gov.di.authentication.helpers.RequestHelper.requestWithSession;
 import static uk.gov.di.entity.UpdateProfileType.ADD_PHONE_NUMBER;
 
 public class UpdateProfileIntegrationTest extends IntegrationTestEndpoints {
@@ -33,19 +26,8 @@ public class UpdateProfileIntegrationTest extends IntegrationTestEndpoints {
         UpdateProfileRequest request =
                 new UpdateProfileRequest(EMAIL_ADDRESS, ADD_PHONE_NUMBER, "0123456789");
 
-        Response response = sendRequest(sessionId, request);
+        Response response = requestWithSession(UPDATE_PROFILE_ENDPOINT, request, sessionId);
+
         assertEquals(200, response.getStatus());
-    }
-
-    private Response sendRequest(String sessionId, UpdateProfileRequest request) {
-        Client client = ClientBuilder.newClient();
-        WebTarget webTarget = client.target(ROOT_RESOURCE_URL + UPDATE_PROFILE_ENDPOINT);
-        Invocation.Builder invocationBuilder = webTarget.request(MediaType.APPLICATION_JSON);
-        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
-        headers.add("Session-Id", sessionId);
-
-        return invocationBuilder
-                .headers(headers)
-                .post(Entity.entity(request, MediaType.APPLICATION_JSON));
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/helpers/RequestHelper.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/helpers/RequestHelper.java
@@ -1,0 +1,24 @@
+package uk.gov.di.authentication.helpers;
+
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
+
+import static uk.gov.di.authentication.api.IntegrationTestEndpoints.ROOT_RESOURCE_URL;
+
+public class RequestHelper {
+
+    public static Response requestWithSession(String endpoint, Object body, String sessionId) {
+        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
+        headers.add("Session-Id", sessionId);
+
+        return ClientBuilder.newClient()
+                .target(ROOT_RESOURCE_URL + endpoint)
+                .request(MediaType.APPLICATION_JSON)
+                .headers(headers)
+                .post(Entity.entity(body, MediaType.APPLICATION_JSON));
+    }
+}


### PR DESCRIPTION
## What?

Create a helper for making API requests with a sessionID.

## Why?

Removes duplication across the integration tests

One-off requests or requests with no session have not been changed.
