### PR TITLE
BAU: Add correct perms to API gateway logging role

### DIFF
--- a/ci/terraform/aws/api-gateway.tf
+++ b/ci/terraform/aws/api-gateway.tf
@@ -34,8 +34,11 @@ resource "aws_iam_policy" "api_gateway_logging_policy" {
       "Action": [
         "logs:CreateLogGroup",
         "logs:CreateLogStream",
+        "logs:DescribeLogGroups",
+        "logs:DescribeLogStreams",
         "logs:PutLogEvents",
-        "logs:CreateLogGroup"
+        "logs:GetLogEvents",
+        "logs:FilterLogEvents"
       ],
       "Resource": "arn:aws:logs:*:*:*",
       "Effect": "Allow"


### PR DESCRIPTION
## What?

- Add correct perms to API gateway logging role

## Why?

The permissions we added we were not pervasive enough for API gateway.

## Related PRs

#234 