### PR TITLE
GOVSI-679: Generate stub client details in Terraform

### DIFF
--- a/ci/terraform/aws/outputs.tf
+++ b/ci/terraform/aws/outputs.tf
@@ -5,3 +5,13 @@ output "base_url" {
 output "api_gateway_root_id" {
   value = aws_api_gateway_rest_api.di_authentication_api.id
 }
+
+output "stub_rp_client_credentials" {
+  value = [for i, rp in var.stub_rp_clients : {
+    client_name = rp.client_name
+    client_id = random_string.stub_rp_client_id[i].result
+    private_key = tls_private_key.stub_rp_client_private_key[i].private_key_pem
+    public_key = tls_private_key.stub_rp_client_private_key[i].public_key_pem
+  }]
+  sensitive = true
+}

--- a/ci/terraform/aws/stub-rp-clients.tf
+++ b/ci/terraform/aws/stub-rp-clients.tf
@@ -1,0 +1,67 @@
+resource "tls_private_key" "stub_rp_client_private_key" {
+  count     = length(var.stub_rp_clients)
+
+  algorithm = "RSA"
+  rsa_bits  = 2048
+}
+
+resource "random_string" "stub_rp_client_id" {
+  count     = length(var.stub_rp_clients)
+
+  lower   = true
+  upper   = true
+  special = false
+  number  = true
+  length = 32
+}
+
+
+resource "aws_dynamodb_table_item" "stub_rp_client" {
+  count     = length(var.stub_rp_clients)
+
+  table_name = aws_dynamodb_table.client_registry_table.name
+  hash_key   = aws_dynamodb_table.client_registry_table.hash_key
+
+  item     = jsonencode({
+    ClientID = {
+      S = random_string.stub_rp_client_id[count.index].result
+    }
+    ClientName = {
+      S = var.stub_rp_clients[count.index].client_name
+    }
+    Contacts = {
+      L = [{
+        S = "contact+${var.stub_rp_clients[count.index].client_name}@example.com"
+      }]
+    }
+    PostLogoutRedirectUrls = {
+      L = [for url in var.stub_rp_clients[count.index].logout_urls: {
+        S = url
+      }]
+    }
+    RedirectUrls = {
+      L = [for url in var.stub_rp_clients[count.index].callback_urls: {
+        S = url
+      }]
+    }
+    Scopes = {
+      L = [
+        {
+          S = "openid"
+        },
+        {
+          S = "phone"
+        },
+        {
+          S = "email"
+        },
+      ]
+    }
+    PublicKey = {
+      S = replace(replace(
+        replace(
+          tls_private_key.stub_rp_client_private_key[count.index].public_key_pem, "-----BEGIN PUBLIC KEY-----", ""),
+              "-----END PUBLIC KEY-----", ""), "\n", "")
+    }
+  })
+}

--- a/ci/terraform/aws/variables.tf
+++ b/ci/terraform/aws/variables.tf
@@ -95,3 +95,9 @@ variable "logging_endpoint_arn" {
   default     = ""
   description = "Amazon Resource Name (ARN) for the endpoint to ship logs to"
 }
+
+variable "stub_rp_clients" {
+  default     = []
+  type        = list(object({client_name: string, callback_urls: list(string), logout_urls: list(string)}))
+  description = "The details of RP clients to provision in the Client table"
+}


### PR DESCRIPTION
## What?

Use Terraform to optionally seed client data into the client registry for the stub RP(s).

By setting the new `stub_rp_clients` variable to something like:
```
stub_rp_clients = [
    {
      client_name = "di-auth-stub-relying-party-build"
      callback_urls = [
        "http://localhost:8081/oidc/authorization-code/callback",
        "https://di-auth-stub-relying-party-build.london.cloudapps.digital/oidc/authorization-code/callback",
      ]
      logout_urls = []
    }
  ]
```
we can generate the key pairs and provision the client into the client registry.

## Why?

To avoid having to manage secrets in SSM or hard-code client IDs in the pipeline.

