### PR TITLE
BAU: Bring environment names in line

### DIFF
--- a/ci/pipeline.yaml
+++ b/ci/pipeline.yaml
@@ -61,7 +61,7 @@ jobs:
           params:
             DEPLOYER_ROLE_ARN: ((deployer-role-arn))
             BUILD_NOTIFY_API_KEY: ((build-notify-api-key))
-            DEPLOY_ENVIRONMENT: test
+            DEPLOY_ENVIRONMENT: build
           inputs:
             - name: lambda-zip
             - name: di-authentication-api
@@ -97,7 +97,7 @@ jobs:
               tag: 1.0.0
           params:
             DEPLOYER_ROLE_ARN: ((deployer-role-arn))
-            DEPLOY_ENVIRONMENT: test
+            DEPLOY_ENVIRONMENT: build
           inputs:
             - name: lambda-zip
             - name: di-authentication-api


### PR DESCRIPTION
## What?

- Rename the environment that is deployed in the pipeline from `test` to `build`

## Why?

In PaaS we have a `build` space, but in AWS we currently deploy a `test` environment, lets make them match.
