### PR TITLE
BAU: Add Lambda Logging in build.gradle

### DIFF
--- a/serverless/lambda/build.gradle
+++ b/serverless/lambda/build.gradle
@@ -28,6 +28,8 @@ dependencies {
             "uk.gov.service.notify:notifications-java-client:3.17.2-RELEASE",
             "org.bouncycastle:bcprov-jdk15on:1.69",
             "com.googlecode.libphonenumber:libphonenumber:8.12.28"
+    runtimeOnly "org.apache.logging.log4j:log4j-slf4j18-impl:2.13.0",
+                "com.amazonaws:aws-lambda-java-log4j2:1.2.0"
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.2',
             'org.junit.jupiter:junit-jupiter-params:5.7.2',
             'com.amazonaws:aws-lambda-java-tests:1.0.2',


### PR DESCRIPTION
## What?

Add Log4J dependencies to enable correct logging in lambdas

## Why?

To enable logging in the lambdas