### PR TITLE
BAU: Tidy up Terraform

### DIFF
--- a/ci/terraform/aws/api-gateway.tf
+++ b/ci/terraform/aws/api-gateway.tf
@@ -159,6 +159,9 @@ resource "aws_api_gateway_account" "api_gateway_logging_role" {
 }
 
 resource "aws_api_gateway_method_settings" "api_gateway_logging_settings" {
+
+  count = var.enable_api_gateway_execution_logging ? 1 : 0
+
   rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
   stage_name  = var.api_deployment_stage_name
   method_path = "*/*"

--- a/ci/terraform/aws/api-gateway.tf
+++ b/ci/terraform/aws/api-gateway.tf
@@ -1,23 +1,49 @@
+data "aws_iam_policy_document" "api_gateway_can_assume_policy" {
+  version = "2012-10-17"
+
+  statement {
+    effect = "Allow"
+    principals {
+      identifiers = [
+        "apigateway.amazonaws.com"
+      ]
+      type = "Service"
+    }
+
+    actions = [
+      "sts:AssumeRole"
+    ]
+  }
+}
+
 resource "aws_iam_role" "api_gateway_logging_iam_role" {
   name = "${var.environment}-api-gateway-logging-lambda-role"
 
-  assume_role_policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "apigateway.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-EOF
+  assume_role_policy = data.aws_iam_policy_document.api_gateway_can_assume_policy.json
+
   tags = {
     environment = var.environment
+  }
+}
+
+data "aws_iam_policy_document" "api_gateway_logging_policy" {
+  version = "2012-10-17"
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:DescribeLogGroups",
+      "logs:DescribeLogStreams",
+      "logs:PutLogEvents",
+      "logs:GetLogEvents",
+      "logs:FilterLogEvents",
+    ]
+
+    resources = [
+      "arn:aws:logs:*:*:*",
+    ]
   }
 }
 
@@ -26,26 +52,7 @@ resource "aws_iam_policy" "api_gateway_logging_policy" {
   path        = "/"
   description = "IAM policy for logging for API Gateway"
 
-  policy = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "logs:CreateLogGroup",
-        "logs:CreateLogStream",
-        "logs:DescribeLogGroups",
-        "logs:DescribeLogStreams",
-        "logs:PutLogEvents",
-        "logs:GetLogEvents",
-        "logs:FilterLogEvents"
-      ],
-      "Resource": "arn:aws:logs:*:*:*",
-      "Effect": "Allow"
-    }
-  ]
-}
-EOF
+  policy = data.aws_iam_policy_document.api_gateway_logging_policy.json
 }
 
 resource "aws_iam_role_policy_attachment" "api_gateway_logging_logs" {

--- a/ci/terraform/aws/sqs.tf
+++ b/ci/terraform/aws/sqs.tf
@@ -1,7 +1,7 @@
 resource "aws_iam_role" "email_lambda_iam_role" {
   name = "${var.environment}-email-notification-sqs-lambda-role"
 
-  assume_role_policy = var.lambda_iam_policy
+  assume_role_policy = data.aws_iam_policy_document.lambda_can_assume_policy.json
 
   tags = {
     environment = var.environment
@@ -18,7 +18,7 @@ resource "aws_iam_role_policy_attachment" "emaiL_lambda_logging_policy" {
   ]
 }
 
-resource "aws_iam_role_policy_attachment" "emaiL_lambda_networking_policy" {
+resource "aws_iam_role_policy_attachment" "email_lambda_networking_policy" {
   role       = aws_iam_role.email_lambda_iam_role.name
   policy_arn = aws_iam_policy.endpoint_networking_policy.arn
 

--- a/ci/terraform/aws/variables.tf
+++ b/ci/terraform/aws/variables.tf
@@ -78,3 +78,8 @@ variable "redis_use_tls" {
 variable "service_domain_name" {
   default = "auth.ida.digital.cabinet-office.gov.uk"
 }
+
+variable "enable_api_gateway_execution_logging" {
+  default     = true
+  description = "Whether to enable logging of API gateway runs (including capturing of requests/responses)"
+}

--- a/ci/terraform/aws/variables.tf
+++ b/ci/terraform/aws/variables.tf
@@ -34,25 +34,6 @@ variable "api_base_url" {
   default = "http://localhost:8080"
 }
 
-variable "lambda_iam_policy" {
-  type    = string
-  default = <<EOF
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": "sts:AssumeRole",
-      "Principal": {
-        "Service": "lambda.amazonaws.com"
-      },
-      "Effect": "Allow",
-      "Sid": ""
-    }
-  ]
-}
-EOF
-}
-
 variable "aws_endpoint" {
   type    = string
   default = null


### PR DESCRIPTION
## What?

- Use `aws_iam_policy_document` data sources instead of heredoc style JSON blobs
- Make API gateway logging optional

## Why?

The use of data sources is tidier than heredocs.
API gateway logging, is a useful debugging tool but probably not wanted in all environments.
