### PR TITLE
BAU: Fix integration test random fails

### DIFF
--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -20,6 +20,8 @@ dependencies {
             'org.eclipse.jetty:jetty-server:11.0.6',
             "software.amazon.awssdk:sqs:2.16.88",
             "org.awaitility:awaitility:4.1.0",
+            "com.amazonaws:aws-java-sdk-dynamodb:1.12.35",
+            "io.lettuce:lettuce-core:6.1.4.RELEASE",
             project(":serverless:lambda")
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.2'
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -6,7 +6,7 @@ import jakarta.ws.rs.client.Invocation;
 import jakarta.ws.rs.core.Cookie;
 import jakarta.ws.rs.core.Response;
 import org.glassfish.jersey.client.ClientProperties;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.helpers.DynamoHelper;
 import uk.gov.di.authentication.helpers.RedisHelper;
@@ -37,8 +37,8 @@ public class AuthorisationIntegrationTest extends IntegrationTestEndpoints {
 
     private static final ConfigurationService configurationService = new ConfigurationService();
 
-    @BeforeAll
-    public static void setup() {
+    @BeforeEach
+    public void setup() {
         DynamoHelper.registerClient(
                 CLIENT_ID,
                 "test-client",

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -5,6 +5,7 @@ import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.client.Invocation;
 import jakarta.ws.rs.core.Cookie;
 import jakarta.ws.rs.core.Response;
+import org.glassfish.jersey.client.ClientProperties;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.helpers.DynamoHelper;
@@ -128,6 +129,7 @@ public class AuthorisationIntegrationTest extends IntegrationTestEndpoints {
 
         Invocation.Builder builder =
                 client.target(ROOT_RESOURCE_URL + AUTHORIZE_ENDPOINT)
+                        .property(ClientProperties.FOLLOW_REDIRECTS, false)
                         .queryParam("response_type", "code")
                         .queryParam("redirect_uri", "localhost")
                         .queryParam("state", "8VAVNSxHO1HwiNDhwchQKdd7eOUK3ltKfQzwPDxu9LU")

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IntegrationTestEndpoints.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IntegrationTestEndpoints.java
@@ -1,5 +1,9 @@
 package uk.gov.di.authentication.api;
 
+import org.junit.jupiter.api.BeforeEach;
+import uk.gov.di.authentication.helpers.DynamoHelper;
+import uk.gov.di.authentication.helpers.RedisHelper;
+
 import java.util.Optional;
 
 public class IntegrationTestEndpoints {
@@ -10,4 +14,10 @@ public class IntegrationTestEndpoints {
     public static final String ROOT_RESOURCE_URL =
             Optional.ofNullable(System.getenv().get("ROOT_RESOURCE_URL"))
                     .orElse(String.format(LOCAL_ENDPOINT_FORMAT, LOCAL_API_GATEWAY_ID));
+
+    @BeforeEach
+    public void flushData() {
+        RedisHelper.flushData();
+        DynamoHelper.flushData();
+    }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
@@ -3,6 +3,7 @@ package uk.gov.di.authentication.api;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.helpers.DynamoHelper;
 import uk.gov.di.authentication.helpers.RedisHelper;
 import uk.gov.di.authentication.helpers.RequestHelper;
 import uk.gov.di.entity.BaseAPIResponse;
@@ -86,6 +87,7 @@ public class VerifyCodeIntegrationTest extends IntegrationTestEndpoints {
         String code = RedisHelper.generateAndSavePhoneNumberCode(EMAIL_ADDRESS, 900);
         VerifyCodeRequest codeRequest =
                 new VerifyCodeRequest(NotificationType.VERIFY_PHONE_NUMBER, code);
+        DynamoHelper.signUp(EMAIL_ADDRESS, "password");
 
         Response response =
                 RequestHelper.requestWithSession(VERIFY_CODE_ENDPOINT, codeRequest, sessionId);

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -64,7 +64,7 @@ if [[ ${RUN_INTEGRATION} -eq 1 ]]; then
   export AWS_ACCESS_KEY_ID="mock-access-key"
   export AWS_SECRET_ACCESS_KEY="mock-secret-key"
   export STUB_RELYING_PARTY_REDIRECT_URI="https://di-auth-stub-relying-party-build.london.cloudapps.digital/"
-  export LOGIN_URI="https://di-authentication-frontend.london.cloudapps.digital/"
+  export LOGIN_URI="http://localhost:3000/"
 
   startup
 
@@ -78,6 +78,7 @@ fi
 
 if [ ${build_and_test_exit_code} -ne 0 ]; then
   printf "\npre-commit failed.\n"
+  exit ${build_and_test_exit_code}
 else
   if [[ ${IN_GITHUB_ACTIONS} -eq 0 ]]; then
     funky_success


### PR DESCRIPTION
## What?

- Ensure `pre-commit.sh` exits with the correct code so that GitHub actions reports the failures correctly.
- Update `LOGIN_URL` in `pre-commit.sh` is correct.
- Stop the Jersey client from following re-directs when 
- When running integration tests ensure that data in Dynamo and Redis is flushed by adding a `@BeforeEach` to the base class (note this will always be executed before any `@BeforeEach` methods in the sub-class ... according to the JUnit docs)
- Setup VerifyCode data correctly before running test (we weren't stubbing this data, so depending on the order tests are run in, we were getting failures).

## Why?

We were getting random failures of several integration tests, which were not being reported correctly. This PR fixes the issue with reporting the errors and, hopefully, will stop the randomness.
