### PR TITLE
BAU: Parse request bodies with library

### DIFF
--- a/serverless/lambda/src/main/java/uk/gov/di/helpers/RequestBodyHelper.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/helpers/RequestBodyHelper.java
@@ -9,7 +9,7 @@ import java.util.Map;
 
 public class RequestBodyHelper {
 
-    public static final Map<String, String> PARSE_REQUEST_BODY(String body) {
+    public static Map<String, String> PARSE_REQUEST_BODY(String body) {
         Map<String, String> query_pairs = new HashMap<>();
 
         for (NameValuePair pair : URLEncodedUtils.parse(body, Charset.defaultCharset())) {

--- a/serverless/lambda/src/main/java/uk/gov/di/helpers/RequestBodyHelper.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/helpers/RequestBodyHelper.java
@@ -9,7 +9,7 @@ import java.util.Map;
 
 public class RequestBodyHelper {
 
-    public static Map<String, String> PARSE_REQUEST_BODY(String body) {
+    public static Map<String, String> parseRequestBody(String body) {
         Map<String, String> query_pairs = new HashMap<>();
 
         for (NameValuePair pair : URLEncodedUtils.parse(body, Charset.defaultCharset())) {

--- a/serverless/lambda/src/main/java/uk/gov/di/helpers/RequestBodyHelper.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/helpers/RequestBodyHelper.java
@@ -1,5 +1,9 @@
 package uk.gov.di.helpers;
 
+import org.apache.http.NameValuePair;
+import org.apache.http.client.utils.URLEncodedUtils;
+
+import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -7,11 +11,11 @@ public class RequestBodyHelper {
 
     public static final Map<String, String> PARSE_REQUEST_BODY(String body) {
         Map<String, String> query_pairs = new HashMap<>();
-        String[] splitString = body.split("&");
-        for (String pair : splitString) {
-            int index = pair.indexOf("=");
-            query_pairs.put(pair.substring(0, index), pair.substring(index + 1));
+
+        for (NameValuePair pair : URLEncodedUtils.parse(body, Charset.defaultCharset())) {
+            query_pairs.put(pair.getName(), pair.getValue());
         }
+
         return query_pairs;
     }
 }

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/TokenHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/TokenHandler.java
@@ -25,7 +25,7 @@ import java.util.Optional;
 
 import static uk.gov.di.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
-import static uk.gov.di.helpers.RequestBodyHelper.PARSE_REQUEST_BODY;
+import static uk.gov.di.helpers.RequestBodyHelper.parseRequestBody;
 
 public class TokenHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -101,7 +101,7 @@ public class TokenHandler
     }
 
     private Map<String, String> parseRequestParameters(String requestString) throws ParseException {
-        Map<String, String> requestBody = PARSE_REQUEST_BODY(requestString);
+        Map<String, String> requestBody = parseRequestBody(requestString);
         if (!requestBody.containsKey("code")
                 || !requestBody.containsKey("client_id")
                 || !requestBody.containsKey("grant_type")

--- a/serverless/lambda/src/test/java/uk/gov/di/helpers/RequestBodyHelperTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/helpers/RequestBodyHelperTest.java
@@ -1,0 +1,18 @@
+package uk.gov.di.helpers;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsMapContaining.hasEntry;
+import static uk.gov.di.helpers.RequestBodyHelper.parseRequestBody;
+
+class RequestBodyHelperTest {
+
+    @Test
+    void takesLastValueIfMultipleInstancesOfKey() {
+
+        var input = "key=one&key=two";
+
+        assertThat(parseRequestBody(input), hasEntry("key", "two"));
+    }
+}

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/AuthorisationHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/AuthorisationHandlerTest.java
@@ -68,7 +68,7 @@ class AuthorisationHandlerTest {
                         "state", "some-state"));
         APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
         URI uri = URI.create(response.getHeaders().get("Location"));
-        Map<String, String> requestParams = RequestBodyHelper.PARSE_REQUEST_BODY(uri.getQuery());
+        Map<String, String> requestParams = RequestBodyHelper.parseRequestBody(uri.getQuery());
 
         final String expectedCookieString =
                 "gs=a-session-id.client-session-id; Max-Age=1800; Secure; HttpOnly;";


### PR DESCRIPTION
## What?

Use an (already included) Apache library to parse request bodies into key-value pairs

## Why?

It's more robust and handles things like URL encoding
