### PR TITLE
GOVSI-598 - Refactor Client Session Storage

### DIFF
--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -16,6 +16,7 @@ dependencies {
             'org.glassfish.jersey.core:jersey-client:3.0.2',
             'org.glassfish.jersey.inject:jersey-hk2:3.0.2',
             'org.glassfish.jersey.media:jersey-media-json-jackson:3.0.2',
+            "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.12.4",
             'org.eclipse.jetty:jetty-server:11.0.5',
             "software.amazon.awssdk:sqs:2.16.88",
             "org.awaitility:awaitility:4.1.0",

--- a/integration-tests/src/test/java/uk/gov/di/authentication/helpers/RedisHelper.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/helpers/RedisHelper.java
@@ -33,7 +33,7 @@ public class RedisHelper {
             throws IOException {
         try (RedisConnectionService redis =
                 new RedisConnectionService(REDIS_HOST, 6379, false, REDIS_PASSWORD)) {
-            Session session = new Session(sessionId, clientSessionId);
+            Session session = new Session(sessionId);
             redis.saveWithExpiry(
                     session.getSessionId(), OBJECT_MAPPER.writeValueAsString(session), 1800);
             return session.getSessionId();

--- a/integration-tests/src/test/java/uk/gov/di/authentication/helpers/RedisHelper.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/helpers/RedisHelper.java
@@ -1,6 +1,9 @@
 package uk.gov.di.authentication.helpers;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import uk.gov.di.entity.ClientSession;
 import uk.gov.di.entity.Session;
 import uk.gov.di.entity.SessionState;
 import uk.gov.di.helpers.IdGenerator;
@@ -9,6 +12,7 @@ import uk.gov.di.services.CodeStorageService;
 import uk.gov.di.services.RedisConnectionService;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -22,6 +26,8 @@ public class RedisHelper {
             System.getenv().getOrDefault("REDIS_HOST", "localhost");
     private static final Optional<String> REDIS_PASSWORD =
             Optional.ofNullable(System.getenv("REDIS_PASSWORD"));
+    private static final ObjectMapper OBJECT_MAPPER =
+            JsonMapper.builder().addModule(new JavaTimeModule()).build();
 
     public static String createSession(String sessionId, String clientSessionId)
             throws IOException {
@@ -29,7 +35,7 @@ public class RedisHelper {
                 new RedisConnectionService(REDIS_HOST, 6379, false, REDIS_PASSWORD)) {
             Session session = new Session(sessionId, clientSessionId);
             redis.saveWithExpiry(
-                    session.getSessionId(), new ObjectMapper().writeValueAsString(session), 1800);
+                    session.getSessionId(), OBJECT_MAPPER.writeValueAsString(session), 1800);
             return session.getSessionId();
         }
     }
@@ -42,11 +48,11 @@ public class RedisHelper {
             String clientSessionId, String sessionId, Map<String, List<String>> authRequest) {
         try (RedisConnectionService redis =
                 new RedisConnectionService(REDIS_HOST, 6379, false, REDIS_PASSWORD)) {
-            Session session =
-                    new ObjectMapper().readValue(redis.getValue(sessionId), Session.class);
-            session.addClientSessionAuthorisationRequest(clientSessionId, authRequest);
+            Session session = OBJECT_MAPPER.readValue(redis.getValue(sessionId), Session.class);
+            session.setClientSession(
+                    clientSessionId, new ClientSession(authRequest, LocalDateTime.now()));
             redis.saveWithExpiry(
-                    session.getSessionId(), new ObjectMapper().writeValueAsString(session), 1800);
+                    session.getSessionId(), OBJECT_MAPPER.writeValueAsString(session), 1800);
 
         } catch (IOException e) {
             throw new RuntimeException(e);
@@ -56,11 +62,10 @@ public class RedisHelper {
     public static void addEmailToSession(String sessionId, String emailAddress) {
         try (RedisConnectionService redis =
                 new RedisConnectionService(REDIS_HOST, 6379, false, REDIS_PASSWORD)) {
-            Session session =
-                    new ObjectMapper().readValue(redis.getValue(sessionId), Session.class);
+            Session session = OBJECT_MAPPER.readValue(redis.getValue(sessionId), Session.class);
             session.setEmailAddress(emailAddress);
             redis.saveWithExpiry(
-                    session.getSessionId(), new ObjectMapper().writeValueAsString(session), 1800);
+                    session.getSessionId(), OBJECT_MAPPER.writeValueAsString(session), 1800);
 
         } catch (IOException e) {
             throw new RuntimeException(e);
@@ -70,11 +75,10 @@ public class RedisHelper {
     public static void setSessionState(String sessionId, SessionState state) {
         try (RedisConnectionService redis =
                 new RedisConnectionService(REDIS_HOST, 6379, false, REDIS_PASSWORD)) {
-            Session session =
-                    new ObjectMapper().readValue(redis.getValue(sessionId), Session.class);
+            Session session = OBJECT_MAPPER.readValue(redis.getValue(sessionId), Session.class);
             session.setState(state);
             redis.saveWithExpiry(
-                    session.getSessionId(), new ObjectMapper().writeValueAsString(session), 1800);
+                    session.getSessionId(), OBJECT_MAPPER.writeValueAsString(session), 1800);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -107,9 +111,7 @@ public class RedisHelper {
         try (RedisConnectionService redis =
                 new RedisConnectionService(REDIS_HOST, 6379, false, REDIS_PASSWORD)) {
 
-            var code = new CodeGeneratorService().sixDigitCode();
             new CodeStorageService(redis).saveCodeBlockedForSession(email, sessionId, 10);
-            ;
         }
     }
 }

--- a/serverless/lambda/build.gradle
+++ b/serverless/lambda/build.gradle
@@ -19,6 +19,7 @@ dependencies {
             "com.fasterxml.jackson.core:jackson-core:2.12.3",
             "com.fasterxml.jackson.core:jackson-databind:2.12.3",
             "com.fasterxml.jackson.core:jackson-annotations:2.12.3",
+            "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.12.4",
             "io.lettuce:lettuce-core:6.1.3.RELEASE",
             "uk.gov.service.notify:notifications-java-client:3.17.2-RELEASE",
             "org.bouncycastle:bcprov-jdk15on:1.69",

--- a/serverless/lambda/src/main/java/uk/gov/di/entity/ClientSession.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/entity/ClientSession.java
@@ -1,0 +1,44 @@
+package uk.gov.di.entity;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+public class ClientSession {
+
+    @JsonProperty("auth_request_params")
+    private Map<String, List<String>> authRequestParams;
+
+    @JsonProperty("id_token_hint")
+    private String idTokenHint;
+
+    @JsonProperty("creation_date")
+    private LocalDateTime creationDate;
+
+    public ClientSession(
+            @JsonProperty(required = true, value = "auth_request_params")
+                    Map<String, List<String>> authRequestParams,
+            @JsonProperty(required = true, value = "creation_date") LocalDateTime creationDate) {
+        this.authRequestParams = authRequestParams;
+        this.creationDate = creationDate;
+    }
+
+    public ClientSession setIdTokenHint(String idTokenHint) {
+        this.idTokenHint = idTokenHint;
+        return this;
+    }
+
+    public Map<String, List<String>> getAuthRequestParams() {
+        return authRequestParams;
+    }
+
+    public String getIdTokenHint() {
+        return idTokenHint;
+    }
+
+    public LocalDateTime getCreationDate() {
+        return creationDate;
+    }
+}

--- a/serverless/lambda/src/main/java/uk/gov/di/entity/Session.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/entity/Session.java
@@ -13,9 +13,6 @@ public class Session {
     @JsonProperty("session_id")
     private String sessionId;
 
-    @JsonProperty("client_session_id")
-    private String clientSessionId;
-
     @JsonProperty("client_sessions")
     private Map<String, ClientSession> clientSessions;
 
@@ -28,9 +25,8 @@ public class Session {
     @JsonProperty("retry_count")
     private int retryCount;
 
-    public Session(String sessionId, String clientSessionId) {
+    public Session(String sessionId) {
         this.sessionId = sessionId;
-        this.clientSessionId = clientSessionId;
         this.state = NEW;
         this.clientSessions = new HashMap<>();
     }
@@ -38,12 +34,10 @@ public class Session {
     @JsonCreator
     public Session(
             @JsonProperty("session_id") String sessionId,
-            @JsonProperty("client_session_id") String clientSessionId,
             @JsonProperty("client_sessions") Map<String, ClientSession> clientSessions,
             @JsonProperty("state") SessionState state,
             @JsonProperty("email_address") String emailAddress) {
         this.sessionId = sessionId;
-        this.clientSessionId = clientSessionId;
         this.clientSessions = clientSessions;
         this.state = state;
         this.emailAddress = emailAddress;
@@ -55,10 +49,6 @@ public class Session {
 
     public void setSessionId(String sessionId) {
         this.sessionId = sessionId;
-    }
-
-    public String getClientSessionId() {
-        return clientSessionId;
     }
 
     public Map<String, ClientSession> getClientSessions() {

--- a/serverless/lambda/src/main/java/uk/gov/di/entity/Session.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/entity/Session.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import static uk.gov.di.entity.SessionState.NEW;
@@ -17,8 +16,8 @@ public class Session {
     @JsonProperty("client_session_id")
     private String clientSessionId;
 
-    @JsonProperty("authentication_requests")
-    private Map<String, Map<String, List<String>>> authenticationRequests;
+    @JsonProperty("client_sessions")
+    private Map<String, ClientSession> clientSessions;
 
     @JsonProperty("state")
     private SessionState state;
@@ -33,20 +32,19 @@ public class Session {
         this.sessionId = sessionId;
         this.clientSessionId = clientSessionId;
         this.state = NEW;
-        this.authenticationRequests = new HashMap<>();
+        this.clientSessions = new HashMap<>();
     }
 
     @JsonCreator
     public Session(
             @JsonProperty("session_id") String sessionId,
             @JsonProperty("client_session_id") String clientSessionId,
-            @JsonProperty("authentication_requests")
-                    Map<String, Map<String, List<String>>> authenticationRequests,
+            @JsonProperty("client_sessions") Map<String, ClientSession> clientSessions,
             @JsonProperty("state") SessionState state,
             @JsonProperty("email_address") String emailAddress) {
         this.sessionId = sessionId;
         this.clientSessionId = clientSessionId;
-        this.authenticationRequests = authenticationRequests;
+        this.clientSessions = clientSessions;
         this.state = state;
         this.emailAddress = emailAddress;
     }
@@ -63,13 +61,12 @@ public class Session {
         return clientSessionId;
     }
 
-    public Map<String, Map<String, List<String>>> getAuthenticationRequests() {
-        return authenticationRequests;
+    public Map<String, ClientSession> getClientSessions() {
+        return clientSessions;
     }
 
-    public Session addClientSessionAuthorisationRequest(
-            String clientSessionId, Map<String, List<String>> authRequest) {
-        authenticationRequests.put(clientSessionId, authRequest);
+    public Session setClientSession(String clientSessionId, ClientSession clientSessions) {
+        this.clientSessions.put(clientSessionId, clientSessions);
         return this;
     }
 

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/AuthCodeHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/AuthCodeHandler.java
@@ -68,8 +68,9 @@ public class AuthCodeHandler
             authCodeRequest = objectMapper.readValue(input.getBody(), AuthCodeRequest.class);
             Map<String, List<String>> authRequest =
                     session.get()
-                            .getAuthenticationRequests()
-                            .get(authCodeRequest.getClientSessionId());
+                            .getClientSessions()
+                            .get(authCodeRequest.getClientSessionId())
+                            .getAuthRequestParams();
             authorizationRequest = AuthorizationRequest.parse(authRequest);
             if (!authorizationService.isClientRedirectUriValid(
                     authorizationRequest.getClientID(), authorizationRequest.getRedirectionURI())) {

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/AuthorisationHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/AuthorisationHandler.java
@@ -12,6 +12,7 @@ import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.openid.connect.sdk.AuthenticationErrorResponse;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+import uk.gov.di.entity.ClientSession;
 import uk.gov.di.entity.Session;
 import uk.gov.di.services.ClientService;
 import uk.gov.di.services.ConfigurationService;
@@ -19,6 +20,7 @@ import uk.gov.di.services.DynamoClientService;
 import uk.gov.di.services.SessionService;
 
 import java.net.URLEncoder;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -129,7 +131,8 @@ public class AuthorisationHandler
             ClientID clientId) {
         String oldSessionId = session.getSessionId();
         sessionService.updateSessionId(session);
-        session.addClientSessionAuthorisationRequest(session.getClientSessionId(), authRequest);
+        session.setClientSession(
+                session.getClientSessionId(), new ClientSession(authRequest, LocalDateTime.now()));
         logger.log(
                 format(
                         "Updated session id from %s to %s for client %s - client session id = %s",
@@ -147,7 +150,8 @@ public class AuthorisationHandler
             Scope scope,
             ClientID clientId) {
         Session session = sessionService.createSession();
-        session.addClientSessionAuthorisationRequest(session.getClientSessionId(), authRequest);
+        session.setClientSession(
+                session.getClientSessionId(), new ClientSession(authRequest, LocalDateTime.now()));
         logger.log(
                 format(
                         "Created session %s for client %s - client session id = %s",

--- a/serverless/lambda/src/main/java/uk/gov/di/services/SessionService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/SessionService.java
@@ -1,6 +1,8 @@
 package uk.gov.di.services;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.di.entity.Session;
@@ -18,7 +20,8 @@ public class SessionService {
     private static final String SESSION_ID_HEADER = "Session-Id";
     public static final String REQUEST_COOKIE_HEADER = "Cookie";
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final ObjectMapper OBJECT_MAPPER =
+            JsonMapper.builder().addModule(new JavaTimeModule()).build();
 
     private final ConfigurationService configurationService;
     private final RedisConnectionService redisConnectionService;
@@ -111,7 +114,7 @@ public class SessionService {
         }
     }
 
-    private Optional<Session> readSessionFromRedis(String sessionId) {
+    public Optional<Session> readSessionFromRedis(String sessionId) {
         try {
             if (redisConnectionService.keyExists(sessionId)) {
                 return Optional.of(

--- a/serverless/lambda/src/main/java/uk/gov/di/services/SessionService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/SessionService.java
@@ -44,7 +44,11 @@ public class SessionService {
     }
 
     public Session createSession() {
-        return new Session(IdGenerator.generate(), IdGenerator.generate());
+        return new Session(IdGenerator.generate());
+    }
+
+    public String generateClientSessionID() {
+        return IdGenerator.generate();
     }
 
     public void save(Session session) {

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/AuthCodeHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/AuthCodeHandlerTest.java
@@ -13,6 +13,7 @@ import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.openid.connect.sdk.AuthenticationSuccessResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.entity.ClientSession;
 import uk.gov.di.entity.ErrorResponse;
 import uk.gov.di.entity.Session;
 import uk.gov.di.exceptions.ClientNotFoundException;
@@ -22,6 +23,7 @@ import uk.gov.di.services.ConfigurationService;
 import uk.gov.di.services.SessionService;
 
 import java.net.URI;
+import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.Optional;
 
@@ -171,9 +173,11 @@ class AuthCodeHandlerTest {
                 .thenReturn(
                         Optional.of(
                                 new Session(SESSION_ID, CLIENT_SESSION_ID)
-                                        .addClientSessionAuthorisationRequest(
+                                        .setClientSession(
                                                 CLIENT_SESSION_ID,
-                                                authorizationRequest.toParameters())));
+                                                new ClientSession(
+                                                        authorizationRequest.toParameters(),
+                                                        LocalDateTime.now()))));
         return authorizationRequest;
     }
 }

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/AuthCodeHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/AuthCodeHandlerTest.java
@@ -172,7 +172,7 @@ class AuthCodeHandlerTest {
         when(sessionService.getSessionFromRequestHeaders(anyMap()))
                 .thenReturn(
                         Optional.of(
-                                new Session(SESSION_ID, CLIENT_SESSION_ID)
+                                new Session(SESSION_ID)
                                         .setClientSession(
                                                 CLIENT_SESSION_ID,
                                                 new ClientSession(

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/CheckUserExistsHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/CheckUserExistsHandlerTest.java
@@ -132,6 +132,6 @@ class CheckUserExistsHandlerTest {
 
     private void usingValidSession() {
         when(sessionService.getSessionFromRequestHeaders(anyMap()))
-                .thenReturn(Optional.of(new Session("a-session-id", "client-session-id")));
+                .thenReturn(Optional.of(new Session("a-session-id")));
     }
 }

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/LoginHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/LoginHandlerTest.java
@@ -129,6 +129,6 @@ class LoginHandlerTest {
 
     private void usingValidSession() {
         when(sessionService.getSessionFromRequestHeaders(anyMap()))
-                .thenReturn(Optional.of(new Session("a-session-id", "client-session-id")));
+                .thenReturn(Optional.of(new Session("a-session-id")));
     }
 }

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/LogoutHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/LogoutHandlerTest.java
@@ -70,7 +70,7 @@ class LogoutHandlerTest {
 
     private void generateValidSession() {
         when(sessionService.getSessionFromRequestHeaders(anyMap()))
-                .thenReturn(Optional.of(new Session(SESSION_ID, CLIENT_SESSION_ID)));
+                .thenReturn(Optional.of(new Session(SESSION_ID)));
     }
 
     private String buildCookieString() {

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/MfaHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/MfaHandlerTest.java
@@ -105,9 +105,6 @@ public class MfaHandlerTest {
 
     private void usingValidSession(String email) {
         when(sessionService.getSessionFromRequestHeaders(anyMap()))
-                .thenReturn(
-                        Optional.of(
-                                new Session("a-session-id", "client-session-id")
-                                        .setEmailAddress(email)));
+                .thenReturn(Optional.of(new Session("a-session-id").setEmailAddress(email)));
     }
 }

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/SendNotificationHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/SendNotificationHandlerTest.java
@@ -143,10 +143,7 @@ class SendNotificationHandlerTest {
         when(validationService.validateEmailAddress(eq("joe.bloggs")))
                 .thenReturn(Optional.of(ErrorResponse.ERROR_1004));
         when(sessionService.getSessionFromRequestHeaders(anyMap()))
-                .thenReturn(
-                        Optional.of(
-                                new Session("a-session-id", "client-session-id")
-                                        .setEmailAddress("joe.bloggs")));
+                .thenReturn(Optional.of(new Session("a-session-id").setEmailAddress("joe.bloggs")));
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setHeaders(Map.of("Session-Id", "a-session-id"));
         event.setBody(
@@ -266,8 +263,7 @@ class SendNotificationHandlerTest {
         when(sessionService.getSessionFromRequestHeaders(anyMap()))
                 .thenReturn(
                         Optional.of(
-                                new Session("a-session-id", "client-session-id")
-                                        .setEmailAddress(TEST_EMAIL_ADDRESS)));
+                                new Session("a-session-id").setEmailAddress(TEST_EMAIL_ADDRESS)));
     }
 
     private boolean isSessionWithEmailSent(Session session) {

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/SignUpHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/SignUpHandlerTest.java
@@ -137,6 +137,6 @@ class SignUpHandlerTest {
 
     private void usingValidSession() {
         when(sessionService.getSessionFromRequestHeaders(anyMap()))
-                .thenReturn(Optional.of(new Session("a-session-id", "client-session-id")));
+                .thenReturn(Optional.of(new Session("a-session-id")));
     }
 }

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/UpdateProfileHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/UpdateProfileHandlerTest.java
@@ -82,7 +82,6 @@ class UpdateProfileHandlerTest {
         when(sessionService.getSessionFromRequestHeaders(anyMap()))
                 .thenReturn(
                         Optional.of(
-                                new Session("a-session-id", "client-session-id")
-                                        .setEmailAddress(TEST_EMAIL_ADDRESS)));
+                                new Session("a-session-id").setEmailAddress(TEST_EMAIL_ADDRESS)));
     }
 }

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/VerifyCodeRequestHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/VerifyCodeRequestHandlerTest.java
@@ -53,8 +53,7 @@ class VerifyCodeRequestHandlerTest {
     private final DynamoService dynamoService = mock(DynamoService.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final ValidationService validationService = mock(ValidationService.class);
-    private final Session session =
-            new Session("session-id", "client-session-id").setEmailAddress(TEST_EMAIL_ADDRESS);
+    private final Session session = new Session("session-id").setEmailAddress(TEST_EMAIL_ADDRESS);
     private VerifyCodeHandler handler;
 
     @BeforeEach

--- a/serverless/lambda/src/test/java/uk/gov/di/services/SessionServiceTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/services/SessionServiceTest.java
@@ -1,8 +1,14 @@
 package uk.gov.di.services;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.entity.ClientSession;
 import uk.gov.di.entity.Session;
 
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -26,32 +32,31 @@ class SessionServiceTest {
 
     private final RedisConnectionService redis = mock(RedisConnectionService.class);
     private final ConfigurationService configuration = mock(ConfigurationService.class);
+    private final ObjectMapper objectMapper =
+            JsonMapper.builder().addModule(new JavaTimeModule()).build();
 
     private final SessionService sessionService = new SessionService(configuration, redis);
 
     @Test
-    public void shouldPersistSessionToRedisWithExpiry() {
+    public void shouldPersistSessionToRedisWithExpiry() throws JsonProcessingException {
         when(configuration.getSessionExpiry()).thenReturn(1234L);
 
+        ClientSession clientSession =
+                new ClientSession(Map.of("client_id", List.of("a-client-id")), LocalDateTime.now());
         var session =
                 new Session("session-id", "client-session-id")
-                        .addClientSessionAuthorisationRequest(
-                                "client-session-id", Map.of("client_id", List.of("a-client-id")));
+                        .setClientSession("client-session-id", clientSession);
 
         sessionService.save(session);
 
-        var serialisedSession =
-                "{\"session_id\":\"session-id\",\"client_session_id\":\"client-session-id\",\"authentication_requests\":{\"client-session-id\":{\"client_id\":[\"a-client-id\"]}},\"state\":\"NEW\",\"email_address\":null,\"retry_count\":0}";
-        verify(redis).saveWithExpiry("session-id", serialisedSession, 1234L);
+        verify(redis, times(1))
+                .saveWithExpiry("session-id", objectMapper.writeValueAsString(session), 1234L);
     }
 
     @Test
-    public void shouldRetrieveSessionUsingRequestHeaders() {
-        var serialisedSession =
-                "{\"session_id\":\"session-id\",\"client_session_id\":\"client-session-id\",\"authentication_requests\":{}},\"state\":\"NEW\",\"email_address\":null,\"retry_count\":0}";
-
+    public void shouldRetrieveSessionUsingRequestHeaders() throws JsonProcessingException {
         when(redis.keyExists("session-id")).thenReturn(true);
-        when(redis.getValue("session-id")).thenReturn(serialisedSession);
+        when(redis.getValue("session-id")).thenReturn(generateSearlizedSession());
 
         var sessionInRedis =
                 sessionService.getSessionFromRequestHeaders(Map.of("Session-Id", "session-id"));
@@ -116,19 +121,17 @@ class SessionServiceTest {
     }
 
     @Test
-    void shouldReturnSessionFromSessionCookieCalledWithValidCookieHeaderValues() {
-        String serialisedSession =
-                "{\"session_id\":\"session-id\",\"client_session_id\":\"client-session-id\",\"authentication_requests\":{\"client-session-id\":{\"client_id\":[\"a-client-id\"]}},\"state\":\"NEW\",\"email_address\":null,\"retry_count\":0}";
-
+    void shouldReturnSessionFromSessionCookieCalledWithValidCookieHeaderValues()
+            throws JsonProcessingException {
         when(redis.keyExists("session-id")).thenReturn(true);
-        when(redis.getValue("session-id")).thenReturn(serialisedSession);
+        when(redis.getValue("session-id")).thenReturn(generateSearlizedSession());
 
-        Optional<Session> session =
+        Optional<Session> sessionFromSessionCookie =
                 sessionService.getSessionFromSessionCookie(
                         Map.ofEntries(Map.entry(REQUEST_COOKIE_HEADER, "gs=session-id.456;")));
 
-        assertTrue(session.isPresent());
-        assertEquals("session-id", session.get().getSessionId());
+        assertTrue(sessionFromSessionCookie.isPresent());
+        assertEquals("session-id", sessionFromSessionCookie.get().getSessionId());
     }
 
     @Test
@@ -145,13 +148,26 @@ class SessionServiceTest {
     void shouldUpdateSessionIdInRedisAndDeleteOldKey() {
         var session =
                 new Session("session-id", "client-session-id")
-                        .addClientSessionAuthorisationRequest(
-                                "client-session-id", Map.of("client_id", List.of("a-client-id")));
+                        .setClientSession(
+                                "client-session-id",
+                                new ClientSession(
+                                        Map.of("client_id", List.of("a-client-id")),
+                                        LocalDateTime.now()));
 
         sessionService.save(session);
         sessionService.updateSessionId(session);
 
         verify(redis, times(2)).saveWithExpiry(anyString(), anyString(), anyLong());
         verify(redis).deleteValue("session-id");
+    }
+
+    private String generateSearlizedSession() throws JsonProcessingException {
+        ClientSession clientSession =
+                new ClientSession(Map.of("client_id", List.of("a-client-id")), LocalDateTime.now());
+        var session =
+                new Session("session-id", "client-session-id")
+                        .setClientSession("client-session-id", clientSession);
+
+        return objectMapper.writeValueAsString(session);
     }
 }

--- a/serverless/lambda/src/test/java/uk/gov/di/services/SessionServiceTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/services/SessionServiceTest.java
@@ -44,8 +44,7 @@ class SessionServiceTest {
         ClientSession clientSession =
                 new ClientSession(Map.of("client_id", List.of("a-client-id")), LocalDateTime.now());
         var session =
-                new Session("session-id", "client-session-id")
-                        .setClientSession("client-session-id", clientSession);
+                new Session("session-id").setClientSession("client-session-id", clientSession);
 
         sessionService.save(session);
 
@@ -147,7 +146,7 @@ class SessionServiceTest {
     @Test
     void shouldUpdateSessionIdInRedisAndDeleteOldKey() {
         var session =
-                new Session("session-id", "client-session-id")
+                new Session("session-id")
                         .setClientSession(
                                 "client-session-id",
                                 new ClientSession(
@@ -165,8 +164,7 @@ class SessionServiceTest {
         ClientSession clientSession =
                 new ClientSession(Map.of("client_id", List.of("a-client-id")), LocalDateTime.now());
         var session =
-                new Session("session-id", "client-session-id")
-                        .setClientSession("client-session-id", clientSession);
+                new Session("session-id").setClientSession("client-session-id", clientSession);
 
         return objectMapper.writeValueAsString(session);
     }


### PR DESCRIPTION
## What?

- Store clientSessionID against the ClientSession in the users session rather than against just the authnRequests 
- Remove the top level ClientSessionID from the Session
- Generate a new ClientSessionID in the AuthorizationHandler
- Add the jackson-datatype-jsr310 dependency 


## Why?
-  We need to store more than just the authentication request against the clientSessionID. Create a ClientSessionObject which will contain the authrequestparams, creationdate and ID Token hint. This will be searlized and stored in the users session against the clientSessionID which represents the RP which the auth request came from. The Id token hint will only be added in the TokenHandler once the ID token has been created. 
- We never need the ClientSessionID at the top level of the Session so lets remove it and just keep it associated with the clientSessions map
- We will require a new clientSessionID each time regardless if the user has an existing session or not. Previously we were only ever creating one when we created a new session which meant we would always overwrite what was in the clientSessions map
- Add the jackson-datatype-jsr310 so we can successfully de/serialize LocalDateTime when we store it in Redis. This works by building the ObjectMappers we use like - JsonMapper.builder().addModule(new JavaTimeModule())
