### PR TITLE
GOVSI-463 - Use OIDC errors in the Auth Code handler

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.helpers.DynamoHelper;
 import uk.gov.di.authentication.helpers.RedisHelper;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.entity.ResponseHeaders;
 import uk.gov.di.entity.SessionState;
 
 import java.security.KeyPair;
@@ -62,7 +63,7 @@ public class AuthorisationIntegrationTest extends IntegrationTestEndpoints {
                         Optional.of(INVALID_CLIENT_ID), Optional.empty(), Optional.empty());
         assertEquals(302, response.getStatus());
         assertThat(
-                getHeaderValueByParamName(response, "Location"),
+                getHeaderValueByParamName(response, ResponseHeaders.LOCATION),
                 containsString(OAuth2Error.UNAUTHORIZED_CLIENT.getCode()));
     }
 
@@ -73,7 +74,7 @@ public class AuthorisationIntegrationTest extends IntegrationTestEndpoints {
 
         assertEquals(302, response.getStatus());
         assertThat(
-                getHeaderValueByParamName(response, "Location"),
+                getHeaderValueByParamName(response, ResponseHeaders.LOCATION),
                 startsWith(configurationService.getLoginURI().toString()));
         assertNotNull(response.getCookies().get("gs"));
     }
@@ -88,7 +89,7 @@ public class AuthorisationIntegrationTest extends IntegrationTestEndpoints {
 
         assertEquals(302, response.getStatus());
         assertThat(
-                getHeaderValueByParamName(response, "Location"),
+                getHeaderValueByParamName(response, ResponseHeaders.LOCATION),
                 startsWith(configurationService.getLoginURI().toString()));
         assertNotNull(response.getCookies().get("gs"));
     }
@@ -103,7 +104,7 @@ public class AuthorisationIntegrationTest extends IntegrationTestEndpoints {
 
         assertEquals(302, response.getStatus());
         assertThat(
-                getHeaderValueByParamName(response, "Location"),
+                getHeaderValueByParamName(response, ResponseHeaders.LOCATION),
                 startsWith(configurationService.getLoginURI().toString()));
         assertNotNull(response.getCookies().get("gs"));
     }
@@ -120,7 +121,7 @@ public class AuthorisationIntegrationTest extends IntegrationTestEndpoints {
 
         assertEquals(302, response.getStatus());
         assertThat(
-                getHeaderValueByParamName(response, "Location"),
+                getHeaderValueByParamName(response, ResponseHeaders.LOCATION),
                 startsWith(configurationService.getLoginURI().toString()));
         assertNotNull(response.getCookies().get("gs"));
         assertThat(response.getCookies().get("gs").getValue(), not(startsWith(sessionId)));
@@ -150,7 +151,7 @@ public class AuthorisationIntegrationTest extends IntegrationTestEndpoints {
                         Optional.of(CLIENT_ID), Optional.empty(), Optional.of(NONE.toString()));
         assertEquals(302, response.getStatus());
         assertThat(
-                getHeaderValueByParamName(response, "Location"),
+                getHeaderValueByParamName(response, ResponseHeaders.LOCATION),
                 containsString(OIDCError.LOGIN_REQUIRED_CODE));
     }
 
@@ -168,7 +169,7 @@ public class AuthorisationIntegrationTest extends IntegrationTestEndpoints {
         assertNotNull(response.getCookies().get("gs"));
         assertThat(response.getCookies().get("gs").getValue(), not(startsWith(sessionId)));
         assertThat(
-                getHeaderValueByParamName(response, "Location"),
+                getHeaderValueByParamName(response, ResponseHeaders.LOCATION),
                 startsWith(configurationService.getAuthCodeURI().toString()));
     }
 
@@ -186,7 +187,7 @@ public class AuthorisationIntegrationTest extends IntegrationTestEndpoints {
         assertNotNull(response.getCookies().get("gs"));
         assertThat(response.getCookies().get("gs").getValue(), not(startsWith(sessionId)));
         assertThat(
-                getHeaderValueByParamName(response, "Location"),
+                getHeaderValueByParamName(response, ResponseHeaders.LOCATION),
                 startsWith(configurationService.getLoginURI().toString()));
         /*
            TODO:

--- a/serverless/lambda/src/main/java/uk/gov/di/entity/ResponseHeaders.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/entity/ResponseHeaders.java
@@ -1,0 +1,6 @@
+package uk.gov.di.entity;
+
+public interface ResponseHeaders {
+    String LOCATION = "Location";
+    String SET_COOKIE = "Set-Cookie";
+}

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/AuthCodeHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/AuthCodeHandler.java
@@ -5,9 +5,16 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.oauth2.sdk.ResponseMode;
+import com.nimbusds.oauth2.sdk.id.State;
+import com.nimbusds.openid.connect.sdk.AuthenticationErrorResponse;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import com.nimbusds.openid.connect.sdk.AuthenticationSuccessResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.entity.ErrorResponse;
 import uk.gov.di.entity.Session;
@@ -20,6 +27,7 @@ import uk.gov.di.services.AuthorizationService;
 import uk.gov.di.services.ClientSessionService;
 import uk.gov.di.services.SessionService;
 
+import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -36,6 +44,11 @@ public class AuthCodeHandler
     private final ConfigurationService configurationService;
     private final AuthorizationService authorizationService;
     private final ClientSessionService clientSessionService;
+    private static final Logger LOGGER = LoggerFactory.getLogger(AuthCodeHandler.class);
+
+    private interface ResponseHeaders {
+        String LOCATION = "Location";
+    }
 
     public AuthCodeHandler(
             SessionService sessionService,
@@ -87,15 +100,23 @@ public class AuthCodeHandler
                             .getClientSession(sessionCookieIds.getClientSessionId())
                             .getAuthRequestParams();
             authenticationRequest = AuthenticationRequest.parse(authRequest);
+        } catch (ParseException e) {
+            LOGGER.error("Authentication request could not be parsed", e);
+            if (e.getRedirectionURI() == null) {
+                throw new RuntimeException(
+                        "Redirect URI or Client ID is missing from auth request", e);
+            }
+            return generateErrorResponse(
+                    e.getRedirectionURI(), e.getState(), e.getResponseMode(), e.getErrorObject());
+        }
+        try {
             if (!authorizationService.isClientRedirectUriValid(
                     authenticationRequest.getClientID(),
                     authenticationRequest.getRedirectionURI())) {
                 return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1016);
             }
-        } catch (ParseException e) {
-            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
         } catch (ClientNotFoundException e) {
-            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1015);
+            return generateErrorResponse(authenticationRequest, OAuth2Error.INVALID_CLIENT);
         }
 
         AuthorizationCode authCode =
@@ -108,5 +129,28 @@ public class AuthCodeHandler
         return new APIGatewayProxyResponseEvent()
                 .withStatusCode(302)
                 .withHeaders(Map.of("Location", authenticationResponse.toURI().toString()));
+    }
+
+    private APIGatewayProxyResponseEvent generateErrorResponse(
+            AuthenticationRequest authRequest, ErrorObject errorObject) {
+
+        return generateErrorResponse(
+                authRequest.getRedirectionURI(),
+                authRequest.getState(),
+                authRequest.getResponseMode(),
+                errorObject);
+    }
+
+    private APIGatewayProxyResponseEvent generateErrorResponse(
+            URI redirectUri, State state, ResponseMode responseMode, ErrorObject errorObject) {
+        LOGGER.error(
+                "Returning error response: {} {}",
+                errorObject.getCode(),
+                errorObject.getDescription());
+        AuthenticationErrorResponse error =
+                new AuthenticationErrorResponse(redirectUri, errorObject, state, responseMode);
+        return new APIGatewayProxyResponseEvent()
+                .withStatusCode(302)
+                .withHeaders(Map.of(ResponseHeaders.LOCATION, error.toURI().toString()));
     }
 }

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/AuthCodeHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/AuthCodeHandler.java
@@ -17,6 +17,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.entity.ErrorResponse;
+import uk.gov.di.entity.ResponseHeaders;
 import uk.gov.di.entity.Session;
 import uk.gov.di.exceptions.ClientNotFoundException;
 import uk.gov.di.helpers.CookieHelper;
@@ -45,10 +46,6 @@ public class AuthCodeHandler
     private final AuthorizationService authorizationService;
     private final ClientSessionService clientSessionService;
     private static final Logger LOGGER = LoggerFactory.getLogger(AuthCodeHandler.class);
-
-    private interface ResponseHeaders {
-        String LOCATION = "Location";
-    }
 
     public AuthCodeHandler(
             SessionService sessionService,
@@ -128,7 +125,10 @@ public class AuthCodeHandler
         sessionService.save(session.setState(AUTHENTICATED));
         return new APIGatewayProxyResponseEvent()
                 .withStatusCode(302)
-                .withHeaders(Map.of("Location", authenticationResponse.toURI().toString()));
+                .withHeaders(
+                        Map.of(
+                                ResponseHeaders.LOCATION,
+                                authenticationResponse.toURI().toString()));
     }
 
     private APIGatewayProxyResponseEvent generateErrorResponse(

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/AuthorisationHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/AuthorisationHandler.java
@@ -79,8 +79,9 @@ public class AuthorisationHandler
         } catch (ParseException e) {
             LOGGER.error("Authentication request could not be parsed", e);
             if (e.getRedirectionURI() == null) {
-                LOGGER.error("Redirect URI is missing from request");
-                throw new RuntimeException("Redirect URI is missing");
+                LOGGER.error("Redirect URI or Client ID is missing from auth request");
+                throw new RuntimeException(
+                        "Redirect URI or ClientID is missing from auth request", e);
             }
             return generateErrorResponse(
                     e.getRedirectionURI(), e.getState(), e.getResponseMode(), e.getErrorObject());

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/AuthorisationHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/AuthorisationHandler.java
@@ -17,6 +17,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.entity.ClientSession;
+import uk.gov.di.entity.ResponseHeaders;
 import uk.gov.di.entity.Session;
 import uk.gov.di.entity.SessionState;
 import uk.gov.di.services.AuthorizationService;
@@ -43,11 +44,6 @@ public class AuthorisationHandler
     private final ConfigurationService configurationService;
     private final ClientSessionService clientSessionService;
     private final AuthorizationService authorizationService;
-
-    private interface ResponseHeaders {
-        String LOCATION = "Location";
-        String SET_COOKIE = "Set-Cookie";
-    }
 
     public AuthorisationHandler(
             ConfigurationService configurationService,

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/LogoutHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/LogoutHandler.java
@@ -10,6 +10,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.entity.ClientRegistry;
+import uk.gov.di.entity.ResponseHeaders;
 import uk.gov.di.entity.Session;
 import uk.gov.di.helpers.CookieHelper;
 import uk.gov.di.services.ClientSessionService;
@@ -163,6 +164,6 @@ public class LogoutHandler
         }
         return new APIGatewayProxyResponseEvent()
                 .withStatusCode(302)
-                .withHeaders(Map.of("Location", uri.toString()));
+                .withHeaders(Map.of(ResponseHeaders.LOCATION, uri.toString()));
     }
 }

--- a/serverless/lambda/src/main/java/uk/gov/di/services/AuthorizationService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/AuthorizationService.java
@@ -3,7 +3,10 @@ package uk.gov.di.services;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
+import com.nimbusds.oauth2.sdk.ResponseMode;
 import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.id.State;
+import com.nimbusds.openid.connect.sdk.AuthenticationErrorResponse;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import com.nimbusds.openid.connect.sdk.AuthenticationSuccessResponse;
 import org.slf4j.Logger;
@@ -83,6 +86,21 @@ public class AuthorizationService {
             return Optional.of(OAuth2Error.INVALID_SCOPE);
         }
         return Optional.empty();
+    }
+
+    public AuthenticationErrorResponse generateAuthenticationErrorResponse(
+            AuthenticationRequest authRequest, ErrorObject errorObject) {
+
+        return generateAuthenticationErrorResponse(
+                authRequest.getRedirectionURI(),
+                authRequest.getState(),
+                authRequest.getResponseMode(),
+                errorObject);
+    }
+
+    public AuthenticationErrorResponse generateAuthenticationErrorResponse(
+            URI redirectUri, State state, ResponseMode responseMode, ErrorObject errorObject) {
+        return new AuthenticationErrorResponse(redirectUri, errorObject, state, responseMode);
     }
 
     private boolean areScopesValid(List<String> scopes) {

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/AuthCodeHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/AuthCodeHandlerTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.entity.ClientSession;
 import uk.gov.di.entity.ErrorResponse;
+import uk.gov.di.entity.ResponseHeaders;
 import uk.gov.di.entity.Session;
 import uk.gov.di.entity.SessionState;
 import uk.gov.di.exceptions.ClientNotFoundException;
@@ -107,7 +108,7 @@ class AuthCodeHandlerTest {
 
         assertThat(response, hasStatus(302));
         assertThat(
-                response.getHeaders().get("Location"),
+                response.getHeaders().get(ResponseHeaders.LOCATION),
                 equalTo(authSuccessResponse.toURI().toString()));
     }
 
@@ -153,7 +154,7 @@ class AuthCodeHandlerTest {
         assertEquals(
                 "http://localhost/redirect?error=invalid_client&error_description=Client+authentication+failed&state="
                         + state,
-                response.getHeaders().get("Location"));
+                response.getHeaders().get(ResponseHeaders.LOCATION));
     }
 
     @Test
@@ -169,7 +170,7 @@ class AuthCodeHandlerTest {
         assertThat(response, hasStatus(302));
         assertEquals(
                 "http://localhost/redirect?error=invalid_request&error_description=Invalid+request%3A+Missing+response_type+parameter",
-                response.getHeaders().get("Location"));
+                response.getHeaders().get(ResponseHeaders.LOCATION));
     }
 
     @Test

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/AuthorisationHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/AuthorisationHandlerTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.entity.ClientSession;
+import uk.gov.di.entity.ResponseHeaders;
 import uk.gov.di.entity.Session;
 import uk.gov.di.entity.SessionState;
 import uk.gov.di.services.AuthorizationService;
@@ -79,7 +80,7 @@ class AuthorisationHandlerTest {
                         "response_type", "code",
                         "state", "some-state"));
         APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
-        URI uri = URI.create(response.getHeaders().get("Location"));
+        URI uri = URI.create(response.getHeaders().get(ResponseHeaders.LOCATION));
         final String expectedCookieString =
                 "gs=a-session-id.client-session-id; Max-Age=1800; Domain=auth.ida.digital.cabinet-office.gov.uk; Secure; HttpOnly;";
 
@@ -109,7 +110,7 @@ class AuthorisationHandlerTest {
         assertEquals(
                 "http://localhost:8080?error=invalid_request&error_description=Invalid+request%3A+Missing+response_type+parameter&state="
                         + state,
-                response.getHeaders().get("Location"));
+                response.getHeaders().get(ResponseHeaders.LOCATION));
     }
 
     @Test
@@ -129,7 +130,7 @@ class AuthorisationHandlerTest {
         assertThat(response, hasStatus(302));
         assertEquals(
                 "http://localhost:8080?error=invalid_scope&error_description=Invalid%2C+unknown+or+malformed+scope",
-                response.getHeaders().get("Location"));
+                response.getHeaders().get(ResponseHeaders.LOCATION));
     }
 
     @Test
@@ -148,7 +149,7 @@ class AuthorisationHandlerTest {
         when(configService.getDomainName()).thenReturn(domainName);
 
         APIGatewayProxyResponseEvent response = handler.handleRequest(withRequestEvent(), context);
-        URI uri = URI.create(response.getHeaders().get("Location"));
+        URI uri = URI.create(response.getHeaders().get(ResponseHeaders.LOCATION));
 
         assertThat(response, hasStatus(302));
         assertEquals(loginUrl.getAuthority(), uri.getAuthority());
@@ -168,7 +169,7 @@ class AuthorisationHandlerTest {
         when(configService.getAuthCodeURI()).thenReturn(authCodeUri);
 
         APIGatewayProxyResponseEvent response = handler.handleRequest(withRequestEvent(), context);
-        URI uri = URI.create(response.getHeaders().get("Location"));
+        URI uri = URI.create(response.getHeaders().get(ResponseHeaders.LOCATION));
 
         assertThat(response, hasStatus(302));
         assertEquals(authCodeUri, uri);
@@ -187,7 +188,7 @@ class AuthorisationHandlerTest {
                 handler.handleRequest(withPromptRequestEvent("none"), context);
         assertThat(response, hasStatus(302));
         assertThat(
-                getHeaderValueByParamName(response, "Location"),
+                getHeaderValueByParamName(response, ResponseHeaders.LOCATION),
                 containsString("error=login_required"));
     }
 
@@ -204,7 +205,7 @@ class AuthorisationHandlerTest {
 
         APIGatewayProxyResponseEvent response =
                 handler.handleRequest(withPromptRequestEvent("none"), context);
-        URI uri = URI.create(response.getHeaders().get("Location"));
+        URI uri = URI.create(response.getHeaders().get(ResponseHeaders.LOCATION));
 
         assertThat(response, hasStatus(302));
         assertEquals(authCodeUri, uri);
@@ -232,7 +233,7 @@ class AuthorisationHandlerTest {
 
         APIGatewayProxyResponseEvent response =
                 handler.handleRequest(withPromptRequestEvent("login"), context);
-        URI uri = URI.create(response.getHeaders().get("Location"));
+        URI uri = URI.create(response.getHeaders().get(ResponseHeaders.LOCATION));
 
         assertThat(response, hasStatus(302));
         assertEquals(loginUrl.getAuthority(), uri.getAuthority());
@@ -252,7 +253,7 @@ class AuthorisationHandlerTest {
 
         APIGatewayProxyResponseEvent response =
                 handler.handleRequest(withPromptRequestEvent("login"), context);
-        URI uri = URI.create(response.getHeaders().get("Location"));
+        URI uri = URI.create(response.getHeaders().get(ResponseHeaders.LOCATION));
 
         assertThat(response, hasStatus(302));
         assertEquals(loginUrl.getAuthority(), uri.getAuthority());
@@ -270,7 +271,7 @@ class AuthorisationHandlerTest {
         assertThat(response, hasStatus(302));
         assertEquals(
                 "http://localhost:8080?error=invalid_request&error_description=Invalid+request%3A+Invalid+prompt+parameter%3A+Unknown+prompt+type%3A+unrecognised&state=some-state",
-                response.getHeaders().get("Location"));
+                response.getHeaders().get(ResponseHeaders.LOCATION));
     }
 
     @Test
@@ -282,7 +283,7 @@ class AuthorisationHandlerTest {
         assertThat(response, hasStatus(302));
         assertEquals(
                 "http://localhost:8080?error=invalid_request&error_description=Invalid+request%3A+Invalid+prompt+parameter%3A+Invalid+prompt%3A+none+login&state=some-state",
-                response.getHeaders().get("Location"));
+                response.getHeaders().get(ResponseHeaders.LOCATION));
     }
 
     @Test
@@ -293,7 +294,7 @@ class AuthorisationHandlerTest {
                 handler.handleRequest(withPromptRequestEvent("login consent"), context);
         assertThat(response, hasStatus(302));
         assertThat(
-                getHeaderValueByParamName(response, "Location"),
+                getHeaderValueByParamName(response, ResponseHeaders.LOCATION),
                 containsString(OIDCError.UNMET_AUTHENTICATION_REQUIREMENTS_CODE));
     }
 
@@ -305,7 +306,7 @@ class AuthorisationHandlerTest {
                 handler.handleRequest(withPromptRequestEvent("consent"), context);
         assertThat(response, hasStatus(302));
         assertThat(
-                getHeaderValueByParamName(response, "Location"),
+                getHeaderValueByParamName(response, ResponseHeaders.LOCATION),
                 containsString(OIDCError.UNMET_AUTHENTICATION_REQUIREMENTS_CODE));
     }
 
@@ -317,7 +318,7 @@ class AuthorisationHandlerTest {
                 handler.handleRequest(withPromptRequestEvent("select_account"), context);
         assertThat(response, hasStatus(302));
         assertThat(
-                getHeaderValueByParamName(response, "Location"),
+                getHeaderValueByParamName(response, ResponseHeaders.LOCATION),
                 containsString(OIDCError.UNMET_AUTHENTICATION_REQUIREMENTS_CODE));
     }
 
@@ -338,7 +339,7 @@ class AuthorisationHandlerTest {
         when(configService.getDomainName()).thenReturn(domainName);
 
         APIGatewayProxyResponseEvent response = handler.handleRequest(withRequestEvent(), context);
-        URI uri = URI.create(response.getHeaders().get("Location"));
+        URI uri = URI.create(response.getHeaders().get(ResponseHeaders.LOCATION));
 
         assertThat(response, hasStatus(302));
         assertEquals(loginUrl.getAuthority(), uri.getAuthority());
@@ -356,7 +357,7 @@ class AuthorisationHandlerTest {
         session.setState(SessionState.AUTHENTICATION_REQUIRED);
 
         APIGatewayProxyResponseEvent response = handler.handleRequest(withRequestEvent(), context);
-        URI uri = URI.create(response.getHeaders().get("Location"));
+        URI uri = URI.create(response.getHeaders().get(ResponseHeaders.LOCATION));
 
         assertThat(response, hasStatus(302));
         assertEquals(loginUrl.getAuthority(), uri.getAuthority());

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/LogoutHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/LogoutHandlerTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.entity.ClientRegistry;
 import uk.gov.di.entity.ClientSession;
+import uk.gov.di.entity.ResponseHeaders;
 import uk.gov.di.entity.Session;
 import uk.gov.di.helpers.TokenGenerator;
 import uk.gov.di.services.ClientSessionService;
@@ -53,7 +54,6 @@ class LogoutHandlerTest {
     private static final String COOKIE = "Cookie";
     private static final String SESSION_ID = "a-session-id";
     private static final String CLIENT_SESSION_ID = "client-session-id";
-    private static final String TEST_EMAIL = "joe.bloggs@digital.cabinet-office.gov.uk";
     private static final URI DEFAULT_LOGOUT_URI =
             URI.create("https://di-authentication-frontend.london.cloudapps.digital/signed-out");
     private static final URI CLIENT_LOGOUT_URI = URI.create("http://localhost/logout");
@@ -96,7 +96,7 @@ class LogoutHandlerTest {
 
         assertThat(response, hasStatus(302));
         assertThat(
-                response.getHeaders().get("Location"),
+                response.getHeaders().get(ResponseHeaders.LOCATION),
                 equalTo(CLIENT_LOGOUT_URI + "?state=" + STATE));
     }
 
@@ -119,7 +119,9 @@ class LogoutHandlerTest {
 
         verify(sessionService, times(1)).deleteSessionFromRedis(SESSION_ID);
         assertThat(response, hasStatus(302));
-        assertThat(response.getHeaders().get("Location"), equalTo(CLIENT_LOGOUT_URI.toString()));
+        assertThat(
+                response.getHeaders().get(ResponseHeaders.LOCATION),
+                equalTo(CLIENT_LOGOUT_URI.toString()));
     }
 
     @Test
@@ -135,7 +137,7 @@ class LogoutHandlerTest {
 
         assertThat(response, hasStatus(302));
         assertThat(
-                response.getHeaders().get("Location"),
+                response.getHeaders().get(ResponseHeaders.LOCATION),
                 equalTo(DEFAULT_LOGOUT_URI + "?state=" + STATE));
         verify(sessionService, times(0)).deleteSessionFromRedis(SESSION_ID);
     }
@@ -240,7 +242,7 @@ class LogoutHandlerTest {
 
         assertThat(response, hasStatus(302));
         assertThat(
-                response.getHeaders().get("Location"),
+                response.getHeaders().get(ResponseHeaders.LOCATION),
                 equalTo(DEFAULT_LOGOUT_URI + "?state=" + STATE));
         verify(sessionService, times(1)).deleteSessionFromRedis(SESSION_ID);
     }


### PR DESCRIPTION
## What?

-  Use OIDC errors in the Auth Code handler
- Create a ResponseHeaders interface

## Why?

- The auth code lambda should redirect an OIDC error via a 302 redirect to the user when there is an issue with either the auth request or the client id. In theory this should never really happen as it would have been validated on the AuthorizationHandler but it gives us more protection
- So there is a single point of truth for ResponseHeaders to be declared and used