### PR TITLE
GOVSI-650 - Read the scopes from the auth request in token endpoint

### DIFF
--- a/ci/terraform/aws/token.tf
+++ b/ci/terraform/aws/token.tf
@@ -9,6 +9,10 @@ module "token" {
     ENVIRONMENT = var.environment
     BASE_URL = "${local.api_base_url}/token"
     DYNAMO_ENDPOINT = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    REDIS_HOST     = var.use_localstack ? var.external_redis_host : aws_elasticache_replication_group.sessions_store[0].primary_endpoint_address
+    REDIS_PORT     = var.use_localstack ? var.external_redis_port : aws_elasticache_replication_group.sessions_store[0].port
+    REDIS_PASSWORD = var.use_localstack ? var.external_redis_password : random_password.redis_password.result
+    REDIS_TLS      = var.redis_use_tls
   }
   handler_function_name = "uk.gov.di.lambdas.TokenHandler::handleRequest"
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
@@ -27,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class AuthCodeIntegrationTest extends IntegrationTestEndpoints {
 
     private static final String AUTH_CODE_ENDPOINT = "/auth-code";
+    private static final String EMAIL = "joe.bloggs@digital.cabinet-office.gov.uk";
     private static final URI REDIRECT_URI =
             URI.create(System.getenv("STUB_RELYING_PARTY_REDIRECT_URI"));
     private static final ClientID CLIENT_ID = new ClientID("test-client");
@@ -39,7 +40,7 @@ public class AuthCodeIntegrationTest extends IntegrationTestEndpoints {
         KeyPair keyPair = generateRsaKeyPair();
         RedisHelper.createSession(sessionId);
         RedisHelper.addAuthRequestToSession(
-                clientSessionId, sessionId, generateAuthRequest().toParameters());
+                clientSessionId, sessionId, generateAuthRequest().toParameters(), EMAIL);
         setUpDynamo(keyPair);
         MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
         headers.add(COOKIE, buildCookieString(sessionId, clientSessionId));
@@ -66,7 +67,7 @@ public class AuthCodeIntegrationTest extends IntegrationTestEndpoints {
                 CLIENT_ID.getValue(),
                 "test-client",
                 singletonList(REDIRECT_URI.toString()),
-                singletonList("joe.bloggs@digital.cabinet-office.gov.uk"),
+                singletonList(EMAIL),
                 singletonList("openid"),
                 Base64.getMimeEncoder().encodeToString(keyPair.getPublic().getEncoded()),
                 singletonList("http://localhost/post-redirect-logout"));

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
@@ -44,7 +44,10 @@ public class LogoutIntegrationTest extends IntegrationTestEndpoints {
                         "client-id", new Subject(), "http://localhost/issuer", signingKey);
         RedisHelper.createSession(sessionId);
         RedisHelper.addAuthRequestToSession(
-                clientSessionId, sessionId, generateAuthRequest().toParameters());
+                clientSessionId,
+                sessionId,
+                generateAuthRequest().toParameters(),
+                "joe.bloggs@digital.cabinet-office.gov.uk");
         RedisHelper.addIDTokenToSession(clientSessionId, signedJWT.serialize());
         DynamoHelper.registerClient(
                 "client-id",

--- a/serverless/lambda/src/main/java/uk/gov/di/entity/ClientSession.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/entity/ClientSession.java
@@ -17,12 +17,17 @@ public class ClientSession {
     @JsonProperty("creation_date")
     private LocalDateTime creationDate;
 
+    @JsonProperty("email")
+    private String email;
+
     public ClientSession(
             @JsonProperty(required = true, value = "auth_request_params")
                     Map<String, List<String>> authRequestParams,
-            @JsonProperty(required = true, value = "creation_date") LocalDateTime creationDate) {
+            @JsonProperty(required = true, value = "creation_date") LocalDateTime creationDate,
+            @JsonProperty(required = true, value = "email") String email) {
         this.authRequestParams = authRequestParams;
         this.creationDate = creationDate;
+        this.email = email;
     }
 
     public ClientSession setIdTokenHint(String idTokenHint) {
@@ -36,6 +41,10 @@ public class ClientSession {
 
     public String getIdTokenHint() {
         return idTokenHint;
+    }
+
+    public String getEmail() {
+        return email;
     }
 
     public LocalDateTime getCreationDate() {

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/AuthorisationHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/AuthorisationHandler.java
@@ -145,7 +145,10 @@ public class AuthorisationHandler
             URI redirectURI) {
         String clientSessionID =
                 clientSessionService.generateClientSession(
-                        new ClientSession(authRequestParameters, LocalDateTime.now()));
+                        new ClientSession(
+                                authRequestParameters,
+                                LocalDateTime.now(),
+                                session.getEmailAddress()));
         updateSessionId(session, authenticationRequest.getClientID(), clientSessionID);
         return redirect(session, clientSessionID, redirectURI);
     }
@@ -180,7 +183,8 @@ public class AuthorisationHandler
 
         String clientSessionID =
                 clientSessionService.generateClientSession(
-                        new ClientSession(authRequest, LocalDateTime.now()));
+                        new ClientSession(
+                                authRequest, LocalDateTime.now(), session.getEmailAddress()));
         session.addClientSession(clientSessionID);
         LOGGER.info(
                 "Created session {} for client {} - client session id = {}",

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/AuthCodeHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/AuthCodeHandlerTest.java
@@ -45,6 +45,7 @@ class AuthCodeHandlerTest {
     private static final String SESSION_ID = "a-session-id";
     private static final String CLIENT_SESSION_ID = "client-session-id";
     private static final String COOKIE = "Cookie";
+    private static final String EMAIL = "joe.bloggs@digital.cabinet-office.gov.uk";
     private static final URI REDIRECT_URI = URI.create("http://localhost/redirect");
     private final AuthorizationService authorizationService = mock(AuthorizationService.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
@@ -174,7 +175,7 @@ class AuthCodeHandlerTest {
                 .thenReturn(
                         Optional.of(new Session(SESSION_ID).addClientSession(CLIENT_SESSION_ID)));
         when(clientSessionService.getClientSession(CLIENT_SESSION_ID))
-                .thenReturn(new ClientSession(authRequest, LocalDateTime.now()));
+                .thenReturn(new ClientSession(authRequest, LocalDateTime.now(), EMAIL));
     }
 
     private String buildCookieString() {

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/LogoutHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/LogoutHandlerTest.java
@@ -52,6 +52,7 @@ class LogoutHandlerTest {
     private static final String COOKIE = "Cookie";
     private static final String SESSION_ID = "a-session-id";
     private static final String CLIENT_SESSION_ID = "client-session-id";
+    private static final String TEST_EMAIL = "joe.bloggs@digital.cabinet-office.gov.uk";
     private static final URI DEFAULT_LOGOUT_URI =
             URI.create("https://di-authentication-frontend.london.cloudapps.digital/signed-out");
     private static final URI CLIENT_LOGOUT_URI = URI.create("http://localhost/logout");
@@ -257,7 +258,8 @@ class LogoutHandlerTest {
                                 List.of("code"),
                                 "state",
                                 List.of("some-state")),
-                        LocalDateTime.now());
+                        LocalDateTime.now(),
+                        TEST_EMAIL);
         clientSession.setIdTokenHint(idToken.serialize());
         when(clientSessionService.getClientSession(CLIENT_SESSION_ID)).thenReturn(clientSession);
     }

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/TokenHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/TokenHandlerTest.java
@@ -8,8 +8,12 @@ import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import com.nimbusds.oauth2.sdk.AuthorizationRequest;
+import com.nimbusds.oauth2.sdk.ResponseType;
+import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.auth.PrivateKeyJWT;
 import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.oauth2.sdk.util.URLUtils;
@@ -96,7 +100,6 @@ public class TokenHandlerTest {
                         .setPublicKey(
                                 Base64.getMimeEncoder()
                                         .encodeToString(keyPair.getPublic().getEncoded()));
-
         BearerAccessToken accessToken = new BearerAccessToken();
         when(configurationService.getBaseURL()).thenReturn(Optional.of(ENDPOINT_URI));
         when(clientService.getClient(eq(CLIENT_ID))).thenReturn(Optional.of(clientRegistry));
@@ -113,7 +116,11 @@ public class TokenHandlerTest {
         when(authorisationCodeService.getClientSessionIdForCode(authCode))
                 .thenReturn(Optional.of(CLIENT_SESSION_ID));
         when(clientSessionService.getClientSession(CLIENT_SESSION_ID))
-                .thenReturn(new ClientSession(Map.of(), LocalDateTime.now()));
+                .thenReturn(
+                        new ClientSession(
+                                generateAuthRequest().toParameters(),
+                                LocalDateTime.now(),
+                                TEST_EMAIL));
 
         APIGatewayProxyResponseEvent result =
                 generateApiGatewayRequest(privateKeyJWT, CLIENT_ID, authCode);
@@ -213,6 +220,18 @@ public class TokenHandlerTest {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setBody(requestParams);
         return handler.handleRequest(event, context);
+    }
+
+    private AuthorizationRequest generateAuthRequest() {
+        Scope scopeValues = new Scope();
+        scopeValues.add("openid");
+        ResponseType responseType = new ResponseType(ResponseType.Value.CODE);
+        State state = new State();
+        return new AuthorizationRequest.Builder(responseType, new ClientID(CLIENT_ID))
+                .redirectionURI(URI.create("http://localhost:8080/redirect"))
+                .state(state)
+                .scope(scopeValues)
+                .build();
     }
 
     private KeyPair generateRsaKeyPair() {

--- a/serverless/lambda/src/test/java/uk/gov/di/services/SessionServiceTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/services/SessionServiceTest.java
@@ -5,12 +5,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.junit.jupiter.api.Test;
-import uk.gov.di.entity.ClientSession;
 import uk.gov.di.entity.Session;
 
-import java.time.LocalDateTime;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -145,8 +142,6 @@ class SessionServiceTest {
     }
 
     private String generateSearlizedSession() throws JsonProcessingException {
-        ClientSession clientSession =
-                new ClientSession(Map.of("client_id", List.of("a-client-id")), LocalDateTime.now());
         var session = new Session("session-id").addClientSession("client-session-id");
 
         return objectMapper.writeValueAsString(session);


### PR DESCRIPTION
## What?

- Store the email in the client session id so once we have the client session id we can get the correct Subject to add to the token
- Get the authRequest out of the ClientSession and extract the scopes so they can be added to the token
- Add Redis config to the Token.tf so it can access Redis


## Why?
- Because the email was being previously hardcoded 
- We were ignoring the scopes in the Auth Request and using the ones in the client registry. The ones in the client registry should be used to validate the scopes in the Auth Request against. 
