### PR TITLE
GOVSI-523 - Create bones for the Logout lambda

### DIFF
--- a/ci/terraform/aws/api-gateway.tf
+++ b/ci/terraform/aws/api-gateway.tf
@@ -43,6 +43,7 @@ resource "aws_api_gateway_deployment" "deployment" {
       module.verify_code.resource_id,
       module.mfa.resource_id,
       module.auth-code.resource_id,
+      module.logout.resource_id,
     ]))
   }
 
@@ -63,6 +64,7 @@ resource "aws_api_gateway_deployment" "deployment" {
     module.verify_code,
     module.mfa,
     module.auth-code,
+    module.logout,
   ]
 }
 
@@ -85,6 +87,7 @@ resource "aws_api_gateway_stage" "endpoint_stage" {
     module.verify_code,
     module.mfa,
     module.auth-code,
+    module.logout,
     aws_api_gateway_deployment.deployment,
   ]
 }

--- a/ci/terraform/aws/logout.tf
+++ b/ci/terraform/aws/logout.tf
@@ -1,0 +1,37 @@
+module "logout" {
+  source = "../modules/endpoint-module"
+
+  endpoint_name   = "logout"
+  endpoint_method = "GET"
+  environment     = var.environment
+
+  handler_environment_variables = {
+    DEFAULT_LOGOUT_URI = "https://www.gov.uk/"
+    BASE_URL       = local.api_base_url
+    REDIS_HOST     = var.use_localstack ? var.external_redis_host : aws_elasticache_replication_group.sessions_store[0].primary_endpoint_address
+    REDIS_PORT     = var.use_localstack ? var.external_redis_port : aws_elasticache_replication_group.sessions_store[0].port
+    REDIS_PASSWORD = var.use_localstack ? var.external_redis_password : random_password.redis_password.result
+    REDIS_TLS      = var.redis_use_tls
+    ENVIRONMENT    = var.environment
+    DYNAMO_ENDPOINT = var.use_localstack ? var.lambda_dynamo_endpoint : null
+  }
+  handler_function_name = "uk.gov.di.lambdas.LogoutHandler::handleRequest"
+
+  rest_api_id               = aws_api_gateway_rest_api.di_authentication_api.id
+  root_resource_id          = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
+  execution_arn             = aws_api_gateway_rest_api.di_authentication_api.execution_arn
+  api_deployment_stage_name = var.api_deployment_stage_name
+  lambda_zip_file           = var.lambda_zip_file
+  security_group_id         = aws_vpc.authentication.default_security_group_id
+  subnet_id                 = aws_subnet.authentication.*.id
+  lambda_role_arn           = aws_iam_role.lambda_iam_role.arn
+
+  depends_on = [
+    aws_api_gateway_rest_api.di_authentication_api,
+    aws_api_gateway_resource.connect_resource,
+    aws_api_gateway_resource.wellknown_resource,
+    aws_vpc.authentication,
+    aws_subnet.authentication,
+    aws_elasticache_replication_group.sessions_store,
+  ]
+}

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
@@ -61,7 +61,8 @@ public class AuthCodeIntegrationTest extends IntegrationTestEndpoints {
                 singletonList(REDIRECT_URI.toString()),
                 singletonList("joe.bloggs@digital.cabinet-office.gov.uk"),
                 singletonList("openid"),
-                Base64.getMimeEncoder().encodeToString(keyPair.getPublic().getEncoded()));
+                Base64.getMimeEncoder().encodeToString(keyPair.getPublic().getEncoded()),
+                singletonList("http://localhost/post-redirect-logout"));
     }
 
     private KeyPair generateRsaKeyPair() {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientRegistrationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientRegistrationIntegrationTest.java
@@ -29,7 +29,7 @@ public class ClientRegistrationIntegrationTest extends IntegrationTestEndpoints 
                         singletonList("http://localhost:1000/redirect"),
                         singletonList("test-client@test.com"),
                         "public-key",
-                          singletonList("openid"),
+                        singletonList("openid"),
                         singletonList("http://localhost/post-redirect-logout"));
 
         Response response =

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
@@ -1,0 +1,40 @@
+package uk.gov.di.authentication.api;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.id.Subject;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.helpers.IDTokenGenerator;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class LogoutIntegrationTest extends IntegrationTestEndpoints {
+
+    private static final String LOGOUT_ENDPOINT = "/logout";
+
+    @Test
+    public void shouldReturn302AndRedirectToDefaultLogoutUri() throws JOSEException {
+        RSAKey signingKey =
+                new RSAKeyGenerator(2048).keyID(UUID.randomUUID().toString()).generate();
+        SignedJWT signedJWT =
+                IDTokenGenerator.generateIDToken(
+                        "client-id", new Subject(), "http://localhost/issuer", signingKey);
+        Client client = ClientBuilder.newClient();
+        Response response =
+                client.target(ROOT_RESOURCE_URL + LOGOUT_ENDPOINT)
+                        .queryParam("id_token_hint", signedJWT.serialize())
+                        .queryParam("post_logout_redirect_uri", "http://localhost/redirect")
+                        .queryParam("state", "8VAVNSxHO1HwiNDhwchQKdd7eOUK3ltKfQzwPDxu9LU")
+                        .request()
+                        .get();
+
+        assertEquals(302, response.getStatus());
+    }
+}

--- a/serverless/lambda/src/main/java/uk/gov/di/helpers/IDTokenGenerator.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/helpers/IDTokenGenerator.java
@@ -1,0 +1,46 @@
+package uk.gov.di.helpers;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.oauth2.sdk.id.Audience;
+import com.nimbusds.oauth2.sdk.id.Issuer;
+import com.nimbusds.oauth2.sdk.id.Subject;
+import com.nimbusds.openid.connect.sdk.claims.IDTokenClaimsSet;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.List;
+
+public class IDTokenGenerator {
+
+    public static SignedJWT generateIDToken(
+            String clientId, Subject subject, String issuerUrl, RSAKey signingKey) {
+        LocalDateTime localDateTime = LocalDateTime.now().plusMinutes(2);
+        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant());
+        IDTokenClaimsSet idTokenClaims =
+                new IDTokenClaimsSet(
+                        new Issuer(issuerUrl),
+                        subject,
+                        List.of(new Audience(clientId)),
+                        expiryDate,
+                        new Date());
+        JWSHeader jwsHeader =
+                new JWSHeader.Builder(JWSAlgorithm.RS256).keyID(signingKey.getKeyID()).build();
+        SignedJWT idToken;
+
+        try {
+            RSASSASigner signer = new RSASSASigner(signingKey);
+            idToken = new SignedJWT(jwsHeader, idTokenClaims.toJWTClaimsSet());
+            idToken.sign(signer);
+        } catch (JOSEException | ParseException e) {
+            throw new RuntimeException(e);
+        }
+        return idToken;
+    }
+}

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/LogoutHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/LogoutHandler.java
@@ -1,0 +1,32 @@
+package uk.gov.di.lambdas;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import uk.gov.di.services.ConfigurationService;
+
+import java.util.Map;
+
+public class LogoutHandler
+        implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+
+    private final ConfigurationService configurationService;
+
+    public LogoutHandler() {
+        this.configurationService = new ConfigurationService();
+    }
+
+    public LogoutHandler(ConfigurationService configurationService) {
+        this.configurationService = configurationService;
+    }
+
+    @Override
+    public APIGatewayProxyResponseEvent handleRequest(
+            APIGatewayProxyRequestEvent input, Context context) {
+        return new APIGatewayProxyResponseEvent()
+                .withStatusCode(302)
+                .withHeaders(
+                        Map.of("Location", configurationService.getDefaultLogoutURI().toString()));
+    }
+}

--- a/serverless/lambda/src/main/java/uk/gov/di/services/ConfigurationService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/ConfigurationService.java
@@ -15,6 +15,10 @@ public class ConfigurationService {
         return URI.create(System.getenv("LOGIN_URI"));
     }
 
+    public URI getDefaultLogoutURI() {
+        return URI.create(System.getenv("DEFAULT_LOGOUT_URI"));
+    }
+
     public String getRedisHost() {
         return System.getenv().getOrDefault("REDIS_HOST", "redis");
     }

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/LogoutHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/LogoutHandlerTest.java
@@ -1,0 +1,81 @@
+package uk.gov.di.lambdas;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.id.State;
+import com.nimbusds.oauth2.sdk.id.Subject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.entity.Session;
+import uk.gov.di.helpers.IDTokenGenerator;
+import uk.gov.di.services.ConfigurationService;
+import uk.gov.di.services.SessionService;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static java.lang.String.format;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
+
+class LogoutHandlerTest {
+
+    private final Context context = mock(Context.class);
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private final SessionService sessionService = mock(SessionService.class);
+    private static final String SET_COOKIE = "Set-Cookie";
+    private static final String SESSION_ID = "a-session-id";
+    private static final String CLIENT_SESSION_ID = "client-session-id";
+    private static final URI DEFAULT_LOGOUT_URI = URI.create("http://localhost/logout");
+    private LogoutHandler handler;
+
+    @BeforeEach
+    public void setUp() {
+        handler = new LogoutHandler(configurationService);
+        when(configurationService.getDefaultLogoutURI()).thenReturn(DEFAULT_LOGOUT_URI);
+    }
+
+    @Test
+    public void shouldRedirectToDefaultLogoutUriForSuccessfulRequest() throws JOSEException {
+        RSAKey signingKey =
+                new RSAKeyGenerator(2048).keyID(UUID.randomUUID().toString()).generate();
+        SignedJWT signedJWT =
+                IDTokenGenerator.generateIDToken(
+                        "client-id", new Subject(), "http://localhost-rp", signingKey);
+        State state = new State();
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        generateValidSession();
+        event.setHeaders(Map.of(SET_COOKIE, buildCookieString()));
+        event.setQueryStringParameters(
+                Map.of(
+                        "id_token_hint", signedJWT.serialize(),
+                        "post_logout_redirect_uri", "http://localhost:8000/logout",
+                        "state", state.toString()));
+        APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
+
+        assertThat(response, hasStatus(302));
+        assertThat(response.getHeaders().get("Location"), equalTo(DEFAULT_LOGOUT_URI.toString()));
+    }
+
+    private void generateValidSession() {
+        when(sessionService.getSessionFromRequestHeaders(anyMap()))
+                .thenReturn(Optional.of(new Session(SESSION_ID, CLIENT_SESSION_ID)));
+    }
+
+    private String buildCookieString() {
+        return format(
+                "%s=%s.%s; Max-Age=%d; %s",
+                "gs", SESSION_ID, CLIENT_SESSION_ID, 1800, "Secure; HttpOnly;");
+    }
+}

--- a/serverless/lambda/src/test/java/uk/gov/di/services/SessionServiceTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/services/SessionServiceTest.java
@@ -14,7 +14,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;


### PR DESCRIPTION
## What?
- Create a bare bones Logout Lambda
- Add terraform to create Logout Lambda
- Create a IdTokenGenerator to create an ID token for us as we require it in several places and this will reduce duplication
- Add a default LOGOUT URI

## Why?
- This Lambda will be a GET and be used to clear a users session when it is called by an RP. 
