### PR TITLE
GOVSI-277 - Validate Client config in Registration and Update requests

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientRegistrationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientRegistrationIntegrationTest.java
@@ -20,6 +20,8 @@ public class ClientRegistrationIntegrationTest extends IntegrationTestEndpoints 
 
     private static final String REGISTER_ENDPOINT = "/connect/register";
     private final ObjectMapper objectMapper = new ObjectMapper();
+    private static final String VALID_PUBLIC_CERT =
+            "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxt91w8GsMDdklOpS8ZXAsIM1ztQZd5QT/bRCQahZJeS1a6Os4hbuKwzHlz52zfTNp7BL4RB/KOcRIPhOQLgqeyM+bVngRa1EIfTkugJHS2/gu2Xv0aelwvXj8FZgAPRPD+ps2wiV4tUehrFIsRyHZM3yOp9g6qapCcxF7l0E1PlVkKPcPNmxn2oFiqnP6ZThGbE+N2avdXHcySIqt/v6Hbmk8cDHzSExazW7j/XvA+xnp0nQ5m2GisCZul5If5edCTXD0tKzx/I/gtEG4gkv9kENWOt4grP8/0zjNAl2ac6kpRny3tY5RkKBKCOB1VHwq2lUTSNKs32O1BsA5ByyYQIDAQAB";
 
     @Test
     public void shouldCallRegisterEndpointAndReturn200() throws JsonProcessingException {
@@ -28,7 +30,7 @@ public class ClientRegistrationIntegrationTest extends IntegrationTestEndpoints 
                         "The test client",
                         singletonList("http://localhost:1000/redirect"),
                         singletonList("test-client@test.com"),
-                        "public-key",
+                        VALID_PUBLIC_CERT,
                         singletonList("openid"),
                         singletonList("http://localhost/post-redirect-logout"));
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateClientConfigIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateClientConfigIntegrationTest.java
@@ -21,16 +21,18 @@ public class UpdateClientConfigIntegrationTest extends IntegrationTestEndpoints 
     private final ObjectMapper objectMapper = new ObjectMapper();
     private static final String CLIENT_ID = "client-id-1";
     private static final String BASE_UPDATE_ENDPOINT = "/oidc/clients";
+    private static final String VALID_PUBLIC_CERT =
+            "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxt91w8GsMDdklOpS8ZXAsIM1ztQZd5QT/bRCQahZJeS1a6Os4hbuKwzHlz52zfTNp7BL4RB/KOcRIPhOQLgqeyM+bVngRa1EIfTkugJHS2/gu2Xv0aelwvXj8FZgAPRPD+ps2wiV4tUehrFIsRyHZM3yOp9g6qapCcxF7l0E1PlVkKPcPNmxn2oFiqnP6ZThGbE+N2avdXHcySIqt/v6Hbmk8cDHzSExazW7j/XvA+xnp0nQ5m2GisCZul5If5edCTXD0tKzx/I/gtEG4gkv9kENWOt4grP8/0zjNAl2ac6kpRny3tY5RkKBKCOB1VHwq2lUTSNKs32O1BsA5ByyYQIDAQAB";
 
     @Test
-    public void shouldCallRegisterAndUpdateClientNameSuccessfully() throws JsonProcessingException {
+    public void shouldUpdateClientNameSuccessfully() throws JsonProcessingException {
         DynamoHelper.registerClient(
                 CLIENT_ID,
                 "The test client",
                 singletonList("http://localhost:1000/redirect"),
                 singletonList("test-client@test.com"),
                 singletonList("openid"),
-                "public-key",
+                VALID_PUBLIC_CERT,
                 singletonList("http://localhost/post-redirect-logout"));
 
         UpdateClientConfigRequest updateRequest = new UpdateClientConfigRequest();

--- a/serverless/lambda/src/main/java/uk/gov/di/entity/ClientRegistrationResponse.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/entity/ClientRegistrationResponse.java
@@ -30,6 +30,9 @@ public class ClientRegistrationResponse {
     @JsonProperty("token_endpoint_auth_method")
     private final String tokenAuthMethod = "private_key_jwt";
 
+    @JsonProperty("response_type")
+    private final String responseType = "code";
+
     public ClientRegistrationResponse(
             @JsonProperty(required = true, value = "client_name") String clientName,
             @JsonProperty(required = true, value = "client_id") String clientId,
@@ -76,5 +79,9 @@ public class ClientRegistrationResponse {
 
     public String getTokenAuthMethod() {
         return tokenAuthMethod;
+    }
+
+    public String getResponseType() {
+        return responseType;
     }
 }

--- a/serverless/lambda/src/main/java/uk/gov/di/entity/ErrorResponse.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/entity/ErrorResponse.java
@@ -25,11 +25,7 @@ public enum ErrorResponse {
     ERROR_1017(1017, "Invalid Redirect URI"),
     ERROR_1018(1018, "Invalid authorization code parameter"),
     ERROR_1019(1019, "Invalid transition in user journey"),
-    ERROR_1020(1020, "Client-Session-Id is missing or invalid"),
-    ERROR_1021(1021, "Invalid Post logout redirect URIs"),
-    ERROR_1022(1022, "Invalid Redirect URIs"),
-    ERROR_1023(1023, "Invalid Public Key"),
-    ERROR_1024(1023, "Insufficient Scope");
+    ERROR_1020(1020, "Client-Session-Id is missing or invalid");
 
     @JsonProperty("code")
     private int code;

--- a/serverless/lambda/src/main/java/uk/gov/di/entity/ErrorResponse.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/entity/ErrorResponse.java
@@ -25,7 +25,11 @@ public enum ErrorResponse {
     ERROR_1017(1017, "Invalid Redirect URI"),
     ERROR_1018(1018, "Invalid authorization code parameter"),
     ERROR_1019(1019, "Invalid transition in user journey"),
-    ERROR_1020(1020, "Client-Session-Id is missing or invalid");
+    ERROR_1020(1020, "Client-Session-Id is missing or invalid"),
+    ERROR_1021(1021, "Invalid Post logout redirect URIs"),
+    ERROR_1022(1022, "Invalid Redirect URIs"),
+    ERROR_1023(1023, "Invalid Public Key"),
+    ERROR_1024(1023, "Insufficient Scope");
 
     @JsonProperty("code")
     private int code;

--- a/serverless/lambda/src/main/java/uk/gov/di/entity/UpdateClientConfigRequest.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/entity/UpdateClientConfigRequest.java
@@ -2,7 +2,6 @@ package uk.gov.di.entity;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public class UpdateClientConfigRequest {

--- a/serverless/lambda/src/main/java/uk/gov/di/entity/ValidScopes.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/entity/ValidScopes.java
@@ -1,0 +1,11 @@
+package uk.gov.di.entity;
+
+public enum ValidScopes {
+    OPENID,
+    PHONE,
+    EMAIL;
+
+    public String scopesLowerCase() {
+        return name().toLowerCase();
+    }
+}

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/ClientInfoHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/ClientInfoHandler.java
@@ -9,8 +9,16 @@ import com.nimbusds.oauth2.sdk.AuthorizationRequest;
 import com.nimbusds.oauth2.sdk.ParseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.di.entity.*;
-import uk.gov.di.services.*;
+import uk.gov.di.entity.ClientInfoResponse;
+import uk.gov.di.entity.ClientRegistry;
+import uk.gov.di.entity.ClientSession;
+import uk.gov.di.entity.ErrorResponse;
+import uk.gov.di.entity.Session;
+import uk.gov.di.services.ClientService;
+import uk.gov.di.services.ClientSessionService;
+import uk.gov.di.services.ConfigurationService;
+import uk.gov.di.services.DynamoClientService;
+import uk.gov.di.services.SessionService;
 
 import java.util.List;
 import java.util.Map;

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/ClientRegistrationHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/ClientRegistrationHandler.java
@@ -6,6 +6,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.oauth2.sdk.ErrorObject;
 import uk.gov.di.entity.ClientRegistrationRequest;
 import uk.gov.di.entity.ClientRegistrationResponse;
 import uk.gov.di.entity.ErrorResponse;
@@ -48,10 +49,10 @@ public class ClientRegistrationHandler
         try {
             ClientRegistrationRequest clientRegistrationRequest =
                     objectMapper.readValue(input.getBody(), ClientRegistrationRequest.class);
-            Optional<ErrorResponse> errorResponse =
+            Optional<ErrorObject> errorResponse =
                     validationService.validateClientRegistrationConfig(clientRegistrationRequest);
             if (errorResponse.isPresent()) {
-                return generateApiGatewayProxyErrorResponse(400, errorResponse.get());
+                return generateApiGatewayProxyResponse(400, errorResponse.get());
             }
             String clientID = clientService.generateClientID().toString();
             clientService.addClient(

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/UpdateClientConfigHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/UpdateClientConfigHandler.java
@@ -6,6 +6,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.oauth2.sdk.ErrorObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.di.entity.ClientRegistrationResponse;
@@ -58,10 +59,10 @@ public class UpdateClientConfigHandler
                 LOGGER.error("Client with ClientId {} is not valid", clientId);
                 return generateApiGatewayProxyErrorResponse(401, ErrorResponse.ERROR_1016);
             }
-            Optional<ErrorResponse> errorResponse =
+            Optional<ErrorObject> errorResponse =
                     validationService.validateClientUpdateConfig(updateClientConfigRequest);
             if (errorResponse.isPresent()) {
-                return generateApiGatewayProxyErrorResponse(400, errorResponse.get());
+                return generateApiGatewayProxyResponse(400, errorResponse.get());
             }
             ClientRegistry clientRegistry =
                     clientService.updateClient(clientId, updateClientConfigRequest);

--- a/serverless/lambda/src/main/java/uk/gov/di/services/ClientConfigValidationService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/ClientConfigValidationService.java
@@ -1,0 +1,95 @@
+package uk.gov.di.services;
+
+import uk.gov.di.entity.ClientRegistrationRequest;
+import uk.gov.di.entity.ErrorResponse;
+import uk.gov.di.entity.UpdateClientConfigRequest;
+import uk.gov.di.entity.ValidScopes;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.security.KeyFactory;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.List;
+import java.util.Optional;
+
+public class ClientConfigValidationService {
+
+    public Optional<ErrorResponse> validateClientRegistrationConfig(
+            ClientRegistrationRequest registrationRequest) {
+        if (!Optional.ofNullable(registrationRequest.getPostLogoutRedirectUris())
+                .map(this::areUrisValid)
+                .orElse(true)) {
+            return Optional.of(ErrorResponse.ERROR_1021);
+        }
+        if (!areUrisValid(registrationRequest.getRedirectUris())) {
+            return Optional.of(ErrorResponse.ERROR_1022);
+        }
+        if (!isPublicKeyValid(registrationRequest.getPublicKey())) {
+            return Optional.of(ErrorResponse.ERROR_1023);
+        }
+        if (!areScopesValid(registrationRequest.getScopes())) {
+            return Optional.of(ErrorResponse.ERROR_1024);
+        }
+        return Optional.empty();
+    }
+
+    public Optional<ErrorResponse> validateClientUpdateConfig(
+            UpdateClientConfigRequest registrationRequest) {
+        if (!Optional.ofNullable(registrationRequest.getPostLogoutRedirectUris())
+                .map(this::areUrisValid)
+                .orElse(true)) {
+            return Optional.of(ErrorResponse.ERROR_1021);
+        }
+        if (!Optional.ofNullable(registrationRequest.getRedirectUris())
+                .map(this::areUrisValid)
+                .orElse(true)) {
+            return Optional.of(ErrorResponse.ERROR_1022);
+        }
+        if (!Optional.ofNullable(registrationRequest.getPublicKey())
+                .map(this::isPublicKeyValid)
+                .orElse(true)) {
+            return Optional.of(ErrorResponse.ERROR_1023);
+        }
+        if (!Optional.ofNullable(registrationRequest.getScopes())
+                .map(this::areScopesValid)
+                .orElse(true)) {
+            return Optional.of(ErrorResponse.ERROR_1024);
+        }
+        return Optional.empty();
+    }
+
+    private boolean areUrisValid(List<String> uris) {
+        try {
+            for (String uri : uris) {
+                new URL(uri);
+            }
+        } catch (MalformedURLException e) {
+            return false;
+        }
+        return true;
+    }
+
+    private boolean isPublicKeyValid(String publicKey) {
+        try {
+            byte[] decodedKey = Base64.getMimeDecoder().decode(publicKey);
+            X509EncodedKeySpec x509publicKey = new X509EncodedKeySpec(decodedKey);
+            KeyFactory kf = KeyFactory.getInstance("RSA");
+            kf.generatePublic(x509publicKey);
+        } catch (Exception e) {
+            return false;
+        }
+        return true;
+    }
+
+    private boolean areScopesValid(List<String> scopes) {
+        for (String scope : scopes) {
+            if (Arrays.stream(ValidScopes.values())
+                    .noneMatch((t) -> t.scopesLowerCase().equals(scope))) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/serverless/lambda/src/main/java/uk/gov/di/services/ClientConfigValidationService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/ClientConfigValidationService.java
@@ -1,7 +1,8 @@
 package uk.gov.di.services;
 
+import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.client.RegistrationError;
 import uk.gov.di.entity.ClientRegistrationRequest;
-import uk.gov.di.entity.ErrorResponse;
 import uk.gov.di.entity.UpdateClientConfigRequest;
 import uk.gov.di.entity.ValidScopes;
 
@@ -16,46 +17,53 @@ import java.util.Optional;
 
 public class ClientConfigValidationService {
 
-    public Optional<ErrorResponse> validateClientRegistrationConfig(
+    public static final ErrorObject INVALID_POST_LOGOUT_URI =
+            new ErrorObject("invalid_client_metadata", "Invalid Post logout redirect URIs");
+    public static final ErrorObject INVALID_SCOPE =
+            new ErrorObject("invalid_client_metadata", "Insufficient Scope");
+    public static final ErrorObject INVALID_PUBLIC_KEY =
+            new ErrorObject("invalid_client_metadata", "Invalid Public Key");
+
+    public Optional<ErrorObject> validateClientRegistrationConfig(
             ClientRegistrationRequest registrationRequest) {
         if (!Optional.ofNullable(registrationRequest.getPostLogoutRedirectUris())
                 .map(this::areUrisValid)
                 .orElse(true)) {
-            return Optional.of(ErrorResponse.ERROR_1021);
+            return Optional.of(INVALID_POST_LOGOUT_URI);
         }
         if (!areUrisValid(registrationRequest.getRedirectUris())) {
-            return Optional.of(ErrorResponse.ERROR_1022);
+            return Optional.of(RegistrationError.INVALID_REDIRECT_URI);
         }
         if (!isPublicKeyValid(registrationRequest.getPublicKey())) {
-            return Optional.of(ErrorResponse.ERROR_1023);
+            return Optional.of(INVALID_PUBLIC_KEY);
         }
         if (!areScopesValid(registrationRequest.getScopes())) {
-            return Optional.of(ErrorResponse.ERROR_1024);
+            return Optional.of(INVALID_SCOPE);
         }
         return Optional.empty();
     }
 
-    public Optional<ErrorResponse> validateClientUpdateConfig(
+    public Optional<ErrorObject> validateClientUpdateConfig(
             UpdateClientConfigRequest registrationRequest) {
         if (!Optional.ofNullable(registrationRequest.getPostLogoutRedirectUris())
                 .map(this::areUrisValid)
                 .orElse(true)) {
-            return Optional.of(ErrorResponse.ERROR_1021);
+            return Optional.of(INVALID_POST_LOGOUT_URI);
         }
         if (!Optional.ofNullable(registrationRequest.getRedirectUris())
                 .map(this::areUrisValid)
                 .orElse(true)) {
-            return Optional.of(ErrorResponse.ERROR_1022);
+            return Optional.of(RegistrationError.INVALID_REDIRECT_URI);
         }
         if (!Optional.ofNullable(registrationRequest.getPublicKey())
                 .map(this::isPublicKeyValid)
                 .orElse(true)) {
-            return Optional.of(ErrorResponse.ERROR_1023);
+            return Optional.of(INVALID_PUBLIC_KEY);
         }
         if (!Optional.ofNullable(registrationRequest.getScopes())
                 .map(this::areScopesValid)
                 .orElse(true)) {
-            return Optional.of(ErrorResponse.ERROR_1024);
+            return Optional.of(INVALID_SCOPE);
         }
         return Optional.empty();
     }

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/ClientRegistrationHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/ClientRegistrationHandlerTest.java
@@ -8,16 +8,20 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.entity.ClientRegistrationRequest;
 import uk.gov.di.entity.ClientRegistrationResponse;
 import uk.gov.di.entity.ErrorResponse;
+import uk.gov.di.services.ClientConfigValidationService;
 import uk.gov.di.services.ClientService;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -28,12 +32,14 @@ class ClientRegistrationHandlerTest {
 
     private final Context context = mock(Context.class);
     private final ClientService clientService = mock(ClientService.class);
+    private final ClientConfigValidationService configValidationService =
+            mock(ClientConfigValidationService.class);
     private final ObjectMapper objectMapper = new ObjectMapper();
     private ClientRegistrationHandler handler;
 
     @BeforeEach
     public void setup() {
-        handler = new ClientRegistrationHandler(clientService);
+        handler = new ClientRegistrationHandler(clientService, configValidationService);
     }
 
     @Test
@@ -43,6 +49,9 @@ class ClientRegistrationHandlerTest {
         String clientName = "test-client";
         List<String> redirectUris = List.of("http://localhost:8080/redirect-uri");
         List<String> contacts = List.of("joe.bloggs@test.com");
+        when(configValidationService.validateClientRegistrationConfig(
+                        any(ClientRegistrationRequest.class)))
+                .thenReturn(Optional.empty());
         when(clientService.generateClientID()).thenReturn(new ClientID(clientId));
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
@@ -79,5 +88,19 @@ class ClientRegistrationHandlerTest {
 
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1001));
+    }
+
+    @Test
+    public void shouldReturn400ResponseIfRequestFailsValidation() {
+        when(configValidationService.validateClientRegistrationConfig(
+                        any(ClientRegistrationRequest.class)))
+                .thenReturn(Optional.of(ErrorResponse.ERROR_1023));
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        event.setBody(
+                "{ \"client_name\": \"test-client\", \"redirect_uris\": [\"http://localhost:8080/redirect-uri\"], \"contacts\": [\"joe.bloggs@test.com\"], \"scopes\": [\"openid\"],  \"public_key\": \"some-public-key\", \"post_logout_redirect_uris\": [\"http://localhost:8080/post-logout-redirect-uri\"]}");
+        APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
+
+        assertThat(result, hasStatus(400));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1023));
     }
 }

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/ClientRegistrationHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/ClientRegistrationHandlerTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
+import static uk.gov.di.services.ClientConfigValidationService.INVALID_PUBLIC_KEY;
 
 class ClientRegistrationHandlerTest {
 
@@ -94,13 +95,13 @@ class ClientRegistrationHandlerTest {
     public void shouldReturn400ResponseIfRequestFailsValidation() {
         when(configValidationService.validateClientRegistrationConfig(
                         any(ClientRegistrationRequest.class)))
-                .thenReturn(Optional.of(ErrorResponse.ERROR_1023));
+                .thenReturn(Optional.of(INVALID_PUBLIC_KEY));
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setBody(
                 "{ \"client_name\": \"test-client\", \"redirect_uris\": [\"http://localhost:8080/redirect-uri\"], \"contacts\": [\"joe.bloggs@test.com\"], \"scopes\": [\"openid\"],  \"public_key\": \"some-public-key\", \"post_logout_redirect_uris\": [\"http://localhost:8080/post-logout-redirect-uri\"]}");
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(400));
-        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1023));
+        assertThat(result, hasJsonBody(INVALID_PUBLIC_KEY));
     }
 }

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/UpdateClientConfigHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/UpdateClientConfigHandlerTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.entity.ClientRegistrationResponse;
 import uk.gov.di.entity.ClientRegistry;
-import uk.gov.di.entity.ErrorResponse;
 import uk.gov.di.entity.UpdateClientConfigRequest;
 import uk.gov.di.services.ClientConfigValidationService;
 import uk.gov.di.services.ClientService;
@@ -28,6 +27,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
+import static uk.gov.di.services.ClientConfigValidationService.INVALID_PUBLIC_KEY;
 
 class UpdateClientConfigHandlerTest {
 
@@ -102,7 +102,7 @@ class UpdateClientConfigHandlerTest {
         when(clientService.isValidClient(CLIENT_ID)).thenReturn(true);
         when(clientValidationService.validateClientUpdateConfig(
                         any(UpdateClientConfigRequest.class)))
-                .thenReturn(Optional.of(ErrorResponse.ERROR_1023));
+                .thenReturn(Optional.of(INVALID_PUBLIC_KEY));
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setBody(
@@ -113,7 +113,7 @@ class UpdateClientConfigHandlerTest {
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(400));
-        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1023));
+        assertThat(result, hasJsonBody(INVALID_PUBLIC_KEY));
     }
 
     private ClientRegistry createClientRegistry() {

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/UpdateClientConfigHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/UpdateClientConfigHandlerTest.java
@@ -9,11 +9,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.entity.ClientRegistrationResponse;
 import uk.gov.di.entity.ClientRegistry;
+import uk.gov.di.entity.ErrorResponse;
 import uk.gov.di.entity.UpdateClientConfigRequest;
+import uk.gov.di.services.ClientConfigValidationService;
 import uk.gov.di.services.ClientService;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static java.lang.String.format;
 import static java.util.Collections.singletonList;
@@ -23,6 +26,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 class UpdateClientConfigHandlerTest {
@@ -32,16 +36,21 @@ class UpdateClientConfigHandlerTest {
     private static final List<String> SCOPES = singletonList("openid");
     private final Context context = mock(Context.class);
     private final ClientService clientService = mock(ClientService.class);
+    private final ClientConfigValidationService clientValidationService =
+            mock(ClientConfigValidationService.class);
     private UpdateClientConfigHandler handler;
 
     @BeforeEach
     public void setUp() {
-        handler = new UpdateClientConfigHandler(clientService);
+        handler = new UpdateClientConfigHandler(clientService, clientValidationService);
     }
 
     @Test
     public void shouldReturn200ForAValidRequest() throws JsonProcessingException {
         when(clientService.isValidClient(CLIENT_ID)).thenReturn(true);
+        when(clientValidationService.validateClientUpdateConfig(
+                        any(UpdateClientConfigRequest.class)))
+                .thenReturn(Optional.empty());
         when(clientService.updateClient(eq(CLIENT_ID), any(UpdateClientConfigRequest.class)))
                 .thenReturn(createClientRegistry());
 
@@ -86,6 +95,25 @@ class UpdateClientConfigHandlerTest {
         event.setBody(format("{\"client_name\": \"%s\"}", CLIENT_NAME));
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
         assertThat(result, hasStatus(401));
+    }
+
+    @Test
+    public void shouldReturn400WhenRequestFailsValidation() {
+        when(clientService.isValidClient(CLIENT_ID)).thenReturn(true);
+        when(clientValidationService.validateClientUpdateConfig(
+                        any(UpdateClientConfigRequest.class)))
+                .thenReturn(Optional.of(ErrorResponse.ERROR_1023));
+
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        event.setBody(
+                format(
+                        "{\"client_name\": \"%s\", \"public_key\": \"%s\"}",
+                        CLIENT_NAME, "rubbush-public-keu"));
+        event.setPathParameters(Map.of("clientId", CLIENT_ID));
+        APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
+
+        assertThat(result, hasStatus(400));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1023));
     }
 
     private ClientRegistry createClientRegistry() {

--- a/serverless/lambda/src/test/java/uk/gov/di/services/ClientConfigValidationServiceTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/services/ClientConfigValidationServiceTest.java
@@ -1,8 +1,9 @@
 package uk.gov.di.services;
 
+import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.client.RegistrationError;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.entity.ClientRegistrationRequest;
-import uk.gov.di.entity.ErrorResponse;
 import uk.gov.di.entity.UpdateClientConfigRequest;
 
 import java.util.List;
@@ -11,6 +12,9 @@ import java.util.Optional;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static uk.gov.di.services.ClientConfigValidationService.INVALID_POST_LOGOUT_URI;
+import static uk.gov.di.services.ClientConfigValidationService.INVALID_PUBLIC_KEY;
+import static uk.gov.di.services.ClientConfigValidationService.INVALID_SCOPE;
 
 class ClientConfigValidationServiceTest {
 
@@ -21,7 +25,7 @@ class ClientConfigValidationServiceTest {
 
     @Test
     public void shouldPassValidationForValidRegistrationRequest() {
-        Optional<ErrorResponse> errorResponse =
+        Optional<ErrorObject> errorResponse =
                 validationService.validateClientRegistrationConfig(
                         generateClientRegRequest(
                                 singletonList("http://localhost:1000/redirect"),
@@ -33,55 +37,55 @@ class ClientConfigValidationServiceTest {
 
     @Test
     public void shouldReturnErrorForInvalidPostLogoutUriInRegistrationRequest() {
-        Optional<ErrorResponse> errorResponse =
+        Optional<ErrorObject> errorResponse =
                 validationService.validateClientRegistrationConfig(
                         generateClientRegRequest(
                                 singletonList("http://localhost:1000/redirect"),
                                 VALID_PUBLIC_CERT,
                                 singletonList("openid"),
                                 singletonList("invalid-logout-uri")));
-        assertThat(errorResponse, equalTo(Optional.of(ErrorResponse.ERROR_1021)));
+        assertThat(errorResponse, equalTo(Optional.of(INVALID_POST_LOGOUT_URI)));
     }
 
     @Test
     public void shouldReturnErrorForInvalidRedirectUriInRegistrationequest() {
-        Optional<ErrorResponse> errorResponse =
+        Optional<ErrorObject> errorResponse =
                 validationService.validateClientRegistrationConfig(
                         generateClientRegRequest(
                                 singletonList("invalid-redirect-uri"),
                                 VALID_PUBLIC_CERT,
                                 singletonList("openid"),
                                 singletonList("http://localhost/post-redirect-logout")));
-        assertThat(errorResponse, equalTo(Optional.of(ErrorResponse.ERROR_1022)));
+        assertThat(errorResponse, equalTo(Optional.of(RegistrationError.INVALID_REDIRECT_URI)));
     }
 
     @Test
     public void shouldReturnErrorForInvalidPublicKeyInRegistrationRequest() {
-        Optional<ErrorResponse> errorResponse =
+        Optional<ErrorObject> errorResponse =
                 validationService.validateClientRegistrationConfig(
                         generateClientRegRequest(
                                 singletonList("http://localhost:1000/redirect"),
                                 "invalid-public-cert",
                                 singletonList("openid"),
                                 singletonList("http://localhost/post-redirect-logout")));
-        assertThat(errorResponse, equalTo(Optional.of(ErrorResponse.ERROR_1023)));
+        assertThat(errorResponse, equalTo(Optional.of(INVALID_PUBLIC_KEY)));
     }
 
     @Test
     public void shouldReturnErrorForInvalidScopesInRegistrationRequest() {
-        Optional<ErrorResponse> errorResponse =
+        Optional<ErrorObject> errorResponse =
                 validationService.validateClientRegistrationConfig(
                         generateClientRegRequest(
                                 singletonList("http://localhost:1000/redirect"),
                                 VALID_PUBLIC_CERT,
                                 List.of("openid", "email", "fax"),
                                 singletonList("http://localhost/post-redirect-logout")));
-        assertThat(errorResponse, equalTo(Optional.of(ErrorResponse.ERROR_1024)));
+        assertThat(errorResponse, equalTo(Optional.of(INVALID_SCOPE)));
     }
 
     @Test
     public void shouldPassValidationForValidUpdateRequest() {
-        Optional<ErrorResponse> errorResponse =
+        Optional<ErrorObject> errorResponse =
                 validationService.validateClientUpdateConfig(
                         generateClientUpdateRequest(
                                 singletonList("http://localhost:1000/redirect"),
@@ -93,57 +97,57 @@ class ClientConfigValidationServiceTest {
 
     @Test
     public void shouldReturnOptionalEmptyForEmptyUpdateRequest() {
-        Optional<ErrorResponse> errorResponse =
+        Optional<ErrorObject> errorResponse =
                 validationService.validateClientUpdateConfig(new UpdateClientConfigRequest());
         assertThat(errorResponse, equalTo(Optional.empty()));
     }
 
     @Test
     public void shouldReturnErrorForInvalidPostLogoutUriInUpdateRequest() {
-        Optional<ErrorResponse> errorResponse =
+        Optional<ErrorObject> errorResponse =
                 validationService.validateClientUpdateConfig(
                         generateClientUpdateRequest(
                                 singletonList("http://localhost:1000/redirect"),
                                 VALID_PUBLIC_CERT,
                                 singletonList("openid"),
                                 singletonList("invalid-logout-uri")));
-        assertThat(errorResponse, equalTo(Optional.of(ErrorResponse.ERROR_1021)));
+        assertThat(errorResponse, equalTo(Optional.of(INVALID_POST_LOGOUT_URI)));
     }
 
     @Test
     public void shouldReturnErrorForInvalidRedirectUriInUpdateRequest() {
-        Optional<ErrorResponse> errorResponse =
+        Optional<ErrorObject> errorResponse =
                 validationService.validateClientUpdateConfig(
                         generateClientUpdateRequest(
                                 singletonList("invalid-redirect-uri"),
                                 VALID_PUBLIC_CERT,
                                 singletonList("openid"),
                                 singletonList("http://localhost/post-redirect-logout")));
-        assertThat(errorResponse, equalTo(Optional.of(ErrorResponse.ERROR_1022)));
+        assertThat(errorResponse, equalTo(Optional.of(RegistrationError.INVALID_REDIRECT_URI)));
     }
 
     @Test
     public void shouldReturnErrorForInvalidPublicKeyInUpdateRequest() {
-        Optional<ErrorResponse> errorResponse =
+        Optional<ErrorObject> errorResponse =
                 validationService.validateClientUpdateConfig(
                         generateClientUpdateRequest(
                                 singletonList("http://localhost:1000/redirect"),
                                 "invalid-public-cert",
                                 singletonList("openid"),
                                 singletonList("http://localhost/post-redirect-logout")));
-        assertThat(errorResponse, equalTo(Optional.of(ErrorResponse.ERROR_1023)));
+        assertThat(errorResponse, equalTo(Optional.of(INVALID_PUBLIC_KEY)));
     }
 
     @Test
     public void shouldReturnErrorForInvalidScopesInUpdateRequest() {
-        Optional<ErrorResponse> errorResponse =
+        Optional<ErrorObject> errorResponse =
                 validationService.validateClientUpdateConfig(
                         generateClientUpdateRequest(
                                 singletonList("http://localhost:1000/redirect"),
                                 VALID_PUBLIC_CERT,
                                 List.of("openid", "email", "fax"),
                                 singletonList("http://localhost/post-redirect-logout")));
-        assertThat(errorResponse, equalTo(Optional.of(ErrorResponse.ERROR_1024)));
+        assertThat(errorResponse, equalTo(Optional.of(INVALID_SCOPE)));
     }
 
     private ClientRegistrationRequest generateClientRegRequest(

--- a/serverless/lambda/src/test/java/uk/gov/di/services/ClientConfigValidationServiceTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/services/ClientConfigValidationServiceTest.java
@@ -1,0 +1,176 @@
+package uk.gov.di.services;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.di.entity.ClientRegistrationRequest;
+import uk.gov.di.entity.ErrorResponse;
+import uk.gov.di.entity.UpdateClientConfigRequest;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Collections.singletonList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class ClientConfigValidationServiceTest {
+
+    private final ClientConfigValidationService validationService =
+            new ClientConfigValidationService();
+    private static final String VALID_PUBLIC_CERT =
+            "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxt91w8GsMDdklOpS8ZXAsIM1ztQZd5QT/bRCQahZJeS1a6Os4hbuKwzHlz52zfTNp7BL4RB/KOcRIPhOQLgqeyM+bVngRa1EIfTkugJHS2/gu2Xv0aelwvXj8FZgAPRPD+ps2wiV4tUehrFIsRyHZM3yOp9g6qapCcxF7l0E1PlVkKPcPNmxn2oFiqnP6ZThGbE+N2avdXHcySIqt/v6Hbmk8cDHzSExazW7j/XvA+xnp0nQ5m2GisCZul5If5edCTXD0tKzx/I/gtEG4gkv9kENWOt4grP8/0zjNAl2ac6kpRny3tY5RkKBKCOB1VHwq2lUTSNKs32O1BsA5ByyYQIDAQAB";
+
+    @Test
+    public void shouldPassValidationForValidRegistrationRequest() {
+        Optional<ErrorResponse> errorResponse =
+                validationService.validateClientRegistrationConfig(
+                        generateClientRegRequest(
+                                singletonList("http://localhost:1000/redirect"),
+                                VALID_PUBLIC_CERT,
+                                singletonList("openid"),
+                                singletonList("http://localhost/post-redirect-logout")));
+        assertThat(errorResponse, equalTo(Optional.empty()));
+    }
+
+    @Test
+    public void shouldReturnErrorForInvalidPostLogoutUriInRegistrationRequest() {
+        Optional<ErrorResponse> errorResponse =
+                validationService.validateClientRegistrationConfig(
+                        generateClientRegRequest(
+                                singletonList("http://localhost:1000/redirect"),
+                                VALID_PUBLIC_CERT,
+                                singletonList("openid"),
+                                singletonList("invalid-logout-uri")));
+        assertThat(errorResponse, equalTo(Optional.of(ErrorResponse.ERROR_1021)));
+    }
+
+    @Test
+    public void shouldReturnErrorForInvalidRedirectUriInRegistrationequest() {
+        Optional<ErrorResponse> errorResponse =
+                validationService.validateClientRegistrationConfig(
+                        generateClientRegRequest(
+                                singletonList("invalid-redirect-uri"),
+                                VALID_PUBLIC_CERT,
+                                singletonList("openid"),
+                                singletonList("http://localhost/post-redirect-logout")));
+        assertThat(errorResponse, equalTo(Optional.of(ErrorResponse.ERROR_1022)));
+    }
+
+    @Test
+    public void shouldReturnErrorForInvalidPublicKeyInRegistrationRequest() {
+        Optional<ErrorResponse> errorResponse =
+                validationService.validateClientRegistrationConfig(
+                        generateClientRegRequest(
+                                singletonList("http://localhost:1000/redirect"),
+                                "invalid-public-cert",
+                                singletonList("openid"),
+                                singletonList("http://localhost/post-redirect-logout")));
+        assertThat(errorResponse, equalTo(Optional.of(ErrorResponse.ERROR_1023)));
+    }
+
+    @Test
+    public void shouldReturnErrorForInvalidScopesInRegistrationRequest() {
+        Optional<ErrorResponse> errorResponse =
+                validationService.validateClientRegistrationConfig(
+                        generateClientRegRequest(
+                                singletonList("http://localhost:1000/redirect"),
+                                VALID_PUBLIC_CERT,
+                                List.of("openid", "email", "fax"),
+                                singletonList("http://localhost/post-redirect-logout")));
+        assertThat(errorResponse, equalTo(Optional.of(ErrorResponse.ERROR_1024)));
+    }
+
+    @Test
+    public void shouldPassValidationForValidUpdateRequest() {
+        Optional<ErrorResponse> errorResponse =
+                validationService.validateClientUpdateConfig(
+                        generateClientUpdateRequest(
+                                singletonList("http://localhost:1000/redirect"),
+                                VALID_PUBLIC_CERT,
+                                singletonList("openid"),
+                                singletonList("http://localhost/post-redirect-logout")));
+        assertThat(errorResponse, equalTo(Optional.empty()));
+    }
+
+    @Test
+    public void shouldReturnOptionalEmptyForEmptyUpdateRequest() {
+        Optional<ErrorResponse> errorResponse =
+                validationService.validateClientUpdateConfig(
+                        new UpdateClientConfigRequest());
+        assertThat(errorResponse, equalTo(Optional.empty()));
+    }
+
+    @Test
+    public void shouldReturnErrorForInvalidPostLogoutUriInUpdateRequest() {
+        Optional<ErrorResponse> errorResponse =
+                validationService.validateClientUpdateConfig(
+                        generateClientUpdateRequest(
+                                singletonList("http://localhost:1000/redirect"),
+                                VALID_PUBLIC_CERT,
+                                singletonList("openid"),
+                                singletonList("invalid-logout-uri")));
+        assertThat(errorResponse, equalTo(Optional.of(ErrorResponse.ERROR_1021)));
+    }
+
+    @Test
+    public void shouldReturnErrorForInvalidRedirectUriInUpdateRequest() {
+        Optional<ErrorResponse> errorResponse =
+                validationService.validateClientUpdateConfig(
+                        generateClientUpdateRequest(
+                                singletonList("invalid-redirect-uri"),
+                                VALID_PUBLIC_CERT,
+                                singletonList("openid"),
+                                singletonList("http://localhost/post-redirect-logout")));
+        assertThat(errorResponse, equalTo(Optional.of(ErrorResponse.ERROR_1022)));
+    }
+
+    @Test
+    public void shouldReturnErrorForInvalidPublicKeyInUpdateRequest() {
+        Optional<ErrorResponse> errorResponse =
+                validationService.validateClientUpdateConfig(
+                        generateClientUpdateRequest(
+                                singletonList("http://localhost:1000/redirect"),
+                                "invalid-public-cert",
+                                singletonList("openid"),
+                                singletonList("http://localhost/post-redirect-logout")));
+        assertThat(errorResponse, equalTo(Optional.of(ErrorResponse.ERROR_1023)));
+    }
+
+    @Test
+    public void shouldReturnErrorForInvalidScopesInUpdateRequest() {
+        Optional<ErrorResponse> errorResponse =
+                validationService.validateClientUpdateConfig(
+                        generateClientUpdateRequest(
+                                singletonList("http://localhost:1000/redirect"),
+                                VALID_PUBLIC_CERT,
+                                List.of("openid", "email", "fax"),
+                                singletonList("http://localhost/post-redirect-logout")));
+        assertThat(errorResponse, equalTo(Optional.of(ErrorResponse.ERROR_1024)));
+    }
+
+    private ClientRegistrationRequest generateClientRegRequest(
+            List<String> redirectUri,
+            String publicCert,
+            List<String> scopes,
+            List<String> postLogoutUris) {
+        return new ClientRegistrationRequest(
+                "The test client",
+                redirectUri,
+                singletonList("test-client@test.com"),
+                publicCert,
+                scopes,
+                postLogoutUris);
+    }
+
+    private UpdateClientConfigRequest generateClientUpdateRequest(
+            List<String> redirectUri,
+            String publicCert,
+            List<String> scopes,
+            List<String> postLogoutUris) {
+        UpdateClientConfigRequest configRequest = new UpdateClientConfigRequest();
+        configRequest.setScopes(scopes);
+        configRequest.setRedirectUris(redirectUri);
+        configRequest.setPublicKey(publicCert);
+        configRequest.setPostLogoutRedirectUris(postLogoutUris);
+        return configRequest;
+    }
+}

--- a/serverless/lambda/src/test/java/uk/gov/di/services/ClientConfigValidationServiceTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/services/ClientConfigValidationServiceTest.java
@@ -94,8 +94,7 @@ class ClientConfigValidationServiceTest {
     @Test
     public void shouldReturnOptionalEmptyForEmptyUpdateRequest() {
         Optional<ErrorResponse> errorResponse =
-                validationService.validateClientUpdateConfig(
-                        new UpdateClientConfigRequest());
+                validationService.validateClientUpdateConfig(new UpdateClientConfigRequest());
         assertThat(errorResponse, equalTo(Optional.empty()));
     }
 


### PR DESCRIPTION
## What?

- Validate Client config in Registration and Update requests
- When a validation error occurs then generate an OIDC constructed error and send that back to the client 
- Hardcode the response_type as code in the Registration response
- Remove wildcard imports

## Why?

- So we can be confident that any public key, scopes or uris that the client registers with are valid. This prevents us finding out there are issues later down the line so we can fail fast