### PR TITLE
GOVSI-670: Implement state transition checks (1)

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
@@ -7,6 +7,7 @@ import uk.gov.di.authentication.helpers.DynamoHelper;
 import uk.gov.di.authentication.helpers.RedisHelper;
 import uk.gov.di.authentication.helpers.RequestHelper;
 import uk.gov.di.entity.BaseAPIResponse;
+import uk.gov.di.entity.ErrorResponse;
 import uk.gov.di.entity.NotificationType;
 import uk.gov.di.entity.SessionState;
 import uk.gov.di.entity.VerifyCodeRequest;
@@ -25,6 +26,7 @@ public class VerifyCodeIntegrationTest extends IntegrationTestEndpoints {
     @Test
     public void shouldCallVerifyCodeEndpointToVerifyEmailCodeAndReturn200() throws IOException {
         String sessionId = RedisHelper.createSession();
+        RedisHelper.setSessionState(sessionId, SessionState.VERIFY_EMAIL_CODE_SENT);
         RedisHelper.addEmailToSession(sessionId, EMAIL_ADDRESS);
 
         String code = RedisHelper.generateAndSaveEmailCode(EMAIL_ADDRESS, 900);
@@ -40,6 +42,7 @@ public class VerifyCodeIntegrationTest extends IntegrationTestEndpoints {
     public void shouldCallVerifyCodeEndpointAndReturn200WitUpdatedStateWhenEmailCodeHasExpired()
             throws IOException, InterruptedException {
         String sessionId = RedisHelper.createSession();
+        RedisHelper.setSessionState(sessionId, SessionState.VERIFY_EMAIL_CODE_SENT);
         RedisHelper.addEmailToSession(sessionId, EMAIL_ADDRESS);
 
         String code = RedisHelper.generateAndSaveEmailCode(EMAIL_ADDRESS, 2);
@@ -60,6 +63,7 @@ public class VerifyCodeIntegrationTest extends IntegrationTestEndpoints {
     public void shouldReturn200WithNewStateWhenUserTriesEmailCodeThatTheyHaveAlreadyUsed()
             throws IOException {
         String sessionId = RedisHelper.createSession();
+        RedisHelper.setSessionState(sessionId, SessionState.VERIFY_EMAIL_CODE_SENT);
         RedisHelper.addEmailToSession(sessionId, EMAIL_ADDRESS);
         String code = RedisHelper.generateAndSaveEmailCode(EMAIL_ADDRESS, 900);
         VerifyCodeRequest codeRequest = new VerifyCodeRequest(NotificationType.VERIFY_EMAIL, code);
@@ -141,6 +145,7 @@ public class VerifyCodeIntegrationTest extends IntegrationTestEndpoints {
     @Test
     public void shouldReturnMaxCodesReachedIfEmailCodeIsBlocked() throws IOException {
         String sessionId = RedisHelper.createSession();
+        RedisHelper.setSessionState(sessionId, SessionState.EMAIL_CODE_NOT_VALID);
         RedisHelper.addEmailToSession(sessionId, EMAIL_ADDRESS);
         RedisHelper.blockPhoneCode(EMAIL_ADDRESS, sessionId);
 
@@ -155,6 +160,24 @@ public class VerifyCodeIntegrationTest extends IntegrationTestEndpoints {
         BaseAPIResponse codeResponse =
                 objectMapper.readValue(response.readEntity(String.class), BaseAPIResponse.class);
         assertEquals(SessionState.EMAIL_CODE_MAX_RETRIES_REACHED, codeResponse.getSessionState());
+    }
+
+    @Test
+    public void shouldReturn400IfStateTransitionIsInvalid() throws IOException {
+        String sessionId = RedisHelper.createSession();
+        RedisHelper.setSessionState(sessionId, SessionState.NEW);
+        RedisHelper.addEmailToSession(sessionId, EMAIL_ADDRESS);
+
+        String code = RedisHelper.generateAndSaveEmailCode(EMAIL_ADDRESS, 900);
+        VerifyCodeRequest codeRequest = new VerifyCodeRequest(NotificationType.VERIFY_EMAIL, code);
+
+        Response response =
+                RequestHelper.requestWithSession(VERIFY_CODE_ENDPOINT, codeRequest, sessionId);
+
+        assertEquals(400, response.getStatus());
+        assertEquals(
+                new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1019),
+                response.readEntity(String.class));
     }
 
     @Test

--- a/serverless/lambda/src/main/java/uk/gov/di/helpers/StateMachine.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/helpers/StateMachine.java
@@ -10,6 +10,8 @@ import static java.util.Collections.emptyList;
 import static java.util.Map.entry;
 import static java.util.Map.ofEntries;
 import static uk.gov.di.entity.SessionState.AUTHENTICATION_REQUIRED;
+import static uk.gov.di.entity.SessionState.EMAIL_CODE_MAX_RETRIES_REACHED;
+import static uk.gov.di.entity.SessionState.EMAIL_CODE_NOT_VALID;
 import static uk.gov.di.entity.SessionState.EMAIL_CODE_VERIFIED;
 import static uk.gov.di.entity.SessionState.NEW;
 import static uk.gov.di.entity.SessionState.TWO_FACTOR_REQUIRED;
@@ -39,7 +41,19 @@ public class StateMachine<T> {
                         entry(
                                 USER_NOT_FOUND,
                                 List.of(AUTHENTICATION_REQUIRED, VERIFY_EMAIL_CODE_SENT)),
-                        entry(EMAIL_CODE_VERIFIED, List.of(TWO_FACTOR_REQUIRED)));
+                        entry(
+                                VERIFY_EMAIL_CODE_SENT,
+                                List.of(EMAIL_CODE_VERIFIED, EMAIL_CODE_NOT_VALID)),
+                        entry(
+                                EMAIL_CODE_NOT_VALID,
+                                List.of(
+                                        EMAIL_CODE_VERIFIED,
+                                        EMAIL_CODE_NOT_VALID,
+                                        EMAIL_CODE_MAX_RETRIES_REACHED)),
+                        entry(EMAIL_CODE_MAX_RETRIES_REACHED, Collections.emptyList()),
+                        entry(
+                                EMAIL_CODE_VERIFIED,
+                                List.of(EMAIL_CODE_NOT_VALID, TWO_FACTOR_REQUIRED)));
 
         return new StateMachine<>(states);
     }

--- a/serverless/lambda/src/main/java/uk/gov/di/helpers/StateMachine.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/helpers/StateMachine.java
@@ -26,6 +26,10 @@ public class StateMachine<T> {
         return states.getOrDefault(from, emptyList()).contains(to);
     }
 
+    public static boolean isInvalidUserJourneyTransition(SessionState from, SessionState to) {
+        return !userJourneyStateMachine().isValidTransition(from, to);
+    }
+
     public static StateMachine<SessionState> userJourneyStateMachine() {
         var states =
                 ofEntries(

--- a/serverless/lambda/src/main/java/uk/gov/di/helpers/StateMachine.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/helpers/StateMachine.java
@@ -11,8 +11,10 @@ import static java.util.Map.entry;
 import static java.util.Map.ofEntries;
 import static uk.gov.di.entity.SessionState.AUTHENTICATION_REQUIRED;
 import static uk.gov.di.entity.SessionState.EMAIL_CODE_VERIFIED;
+import static uk.gov.di.entity.SessionState.NEW;
 import static uk.gov.di.entity.SessionState.TWO_FACTOR_REQUIRED;
 import static uk.gov.di.entity.SessionState.USER_NOT_FOUND;
+import static uk.gov.di.entity.SessionState.VERIFY_EMAIL_CODE_SENT;
 
 public class StateMachine<T> {
 
@@ -31,10 +33,12 @@ public class StateMachine<T> {
     }
 
     public static StateMachine<SessionState> userJourneyStateMachine() {
-        var states =
+        Map<SessionState, List<SessionState>> states =
                 ofEntries(
-                        entry(USER_NOT_FOUND, List.of(EMAIL_CODE_VERIFIED)),
-                        entry(AUTHENTICATION_REQUIRED, List.of(TWO_FACTOR_REQUIRED)),
+                        entry(NEW, List.of(USER_NOT_FOUND)),
+                        entry(
+                                USER_NOT_FOUND,
+                                List.of(AUTHENTICATION_REQUIRED, VERIFY_EMAIL_CODE_SENT)),
                         entry(EMAIL_CODE_VERIFIED, List.of(TWO_FACTOR_REQUIRED)));
 
         return new StateMachine<>(states);


### PR DESCRIPTION
## What?

Implement state transition protection for `CheckUserExistsHandler` and `VerifyCodeHandler` (email code only)

## Why?

This prevents the application jumping around the process out-of-order.
