### PR TITLE
BAU: Add permission to global secondary index

### DIFF
--- a/ci/terraform/aws/dynamodb.tf
+++ b/ci/terraform/aws/dynamodb.tf
@@ -104,7 +104,8 @@ data "aws_iam_policy_document" "dynamo_policy_document" {
     resources = [
       aws_dynamodb_table.user_credentials_table.arn,
       aws_dynamodb_table.user_profile_table.arn,
-      aws_dynamodb_table.client_registry_table.arn
+      "${aws_dynamodb_table.user_profile_table.arn}/index/*",
+      aws_dynamodb_table.client_registry_table.arn,
     ]
   }
 }


### PR DESCRIPTION
## What?

- Add permission to global secondary index

## Why?

The `userinfo` endpoint is failing with a permission denied error.
