### PR TITLE
BAU: Use SL4J2 instead of the default lambda logger

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,9 @@ dependencies {
             "com.nimbusds:nimbus-jose-jwt:${dependencyVersions.nimbus_jose_jwt}",
             "commons-codec:commons-codec:1.15"
 
+    runtimeOnly "org.apache.logging.log4j:log4j-slf4j18-impl:2.13.0",
+            "com.amazonaws:aws-lambda-java-log4j2:1.2.0"
+
     testImplementation "org.junit.jupiter:junit-jupiter-api:${dependencyVersions.junit_version}",
             "org.mockito:mockito-core:${dependencyVersions.mockito_version}",
             "org.mockito:mockito-junit-jupiter:${dependencyVersions.mockito_version}"
@@ -52,4 +55,3 @@ test {
 mainClassName = 'uk.gov.di.AuthenticationApiApplication'
 
 compileJava.dependsOn 'spotlessApply'
-

--- a/serverless/lambda/src/main/resources/log4j2.xml
+++ b/serverless/lambda/src/main/resources/log4j2.xml
@@ -1,0 +1,16 @@
+<Configuration status="WARN">
+    <Appenders>
+        <Lambda name="Lambda">
+            <PatternLayout>
+                <pattern>RequestId = %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
+            </PatternLayout>
+        </Lambda>
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="Lambda"/>
+        </Root>
+        <Logger name="software.amazon.awssdk" level="WARN" />
+        <Logger name="software.amazon.awssdk.request" level="DEBUG" />
+    </Loggers>
+</Configuration>

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/AuthorisationHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/AuthorisationHandlerTest.java
@@ -1,7 +1,6 @@
 package uk.gov.di.lambdas;
 
 import com.amazonaws.services.lambda.runtime.Context;
-import com.amazonaws.services.lambda.runtime.LambdaLogger;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.nimbusds.oauth2.sdk.AuthorizationRequest;
@@ -41,7 +40,6 @@ class AuthorisationHandlerTest {
     @BeforeEach
     public void setUp() {
         handler = new AuthorisationHandler(clientService, configService, sessionService);
-        when(context.getLogger()).thenReturn(mock(LambdaLogger.class));
     }
 
     @Test

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/SendNotificationHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/SendNotificationHandlerTest.java
@@ -1,7 +1,6 @@
 package uk.gov.di.lambdas;
 
 import com.amazonaws.services.lambda.runtime.Context;
-import com.amazonaws.services.lambda.runtime.LambdaLogger;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -70,7 +69,6 @@ class SendNotificationHandlerTest {
 
     @BeforeEach
     void setup() {
-        when(context.getLogger()).thenReturn(mock(LambdaLogger.class));
         when(configurationService.getCodeExpiry()).thenReturn(CODE_EXPIRY_TIME);
         when(codeGeneratorService.sixDigitCode()).thenReturn(TEST_SIX_DIGIT_CODE);
     }

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/UserInfoHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/UserInfoHandlerTest.java
@@ -1,7 +1,6 @@
 package uk.gov.di.lambdas;
 
 import com.amazonaws.services.lambda.runtime.Context;
-import com.amazonaws.services.lambda.runtime.LambdaLogger;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.nimbusds.oauth2.sdk.ParseException;
@@ -53,7 +52,6 @@ public class UserInfoHandlerTest {
         when(userInfoService.getInfoForEmail(eq(EMAIL_ADDRESS.get()))).thenReturn(userInfo);
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setHeaders(Map.of("Authorization", new BearerAccessToken().toAuthorizationHeader()));
-        when(context.getLogger()).thenReturn(mock(LambdaLogger.class));
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(200));
@@ -65,7 +63,6 @@ public class UserInfoHandlerTest {
     public void shouldReturn401WhenBearerTokenIsNotParseable() {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setHeaders(Map.of("Authorization", "this-is-not-a-valid-token"));
-        when(context.getLogger()).thenReturn(mock(LambdaLogger.class));
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(401));
@@ -75,7 +72,6 @@ public class UserInfoHandlerTest {
     @Test
     public void shouldReturn401WhenAuthorizationHeaderIsMissing() {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        when(context.getLogger()).thenReturn(mock(LambdaLogger.class));
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(401));
@@ -89,7 +85,6 @@ public class UserInfoHandlerTest {
 
         when(tokenService.getEmailForToken(any(BearerAccessToken.class)))
                 .thenReturn(Optional.empty());
-        when(context.getLogger()).thenReturn(mock(LambdaLogger.class));
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(401));


### PR DESCRIPTION
## What?

- Add the SL4J2 runtime dependency
- Add the AWS Lambda SL4J2 library
- Add configuration to include lambda request ID in log entries
- Replace all uses of the lambda logger with SL4J instances.

## Why?

The lambda logger has limited functionality, lets use SL4J2 instead
