### PR TITLE
GOVSI-463 - Add OIDC errors to the update client config endpoint

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
@@ -1,9 +1,11 @@
 package uk.gov.di.authentication.api;
 
-import com.nimbusds.oauth2.sdk.AuthorizationRequest;
 import com.nimbusds.oauth2.sdk.ResponseType;
+import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.id.State;
+import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.core.MultivaluedHashMap;
@@ -55,11 +57,12 @@ public class AuthCodeIntegrationTest extends IntegrationTestEndpoints {
         assertEquals(302, response.getStatus());
     }
 
-    private AuthorizationRequest generateAuthRequest() {
+    private AuthenticationRequest generateAuthRequest() {
         ResponseType responseType = new ResponseType(ResponseType.Value.CODE);
         State state = new State();
-        return new AuthorizationRequest.Builder(responseType, CLIENT_ID)
-                .redirectionURI(REDIRECT_URI)
+        Scope scope = new Scope();
+        scope.add(OIDCScopeValue.OPENID);
+        return new AuthenticationRequest.Builder(responseType, scope, CLIENT_ID, REDIRECT_URI)
                 .state(state)
                 .build();
     }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
@@ -4,11 +4,13 @@ import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
 import com.nimbusds.jwt.SignedJWT;
-import com.nimbusds.oauth2.sdk.AuthorizationRequest;
 import com.nimbusds.oauth2.sdk.ResponseType;
+import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.oauth2.sdk.id.Subject;
+import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.core.MultivaluedHashMap;
@@ -83,11 +85,16 @@ public class LogoutIntegrationTest extends IntegrationTestEndpoints {
                                         + "8VAVNSxHO1HwiNDhwchQKdd7eOUK3ltKfQzwPDxu9LU"));
     }
 
-    private AuthorizationRequest generateAuthRequest() {
+    private AuthenticationRequest generateAuthRequest() {
         ResponseType responseType = new ResponseType(ResponseType.Value.CODE);
         State state = new State();
-        return new AuthorizationRequest.Builder(responseType, new ClientID("test-client"))
-                .redirectionURI(URI.create("http://localhost:8080/redirect"))
+        Scope scope = new Scope();
+        scope.add(OIDCScopeValue.OPENID);
+        return new AuthenticationRequest.Builder(
+                        responseType,
+                        scope,
+                        new ClientID("test-client"),
+                        URI.create("http://localhost:8080/redirect"))
                 .state(state)
                 .build();
     }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
@@ -3,13 +3,13 @@ package uk.gov.di.authentication.api;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
-import com.nimbusds.oauth2.sdk.AuthorizationRequest;
 import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.auth.PrivateKeyJWT;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.oauth2.sdk.util.URLUtils;
+import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.client.Entity;
@@ -99,15 +99,17 @@ public class TokenIntegrationTest extends IntegrationTestEndpoints {
         return kpg.generateKeyPair();
     }
 
-    private AuthorizationRequest generateAuthRequest() {
+    private AuthenticationRequest generateAuthRequest() {
         Scope scopeValues = new Scope();
         scopeValues.add("openid");
         ResponseType responseType = new ResponseType(ResponseType.Value.CODE);
         State state = new State();
-        return new AuthorizationRequest.Builder(responseType, new ClientID(CLIENT_ID))
-                .redirectionURI(URI.create("http://localhost/redirect"))
+        return new AuthenticationRequest.Builder(
+                        responseType,
+                        scopeValues,
+                        new ClientID(CLIENT_ID),
+                        URI.create("http://localhost/redirect"))
                 .state(state)
-                .scope(scopeValues)
                 .build();
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateClientConfigIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateClientConfigIntegrationTest.java
@@ -2,6 +2,7 @@ package uk.gov.di.authentication.api;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.oauth2.sdk.OAuth2Error;
 import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.MediaType;
@@ -10,7 +11,6 @@ import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.helpers.DynamoHelper;
 import uk.gov.di.entity.ClientRegistrationResponse;
-import uk.gov.di.entity.ErrorResponse;
 import uk.gov.di.entity.UpdateClientConfigRequest;
 
 import static java.util.Collections.singletonList;
@@ -54,7 +54,7 @@ public class UpdateClientConfigIntegrationTest extends IntegrationTestEndpoints 
     }
 
     @Test
-    public void shouldReturn401WhenClientIsUnauthorized() throws JsonProcessingException {
+    public void shouldReturn400WhenClientIsUnauthorized() {
         UpdateClientConfigRequest updateRequest = new UpdateClientConfigRequest();
         updateRequest.setClientName("new-client-name");
 
@@ -65,9 +65,9 @@ public class UpdateClientConfigIntegrationTest extends IntegrationTestEndpoints 
                         .headers(new MultivaluedHashMap<>())
                         .post(Entity.entity(updateRequest, MediaType.APPLICATION_JSON));
 
-        assertEquals(401, response.getStatus());
+        assertEquals(400, response.getStatus());
         assertEquals(
-                new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1015),
+                OAuth2Error.INVALID_CLIENT.toJSONObject().toJSONString(),
                 response.readEntity(String.class));
     }
 }

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/AuthorisationHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/AuthorisationHandler.java
@@ -4,7 +4,6 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.nimbusds.oauth2.sdk.AuthorizationRequest;
 import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.ResponseMode;
@@ -209,7 +208,7 @@ public class AuthorisationHandler
     }
 
     private APIGatewayProxyResponseEvent generateErrorResponse(
-            AuthorizationRequest authRequest, ErrorObject errorObject) {
+            AuthenticationRequest authRequest, ErrorObject errorObject) {
 
         return generateErrorResponse(
                 authRequest.getRedirectionURI(),

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/ClientInfoHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/ClientInfoHandler.java
@@ -5,8 +5,8 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.nimbusds.oauth2.sdk.AuthorizationRequest;
 import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -78,7 +78,7 @@ public class ClientInfoHandler
         try {
             Map<String, List<String>> authRequest = clientSession.get().getAuthRequestParams();
 
-            String clientID = AuthorizationRequest.parse(authRequest).getClientID().getValue();
+            String clientID = AuthenticationRequest.parse(authRequest).getClientID().getValue();
 
             Optional<ClientRegistry> optionalClientRegistry = clientService.getClient(clientID);
 

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/UpdateClientConfigHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/UpdateClientConfigHandler.java
@@ -7,12 +7,12 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.OAuth2Error;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.entity.ClientRegistrationResponse;
 import uk.gov.di.entity.ClientRegistry;
-import uk.gov.di.entity.ErrorResponse;
 import uk.gov.di.entity.UpdateClientConfigRequest;
 import uk.gov.di.services.ClientConfigValidationService;
 import uk.gov.di.services.ClientService;
@@ -20,7 +20,6 @@ import uk.gov.di.services.DynamoClientService;
 
 import java.util.Optional;
 
-import static uk.gov.di.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 
 public class UpdateClientConfigHandler
@@ -57,7 +56,8 @@ public class UpdateClientConfigHandler
                     objectMapper.readValue(input.getBody(), UpdateClientConfigRequest.class);
             if (!clientService.isValidClient(clientId)) {
                 LOGGER.error("Client with ClientId {} is not valid", clientId);
-                return generateApiGatewayProxyErrorResponse(401, ErrorResponse.ERROR_1015);
+                return generateApiGatewayProxyResponse(
+                        400, OAuth2Error.INVALID_CLIENT.toJSONObject().toJSONString());
             }
             Optional<ErrorObject> errorResponse =
                     validationService.validateClientUpdateConfig(updateClientConfigRequest);
@@ -81,7 +81,8 @@ public class UpdateClientConfigHandler
             LOGGER.error(
                     "Request with path parameters {} is missing request parameters",
                     input.getPathParameters());
-            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
+            return generateApiGatewayProxyResponse(
+                    400, OAuth2Error.INVALID_REQUEST.toJSONObject().toJSONString());
         }
     }
 }

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/UpdateProfileHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/UpdateProfileHandler.java
@@ -6,8 +6,8 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.nimbusds.oauth2.sdk.AuthorizationRequest;
 import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -101,10 +101,10 @@ public class UpdateProfileHandler
                     }
 
                     try {
-                        AuthorizationRequest authorizationRequest =
-                                AuthorizationRequest.parse(
+                        AuthenticationRequest authRequest =
+                                AuthenticationRequest.parse(
                                         clientSession.get().getAuthRequestParams());
-                        clientId = authorizationRequest.getClientID().getValue();
+                        clientId = authRequest.getClientID().getValue();
                     } catch (ParseException e) {
                         LOGGER.info("Cannot retreive auth request params from client session id.");
                         return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);

--- a/serverless/lambda/src/main/java/uk/gov/di/services/AuthorizationService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/AuthorizationService.java
@@ -1,10 +1,10 @@
 package uk.gov.di.services;
 
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
-import com.nimbusds.oauth2.sdk.AuthorizationRequest;
 import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import com.nimbusds.openid.connect.sdk.AuthenticationSuccessResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,7 +47,7 @@ public class AuthorizationService {
     }
 
     public AuthenticationSuccessResponse generateSuccessfulAuthResponse(
-            AuthorizationRequest authRequest, AuthorizationCode authorizationCode) {
+            AuthenticationRequest authRequest, AuthorizationCode authorizationCode) {
         return new AuthenticationSuccessResponse(
                 authRequest.getRedirectionURI(),
                 authorizationCode,
@@ -58,7 +58,7 @@ public class AuthorizationService {
                 authRequest.getResponseMode());
     }
 
-    public Optional<ErrorObject> validateAuthRequest(AuthorizationRequest authRequest) {
+    public Optional<ErrorObject> validateAuthRequest(AuthenticationRequest authRequest) {
         Optional<ClientRegistry> client =
                 dynamoClientService.getClient(authRequest.getClientID().toString());
         if (client.isEmpty()) {

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/AuthorisationHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/AuthorisationHandlerTest.java
@@ -3,9 +3,9 @@ package uk.gov.di.lambdas;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.nimbusds.oauth2.sdk.AuthorizationRequest;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.id.State;
+import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import com.nimbusds.openid.connect.sdk.OIDCError;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -60,7 +60,7 @@ class AuthorisationHandlerTest {
         final URI loginUrl = URI.create("http://example.com");
         final Session session = new Session("a-session-id");
 
-        when(authorizationService.validateAuthRequest(any(AuthorizationRequest.class)))
+        when(authorizationService.validateAuthRequest(any(AuthenticationRequest.class)))
                 .thenReturn(Optional.empty());
         when(configService.getLoginURI()).thenReturn(loginUrl);
         when(configService.getDomainName()).thenReturn(domainName);
@@ -91,7 +91,7 @@ class AuthorisationHandlerTest {
 
     @Test
     void shouldReturn400WhenAuthorisationRequestCannotBeParsed() {
-        when(authorizationService.validateAuthRequest(any(AuthorizationRequest.class)))
+        when(authorizationService.validateAuthRequest(any(AuthenticationRequest.class)))
                 .thenReturn(Optional.empty());
         State state = new State();
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
@@ -114,7 +114,7 @@ class AuthorisationHandlerTest {
 
     @Test
     void shouldReturn400WhenAuthorisationRequestContainsInvalidData() {
-        when(authorizationService.validateAuthRequest(any(AuthorizationRequest.class)))
+        when(authorizationService.validateAuthRequest(any(AuthenticationRequest.class)))
                 .thenReturn(Optional.of(OAuth2Error.INVALID_SCOPE));
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setQueryStringParameters(
@@ -137,7 +137,7 @@ class AuthorisationHandlerTest {
         final URI loginUrl = URI.create("http://example.com");
         final Session session = new Session("a-session-id");
 
-        when(authorizationService.validateAuthRequest(any(AuthorizationRequest.class)))
+        when(authorizationService.validateAuthRequest(any(AuthenticationRequest.class)))
                 .thenReturn(Optional.empty());
         when(configService.getLoginURI()).thenReturn(loginUrl);
         when(sessionService.createSession()).thenReturn(session);
@@ -181,7 +181,7 @@ class AuthorisationHandlerTest {
 
     @Test
     void shouldReturnErrorWhenPromptParamNoneAndNotLoggedIn() {
-        when(authorizationService.validateAuthRequest(any(AuthorizationRequest.class)))
+        when(authorizationService.validateAuthRequest(any(AuthenticationRequest.class)))
                 .thenReturn(Optional.empty());
         APIGatewayProxyResponseEvent response =
                 handler.handleRequest(withPromptRequestEvent("none"), context);
@@ -220,7 +220,7 @@ class AuthorisationHandlerTest {
         final URI loginUrl = URI.create("http://example.com");
         final Session session = new Session("a-session-id");
 
-        when(authorizationService.validateAuthRequest(any(AuthorizationRequest.class)))
+        when(authorizationService.validateAuthRequest(any(AuthenticationRequest.class)))
                 .thenReturn(Optional.empty());
         when(configService.getLoginURI()).thenReturn(loginUrl);
         when(sessionService.createSession()).thenReturn(session);
@@ -263,7 +263,7 @@ class AuthorisationHandlerTest {
 
     @Test
     void shouldReturnErrorWhenUnrecognisedPromptValue() {
-        when(authorizationService.validateAuthRequest(any(AuthorizationRequest.class)))
+        when(authorizationService.validateAuthRequest(any(AuthenticationRequest.class)))
                 .thenReturn(Optional.empty());
         APIGatewayProxyResponseEvent response =
                 handler.handleRequest(withPromptRequestEvent("unrecognised"), context);
@@ -275,7 +275,7 @@ class AuthorisationHandlerTest {
 
     @Test
     void shouldReturnErrorWhenPromptParamWithMultipleValuesNoneAndLogin() {
-        when(authorizationService.validateAuthRequest(any(AuthorizationRequest.class)))
+        when(authorizationService.validateAuthRequest(any(AuthenticationRequest.class)))
                 .thenReturn(Optional.empty());
         APIGatewayProxyResponseEvent response =
                 handler.handleRequest(withPromptRequestEvent("none login"), context);
@@ -287,7 +287,7 @@ class AuthorisationHandlerTest {
 
     @Test
     void shouldReturnErrorWhenPromptParamWithUnsupportedMultipleValues() {
-        when(authorizationService.validateAuthRequest(any(AuthorizationRequest.class)))
+        when(authorizationService.validateAuthRequest(any(AuthenticationRequest.class)))
                 .thenReturn(Optional.empty());
         APIGatewayProxyResponseEvent response =
                 handler.handleRequest(withPromptRequestEvent("login consent"), context);
@@ -299,7 +299,7 @@ class AuthorisationHandlerTest {
 
     @Test
     void shouldReturnErrorWhenPromptParamConsent() {
-        when(authorizationService.validateAuthRequest(any(AuthorizationRequest.class)))
+        when(authorizationService.validateAuthRequest(any(AuthenticationRequest.class)))
                 .thenReturn(Optional.empty());
         APIGatewayProxyResponseEvent response =
                 handler.handleRequest(withPromptRequestEvent("consent"), context);
@@ -311,7 +311,7 @@ class AuthorisationHandlerTest {
 
     @Test
     void shouldReturnErrorWhenPromptParamSelectAccount() {
-        when(authorizationService.validateAuthRequest(any(AuthorizationRequest.class)))
+        when(authorizationService.validateAuthRequest(any(AuthenticationRequest.class)))
                 .thenReturn(Optional.empty());
         APIGatewayProxyResponseEvent response =
                 handler.handleRequest(withPromptRequestEvent("select_account"), context);
@@ -326,7 +326,7 @@ class AuthorisationHandlerTest {
         final URI loginUrl = URI.create("http://example.com");
         final Session session = new Session("a-session-id");
 
-        when(authorizationService.validateAuthRequest(any(AuthorizationRequest.class)))
+        when(authorizationService.validateAuthRequest(any(AuthenticationRequest.class)))
                 .thenReturn(Optional.empty());
         when(configService.getLoginURI()).thenReturn(loginUrl);
         when(sessionService.getSessionFromSessionCookie(any())).thenReturn(Optional.empty());
@@ -392,7 +392,7 @@ class AuthorisationHandlerTest {
 
     private void whenLoggedIn(Session session, URI loginUrl) {
         session.setState(SessionState.AUTHENTICATED);
-        when(authorizationService.validateAuthRequest(any(AuthorizationRequest.class)))
+        when(authorizationService.validateAuthRequest(any(AuthenticationRequest.class)))
                 .thenReturn(Optional.empty());
         when(configService.getLoginURI()).thenReturn(loginUrl);
         when(sessionService.getSessionFromSessionCookie(any())).thenReturn(Optional.of(session));

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/TokenHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/TokenHandlerTest.java
@@ -8,7 +8,6 @@ import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
 import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
-import com.nimbusds.oauth2.sdk.AuthorizationRequest;
 import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.ResponseType;
@@ -19,6 +18,7 @@ import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.oauth2.sdk.util.URLUtils;
+import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import com.nimbusds.openid.connect.sdk.OIDCTokenResponse;
 import com.nimbusds.openid.connect.sdk.token.OIDCTokens;
 import org.junit.jupiter.api.BeforeEach;
@@ -272,13 +272,15 @@ public class TokenHandlerTest {
         return generateApiGatewayRequest(privateKeyJWT, authorisationCode, REDIRECT_URI);
     }
 
-    private AuthorizationRequest generateAuthRequest() {
+    private AuthenticationRequest generateAuthRequest() {
         ResponseType responseType = new ResponseType(ResponseType.Value.CODE);
         State state = new State();
-        return new AuthorizationRequest.Builder(responseType, new ClientID(CLIENT_ID))
-                .redirectionURI(URI.create(REDIRECT_URI))
+        return new AuthenticationRequest.Builder(
+                        responseType,
+                        Scope.parse(SCOPES),
+                        new ClientID(CLIENT_ID),
+                        URI.create(REDIRECT_URI))
                 .state(state)
-                .scope(Scope.parse(SCOPES))
                 .build();
     }
 

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/UpdateClientConfigHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/UpdateClientConfigHandlerTest.java
@@ -5,6 +5,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.oauth2.sdk.OAuth2Error;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.entity.ClientRegistrationResponse;
@@ -75,6 +76,7 @@ class UpdateClientConfigHandlerTest {
         event.setBody(format("{\"client_name\": \"%s\"}", CLIENT_NAME));
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
         assertThat(result, hasStatus(400));
+        assertThat(result, hasBody(OAuth2Error.INVALID_REQUEST.toJSONObject().toJSONString()));
     }
 
     @Test
@@ -84,6 +86,7 @@ class UpdateClientConfigHandlerTest {
         event.setPathParameters(Map.of("clientId", CLIENT_ID));
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
         assertThat(result, hasStatus(400));
+        assertThat(result, hasBody(OAuth2Error.INVALID_REQUEST.toJSONObject().toJSONString()));
     }
 
     @Test
@@ -94,7 +97,8 @@ class UpdateClientConfigHandlerTest {
         event.setPathParameters(Map.of("clientId", CLIENT_ID));
         event.setBody(format("{\"client_name\": \"%s\"}", CLIENT_NAME));
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
-        assertThat(result, hasStatus(401));
+        assertThat(result, hasStatus(400));
+        assertThat(result, hasBody(OAuth2Error.INVALID_CLIENT.toJSONObject().toJSONString()));
     }
 
     @Test


### PR DESCRIPTION
## What?

- Add OIDC errors to the update client config endpoint
- There are inconsistencies with our usage of AuthorizationRequest and AuthenticationRequest. We should explicitly be using AuthenticationRequest as that ensures we are compliant with the OIDC spec as scopes and redirect_uri are not optional. 

## Why?

- To be compliant with the OIDC spec