### PR TITLE
GOVSI-277 - Create update client config endpoint

### DIFF
--- a/ci/terraform/aws/api-gateway.tf
+++ b/ci/terraform/aws/api-gateway.tf
@@ -80,6 +80,18 @@ resource "aws_api_gateway_resource" "connect_resource" {
   path_part   = "connect"
 }
 
+resource "aws_api_gateway_resource" "oidc_resource" {
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
+  parent_id   = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
+  path_part   = "oidc"
+}
+
+resource "aws_api_gateway_resource" "clients_resource" {
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
+  parent_id   = aws_api_gateway_resource.oidc_resource.id
+  path_part   = "clients"
+}
+
 data "aws_region" "current"{
 }
 
@@ -106,6 +118,7 @@ resource "aws_api_gateway_deployment" "deployment" {
       module.mfa.resource_id,
       module.auth-code.resource_id,
       module.logout.resource_id,
+      module.update.resource_id,
       module.client-info.resource_id,
     ]))
   }
@@ -127,6 +140,7 @@ resource "aws_api_gateway_deployment" "deployment" {
     module.verify_code,
     module.mfa,
     module.auth-code,
+    module.update,
     module.logout,
     module.client-info,
   ]
@@ -152,6 +166,7 @@ resource "aws_api_gateway_stage" "endpoint_stage" {
     module.mfa,
     module.auth-code,
     module.logout,
+    module.update,
     module.client-info,
     aws_api_gateway_deployment.deployment,
   ]

--- a/ci/terraform/aws/auth-code.tf
+++ b/ci/terraform/aws/auth-code.tf
@@ -2,6 +2,7 @@ module "auth-code" {
   source = "../modules/endpoint-module"
 
   endpoint_name   = "auth-code"
+  path_part       = "auth-code"
   endpoint_method = "GET"
 
   handler_environment_variables = {

--- a/ci/terraform/aws/authorize.tf
+++ b/ci/terraform/aws/authorize.tf
@@ -2,6 +2,7 @@ module "authorize" {
   source = "../modules/endpoint-module"
 
   endpoint_name   = "authorize"
+  path_part       = "authorize"
   endpoint_method = "GET"
   environment     = var.environment
 

--- a/ci/terraform/aws/client-info.tf
+++ b/ci/terraform/aws/client-info.tf
@@ -2,6 +2,7 @@ module "client-info" {
   source = "../modules/endpoint-module"
 
   endpoint_name   = "client-info"
+  path_part       = "client-info"
   endpoint_method = "GET"
   environment     = var.environment
 

--- a/ci/terraform/aws/jwks.tf
+++ b/ci/terraform/aws/jwks.tf
@@ -2,6 +2,7 @@ module "jwks" {
   source = "../modules/endpoint-module"
 
   endpoint_name   = "jwks.json"
+  path_part       = "jwks.json"
   endpoint_method = "GET"
   environment     = var.environment
 

--- a/ci/terraform/aws/login.tf
+++ b/ci/terraform/aws/login.tf
@@ -2,6 +2,7 @@ module "login" {
   source = "../modules/endpoint-module"
 
   endpoint_name   = "login"
+  path_part       = "login"
   endpoint_method = "POST"
   handler_environment_variables = {
     ENVIRONMENT = var.environment

--- a/ci/terraform/aws/logout.tf
+++ b/ci/terraform/aws/logout.tf
@@ -2,6 +2,7 @@ module "logout" {
   source = "../modules/endpoint-module"
 
   endpoint_name   = "logout"
+  path_part       = "logout"
   endpoint_method = "GET"
   environment     = var.environment
 

--- a/ci/terraform/aws/mfa.tf
+++ b/ci/terraform/aws/mfa.tf
@@ -2,6 +2,7 @@ module "mfa" {
   source = "../modules/endpoint-module"
 
   endpoint_name   = "mfa"
+  path_part       = "mfa"
   endpoint_method = "POST"
   environment     = var.environment
 

--- a/ci/terraform/aws/register.tf
+++ b/ci/terraform/aws/register.tf
@@ -2,6 +2,7 @@ module "register" {
   source = "../modules/endpoint-module"
 
   endpoint_name   = "register"
+  path_part       = "register"
   endpoint_method = "POST"
 
   handler_environment_variables = {

--- a/ci/terraform/aws/send_notification.tf
+++ b/ci/terraform/aws/send_notification.tf
@@ -2,6 +2,7 @@ module "send_notification" {
   source = "../modules/endpoint-module"
 
   endpoint_name   = "send-notification"
+  path_part       = "send-notification"
   endpoint_method = "POST"
   environment     = var.environment
 

--- a/ci/terraform/aws/signup.tf
+++ b/ci/terraform/aws/signup.tf
@@ -2,6 +2,7 @@ module "signup" {
   source = "../modules/endpoint-module"
 
   endpoint_name   = "signup"
+  path_part       = "signup"
   endpoint_method = "POST"
   environment     = var.environment
 

--- a/ci/terraform/aws/token.tf
+++ b/ci/terraform/aws/token.tf
@@ -2,6 +2,7 @@ module "token" {
   source = "../modules/endpoint-module"
 
   endpoint_name   = "token"
+  path_part       = "token"
   endpoint_method = "POST"
   environment     = var.environment
 

--- a/ci/terraform/aws/update.tf
+++ b/ci/terraform/aws/update.tf
@@ -1,24 +1,26 @@
-module "openid_configuration_discovery" {
+module "update" {
   source = "../modules/endpoint-module"
 
-  endpoint_name   = "openid-configuration"
-  path_part       = "openid-configuration"
-  endpoint_method = "GET"
-  environment     = var.environment
+  path_part       = "{clientId}"
+  endpoint_name   = "update-client-info"
+  endpoint_method = "POST"
 
   handler_environment_variables = {
+    ENVIRONMENT = var.environment
     BASE_URL = local.api_base_url
+    DYNAMO_ENDPOINT = var.use_localstack ? var.lambda_dynamo_endpoint : null
   }
-  handler_function_name = "uk.gov.di.lambdas.WellknownHandler::handleRequest"
+  handler_function_name = "uk.gov.di.lambdas.UpdateClientConfigHandler::handleRequest"
 
   rest_api_id               = aws_api_gateway_rest_api.di_authentication_api.id
-  root_resource_id          = aws_api_gateway_resource.wellknown_resource.id
+  root_resource_id          = aws_api_gateway_resource.clients_resource.id
   execution_arn             = aws_api_gateway_rest_api.di_authentication_api.execution_arn
   api_deployment_stage_name = var.api_deployment_stage_name
   lambda_zip_file           = var.lambda_zip_file
   security_group_id         = aws_vpc.authentication.default_security_group_id
   subnet_id                 = aws_subnet.authentication.*.id
   lambda_role_arn           = aws_iam_role.lambda_iam_role.arn
+  environment               = var.environment
 
   depends_on = [
     aws_api_gateway_rest_api.di_authentication_api,

--- a/ci/terraform/aws/update_profile.tf
+++ b/ci/terraform/aws/update_profile.tf
@@ -2,6 +2,7 @@ module "update_profile" {
   source = "../modules/endpoint-module"
 
   endpoint_name   = "update-profile"
+  path_part       = "update-profile"
   endpoint_method = "POST"
   environment     = var.environment
 

--- a/ci/terraform/aws/userexists.tf
+++ b/ci/terraform/aws/userexists.tf
@@ -2,6 +2,7 @@ module "userexists" {
   source = "../modules/endpoint-module"
 
   endpoint_name   = "user-exists"
+  path_part       = "user-exists"
   endpoint_method = "POST"
   environment     = var.environment
 

--- a/ci/terraform/aws/userinfo.tf
+++ b/ci/terraform/aws/userinfo.tf
@@ -2,6 +2,7 @@ module "userinfo" {
   source = "../modules/endpoint-module"
 
   endpoint_name   = "userinfo"
+  path_part       = "userinfo"
   endpoint_method = "GET"
   environment     = var.environment
 

--- a/ci/terraform/aws/verify_code.tf
+++ b/ci/terraform/aws/verify_code.tf
@@ -2,6 +2,7 @@ module "verify_code" {
   source = "../modules/endpoint-module"
 
   endpoint_name   = "verify-code"
+  path_part       = "verify-code"
   endpoint_method = "POST"
   environment     = var.environment
 

--- a/ci/terraform/modules/endpoint-module/api-gateway.tf
+++ b/ci/terraform/modules/endpoint-module/api-gateway.tf
@@ -1,7 +1,7 @@
 resource "aws_api_gateway_resource" "endpoint_resource" {
   rest_api_id = var.rest_api_id
   parent_id   = var.root_resource_id
-  path_part   = var.endpoint_name
+  path_part   = var.path_part
 }
 
 resource "aws_api_gateway_method" "endpoint_method" {
@@ -9,7 +9,9 @@ resource "aws_api_gateway_method" "endpoint_method" {
   resource_id   = aws_api_gateway_resource.endpoint_resource.id
   http_method   = var.endpoint_method
   authorization = "NONE"
-  request_parameters   = {}
+  request_parameters   = {
+    "method.request.path.clientId" = true
+  }
 
   depends_on = [
     aws_api_gateway_resource.endpoint_resource

--- a/ci/terraform/modules/endpoint-module/variables.tf
+++ b/ci/terraform/modules/endpoint-module/variables.tf
@@ -2,6 +2,10 @@ variable "endpoint_name" {
   type = string
 }
 
+variable "path_part" {
+  type = string
+}
+
 variable "endpoint_method" {
   type = string
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateClientConfigIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateClientConfigIntegrationTest.java
@@ -1,0 +1,71 @@
+package uk.gov.di.authentication.api;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.helpers.DynamoHelper;
+import uk.gov.di.entity.ClientRegistrationResponse;
+import uk.gov.di.entity.ErrorResponse;
+import uk.gov.di.entity.UpdateClientConfigRequest;
+
+import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class UpdateClientConfigIntegrationTest extends IntegrationTestEndpoints {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private static final String CLIENT_ID = "client-id-1";
+    private static final String BASE_UPDATE_ENDPOINT = "/oidc/clients";
+
+    @Test
+    public void shouldCallRegisterAndUpdateClientNameSuccessfully() throws JsonProcessingException {
+        DynamoHelper.registerClient(
+                CLIENT_ID,
+                "The test client",
+                singletonList("http://localhost:1000/redirect"),
+                singletonList("test-client@test.com"),
+                singletonList("openid"),
+                "public-key",
+                singletonList("http://localhost/post-redirect-logout"));
+
+        UpdateClientConfigRequest updateRequest = new UpdateClientConfigRequest();
+        updateRequest.setClientName("new-client-name");
+
+        Response response =
+                ClientBuilder.newClient()
+                        .target(ROOT_RESOURCE_URL + BASE_UPDATE_ENDPOINT + "/" + CLIENT_ID)
+                        .request(MediaType.APPLICATION_JSON)
+                        .headers(new MultivaluedHashMap<>())
+                        .post(Entity.entity(updateRequest, MediaType.APPLICATION_JSON));
+
+        assertEquals(200, response.getStatus());
+        ClientRegistrationResponse clientResponse =
+                objectMapper.readValue(
+                        response.readEntity(String.class), ClientRegistrationResponse.class);
+        assertEquals("new-client-name", clientResponse.getClientName());
+        assertEquals(CLIENT_ID, clientResponse.getClientId());
+    }
+
+    @Test
+    public void shouldReturn401WhenClientIsUnauthorized() throws JsonProcessingException {
+        UpdateClientConfigRequest updateRequest = new UpdateClientConfigRequest();
+        updateRequest.setClientName("new-client-name");
+
+        Response response =
+                ClientBuilder.newClient()
+                        .target(ROOT_RESOURCE_URL + BASE_UPDATE_ENDPOINT + "/" + CLIENT_ID)
+                        .request(MediaType.APPLICATION_JSON)
+                        .headers(new MultivaluedHashMap<>())
+                        .post(Entity.entity(updateRequest, MediaType.APPLICATION_JSON));
+
+        assertEquals(401, response.getStatus());
+        assertEquals(
+                new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1016),
+                response.readEntity(String.class));
+    }
+}

--- a/serverless/lambda/src/main/java/uk/gov/di/entity/ClientRegistrationResponse.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/entity/ClientRegistrationResponse.java
@@ -7,31 +7,42 @@ import java.util.List;
 public class ClientRegistrationResponse {
 
     @JsonProperty("client_name")
-    private String clientName;
+    private final String clientName;
 
     @JsonProperty("client_id")
-    private String clientId;
+    private final String clientId;
 
     @JsonProperty("redirect_uris")
-    private List<String> redirectUris;
+    private final List<String> redirectUris;
 
     @JsonProperty("contacts")
-    private List<String> contacts;
+    private final List<String> contacts;
+
+    @JsonProperty("scopes")
+    private final List<String> scopes;
 
     @JsonProperty("post_logout_redirect_uris")
-    private List<String> postLogoutRedirectUris;
+    private final List<String> postLogoutRedirectUris;
+
+    @JsonProperty("subject_type")
+    private final String subjectType = "Public";
+
+    @JsonProperty("token_endpoint_auth_method")
+    private final String tokenAuthMethod = "private_key_jwt";
 
     public ClientRegistrationResponse(
             @JsonProperty(required = true, value = "client_name") String clientName,
             @JsonProperty(required = true, value = "client_id") String clientId,
             @JsonProperty(required = true, value = "redirect_uris") List<String> redirectUris,
             @JsonProperty(required = true, value = "contacts") List<String> contacts,
+            @JsonProperty(required = true, value = "scopes") List<String> scopes,
             @JsonProperty(value = "post_logout_redirect_uris")
                     List<String> postLogoutRedirectUris) {
         this.clientName = clientName;
         this.clientId = clientId;
         this.redirectUris = redirectUris;
         this.contacts = contacts;
+        this.scopes = scopes;
         this.postLogoutRedirectUris = postLogoutRedirectUris;
     }
 
@@ -51,7 +62,19 @@ public class ClientRegistrationResponse {
         return contacts;
     }
 
+    public List<String> getScopes() {
+        return scopes;
+    }
+
     public List<String> getPostLogoutRedirectUris() {
         return postLogoutRedirectUris;
+    }
+
+    public String getSubjectType() {
+        return subjectType;
+    }
+
+    public String getTokenAuthMethod() {
+        return tokenAuthMethod;
     }
 }

--- a/serverless/lambda/src/main/java/uk/gov/di/entity/UpdateClientConfigRequest.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/entity/UpdateClientConfigRequest.java
@@ -28,10 +28,7 @@ public class UpdateClientConfigRequest {
     @JsonProperty("post_logout_redirect_uris")
     private List<String> postLogoutRedirectUris = new ArrayList<>();
 
-    public UpdateClientConfigRequest(
-            @JsonProperty(required = true, value = "client_id") String clientId) {
-        this.clientId = clientId;
-    }
+    public UpdateClientConfigRequest() {}
 
     public String getClientId() {
         return clientId;

--- a/serverless/lambda/src/main/java/uk/gov/di/entity/UpdateClientConfigRequest.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/entity/UpdateClientConfigRequest.java
@@ -1,0 +1,99 @@
+package uk.gov.di.entity;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class UpdateClientConfigRequest {
+
+    @JsonProperty("client_id")
+    private String clientId;
+
+    @JsonProperty("client_name")
+    private String clientName;
+
+    @JsonProperty("redirect_uris")
+    private List<String> redirectUris;
+
+    @JsonProperty("contacts")
+    private List<String> contacts;
+
+    @JsonProperty("public_key")
+    private String publicKey;
+
+    @JsonProperty("scopes")
+    private List<String> scopes;
+
+    @JsonProperty("post_logout_redirect_uris")
+    private List<String> postLogoutRedirectUris = new ArrayList<>();
+
+    public UpdateClientConfigRequest(
+            @JsonProperty(required = true, value = "client_id") String clientId) {
+        this.clientId = clientId;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public String getClientName() {
+        return clientName;
+    }
+
+    public List<String> getRedirectUris() {
+        return redirectUris;
+    }
+
+    public List<String> getContacts() {
+        return contacts;
+    }
+
+    public String getPublicKey() {
+        return publicKey;
+    }
+
+    public List<String> getScopes() {
+        return scopes;
+    }
+
+    public List<String> getPostLogoutRedirectUris() {
+        return postLogoutRedirectUris;
+    }
+
+    public UpdateClientConfigRequest setClientId(String clientId) {
+        this.clientId = clientId;
+        return this;
+    }
+
+    public UpdateClientConfigRequest setClientName(String clientName) {
+        this.clientName = clientName;
+        return this;
+    }
+
+    public UpdateClientConfigRequest setRedirectUris(List<String> redirectUris) {
+        this.redirectUris = redirectUris;
+        return this;
+    }
+
+    public UpdateClientConfigRequest setContacts(List<String> contacts) {
+        this.contacts = contacts;
+        return this;
+    }
+
+    public UpdateClientConfigRequest setPublicKey(String publicKey) {
+        this.publicKey = publicKey;
+        return this;
+    }
+
+    public UpdateClientConfigRequest setScopes(List<String> scopes) {
+        this.scopes = scopes;
+        return this;
+    }
+
+    public UpdateClientConfigRequest setPostLogoutRedirectUris(
+            List<String> postLogoutRedirectUris) {
+        this.postLogoutRedirectUris = postLogoutRedirectUris;
+        return this;
+    }
+}

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/ClientRegistrationHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/ClientRegistrationHandler.java
@@ -57,6 +57,7 @@ public class ClientRegistrationHandler
                             clientID,
                             clientRegistrationRequest.getRedirectUris(),
                             clientRegistrationRequest.getContacts(),
+                            clientRegistrationRequest.getScopes(),
                             clientRegistrationRequest.getPostLogoutRedirectUris());
 
             return generateApiGatewayProxyResponse(200, clientRegistrationResponse);

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/UpdateClientConfigHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/UpdateClientConfigHandler.java
@@ -52,6 +52,7 @@ public class UpdateClientConfigHandler
                             clientRegistry.getClientID(),
                             clientRegistry.getRedirectUrls(),
                             clientRegistry.getContacts(),
+                            clientRegistry.getScopes(),
                             clientRegistry.getPostLogoutRedirectUrls());
             return generateApiGatewayProxyResponse(200, clientRegistrationResponse);
         } catch (JsonProcessingException e) {

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/UpdateClientConfigHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/UpdateClientConfigHandler.java
@@ -1,0 +1,61 @@
+package uk.gov.di.lambdas;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import uk.gov.di.entity.ClientRegistrationResponse;
+import uk.gov.di.entity.ClientRegistry;
+import uk.gov.di.entity.ErrorResponse;
+import uk.gov.di.entity.UpdateClientConfigRequest;
+import uk.gov.di.services.ClientService;
+import uk.gov.di.services.ConfigurationService;
+import uk.gov.di.services.DynamoClientService;
+
+import static uk.gov.di.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
+import static uk.gov.di.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
+
+public class UpdateClientConfigHandler
+        implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+
+    private final ClientService clientService;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public UpdateClientConfigHandler(ClientService clientService) {
+        this.clientService = clientService;
+    }
+
+    public UpdateClientConfigHandler() {
+        ConfigurationService configurationService = new ConfigurationService();
+        this.clientService =
+                new DynamoClientService(
+                        configurationService.getAwsRegion(),
+                        configurationService.getEnvironment(),
+                        configurationService.getDynamoEndpointUri());
+    }
+
+    @Override
+    public APIGatewayProxyResponseEvent handleRequest(
+            APIGatewayProxyRequestEvent input, Context context) {
+        try {
+            UpdateClientConfigRequest updateClientConfigRequest =
+                    objectMapper.readValue(input.getBody(), UpdateClientConfigRequest.class);
+            if (!clientService.isValidClient(updateClientConfigRequest.getClientId())) {
+                return generateApiGatewayProxyErrorResponse(401, ErrorResponse.ERROR_1016);
+            }
+            ClientRegistry clientRegistry = clientService.updateClient(updateClientConfigRequest);
+            ClientRegistrationResponse clientRegistrationResponse =
+                    new ClientRegistrationResponse(
+                            clientRegistry.getClientName(),
+                            clientRegistry.getClientID(),
+                            clientRegistry.getRedirectUrls(),
+                            clientRegistry.getContacts(),
+                            clientRegistry.getPostLogoutRedirectUrls());
+            return generateApiGatewayProxyResponse(200, clientRegistrationResponse);
+        } catch (JsonProcessingException e) {
+            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
+        }
+    }
+}

--- a/serverless/lambda/src/main/java/uk/gov/di/services/ClientService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/ClientService.java
@@ -27,5 +27,5 @@ public interface ClientService {
 
     ClientID generateClientID();
 
-    ClientRegistry updateClient(UpdateClientConfigRequest updateRequest);
+    ClientRegistry updateClient(String clientId, UpdateClientConfigRequest updateRequest);
 }

--- a/serverless/lambda/src/main/java/uk/gov/di/services/ClientService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/ClientService.java
@@ -4,6 +4,7 @@ import com.nimbusds.oauth2.sdk.AuthorizationRequest;
 import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import uk.gov.di.entity.ClientRegistry;
+import uk.gov.di.entity.UpdateClientConfigRequest;
 
 import java.util.List;
 import java.util.Optional;
@@ -25,4 +26,6 @@ public interface ClientService {
     Optional<ClientRegistry> getClient(String clientId);
 
     ClientID generateClientID();
+
+    ClientRegistry updateClient(UpdateClientConfigRequest updateRequest);
 }

--- a/serverless/lambda/src/main/java/uk/gov/di/services/DynamoClientService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/DynamoClientService.java
@@ -12,6 +12,7 @@ import com.nimbusds.openid.connect.sdk.OIDCError;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.di.entity.ClientRegistry;
+import uk.gov.di.entity.UpdateClientConfigRequest;
 import uk.gov.di.helpers.IdGenerator;
 
 import java.util.List;
@@ -79,6 +80,22 @@ public class DynamoClientService implements ClientService {
                         .setPublicKey(publicKey)
                         .setPostLogoutRedirectUrls(postLogoutRedirectUris);
         clientRegistryMapper.save(clientRegistry);
+    }
+
+    @Override
+    public ClientRegistry updateClient(UpdateClientConfigRequest updateRequest) {
+        ClientRegistry clientRegistry =
+                clientRegistryMapper.load(ClientRegistry.class, updateRequest.getClientId());
+        Optional.ofNullable(updateRequest.getRedirectUris())
+                .ifPresent(clientRegistry::setRedirectUrls);
+        Optional.ofNullable(updateRequest.getClientName()).ifPresent(clientRegistry::setClientName);
+        Optional.ofNullable(updateRequest.getContacts()).ifPresent(clientRegistry::setContacts);
+        Optional.ofNullable(updateRequest.getScopes()).ifPresent(clientRegistry::setScopes);
+        Optional.ofNullable(updateRequest.getPostLogoutRedirectUris())
+                .ifPresent(clientRegistry::setPostLogoutRedirectUrls);
+        Optional.ofNullable(updateRequest.getPublicKey()).ifPresent(clientRegistry::setPublicKey);
+        clientRegistryMapper.save(clientRegistry);
+        return clientRegistry;
     }
 
     @Override

--- a/serverless/lambda/src/main/java/uk/gov/di/services/DynamoClientService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/DynamoClientService.java
@@ -83,9 +83,8 @@ public class DynamoClientService implements ClientService {
     }
 
     @Override
-    public ClientRegistry updateClient(UpdateClientConfigRequest updateRequest) {
-        ClientRegistry clientRegistry =
-                clientRegistryMapper.load(ClientRegistry.class, updateRequest.getClientId());
+    public ClientRegistry updateClient(String clientId, UpdateClientConfigRequest updateRequest) {
+        ClientRegistry clientRegistry = clientRegistryMapper.load(ClientRegistry.class, clientId);
         Optional.ofNullable(updateRequest.getRedirectUris())
                 .ifPresent(clientRegistry::setRedirectUrls);
         Optional.ofNullable(updateRequest.getClientName()).ifPresent(clientRegistry::setClientName);

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/ClientInfoHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/ClientInfoHandlerTest.java
@@ -49,13 +49,16 @@ public class ClientInfoHandlerTest {
 
     @BeforeEach
     public void beforEach() {
-        handler = new ClientInfoHandler(configurationService, clientSessionService, clientService, sessionService);
+        handler =
+                new ClientInfoHandler(
+                        configurationService, clientSessionService, clientService, sessionService);
         clientRegistry = new ClientRegistry();
         clientRegistry.setClientID(TEST_CLIENT_ID);
         clientRegistry.setClientName(TEST_CLIENT_NAME);
         when(clientService.getClient(TEST_CLIENT_ID)).thenReturn(Optional.of(clientRegistry));
         when(clientService.getClient(UNKNOWN_TEST_CLIENT_ID)).thenReturn(Optional.empty());
-        when(sessionService.getSessionFromRequestHeaders(any())).thenReturn(Optional.of(new Session("session-id")));
+        when(sessionService.getSessionFromRequestHeaders(any()))
+                .thenReturn(Optional.of(new Session("session-id")));
     }
 
     @Test

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/ClientRegistrationHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/ClientRegistrationHandlerTest.java
@@ -17,7 +17,7 @@ import java.util.UUID;
 
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -54,7 +54,11 @@ class ClientRegistrationHandlerTest {
         assertThat(result, hasStatus(200));
         ClientRegistrationResponse clientRegistrationResponseResult =
                 objectMapper.readValue(result.getBody(), ClientRegistrationResponse.class);
-        assertEquals(clientId, clientRegistrationResponseResult.getClientId());
+        assertThat(clientRegistrationResponseResult.getClientId(), equalTo(clientId));
+        assertThat(
+                clientRegistrationResponseResult.getTokenAuthMethod(), equalTo("private_key_jwt"));
+        assertThat(clientRegistrationResponseResult.getSubjectType(), equalTo("Public"));
+        assertThat(clientRegistrationResponseResult.getScopes(), equalTo(singletonList("openid")));
         verify(clientService)
                 .addClient(
                         clientId,

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/UpdateClientConfigHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/UpdateClientConfigHandlerTest.java
@@ -1,0 +1,89 @@
+package uk.gov.di.lambdas;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.entity.ClientRegistrationResponse;
+import uk.gov.di.entity.ClientRegistry;
+import uk.gov.di.entity.UpdateClientConfigRequest;
+import uk.gov.di.services.ClientService;
+
+import static java.lang.String.format;
+import static java.util.Collections.singletonList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
+
+class UpdateClientConfigHandlerTest {
+
+    private static final String CLIENT_ID = "client-id-1";
+    private static final String CLIENT_NAME = "client-name-one";
+    private final Context context = mock(Context.class);
+    private final ClientService clientService = mock(ClientService.class);
+    private UpdateClientConfigHandler handler;
+
+    @BeforeEach
+    public void setUp() {
+        handler = new UpdateClientConfigHandler(clientService);
+    }
+
+    @Test
+    public void shouldReturn200ForAValidRequest() throws JsonProcessingException {
+        when(clientService.isValidClient(CLIENT_ID)).thenReturn(true);
+        when(clientService.updateClient(any(UpdateClientConfigRequest.class)))
+                .thenReturn(createClientRegistry());
+
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        event.setBody(
+                format(
+                        "{ \"client_id\": \"%s\", \"client_name\": \"%s\"}",
+                        CLIENT_ID, CLIENT_NAME));
+        APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
+
+        assertThat(result, hasStatus(200));
+        ClientRegistrationResponse clientRegistrationResponse =
+                new ObjectMapper().readValue(result.getBody(), ClientRegistrationResponse.class);
+        assertEquals(CLIENT_ID, clientRegistrationResponse.getClientId());
+        assertEquals(CLIENT_NAME, clientRegistrationResponse.getClientName());
+    }
+
+    @Test
+    public void shouldReturn400WhenRequestIsMissingClientID() {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        event.setBody(format("{\"client_name\": \"%s\"}", CLIENT_NAME));
+        APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
+        assertThat(result, hasStatus(400));
+    }
+
+    @Test
+    public void shouldReturn401WhenClientIdIsInvalid() {
+        when(clientService.isValidClient(CLIENT_ID)).thenReturn(false);
+
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        event.setBody(
+                format(
+                        "{ \"client_id\": \"%s\", \"client_name\": \"%s\"}",
+                        CLIENT_ID, CLIENT_NAME));
+        APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
+        assertThat(result, hasStatus(401));
+    }
+
+    private ClientRegistry createClientRegistry() {
+        ClientRegistry clientRegistry = new ClientRegistry();
+        clientRegistry.setClientName(CLIENT_NAME);
+        clientRegistry.setClientID(CLIENT_ID);
+        clientRegistry.setPublicKey("public-key");
+        clientRegistry.setScopes(singletonList("openid"));
+        clientRegistry.setRedirectUrls(singletonList("http://localhost/redirect"));
+        clientRegistry.setContacts(singletonList("contant-name"));
+        clientRegistry.setPostLogoutRedirectUrls(singletonList("localhost/logout"));
+        return clientRegistry;
+    }
+}

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/UpdateClientConfigHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/UpdateClientConfigHandlerTest.java
@@ -12,10 +12,12 @@ import uk.gov.di.entity.ClientRegistry;
 import uk.gov.di.entity.UpdateClientConfigRequest;
 import uk.gov.di.services.ClientService;
 
+import java.util.List;
+
 import static java.lang.String.format;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.core.IsEqual.equalTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -25,6 +27,7 @@ class UpdateClientConfigHandlerTest {
 
     private static final String CLIENT_ID = "client-id-1";
     private static final String CLIENT_NAME = "client-name-one";
+    private static final List<String> SCOPES = singletonList("openid");
     private final Context context = mock(Context.class);
     private final ClientService clientService = mock(ClientService.class);
     private UpdateClientConfigHandler handler;
@@ -50,8 +53,11 @@ class UpdateClientConfigHandlerTest {
         assertThat(result, hasStatus(200));
         ClientRegistrationResponse clientRegistrationResponse =
                 new ObjectMapper().readValue(result.getBody(), ClientRegistrationResponse.class);
-        assertEquals(CLIENT_ID, clientRegistrationResponse.getClientId());
-        assertEquals(CLIENT_NAME, clientRegistrationResponse.getClientName());
+        assertThat(clientRegistrationResponse.getClientId(), equalTo(CLIENT_ID));
+        assertThat(clientRegistrationResponse.getClientName(), equalTo(CLIENT_NAME));
+        assertThat(clientRegistrationResponse.getSubjectType(), equalTo("Public"));
+        assertThat(clientRegistrationResponse.getTokenAuthMethod(), equalTo("private_key_jwt"));
+        assertThat(clientRegistrationResponse.getScopes(), equalTo(SCOPES));
     }
 
     @Test
@@ -80,7 +86,7 @@ class UpdateClientConfigHandlerTest {
         clientRegistry.setClientName(CLIENT_NAME);
         clientRegistry.setClientID(CLIENT_ID);
         clientRegistry.setPublicKey("public-key");
-        clientRegistry.setScopes(singletonList("openid"));
+        clientRegistry.setScopes(SCOPES);
         clientRegistry.setRedirectUrls(singletonList("http://localhost/redirect"));
         clientRegistry.setContacts(singletonList("contant-name"));
         clientRegistry.setPostLogoutRedirectUrls(singletonList("localhost/logout"));


### PR DESCRIPTION
## What?

- Create an endpoint which can be called via /oidc/clients/{client_id} where client_id is a path parameter. They can update any number of parameters at any one time as long as they pass in a valid client_id. We will then return the entire updated client config in the response
- Change the lambda terraform to add a path_part variable.
- Add integration and unit tests

## Why?

- Clients will need to update their config. 
- The endpoint_name in each of the lambdas terraform was used for the aws_function_name and the path_part for the aws_api_gateway_resource. As we want the final path part of this lambda to be a path parameter we don't want to reuse the endpoint name for the aws_api_gateway_resource. Create a new path_part variable and configure it in each lambda.

