### PR TITLE
Add logout endpoint to wellknown endpoint

### DIFF
--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/WellknownHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/WellknownHandler.java
@@ -82,6 +82,7 @@ public class WellknownHandler
                             JWSAlgorithm.HS384,
                             JWSAlgorithm.HS512));
             providerMetadata.setServiceDocsURI(new URI("http://TBA"));
+            providerMetadata.setEndSessionEndpointURI(buildURI("/logout", baseUrl));
 
             return generateApiGatewayProxyResponse(200, providerMetadata.toString());
         } catch (URISyntaxException | NoSuchElementException e) {


### PR DESCRIPTION
## What?

Add logout url to well known endpoint.

## Why?

This provides the necessary information to service teams integrating. 

