### PR TITLE
GOVSI-635 - Validate scopes before returning UserInfo

### DIFF
--- a/ci/terraform/aws/dynamodb.tf
+++ b/ci/terraform/aws/dynamodb.tf
@@ -51,8 +51,7 @@ resource "aws_dynamodb_table" "user_profile_table" {
     hash_key           = "SubjectID"
     write_capacity     = 5
     read_capacity      = 5
-    projection_type    = "INCLUDE"
-    non_key_attributes = ["Email"]
+    projection_type    = "ALL"
   }
 
   server_side_encryption {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
@@ -1,5 +1,9 @@
 package uk.gov.di.authentication.api;
 
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
@@ -11,6 +15,11 @@ import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.helpers.DynamoHelper;
 import uk.gov.di.authentication.helpers.RedisHelper;
+import uk.gov.di.helpers.TokenGenerator;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
 
 import static com.nimbusds.oauth2.sdk.token.BearerTokenError.INVALID_TOKEN;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -22,14 +31,26 @@ public class UserInfoIntegrationTest extends IntegrationTestEndpoints {
 
     private static final String USERINFO_ENDPOINT = "/userinfo";
     private static final String TEST_EMAIL_ADDRESS = "joe.bloggs@digital.cabinet-office.gov.uk";
+    private static final String TEST_PHONE_NUMBER = "01234567890";
     private static final String TEST_PASSWORD = "password-1";
 
     @Test
-    public void shouldCallUserInfoWithAccessTokenAndReturn200() {
-        AccessToken accessToken = new BearerAccessToken();
+    public void shouldCallUserInfoWithAccessTokenAndReturn200() throws JOSEException {
+        RSAKey signingKey =
+                new RSAKeyGenerator(2048).keyID(UUID.randomUUID().toString()).generate();
+        List<String> scopes = new ArrayList<>();
+        scopes.add("email");
+        scopes.add("phone");
+        scopes.add("oidc");
+        SignedJWT signedAccessToken =
+                TokenGenerator.generateAccessToken(
+                        "client-id-one", "issuer-id", scopes, signingKey);
+        AccessToken accessToken = new BearerAccessToken(signedAccessToken.serialize());
         Subject subject = new Subject();
         RedisHelper.addAccessTokenToRedis(accessToken.toJSONString(), subject.toString(), 300L);
         DynamoHelper.signUp(TEST_EMAIL_ADDRESS, TEST_PASSWORD, subject);
+        DynamoHelper.addPhoneNumber(TEST_EMAIL_ADDRESS, TEST_PHONE_NUMBER);
+        DynamoHelper.setPhoneNumberVerified(TEST_EMAIL_ADDRESS, true);
         Client client = ClientBuilder.newClient();
         Response response =
                 client.target(ROOT_RESOURCE_URL + USERINFO_ENDPOINT)
@@ -40,6 +61,9 @@ public class UserInfoIntegrationTest extends IntegrationTestEndpoints {
         assertEquals(200, response.getStatus());
         UserInfo expectedUserInfoResponse = new UserInfo(subject);
         expectedUserInfoResponse.setEmailAddress(TEST_EMAIL_ADDRESS);
+        expectedUserInfoResponse.setEmailVerified(true);
+        expectedUserInfoResponse.setPhoneNumber(TEST_PHONE_NUMBER);
+        expectedUserInfoResponse.setPhoneNumberVerified(true);
         assertThat(
                 response.readEntity(String.class),
                 equalTo(expectedUserInfoResponse.toJSONString()));

--- a/integration-tests/src/test/java/uk/gov/di/authentication/helpers/DynamoHelper.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/helpers/DynamoHelper.java
@@ -35,6 +35,10 @@ public class DynamoHelper {
         DYNAMO_SERVICE.updatePhoneNumber(email, phoneNumber);
     }
 
+    public static void setPhoneNumberVerified(String email, boolean isVerified) {
+        DYNAMO_SERVICE.updatePhoneNumberVerifiedStatus(email, isVerified);
+    }
+
     public static void registerClient(
             String clientID,
             String clientName,

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/TokenHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/TokenHandler.java
@@ -97,7 +97,11 @@ public class TokenHandler
         Subject subject = authenticationService.getSubjectFromEmail(email);
         AccessToken accessToken =
                 tokenService.generateAndStoreAccessToken(
-                        clientID, subject, client.get().getScopes()); //TODO the scopes need to come from the auth request params
+                        clientID,
+                        subject,
+                        client.get()
+                                .getScopes()); // TODO the scopes need to come from the auth request
+        // params
         SignedJWT idToken = tokenService.generateIDToken(clientID, subject);
         OIDCTokens oidcTokens = new OIDCTokens(idToken, accessToken, null);
         OIDCTokenResponse tokenResponse = new OIDCTokenResponse(oidcTokens);

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/UserInfoHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/UserInfoHandlerTest.java
@@ -3,28 +3,37 @@ package uk.gov.di.lambdas;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.id.Subject;
+import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.openid.connect.sdk.UserInfoErrorResponse;
 import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.entity.UserProfile;
+import uk.gov.di.helpers.TokenGenerator;
 import uk.gov.di.services.AuthenticationService;
 import uk.gov.di.services.ConfigurationService;
 import uk.gov.di.services.TokenService;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 
 import static com.nimbusds.oauth2.sdk.token.BearerTokenError.INVALID_TOKEN;
 import static com.nimbusds.oauth2.sdk.token.BearerTokenError.MISSING_TOKEN;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -33,6 +42,7 @@ import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 public class UserInfoHandlerTest {
 
     private static final String EMAIL_ADDRESS = "joe.bloggs@digital.cabinet-office.gov.uk";
+    private static final String PHONE_NUMBER = "01234567890";
     private static final Subject SUBJECT = new Subject();
     private final Context context = mock(Context.class);
     private final TokenService tokenService = mock(TokenService.class);
@@ -48,28 +58,40 @@ public class UserInfoHandlerTest {
     }
 
     @Test
-    public void shouldReturn200IfSuccessfulRequest() throws ParseException {
+    public void shouldReturn200WithUserInfoBasedOnScopesForSuccessfulRequest()
+            throws ParseException, JOSEException {
+        RSAKey signingKey =
+                new RSAKeyGenerator(2048).keyID(UUID.randomUUID().toString()).generate();
+        List<String> scopes = new ArrayList<>();
+        scopes.add("email");
+        scopes.add("phone");
+        SignedJWT signedAccessToken =
+                TokenGenerator.generateAccessToken("client-id", "issuer-url", scopes, signingKey);
+        AccessToken accessToken = new BearerAccessToken(signedAccessToken.serialize());
         UserProfile userProfile =
                 new UserProfile()
                         .setEmail(EMAIL_ADDRESS)
                         .setEmailVerified(true)
-                        .setPhoneNumber("01234567890")
+                        .setPhoneNumber(PHONE_NUMBER)
                         .setPhoneNumberVerified(true)
                         .setSubjectID(SUBJECT.toString())
                         .setCreated(LocalDateTime.now().toString())
                         .setUpdated(LocalDateTime.now().toString());
-        when(tokenService.getSubjectWithAccessToken(any(BearerAccessToken.class)))
+        when(tokenService.getSubjectWithAccessToken(accessToken))
                 .thenReturn(Optional.of(SUBJECT.toString()));
         when(authenticationService.getUserProfileFromSubject(SUBJECT.toString()))
                 .thenReturn(userProfile);
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        event.setHeaders(Map.of("Authorization", new BearerAccessToken().toAuthorizationHeader()));
+        event.setHeaders(Map.of("Authorization", accessToken.toAuthorizationHeader()));
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(200));
         UserInfo parsedResultBody = UserInfo.parse(result.getBody());
-        assertThat(parsedResultBody.getEmailAddress(), equalTo(EMAIL_ADDRESS));
         assertThat(parsedResultBody.getSubject(), equalTo(SUBJECT));
+        assertThat(parsedResultBody.getEmailAddress(), equalTo(EMAIL_ADDRESS));
+        assertTrue(parsedResultBody.getEmailVerified());
+        assertThat(parsedResultBody.getPhoneNumber(), equalTo(PHONE_NUMBER));
+        assertTrue(parsedResultBody.getPhoneNumberVerified());
     }
 
     @Test


### PR DESCRIPTION
## What?

- We store the scopes in the access token. When we retrieve the accesstoken in the userinfo endpoint, check to see what scopes exist and send back the userinfo based on what is returned.
- Change the projection_type of the GSI on the user_profile table to ALL instead of INCLUDE. This means that we can use Subject to return all information relevant to that row whereas previously it was only returning EMAIL.

## Why?

- So we only send back user information which the client has requested and is authorized to receive 