### PR TITLE
GOVSI-277 - Don't initialize an empty list for the PostLogoutUri when updating Client config

### DIFF
--- a/serverless/lambda/src/main/java/uk/gov/di/entity/UpdateClientConfigRequest.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/entity/UpdateClientConfigRequest.java
@@ -26,7 +26,7 @@ public class UpdateClientConfigRequest {
     private List<String> scopes;
 
     @JsonProperty("post_logout_redirect_uris")
-    private List<String> postLogoutRedirectUris = new ArrayList<>();
+    private List<String> postLogoutRedirectUris;
 
     public UpdateClientConfigRequest() {}
 


### PR DESCRIPTION
## What?

- Don't initialize an empty list for the PostLogoutUri when updating Client config

## Why?

- Because it will delete the PostLogoutUri and replace it with an empty list