### PR TITLE
GOVSI-647 - Set Domain in Cookie

### DIFF
--- a/ci/terraform/aws/authorize.tf
+++ b/ci/terraform/aws/authorize.tf
@@ -7,6 +7,7 @@ module "authorize" {
 
   handler_environment_variables = {
     BASE_URL       = local.api_base_url
+    DOMAIN_NAME    =  "${var.environment}.${var.service_domain_name}"
     LOGIN_URI      = var.use_localstack ? "http://localhost:3000/" : "https://front.${var.environment}.${var.service_domain_name}/"
     REDIS_HOST     = var.use_localstack ? var.external_redis_host : aws_elasticache_replication_group.sessions_store[0].primary_endpoint_address
     REDIS_PORT     = var.use_localstack ? var.external_redis_port : aws_elasticache_replication_group.sessions_store[0].port

--- a/serverless/lambda/src/main/java/uk/gov/di/services/ConfigurationService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/ConfigurationService.java
@@ -92,6 +92,10 @@ public class ConfigurationService {
         return Optional.ofNullable(System.getenv("DYNAMO_ENDPOINT"));
     }
 
+    public String getDomainName() {
+        return System.getenv("DOMAIN_NAME");
+    }
+
     public int getCodeMaxRetries() {
         return Integer.parseInt(System.getenv().getOrDefault("CODE_MAX_RETRIES", "5"));
     }


### PR DESCRIPTION
## What?

- Now that we have a domain we can use for the time-being, let's set it in the Cookie so it can be used by our frontend which is also on the same sub domain.
- Don't send the scopes or session-id separately in the redirect. The session-id is in the Cookie and the scopes are not used.

## Why?

- Now that we have a domain we can use for the time-being, let's set it in the Cookie so it can be used by our frontend which is also on the same sub domain.
