### PR TITLE
GOVSI-498: Allow skipping of login to enable SSO

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -166,7 +166,7 @@ public class AuthorisationIntegrationTest extends IntegrationTestEndpoints {
         assertThat(response.getCookies().get("gs").getValue(), not(startsWith(sessionId)));
         assertThat(
                 getHeaderValueByParamName(response, "Location"),
-                startsWith(configurationService.getLoginURI().toString()));
+                startsWith(configurationService.getAuthCodeURI().toString()));
     }
 
     @Test

--- a/serverless/lambda/src/main/java/uk/gov/di/entity/ClientRegistrationRequest.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/entity/ClientRegistrationRequest.java
@@ -28,8 +28,7 @@ public class ClientRegistrationRequest {
 
     public ClientRegistrationRequest(
             @JsonProperty(required = true, value = "client_name") String clientName,
-            @JsonProperty(required = true, value = "redirect_uris")
-                    List<String> redirectUris,
+            @JsonProperty(required = true, value = "redirect_uris") List<String> redirectUris,
             @JsonProperty(required = true, value = "contacts") List<String> contacts,
             @JsonProperty(required = true, value = "public_key") String publicKey,
             @JsonProperty(required = true, value = "scopes") List<String> scopes,

--- a/serverless/lambda/src/main/java/uk/gov/di/services/ConfigurationService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/ConfigurationService.java
@@ -15,6 +15,10 @@ public class ConfigurationService {
         return URI.create(System.getenv("LOGIN_URI"));
     }
 
+    public URI getAuthCodeURI() {
+        return URI.create(System.getenv().getOrDefault("AUTH_CODE_URI", "/auth-code"));
+    }
+
     public URI getSkipLoginURI() {
         return URI.create(System.getenv().getOrDefault("SKIP_LOGIN_URI", "http://skip-login"));
     }

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/AuthorisationHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/AuthorisationHandlerTest.java
@@ -153,16 +153,18 @@ class AuthorisationHandlerTest {
     @Test
     void shouldSkipLoginWhenPromptParamAbsentAndLoggedIn() {
         final URI loginUrl = URI.create("http://example.com");
+        final URI authCodeUri = URI.create("/auth-code");
         final Session session = new Session("a-session-id");
         session.addClientSession("old-client-session-id");
 
         whenLoggedIn(session, loginUrl);
+        when(configService.getAuthCodeURI()).thenReturn(authCodeUri);
 
         APIGatewayProxyResponseEvent response = handler.handleRequest(withRequestEvent(), context);
         URI uri = URI.create(response.getHeaders().get("Location"));
 
         assertThat(response, hasStatus(302));
-        assertEquals(loginUrl.getAuthority(), uri.getAuthority());
+        assertEquals(authCodeUri, uri);
         assertEquals(EXPECTED_COOKIE_STRING, response.getHeaders().get("Set-Cookie"));
         verify(sessionService).save(eq(session));
         assertEquals(SessionState.AUTHENTICATED, session.getState());
@@ -185,17 +187,20 @@ class AuthorisationHandlerTest {
     @Test
     void shouldSkipLoginWhenPromptParamNoneAndLoggedIn() {
         final URI loginUrl = URI.create("http://example.com");
+        final URI authCodeUri = URI.create("/auth-code");
+
         final Session session = new Session("a-session-id");
         session.addClientSession("old-client-session-id");
 
         whenLoggedIn(session, loginUrl);
+        when(configService.getAuthCodeURI()).thenReturn(authCodeUri);
 
         APIGatewayProxyResponseEvent response =
                 handler.handleRequest(withPromptRequestEvent("none"), context);
         URI uri = URI.create(response.getHeaders().get("Location"));
 
         assertThat(response, hasStatus(302));
-        assertEquals(loginUrl.getAuthority(), uri.getAuthority());
+        assertEquals(authCodeUri, uri);
         assertEquals(EXPECTED_COOKIE_STRING, response.getHeaders().get("Set-Cookie"));
         verify(sessionService).save(eq(session));
         assertEquals(SessionState.AUTHENTICATED, session.getState());


### PR DESCRIPTION
## What?

If a user is logged in, and no specific `prompt` functionality has been requested, skip the UI and issue auth-code straight away.

## Why?

This is required to have proper SSO functionality.