### PR TITLE
GOVSI-281: update existing consent flag when one already exists

### DIFF
--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/UpdateProfileHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/UpdateProfileHandler.java
@@ -34,7 +34,7 @@ import static uk.gov.di.helpers.ApiGatewayResponseHelper.generateApiGatewayProxy
 public class UpdateProfileHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ClientInfoHandler.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(UpdateProfileHandler.class);
 
     private final AuthenticationService authenticationService;
     private final SessionService sessionService;
@@ -113,6 +113,7 @@ public class UpdateProfileHandler
                             authenticationService.getUserConsents(profileRequest.getEmail());
 
                     if (clientConsents.isPresent() && clientConsents.get().containsKey(clientId)) {
+                        clientConsents.get().get(clientId).clear();
                         clientConsents
                                 .get()
                                 .get(clientId)


### PR DESCRIPTION
## What?

Update existing consent flag when one already exists.

## Why?

Handler was adding an additional consent flag to the list rather than updating the existing one.

## Related PRs

#281
