### PR TITLE
GOVSI-494: read session cookie for existing sessions

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -2,16 +2,28 @@ package uk.gov.di.authentication.api;
 
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.Invocation;
+import jakarta.ws.rs.core.Cookie;
 import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.helpers.DynamoHelper;
+import uk.gov.di.authentication.helpers.RedisHelper;
+import uk.gov.di.entity.SessionState;
+import uk.gov.di.services.ConfigurationService;
 
+import java.io.IOException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
+import java.util.Optional;
 
+import static java.lang.String.format;
 import static java.util.Collections.singletonList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -19,39 +31,87 @@ public class AuthorisationIntegrationTest extends IntegrationTestEndpoints {
 
     private static final String AUTHORIZE_ENDPOINT = "/authorize";
 
-    @Test
-    public void shouldSetCookieAndReturn302WhenAuthorisationSucceeds() {
+    private static final String CLIENT_ID = "test-client";
+    private static final KeyPair KEY_PAIR = generateRsaKeyPair();
 
-        String clientID = "test-client";
-        KeyPair keyPair = generateRsaKeyPair();
-        setUpDynamo(keyPair, clientID);
+    private static final ConfigurationService configurationService = new ConfigurationService();
 
-        Client client = ClientBuilder.newClient();
-        Response response =
-                client.target(ROOT_RESOURCE_URL + AUTHORIZE_ENDPOINT)
-                        .queryParam("response_type", "code")
-                        .queryParam("redirect_uri", "localhost")
-                        .queryParam("state", "8VAVNSxHO1HwiNDhwchQKdd7eOUK3ltKfQzwPDxu9LU")
-                        .queryParam("client_id", "test-client")
-                        .queryParam("scope", "openid")
-                        .request()
-                        .get();
-
-        assertEquals(302, response.getStatus());
-        assertNotNull(response.getCookies().get("gs"));
-    }
-
-    private void setUpDynamo(KeyPair keyPair, String clientID) {
+    @BeforeAll
+    public static void setup() {
         DynamoHelper.registerClient(
-                clientID,
+                CLIENT_ID,
                 "test-client",
                 singletonList("localhost"),
                 singletonList("joe.bloggs@digital.cabinet-office.gov.uk"),
                 singletonList("openid"),
-                Base64.getMimeEncoder().encodeToString(keyPair.getPublic().getEncoded()));
+                Base64.getMimeEncoder().encodeToString(KEY_PAIR.getPublic().getEncoded()));
     }
 
-    private KeyPair generateRsaKeyPair() {
+    @Test
+    public void shouldRedirectToLoginWhenNoCookie() {
+        Response response = doAuthorisationRequest(Optional.empty());
+
+        assertEquals(302, response.getStatus());
+        assertThat(
+                response.getHeaders().get("Location").get(0).toString(),
+                startsWith(configurationService.getLoginURI().toString()));
+        assertNotNull(response.getCookies().get("gs"));
+    }
+
+    @Test
+    public void shouldRedirectToLoginWhenBadCookie() {
+        Response response = doAuthorisationRequest(Optional.of(new Cookie("gs", "this is bad")));
+
+        assertEquals(302, response.getStatus());
+        assertThat(
+                response.getHeaders().get("Location").get(0).toString(),
+                startsWith(configurationService.getLoginURI().toString()));
+        assertNotNull(response.getCookies().get("gs"));
+    }
+
+    @Test
+    public void shouldRedirectToLoginWhenCookieHasUnknownSessionId() {
+        Response response = doAuthorisationRequest(Optional.of(new Cookie("gs", "123.456")));
+
+        assertEquals(302, response.getStatus());
+        assertThat(
+                response.getHeaders().get("Location").get(0).toString(),
+                startsWith(configurationService.getLoginURI().toString()));
+        assertNotNull(response.getCookies().get("gs"));
+    }
+
+    @Test
+    public void shouldRedirectToLoginWhenSessionFromCookieIsNotAuthenticated() throws IOException {
+        String sessionId = RedisHelper.createSession();
+        RedisHelper.setSessionState(sessionId, SessionState.AUTHENTICATION_REQUIRED);
+
+        Response response =
+                doAuthorisationRequest(Optional.of(new Cookie("gs", format("%s.456", sessionId))));
+
+        assertEquals(302, response.getStatus());
+        assertThat(
+                response.getHeaders().get("Location").get(0).toString(),
+                startsWith(configurationService.getLoginURI().toString()));
+        assertNotNull(response.getCookies().get("gs"));
+        assertThat(response.getCookies().get("gs").getValue(), not(startsWith(sessionId)));
+    }
+
+    @Test
+    public void shouldIssueAuthorisationCodeWhenSessionFromCookieIsAuthenticated()
+            throws IOException {
+        String sessionId = RedisHelper.createSession();
+        RedisHelper.setSessionState(sessionId, SessionState.AUTHENTICATED);
+
+        Response response =
+                doAuthorisationRequest(Optional.of(new Cookie("gs", format("%s.456", sessionId))));
+
+        assertEquals(302, response.getStatus());
+        // TODO: Update assertions to reflect code issuance, once we've written that code
+        assertNotNull(response.getCookies().get("gs"));
+        assertThat(response.getCookies().get("gs").getValue(), not(startsWith(sessionId)));
+    }
+
+    private static KeyPair generateRsaKeyPair() {
         KeyPairGenerator kpg;
         try {
             kpg = KeyPairGenerator.getInstance("RSA");
@@ -60,5 +120,22 @@ public class AuthorisationIntegrationTest extends IntegrationTestEndpoints {
         }
         kpg.initialize(2048);
         return kpg.generateKeyPair();
+    }
+
+    private Response doAuthorisationRequest(Optional<Cookie> cookie) {
+        Client client = ClientBuilder.newClient();
+
+        Invocation.Builder builder =
+                client.target(ROOT_RESOURCE_URL + AUTHORIZE_ENDPOINT)
+                        .queryParam("response_type", "code")
+                        .queryParam("redirect_uri", "localhost")
+                        .queryParam("state", "8VAVNSxHO1HwiNDhwchQKdd7eOUK3ltKfQzwPDxu9LU")
+                        .queryParam("client_id", "test-client")
+                        .queryParam("scope", "openid")
+                        .request();
+
+        cookie.ifPresent(builder::cookie);
+
+        return builder.get();
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/helpers/RedisHelper.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/helpers/RedisHelper.java
@@ -2,6 +2,7 @@ package uk.gov.di.authentication.helpers;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import uk.gov.di.entity.Session;
+import uk.gov.di.entity.SessionState;
 import uk.gov.di.helpers.IdGenerator;
 import uk.gov.di.services.CodeGeneratorService;
 import uk.gov.di.services.CodeStorageService;
@@ -61,6 +62,19 @@ public class RedisHelper {
             redis.saveWithExpiry(
                     session.getSessionId(), new ObjectMapper().writeValueAsString(session), 1800);
 
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void setSessionState(String sessionId, SessionState state) {
+        try (RedisConnectionService redis =
+                new RedisConnectionService(REDIS_HOST, 6379, false, REDIS_PASSWORD)) {
+            Session session =
+                    new ObjectMapper().readValue(redis.getValue(sessionId), Session.class);
+            session.setState(state);
+            redis.saveWithExpiry(
+                    session.getSessionId(), new ObjectMapper().writeValueAsString(session), 1800);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -64,6 +64,8 @@ if [[ ${RUN_INTEGRATION} -eq 1 ]]; then
   export AWS_ACCESS_KEY_ID="mock-access-key"
   export AWS_SECRET_ACCESS_KEY="mock-secret-key"
   export STUB_RELYING_PARTY_REDIRECT_URI="https://di-auth-stub-relying-party-build.london.cloudapps.digital/"
+  export LOGIN_URI="https://di-authentication-frontend.london.cloudapps.digital/"
+
   startup
 
   set +e

--- a/serverless/lambda/src/main/java/uk/gov/di/entity/Session.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/entity/Session.java
@@ -55,6 +55,10 @@ public class Session {
         return sessionId;
     }
 
+    public void setSessionId(String sessionId) {
+        this.sessionId = sessionId;
+    }
+
     public String getClientSessionId() {
         return clientSessionId;
     }

--- a/serverless/lambda/src/main/java/uk/gov/di/services/SessionService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/SessionService.java
@@ -1,15 +1,23 @@
 package uk.gov.di.services;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import uk.gov.di.entity.Session;
 import uk.gov.di.helpers.IdGenerator;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class SessionService {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(SessionService.class);
+
     private static final String SESSION_ID_HEADER = "Session-Id";
+    public static final String REQUEST_COOKIE_HEADER = "Cookie";
+
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private final ConfigurationService configurationService;
@@ -47,18 +55,71 @@ public class SessionService {
         }
     }
 
+    public void updateSessionId(Session session) {
+        try {
+
+            String oldSessionId = session.getSessionId();
+            session.setSessionId(IdGenerator.generate());
+            save(session);
+            redisConnectionService.deleteValue(oldSessionId);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     public Optional<Session> getSessionFromRequestHeaders(Map<String, String> headers) {
         if (headers == null || headers.isEmpty() || !headers.containsKey(SESSION_ID_HEADER)) {
             return Optional.empty();
         }
         try {
             String sessionId = headers.get(SESSION_ID_HEADER);
+            return readSessionFromRedis(sessionId);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public Optional<Session> getSessionFromSessionCookie(Map<String, String> headers) {
+        if (headers == null
+                || headers.isEmpty()
+                || !headers.containsKey(REQUEST_COOKIE_HEADER)
+                || headers.get(REQUEST_COOKIE_HEADER).isEmpty()) {
+            return Optional.empty();
+        }
+
+        final String COOKIE_REGEX = "gs=(?<sid>[^.;]+)\\.(?<csid>[^.;]+);";
+
+        try {
+            String cookies = headers.getOrDefault(REQUEST_COOKIE_HEADER, "");
+
+            LOGGER.debug("Session Cookie: {}", cookies);
+
+            Matcher cookiesMatcher = Pattern.compile(COOKIE_REGEX).matcher(cookies);
+            Optional<String> sid = Optional.empty();
+
+            try {
+                if (cookiesMatcher.find()) {
+                    sid = Optional.ofNullable(cookiesMatcher.group("sid"));
+                }
+            } catch (IllegalStateException | IllegalArgumentException ise) {
+                LOGGER.error("Unable to parse Session Cookie: {}", ise.getMessage());
+                return Optional.empty();
+            }
+            return sid.flatMap(this::readSessionFromRedis);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Optional<Session> readSessionFromRedis(String sessionId) {
+        try {
             if (redisConnectionService.keyExists(sessionId)) {
                 return Optional.of(
                         OBJECT_MAPPER.readValue(
                                 redisConnectionService.getValue(sessionId), Session.class));
+            } else {
+                return Optional.empty();
             }
-            return Optional.empty();
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/serverless/lambda/src/test/java/uk/gov/di/services/SessionServiceTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/services/SessionServiceTest.java
@@ -6,14 +6,22 @@ import uk.gov.di.entity.Session;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.services.SessionService.REQUEST_COOKIE_HEADER;
 
 class SessionServiceTest {
 
@@ -80,5 +88,71 @@ class SessionServiceTest {
                 sessionService.getSessionFromRequestHeaders(Map.of("Session-Id", "session-id"));
 
         assertTrue(session.isEmpty());
+    }
+
+    @Test
+    void
+            shouldReturnOptionalEmptyWhenGetSessionFromSessionCookieCalledWithIncorrectCookieHeaderValues() {
+        assertEquals(Optional.empty(), sessionService.getSessionFromSessionCookie(Map.of()));
+        assertEquals(
+                Optional.empty(),
+                sessionService.getSessionFromSessionCookie(
+                        Map.ofEntries(Map.entry("header", "value"))));
+        assertEquals(
+                Optional.empty(),
+                sessionService.getSessionFromSessionCookie(
+                        Map.ofEntries(Map.entry(REQUEST_COOKIE_HEADER, ""))));
+        assertEquals(
+                Optional.empty(),
+                sessionService.getSessionFromSessionCookie(
+                        Map.ofEntries(Map.entry(REQUEST_COOKIE_HEADER, "gs=this is bad"))));
+        assertEquals(
+                Optional.empty(),
+                sessionService.getSessionFromSessionCookie(
+                        Map.ofEntries(Map.entry(REQUEST_COOKIE_HEADER, "gs=no-semi-colon.123"))));
+        assertEquals(
+                Optional.empty(),
+                sessionService.getSessionFromSessionCookie(
+                        Map.ofEntries(Map.entry(REQUEST_COOKIE_HEADER, "gs=no-dot;"))));
+    }
+
+    @Test
+    void shouldReturnSessionFromSessionCookieCalledWithValidCookieHeaderValues() {
+        String serialisedSession =
+                "{\"session_id\":\"session-id\",\"client_session_id\":\"client-session-id\",\"authentication_requests\":{\"client-session-id\":{\"client_id\":[\"a-client-id\"]}},\"state\":\"NEW\",\"email_address\":null,\"retry_count\":0}";
+
+        when(redis.keyExists("session-id")).thenReturn(true);
+        when(redis.getValue("session-id")).thenReturn(serialisedSession);
+
+        Optional<Session> session =
+                sessionService.getSessionFromSessionCookie(
+                        Map.ofEntries(Map.entry(REQUEST_COOKIE_HEADER, "gs=session-id.456;")));
+
+        assertTrue(session.isPresent());
+        assertEquals("session-id", session.get().getSessionId());
+    }
+
+    @Test
+    void shouldNotReturnSessionFromSessionCookieCalledWithMissingSessionId() {
+        when(redis.keyExists("session-id")).thenReturn(false);
+        Optional<Session> session =
+                sessionService.getSessionFromSessionCookie(
+                        Map.ofEntries(Map.entry(REQUEST_COOKIE_HEADER, "gs=session-id.456;")));
+
+        assertFalse(session.isPresent());
+    }
+
+    @Test
+    void shouldUpdateSessionIdInRedisAndDeleteOldKey() {
+        var session =
+                new Session("session-id", "client-session-id")
+                        .addClientSessionAuthorisationRequest(
+                                "client-session-id", Map.of("client_id", List.of("a-client-id")));
+
+        sessionService.save(session);
+        sessionService.updateSessionId(session);
+
+        verify(redis, times(2)).saveWithExpiry(anyString(), anyString(), anyLong());
+        verify(redis).deleteValue("session-id");
     }
 }


### PR DESCRIPTION
## What?

Read session cookie for existing sessions.

The session cookie is first set by /authorize when an a user is not logged-in.  If they subsequently try to login (again) to another service then:

- Read the existing session cookie.
- Generate a new session id.
- Update the existing session with the new id in Redis.
- Delete the old session key from Redis.
- Redirect back to the application with the new session cookie.

Added integration and unit tests.

Changes will be made to the redirect when the complete login flow is available in the application.

## Why?

Support SSO to multiple services.

## Related PRs

#175 
#177 
