### PR TITLE
GOVSI-500: Protect user journey transitions with state machine

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/SignupIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/SignupIntegrationTest.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static uk.gov.di.entity.SessionState.AUTHENTICATION_REQUIRED;
 import static uk.gov.di.entity.SessionState.TWO_FACTOR_REQUIRED;
 
 public class SignupIntegrationTest extends IntegrationTestEndpoints {
@@ -23,6 +24,8 @@ public class SignupIntegrationTest extends IntegrationTestEndpoints {
     @Test
     public void shouldCallSignupEndpointAndReturn200() throws IOException {
         String sessionId = RedisHelper.createSession();
+
+        RedisHelper.setSessionState(sessionId, AUTHENTICATION_REQUIRED);
 
         SignupRequest request =
                 new SignupRequest("joe.bloggs+5@digital.cabinet-office.gov.uk", "password-1");

--- a/serverless/lambda/src/main/java/uk/gov/di/entity/ErrorResponse.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/entity/ErrorResponse.java
@@ -23,7 +23,8 @@ public enum ErrorResponse {
     ERROR_1015(1015, "Unable to Verify Signature of Private Key JWT"),
     ERROR_1016(1016, "Client not found"),
     ERROR_1017(1017, "Invalid Redirect URI"),
-    ERROR_1018(1018, "Invalid authorization code parameter");
+    ERROR_1018(1018, "Invalid authorization code parameter"),
+    ERROR_1019(1019, "Invalid transition in user journey");
 
     @JsonProperty("code")
     private int code;

--- a/serverless/lambda/src/main/java/uk/gov/di/helpers/StateMachine.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/helpers/StateMachine.java
@@ -1,10 +1,17 @@
 package uk.gov.di.helpers;
 
+import uk.gov.di.entity.SessionState;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
 import static java.util.Collections.emptyList;
+import static java.util.Map.entry;
+import static java.util.Map.ofEntries;
+import static uk.gov.di.entity.SessionState.AUTHENTICATION_REQUIRED;
+import static uk.gov.di.entity.SessionState.TWO_FACTOR_REQUIRED;
+import static uk.gov.di.entity.SessionState.USER_NOT_FOUND;
 
 public class StateMachine<T> {
 
@@ -16,5 +23,14 @@ public class StateMachine<T> {
 
     public boolean isValidTransition(T from, T to) {
         return states.getOrDefault(from, emptyList()).contains(to);
+    }
+
+    public static StateMachine<SessionState> userJourneyStateMachine() {
+        var states =
+                ofEntries(
+                        entry(USER_NOT_FOUND, List.of(TWO_FACTOR_REQUIRED)),
+                        entry(AUTHENTICATION_REQUIRED, List.of(TWO_FACTOR_REQUIRED)));
+
+        return new StateMachine<>(states);
     }
 }

--- a/serverless/lambda/src/main/java/uk/gov/di/helpers/StateMachine.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/helpers/StateMachine.java
@@ -1,0 +1,20 @@
+package uk.gov.di.helpers;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.emptyList;
+
+public class StateMachine<T> {
+
+    private final Map<T, List<T>> states;
+
+    public StateMachine(Map<T, List<T>> states) {
+        this.states = Collections.unmodifiableMap(states);
+    }
+
+    public boolean isValidTransition(T from, T to) {
+        return states.getOrDefault(from, emptyList()).contains(to);
+    }
+}

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/SignUpHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/SignUpHandler.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import static uk.gov.di.entity.SessionState.TWO_FACTOR_REQUIRED;
 import static uk.gov.di.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
+import static uk.gov.di.helpers.StateMachine.userJourneyStateMachine;
 
 public class SignUpHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -57,6 +58,11 @@ public class SignUpHandler
         Optional<Session> session = sessionService.getSessionFromRequestHeaders(input.getHeaders());
         if (session.isEmpty()) {
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1000);
+        }
+
+        if (!userJourneyStateMachine()
+                .isValidTransition(session.get().getState(), TWO_FACTOR_REQUIRED)) {
+            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1019);
         }
 
         try {

--- a/serverless/lambda/src/test/java/uk/gov/di/helpers/StateMachineTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/helpers/StateMachineTest.java
@@ -1,0 +1,42 @@
+package uk.gov.di.helpers;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static uk.gov.di.helpers.StateMachineTest.State.STATE_1;
+import static uk.gov.di.helpers.StateMachineTest.State.STATE_2;
+import static uk.gov.di.helpers.StateMachineTest.State.STATE_3;
+
+public class StateMachineTest {
+
+    enum State {
+        STATE_1,
+        STATE_2,
+        STATE_3,
+    }
+
+    @Test
+    public void returnsTrueForValidTransition() {
+        var stateMachine = new StateMachine<>(Map.of(STATE_1, List.of(STATE_2)));
+
+        assertTrue(stateMachine.isValidTransition(STATE_1, STATE_2));
+    }
+
+    @Test
+    public void returnsFalseForValidTransition() {
+        var stateMachine = new StateMachine<>(Map.of(STATE_1, List.of(STATE_2)));
+
+        assertFalse(stateMachine.isValidTransition(STATE_2, STATE_1));
+    }
+
+    @Test
+    public void returnsFalseForMissingTransition() {
+        var stateMachine = new StateMachine<>(Map.of(STATE_1, List.of(STATE_2)));
+
+        assertFalse(stateMachine.isValidTransition(STATE_3, STATE_1));
+    }
+}


### PR DESCRIPTION
## What?

This PR adds a state-machine capability and implements transition protection on one of the user account registration endpoints.

## Why?

We want to ensure that users, whether accidentally or deliberately, cannot jump between parts of the journey and circumvent (or skip entirely) steps.

# Outstanding questions

- Is `SessionState` the right representation of the state of a user, or will it be more closely aligned with what we eventually send to the audit processing service?
- Do we need to provide another endpoint that can rely the current user state to the frontend?
- Is throwing a general error ("Invalid transition in user journey") sufficient or should it be tailored to the endpoint and previous state?
