### PR TITLE
GOVSI-495: handle multiple cookies in a cookie header

### DIFF
--- a/serverless/lambda/src/main/java/uk/gov/di/helpers/CookieHelper.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/helpers/CookieHelper.java
@@ -4,6 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.HttpCookie;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
 
@@ -20,14 +21,23 @@ public class CookieHelper {
             return Optional.empty();
         }
         String cookies = headers.get(REQUEST_COOKIE_HEADER);
+
         LOGGER.debug("Session Cookie: {}", cookies);
+
+        String[] cookiesList = cookies.split(";");
+        String cookie =
+                Arrays.stream(cookiesList)
+                        .filter(t -> t.trim().startsWith("gs="))
+                        .findFirst()
+                        .orElse(null);
+
+        if (cookie == null) {
+            return Optional.empty();
+        }
+
         HttpCookie httpCookie;
         try {
-            httpCookie =
-                    HttpCookie.parse(cookies).stream()
-                            .filter(t -> t.getName().equals("gs"))
-                            .findFirst()
-                            .orElse(null);
+            httpCookie = HttpCookie.parse(cookie).stream().findFirst().orElse(null);
         } catch (IllegalArgumentException e) {
             return Optional.empty();
         }

--- a/serverless/lambda/src/test/java/uk/gov/di/helpers/CookieHelperTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/helpers/CookieHelperTest.java
@@ -13,6 +13,18 @@ import static uk.gov.di.helpers.CookieHelper.SessionCookieIds;
 public class CookieHelperTest {
 
     @Test
+    void shouldReturnIdsFromValidCookieStringWithMultipleCookeies() {
+        String cookieString = "Version=1; gs=session-id.456;name=ts";
+        Map<String, String> headers =
+                Map.ofEntries(Map.entry(REQUEST_COOKIE_HEADER, cookieString.toString()));
+
+        Optional<SessionCookieIds> ids = CookieHelper.parseSessionCookie(headers);
+
+        assertEquals("session-id", ids.get().getSessionId());
+        assertEquals("456", ids.get().getClientSessionId());
+    }
+
+    @Test
     void shouldReturnIdsFromValidCookie() {
         HttpCookie cookie = new HttpCookie("gs", "session-id.456");
         Map<String, String> headers =


### PR DESCRIPTION
## What?

Handle multiple cookies in a cookie header.
Update the cookie helper to retrieve the gs cookie first before passing it to HttpCookie.

## Why?

The java HttpCookie.parse method only reads the first cookie in a cookie header and discards any others.

