### PR TITLE
BAU - Fix secondary keys for Dynamo and don't follow redirect on integration test

### DIFF
--- a/ci/terraform/aws/dynamodb.tf
+++ b/ci/terraform/aws/dynamodb.tf
@@ -20,8 +20,7 @@ resource "aws_dynamodb_table" "user_credentials_table" {
     hash_key           = "SubjectID"
     write_capacity     = 5
     read_capacity      = 5
-    projection_type    = "INCLUDE"
-    non_key_attributes = ["Email"]
+    projection_type    = "ALL"
   }
 
   server_side_encryption {
@@ -81,8 +80,7 @@ resource "aws_dynamodb_table" "client_registry_table" {
     hash_key           = "ClientName"
     write_capacity     = 5
     read_capacity      = 5
-    projection_type    = "INCLUDE"
-    non_key_attributes = ["ClientID"]
+    projection_type    = "ALL"
   }
 }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
@@ -14,6 +14,7 @@ import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
+import org.glassfish.jersey.client.ClientProperties;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.helpers.DynamoHelper;
 import uk.gov.di.authentication.helpers.RedisHelper;
@@ -65,6 +66,7 @@ public class LogoutIntegrationTest extends IntegrationTestEndpoints {
                                 "post_logout_redirect_uri",
                                 "https://di-auth-stub-relying-party-build.london.cloudapps.digital/")
                         .queryParam("state", "8VAVNSxHO1HwiNDhwchQKdd7eOUK3ltKfQzwPDxu9LU")
+                        .property(ClientProperties.FOLLOW_REDIRECTS, Boolean.FALSE)
                         .request()
                         .headers(headers)
                         .get();

--- a/serverless/lambda/src/main/java/uk/gov/di/entity/ClientRegistry.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/entity/ClientRegistry.java
@@ -2,6 +2,7 @@ package uk.gov.di.entity;
 
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBAttribute;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBIndexHashKey;
 
 import java.util.List;
 
@@ -25,7 +26,7 @@ public class ClientRegistry {
         return this;
     }
 
-    @DynamoDBAttribute(attributeName = "ClientName")
+    @DynamoDBIndexHashKey(globalSecondaryIndexName = "ClientNameIndex", attributeName = "ClientName")
     public String getClientName() {
         return clientName;
     }

--- a/serverless/lambda/src/main/java/uk/gov/di/entity/ClientRegistry.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/entity/ClientRegistry.java
@@ -26,7 +26,9 @@ public class ClientRegistry {
         return this;
     }
 
-    @DynamoDBIndexHashKey(globalSecondaryIndexName = "ClientNameIndex", attributeName = "ClientName")
+    @DynamoDBIndexHashKey(
+            globalSecondaryIndexName = "ClientNameIndex",
+            attributeName = "ClientName")
     public String getClientName() {
         return clientName;
     }

--- a/serverless/lambda/src/main/java/uk/gov/di/entity/UserCredentials.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/entity/UserCredentials.java
@@ -2,6 +2,7 @@ package uk.gov.di.entity;
 
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBAttribute;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBIndexHashKey;
 
 public class UserCredentials {
 
@@ -23,7 +24,7 @@ public class UserCredentials {
         return this;
     }
 
-    @DynamoDBAttribute(attributeName = "SubjectID")
+    @DynamoDBIndexHashKey(globalSecondaryIndexName = "SubjectIDIndex", attributeName = "SubjectID")
     public String getSubjectID() {
         return subjectID;
     }


### PR DESCRIPTION
## What?

- Fix secondary keys for Dynamo and don't follow redirect on integration test

## Why?

- I discovered that the way the secondary index was previously configured didn't work. This was discovered on the UserProfile. Make the same changes to the UserCredentials and ClientRegistry table as we did there
- 