### PR TITLE
Add (optional) logout registration URIs to client registration endpoint

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -44,7 +44,8 @@ public class AuthorisationIntegrationTest extends IntegrationTestEndpoints {
                 singletonList("localhost"),
                 singletonList("joe.bloggs@digital.cabinet-office.gov.uk"),
                 singletonList("openid"),
-                Base64.getMimeEncoder().encodeToString(KEY_PAIR.getPublic().getEncoded()));
+                Base64.getMimeEncoder().encodeToString(KEY_PAIR.getPublic().getEncoded()),
+                singletonList("http://localhost/post-redirect-logout"));
     }
 
     @Test

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientRegistrationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientRegistrationIntegrationTest.java
@@ -29,7 +29,8 @@ public class ClientRegistrationIntegrationTest extends IntegrationTestEndpoints 
                         singletonList("http://localhost:1000/redirect"),
                         singletonList("test-client@test.com"),
                         "public-key",
-                        singletonList("openid"));
+                          singletonList("openid"),
+                        singletonList("http://localhost/post-redirect-logout"));
 
         Response response =
                 ClientBuilder.newClient()

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
@@ -73,7 +73,8 @@ public class TokenIntegrationTest extends IntegrationTestEndpoints {
                 singletonList("http://localhost/redirect"),
                 singletonList("joe.bloggs@digital.cabinet-office.gov.uk"),
                 singletonList("openid"),
-                Base64.getMimeEncoder().encodeToString(keyPair.getPublic().getEncoded()));
+                Base64.getMimeEncoder().encodeToString(keyPair.getPublic().getEncoded()),
+                singletonList("http://localhost/post-logout-redirect"));
         DynamoHelper.signUp("joe.bloggs@digital.cabinet-office.gov.uk", "password-1");
     }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/helpers/DynamoHelper.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/helpers/DynamoHelper.java
@@ -36,9 +36,16 @@ public class DynamoHelper {
             List<String> redirectUris,
             List<String> contacts,
             List<String> scopes,
-            String publicKey) {
+            String publicKey,
+            List<String> postLogoutRedirectUris) {
         DYNAMO_CLIENT_SERVICE.addClient(
-                clientID, clientName, redirectUris, contacts, scopes, publicKey);
+                clientID,
+                clientName,
+                redirectUris,
+                contacts,
+                scopes,
+                publicKey,
+                postLogoutRedirectUris);
     }
 
     public static boolean clientExists(String clientID) {

--- a/serverless/lambda/src/main/java/uk/gov/di/entity/ClientRegistrationRequest.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/entity/ClientRegistrationRequest.java
@@ -21,17 +21,23 @@ public class ClientRegistrationRequest {
     @JsonProperty("scopes")
     private List<String> scopes;
 
+    @JsonProperty("post_logout_redirect_uris")
+    private List<String> postLogoutRedirectUris;
+
     public ClientRegistrationRequest(
             @JsonProperty(required = true, value = "client_name") String clientName,
             @JsonProperty(required = true, value = "redirect_uris") List<String> redirectUris,
             @JsonProperty(required = true, value = "contacts") List<String> contacts,
             @JsonProperty(required = true, value = "public_key") String publicKey,
-            @JsonProperty(required = true, value = "scopes") List<String> scopes) {
+            @JsonProperty(required = true, value = "scopes") List<String> scopes,
+            @JsonProperty(value = "post_logout_redirect_uris")
+                    List<String> postLogoutRedirectUris) {
         this.clientName = clientName;
         this.redirectUris = redirectUris;
         this.contacts = contacts;
         this.publicKey = publicKey;
         this.scopes = scopes;
+        this.postLogoutRedirectUris = postLogoutRedirectUris;
     }
 
     public String getClientName() {
@@ -52,5 +58,9 @@ public class ClientRegistrationRequest {
 
     public List<String> getScopes() {
         return scopes;
+    }
+
+    public List<String> getPostLogoutRedirectUris() {
+        return postLogoutRedirectUris;
     }
 }

--- a/serverless/lambda/src/main/java/uk/gov/di/entity/ClientRegistrationResponse.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/entity/ClientRegistrationResponse.java
@@ -18,15 +18,21 @@ public class ClientRegistrationResponse {
     @JsonProperty("contacts")
     private List<String> contacts;
 
+    @JsonProperty("post_logout_redirect_uris")
+    private List<String> postLogoutRedirectUris;
+
     public ClientRegistrationResponse(
             @JsonProperty(required = true, value = "client_name") String clientName,
             @JsonProperty(required = true, value = "client_id") String clientId,
             @JsonProperty(required = true, value = "redirect_uris") List<String> redirectUris,
-            @JsonProperty(required = true, value = "contacts") List<String> contacts) {
+            @JsonProperty(required = true, value = "contacts") List<String> contacts,
+            @JsonProperty(value = "post_logout_redirect_uris")
+                    List<String> postLogoutRedirectUris) {
         this.clientName = clientName;
         this.clientId = clientId;
         this.redirectUris = redirectUris;
         this.contacts = contacts;
+        this.postLogoutRedirectUris = postLogoutRedirectUris;
     }
 
     public String getClientName() {
@@ -43,5 +49,9 @@ public class ClientRegistrationResponse {
 
     public List<String> getContacts() {
         return contacts;
+    }
+
+    public List<String> getPostLogoutRedirectUris() {
+        return postLogoutRedirectUris;
     }
 }

--- a/serverless/lambda/src/main/java/uk/gov/di/entity/ClientRegistry.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/entity/ClientRegistry.java
@@ -10,6 +10,7 @@ public class ClientRegistry {
     private String clientID;
     private String clientName;
     private String publicKey;
+    private List<String> postLogoutRedirectUrls;
     private List<String> scopes;
     private List<String> redirectUrls;
     private List<String> contacts;
@@ -71,6 +72,16 @@ public class ClientRegistry {
 
     public ClientRegistry setContacts(List<String> contacts) {
         this.contacts = contacts;
+        return this;
+    }
+
+    @DynamoDBAttribute(attributeName = "PostLogoutRedirectUrls")
+    public List<String> getPostLogoutRedirectUrls() {
+        return postLogoutRedirectUrls;
+    }
+
+    public ClientRegistry setPostLogoutRedirectUrls(List<String> postLogoutRedirectUrls) {
+        this.postLogoutRedirectUrls = postLogoutRedirectUrls;
         return this;
     }
 }

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/ClientRegistrationHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/ClientRegistrationHandler.java
@@ -48,14 +48,16 @@ public class ClientRegistrationHandler
                     clientRegistrationRequest.getRedirectUris(),
                     clientRegistrationRequest.getContacts(),
                     clientRegistrationRequest.getScopes(),
-                    clientRegistrationRequest.getPublicKey());
+                    clientRegistrationRequest.getPublicKey(),
+                    clientRegistrationRequest.getPostLogoutRedirectUris());
 
             ClientRegistrationResponse clientRegistrationResponse =
                     new ClientRegistrationResponse(
                             clientRegistrationRequest.getClientName(),
                             clientID,
                             clientRegistrationRequest.getRedirectUris(),
-                            clientRegistrationRequest.getContacts());
+                            clientRegistrationRequest.getContacts(),
+                            clientRegistrationRequest.getPostLogoutRedirectUris());
 
             return generateApiGatewayProxyResponse(200, clientRegistrationResponse);
         } catch (JsonProcessingException e) {

--- a/serverless/lambda/src/main/java/uk/gov/di/services/ClientService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/ClientService.java
@@ -19,7 +19,8 @@ public interface ClientService {
             List<String> redirectUris,
             List<String> contacts,
             List<String> scopes,
-            String publicKey);
+            String publicKey,
+            List<String> postLogoutRedirectUris);
 
     Optional<ClientRegistry> getClient(String clientId);
 

--- a/serverless/lambda/src/main/java/uk/gov/di/services/DynamoClientService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/DynamoClientService.java
@@ -62,7 +62,8 @@ public class DynamoClientService implements ClientService {
             List<String> redirectUris,
             List<String> contacts,
             List<String> scopes,
-            String publicKey) {
+            String publicKey,
+            List<String> postLogoutRedirectUris) {
         ClientRegistry clientRegistry =
                 new ClientRegistry()
                         .setClientID(clientID)
@@ -70,7 +71,8 @@ public class DynamoClientService implements ClientService {
                         .setRedirectUrls(redirectUris)
                         .setContacts(contacts)
                         .setScopes(scopes)
-                        .setPublicKey(publicKey);
+                        .setPublicKey(publicKey)
+                        .setPostLogoutRedirectUrls(postLogoutRedirectUris);
         clientRegistryMapper.save(clientRegistry);
     }
 

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/ClientRegistrationHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/ClientRegistrationHandlerTest.java
@@ -18,9 +18,7 @@ import java.util.UUID;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
 import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
@@ -46,8 +44,9 @@ class ClientRegistrationHandlerTest {
         when(clientService.generateClientID()).thenReturn(new ClientID(clientId));
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+
         event.setBody(
-                "{ \"client_name\": \"test-client\", \"redirect_uris\": [\"http://localhost:8080/redirect-uri\"], \"contacts\": [\"joe.bloggs@test.com\"], \"scopes\": [\"openid\"],  \"public_key\": \"some-public-key\"}");
+                "{ \"client_name\": \"test-client\", \"redirect_uris\": [\"http://localhost:8080/redirect-uri\"], \"contacts\": [\"joe.bloggs@test.com\"], \"scopes\": [\"openid\"],  \"public_key\": \"some-public-key\", \"post_logout_redirect_uris\": [\"http://localhost:8080/post-logout-redirect-uri\"]}");
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(200));
@@ -61,7 +60,8 @@ class ClientRegistrationHandlerTest {
                         redirectUris,
                         contacts,
                         singletonList("openid"),
-                        "some-public-key");
+                        "some-public-key",
+                        singletonList("http://localhost:8080/post-logout-redirect-uri"));
     }
 
     @Test


### PR DESCRIPTION
## What?

Add post redirect uris to client register endpoint.

## Why?

To allow the service to support custom logout redirect uris for a client.

