### PR TITLE
GOVSI-277 - Add the client_id to the aws_api_gateway_integration resource request parameters

### DIFF
--- a/ci/terraform/aws/update.tf
+++ b/ci/terraform/aws/update.tf
@@ -4,6 +4,8 @@ module "update" {
   path_part       = "{clientId}"
   endpoint_name   = "update-client-info"
   endpoint_method = "POST"
+  method_request_parameters =  {"method.request.path.clientId" = true}
+  integration_request_parameters = {"integration.request.path.clientId" = "method.request.path.clientId"}
 
   handler_environment_variables = {
     ENVIRONMENT = var.environment

--- a/ci/terraform/modules/endpoint-module/api-gateway.tf
+++ b/ci/terraform/modules/endpoint-module/api-gateway.tf
@@ -9,10 +9,7 @@ resource "aws_api_gateway_method" "endpoint_method" {
   resource_id   = aws_api_gateway_resource.endpoint_resource.id
   http_method   = var.endpoint_method
   authorization = "NONE"
-  request_parameters   = {
-    "method.request.path.clientId" = true
-  }
-
+  request_parameters   = var.method_request_parameters
   depends_on = [
     aws_api_gateway_resource.endpoint_resource
   ]
@@ -22,7 +19,7 @@ resource "aws_api_gateway_integration" "endpoint_integration" {
   rest_api_id          = var.rest_api_id
   resource_id          = aws_api_gateway_resource.endpoint_resource.id
   http_method          = aws_api_gateway_method.endpoint_method.http_method
-  request_parameters   = aws_api_gateway_method.endpoint_method.request_parameters
+  request_parameters   = var.integration_request_parameters
 
   integration_http_method = "POST"
   type                    = "AWS_PROXY"

--- a/ci/terraform/modules/endpoint-module/variables.tf
+++ b/ci/terraform/modules/endpoint-module/variables.tf
@@ -6,6 +6,16 @@ variable "path_part" {
   type = string
 }
 
+variable "method_request_parameters" {
+  type = map(bool)
+  default = {}
+}
+
+variable "integration_request_parameters" {
+  type = map(string)
+  default = {}
+}
+
 variable "endpoint_method" {
   type = string
 }


### PR DESCRIPTION
## What?
- Set method_request_parameters and integration_request_parameters in the module variables.tf and assign the value in the update.tf.

## Why?

- To fix the broken build