### PR TITLE
Fix well known endpoint urls

### DIFF
--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/WellknownHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/WellknownHandler.java
@@ -46,12 +46,12 @@ public class WellknownHandler
                     new OIDCProviderMetadata(
                             new Issuer(baseUrl),
                             List.of(SubjectType.PUBLIC, SubjectType.PAIRWISE),
-                            buildURI(".well-known/jwks.json", baseUrl));
+                            buildURI("/.well-known/jwks.json", baseUrl));
 
-            providerMetadata.setTokenEndpointURI(buildURI("token", baseUrl));
-            providerMetadata.setUserInfoEndpointURI(buildURI("userinfo", baseUrl));
-            providerMetadata.setAuthorizationEndpointURI(buildURI("authorize", baseUrl));
-            providerMetadata.setRegistrationEndpointURI(buildURI("connect/register", baseUrl));
+            providerMetadata.setTokenEndpointURI(buildURI("/token", baseUrl));
+            providerMetadata.setUserInfoEndpointURI(buildURI("/userinfo", baseUrl));
+            providerMetadata.setAuthorizationEndpointURI(buildURI("/authorize", baseUrl));
+            providerMetadata.setRegistrationEndpointURI(buildURI("/connect/register", baseUrl));
             providerMetadata.setTokenEndpointAuthMethods(
                     List.of(ClientAuthenticationMethod.PRIVATE_KEY_JWT));
             providerMetadata.setScopes(

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/WellknownHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/WellknownHandlerTest.java
@@ -35,7 +35,7 @@ class WellknownHandlerTest {
 
     @Test
     public void shouldReturn200WhenRequestIsSuccessful() throws ParseException {
-        when(configService.getBaseURL()).thenReturn(Optional.of("http://localhost:8080/"));
+        when(configService.getBaseURL()).thenReturn(Optional.of("http://localhost:8080"));
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);


### PR DESCRIPTION
## What?

Fix well known endpoint urls

## Why?

/ were missing from the url when using an OIDC client it failed.

