### PR TITLE
GOVSI-606: Use custom domain for API gateway

### DIFF
--- a/ci/terraform/aws/api-gateway.tf
+++ b/ci/terraform/aws/api-gateway.tf
@@ -91,3 +91,11 @@ resource "aws_api_gateway_stage" "endpoint_stage" {
     aws_api_gateway_deployment.deployment,
   ]
 }
+
+resource "aws_api_gateway_base_path_mapping" "api" {
+  count = var.use_localstack ? 0 : 1
+
+  api_id      = aws_api_gateway_rest_api.di_authentication_api.id
+  stage_name  = aws_api_gateway_stage.endpoint_stage.stage_name
+  domain_name = "api.${var.environment}.${var.service_domain_name}"
+}

--- a/ci/terraform/aws/authorize.tf
+++ b/ci/terraform/aws/authorize.tf
@@ -7,7 +7,7 @@ module "authorize" {
 
   handler_environment_variables = {
     BASE_URL       = local.api_base_url
-    LOGIN_URI      = "https://di-authentication-frontend.london.cloudapps.digital/"
+    LOGIN_URI      = var.use_localstack ? "http://localhost:3000/" : "https://front.${var.environment}.${var.service_domain_name}/"
     REDIS_HOST     = var.use_localstack ? var.external_redis_host : aws_elasticache_replication_group.sessions_store[0].primary_endpoint_address
     REDIS_PORT     = var.use_localstack ? var.external_redis_port : aws_elasticache_replication_group.sessions_store[0].port
     REDIS_PASSWORD = var.use_localstack ? var.external_redis_password : random_password.redis_password.result

--- a/ci/terraform/aws/variables.tf
+++ b/ci/terraform/aws/variables.tf
@@ -22,7 +22,6 @@ variable "notify_url" {
 
 variable "environment" {
   type    = string
-  default = "test"
 }
 
 variable "api_deployment_stage_name" {
@@ -93,4 +92,8 @@ variable "external_redis_password" {
 variable "redis_use_tls" {
   type    = string
   default = "true"
+}
+
+variable "service_domain_name" {
+  default = "auth.ida.digital.cabinet-office.gov.uk"
 }


### PR DESCRIPTION
## What?

- Add API gateway stage to custom domain name mapping
- Replace hard-coded redirect URL with calculated based on environment
- Allow the passing in of the service domain name using variable

## Why?

To allow sharing of cookies between front and back end endpoints.

## Related PRs

https://github.com/alphagov/di-authentication-frontend/pull/133