### PR TITLE
GOVSI-463 - Use OIDC errors for OIDC endpoints

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
@@ -41,11 +41,12 @@ public class TokenIntegrationTest extends IntegrationTestEndpoints {
     private static final String TOKEN_ENDPOINT = "/token";
     private static final String TEST_EMAIL = "joe.bloggs@digital.cabinet-office.gov.uk";
     private static final String CLIENT_ID = "test-id";
+    private static final String REDIRECT_URI = "http://localhost/redirect";
 
     @Test
     public void shouldCallTokenResourceAndReturn200() throws JOSEException {
         KeyPair keyPair = generateRsaKeyPair();
-        setUpDynamo(keyPair, CLIENT_ID);
+        setUpDynamo(keyPair);
         PrivateKey privateKey = keyPair.getPrivate();
         PrivateKeyJWT privateKeyJWT =
                 new PrivateKeyJWT(
@@ -62,7 +63,7 @@ public class TokenIntegrationTest extends IntegrationTestEndpoints {
         customParams.put("grant_type", Collections.singletonList("authorization_code"));
         customParams.put("client_id", Collections.singletonList(CLIENT_ID));
         customParams.put("code", Collections.singletonList(code));
-        customParams.put("redirect_uri", Collections.singletonList("http://localhost/redirect"));
+        customParams.put("redirect_uri", Collections.singletonList(REDIRECT_URI));
         Map<String, List<String>> privateKeyParams = privateKeyJWT.toParameters();
         privateKeyParams.putAll(customParams);
         Client client = ClientBuilder.newClient();
@@ -75,11 +76,11 @@ public class TokenIntegrationTest extends IntegrationTestEndpoints {
         assertEquals(200, response.getStatus());
     }
 
-    private void setUpDynamo(KeyPair keyPair, String clientID) {
+    private void setUpDynamo(KeyPair keyPair) {
         DynamoHelper.registerClient(
-                clientID,
+                CLIENT_ID,
                 "test-client",
-                singletonList("http://localhost/redirect"),
+                singletonList(REDIRECT_URI),
                 singletonList(TEST_EMAIL),
                 singletonList("openid"),
                 Base64.getMimeEncoder().encodeToString(keyPair.getPublic().getEncoded()),

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateClientConfigIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateClientConfigIntegrationTest.java
@@ -67,7 +67,7 @@ public class UpdateClientConfigIntegrationTest extends IntegrationTestEndpoints 
 
         assertEquals(401, response.getStatus());
         assertEquals(
-                new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1016),
+                new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1015),
                 response.readEntity(String.class));
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserExistsIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserExistsIntegrationTest.java
@@ -78,6 +78,6 @@ public class UserExistsIntegrationTest extends IntegrationTestEndpoints {
 
         String responseString = response.readEntity(String.class);
 
-        assertEquals(responseString, objectMapper.writeValueAsString(ErrorResponse.ERROR_1019));
+        assertEquals(responseString, objectMapper.writeValueAsString(ErrorResponse.ERROR_1017));
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
@@ -179,7 +179,7 @@ public class VerifyCodeIntegrationTest extends IntegrationTestEndpoints {
 
         assertEquals(400, response.getStatus());
         assertEquals(
-                new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1019),
+                new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1017),
                 response.readEntity(String.class));
     }
 
@@ -199,7 +199,7 @@ public class VerifyCodeIntegrationTest extends IntegrationTestEndpoints {
 
         assertEquals(400, response.getStatus());
         assertEquals(
-                new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1019),
+                new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1017),
                 response.readEntity(String.class));
     }
 
@@ -232,7 +232,7 @@ public class VerifyCodeIntegrationTest extends IntegrationTestEndpoints {
 
         assertEquals(400, response.getStatus());
         assertEquals(
-                new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1019),
+                new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1017),
                 response.readEntity(String.class));
     }
 }

--- a/serverless/lambda/src/main/java/uk/gov/di/entity/ErrorResponse.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/entity/ErrorResponse.java
@@ -20,12 +20,10 @@ public enum ErrorResponse {
     ERROR_1012(1012, "Phone number is invalid"),
     ERROR_1013(1013, "Update profile type is invalid"),
     ERROR_1014(1014, "Phone number is not registered"),
-    ERROR_1015(1015, "Unable to Verify Signature of Private Key JWT"),
-    ERROR_1016(1016, "Client not found"),
-    ERROR_1017(1017, "Invalid Redirect URI"),
-    ERROR_1018(1018, "Invalid authorization code parameter"),
-    ERROR_1019(1019, "Invalid transition in user journey"),
-    ERROR_1020(1020, "Client-Session-Id is missing or invalid");
+    ERROR_1015(1015, "Client not found"),
+    ERROR_1016(1016, "Invalid Redirect URI"),
+    ERROR_1017(1017, "Invalid transition in user journey"),
+    ERROR_1018(1018, "Client-Session-Id is missing or invalid");
 
     @JsonProperty("code")
     private int code;

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/AuthCodeHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/AuthCodeHandler.java
@@ -77,7 +77,7 @@ public class AuthCodeHandler
         try {
             validateStateTransition(session, AUTHENTICATED);
         } catch (StateMachine.InvalidStateTransitionException e) {
-            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1019);
+            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1017);
         }
 
         AuthorizationRequest authorizationRequest;
@@ -89,12 +89,12 @@ public class AuthCodeHandler
             authorizationRequest = AuthorizationRequest.parse(authRequest);
             if (!authorizationService.isClientRedirectUriValid(
                     authorizationRequest.getClientID(), authorizationRequest.getRedirectionURI())) {
-                return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1017);
+                return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1016);
             }
         } catch (ParseException e) {
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
         } catch (ClientNotFoundException e) {
-            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1016);
+            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1015);
         }
 
         AuthorizationCode authCode =

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/CheckUserExistsHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/CheckUserExistsHandler.java
@@ -89,7 +89,7 @@ public class CheckUserExistsHandler
         } catch (JsonProcessingException e) {
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
         } catch (InvalidStateTransitionException e) {
-            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1019);
+            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1017);
         }
     }
 }

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/ClientInfoHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/ClientInfoHandler.java
@@ -72,7 +72,7 @@ public class ClientInfoHandler
 
         if (clientSession.isEmpty()) {
             LOGGER.info("ClientSession not found.");
-            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1020);
+            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1018);
         }
 
         try {
@@ -84,7 +84,7 @@ public class ClientInfoHandler
 
             if (optionalClientRegistry.isEmpty()) {
                 LOGGER.info("Client not found in ClientRegistry for ClientID: {}", clientID);
-                return generateApiGatewayProxyErrorResponse(403, ErrorResponse.ERROR_1016);
+                return generateApiGatewayProxyErrorResponse(403, ErrorResponse.ERROR_1015);
             }
 
             ClientRegistry clientRegistry = optionalClientRegistry.get();

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/ClientRegistrationHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/ClientRegistrationHandler.java
@@ -7,6 +7,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.OAuth2Error;
 import uk.gov.di.entity.ClientRegistrationRequest;
 import uk.gov.di.entity.ClientRegistrationResponse;
 import uk.gov.di.entity.ErrorResponse;
@@ -52,7 +53,7 @@ public class ClientRegistrationHandler
             Optional<ErrorObject> errorResponse =
                     validationService.validateClientRegistrationConfig(clientRegistrationRequest);
             if (errorResponse.isPresent()) {
-                return generateApiGatewayProxyResponse(400, errorResponse.get());
+                return generateApiGatewayProxyResponse(400, errorResponse.get().toJSONObject().toJSONString());
             }
             String clientID = clientService.generateClientID().toString();
             clientService.addClient(
@@ -75,7 +76,7 @@ public class ClientRegistrationHandler
 
             return generateApiGatewayProxyResponse(200, clientRegistrationResponse);
         } catch (JsonProcessingException e) {
-            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
+            return generateApiGatewayProxyResponse(400, OAuth2Error.INVALID_REQUEST.toJSONObject().toJSONString());
         }
     }
 }

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/ClientRegistrationHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/ClientRegistrationHandler.java
@@ -10,7 +10,6 @@ import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
 import uk.gov.di.entity.ClientRegistrationRequest;
 import uk.gov.di.entity.ClientRegistrationResponse;
-import uk.gov.di.entity.ErrorResponse;
 import uk.gov.di.services.ClientConfigValidationService;
 import uk.gov.di.services.ClientService;
 import uk.gov.di.services.ConfigurationService;
@@ -18,7 +17,6 @@ import uk.gov.di.services.DynamoClientService;
 
 import java.util.Optional;
 
-import static uk.gov.di.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 
 public class ClientRegistrationHandler
@@ -53,7 +51,8 @@ public class ClientRegistrationHandler
             Optional<ErrorObject> errorResponse =
                     validationService.validateClientRegistrationConfig(clientRegistrationRequest);
             if (errorResponse.isPresent()) {
-                return generateApiGatewayProxyResponse(400, errorResponse.get().toJSONObject().toJSONString());
+                return generateApiGatewayProxyResponse(
+                        400, errorResponse.get().toJSONObject().toJSONString());
             }
             String clientID = clientService.generateClientID().toString();
             clientService.addClient(
@@ -76,7 +75,8 @@ public class ClientRegistrationHandler
 
             return generateApiGatewayProxyResponse(200, clientRegistrationResponse);
         } catch (JsonProcessingException e) {
-            return generateApiGatewayProxyResponse(400, OAuth2Error.INVALID_REQUEST.toJSONObject().toJSONString());
+            return generateApiGatewayProxyResponse(
+                    400, OAuth2Error.INVALID_REQUEST.toJSONObject().toJSONString());
         }
     }
 }

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/LoginHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/LoginHandler.java
@@ -82,7 +82,7 @@ public class LoginHandler
         } catch (JsonProcessingException e) {
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
         } catch (InvalidStateTransitionException e) {
-            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1019);
+            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1017);
         }
     }
 }

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/MfaHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/MfaHandler.java
@@ -109,7 +109,7 @@ public class MfaHandler
         } catch (JsonProcessingException e) {
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
         } catch (InvalidStateTransitionException e) {
-            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1019);
+            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1017);
         }
     }
 }

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/SendNotificationHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/SendNotificationHandler.java
@@ -130,7 +130,7 @@ public class SendNotificationHandler
             LOGGER.error("Error parsing request", e);
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
         } catch (InvalidStateTransitionException e) {
-            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1019);
+            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1017);
         }
     }
 

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/SignUpHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/SignUpHandler.java
@@ -89,7 +89,7 @@ public class SignUpHandler
         } catch (JsonProcessingException e) {
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
         } catch (InvalidStateTransitionException e) {
-            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1019);
+            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1017);
         }
     }
 }

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/TokenHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/TokenHandler.java
@@ -4,20 +4,17 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.ParseException;
-import com.nimbusds.oauth2.sdk.auth.PrivateKeyJWT;
 import com.nimbusds.oauth2.sdk.id.Subject;
-import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import com.nimbusds.openid.connect.sdk.OIDCTokenResponse;
-import com.nimbusds.openid.connect.sdk.token.OIDCTokens;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.di.entity.AuthCodeExchangeData;
 import uk.gov.di.entity.ClientRegistry;
 import uk.gov.di.entity.ClientSession;
-import uk.gov.di.entity.ErrorResponse;
 import uk.gov.di.services.AuthenticationService;
 import uk.gov.di.services.AuthorisationCodeService;
 import uk.gov.di.services.ClientService;
@@ -33,7 +30,6 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 
 import static java.lang.String.format;
-import static uk.gov.di.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.helpers.RequestBodyHelper.parseRequestBody;
 
@@ -86,31 +82,36 @@ public class TokenHandler
     @Override
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
-        PrivateKeyJWT privateKeyJWT;
-        Map<String, String> requestBody;
-        try {
-            requestBody = parseRequestParameters(input.getBody());
-            privateKeyJWT = PrivateKeyJWT.parse(input.getBody());
-        } catch (ParseException e) {
-            LOG.error("Couldn't parse Private Key JWT", e);
-            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
-        }
-        String clientID = requestBody.get("client_id");
-        Optional<ClientRegistry> client = clientService.getClient(clientID);
-        if (client.isEmpty()) {
-            LOG.error("Client ID is empty");
-            return generateApiGatewayProxyErrorResponse(403, ErrorResponse.ERROR_1016);
+        Optional<ErrorObject> invalidRequestParamError =
+                tokenService.validateTokenRequestParams(input.getBody());
+        if (invalidRequestParamError.isPresent()) {
+            LOG.error("Parameters missing from Token Request");
+            return generateApiGatewayProxyResponse(
+                    400, invalidRequestParamError.get().toJSONObject().toJSONString());
         }
 
-        boolean privateKeyJWTIsValid =
-                tokenService.validatePrivateKeyJWTSignature(
-                        client.get().getPublicKey(),
-                        privateKeyJWT,
-                        configurationService.getBaseURL().orElseThrow());
-        if (!privateKeyJWTIsValid) {
-            LOG.error("Private Key KWT is not valid");
-            return generateApiGatewayProxyErrorResponse(403, ErrorResponse.ERROR_1015);
+        Map<String, String> requestBody = parseRequestBody(input.getBody());
+        String clientID = requestBody.get("client_id");
+        ClientRegistry client;
+        try {
+            client = clientService.getClient(clientID).orElseThrow();
+        } catch (NoSuchElementException e) {
+            LOG.error("Client not found in Client Registry with Client ID {}", clientID);
+            return generateApiGatewayProxyResponse(
+                    400, OAuth2Error.INVALID_CLIENT.toJSONObject().toJSONString());
         }
+
+        Optional<ErrorObject> invalidPrivateKeyJwtError =
+                tokenService.validatePrivateKeyJWT(
+                        input.getBody(),
+                        client.getPublicKey(),
+                        configurationService.getBaseURL().orElseThrow());
+        if (invalidPrivateKeyJwtError.isPresent()) {
+            LOG.error("Private Key JWT is not valid for Client ID {}", clientID);
+            return generateApiGatewayProxyResponse(
+                    400, invalidPrivateKeyJwtError.get().toJSONObject().toJSONString());
+        }
+
         AuthCodeExchangeData authCodeExchangeData;
         try {
             authCodeExchangeData =
@@ -119,7 +120,8 @@ public class TokenHandler
                             .orElseThrow();
         } catch (NoSuchElementException e) {
             LOG.error("Could not retrieve client session ID from code", e);
-            return generateApiGatewayProxyErrorResponse(403, ErrorResponse.ERROR_1018);
+            return generateApiGatewayProxyResponse(
+                    400, OAuth2Error.INVALID_GRANT.toJSONObject().toJSONString());
         }
         ClientSession clientSession =
                 clientSessionService.getClientSession(authCodeExchangeData.getClientSessionId());
@@ -133,30 +135,21 @@ public class TokenHandler
                             "Unable to parse Auth Request\n Auth Request Params: %s \n Exception: %s",
                             clientSession.getAuthRequestParams(), e));
         }
+        if (!authRequest.getRedirectionURI().toString().equals(requestBody.get("redirect_uri"))) {
+            return generateApiGatewayProxyResponse(
+                    400, OAuth2Error.INVALID_GRANT.toJSONObject().toJSONString());
+        }
         Subject subject =
                 authenticationService.getSubjectFromEmail(authCodeExchangeData.getEmail());
-
-        AccessToken accessToken =
-                tokenService.generateAndStoreAccessToken(
-                        clientID, subject, authRequest.getScope().toStringList());
-        SignedJWT idToken = tokenService.generateIDToken(clientID, subject);
         OIDCTokenResponse tokenResponse =
-                new OIDCTokenResponse(new OIDCTokens(idToken, accessToken, null));
+                tokenService.generateTokenResponse(
+                        clientID, subject, authRequest.getScope().toStringList());
+
         clientSessionService.saveClientSession(
                 authCodeExchangeData.getClientSessionId(),
-                clientSession.setIdTokenHint(idToken.serialize()));
-        LOG.info("Successfully generated tokens.");
+                clientSession.setIdTokenHint(
+                        tokenResponse.getOIDCTokens().getIDToken().serialize()));
+        LOG.info("Successfully generated tokens");
         return generateApiGatewayProxyResponse(200, tokenResponse.toJSONObject().toJSONString());
-    }
-
-    private Map<String, String> parseRequestParameters(String requestString) throws ParseException {
-        Map<String, String> requestBody = parseRequestBody(requestString);
-        if (!requestBody.containsKey("code")
-                || !requestBody.containsKey("client_id")
-                || !requestBody.containsKey("grant_type")
-                || !requestBody.containsKey("redirect_uri")) {
-            throw new ParseException("Request is missing parameters");
-        }
-        return requestBody;
     }
 }

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/UpdateClientConfigHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/UpdateClientConfigHandler.java
@@ -62,7 +62,8 @@ public class UpdateClientConfigHandler
             Optional<ErrorObject> errorResponse =
                     validationService.validateClientUpdateConfig(updateClientConfigRequest);
             if (errorResponse.isPresent()) {
-                return generateApiGatewayProxyResponse(400, errorResponse.get());
+                return generateApiGatewayProxyResponse(
+                        400, errorResponse.get().toJSONObject().toJSONString());
             }
             ClientRegistry clientRegistry =
                     clientService.updateClient(clientId, updateClientConfigRequest);

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/UpdateClientConfigHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/UpdateClientConfigHandler.java
@@ -57,7 +57,7 @@ public class UpdateClientConfigHandler
                     objectMapper.readValue(input.getBody(), UpdateClientConfigRequest.class);
             if (!clientService.isValidClient(clientId)) {
                 LOGGER.error("Client with ClientId {} is not valid", clientId);
-                return generateApiGatewayProxyErrorResponse(401, ErrorResponse.ERROR_1016);
+                return generateApiGatewayProxyErrorResponse(401, ErrorResponse.ERROR_1015);
             }
             Optional<ErrorObject> errorResponse =
                     validationService.validateClientUpdateConfig(updateClientConfigRequest);

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/UpdateProfileHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/UpdateProfileHandler.java
@@ -97,7 +97,7 @@ public class UpdateProfileHandler
 
                     if (clientSession.isEmpty()) {
                         LOGGER.info("ClientSession not found.");
-                        return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1020);
+                        return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1018);
                     }
 
                     try {
@@ -153,7 +153,7 @@ public class UpdateProfileHandler
             LOGGER.info("JsonProcessingException", e);
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
         } catch (InvalidStateTransitionException e) {
-            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1019);
+            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1017);
         }
 
         return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1013);

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/VerifyCodeHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/VerifyCodeHandler.java
@@ -157,7 +157,7 @@ public class VerifyCodeHandler
         } catch (JsonProcessingException e) {
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
         } catch (InvalidStateTransitionException e) {
-            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1019);
+            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1017);
         }
         return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1002);
     }

--- a/serverless/lambda/src/main/java/uk/gov/di/services/TokenService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/TokenService.java
@@ -6,6 +6,10 @@ import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
 import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.GrantType;
+import com.nimbusds.oauth2.sdk.OAuth2Error;
+import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod;
 import com.nimbusds.oauth2.sdk.auth.PrivateKeyJWT;
 import com.nimbusds.oauth2.sdk.auth.Secret;
@@ -17,6 +21,10 @@ import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
+import com.nimbusds.openid.connect.sdk.OIDCTokenResponse;
+import com.nimbusds.openid.connect.sdk.token.OIDCTokens;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import uk.gov.di.helpers.TokenGenerator;
 
 import java.security.KeyFactory;
@@ -27,14 +35,18 @@ import java.security.spec.X509EncodedKeySpec;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+
+import static uk.gov.di.helpers.RequestBodyHelper.parseRequestBody;
 
 public class TokenService {
 
     private final RSAKey signingKey;
     private final ConfigurationService configService;
     private final RedisConnectionService redisConnectionService;
+    private static final Logger LOG = LoggerFactory.getLogger(TokenService.class);
 
     public TokenService(
             ConfigurationService configService, RedisConnectionService redisConnectionService) {
@@ -47,12 +59,19 @@ public class TokenService {
         }
     }
 
-    public SignedJWT generateIDToken(String clientId, Subject subject) {
+    public OIDCTokenResponse generateTokenResponse(
+            String clientID, Subject subject, List<String> scopes) {
+        AccessToken accessToken = generateAndStoreAccessToken(clientID, subject, scopes);
+        SignedJWT idToken = generateIDToken(clientID, subject);
+        return new OIDCTokenResponse(new OIDCTokens(idToken, accessToken, null));
+    }
+
+    private SignedJWT generateIDToken(String clientId, Subject subject) {
         return TokenGenerator.generateIDToken(
                 clientId, subject, configService.getBaseURL().get(), signingKey);
     }
 
-    public AccessToken generateAndStoreAccessToken(
+    private AccessToken generateAndStoreAccessToken(
             String clientId, Subject subject, List<String> scopes) {
         SignedJWT signedJWT =
                 TokenGenerator.generateAccessToken(
@@ -74,8 +93,46 @@ public class TokenService {
         return signingKey;
     }
 
-    public boolean validatePrivateKeyJWTSignature(
-            String publicKey, PrivateKeyJWT privateKeyJWT, String baseUrl) {
+    public Optional<ErrorObject> validateTokenRequestParams(String tokenRequestBody) {
+        Map<String, String> requestBody = parseRequestBody(tokenRequestBody);
+        if (!requestBody.containsKey("client_id")) {
+            return Optional.of(
+                    new ErrorObject(
+                            OAuth2Error.INVALID_REQUEST_CODE,
+                            "Request is missing client_id parameter"));
+        }
+        if (!requestBody.containsKey("redirect_uri")) {
+            return Optional.of(
+                    new ErrorObject(
+                            OAuth2Error.INVALID_REQUEST_CODE,
+                            "Request is missing redirect_uri parameter"));
+        }
+        if (!requestBody.containsKey("grant_type")) {
+            return Optional.of(
+                    new ErrorObject(
+                            OAuth2Error.INVALID_REQUEST_CODE,
+                            "Request is missing grant_type parameter"));
+        }
+        if (!requestBody.get("grant_type").equals(GrantType.AUTHORIZATION_CODE.getValue())) {
+            return Optional.of(OAuth2Error.UNSUPPORTED_GRANT_TYPE);
+        }
+        if (!requestBody.containsKey("code")) {
+            return Optional.of(
+                    new ErrorObject(
+                            OAuth2Error.INVALID_REQUEST_CODE, "Request is missing code parameter"));
+        }
+        return Optional.empty();
+    }
+
+    public Optional<ErrorObject> validatePrivateKeyJWT(
+            String requestString, String publicKey, String baseUrl) {
+        PrivateKeyJWT privateKeyJWT;
+        try {
+            privateKeyJWT = PrivateKeyJWT.parse(requestString);
+        } catch (ParseException e) {
+            LOG.error("Couldn't parse Private Key JWT", e);
+            return Optional.of(OAuth2Error.INVALID_CLIENT);
+        }
         ClientAuthenticationVerifier<?> authenticationVerifier =
                 new ClientAuthenticationVerifier<>(
                         generateClientCredentialsSelector(publicKey),
@@ -83,9 +140,10 @@ public class TokenService {
         try {
             authenticationVerifier.verify(privateKeyJWT, null, null);
         } catch (InvalidClientException | JOSEException e) {
-            return false;
+            LOG.error("Unable to Verify Signature of Private Key JWT", e);
+            return Optional.of(OAuth2Error.INVALID_CLIENT);
         }
-        return true;
+        return Optional.empty();
     }
 
     private ClientCredentialsSelector<?> generateClientCredentialsSelector(String publicKey) {

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/AuthCodeHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/AuthCodeHandlerTest.java
@@ -127,7 +127,7 @@ class AuthCodeHandlerTest {
         APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
 
         assertThat(response, hasStatus(400));
-        assertThat(response, hasJsonBody(ErrorResponse.ERROR_1017));
+        assertThat(response, hasJsonBody(ErrorResponse.ERROR_1016));
     }
 
     @Test
@@ -143,7 +143,7 @@ class AuthCodeHandlerTest {
         APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
 
         assertThat(response, hasStatus(400));
-        assertThat(response, hasJsonBody(ErrorResponse.ERROR_1016));
+        assertThat(response, hasJsonBody(ErrorResponse.ERROR_1015));
     }
 
     @Test
@@ -187,7 +187,7 @@ class AuthCodeHandlerTest {
         APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
 
         assertThat(response, hasStatus(400));
-        assertThat(response, hasJsonBody(ErrorResponse.ERROR_1019));
+        assertThat(response, hasJsonBody(ErrorResponse.ERROR_1017));
     }
 
     private AuthorizationRequest generateValidSessionAndAuthRequest(ClientID clientID) {

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/CheckUserExistsHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/CheckUserExistsHandlerTest.java
@@ -137,7 +137,7 @@ class CheckUserExistsHandlerTest {
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertEquals(400, result.getStatusCode());
-        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1019));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1017));
     }
 
     private void usingValidSession() {

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/ClientInfoHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/ClientInfoHandlerTest.java
@@ -87,7 +87,7 @@ public class ClientInfoHandlerTest {
 
         assertThat(result, hasStatus(400));
 
-        String expectedResponse = new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1020);
+        String expectedResponse = new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1018);
         assertThat(result, hasBody(expectedResponse));
     }
 
@@ -100,7 +100,7 @@ public class ClientInfoHandlerTest {
 
         assertThat(result, hasStatus(403));
 
-        String expectedResponse = new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1016);
+        String expectedResponse = new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1015);
         assertThat(result, hasBody(expectedResponse));
     }
 

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/ClientRegistrationHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/ClientRegistrationHandlerTest.java
@@ -26,7 +26,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
-import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 import static uk.gov.di.services.ClientConfigValidationService.INVALID_PUBLIC_KEY;
 

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/ClientRegistrationHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/ClientRegistrationHandlerTest.java
@@ -5,12 +5,12 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.entity.ClientRegistrationRequest;
 import uk.gov.di.entity.ClientRegistrationResponse;
-import uk.gov.di.entity.ErrorResponse;
 import uk.gov.di.services.ClientConfigValidationService;
 import uk.gov.di.services.ClientService;
 
@@ -25,6 +25,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
 import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 import static uk.gov.di.services.ClientConfigValidationService.INVALID_PUBLIC_KEY;
@@ -88,7 +89,7 @@ class ClientRegistrationHandlerTest {
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(400));
-        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1001));
+        assertThat(result, hasBody(OAuth2Error.INVALID_REQUEST.toJSONObject().toJSONString()));
     }
 
     @Test
@@ -102,6 +103,6 @@ class ClientRegistrationHandlerTest {
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(400));
-        assertThat(result, hasJsonBody(INVALID_PUBLIC_KEY));
+        assertThat(result, hasBody(INVALID_PUBLIC_KEY.toJSONObject().toJSONString()));
     }
 }

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/LoginHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/LoginHandlerTest.java
@@ -144,7 +144,7 @@ class LoginHandlerTest {
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(400));
-        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1019));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1017));
     }
 
     private void usingValidSession() {

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/MfaHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/MfaHandlerTest.java
@@ -127,7 +127,7 @@ public class MfaHandlerTest {
         verifyNoInteractions(sqsClient, codeStorageService);
 
         assertThat(result, hasStatus(400));
-        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1019));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1017));
     }
 
     private void usingValidSession() {

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/SendNotificationHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/SendNotificationHandlerTest.java
@@ -284,7 +284,7 @@ class SendNotificationHandlerTest {
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(400));
-        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1019));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1017));
     }
 
     @Test
@@ -303,7 +303,7 @@ class SendNotificationHandlerTest {
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(400));
-        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1019));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1017));
     }
 
     private void usingValidSession() {

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/SignUpHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/SignUpHandlerTest.java
@@ -153,7 +153,7 @@ class SignUpHandlerTest {
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(400));
-        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1019));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1017));
     }
 
     private void usingValidSession() {

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/TokenHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/TokenHandlerTest.java
@@ -3,12 +3,14 @@ package uk.gov.di.lambdas;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
 import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import com.nimbusds.oauth2.sdk.AuthorizationRequest;
+import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.auth.PrivateKeyJWT;
@@ -17,13 +19,13 @@ import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.oauth2.sdk.util.URLUtils;
+import com.nimbusds.openid.connect.sdk.OIDCTokenResponse;
+import com.nimbusds.openid.connect.sdk.token.OIDCTokens;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.entity.AuthCodeExchangeData;
 import uk.gov.di.entity.ClientRegistry;
 import uk.gov.di.entity.ClientSession;
-import uk.gov.di.entity.ErrorResponse;
-import uk.gov.di.helpers.ObjectMapperFactory;
 import uk.gov.di.services.AuthenticationService;
 import uk.gov.di.services.AuthorisationCodeService;
 import uk.gov.di.services.ClientService;
@@ -44,28 +46,31 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.helpers.TokenGenerator.generateIDToken;
 import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
 import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class TokenHandlerTest {
 
     private static final String TEST_EMAIL = "joe.bloggs@digital.cabinet-office.gov.uk";
+    private static final String REDIRECT_URI = "http://localhost/redirect";
     private static final Subject TEST_SUBJECT = new Subject();
     private static final String CLIENT_ID = "test-id";
     private static final List<String> SCOPES = List.of("openid");
     private static final String ENDPOINT_URI = "http://localhost/token";
     public static final String CLIENT_SESSION_ID = "a-client-session-id";
     private final Context context = mock(Context.class);
-    private final SignedJWT signedJWT = mock(SignedJWT.class);
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final TokenService tokenService = mock(TokenService.class);
@@ -77,6 +82,7 @@ public class TokenHandlerTest {
 
     @BeforeEach
     public void setUp() {
+        when(configurationService.getBaseURL()).thenReturn(Optional.of(ENDPOINT_URI));
         handler =
                 new TokenHandler(
                         clientService,
@@ -88,115 +94,146 @@ public class TokenHandlerTest {
     }
 
     @Test
-    public void shouldReturn200IfSuccessfulRequest() throws JOSEException {
+    public void shouldReturn200ForSuccessfulTokenRequest() throws JOSEException {
         KeyPair keyPair = generateRsaKeyPair();
-        PrivateKeyJWT privateKeyJWT = generatePrivateKeyJWT(CLIENT_ID, keyPair.getPrivate());
-        ClientRegistry clientRegistry =
-                new ClientRegistry()
-                        .setClientID(CLIENT_ID)
-                        .setClientName("test-client")
-                        .setRedirectUrls(singletonList("http://localhost/redirect"))
-                        .setScopes(singletonList("openid"))
-                        .setContacts(singletonList(TEST_EMAIL))
-                        .setPublicKey(
-                                Base64.getMimeEncoder()
-                                        .encodeToString(keyPair.getPublic().getEncoded()));
+        SignedJWT signedJWT =
+                generateIDToken(
+                        CLIENT_ID,
+                        TEST_SUBJECT,
+                        "issuer-url",
+                        new RSAKeyGenerator(2048).keyID(UUID.randomUUID().toString()).generate());
         BearerAccessToken accessToken = new BearerAccessToken();
-        when(configurationService.getBaseURL()).thenReturn(Optional.of(ENDPOINT_URI));
+        OIDCTokenResponse tokenResponse =
+                new OIDCTokenResponse(new OIDCTokens(signedJWT, accessToken, null));
+        PrivateKeyJWT privateKeyJWT = generatePrivateKeyJWT(keyPair.getPrivate());
+        ClientRegistry clientRegistry = generateClientRegistry(keyPair);
+
+        when(tokenService.validateTokenRequestParams(anyString())).thenReturn(Optional.empty());
         when(clientService.getClient(eq(CLIENT_ID))).thenReturn(Optional.of(clientRegistry));
-        when(tokenService.validatePrivateKeyJWTSignature(
-                        eq(clientRegistry.getPublicKey()),
-                        any(PrivateKeyJWT.class),
-                        eq(ENDPOINT_URI)))
-                .thenReturn(true);
-        when(authenticationService.getSubjectFromEmail(eq(TEST_EMAIL))).thenReturn(TEST_SUBJECT);
-        when(tokenService.generateAndStoreAccessToken(eq(CLIENT_ID), eq(TEST_SUBJECT), eq(SCOPES)))
-                .thenReturn(accessToken);
-        when(tokenService.generateIDToken(eq(CLIENT_ID), any(Subject.class))).thenReturn(signedJWT);
+        when(tokenService.validatePrivateKeyJWT(
+                        anyString(), eq(clientRegistry.getPublicKey()), eq(ENDPOINT_URI)))
+                .thenReturn(Optional.empty());
         String authCode = new AuthorizationCode().toString();
         when(authorisationCodeService.getExchangeDataForCode(authCode))
                 .thenReturn(
                         Optional.of(
                                 new AuthCodeExchangeData()
-                                        .setClientSessionId(CLIENT_SESSION_ID)
-                                        .setEmail(TEST_EMAIL)));
+                                        .setEmail(TEST_EMAIL)
+                                        .setClientSessionId(CLIENT_SESSION_ID)));
+
         when(clientSessionService.getClientSession(CLIENT_SESSION_ID))
                 .thenReturn(
                         new ClientSession(
                                 generateAuthRequest().toParameters(), LocalDateTime.now()));
+        when(authenticationService.getSubjectFromEmail(eq(TEST_EMAIL))).thenReturn(TEST_SUBJECT);
+        when(tokenService.generateTokenResponse(eq(CLIENT_ID), any(Subject.class), eq(SCOPES)))
+                .thenReturn(tokenResponse);
 
-        APIGatewayProxyResponseEvent result =
-                generateApiGatewayRequest(privateKeyJWT, CLIENT_ID, authCode);
-
+        APIGatewayProxyResponseEvent result = generateApiGatewayRequest(privateKeyJWT, authCode);
         assertThat(result, hasStatus(200));
         assertTrue(result.getBody().contains(accessToken.getValue()));
     }
 
     @Test
-    public void shouldReturn403IfClientIsNotValid() throws JOSEException, JsonProcessingException {
-        String invalidClientID = "invalid-id";
-        when(clientService.getClient(eq(invalidClientID))).thenReturn(Optional.empty());
+    public void shouldReturn400IfClientIsNotValid() throws JOSEException {
+        when(tokenService.validateTokenRequestParams(anyString())).thenReturn(Optional.empty());
+        when(clientService.getClient(eq(CLIENT_ID))).thenReturn(Optional.empty());
         KeyPair keyPair = generateRsaKeyPair();
-        PrivateKeyJWT privateKeyJWT = generatePrivateKeyJWT(invalidClientID, keyPair.getPrivate());
-
+        PrivateKeyJWT privateKeyJWT = generatePrivateKeyJWT(keyPair.getPrivate());
         APIGatewayProxyResponseEvent result =
-                generateApiGatewayRequest(privateKeyJWT, invalidClientID);
+                generateApiGatewayRequest(privateKeyJWT, new AuthorizationCode().toString());
 
-        assertEquals(403, result.getStatusCode());
-        String expectedResponse =
-                ObjectMapperFactory.getInstance().writeValueAsString(ErrorResponse.ERROR_1016);
-        assertThat(result, hasBody(expectedResponse));
+        assertEquals(400, result.getStatusCode());
+        assertThat(result, hasBody(OAuth2Error.INVALID_CLIENT.toJSONObject().toJSONString()));
     }
 
     @Test
-    public void shouldReturn400IfAnyRequestParametersAreMissing() throws JsonProcessingException {
+    public void shouldReturn400IfClientIdIsNotValid() {
+        ErrorObject error =
+                new ErrorObject(
+                        OAuth2Error.INVALID_REQUEST_CODE, "Request is missing client_id parameter");
+        when(tokenService.validateTokenRequestParams(anyString())).thenReturn(Optional.of(error));
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setBody("code=343242");
 
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertEquals(400, result.getStatusCode());
-        String expectedResponse =
-                ObjectMapperFactory.getInstance().writeValueAsString(ErrorResponse.ERROR_1001);
-        assertThat(result, hasBody(expectedResponse));
+        assertThat(result, hasBody(error.toJSONObject().toJSONString()));
     }
 
     @Test
-    public void shouldReturn403IfSignatureOfPrivateKeyJWTCantBeVerified()
-            throws JOSEException, JsonProcessingException {
+    public void shouldReturn400IfSignatureOfPrivateKeyJWTCantBeVerified() throws JOSEException {
         KeyPair keyPairOne = generateRsaKeyPair();
         KeyPair keyPairTwo = generateRsaKeyPair();
-        ClientRegistry clientRegistry =
-                new ClientRegistry()
-                        .setClientID(CLIENT_ID)
-                        .setClientName("test-client")
-                        .setRedirectUrls(singletonList("http://localhost/redirect"))
-                        .setScopes(singletonList("openid"))
-                        .setContacts(singletonList(TEST_EMAIL))
-                        .setPublicKey(
-                                Base64.getMimeEncoder()
-                                        .encodeToString(keyPairTwo.getPublic().getEncoded()));
-        PrivateKeyJWT privateKeyJWT = generatePrivateKeyJWT(CLIENT_ID, keyPairOne.getPrivate());
-        when(configurationService.getBaseURL()).thenReturn(Optional.of(ENDPOINT_URI));
+        ClientRegistry clientRegistry = generateClientRegistry(keyPairTwo);
+        PrivateKeyJWT privateKeyJWT = generatePrivateKeyJWT(keyPairOne.getPrivate());
+        when(clientService.getClient(eq(CLIENT_ID))).thenReturn(Optional.empty());
         when(clientService.getClient(eq(CLIENT_ID))).thenReturn(Optional.of(clientRegistry));
-        when(tokenService.validatePrivateKeyJWTSignature(
-                        eq(clientRegistry.getPublicKey()),
-                        any(PrivateKeyJWT.class),
-                        eq(ENDPOINT_URI)))
-                .thenReturn(false);
+        when(tokenService.validatePrivateKeyJWT(
+                        anyString(), eq(clientRegistry.getPublicKey()), eq(ENDPOINT_URI)))
+                .thenReturn(Optional.of(OAuth2Error.INVALID_CLIENT));
 
-        APIGatewayProxyResponseEvent result = generateApiGatewayRequest(privateKeyJWT, CLIENT_ID);
+        APIGatewayProxyResponseEvent result =
+                generateApiGatewayRequest(privateKeyJWT, new AuthorizationCode().toString());
 
-        assertThat(result, hasStatus(403));
-        String expectedResponse =
-                ObjectMapperFactory.getInstance().writeValueAsString(ErrorResponse.ERROR_1015);
-        assertThat(result, hasBody(expectedResponse));
+        assertThat(result, hasStatus(400));
+        assertThat(result, hasBody(OAuth2Error.INVALID_CLIENT.toJSONObject().toJSONString()));
     }
 
-    private PrivateKeyJWT generatePrivateKeyJWT(String clientID, PrivateKey privateKey)
+    @Test
+    public void shouldReturn400IfAuthCodeIsNotFound() throws JOSEException {
+        KeyPair keyPair = generateRsaKeyPair();
+        PrivateKeyJWT privateKeyJWT = generatePrivateKeyJWT(keyPair.getPrivate());
+        ClientRegistry clientRegistry = generateClientRegistry(keyPair);
+
+        when(tokenService.validateTokenRequestParams(anyString())).thenReturn(Optional.empty());
+        when(clientService.getClient(eq(CLIENT_ID))).thenReturn(Optional.of(clientRegistry));
+        when(tokenService.validatePrivateKeyJWT(
+                        anyString(), eq(clientRegistry.getPublicKey()), eq(ENDPOINT_URI)))
+                .thenReturn(Optional.empty());
+        String authCode = new AuthorizationCode().toString();
+        when(authorisationCodeService.getExchangeDataForCode(authCode))
+                .thenReturn(Optional.empty());
+
+        APIGatewayProxyResponseEvent result = generateApiGatewayRequest(privateKeyJWT, authCode);
+        assertThat(result, hasStatus(400));
+        assertThat(result, hasBody(OAuth2Error.INVALID_GRANT.toJSONObject().toJSONString()));
+    }
+
+    @Test
+    public void shouldReturn400IfRedirectUriDoesNotMatchRedirectUriFromAuthRequest()
             throws JOSEException {
+        KeyPair keyPair = generateRsaKeyPair();
+        PrivateKeyJWT privateKeyJWT = generatePrivateKeyJWT(keyPair.getPrivate());
+        ClientRegistry clientRegistry = generateClientRegistry(keyPair);
+
+        when(tokenService.validateTokenRequestParams(anyString())).thenReturn(Optional.empty());
+        when(clientService.getClient(eq(CLIENT_ID))).thenReturn(Optional.of(clientRegistry));
+        when(tokenService.validatePrivateKeyJWT(
+                        anyString(), eq(clientRegistry.getPublicKey()), eq(ENDPOINT_URI)))
+                .thenReturn(Optional.empty());
+        String authCode = new AuthorizationCode().toString();
+        when(authorisationCodeService.getExchangeDataForCode(authCode))
+                .thenReturn(
+                        Optional.of(
+                                new AuthCodeExchangeData()
+                                        .setEmail(TEST_EMAIL)
+                                        .setClientSessionId(CLIENT_SESSION_ID)));
+        when(clientSessionService.getClientSession(CLIENT_SESSION_ID))
+                .thenReturn(
+                        new ClientSession(
+                                generateAuthRequest().toParameters(), LocalDateTime.now()));
+
+        APIGatewayProxyResponseEvent result =
+                generateApiGatewayRequest(privateKeyJWT, authCode, "http://invalid-redirect-uri");
+        assertThat(result, hasStatus(400));
+        assertThat(result, hasBody(OAuth2Error.INVALID_GRANT.toJSONObject().toJSONString()));
+    }
+
+    private PrivateKeyJWT generatePrivateKeyJWT(PrivateKey privateKey) throws JOSEException {
         return new PrivateKeyJWT(
-                new ClientID(clientID),
+                new ClientID(CLIENT_ID),
                 URI.create(ENDPOINT_URI),
                 JWSAlgorithm.RS256,
                 (RSAPrivateKey) privateKey,
@@ -204,19 +241,24 @@ public class TokenHandlerTest {
                 null);
     }
 
-    private APIGatewayProxyResponseEvent generateApiGatewayRequest(
-            PrivateKeyJWT privateKeyJWT, String clientID) {
-        return generateApiGatewayRequest(
-                privateKeyJWT, clientID, new AuthorizationCode().toString());
+    private ClientRegistry generateClientRegistry(KeyPair keyPair) {
+        return new ClientRegistry()
+                .setClientID(CLIENT_ID)
+                .setClientName("test-client")
+                .setRedirectUrls(singletonList(REDIRECT_URI))
+                .setScopes(singletonList("openid"))
+                .setContacts(singletonList(TEST_EMAIL))
+                .setPublicKey(
+                        Base64.getMimeEncoder().encodeToString(keyPair.getPublic().getEncoded()));
     }
 
     private APIGatewayProxyResponseEvent generateApiGatewayRequest(
-            PrivateKeyJWT privateKeyJWT, String clientID, String authorisationCode) {
+            PrivateKeyJWT privateKeyJWT, String authorisationCode, String redirectUri) {
         Map<String, List<String>> customParams = new HashMap<>();
         customParams.put("grant_type", Collections.singletonList("authorization_code"));
-        customParams.put("client_id", Collections.singletonList(clientID));
+        customParams.put("client_id", Collections.singletonList(CLIENT_ID));
         customParams.put("code", Collections.singletonList(authorisationCode));
-        customParams.put("redirect_uri", Collections.singletonList("http://localhost/redirect"));
+        customParams.put("redirect_uri", Collections.singletonList(redirectUri));
         Map<String, List<String>> privateKeyParams = privateKeyJWT.toParameters();
         privateKeyParams.putAll(customParams);
         String requestParams = URLUtils.serializeParameters(privateKeyParams);
@@ -225,15 +267,18 @@ public class TokenHandlerTest {
         return handler.handleRequest(event, context);
     }
 
+    private APIGatewayProxyResponseEvent generateApiGatewayRequest(
+            PrivateKeyJWT privateKeyJWT, String authorisationCode) {
+        return generateApiGatewayRequest(privateKeyJWT, authorisationCode, REDIRECT_URI);
+    }
+
     private AuthorizationRequest generateAuthRequest() {
-        Scope scopeValues = new Scope();
-        scopeValues.add("openid");
         ResponseType responseType = new ResponseType(ResponseType.Value.CODE);
         State state = new State();
         return new AuthorizationRequest.Builder(responseType, new ClientID(CLIENT_ID))
-                .redirectionURI(URI.create("http://localhost:8080/redirect"))
+                .redirectionURI(URI.create(REDIRECT_URI))
                 .state(state)
-                .scope(scopeValues)
+                .scope(Scope.parse(SCOPES))
                 .build();
     }
 

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/UpdateClientConfigHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/UpdateClientConfigHandlerTest.java
@@ -25,7 +25,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
+import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
 import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 import static uk.gov.di.services.ClientConfigValidationService.INVALID_PUBLIC_KEY;
 
@@ -113,7 +113,7 @@ class UpdateClientConfigHandlerTest {
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(400));
-        assertThat(result, hasJsonBody(INVALID_PUBLIC_KEY));
+        assertThat(result, hasBody(INVALID_PUBLIC_KEY.toJSONObject().toJSONString()));
     }
 
     private ClientRegistry createClientRegistry() {

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/UpdateProfileHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/UpdateProfileHandlerTest.java
@@ -172,7 +172,7 @@ class UpdateProfileHandlerTest {
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(400));
-        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1019));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1017));
     }
 
     private void usingValidSession() {

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/VerifyCodeRequestHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/VerifyCodeRequestHandlerTest.java
@@ -358,7 +358,7 @@ class VerifyCodeRequestHandlerTest {
         APIGatewayProxyResponseEvent result = makeCallWithCode(CODE, VERIFY_EMAIL.toString());
 
         assertThat(result, hasStatus(400));
-        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1019));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1017));
     }
 
     private APIGatewayProxyResponseEvent makeCallWithCode(String code, String notificationType) {

--- a/serverless/lambda/src/test/java/uk/gov/di/services/TokenServiceTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/services/TokenServiceTest.java
@@ -2,11 +2,14 @@ package uk.gov.di.services;
 
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
-import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.auth.PrivateKeyJWT;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.id.Subject;
-import com.nimbusds.oauth2.sdk.token.AccessToken;
+import com.nimbusds.oauth2.sdk.util.URLUtils;
+import com.nimbusds.openid.connect.sdk.OIDCTokenResponse;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
@@ -16,52 +19,178 @@ import java.security.NoSuchAlgorithmException;
 import java.security.interfaces.RSAPrivateKey;
 import java.text.ParseException;
 import java.util.Base64;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class TokenServiceTest {
 
-    private ConfigurationService configurationService = mock(ConfigurationService.class);
-    private RedisConnectionService redisConnectionService = mock(RedisConnectionService.class);
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private final RedisConnectionService redisConnectionService =
+            mock(RedisConnectionService.class);
     private final TokenService tokenService =
             new TokenService(configurationService, redisConnectionService);
     private static final Subject SUBJECT = new Subject("some-subject");
-    private static final String CLIENT_ID = "some-client-id";
     private static final List<String> SCOPES = List.of("openid", "email", "phone");
+    private static final String CLIENT_ID = "client-id";
+    private static final String AUTH_CODE = new AuthorizationCode().toString();
+    private static final String GRANT_TYPE = "authorization_code";
+    private static final String REDIRECT_URI = "http://localhost/redirect";
     private static final String BASE_URL = "http://example.com";
 
     @Test
-    public void shouldGeneratedAccessTokenAndCallRedisToSave() {
+    public void shouldSuccessfullyGenerateTokenResponse() throws ParseException {
         Optional<String> baseUrl = Optional.of(BASE_URL);
         when(configurationService.getBaseURL()).thenReturn(baseUrl);
         when(configurationService.getAccessTokenExpiry()).thenReturn(300L);
 
-        AccessToken token = tokenService.generateAndStoreAccessToken(CLIENT_ID, SUBJECT, SCOPES);
+        OIDCTokenResponse tokenResponse =
+                tokenService.generateTokenResponse(CLIENT_ID, SUBJECT, SCOPES);
 
+        assertEquals(
+                BASE_URL, tokenResponse.getOIDCTokens().getIDToken().getJWTClaimsSet().getIssuer());
+        assertEquals(
+                SUBJECT.getValue(),
+                tokenResponse.getOIDCTokens().getIDToken().getJWTClaimsSet().getClaim("sub"));
         verify(redisConnectionService)
-                .saveWithExpiry(token.toJSONString(), SUBJECT.toString(), 300L);
+                .saveWithExpiry(
+                        tokenResponse.getOIDCTokens().getAccessToken().toJSONString(),
+                        SUBJECT.toString(),
+                        300L);
     }
 
     @Test
-    public void shouldSuccessfullyGenerateIDtoken() throws ParseException {
-        Optional<String> baseUrl = Optional.of(BASE_URL);
-        when(configurationService.getBaseURL()).thenReturn(baseUrl);
-
-        SignedJWT signedJWT = tokenService.generateIDToken("client-id", SUBJECT);
-
-        assertEquals(BASE_URL, signedJWT.getJWTClaimsSet().getIssuer());
-        assertEquals(SUBJECT.getValue(), signedJWT.getJWTClaimsSet().getClaim("sub"));
-    }
-
-    @Test
-    public void shouldSuccessfullyValidatePrivateKeyJWTSignature() throws JOSEException {
+    public void shouldSuccessfullyValidatePrivateKeyJWT() throws JOSEException {
         KeyPair keyPair = generateRsaKeyPair();
+        String publicKey = Base64.getMimeEncoder().encodeToString(keyPair.getPublic().getEncoded());
+        String requestParams = generateSerialisedPrivateKeyJWT(keyPair);
+        assertThat(
+                tokenService.validatePrivateKeyJWT(
+                        requestParams, publicKey, "http://localhost/token"),
+                equalTo(Optional.empty()));
+    }
+
+    @Test
+    public void shouldReturnErrorIfUnableToValidatePrivateKeyJWT() throws JOSEException {
+        KeyPair keyPair = generateRsaKeyPair();
+        KeyPair keyPairTwo = generateRsaKeyPair();
+        String publicKey =
+                Base64.getMimeEncoder().encodeToString(keyPairTwo.getPublic().getEncoded());
+        String requestParams = generateSerialisedPrivateKeyJWT(keyPair);
+        assertThat(
+                tokenService.validatePrivateKeyJWT(
+                        requestParams, publicKey, "http://localhost/token"),
+                equalTo(Optional.of(OAuth2Error.INVALID_CLIENT)));
+    }
+
+    @Test
+    public void shouldSuccessfullyValidateTokenRequest() {
+        Map<String, List<String>> customParams = new HashMap<>();
+        customParams.put("grant_type", Collections.singletonList(GRANT_TYPE));
+        customParams.put("client_id", Collections.singletonList(CLIENT_ID));
+        customParams.put("code", Collections.singletonList(AUTH_CODE));
+        customParams.put("redirect_uri", Collections.singletonList(REDIRECT_URI));
+        Optional<ErrorObject> errorObject =
+                tokenService.validateTokenRequestParams(URLUtils.serializeParameters(customParams));
+
+        assertThat(errorObject, equalTo(Optional.empty()));
+    }
+
+    @Test
+    public void shouldReturnErrorIfClientIdIsMissingWhenValidatingTokenRequest() {
+        Map<String, List<String>> customParams = new HashMap<>();
+        customParams.put("grant_type", Collections.singletonList(GRANT_TYPE));
+        customParams.put("code", Collections.singletonList(AUTH_CODE));
+        customParams.put("redirect_uri", Collections.singletonList(REDIRECT_URI));
+        Optional<ErrorObject> errorObject =
+                tokenService.validateTokenRequestParams(URLUtils.serializeParameters(customParams));
+
+        assertThat(
+                errorObject,
+                equalTo(
+                        Optional.of(
+                                new ErrorObject(
+                                        OAuth2Error.INVALID_REQUEST_CODE,
+                                        "Request is missing client_id parameter"))));
+    }
+
+    @Test
+    public void shouldReturnErrorIfRedirectUriIsMissingWhenValidatingTokenRequest() {
+        Map<String, List<String>> customParams = new HashMap<>();
+        customParams.put("grant_type", Collections.singletonList(GRANT_TYPE));
+        customParams.put("client_id", Collections.singletonList(CLIENT_ID));
+        customParams.put("code", Collections.singletonList(AUTH_CODE));
+        Optional<ErrorObject> errorObject =
+                tokenService.validateTokenRequestParams(URLUtils.serializeParameters(customParams));
+
+        assertThat(
+                errorObject,
+                equalTo(
+                        Optional.of(
+                                new ErrorObject(
+                                        OAuth2Error.INVALID_REQUEST_CODE,
+                                        "Request is missing redirect_uri parameter"))));
+    }
+
+    @Test
+    public void shouldReturnErrorIfGrantTypeIsMissingWhenValidatingTokenRequest() {
+        Map<String, List<String>> customParams = new HashMap<>();
+        customParams.put("client_id", Collections.singletonList(CLIENT_ID));
+        customParams.put("code", Collections.singletonList(AUTH_CODE));
+        customParams.put("redirect_uri", Collections.singletonList(REDIRECT_URI));
+        Optional<ErrorObject> errorObject =
+                tokenService.validateTokenRequestParams(URLUtils.serializeParameters(customParams));
+
+        assertThat(
+                errorObject,
+                equalTo(
+                        Optional.of(
+                                new ErrorObject(
+                                        OAuth2Error.INVALID_REQUEST_CODE,
+                                        "Request is missing grant_type parameter"))));
+    }
+
+    @Test
+    public void shouldReturnErrorIfCodeIsMissingWhenValidatingTokenRequest() {
+        Map<String, List<String>> customParams = new HashMap<>();
+        customParams.put("grant_type", Collections.singletonList(GRANT_TYPE));
+        customParams.put("client_id", Collections.singletonList(CLIENT_ID));
+        customParams.put("redirect_uri", Collections.singletonList(REDIRECT_URI));
+        Optional<ErrorObject> errorObject =
+                tokenService.validateTokenRequestParams(URLUtils.serializeParameters(customParams));
+
+        assertThat(
+                errorObject,
+                equalTo(
+                        Optional.of(
+                                new ErrorObject(
+                                        OAuth2Error.INVALID_REQUEST_CODE,
+                                        "Request is missing code parameter"))));
+    }
+
+    @Test
+    public void shouldReturnErrorIfGrantIsInvalidWhenValidatingTokenRequest() {
+        Map<String, List<String>> customParams = new HashMap<>();
+        customParams.put("grant_type", Collections.singletonList("client_credentials"));
+        customParams.put("client_id", Collections.singletonList(CLIENT_ID));
+        customParams.put("code", Collections.singletonList(AUTH_CODE));
+        customParams.put("redirect_uri", Collections.singletonList(REDIRECT_URI));
+        Optional<ErrorObject> errorObject =
+                tokenService.validateTokenRequestParams(URLUtils.serializeParameters(customParams));
+
+        assertThat(errorObject, equalTo(Optional.of(OAuth2Error.UNSUPPORTED_GRANT_TYPE)));
+    }
+
+    private String generateSerialisedPrivateKeyJWT(KeyPair keyPair) throws JOSEException {
         PrivateKeyJWT privateKeyJWT =
                 new PrivateKeyJWT(
                         new ClientID("client-id"),
@@ -70,10 +199,9 @@ public class TokenServiceTest {
                         (RSAPrivateKey) keyPair.getPrivate(),
                         null,
                         null);
-        String publicKey = Base64.getMimeEncoder().encodeToString(keyPair.getPublic().getEncoded());
-        assertTrue(
-                tokenService.validatePrivateKeyJWTSignature(
-                        publicKey, privateKeyJWT, "http://localhost/token"));
+        Map<String, List<String>> privateKeyParams = privateKeyJWT.toParameters();
+        privateKeyParams.putAll(privateKeyParams);
+        return URLUtils.serializeParameters(privateKeyParams);
     }
 
     private KeyPair generateRsaKeyPair() {


### PR DESCRIPTION
## What?

- Make the Token endpoint errors compliant with the OIDC spec by sending back errors stated in the spec 
- Remove custom errors we no longer need 
- Only send back the description and the code when returning OIDC errors 
- Send back an OIDC error response if any parameters are missing on the authorize request. (If the redirect_uri parameter is missing then we should throw as we shouldn't send errors to an unvalidated redirect URI)

## Why?

- To be more OIDC compliant than before