### PR TITLE
GOVSI-614: Set up log shipping for API lambdas

### DIFF
--- a/ci/terraform/aws/auth-code.tf
+++ b/ci/terraform/aws/auth-code.tf
@@ -25,6 +25,8 @@ module "auth-code" {
   subnet_id                 = aws_subnet.authentication.*.id
   lambda_role_arn           = aws_iam_role.lambda_iam_role.arn
   environment     = var.environment
+  logging_endpoint_enabled  = var.logging_endpoint_enabled
+  logging_endpoint_arn      = var.logging_endpoint_arn
 
   depends_on = [
     aws_api_gateway_rest_api.di_authentication_api,

--- a/ci/terraform/aws/authorize.tf
+++ b/ci/terraform/aws/authorize.tf
@@ -27,6 +27,8 @@ module "authorize" {
   security_group_id         = aws_vpc.authentication.default_security_group_id
   subnet_id                 = aws_subnet.authentication.*.id
   lambda_role_arn           = aws_iam_role.lambda_iam_role.arn
+  logging_endpoint_enabled  = var.logging_endpoint_enabled
+  logging_endpoint_arn      = var.logging_endpoint_arn
 
   depends_on = [
     aws_api_gateway_rest_api.di_authentication_api,

--- a/ci/terraform/aws/client-info.tf
+++ b/ci/terraform/aws/client-info.tf
@@ -25,6 +25,8 @@ module "client-info" {
   security_group_id         = aws_vpc.authentication.default_security_group_id
   subnet_id                 = aws_subnet.authentication.*.id
   lambda_role_arn           = aws_iam_role.lambda_iam_role.arn
+  logging_endpoint_enabled  = var.logging_endpoint_enabled
+  logging_endpoint_arn      = var.logging_endpoint_arn
 
   depends_on = [
     aws_api_gateway_rest_api.di_authentication_api,

--- a/ci/terraform/aws/jwks.tf
+++ b/ci/terraform/aws/jwks.tf
@@ -19,6 +19,8 @@ module "jwks" {
   security_group_id         = aws_vpc.authentication.default_security_group_id
   subnet_id                 = aws_subnet.authentication.*.id
   lambda_role_arn           = aws_iam_role.lambda_iam_role.arn
+  logging_endpoint_enabled  = var.logging_endpoint_enabled
+  logging_endpoint_arn      = var.logging_endpoint_arn
 
   depends_on = [
     aws_api_gateway_rest_api.di_authentication_api,

--- a/ci/terraform/aws/login.tf
+++ b/ci/terraform/aws/login.tf
@@ -24,4 +24,6 @@ module "login" {
   subnet_id                 = aws_subnet.authentication.*.id
   environment               = var.environment
   lambda_role_arn           = aws_iam_role.lambda_iam_role.arn
+  logging_endpoint_enabled  = var.logging_endpoint_enabled
+  logging_endpoint_arn      = var.logging_endpoint_arn
 }

--- a/ci/terraform/aws/logout.tf
+++ b/ci/terraform/aws/logout.tf
@@ -26,6 +26,8 @@ module "logout" {
   security_group_id         = aws_vpc.authentication.default_security_group_id
   subnet_id                 = aws_subnet.authentication.*.id
   lambda_role_arn           = aws_iam_role.lambda_iam_role.arn
+  logging_endpoint_enabled  = var.logging_endpoint_enabled
+  logging_endpoint_arn      = var.logging_endpoint_arn
 
   depends_on = [
     aws_api_gateway_rest_api.di_authentication_api,

--- a/ci/terraform/aws/mfa.tf
+++ b/ci/terraform/aws/mfa.tf
@@ -25,6 +25,8 @@ module "mfa" {
   security_group_id         = aws_vpc.authentication.default_security_group_id
   subnet_id                 = aws_subnet.authentication.*.id
   lambda_role_arn           = aws_iam_role.dynamo_sqs_lambda_iam_role.arn
+  logging_endpoint_enabled  = var.logging_endpoint_enabled
+  logging_endpoint_arn      = var.logging_endpoint_arn
 
   depends_on = [
     aws_api_gateway_rest_api.di_authentication_api,

--- a/ci/terraform/aws/register.tf
+++ b/ci/terraform/aws/register.tf
@@ -21,6 +21,8 @@ module "register" {
   subnet_id                 = aws_subnet.authentication.*.id
   lambda_role_arn           = aws_iam_role.lambda_iam_role.arn
   environment               = var.environment
+  logging_endpoint_enabled  = var.logging_endpoint_enabled
+  logging_endpoint_arn      = var.logging_endpoint_arn
 
   depends_on = [
     aws_api_gateway_rest_api.di_authentication_api,

--- a/ci/terraform/aws/send_notification.tf
+++ b/ci/terraform/aws/send_notification.tf
@@ -23,6 +23,8 @@ module "send_notification" {
   security_group_id         = aws_vpc.authentication.default_security_group_id
   subnet_id                 = aws_subnet.authentication.*.id
   lambda_role_arn           = aws_iam_role.sqs_lambda_iam_role.arn
+  logging_endpoint_enabled  = var.logging_endpoint_enabled
+  logging_endpoint_arn      = var.logging_endpoint_arn
 
   depends_on = [
     aws_api_gateway_rest_api.di_authentication_api,

--- a/ci/terraform/aws/signup.tf
+++ b/ci/terraform/aws/signup.tf
@@ -25,6 +25,8 @@ module "signup" {
   security_group_id         = aws_vpc.authentication.default_security_group_id
   subnet_id                 = aws_subnet.authentication.*.id
   lambda_role_arn           = aws_iam_role.lambda_iam_role.arn
+  logging_endpoint_enabled  = var.logging_endpoint_enabled
+  logging_endpoint_arn      = var.logging_endpoint_arn
 
   depends_on = [
     aws_api_gateway_rest_api.di_authentication_api,

--- a/ci/terraform/aws/token.tf
+++ b/ci/terraform/aws/token.tf
@@ -25,6 +25,8 @@ module "token" {
   security_group_id         = aws_vpc.authentication.default_security_group_id
   subnet_id                 = aws_subnet.authentication.*.id
   lambda_role_arn           = aws_iam_role.lambda_iam_role.arn
+  logging_endpoint_enabled  = var.logging_endpoint_enabled
+  logging_endpoint_arn      = var.logging_endpoint_arn
 
   depends_on = [
     aws_api_gateway_rest_api.di_authentication_api,

--- a/ci/terraform/aws/update.tf
+++ b/ci/terraform/aws/update.tf
@@ -23,6 +23,8 @@ module "update" {
   subnet_id                 = aws_subnet.authentication.*.id
   lambda_role_arn           = aws_iam_role.lambda_iam_role.arn
   environment               = var.environment
+  logging_endpoint_enabled  = var.logging_endpoint_enabled
+  logging_endpoint_arn      = var.logging_endpoint_arn
 
   depends_on = [
     aws_api_gateway_rest_api.di_authentication_api,

--- a/ci/terraform/aws/update_profile.tf
+++ b/ci/terraform/aws/update_profile.tf
@@ -25,6 +25,8 @@ module "update_profile" {
   security_group_id         = aws_vpc.authentication.default_security_group_id
   subnet_id                 = aws_subnet.authentication.*.id
   lambda_role_arn           = aws_iam_role.lambda_iam_role.arn
+  logging_endpoint_enabled  = var.logging_endpoint_enabled
+  logging_endpoint_arn      = var.logging_endpoint_arn
 
   depends_on = [
     aws_api_gateway_rest_api.di_authentication_api,

--- a/ci/terraform/aws/userexists.tf
+++ b/ci/terraform/aws/userexists.tf
@@ -25,6 +25,8 @@ module "userexists" {
   security_group_id         = aws_vpc.authentication.default_security_group_id
   subnet_id                 = aws_subnet.authentication.*.id
   lambda_role_arn           = aws_iam_role.lambda_iam_role.arn
+  logging_endpoint_enabled  = var.logging_endpoint_enabled
+  logging_endpoint_arn      = var.logging_endpoint_arn
 
   depends_on = [
     aws_api_gateway_rest_api.di_authentication_api,

--- a/ci/terraform/aws/userinfo.tf
+++ b/ci/terraform/aws/userinfo.tf
@@ -25,6 +25,8 @@ module "userinfo" {
   security_group_id         = aws_vpc.authentication.default_security_group_id
   subnet_id                 = aws_subnet.authentication.*.id
   lambda_role_arn           = aws_iam_role.lambda_iam_role.arn
+  logging_endpoint_enabled  = var.logging_endpoint_enabled
+  logging_endpoint_arn      = var.logging_endpoint_arn
 
   depends_on = [
     aws_api_gateway_rest_api.di_authentication_api,

--- a/ci/terraform/aws/variables.tf
+++ b/ci/terraform/aws/variables.tf
@@ -83,3 +83,15 @@ variable "enable_api_gateway_execution_logging" {
   default     = true
   description = "Whether to enable logging of API gateway runs (including capturing of requests/responses)"
 }
+
+variable "logging_endpoint_enabled" {
+  type        = bool
+  default     = false
+  description = "Whether the service should ship its Lambda logs to the `logging_endpoint_arn`"
+}
+
+variable "logging_endpoint_arn" {
+  type        = string
+  default     = ""
+  description = "Amazon Resource Name (ARN) for the endpoint to ship logs to"
+}

--- a/ci/terraform/aws/verify_code.tf
+++ b/ci/terraform/aws/verify_code.tf
@@ -25,6 +25,8 @@ module "verify_code" {
   security_group_id         = aws_vpc.authentication.default_security_group_id
   subnet_id                 = aws_subnet.authentication.*.id
   lambda_role_arn           = aws_iam_role.lambda_iam_role.arn
+  logging_endpoint_enabled  = var.logging_endpoint_enabled
+  logging_endpoint_arn      = var.logging_endpoint_arn
 
   depends_on = [
     aws_api_gateway_rest_api.di_authentication_api,

--- a/ci/terraform/aws/wellknown.tf
+++ b/ci/terraform/aws/wellknown.tf
@@ -19,6 +19,8 @@ module "openid_configuration_discovery" {
   security_group_id         = aws_vpc.authentication.default_security_group_id
   subnet_id                 = aws_subnet.authentication.*.id
   lambda_role_arn           = aws_iam_role.lambda_iam_role.arn
+  logging_endpoint_enabled  = var.logging_endpoint_enabled
+  logging_endpoint_arn      = var.logging_endpoint_arn
 
   depends_on = [
     aws_api_gateway_rest_api.di_authentication_api,

--- a/ci/terraform/modules/endpoint-module/lambda.tf
+++ b/ci/terraform/modules/endpoint-module/lambda.tf
@@ -25,3 +25,11 @@ resource "aws_lambda_function" "endpoint_lambda" {
     environment = var.environment
   }
 }
+
+resource "aws_cloudwatch_log_subscription_filter" "log_subscription" {
+  count           = var.logging_endpoint_enabled ? 1 : 0
+  name            = "${var.endpoint_name}-log-subscription"
+  log_group_name  = "/aws/lambda/${aws_lambda_function.endpoint_lambda.function_name}"
+  filter_pattern  = ""
+  destination_arn = var.logging_endpoint_arn
+}

--- a/ci/terraform/modules/endpoint-module/variables.tf
+++ b/ci/terraform/modules/endpoint-module/variables.tf
@@ -71,3 +71,15 @@ variable "subnet_id" {
 variable "lambda_role_arn" {
   type = string
 }
+
+variable "logging_endpoint_enabled" {
+  type        = bool
+  default     = false
+  description = "Whether the Lambda should ship its logs to the `logging_endpoint_arn`"
+}
+
+variable "logging_endpoint_arn" {
+  type        = string
+  default     = ""
+  description = "Amazon Resource Name (ARN) for the endpoint to ship logs to"
+}


### PR DESCRIPTION
## What?

This PR attaches an optional log group subscription to each lambda, the default is for it to be off.

## Why?

This is part of a set of PRs aimed at creating a one-stop-shop for Authentication logs in an external component.
