### PR TITLE
GOVSI-609: Refactor client session

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
@@ -45,7 +45,7 @@ public class LogoutIntegrationTest extends IntegrationTestEndpoints {
         RedisHelper.createSession(sessionId);
         RedisHelper.addAuthRequestToSession(
                 clientSessionId, sessionId, generateAuthRequest().toParameters());
-        RedisHelper.addIDTokenToSession(sessionId, clientSessionId, signedJWT.serialize());
+        RedisHelper.addIDTokenToSession(clientSessionId, signedJWT.serialize());
         DynamoHelper.registerClient(
                 "client-id",
                 "client-name",

--- a/integration-tests/src/test/java/uk/gov/di/authentication/helpers/RedisHelper.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/helpers/RedisHelper.java
@@ -53,7 +53,7 @@ public class RedisHelper {
             redis.saveWithExpiry(
                     session.getSessionId(), OBJECT_MAPPER.writeValueAsString(session), 1800);
             redis.saveWithExpiry(
-                    clientSessionId,
+                    CLIENT_SESSION_PREFIX.concat(clientSessionId),
                     OBJECT_MAPPER.writeValueAsString(
                             new ClientSession(authRequest, LocalDateTime.now())),
                     1800);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/helpers/RedisHelper.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/helpers/RedisHelper.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 
 import static uk.gov.di.entity.NotificationType.VERIFY_EMAIL;
 import static uk.gov.di.entity.NotificationType.VERIFY_PHONE_NUMBER;
+import static uk.gov.di.services.ClientSessionService.CLIENT_SESSION_PREFIX;
 
 public class RedisHelper {
 
@@ -48,24 +49,33 @@ public class RedisHelper {
         try (RedisConnectionService redis =
                 new RedisConnectionService(REDIS_HOST, 6379, false, REDIS_PASSWORD)) {
             Session session = OBJECT_MAPPER.readValue(redis.getValue(sessionId), Session.class);
-            session.setClientSession(
-                    clientSessionId, new ClientSession(authRequest, LocalDateTime.now()));
+            session.addClientSession(clientSessionId);
             redis.saveWithExpiry(
                     session.getSessionId(), OBJECT_MAPPER.writeValueAsString(session), 1800);
+            redis.saveWithExpiry(
+                    clientSessionId,
+                    OBJECT_MAPPER.writeValueAsString(
+                            new ClientSession(authRequest, LocalDateTime.now())),
+                    1800);
 
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
 
-    public static void addIDTokenToSession(
-            String sessionId, String clientSessionId, String idTokenHint) {
+    public static void addIDTokenToSession(String clientSessionId, String idTokenHint) {
         try (RedisConnectionService redis =
                 new RedisConnectionService(REDIS_HOST, 6379, false, REDIS_PASSWORD)) {
-            Session session = OBJECT_MAPPER.readValue(redis.getValue(sessionId), Session.class);
-            session.getClientSessions().get(clientSessionId).setIdTokenHint(idTokenHint);
+
+            ClientSession clientSession =
+                    OBJECT_MAPPER.readValue(
+                            redis.getValue(CLIENT_SESSION_PREFIX.concat(clientSessionId)),
+                            ClientSession.class);
+            clientSession.setIdTokenHint(idTokenHint);
             redis.saveWithExpiry(
-                    session.getSessionId(), OBJECT_MAPPER.writeValueAsString(session), 1800);
+                    CLIENT_SESSION_PREFIX.concat(clientSessionId),
+                    OBJECT_MAPPER.writeValueAsString(clientSession),
+                    1800);
 
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/serverless/lambda/src/main/java/uk/gov/di/entity/Session.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/entity/Session.java
@@ -3,8 +3,8 @@ package uk.gov.di.entity;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
 
 import static uk.gov.di.entity.SessionState.NEW;
 
@@ -14,7 +14,7 @@ public class Session {
     private String sessionId;
 
     @JsonProperty("client_sessions")
-    private Map<String, ClientSession> clientSessions;
+    private List<String> clientSessions;
 
     @JsonProperty("state")
     private SessionState state;
@@ -28,13 +28,13 @@ public class Session {
     public Session(String sessionId) {
         this.sessionId = sessionId;
         this.state = NEW;
-        this.clientSessions = new HashMap<>();
+        this.clientSessions = new ArrayList<>();
     }
 
     @JsonCreator
     public Session(
             @JsonProperty("session_id") String sessionId,
-            @JsonProperty("client_sessions") Map<String, ClientSession> clientSessions,
+            @JsonProperty("client_sessions") List<String> clientSessions,
             @JsonProperty("state") SessionState state,
             @JsonProperty("email_address") String emailAddress) {
         this.sessionId = sessionId;
@@ -51,12 +51,12 @@ public class Session {
         this.sessionId = sessionId;
     }
 
-    public Map<String, ClientSession> getClientSessions() {
+    public List<String> getClientSessions() {
         return clientSessions;
     }
 
-    public Session setClientSession(String clientSessionId, ClientSession clientSessions) {
-        this.clientSessions.put(clientSessionId, clientSessions);
+    public Session addClientSession(String clientSessionId) {
+        this.clientSessions.add(clientSessionId);
         return this;
     }
 

--- a/serverless/lambda/src/main/java/uk/gov/di/helpers/ObjectMapperFactory.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/helpers/ObjectMapperFactory.java
@@ -1,0 +1,19 @@
+package uk.gov.di.helpers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import java.util.Objects;
+
+public class ObjectMapperFactory {
+    private static ObjectMapper objectMapper;
+
+    public static ObjectMapper getInstance() {
+        if (Objects.isNull(ObjectMapperFactory.objectMapper)) {
+            ObjectMapperFactory.objectMapper =
+                    JsonMapper.builder().addModule(new JavaTimeModule()).build();
+        }
+        return ObjectMapperFactory.objectMapper;
+    }
+}

--- a/serverless/lambda/src/main/java/uk/gov/di/services/ClientSessionService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/ClientSessionService.java
@@ -1,0 +1,55 @@
+package uk.gov.di.services;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.di.entity.ClientSession;
+import uk.gov.di.helpers.IdGenerator;
+import uk.gov.di.helpers.ObjectMapperFactory;
+
+public class ClientSessionService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ClientSessionService.class);
+    public static final String CLIENT_SESSION_PREFIX = "client-session-";
+
+    private final RedisConnectionService redisConnectionService;
+    private final ConfigurationService configurationService;
+    private final ObjectMapper objectMapper;
+
+    public ClientSessionService(ConfigurationService configurationService) {
+        this.configurationService = configurationService;
+        this.redisConnectionService =
+                new RedisConnectionService(
+                        configurationService.getRedisHost(),
+                        configurationService.getRedisPort(),
+                        configurationService.getUseRedisTLS(),
+                        configurationService.getRedisPassword());
+        objectMapper = ObjectMapperFactory.getInstance();
+    }
+
+    public String generateClientSession(ClientSession clientSession) {
+        String id = IdGenerator.generate();
+        try {
+            redisConnectionService.saveWithExpiry(
+                    CLIENT_SESSION_PREFIX.concat(id),
+                    objectMapper.writeValueAsString(clientSession),
+                    configurationService.getSessionExpiry());
+        } catch (JsonProcessingException e) {
+            LOG.error("Error saving client session to Redis", e);
+            throw new RuntimeException(e);
+        }
+        return id;
+    }
+
+    public ClientSession getClientSession(String clientSessionId) {
+        try {
+            String result =
+                    redisConnectionService.getValue(CLIENT_SESSION_PREFIX.concat(clientSessionId));
+            return objectMapper.readValue(result, ClientSession.class);
+        } catch (JsonProcessingException e) {
+            LOG.error("Error getting client session from Redis", e);
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/serverless/lambda/src/main/java/uk/gov/di/services/SessionService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/SessionService.java
@@ -1,13 +1,12 @@
 package uk.gov.di.services;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.di.entity.Session;
 import uk.gov.di.helpers.CookieHelper;
 import uk.gov.di.helpers.IdGenerator;
+import uk.gov.di.helpers.ObjectMapperFactory;
 
 import java.util.Map;
 import java.util.Optional;
@@ -18,8 +17,7 @@ public class SessionService {
 
     private static final String SESSION_ID_HEADER = "Session-Id";
 
-    private static final ObjectMapper OBJECT_MAPPER =
-            JsonMapper.builder().addModule(new JavaTimeModule()).build();
+    private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.getInstance();
 
     private final ConfigurationService configurationService;
     private final RedisConnectionService redisConnectionService;
@@ -43,10 +41,6 @@ public class SessionService {
 
     public Session createSession() {
         return new Session(IdGenerator.generate());
-    }
-
-    public String generateClientSessionID() {
-        return IdGenerator.generate();
     }
 
     public void save(Session session) {

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/AuthCodeHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/AuthCodeHandlerTest.java
@@ -18,6 +18,7 @@ import uk.gov.di.entity.ErrorResponse;
 import uk.gov.di.entity.Session;
 import uk.gov.di.exceptions.ClientNotFoundException;
 import uk.gov.di.services.AuthorizationService;
+import uk.gov.di.services.ClientSessionService;
 import uk.gov.di.services.CodeStorageService;
 import uk.gov.di.services.ConfigurationService;
 import uk.gov.di.services.SessionService;
@@ -51,6 +52,7 @@ class AuthCodeHandlerTest {
     private final CodeStorageService codeStorageService = mock(CodeStorageService.class);
     private final SessionService sessionService = mock(SessionService.class);
     private final Context context = mock(Context.class);
+    private final ClientSessionService clientSessionService = mock(ClientSessionService.class);
     private AuthCodeHandler handler;
 
     @BeforeEach
@@ -60,7 +62,8 @@ class AuthCodeHandlerTest {
                         sessionService,
                         codeStorageService,
                         configurationService,
-                        authorizationService);
+                        authorizationService,
+                        clientSessionService);
     }
 
     @Test
@@ -171,13 +174,11 @@ class AuthCodeHandlerTest {
                         .build();
         when(sessionService.getSessionFromRequestHeaders(anyMap()))
                 .thenReturn(
-                        Optional.of(
-                                new Session(SESSION_ID)
-                                        .setClientSession(
-                                                CLIENT_SESSION_ID,
-                                                new ClientSession(
-                                                        authorizationRequest.toParameters(),
-                                                        LocalDateTime.now()))));
+                        Optional.of(new Session(SESSION_ID).addClientSession(CLIENT_SESSION_ID)));
+        when(clientSessionService.getClientSession(CLIENT_SESSION_ID))
+                .thenReturn(
+                        new ClientSession(
+                                authorizationRequest.toParameters(), LocalDateTime.now()));
         return authorizationRequest;
     }
 }

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/AuthorisationHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/AuthorisationHandlerTest.java
@@ -7,9 +7,11 @@ import com.nimbusds.oauth2.sdk.AuthorizationRequest;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.entity.ClientSession;
 import uk.gov.di.entity.Session;
 import uk.gov.di.helpers.RequestBodyHelper;
 import uk.gov.di.services.ClientService;
+import uk.gov.di.services.ClientSessionService;
 import uk.gov.di.services.ConfigurationService;
 import uk.gov.di.services.SessionService;
 
@@ -34,12 +36,15 @@ class AuthorisationHandlerTest {
     private final ClientService clientService = mock(ClientService.class);
     private final ConfigurationService configService = mock(ConfigurationService.class);
     private final SessionService sessionService = mock(SessionService.class);
+    private final ClientSessionService clientSessionService = mock(ClientSessionService.class);
 
     private AuthorisationHandler handler;
 
     @BeforeEach
     public void setUp() {
-        handler = new AuthorisationHandler(clientService, configService, sessionService);
+        handler =
+                new AuthorisationHandler(
+                        clientService, configService, sessionService, clientSessionService);
     }
 
     @Test
@@ -53,7 +58,8 @@ class AuthorisationHandlerTest {
         when(sessionService.createSession()).thenReturn(session);
         when(configService.getSessionCookieAttributes()).thenReturn("Secure; HttpOnly;");
         when(configService.getSessionCookieMaxAge()).thenReturn(1800);
-        when(sessionService.generateClientSessionID()).thenReturn("client-session-id");
+        when(clientSessionService.generateClientSession(any(ClientSession.class)))
+                .thenReturn("client-session-id");
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setQueryStringParameters(

--- a/serverless/lambda/src/test/java/uk/gov/di/services/SessionServiceTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/services/SessionServiceTest.java
@@ -41,10 +41,7 @@ class SessionServiceTest {
     public void shouldPersistSessionToRedisWithExpiry() throws JsonProcessingException {
         when(configuration.getSessionExpiry()).thenReturn(1234L);
 
-        ClientSession clientSession =
-                new ClientSession(Map.of("client_id", List.of("a-client-id")), LocalDateTime.now());
-        var session =
-                new Session("session-id").setClientSession("client-session-id", clientSession);
+        var session = new Session("session-id").addClientSession("client-session-id");
 
         sessionService.save(session);
 
@@ -128,13 +125,7 @@ class SessionServiceTest {
 
     @Test
     void shouldUpdateSessionIdInRedisAndDeleteOldKey() {
-        var session =
-                new Session("session-id")
-                        .setClientSession(
-                                "client-session-id",
-                                new ClientSession(
-                                        Map.of("client_id", List.of("a-client-id")),
-                                        LocalDateTime.now()));
+        var session = new Session("session-id").addClientSession("client-session-id");
 
         sessionService.save(session);
         sessionService.updateSessionId(session);
@@ -145,13 +136,7 @@ class SessionServiceTest {
 
     @Test
     void shouldDeleteSessionIdFromRedis() {
-        var session =
-                new Session("session-id")
-                        .setClientSession(
-                                "client-session-id",
-                                new ClientSession(
-                                        Map.of("client_id", List.of("a-client-id")),
-                                        LocalDateTime.now()));
+        var session = new Session("session-id").addClientSession("client-session-id");
 
         sessionService.save(session);
         sessionService.deleteSessionFromRedis(session.getSessionId());
@@ -162,8 +147,7 @@ class SessionServiceTest {
     private String generateSearlizedSession() throws JsonProcessingException {
         ClientSession clientSession =
                 new ClientSession(Map.of("client_id", List.of("a-client-id")), LocalDateTime.now());
-        var session =
-                new Session("session-id").setClientSession("client-session-id", clientSession);
+        var session = new Session("session-id").addClientSession("client-session-id");
 
         return objectMapper.writeValueAsString(session);
     }


### PR DESCRIPTION
## What?

- Store client session details in separate Redis index rather than within session

## Why?

When issuing tokens, we have no way of identifying the user session in order to store the issued ID token. We do, however, have access to the client session id as this is stored against the authorisation code.
