### PR TITLE
GOVSI-523 - Add validation and logic to logout endpoint

### DIFF
--- a/ci/terraform/aws/logout.tf
+++ b/ci/terraform/aws/logout.tf
@@ -6,7 +6,7 @@ module "logout" {
   environment     = var.environment
 
   handler_environment_variables = {
-    DEFAULT_LOGOUT_URI = "https://www.gov.uk/"
+    DEFAULT_LOGOUT_URI = "https://di-authentication-frontend.london.cloudapps.digital/signed-out"
     BASE_URL       = local.api_base_url
     REDIS_HOST     = var.use_localstack ? var.external_redis_host : aws_elasticache_replication_group.sessions_store[0].primary_endpoint_address
     REDIS_PORT     = var.use_localstack ? var.external_redis_port : aws_elasticache_replication_group.sessions_store[0].port

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
@@ -34,7 +34,7 @@ public class AuthCodeIntegrationTest extends IntegrationTestEndpoints {
         String clientSessionId = "some-client-session-id";
         AuthCodeRequest authCodeRequest = new AuthCodeRequest(clientSessionId);
         KeyPair keyPair = generateRsaKeyPair();
-        RedisHelper.createSession(sessionId, clientSessionId);
+        RedisHelper.createSession(sessionId);
         RedisHelper.addAuthRequestToSession(
                 clientSessionId, sessionId, generateAuthRequest().toParameters());
         setUpDynamo(keyPair);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
@@ -74,7 +74,8 @@ public class LogoutIntegrationTest extends IntegrationTestEndpoints {
                 response.getHeaders()
                         .get("Location")
                         .contains(
-                                "https://di-auth-stub-relying-party-build.london.cloudapps.digital/"));
+                                "https://di-auth-stub-relying-party-build.london.cloudapps.digital/?state="
+                                        + "8VAVNSxHO1HwiNDhwchQKdd7eOUK3ltKfQzwPDxu9LU"));
     }
 
     private AuthorizationRequest generateAuthRequest() {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
@@ -20,10 +20,10 @@ import uk.gov.di.authentication.helpers.RedisHelper;
 import uk.gov.di.helpers.IDTokenGenerator;
 
 import java.io.IOException;
+import java.net.HttpCookie;
 import java.net.URI;
 import java.util.UUID;
 
-import static java.lang.String.format;
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -88,8 +88,7 @@ public class LogoutIntegrationTest extends IntegrationTestEndpoints {
     }
 
     private String buildCookieString(String sessionID, String clientSessionID) {
-        return format(
-                "%s=%s.%s; Max-Age=%d; %s",
-                "gs", sessionID, clientSessionID, 1800, "Secure; HttpOnly;");
+        var cookie = new HttpCookie("gs", sessionID + "." + clientSessionID);
+        return cookie.toString();
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
@@ -4,6 +4,10 @@ import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
 import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.AuthorizationRequest;
+import com.nimbusds.oauth2.sdk.ResponseType;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
@@ -15,6 +19,7 @@ import uk.gov.di.authentication.helpers.RedisHelper;
 import uk.gov.di.helpers.IDTokenGenerator;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.UUID;
 
 import static java.lang.String.format;
@@ -23,21 +28,24 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class LogoutIntegrationTest extends IntegrationTestEndpoints {
 
     private static final String LOGOUT_ENDPOINT = "/logout";
-    private static final String SET_COOKIE = "Set-Cookie";
+    private static final String COOKIE = "Cookie";
 
     @Test
     public void shouldReturn302AndRedirectToDefaultLogoutUri() throws JOSEException, IOException {
         String sessionId = "session-id";
         String clientSessionId = "client-session-id";
-        RedisHelper.createSession(sessionId, clientSessionId);
         RSAKey signingKey =
                 new RSAKeyGenerator(2048).keyID(UUID.randomUUID().toString()).generate();
         SignedJWT signedJWT =
                 IDTokenGenerator.generateIDToken(
                         "client-id", new Subject(), "http://localhost/issuer", signingKey);
+        RedisHelper.createSession(sessionId);
+        RedisHelper.addAuthRequestToSession(
+                clientSessionId, sessionId, generateAuthRequest().toParameters());
+        RedisHelper.addIDTokenToSession(sessionId, clientSessionId, signedJWT.serialize());
         Client client = ClientBuilder.newClient();
         MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
-        headers.add(SET_COOKIE, buildCookieString(sessionId, clientSessionId));
+        headers.add(COOKIE, buildCookieString(sessionId, clientSessionId));
         Response response =
                 client.target(ROOT_RESOURCE_URL + LOGOUT_ENDPOINT)
                         .queryParam("id_token_hint", signedJWT.serialize())
@@ -48,6 +56,15 @@ public class LogoutIntegrationTest extends IntegrationTestEndpoints {
                         .get();
 
         assertEquals(302, response.getStatus());
+    }
+
+    private AuthorizationRequest generateAuthRequest() {
+        ResponseType responseType = new ResponseType(ResponseType.Value.CODE);
+        State state = new State();
+        return new AuthorizationRequest.Builder(responseType, new ClientID("test-client"))
+                .redirectionURI(URI.create("http://localhost:8080/redirect"))
+                .state(state)
+                .build();
     }
 
     private String buildCookieString(String sessionID, String clientSessionID) {

--- a/serverless/lambda/src/main/java/uk/gov/di/helpers/CookieHelper.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/helpers/CookieHelper.java
@@ -1,0 +1,58 @@
+package uk.gov.di.helpers;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class CookieHelper {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CookieHelper.class);
+
+    public static final String REQUEST_COOKIE_HEADER = "Cookie";
+
+    public static Optional<SessionCookieIds> parseSessionCookie(Map<String, String> headers) {
+        if (headers == null
+                || headers.isEmpty()
+                || !headers.containsKey(REQUEST_COOKIE_HEADER)
+                || headers.get(REQUEST_COOKIE_HEADER).isEmpty()) {
+            return Optional.empty();
+        }
+
+        final String COOKIE_REGEX = "gs=(?<sid>[^.;]+)\\.(?<csid>[^.;]+);";
+
+        String cookies = headers.getOrDefault(REQUEST_COOKIE_HEADER, "");
+
+        LOGGER.debug("Session Cookie: {}", cookies);
+
+        Matcher cookiesMatcher = Pattern.compile(COOKIE_REGEX).matcher(cookies);
+
+        if (cookiesMatcher.find()) {
+            final String sid = cookiesMatcher.group("sid");
+            final String csid = cookiesMatcher.group("csid");
+
+            return Optional.of(
+                    new SessionCookieIds() {
+                        public String getSessionId() {
+                            return sid;
+                        }
+
+                        public String getClientSessionId() {
+                            return csid;
+                        }
+                    });
+        } else {
+            LOGGER.warn("Unable to parse Session Cookie: {}", cookies);
+            return Optional.empty();
+        }
+    }
+
+    public interface SessionCookieIds {
+        String getSessionId();
+
+        String getClientSessionId();
+    }
+}

--- a/serverless/lambda/src/main/java/uk/gov/di/helpers/CookieHelper.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/helpers/CookieHelper.java
@@ -3,10 +3,9 @@ package uk.gov.di.helpers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.HttpCookie;
 import java.util.Map;
 import java.util.Optional;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class CookieHelper {
 
@@ -16,38 +15,43 @@ public class CookieHelper {
 
     public static Optional<SessionCookieIds> parseSessionCookie(Map<String, String> headers) {
         if (headers == null
-                || headers.isEmpty()
                 || !headers.containsKey(REQUEST_COOKIE_HEADER)
                 || headers.get(REQUEST_COOKIE_HEADER).isEmpty()) {
             return Optional.empty();
         }
-
-        final String COOKIE_REGEX = "gs=(?<sid>[^.;]+)\\.(?<csid>[^.;]+);";
-
-        String cookies = headers.getOrDefault(REQUEST_COOKIE_HEADER, "");
-
+        String cookies = headers.get(REQUEST_COOKIE_HEADER);
         LOGGER.debug("Session Cookie: {}", cookies);
-
-        Matcher cookiesMatcher = Pattern.compile(COOKIE_REGEX).matcher(cookies);
-
-        if (cookiesMatcher.find()) {
-            final String sid = cookiesMatcher.group("sid");
-            final String csid = cookiesMatcher.group("csid");
-
-            return Optional.of(
-                    new SessionCookieIds() {
-                        public String getSessionId() {
-                            return sid;
-                        }
-
-                        public String getClientSessionId() {
-                            return csid;
-                        }
-                    });
-        } else {
-            LOGGER.warn("Unable to parse Session Cookie: {}", cookies);
+        HttpCookie httpCookie;
+        try {
+            httpCookie =
+                    HttpCookie.parse(cookies).stream()
+                            .filter(t -> t.getName().equals("gs"))
+                            .findFirst()
+                            .orElse(null);
+        } catch (IllegalArgumentException e) {
             return Optional.empty();
         }
+        if (httpCookie == null) {
+            return Optional.empty();
+        }
+
+        String[] cookieValues = httpCookie.getValue().split("\\.");
+        if (cookieValues.length != 2) {
+            return Optional.empty();
+        }
+        final String sid = cookieValues[0];
+        final String csid = cookieValues[1];
+
+        return Optional.of(
+                new SessionCookieIds() {
+                    public String getSessionId() {
+                        return sid;
+                    }
+
+                    public String getClientSessionId() {
+                        return csid;
+                    }
+                });
     }
 
     public interface SessionCookieIds {

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/LogoutHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/LogoutHandler.java
@@ -4,26 +4,53 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import uk.gov.di.entity.Session;
 import uk.gov.di.services.ConfigurationService;
+import uk.gov.di.services.SessionService;
 
 import java.util.Map;
+import java.util.Optional;
 
 public class LogoutHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     private final ConfigurationService configurationService;
+    private final SessionService sessionService;
 
     public LogoutHandler() {
         this.configurationService = new ConfigurationService();
+        this.sessionService = new SessionService(configurationService);
     }
 
-    public LogoutHandler(ConfigurationService configurationService) {
+    public LogoutHandler(ConfigurationService configurationService, SessionService sessionService) {
         this.configurationService = configurationService;
+        this.sessionService = sessionService;
     }
 
     @Override
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
+        Optional<Session> sessionFromSessionCookie =
+                sessionService.getSessionFromSessionCookie(input.getHeaders());
+        return sessionFromSessionCookie
+                .map(t -> processLogoutRequest(t, input))
+                .orElse(generateDefaultLogoutResponse());
+    }
+
+    private APIGatewayProxyResponseEvent processLogoutRequest(
+            Session session, APIGatewayProxyRequestEvent input) {
+        Map<String, String> queryStringParameters = input.getQueryStringParameters();
+
+        if (!queryStringParameters.containsKey("id_token_hint")
+                || queryStringParameters.get("id_token_hint").isBlank()) {
+            sessionService.deleteSessionFromRedis(session.getSessionId());
+            return generateDefaultLogoutResponse();
+        }
+        sessionService.deleteSessionFromRedis(session.getSessionId());
+        return generateDefaultLogoutResponse();
+    }
+
+    private APIGatewayProxyResponseEvent generateDefaultLogoutResponse() {
         return new APIGatewayProxyResponseEvent()
                 .withStatusCode(302)
                 .withHeaders(

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/LogoutHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/LogoutHandler.java
@@ -4,12 +4,17 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.nimbusds.jwt.SignedJWT;
+import uk.gov.di.entity.ClientRegistry;
 import uk.gov.di.entity.ClientSession;
 import uk.gov.di.entity.Session;
+import uk.gov.di.exceptions.ClientNotFoundException;
 import uk.gov.di.helpers.CookieHelper;
 import uk.gov.di.services.ConfigurationService;
+import uk.gov.di.services.DynamoClientService;
 import uk.gov.di.services.SessionService;
 
+import java.text.ParseException;
 import java.util.Map;
 import java.util.Optional;
 
@@ -20,15 +25,25 @@ public class LogoutHandler
 
     private final ConfigurationService configurationService;
     private final SessionService sessionService;
+    private final DynamoClientService dynamoClientService;
 
     public LogoutHandler() {
         this.configurationService = new ConfigurationService();
         this.sessionService = new SessionService(configurationService);
+        this.dynamoClientService =
+                new DynamoClientService(
+                        configurationService.getAwsRegion(),
+                        configurationService.getEnvironment(),
+                        configurationService.getDynamoEndpointUri());
     }
 
-    public LogoutHandler(ConfigurationService configurationService, SessionService sessionService) {
+    public LogoutHandler(
+            ConfigurationService configurationService,
+            SessionService sessionService,
+            DynamoClientService dynamoClientService) {
         this.configurationService = configurationService;
         this.sessionService = sessionService;
+        this.dynamoClientService = dynamoClientService;
     }
 
     @Override
@@ -47,11 +62,7 @@ public class LogoutHandler
         Optional<CookieHelper.SessionCookieIds> sessionCookieIds =
                 CookieHelper.parseSessionCookie(input.getHeaders());
 
-        boolean sessionContainsClientSessionID =
-                session.getClientSessions()
-                        .containsKey(sessionCookieIds.get().getClientSessionId());
-
-        if (!sessionContainsClientSessionID) {
+        if (!session.getClientSessions().containsKey(sessionCookieIds.get().getClientSessionId())) {
             throw new RuntimeException(
                     format(
                             "Client Session ID does not exist in Session: %s",
@@ -66,19 +77,47 @@ public class LogoutHandler
             throw new RuntimeException(
                     format("ID Token does not exist for Session: %s", session.getSessionId()));
         }
-        if (!validateIDTokenSignature(
+        if (!isIDTokenSignatureValid(
                 queryStringParameters.get("id_token_hint"), session.getSessionId())) {
             throw new RuntimeException(
                     format(
                             "Unable to validate ID token signature for Session: %s",
                             session.getSessionId()));
         }
-
-        sessionService.deleteSessionFromRedis(session.getSessionId());
-        return generateDefaultLogoutResponse();
+        try {
+            String idTokenHint = queryStringParameters.get("id_token_hint");
+            SignedJWT idToken = SignedJWT.parse(idTokenHint);
+            Optional<String> audience =
+                    idToken.getJWTClaimsSet().getAudience().stream().findFirst();
+            return audience.map(
+                            t -> {
+                                final ClientRegistry clientRegistry;
+                                try {
+                                    clientRegistry =
+                                            dynamoClientService
+                                                    .getClient(t)
+                                                    .orElseThrow(
+                                                            () -> new ClientNotFoundException(t));
+                                } catch (ClientNotFoundException e) {
+                                    throw new RuntimeException(
+                                            format(
+                                                    "Client not found in ClientRegistry for ClientID: %s",
+                                                    t));
+                                }
+                                String logoutURI =
+                                        validateClientRedirectUri(
+                                                queryStringParameters, clientRegistry);
+                                return new APIGatewayProxyResponseEvent()
+                                        .withStatusCode(302)
+                                        .withHeaders(Map.of("Location", logoutURI));
+                            })
+                    .orElse(generateDefaultLogoutResponse());
+        } catch (ParseException e) {
+            throw new RuntimeException();
+        }
     }
 
-    private boolean validateIDTokenSignature(String idTokenHint, String sessionID) {
+    private boolean isIDTokenSignatureValid(String idTokenHint, String sessionID) {
         return true;
     }
 
@@ -92,6 +131,16 @@ public class LogoutHandler
             }
         }
         return false;
+    }
+
+    private String validateClientRedirectUri(
+            Map<String, String> queryStringParameters, ClientRegistry clientRegistry) {
+        String postLogoutRedirectUri = queryStringParameters.get("post_logout_redirect_uri");
+        if (!queryStringParameters.get("post_logout_redirect_uri").isBlank()
+                && clientRegistry.getPostLogoutRedirectUrls().contains(postLogoutRedirectUri)) {
+            return postLogoutRedirectUri;
+        }
+        return configurationService.getDefaultLogoutURI().toString();
     }
 
     private APIGatewayProxyResponseEvent generateDefaultLogoutResponse() {

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/LogoutHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/LogoutHandler.java
@@ -4,12 +4,16 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import uk.gov.di.entity.ClientSession;
 import uk.gov.di.entity.Session;
+import uk.gov.di.helpers.CookieHelper;
 import uk.gov.di.services.ConfigurationService;
 import uk.gov.di.services.SessionService;
 
 import java.util.Map;
 import java.util.Optional;
+
+import static java.lang.String.format;
 
 public class LogoutHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -40,14 +44,54 @@ public class LogoutHandler
     private APIGatewayProxyResponseEvent processLogoutRequest(
             Session session, APIGatewayProxyRequestEvent input) {
         Map<String, String> queryStringParameters = input.getQueryStringParameters();
+        Optional<CookieHelper.SessionCookieIds> sessionCookieIds =
+                CookieHelper.parseSessionCookie(input.getHeaders());
 
+        boolean sessionContainsClientSessionID =
+                session.getClientSessions()
+                        .containsKey(sessionCookieIds.get().getClientSessionId());
+
+        if (!sessionContainsClientSessionID) {
+            throw new RuntimeException(
+                    format(
+                            "Client Session ID does not exist in Session: %s",
+                            session.getSessionId()));
+        }
         if (!queryStringParameters.containsKey("id_token_hint")
                 || queryStringParameters.get("id_token_hint").isBlank()) {
             sessionService.deleteSessionFromRedis(session.getSessionId());
             return generateDefaultLogoutResponse();
         }
+        if (!doesIDTokenExistInSession(queryStringParameters.get("id_token_hint"), session)) {
+            throw new RuntimeException(
+                    format("ID Token does not exist for Session: %s", session.getSessionId()));
+        }
+        if (!validateIDTokenSignature(
+                queryStringParameters.get("id_token_hint"), session.getSessionId())) {
+            throw new RuntimeException(
+                    format(
+                            "Unable to validate ID token signature for Session: %s",
+                            session.getSessionId()));
+        }
+
         sessionService.deleteSessionFromRedis(session.getSessionId());
         return generateDefaultLogoutResponse();
+    }
+
+    private boolean validateIDTokenSignature(String idTokenHint, String sessionID) {
+        return true;
+    }
+
+    private boolean doesIDTokenExistInSession(String idTokenHint, Session session) {
+        for (Map.Entry<String, ClientSession> t : session.getClientSessions().entrySet()) {
+            boolean idTokenHintExists =
+                    t.getValue().getIdTokenHint() != null
+                            && t.getValue().getIdTokenHint().equals(idTokenHint);
+            if (idTokenHintExists) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private APIGatewayProxyResponseEvent generateDefaultLogoutResponse() {

--- a/serverless/lambda/src/main/java/uk/gov/di/services/SessionService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/SessionService.java
@@ -6,19 +6,17 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.di.entity.Session;
+import uk.gov.di.helpers.CookieHelper;
 import uk.gov.di.helpers.IdGenerator;
 
 import java.util.Map;
 import java.util.Optional;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class SessionService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SessionService.class);
 
     private static final String SESSION_ID_HEADER = "Session-Id";
-    public static final String REQUEST_COOKIE_HEADER = "Cookie";
 
     private static final ObjectMapper OBJECT_MAPPER =
             JsonMapper.builder().addModule(new JavaTimeModule()).build();
@@ -87,32 +85,9 @@ public class SessionService {
     }
 
     public Optional<Session> getSessionFromSessionCookie(Map<String, String> headers) {
-        if (headers == null
-                || headers.isEmpty()
-                || !headers.containsKey(REQUEST_COOKIE_HEADER)
-                || headers.get(REQUEST_COOKIE_HEADER).isEmpty()) {
-            return Optional.empty();
-        }
-
-        final String COOKIE_REGEX = "gs=(?<sid>[^.;]+)\\.(?<csid>[^.;]+);";
-
         try {
-            String cookies = headers.getOrDefault(REQUEST_COOKIE_HEADER, "");
-
-            LOGGER.debug("Session Cookie: {}", cookies);
-
-            Matcher cookiesMatcher = Pattern.compile(COOKIE_REGEX).matcher(cookies);
-            Optional<String> sid = Optional.empty();
-
-            try {
-                if (cookiesMatcher.find()) {
-                    sid = Optional.ofNullable(cookiesMatcher.group("sid"));
-                }
-            } catch (IllegalStateException | IllegalArgumentException ise) {
-                LOGGER.error("Unable to parse Session Cookie: {}", ise.getMessage());
-                return Optional.empty();
-            }
-            return sid.flatMap(this::readSessionFromRedis);
+            Optional<CookieHelper.SessionCookieIds> ids = CookieHelper.parseSessionCookie(headers);
+            return ids.flatMap(s -> readSessionFromRedis(s.getSessionId()));
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/serverless/lambda/src/main/java/uk/gov/di/services/SessionService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/SessionService.java
@@ -118,6 +118,10 @@ public class SessionService {
         }
     }
 
+    public void deleteSessionFromRedis(String sessionId) {
+        redisConnectionService.deleteValue(sessionId);
+    }
+
     public Optional<Session> readSessionFromRedis(String sessionId) {
         try {
             if (redisConnectionService.keyExists(sessionId)) {

--- a/serverless/lambda/src/main/java/uk/gov/di/services/TokenService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/TokenService.java
@@ -2,8 +2,6 @@ package uk.gov.di.services;
 
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSHeader;
-import com.nimbusds.jose.JWSSigner;
-import com.nimbusds.jose.crypto.RSASSASigner;
 import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
@@ -37,7 +35,6 @@ import java.util.UUID;
 public class TokenService {
 
     private final RSAKey signingKey;
-    private final JWSSigner signer;
 
     private final Map<AccessToken, String> tokensMap = new HashMap<>();
     private final ConfigurationService configService;
@@ -46,7 +43,6 @@ public class TokenService {
         this.configService = configService;
         try {
             signingKey = new RSAKeyGenerator(2048).keyID(UUID.randomUUID().toString()).generate();
-            signer = new RSASSASigner(signingKey);
         } catch (JOSEException e) {
             throw new RuntimeException(e);
         }

--- a/serverless/lambda/src/test/java/uk/gov/di/helpers/CookieHelperTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/helpers/CookieHelperTest.java
@@ -2,6 +2,7 @@ package uk.gov.di.helpers;
 
 import org.junit.jupiter.api.Test;
 
+import java.net.HttpCookie;
 import java.util.Map;
 import java.util.Optional;
 
@@ -13,8 +14,9 @@ public class CookieHelperTest {
 
     @Test
     void shouldReturnIdsFromValidCookie() {
+        HttpCookie cookie = new HttpCookie("gs", "session-id.456");
         Map<String, String> headers =
-                Map.ofEntries(Map.entry(REQUEST_COOKIE_HEADER, "gs=session-id.456;"));
+                Map.ofEntries(Map.entry(REQUEST_COOKIE_HEADER, cookie.toString()));
 
         Optional<SessionCookieIds> ids = CookieHelper.parseSessionCookie(headers);
 
@@ -24,6 +26,11 @@ public class CookieHelperTest {
 
     @Test
     void shouldReturnEmptyIfCookieMalformatted() {
+        assertEquals(
+                Optional.empty(),
+                CookieHelper.parseSessionCookie(
+                        Map.ofEntries(Map.entry(REQUEST_COOKIE_HEADER, "someinvalidvalue"))));
+
         assertEquals(Optional.empty(), CookieHelper.parseSessionCookie(Map.of()));
 
         assertEquals(
@@ -40,10 +47,18 @@ public class CookieHelperTest {
         assertEquals(
                 Optional.empty(),
                 CookieHelper.parseSessionCookie(
-                        Map.ofEntries(Map.entry(REQUEST_COOKIE_HEADER, "gs=no-semi-colon.123"))));
+                        Map.ofEntries(Map.entry(REQUEST_COOKIE_HEADER, "gs=no-dot;"))));
         assertEquals(
                 Optional.empty(),
                 CookieHelper.parseSessionCookie(
-                        Map.ofEntries(Map.entry(REQUEST_COOKIE_HEADER, "gs=no-dot;"))));
+                        Map.ofEntries(
+                                Map.entry(
+                                        REQUEST_COOKIE_HEADER,
+                                        "gs=one-value.two-value.three-value;"))));
+        assertEquals(
+                Optional.empty(),
+                CookieHelper.parseSessionCookie(
+                        Map.ofEntries(
+                                Map.entry(REQUEST_COOKIE_HEADER, "gsdsds=one-value.two-value"))));
     }
 }

--- a/serverless/lambda/src/test/java/uk/gov/di/helpers/CookieHelperTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/helpers/CookieHelperTest.java
@@ -1,0 +1,49 @@
+package uk.gov.di.helpers;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static uk.gov.di.helpers.CookieHelper.REQUEST_COOKIE_HEADER;
+import static uk.gov.di.helpers.CookieHelper.SessionCookieIds;
+
+public class CookieHelperTest {
+
+    @Test
+    void shouldReturnIdsFromValidCookie() {
+        Map<String, String> headers =
+                Map.ofEntries(Map.entry(REQUEST_COOKIE_HEADER, "gs=session-id.456;"));
+
+        Optional<SessionCookieIds> ids = CookieHelper.parseSessionCookie(headers);
+
+        assertEquals("session-id", ids.get().getSessionId());
+        assertEquals("456", ids.get().getClientSessionId());
+    }
+
+    @Test
+    void shouldReturnEmptyIfCookieMalformatted() {
+        assertEquals(Optional.empty(), CookieHelper.parseSessionCookie(Map.of()));
+
+        assertEquals(
+                Optional.empty(),
+                CookieHelper.parseSessionCookie(Map.ofEntries(Map.entry("header", "value"))));
+        assertEquals(
+                Optional.empty(),
+                CookieHelper.parseSessionCookie(
+                        Map.ofEntries(Map.entry(REQUEST_COOKIE_HEADER, ""))));
+        assertEquals(
+                Optional.empty(),
+                CookieHelper.parseSessionCookie(
+                        Map.ofEntries(Map.entry(REQUEST_COOKIE_HEADER, "gs=this is bad"))));
+        assertEquals(
+                Optional.empty(),
+                CookieHelper.parseSessionCookie(
+                        Map.ofEntries(Map.entry(REQUEST_COOKIE_HEADER, "gs=no-semi-colon.123"))));
+        assertEquals(
+                Optional.empty(),
+                CookieHelper.parseSessionCookie(
+                        Map.ofEntries(Map.entry(REQUEST_COOKIE_HEADER, "gs=no-dot;"))));
+    }
+}

--- a/serverless/lambda/src/test/java/uk/gov/di/services/SessionServiceTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/services/SessionServiceTest.java
@@ -160,6 +160,19 @@ class SessionServiceTest {
         verify(redis).deleteValue("session-id");
     }
 
+    @Test
+    void shouldDeleteSessionIdFromRedis() {
+        var session =
+                new Session("session-id")
+                        .addClientSessionAuthorisationRequest(
+                                "client-session-id", Map.of("client_id", List.of("a-client-id")));
+
+        sessionService.save(session);
+        sessionService.deleteSessionFromRedis(session.getSessionId());
+
+        verify(redis).deleteValue("session-id");
+    }
+
     private String generateSearlizedSession() throws JsonProcessingException {
         ClientSession clientSession =
                 new ClientSession(Map.of("client_id", List.of("a-client-id")), LocalDateTime.now());

--- a/serverless/lambda/src/test/java/uk/gov/di/services/SessionServiceTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/services/SessionServiceTest.java
@@ -26,7 +26,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.services.SessionService.REQUEST_COOKIE_HEADER;
+import static uk.gov.di.helpers.CookieHelper.REQUEST_COOKIE_HEADER;
 
 class SessionServiceTest {
 
@@ -96,27 +96,10 @@ class SessionServiceTest {
     @Test
     void
             shouldReturnOptionalEmptyWhenGetSessionFromSessionCookieCalledWithIncorrectCookieHeaderValues() {
-        assertEquals(Optional.empty(), sessionService.getSessionFromSessionCookie(Map.of()));
-        assertEquals(
-                Optional.empty(),
-                sessionService.getSessionFromSessionCookie(
-                        Map.ofEntries(Map.entry("header", "value"))));
-        assertEquals(
-                Optional.empty(),
-                sessionService.getSessionFromSessionCookie(
-                        Map.ofEntries(Map.entry(REQUEST_COOKIE_HEADER, ""))));
         assertEquals(
                 Optional.empty(),
                 sessionService.getSessionFromSessionCookie(
                         Map.ofEntries(Map.entry(REQUEST_COOKIE_HEADER, "gs=this is bad"))));
-        assertEquals(
-                Optional.empty(),
-                sessionService.getSessionFromSessionCookie(
-                        Map.ofEntries(Map.entry(REQUEST_COOKIE_HEADER, "gs=no-semi-colon.123"))));
-        assertEquals(
-                Optional.empty(),
-                sessionService.getSessionFromSessionCookie(
-                        Map.ofEntries(Map.entry(REQUEST_COOKIE_HEADER, "gs=no-dot;"))));
     }
 
     @Test
@@ -164,8 +147,11 @@ class SessionServiceTest {
     void shouldDeleteSessionIdFromRedis() {
         var session =
                 new Session("session-id")
-                        .addClientSessionAuthorisationRequest(
-                                "client-session-id", Map.of("client_id", List.of("a-client-id")));
+                        .setClientSession(
+                                "client-session-id",
+                                new ClientSession(
+                                        Map.of("client_id", List.of("a-client-id")),
+                                        LocalDateTime.now()));
 
         sessionService.save(session);
         sessionService.deleteSessionFromRedis(session.getSessionId());


### PR DESCRIPTION
## What?

- Extract the session from the session cookie when it exists. If it doesn't then we just redirect the user to the default logout URI which is `https://di-authentication-frontend.london.cloudapps.digital/signed-out`
- Move the logic of the cookie parsing into its own helper 
- Validate the ID token in the request. 
- Put a placeholder in for validating the signature of the ID token. We can revisit this when we're not signing the ID token with a key generated on the fly. 
- Validate the client logout_uri
- Send the state back in the response when it is included in the request

## Why?
- This PR implements the logic from the RP initiated logout OIDC spec - https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout
- This creates an endpoint which can be called by a user whilst they are on the RP and allow them to logout by deleting the session. If we can successfully validate the logout URI in the request we will redirect the user to that location otherwise to the default logout URI on the frontend. 
