### PR TITLE
GOVSI-651: Support multi-case cookie headers

### DIFF
--- a/serverless/lambda/build.gradle
+++ b/serverless/lambda/build.gradle
@@ -29,6 +29,7 @@ dependencies {
             "org.bouncycastle:bcprov-jdk15on:1.69",
             "com.googlecode.libphonenumber:libphonenumber:8.12.28"
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.2',
+            'org.junit.jupiter:junit-jupiter-params:5.7.2',
             'com.amazonaws:aws-lambda-java-tests:1.0.2',
             'org.mockito:mockito-core:3.11.2',
             'org.hamcrest:hamcrest:2.2'

--- a/serverless/lambda/src/main/java/uk/gov/di/helpers/CookieHelper.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/helpers/CookieHelper.java
@@ -5,6 +5,7 @@ import org.slf4j.LoggerFactory;
 
 import java.net.HttpCookie;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -15,12 +16,12 @@ public class CookieHelper {
     public static final String REQUEST_COOKIE_HEADER = "Cookie";
 
     public static Optional<SessionCookieIds> parseSessionCookie(Map<String, String> headers) {
-        if (headers == null
-                || !headers.containsKey(REQUEST_COOKIE_HEADER)
-                || headers.get(REQUEST_COOKIE_HEADER).isEmpty()) {
+        var cookieHeader = cookieHeader(headers);
+
+        if (cookieHeader.isEmpty()) {
             return Optional.empty();
         }
-        String cookies = headers.get(REQUEST_COOKIE_HEADER);
+        String cookies = headers.get(cookieHeader.get());
 
         LOGGER.debug("Session Cookie: {}", cookies);
 
@@ -62,6 +63,16 @@ public class CookieHelper {
                         return csid;
                     }
                 });
+    }
+
+    private static Optional<String> cookieHeader(Map<String, String> headers) {
+        if (headers == null) {
+            return Optional.empty();
+        }
+
+        return List.of(REQUEST_COOKIE_HEADER, REQUEST_COOKIE_HEADER.toLowerCase()).stream()
+                .filter(headers.keySet()::contains)
+                .findFirst();
     }
 
     public interface SessionCookieIds {

--- a/serverless/lambda/src/test/java/uk/gov/di/helpers/CookieHelperTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/helpers/CookieHelperTest.java
@@ -15,7 +15,7 @@ import static uk.gov.di.helpers.CookieHelper.SessionCookieIds;
 public class CookieHelperTest {
 
     static Stream<String> inputs() {
-        return Stream.of(REQUEST_COOKIE_HEADER);
+        return Stream.of(REQUEST_COOKIE_HEADER, REQUEST_COOKIE_HEADER.toLowerCase());
     }
 
     @ParameterizedTest(name = "with header {0}")


### PR DESCRIPTION
## What?

This enables `CookieHelper` to parse out cookies from either `Cookie` or `cookie` headers.

## Why?

AWS API Gateway sends lower-case headers which was breaking some flows.
