### PR TITLE
GOVSI-653: Refactor e-mail address storage

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -186,11 +186,11 @@ public class AuthorisationIntegrationTest extends IntegrationTestEndpoints {
                 getHeaderValueByParamName(response, "Location"),
                 startsWith(configurationService.getLoginURI().toString()));
         /*
-            TODO:
-                In this scenario the session state would be set to AUTHENTICATION_REQUIRED.
-                At present there is no way to retrieve the state in an integration test.
-                A further assertion should be added when possible.
-         */
+           TODO:
+               In this scenario the session state would be set to AUTHENTICATION_REQUIRED.
+               At present there is no way to retrieve the state in an integration test.
+               A further assertion should be added when possible.
+        */
     }
 
     private String givenAnExistingSession(SessionState initialState) throws Exception {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/helpers/RedisHelper.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/helpers/RedisHelper.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.api.StatefulRedisConnection;
+import uk.gov.di.entity.AuthCodeExchangeData;
 import uk.gov.di.entity.ClientSession;
 import uk.gov.di.entity.Session;
 import uk.gov.di.entity.SessionState;
@@ -62,7 +63,7 @@ public class RedisHelper {
             redis.saveWithExpiry(
                     CLIENT_SESSION_PREFIX.concat(clientSessionId),
                     OBJECT_MAPPER.writeValueAsString(
-                            new ClientSession(authRequest, LocalDateTime.now(), email)),
+                            new ClientSession(authRequest, LocalDateTime.now())),
                     1800);
 
         } catch (IOException e) {
@@ -170,11 +171,17 @@ public class RedisHelper {
             Map<String, List<String>> authRequest) {
         try (RedisConnectionService redis =
                 new RedisConnectionService(REDIS_HOST, 6379, false, REDIS_PASSWORD)) {
-            redis.saveWithExpiry(AUTH_CODE_PREFIX.concat(authCode), clientSessionId, 300);
+            redis.saveWithExpiry(
+                    AUTH_CODE_PREFIX.concat(authCode),
+                    OBJECT_MAPPER.writeValueAsString(
+                            new AuthCodeExchangeData()
+                                    .setClientSessionId(clientSessionId)
+                                    .setEmail(email)),
+                    300);
             redis.saveWithExpiry(
                     CLIENT_SESSION_PREFIX.concat(clientSessionId),
                     OBJECT_MAPPER.writeValueAsString(
-                            new ClientSession(authRequest, LocalDateTime.now(), email)),
+                            new ClientSession(authRequest, LocalDateTime.now())),
                     300);
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/serverless/lambda/src/main/java/uk/gov/di/entity/AuthCodeExchangeData.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/entity/AuthCodeExchangeData.java
@@ -1,0 +1,28 @@
+package uk.gov.di.entity;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class AuthCodeExchangeData {
+
+    @JsonProperty private String clientSessionId;
+
+    @JsonProperty private String email;
+
+    public String getClientSessionId() {
+        return clientSessionId;
+    }
+
+    public AuthCodeExchangeData setClientSessionId(String clientSessionId) {
+        this.clientSessionId = clientSessionId;
+        return this;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public AuthCodeExchangeData setEmail(String email) {
+        this.email = email;
+        return this;
+    }
+}

--- a/serverless/lambda/src/main/java/uk/gov/di/entity/ClientSession.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/entity/ClientSession.java
@@ -17,17 +17,12 @@ public class ClientSession {
     @JsonProperty("creation_date")
     private LocalDateTime creationDate;
 
-    @JsonProperty("email")
-    private String email;
-
     public ClientSession(
             @JsonProperty(required = true, value = "auth_request_params")
                     Map<String, List<String>> authRequestParams,
-            @JsonProperty(required = true, value = "creation_date") LocalDateTime creationDate,
-            @JsonProperty(required = true, value = "email") String email) {
+            @JsonProperty(required = true, value = "creation_date") LocalDateTime creationDate) {
         this.authRequestParams = authRequestParams;
         this.creationDate = creationDate;
-        this.email = email;
     }
 
     public ClientSession setIdTokenHint(String idTokenHint) {
@@ -41,10 +36,6 @@ public class ClientSession {
 
     public String getIdTokenHint() {
         return idTokenHint;
-    }
-
-    public String getEmail() {
-        return email;
     }
 
     public LocalDateTime getCreationDate() {

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/AuthCodeHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/AuthCodeHandler.java
@@ -90,7 +90,7 @@ public class AuthCodeHandler
 
         AuthorizationCode authCode =
                 authorisationCodeService.generateAuthorisationCode(
-                        sessionCookieIds.getClientSessionId());
+                        sessionCookieIds.getClientSessionId(), session.getEmailAddress());
         AuthenticationSuccessResponse authenticationResponse =
                 authorizationService.generateSuccessfulAuthResponse(authorizationRequest, authCode);
         sessionService.save(session.setState(AUTHENTICATED));

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/AuthorisationHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/AuthorisationHandler.java
@@ -145,10 +145,7 @@ public class AuthorisationHandler
             URI redirectURI) {
         String clientSessionID =
                 clientSessionService.generateClientSession(
-                        new ClientSession(
-                                authRequestParameters,
-                                LocalDateTime.now(),
-                                session.getEmailAddress()));
+                        new ClientSession(authRequestParameters, LocalDateTime.now()));
         updateSessionId(session, authenticationRequest.getClientID(), clientSessionID);
         return redirect(session, clientSessionID, redirectURI);
     }
@@ -183,8 +180,7 @@ public class AuthorisationHandler
 
         String clientSessionID =
                 clientSessionService.generateClientSession(
-                        new ClientSession(
-                                authRequest, LocalDateTime.now(), session.getEmailAddress()));
+                        new ClientSession(authRequest, LocalDateTime.now()));
         session.addClientSession(clientSessionID);
         LOGGER.info(
                 "Created session {} for client {} - client session id = {}",

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/AuthCodeHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/AuthCodeHandlerTest.java
@@ -84,7 +84,7 @@ class AuthCodeHandlerTest {
 
         when(authorizationService.isClientRedirectUriValid(eq(clientID), eq(REDIRECT_URI)))
                 .thenReturn(true);
-        when(authorisationCodeService.generateAuthorisationCode(eq(CLIENT_SESSION_ID)))
+        when(authorisationCodeService.generateAuthorisationCode(eq(CLIENT_SESSION_ID), eq(EMAIL)))
                 .thenReturn(authorizationCode);
         when(authorizationService.generateSuccessfulAuthResponse(
                         any(AuthorizationRequest.class), any(AuthorizationCode.class)))
@@ -173,9 +173,12 @@ class AuthCodeHandlerTest {
     private void generateValidSession(Map<String, List<String>> authRequest) {
         when(sessionService.readSessionFromRedis(SESSION_ID))
                 .thenReturn(
-                        Optional.of(new Session(SESSION_ID).addClientSession(CLIENT_SESSION_ID)));
+                        Optional.of(
+                                new Session(SESSION_ID)
+                                        .addClientSession(CLIENT_SESSION_ID)
+                                        .setEmailAddress(EMAIL)));
         when(clientSessionService.getClientSession(CLIENT_SESSION_ID))
-                .thenReturn(new ClientSession(authRequest, LocalDateTime.now(), EMAIL));
+                .thenReturn(new ClientSession(authRequest, LocalDateTime.now()));
     }
 
     private String buildCookieString() {

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/LogoutHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/LogoutHandlerTest.java
@@ -258,8 +258,7 @@ class LogoutHandlerTest {
                                 List.of("code"),
                                 "state",
                                 List.of("some-state")),
-                        LocalDateTime.now(),
-                        TEST_EMAIL);
+                        LocalDateTime.now());
         clientSession.setIdTokenHint(idToken.serialize());
         when(clientSessionService.getClientSession(CLIENT_SESSION_ID)).thenReturn(clientSession);
     }

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/TokenHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/TokenHandlerTest.java
@@ -19,6 +19,7 @@ import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.oauth2.sdk.util.URLUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.entity.AuthCodeExchangeData;
 import uk.gov.di.entity.ClientRegistry;
 import uk.gov.di.entity.ClientSession;
 import uk.gov.di.entity.ErrorResponse;
@@ -113,14 +114,16 @@ public class TokenHandlerTest {
                 .thenReturn(accessToken);
         when(tokenService.generateIDToken(eq(CLIENT_ID), any(Subject.class))).thenReturn(signedJWT);
         String authCode = new AuthorizationCode().toString();
-        when(authorisationCodeService.getClientSessionIdForCode(authCode))
-                .thenReturn(Optional.of(CLIENT_SESSION_ID));
+        when(authorisationCodeService.getExchangeDataForCode(authCode))
+                .thenReturn(
+                        Optional.of(
+                                new AuthCodeExchangeData()
+                                        .setClientSessionId(CLIENT_SESSION_ID)
+                                        .setEmail(TEST_EMAIL)));
         when(clientSessionService.getClientSession(CLIENT_SESSION_ID))
                 .thenReturn(
                         new ClientSession(
-                                generateAuthRequest().toParameters(),
-                                LocalDateTime.now(),
-                                TEST_EMAIL));
+                                generateAuthRequest().toParameters(), LocalDateTime.now()));
 
         APIGatewayProxyResponseEvent result =
                 generateApiGatewayRequest(privateKeyJWT, CLIENT_ID, authCode);


### PR DESCRIPTION
## What?

Rather than store e-mail address alongside client session data for the duration, store with auth code as it is only needed until the auth code is exchanged for an access token.

## Why?

The e-mail address is needed in a client session context after the token has been issued, and is stored against the session anyway, so the duplication is unwanted.
