### PR TITLE
BAU: run startup locally without running tests

### DIFF
--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -59,12 +59,6 @@ if [[ ${RUN_UNIT} -eq 1 ]]; then
 fi
 
 if [[ ${RUN_INTEGRATION} -eq 1 ]]; then
-  export TF_VAR_notify_url="http://notify.internal:8888"
-  export TF_VAR_notify_api_key="my_test_key-$(uuidgen)-$(uuidgen)"
-  export AWS_ACCESS_KEY_ID="mock-access-key"
-  export AWS_SECRET_ACCESS_KEY="mock-secret-key"
-  export STUB_RELYING_PARTY_REDIRECT_URI="https://di-auth-stub-relying-party-build.london.cloudapps.digital/"
-  export LOGIN_URI="http://localhost:3000/"
 
   startup
 

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -69,13 +69,20 @@ function funky_started() {
 }
 
 startup() {
+  export TF_VAR_notify_url="http://notify.internal:8888"
+  export TF_VAR_notify_api_key="my_test_key-$(uuidgen)-$(uuidgen)"
+  export AWS_ACCESS_KEY_ID="mock-access-key"
+  export AWS_SECRET_ACCESS_KEY="mock-secret-key"
+  export STUB_RELYING_PARTY_REDIRECT_URI="https://di-auth-stub-relying-party-build.london.cloudapps.digital/"
+  export LOGIN_URI="http://localhost:3000/"
+
   stop_docker_services aws redis dynamodb
   printf "\nStarting di-authentication-api...\n"
   ./gradlew clean build -x test
   printf "\nStarting Docker services...\n"
   startup_docker aws redis dynamodb
   run_terraform ci/terraform/aws
-  if [[ ${IN_GITHUB_ACTIONS} -eq 0 ]]; then
+  if [[ -z ${IN_GITHUB_ACTIONS+x} ||  ${IN_GITHUB_ACTIONS} -eq 0 ]]; then
     funky_started
   else
     printf "\nServices Started!\n"


### PR DESCRIPTION
## What?

Ability to run startup.sh locally without tests or the rest of pre-commit.

## Why?

Able to start the apps and apply terraform without running any tests and then stopping the apps.  This means you can run and test integration tests in the IDE against the running api.