### PR TITLE
GOVSI-522: Store ID token against client sessions

### DIFF
--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -20,6 +20,8 @@ dependencies {
             'org.eclipse.jetty:jetty-server:11.0.6',
             "software.amazon.awssdk:sqs:2.16.88",
             "org.awaitility:awaitility:4.1.0",
+            "com.amazonaws:aws-java-sdk-dynamodb:1.12.35",
+            "io.lettuce:lettuce-core:6.1.4.RELEASE",
             project(":serverless:lambda")
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.2'
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -6,7 +6,7 @@ import jakarta.ws.rs.client.Invocation;
 import jakarta.ws.rs.core.Cookie;
 import jakarta.ws.rs.core.Response;
 import org.glassfish.jersey.client.ClientProperties;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.helpers.DynamoHelper;
 import uk.gov.di.authentication.helpers.RedisHelper;
@@ -37,8 +37,8 @@ public class AuthorisationIntegrationTest extends IntegrationTestEndpoints {
 
     private static final ConfigurationService configurationService = new ConfigurationService();
 
-    @BeforeAll
-    public static void setup() {
+    @BeforeEach
+    public void setup() {
         DynamoHelper.registerClient(
                 CLIENT_ID,
                 "test-client",

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -5,6 +5,7 @@ import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.client.Invocation;
 import jakarta.ws.rs.core.Cookie;
 import jakarta.ws.rs.core.Response;
+import org.glassfish.jersey.client.ClientProperties;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.helpers.DynamoHelper;
@@ -128,6 +129,7 @@ public class AuthorisationIntegrationTest extends IntegrationTestEndpoints {
 
         Invocation.Builder builder =
                 client.target(ROOT_RESOURCE_URL + AUTHORIZE_ENDPOINT)
+                        .property(ClientProperties.FOLLOW_REDIRECTS, false)
                         .queryParam("response_type", "code")
                         .queryParam("redirect_uri", "localhost")
                         .queryParam("state", "8VAVNSxHO1HwiNDhwchQKdd7eOUK3ltKfQzwPDxu9LU")

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IntegrationTestEndpoints.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IntegrationTestEndpoints.java
@@ -1,5 +1,9 @@
 package uk.gov.di.authentication.api;
 
+import org.junit.jupiter.api.BeforeEach;
+import uk.gov.di.authentication.helpers.DynamoHelper;
+import uk.gov.di.authentication.helpers.RedisHelper;
+
 import java.util.Optional;
 
 public class IntegrationTestEndpoints {
@@ -10,4 +14,10 @@ public class IntegrationTestEndpoints {
     public static final String ROOT_RESOURCE_URL =
             Optional.ofNullable(System.getenv().get("ROOT_RESOURCE_URL"))
                     .orElse(String.format(LOCAL_ENDPOINT_FORMAT, LOCAL_API_GATEWAY_ID));
+
+    @BeforeEach
+    public void flushData() {
+        RedisHelper.flushData();
+        DynamoHelper.flushData();
+    }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
@@ -15,6 +15,7 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.helpers.DynamoHelper;
+import uk.gov.di.authentication.helpers.RedisHelper;
 
 import java.net.URI;
 import java.security.KeyPair;
@@ -49,10 +50,12 @@ public class TokenIntegrationTest extends IntegrationTestEndpoints {
                         (RSAPrivateKey) privateKey,
                         null,
                         null);
+        String code = new AuthorizationCode().toString();
+        RedisHelper.addAuthCode(code, "a-client-session-id");
         Map<String, List<String>> customParams = new HashMap<>();
         customParams.put("grant_type", Collections.singletonList("authorization_code"));
         customParams.put("client_id", Collections.singletonList(clientID));
-        customParams.put("code", Collections.singletonList(new AuthorizationCode().toString()));
+        customParams.put("code", Collections.singletonList(code));
         customParams.put("redirect_uri", Collections.singletonList("http://localhost/redirect"));
         Map<String, List<String>> privateKeyParams = privateKeyJWT.toParameters();
         privateKeyParams.putAll(customParams);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
@@ -3,6 +3,7 @@ package uk.gov.di.authentication.api;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.helpers.DynamoHelper;
 import uk.gov.di.authentication.helpers.RedisHelper;
 import uk.gov.di.authentication.helpers.RequestHelper;
 import uk.gov.di.entity.BaseAPIResponse;
@@ -86,6 +87,7 @@ public class VerifyCodeIntegrationTest extends IntegrationTestEndpoints {
         String code = RedisHelper.generateAndSavePhoneNumberCode(EMAIL_ADDRESS, 900);
         VerifyCodeRequest codeRequest =
                 new VerifyCodeRequest(NotificationType.VERIFY_PHONE_NUMBER, code);
+        DynamoHelper.signUp(EMAIL_ADDRESS, "password");
 
         Response response =
                 RequestHelper.requestWithSession(VERIFY_CODE_ENDPOINT, codeRequest, sessionId);

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -64,7 +64,7 @@ if [[ ${RUN_INTEGRATION} -eq 1 ]]; then
   export AWS_ACCESS_KEY_ID="mock-access-key"
   export AWS_SECRET_ACCESS_KEY="mock-secret-key"
   export STUB_RELYING_PARTY_REDIRECT_URI="https://di-auth-stub-relying-party-build.london.cloudapps.digital/"
-  export LOGIN_URI="https://di-authentication-frontend.london.cloudapps.digital/"
+  export LOGIN_URI="http://localhost:3000/"
 
   startup
 
@@ -78,6 +78,7 @@ fi
 
 if [ ${build_and_test_exit_code} -ne 0 ]; then
   printf "\npre-commit failed.\n"
+  exit ${build_and_test_exit_code}
 else
   if [[ ${IN_GITHUB_ACTIONS} -eq 0 ]]; then
     funky_success

--- a/serverless/lambda/src/main/java/uk/gov/di/entity/ErrorResponse.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/entity/ErrorResponse.java
@@ -22,7 +22,8 @@ public enum ErrorResponse {
     ERROR_1014(1014, "Phone number is not registered"),
     ERROR_1015(1015, "Unable to Verify Signature of Private Key JWT"),
     ERROR_1016(1016, "Client not found"),
-    ERROR_1017(1017, "Invalid Redirect URI");
+    ERROR_1017(1017, "Invalid Redirect URI"),
+    ERROR_1018(1018, "Invalid authorization code parameter");
 
     @JsonProperty("code")
     private int code;

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/TokenHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/TokenHandler.java
@@ -100,7 +100,7 @@ public class TokenHandler
             return generateApiGatewayProxyErrorResponse(403, ErrorResponse.ERROR_1015);
         }
         String code = requestBody.get("code");
-        Optional<String> clientSessionId = authorisationCodeService.getSessionIdForCode(code);
+        Optional<String> clientSessionId = authorisationCodeService.getClientSessionIdForCode(code);
         if (clientSessionId.isEmpty()) {
             return generateApiGatewayProxyErrorResponse(403, ErrorResponse.ERROR_1018);
         }

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/TokenHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/TokenHandler.java
@@ -14,7 +14,9 @@ import com.nimbusds.openid.connect.sdk.token.OIDCTokens;
 import uk.gov.di.entity.ClientRegistry;
 import uk.gov.di.entity.ErrorResponse;
 import uk.gov.di.services.AuthenticationService;
+import uk.gov.di.services.AuthorisationCodeService;
 import uk.gov.di.services.ClientService;
+import uk.gov.di.services.ClientSessionService;
 import uk.gov.di.services.ConfigurationService;
 import uk.gov.di.services.DynamoClientService;
 import uk.gov.di.services.DynamoService;
@@ -35,16 +37,22 @@ public class TokenHandler
     private final TokenService tokenService;
     private final AuthenticationService authenticationService;
     private final ConfigurationService configurationService;
+    private final AuthorisationCodeService authorisationCodeService;
+    private final ClientSessionService clientSessionService;
 
     public TokenHandler(
             ClientService clientService,
             TokenService tokenService,
             AuthenticationService authenticationService,
-            ConfigurationService configurationService) {
+            ConfigurationService configurationService,
+            AuthorisationCodeService authorisationCodeService,
+            ClientSessionService clientSessionService) {
         this.clientService = clientService;
         this.tokenService = tokenService;
         this.authenticationService = authenticationService;
         this.configurationService = configurationService;
+        this.authorisationCodeService = authorisationCodeService;
+        this.clientSessionService = clientSessionService;
     }
 
     public TokenHandler() {
@@ -62,6 +70,8 @@ public class TokenHandler
                         configurationService.getAwsRegion(),
                         configurationService.getEnvironment(),
                         configurationService.getDynamoEndpointUri());
+        this.authorisationCodeService = new AuthorisationCodeService(configurationService);
+        this.clientSessionService = new ClientSessionService(configurationService);
     }
 
     @Override
@@ -80,6 +90,7 @@ public class TokenHandler
         if (client.isEmpty()) {
             return generateApiGatewayProxyErrorResponse(403, ErrorResponse.ERROR_1016);
         }
+
         boolean privateKeyJWTIsValid =
                 tokenService.validatePrivateKeyJWTSignature(
                         client.get().getPublicKey(),
@@ -88,6 +99,12 @@ public class TokenHandler
         if (!privateKeyJWTIsValid) {
             return generateApiGatewayProxyErrorResponse(403, ErrorResponse.ERROR_1015);
         }
+        String code = requestBody.get("code");
+        Optional<String> clientSessionId = authorisationCodeService.getSessionIdForCode(code);
+        if (clientSessionId.isEmpty()) {
+            return generateApiGatewayProxyErrorResponse(403, ErrorResponse.ERROR_1018);
+        }
+
         //        TODO: String email = authorizationCodeService.getEmailForCode(code);
         String email = "joe.bloggs@digital.cabinet-office.gov.uk";
 
@@ -106,6 +123,11 @@ public class TokenHandler
         OIDCTokens oidcTokens = new OIDCTokens(idToken, accessToken, null);
         OIDCTokenResponse tokenResponse = new OIDCTokenResponse(oidcTokens);
 
+        clientSessionService.saveClientSession(
+                clientSessionId.get(),
+                clientSessionService
+                        .getClientSession(clientSessionId.get())
+                        .setIdTokenHint(idToken.serialize()));
         return generateApiGatewayProxyResponse(200, tokenResponse.toJSONObject().toJSONString());
     }
 

--- a/serverless/lambda/src/main/java/uk/gov/di/services/AuthorisationCodeService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/AuthorisationCodeService.java
@@ -1,0 +1,35 @@
+package uk.gov.di.services;
+
+import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+
+public class AuthorisationCodeService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AuthorisationCodeService.class);
+    private static final String AUTH_CODE_PREFIX = "auth-code-";
+
+    private final RedisConnectionService redisConnectionService;
+
+    public AuthorisationCodeService(ConfigurationService configurationService) {
+        this.redisConnectionService =
+                new RedisConnectionService(
+                        configurationService.getRedisHost(),
+                        configurationService.getRedisPort(),
+                        configurationService.getUseRedisTLS(),
+                        configurationService.getRedisPassword());
+    }
+
+    public AuthorizationCode generateAuthorisationCode(String sessionId) {
+        AuthorizationCode authorizationCode = new AuthorizationCode();
+        redisConnectionService.saveWithExpiry(
+                AUTH_CODE_PREFIX.concat(authorizationCode.getValue()), sessionId, 60);
+        return authorizationCode;
+    }
+
+    public Optional<String> getSessionIdForCode(String code) {
+        return Optional.ofNullable(redisConnectionService.popValue(AUTH_CODE_PREFIX.concat(code)));
+    }
+}

--- a/serverless/lambda/src/main/java/uk/gov/di/services/ClientSessionService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/ClientSessionService.java
@@ -52,4 +52,17 @@ public class ClientSessionService {
             throw new RuntimeException(e);
         }
     }
+
+    public ClientSession saveClientSession(String clientSessionId, ClientSession clientSession) {
+        try {
+            redisConnectionService.saveWithExpiry(
+                    CLIENT_SESSION_PREFIX.concat(clientSessionId),
+                    objectMapper.writeValueAsString(clientSession),
+                    configurationService.getSessionExpiry());
+            return clientSession;
+        } catch (JsonProcessingException e) {
+            LOG.error("Error saving client session to Redis", e);
+            throw new RuntimeException(e);
+        }
+    }
 }

--- a/serverless/lambda/src/main/java/uk/gov/di/services/RedisConnectionService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/RedisConnectionService.java
@@ -2,7 +2,9 @@ package uk.gov.di.services;
 
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.RedisURI;
+import io.lettuce.core.TransactionResult;
 import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.sync.RedisCommands;
 
 import java.util.Optional;
 
@@ -47,6 +49,17 @@ public class RedisConnectionService implements AutoCloseable {
     public long deleteValue(String key) {
         try (StatefulRedisConnection<String, String> connection = client.connect()) {
             return connection.sync().del(key);
+        }
+    }
+
+    public String popValue(String key) {
+        try (StatefulRedisConnection<String, String> connection = client.connect()) {
+            RedisCommands<String, String> commands = connection.sync();
+            commands.multi();
+            commands.get(key);
+            commands.del(key);
+            TransactionResult result = commands.exec();
+            return result.get(0);
         }
     }
 

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/AuthCodeHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/AuthCodeHandlerTest.java
@@ -17,9 +17,9 @@ import uk.gov.di.entity.ClientSession;
 import uk.gov.di.entity.ErrorResponse;
 import uk.gov.di.entity.Session;
 import uk.gov.di.exceptions.ClientNotFoundException;
+import uk.gov.di.services.AuthorisationCodeService;
 import uk.gov.di.services.AuthorizationService;
 import uk.gov.di.services.ClientSessionService;
-import uk.gov.di.services.CodeStorageService;
 import uk.gov.di.services.ConfigurationService;
 import uk.gov.di.services.SessionService;
 
@@ -33,7 +33,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -49,7 +48,8 @@ class AuthCodeHandlerTest {
     private static final URI REDIRECT_URI = URI.create("http://localhost/redirect");
     private final AuthorizationService authorizationService = mock(AuthorizationService.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
-    private final CodeStorageService codeStorageService = mock(CodeStorageService.class);
+    private final AuthorisationCodeService authorisationCodeService =
+            mock(AuthorisationCodeService.class);
     private final SessionService sessionService = mock(SessionService.class);
     private final Context context = mock(Context.class);
     private final ClientSessionService clientSessionService = mock(ClientSessionService.class);
@@ -60,7 +60,7 @@ class AuthCodeHandlerTest {
         handler =
                 new AuthCodeHandler(
                         sessionService,
-                        codeStorageService,
+                        authorisationCodeService,
                         configurationService,
                         authorizationService,
                         clientSessionService);
@@ -93,8 +93,7 @@ class AuthCodeHandlerTest {
         event.setBody(format("{ \"client_session_id\": \"%s\"}", CLIENT_SESSION_ID));
         APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
 
-        verify(codeStorageService)
-                .saveAuthorizationCode(anyString(), eq(CLIENT_SESSION_ID), eq(300L));
+        verify(authorisationCodeService).generateAuthorisationCode(eq(CLIENT_SESSION_ID));
         assertThat(response, hasStatus(302));
         assertThat(
                 response.getHeaders().get("Location"),

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/TokenHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/TokenHandlerTest.java
@@ -4,7 +4,6 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jwt.SignedJWT;
@@ -17,9 +16,13 @@ import com.nimbusds.oauth2.sdk.util.URLUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.entity.ClientRegistry;
+import uk.gov.di.entity.ClientSession;
 import uk.gov.di.entity.ErrorResponse;
+import uk.gov.di.helpers.ObjectMapperFactory;
 import uk.gov.di.services.AuthenticationService;
+import uk.gov.di.services.AuthorisationCodeService;
 import uk.gov.di.services.ClientService;
+import uk.gov.di.services.ClientSessionService;
 import uk.gov.di.services.ConfigurationService;
 import uk.gov.di.services.TokenService;
 
@@ -29,6 +32,7 @@ import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.interfaces.RSAPrivateKey;
+import java.time.LocalDateTime;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
@@ -54,19 +58,28 @@ public class TokenHandlerTest {
     private static final String CLIENT_ID = "test-id";
     private static final List<String> SCOPES = List.of("openid");
     private static final String ENDPOINT_URI = "http://localhost/token";
+    public static final String CLIENT_SESSION_ID = "a-client-session-id";
     private final Context context = mock(Context.class);
     private final SignedJWT signedJWT = mock(SignedJWT.class);
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final TokenService tokenService = mock(TokenService.class);
     private final ClientService clientService = mock(ClientService.class);
+    private final AuthorisationCodeService authorisationCodeService =
+            mock(AuthorisationCodeService.class);
+    private final ClientSessionService clientSessionService = mock(ClientSessionService.class);
     private TokenHandler handler;
 
     @BeforeEach
     public void setUp() {
         handler =
                 new TokenHandler(
-                        clientService, tokenService, authenticationService, configurationService);
+                        clientService,
+                        tokenService,
+                        authenticationService,
+                        configurationService,
+                        authorisationCodeService,
+                        clientSessionService);
     }
 
     @Test
@@ -96,8 +109,14 @@ public class TokenHandlerTest {
         when(tokenService.generateAndStoreAccessToken(eq(CLIENT_ID), eq(TEST_SUBJECT), eq(SCOPES)))
                 .thenReturn(accessToken);
         when(tokenService.generateIDToken(eq(CLIENT_ID), any(Subject.class))).thenReturn(signedJWT);
+        String authCode = new AuthorizationCode().toString();
+        when(authorisationCodeService.getSessionIdForCode(authCode))
+                .thenReturn(Optional.of(CLIENT_SESSION_ID));
+        when(clientSessionService.getClientSession(CLIENT_SESSION_ID))
+                .thenReturn(new ClientSession(Map.of(), LocalDateTime.now()));
 
-        APIGatewayProxyResponseEvent result = generateApiGatewayRequest(privateKeyJWT, CLIENT_ID);
+        APIGatewayProxyResponseEvent result =
+                generateApiGatewayRequest(privateKeyJWT, CLIENT_ID, authCode);
 
         assertThat(result, hasStatus(200));
         assertTrue(result.getBody().contains(accessToken.getValue()));
@@ -114,7 +133,8 @@ public class TokenHandlerTest {
                 generateApiGatewayRequest(privateKeyJWT, invalidClientID);
 
         assertEquals(403, result.getStatusCode());
-        String expectedResponse = new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1016);
+        String expectedResponse =
+                ObjectMapperFactory.getInstance().writeValueAsString(ErrorResponse.ERROR_1016);
         assertThat(result, hasBody(expectedResponse));
     }
 
@@ -126,7 +146,8 @@ public class TokenHandlerTest {
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertEquals(400, result.getStatusCode());
-        String expectedResponse = new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1001);
+        String expectedResponse =
+                ObjectMapperFactory.getInstance().writeValueAsString(ErrorResponse.ERROR_1001);
         assertThat(result, hasBody(expectedResponse));
     }
 
@@ -157,7 +178,8 @@ public class TokenHandlerTest {
         APIGatewayProxyResponseEvent result = generateApiGatewayRequest(privateKeyJWT, CLIENT_ID);
 
         assertThat(result, hasStatus(403));
-        String expectedResponse = new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1015);
+        String expectedResponse =
+                ObjectMapperFactory.getInstance().writeValueAsString(ErrorResponse.ERROR_1015);
         assertThat(result, hasBody(expectedResponse));
     }
 
@@ -174,10 +196,16 @@ public class TokenHandlerTest {
 
     private APIGatewayProxyResponseEvent generateApiGatewayRequest(
             PrivateKeyJWT privateKeyJWT, String clientID) {
+        return generateApiGatewayRequest(
+                privateKeyJWT, clientID, new AuthorizationCode().toString());
+    }
+
+    private APIGatewayProxyResponseEvent generateApiGatewayRequest(
+            PrivateKeyJWT privateKeyJWT, String clientID, String authorisationCode) {
         Map<String, List<String>> customParams = new HashMap<>();
         customParams.put("grant_type", Collections.singletonList("authorization_code"));
         customParams.put("client_id", Collections.singletonList(clientID));
-        customParams.put("code", Collections.singletonList(new AuthorizationCode().toString()));
+        customParams.put("code", Collections.singletonList(authorisationCode));
         customParams.put("redirect_uri", Collections.singletonList("http://localhost/redirect"));
         Map<String, List<String>> privateKeyParams = privateKeyJWT.toParameters();
         privateKeyParams.putAll(customParams);

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/TokenHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/TokenHandlerTest.java
@@ -110,7 +110,7 @@ public class TokenHandlerTest {
                 .thenReturn(accessToken);
         when(tokenService.generateIDToken(eq(CLIENT_ID), any(Subject.class))).thenReturn(signedJWT);
         String authCode = new AuthorizationCode().toString();
-        when(authorisationCodeService.getSessionIdForCode(authCode))
+        when(authorisationCodeService.getClientSessionIdForCode(authCode))
                 .thenReturn(Optional.of(CLIENT_SESSION_ID));
         when(clientSessionService.getClientSession(CLIENT_SESSION_ID))
                 .thenReturn(new ClientSession(Map.of(), LocalDateTime.now()));


### PR DESCRIPTION
## What?

- When issuing tokens from the `token` endpoint, ensure the issued ID token is stored against the client session
- Refactor code generation and storage into own class

## Why?

We need to store the ID tokens as they will be used as hints during by `logout` endpoint.