### PR TITLE
BAU: add docker checks to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,12 @@ updates:
     target-branch: main
     labels:
       - dependabot
+  - package-ecosystem: docker
+    directory: "/docker"
+    schedule:
+      interval: daily
+      time: "03:00"
+    open-pull-requests-limit: 10
+    target-branch: main
+    labels:
+    - dependabot


### PR DESCRIPTION

## What?

Add docker checks to dependabot

## Why?

These checks are not enabled.
Localstack version has fallen behind.

