### PR TITLE
BAU: Create and use `hasJsonBody` matcher in tests

### DIFF
--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/CheckUserExistsHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/CheckUserExistsHandlerTest.java
@@ -27,7 +27,7 @@ import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
+import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 
 class CheckUserExistsHandlerTest {
 
@@ -87,7 +87,7 @@ class CheckUserExistsHandlerTest {
     }
 
     @Test
-    public void shouldReturn400IfRequestIsMissingEmail() throws JsonProcessingException {
+    public void shouldReturn400IfRequestIsMissingEmail() {
         usingValidSession();
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
@@ -96,26 +96,22 @@ class CheckUserExistsHandlerTest {
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertEquals(400, result.getStatusCode());
-
-        String expectedResponse = new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1001);
-        assertThat(result, hasBody(expectedResponse));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1001));
     }
 
     @Test
-    public void shouldReturn400IfRequestIsMissingSessionId() throws JsonProcessingException {
+    public void shouldReturn400IfRequestIsMissingSessionId() {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setBody("{ \"email\": \"joe.bloggs@digital.cabinet-office.gov.uk\" }");
 
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertEquals(400, result.getStatusCode());
-
-        String expectedResponse = new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1000);
-        assertThat(result, hasBody(expectedResponse));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1000));
     }
 
     @Test
-    public void shouldReturn400IfEmailAddressIsInvalid() throws JsonProcessingException {
+    public void shouldReturn400IfEmailAddressIsInvalid() {
         usingValidSession();
         when(validationService.validateEmailAddress(eq("joe.bloggs")))
                 .thenReturn(Optional.of(ErrorResponse.ERROR_1004));
@@ -126,13 +122,11 @@ class CheckUserExistsHandlerTest {
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertEquals(400, result.getStatusCode());
-        String expectedResponse = new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1004);
-
-        assertThat(result, hasBody(expectedResponse));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1004));
     }
 
     @Test
-    public void shouldReturn400IfUserTransitionsFromWrongState() throws JsonProcessingException {
+    public void shouldReturn400IfUserTransitionsFromWrongState() {
         usingValidSession();
 
         session.setState(SessionState.AUTHENTICATED);
@@ -143,10 +137,7 @@ class CheckUserExistsHandlerTest {
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertEquals(400, result.getStatusCode());
-        String expectedResponse = new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1019);
-
-        // TODO: implement `hasJsonBody` matcher to remove duplication across tests
-        assertThat(result, hasBody(expectedResponse));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1019));
     }
 
     private void usingValidSession() {

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/ClientRegistrationHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/ClientRegistrationHandlerTest.java
@@ -18,8 +18,10 @@ import java.util.UUID;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.*;
-import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 class ClientRegistrationHandlerTest {
@@ -65,14 +67,13 @@ class ClientRegistrationHandlerTest {
     }
 
     @Test
-    public void shouldReturn400IfAnyRequestParametersAreMissing() throws JsonProcessingException {
+    public void shouldReturn400IfAnyRequestParametersAreMissing() {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setBody(
                 "{\"redirect_uris\": [\"http://localhost:8080/redirect-uri\"], \"contacts\": [\"joe.bloggs@test.com\"] }");
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(400));
-        String expectedResponse = new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1001);
-        assertThat(result, hasBody(expectedResponse));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1001));
     }
 }

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/LoginHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/LoginHandlerTest.java
@@ -24,7 +24,7 @@ import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.entity.SessionState.LOGGED_IN;
-import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
+import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 class LoginHandlerTest {
@@ -64,7 +64,7 @@ class LoginHandlerTest {
     }
 
     @Test
-    public void shouldReturn401IfUserHasInvalidCredentials() throws JsonProcessingException {
+    public void shouldReturn401IfUserHasInvalidCredentials() {
         when(authenticationService.userExists(EMAIL)).thenReturn(true);
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setHeaders(Map.of("Session-Id", "a-session-id"));
@@ -75,12 +75,11 @@ class LoginHandlerTest {
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(401));
-        String expectedResponse = new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1008);
-        assertThat(result, hasBody(expectedResponse));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1008));
     }
 
     @Test
-    public void shouldReturn400IfAnyRequestParametersAreMissing() throws JsonProcessingException {
+    public void shouldReturn400IfAnyRequestParametersAreMissing() {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setHeaders(Map.of("Session-Id", "a-session-id"));
         event.setBody(format("{ \"password\": \"%s\"}", PASSWORD));
@@ -90,12 +89,11 @@ class LoginHandlerTest {
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(400));
-        String expectedResponse = new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1001);
-        assertThat(result, hasBody(expectedResponse));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1001));
     }
 
     @Test
-    public void shouldReturn400IfSessionIdIsInvalid() throws JsonProcessingException {
+    public void shouldReturn400IfSessionIdIsInvalid() {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setHeaders(Map.of("Session-Id", "a-session-id"));
         event.setBody(format("{ \"password\": \"%s\"}", PASSWORD));
@@ -107,12 +105,11 @@ class LoginHandlerTest {
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(400));
-        String expectedResponse = new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1000);
-        assertThat(result, hasBody(expectedResponse));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1000));
     }
 
     @Test
-    public void shouldReturn400IfUserDoesNotHaveAnAccount() throws JsonProcessingException {
+    public void shouldReturn400IfUserDoesNotHaveAnAccount() {
         when(authenticationService.userExists(EMAIL)).thenReturn(false);
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setHeaders(Map.of("Session-Id", "a-session-id"));
@@ -123,8 +120,7 @@ class LoginHandlerTest {
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(400));
-        String expectedResponse = new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1010);
-        assertThat(result, hasBody(expectedResponse));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1010));
     }
 
     private void usingValidSession() {

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/MfaHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/MfaHandlerTest.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.entity.NotificationType.MFA_SMS;
-import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
+import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class MfaHandlerTest {
@@ -88,8 +88,7 @@ public class MfaHandlerTest {
     }
 
     @Test
-    public void shouldReturnErrorResponseWhenUsersPhoneNumberIsNotStored()
-            throws JsonProcessingException {
+    public void shouldReturnErrorResponseWhenUsersPhoneNumberIsNotStored() {
         usingValidSession(TEST_EMAIL_ADDRESS);
         when(authenticationService.getPhoneNumber(TEST_EMAIL_ADDRESS)).thenReturn(Optional.empty());
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
@@ -99,8 +98,7 @@ public class MfaHandlerTest {
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(400));
-        String expectedResponse = new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1014);
-        assertThat(result, hasBody(expectedResponse));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1014));
     }
 
     private void usingValidSession(String email) {

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/SendNotificationHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/SendNotificationHandlerTest.java
@@ -43,7 +43,7 @@ import static uk.gov.di.entity.NotificationType.VERIFY_EMAIL;
 import static uk.gov.di.entity.NotificationType.VERIFY_PHONE_NUMBER;
 import static uk.gov.di.entity.SessionState.VERIFY_EMAIL_CODE_SENT;
 import static uk.gov.di.entity.SessionState.VERIFY_PHONE_NUMBER_CODE_SENT;
-import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
+import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 
 class SendNotificationHandlerTest {
 
@@ -124,7 +124,7 @@ class SendNotificationHandlerTest {
     }
 
     @Test
-    public void shouldReturn400IfRequestIsMissingEmail() throws JsonProcessingException {
+    public void shouldReturn400IfRequestIsMissingEmail() {
         usingValidSession();
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setHeaders(Map.of("Session-Id", "a-session-id"));
@@ -132,12 +132,11 @@ class SendNotificationHandlerTest {
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertEquals(400, result.getStatusCode());
-        String expectedResponse = new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1001);
-        assertThat(result, hasBody(expectedResponse));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1001));
     }
 
     @Test
-    public void shouldReturn400IfEmailAddressIsInvalid() throws JsonProcessingException {
+    public void shouldReturn400IfEmailAddressIsInvalid() {
         when(validationService.validateEmailAddress(eq("joe.bloggs")))
                 .thenReturn(Optional.of(ErrorResponse.ERROR_1004));
         when(sessionService.getSessionFromRequestHeaders(anyMap()))
@@ -152,9 +151,7 @@ class SendNotificationHandlerTest {
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertEquals(400, result.getStatusCode());
-        String expectedResponse = new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1004);
-
-        assertThat(result, hasBody(expectedResponse));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1004));
     }
 
     @Test
@@ -181,7 +178,7 @@ class SendNotificationHandlerTest {
     }
 
     @Test
-    public void shouldReturn400WhenInvalidNotificationType() throws JsonProcessingException {
+    public void shouldReturn400WhenInvalidNotificationType() {
         when(validationService.validateEmailAddress(eq(TEST_EMAIL_ADDRESS)))
                 .thenReturn(Optional.empty());
 
@@ -195,9 +192,7 @@ class SendNotificationHandlerTest {
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertEquals(400, result.getStatusCode());
-
-        String expectedResponse = new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1001);
-        assertThat(result, hasBody(expectedResponse));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1001));
 
         verify(awsSqsClient, never()).send(anyString());
         verify(codeStorageService, never())
@@ -222,8 +217,7 @@ class SendNotificationHandlerTest {
     }
 
     @Test
-    public void shouldReturn400WhenVerifyTypeIsVerifyPhoneNumberButRequestIsMissingNumber()
-            throws JsonProcessingException {
+    public void shouldReturn400WhenVerifyTypeIsVerifyPhoneNumberButRequestIsMissingNumber() {
         usingValidSession();
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setHeaders(Map.of("Session-Id", "a-session-id"));
@@ -234,12 +228,11 @@ class SendNotificationHandlerTest {
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertEquals(400, result.getStatusCode());
-        String expectedResponse = new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1011);
-        assertThat(result, hasBody(expectedResponse));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1011));
     }
 
     @Test
-    public void shouldReturn400WhenPhoneNumberIsInvalid() throws JsonProcessingException {
+    public void shouldReturn400WhenPhoneNumberIsInvalid() {
         when(validationService.validatePhoneNumber(eq("123456789")))
                 .thenReturn(Optional.of(ErrorResponse.ERROR_1012));
         usingValidSession();
@@ -252,9 +245,7 @@ class SendNotificationHandlerTest {
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertEquals(400, result.getStatusCode());
-        String expectedResponse = new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1012);
-
-        assertThat(result, hasBody(expectedResponse));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1012));
     }
 
     private void usingValidSession() {

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/SignUpHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/SignUpHandlerTest.java
@@ -29,8 +29,10 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.entity.SessionState.*;
-import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
+import static uk.gov.di.entity.SessionState.EMAIL_CODE_VERIFIED;
+import static uk.gov.di.entity.SessionState.NEW;
+import static uk.gov.di.entity.SessionState.TWO_FACTOR_REQUIRED;
+import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 class SignUpHandlerTest {
@@ -78,7 +80,7 @@ class SignUpHandlerTest {
     }
 
     @Test
-    public void shouldReturn400IfSessionIdMissing() throws JsonProcessingException {
+    public void shouldReturn400IfSessionIdMissing() {
         String password = "computer-1";
         when(validationService.validatePassword(eq(password))).thenReturn(Optional.empty());
 
@@ -87,13 +89,11 @@ class SignUpHandlerTest {
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(400));
-
-        String expectedResponse = new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1000);
-        assertThat(result, hasBody(expectedResponse));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1000));
     }
 
     @Test
-    public void shouldReturn400IfAnyRequestParametersAreMissing() throws JsonProcessingException {
+    public void shouldReturn400IfAnyRequestParametersAreMissing() {
         session.setState(EMAIL_CODE_VERIFIED);
         usingValidSession();
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
@@ -102,13 +102,11 @@ class SignUpHandlerTest {
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(400));
-
-        String expectedResponse = new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1001);
-        assertThat(result, hasBody(expectedResponse));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1001));
     }
 
     @Test
-    public void shouldReturn400IfPasswordFailsValidation() throws JsonProcessingException {
+    public void shouldReturn400IfPasswordFailsValidation() {
         session.setState(EMAIL_CODE_VERIFIED);
         String password = "computer";
         when(validationService.validatePassword(eq(password)))
@@ -121,14 +119,11 @@ class SignUpHandlerTest {
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(400));
-
-        String expectedResponse = new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1007);
-
-        assertThat(result, hasBody(expectedResponse));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1007));
     }
 
     @Test
-    public void shouldReturn400IfUserAlreadyExists() throws JsonProcessingException {
+    public void shouldReturn400IfUserAlreadyExists() {
         session.setState(EMAIL_CODE_VERIFIED);
         String password = "computer-1";
         when(validationService.validatePassword(eq(password))).thenReturn(Optional.empty());
@@ -141,15 +136,11 @@ class SignUpHandlerTest {
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(400));
-
-        String expectedResponse = new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1009);
-
-        assertThat(result, hasBody(expectedResponse));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1009));
     }
 
     @Test
-    public void shouldReturn400IfUserTransitionsToHelperFromWrongState()
-            throws JsonProcessingException {
+    public void shouldReturn400IfUserTransitionsToHelperFromWrongState() {
         session.setState(NEW);
 
         String password = "computer-1";
@@ -162,10 +153,7 @@ class SignUpHandlerTest {
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(400));
-
-        String expectedResponse = new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1019);
-
-        assertThat(result, hasBody(expectedResponse));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1019));
     }
 
     private void usingValidSession() {

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/UpdateProfileHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/UpdateProfileHandlerTest.java
@@ -3,8 +3,6 @@ package uk.gov.di.lambdas;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.entity.ErrorResponse;
@@ -24,7 +22,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.entity.UpdateProfileType.ADD_PHONE_NUMBER;
-import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
+import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 class UpdateProfileHandlerTest {
@@ -42,7 +40,7 @@ class UpdateProfileHandlerTest {
     }
 
     @Test
-    public void shouldReturn200WhenUpdatingPhoneNumber() throws JsonProcessingException {
+    public void shouldReturn200WhenUpdatingPhoneNumber() {
         when(authenticationService.userExists(eq("joe.bloggs@test.com"))).thenReturn(false);
         usingValidSession();
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
@@ -59,7 +57,7 @@ class UpdateProfileHandlerTest {
     }
 
     @Test
-    public void shouldReturn400WhenRequestIsMissingParameters() throws JsonProcessingException {
+    public void shouldReturn400WhenRequestIsMissingParameters() {
         when(authenticationService.userExists(eq("joe.bloggs@test.com"))).thenReturn(false);
         usingValidSession();
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
@@ -74,8 +72,7 @@ class UpdateProfileHandlerTest {
                 .updatePhoneNumber(eq(TEST_EMAIL_ADDRESS), eq(PHONE_NUMBER));
 
         assertThat(result, hasStatus(400));
-        String expectedResponse = new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1001);
-        assertThat(result, hasBody(expectedResponse));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1001));
     }
 
     private void usingValidSession() {

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/VerifyCodeRequestHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/VerifyCodeRequestHandlerTest.java
@@ -42,7 +42,7 @@ import static uk.gov.di.entity.SessionState.PHONE_NUMBER_CODE_MAX_RETRIES_REACHE
 import static uk.gov.di.entity.SessionState.PHONE_NUMBER_CODE_NOT_VALID;
 import static uk.gov.di.entity.SessionState.PHONE_NUMBER_CODE_VERIFIED;
 import static uk.gov.di.entity.SessionState.VERIFY_EMAIL_CODE_SENT;
-import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
+import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 class VerifyCodeRequestHandlerTest {
@@ -148,7 +148,7 @@ class VerifyCodeRequestHandlerTest {
     }
 
     @Test
-    public void shouldReturn400IfRequestIsMissingNotificationType() throws JsonProcessingException {
+    public void shouldReturn400IfRequestIsMissingNotificationType() {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setHeaders(Map.of("Session-Id", "a-session-id"));
         event.setBody(format("{ \"code\": \"%s\"}", CODE));
@@ -157,29 +157,24 @@ class VerifyCodeRequestHandlerTest {
 
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
         assertThat(result, hasStatus(400));
-
-        String expectedResponse = new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1001);
-        assertThat(result, hasBody(expectedResponse));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1001));
     }
 
     @Test
-    public void shouldReturn400IfSessionIdIsInvalid() throws JsonProcessingException {
+    public void shouldReturn400IfSessionIdIsInvalid() {
         APIGatewayProxyResponseEvent result =
                 makeCallWithCode("123456", VERIFY_EMAIL.toString(), Optional.empty());
 
         assertThat(result, hasStatus(400));
-        String expectedResponse = new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1000);
-        assertThat(result, hasBody(expectedResponse));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1000));
     }
 
     @Test
-    public void shouldReturn400IfNotificationTypeIsNotValid() throws JsonProcessingException {
+    public void shouldReturn400IfNotificationTypeIsNotValid() {
         APIGatewayProxyResponseEvent result = makeCallWithCode(CODE, "VERIFY_TEXT");
 
-        String expectedResponse = new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1001);
-
         assertThat(result, hasStatus(400));
-        assertThat(result, hasBody(expectedResponse));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1001));
     }
 
     @Test
@@ -340,8 +335,7 @@ class VerifyCodeRequestHandlerTest {
     }
 
     @Test
-    public void shouldReturn400IfUserTransitionsFromWrongStateForEmailCode()
-            throws JsonProcessingException {
+    public void shouldReturn400IfUserTransitionsFromWrongStateForEmailCode() {
         session.setState(SessionState.NEW);
 
         when(configurationService.getCodeMaxRetries()).thenReturn(5);
@@ -352,10 +346,8 @@ class VerifyCodeRequestHandlerTest {
                 .thenReturn(EMAIL_CODE_VERIFIED);
         APIGatewayProxyResponseEvent result = makeCallWithCode(CODE, VERIFY_EMAIL.toString());
 
-        String expectedResponse = new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1019);
-
         assertThat(result, hasStatus(400));
-        assertThat(result, hasBody(expectedResponse));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1019));
     }
 
     private APIGatewayProxyResponseEvent makeCallWithCode(String code, String notificationType) {

--- a/serverless/lambda/src/test/java/uk/gov/di/matchers/APIGatewayProxyResponseEventMatcher.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/matchers/APIGatewayProxyResponseEventMatcher.java
@@ -1,6 +1,8 @@
 package uk.gov.di.matchers;
 
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 
@@ -51,5 +53,15 @@ public class APIGatewayProxyResponseEventMatcher<T>
     public static APIGatewayProxyResponseEventMatcher<String> hasBody(String body) {
         return new APIGatewayProxyResponseEventMatcher<>(
                 "body", APIGatewayProxyResponseEvent::getBody, body);
+    }
+
+    public static APIGatewayProxyResponseEventMatcher<String> hasJsonBody(Object body) {
+        try {
+            var expectedValue = new ObjectMapper().writeValueAsString(body);
+            return new APIGatewayProxyResponseEventMatcher<>(
+                    "body", APIGatewayProxyResponseEvent::getBody, expectedValue);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
     }
 }


### PR DESCRIPTION
## What?

Create and use a matcher that takes an object and compares the `APIGatewayProxyRequestEvent.getBody()` to the serialisation of that object.

## Why?

Remove duplication and tidy up assertions
