### PR TITLE
GOVSI-623 - Use KMS to sign ID tokens 

### DIFF
--- a/ci/terraform/aws/jwks.tf
+++ b/ci/terraform/aws/jwks.tf
@@ -8,6 +8,8 @@ module "jwks" {
 
   handler_environment_variables = {
     BASE_URL = local.api_base_url
+    LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
+    TOKEN_SIGNING_KEY_ID = aws_kms_key.id_token_signing_key.key_id
   }
   handler_function_name = "uk.gov.di.lambdas.JwksHandler::handleRequest"
 

--- a/ci/terraform/aws/kms.tf
+++ b/ci/terraform/aws/kms.tf
@@ -17,10 +17,7 @@ data "aws_iam_policy_document" "kms_policy_document" {
     effect = "Allow"
 
     actions = [
-      "kms:ListKeys",
-      "kms:ListAliases",
       "kms:Sign",
-      "kms:Verify",
       "kms:GetPublicKey",
     ]
     resources = [

--- a/ci/terraform/aws/kms.tf
+++ b/ci/terraform/aws/kms.tf
@@ -1,0 +1,45 @@
+resource "aws_kms_key" "id_token_signing_key" {
+  description             = "KMS signing key for ID tokens"
+  deletion_window_in_days = 30
+  key_usage               = "SIGN_VERIFY"
+  customer_master_key_spec = "ECC_NIST_P256"
+}
+
+resource "aws_kms_alias" "id_token_signing_key_alias" {
+  name          = "alias/id-token-signing-key-alias"
+  target_key_id = aws_kms_key.id_token_signing_key.key_id
+}
+
+data "aws_iam_policy_document" "kms_policy_document" {
+  count = var.use_localstack ? 0 : 1
+  statement {
+    sid    = "AllowAccessToKmsSigningKey"
+    effect = "Allow"
+
+    actions = [
+      "kms:ListKeys",
+      "kms:ListAliases",
+      "kms:Sign",
+      "kms:Verify",
+      "kms:GetPublicKey",
+    ]
+    resources = [
+      aws_kms_key.id_token_signing_key.arn,
+    ]
+  }
+}
+
+resource "aws_iam_policy" "lambda_kms_policy" {
+  count = var.use_localstack ? 0 : 1
+  name        = "${var.environment}-standard-lambda-kms-policy"
+  path        = "/"
+  description = "IAM policy for managing KMS connection for a lambda"
+
+  policy = data.aws_iam_policy_document.kms_policy_document[0].json
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_kms" {
+  count = var.use_localstack ? 0 : 1
+  role       = aws_iam_role.lambda_iam_role.name
+  policy_arn = aws_iam_policy.lambda_kms_policy[0].arn
+}

--- a/ci/terraform/aws/kms.tf
+++ b/ci/terraform/aws/kms.tf
@@ -6,7 +6,7 @@ resource "aws_kms_key" "id_token_signing_key" {
 }
 
 resource "aws_kms_alias" "id_token_signing_key_alias" {
-  name          = "alias/id-token-signing-key-alias"
+  name          = "alias/${var.environment}-id-token-signing-key-alias"
   target_key_id = aws_kms_key.id_token_signing_key.key_id
 }
 

--- a/ci/terraform/aws/site.tf
+++ b/ci/terraform/aws/site.tf
@@ -44,6 +44,7 @@ provider "aws" {
     sqs         = var.aws_endpoint
     sts         = var.aws_endpoint
     elasticache = var.aws_endpoint
+    kms         = var.aws_endpoint
     dynamodb    = var.aws_dynamodb_endpoint
   }
 }

--- a/ci/terraform/aws/token.tf
+++ b/ci/terraform/aws/token.tf
@@ -7,13 +7,15 @@ module "token" {
   environment     = var.environment
 
   handler_environment_variables = {
-    ENVIRONMENT = var.environment
-    BASE_URL = "${local.api_base_url}/token"
-    DYNAMO_ENDPOINT = var.use_localstack ? var.lambda_dynamo_endpoint : null
-    REDIS_HOST     = var.use_localstack ? var.external_redis_host : aws_elasticache_replication_group.sessions_store[0].primary_endpoint_address
-    REDIS_PORT     = var.use_localstack ? var.external_redis_port : aws_elasticache_replication_group.sessions_store[0].port
-    REDIS_PASSWORD = var.use_localstack ? var.external_redis_password : random_password.redis_password.result
-    REDIS_TLS      = var.redis_use_tls
+    ENVIRONMENT      = var.environment
+    BASE_URL         = "${local.api_base_url}/token"
+    DYNAMO_ENDPOINT  = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    REDIS_HOST       = var.use_localstack ? var.external_redis_host : aws_elasticache_replication_group.sessions_store[0].primary_endpoint_address
+    REDIS_PORT       = var.use_localstack ? var.external_redis_port : aws_elasticache_replication_group.sessions_store[0].port
+    REDIS_PASSWORD   = var.use_localstack ? var.external_redis_password : random_password.redis_password.result
+    REDIS_TLS        = var.redis_use_tls
+    TOKEN_SIGNING_KEY_ID = aws_kms_key.id_token_signing_key.key_id
+    LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
   }
   handler_function_name = "uk.gov.di.lambdas.TokenHandler::handleRequest"
 

--- a/ci/terraform/aws/variables.tf
+++ b/ci/terraform/aws/variables.tf
@@ -70,6 +70,12 @@ variable "external_redis_password" {
   default = null
 }
 
+variable "localstack_endpoint" {
+  type    = string
+  default = "http://localhost:45678/"
+}
+
+
 variable "redis_use_tls" {
   type    = string
   default = "true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: docker
       dockerfile: localstack.Dockerfile
     environment:
-      SERVICES: lambda, apigateway, iam, ec2, sqs, s3, sts
+      SERVICES: lambda, apigateway, iam, ec2, sqs, s3, sts, kms
       EDGE_PORT: "45678"
       EXTERNAL_HOSTNAME: ${AWS_HOSTNAME:-localhost}
       DEFAULT_REGION: eu-west-2

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/JwksIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/JwksIntegrationTest.java
@@ -1,0 +1,27 @@
+package uk.gov.di.authentication.api;
+
+import com.nimbusds.jose.jwk.JWKSet;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+
+import java.text.ParseException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class JwksIntegrationTest extends IntegrationTestEndpoints {
+
+    private static final String JWKS_ENDPOINT = "/.well-known/jwks.json";
+
+    @Test
+    public void shouldReturn200AndClientInfoResponseForValidClient() throws ParseException {
+        Client client = ClientBuilder.newClient();
+        Response response = client.target(ROOT_RESOURCE_URL + JWKS_ENDPOINT).request().get();
+
+        assertEquals(200, response.getStatus());
+        String responseString = response.readEntity(String.class);
+        assertTrue(JWKSet.parse(responseString).getKeys().size() == 1);
+    }
+}

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
@@ -20,7 +20,7 @@ import org.glassfish.jersey.client.ClientProperties;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.helpers.DynamoHelper;
 import uk.gov.di.authentication.helpers.RedisHelper;
-import uk.gov.di.helpers.TokenGenerator;
+import uk.gov.di.authentication.helpers.TokenGeneratorHelper;
 
 import java.io.IOException;
 import java.net.HttpCookie;
@@ -43,7 +43,7 @@ public class LogoutIntegrationTest extends IntegrationTestEndpoints {
         RSAKey signingKey =
                 new RSAKeyGenerator(2048).keyID(UUID.randomUUID().toString()).generate();
         SignedJWT signedJWT =
-                TokenGenerator.generateIDToken(
+                TokenGeneratorHelper.generateIDToken(
                         "client-id", new Subject(), "http://localhost/issuer", signingKey);
         RedisHelper.createSession(sessionId);
         RedisHelper.addAuthRequestToSession(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
@@ -15,7 +15,7 @@ import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.helpers.DynamoHelper;
 import uk.gov.di.authentication.helpers.RedisHelper;
-import uk.gov.di.helpers.TokenGenerator;
+import uk.gov.di.authentication.helpers.TokenGeneratorHelper;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -43,7 +43,7 @@ public class UserInfoIntegrationTest extends IntegrationTestEndpoints {
         scopes.add("phone");
         scopes.add("oidc");
         SignedJWT signedAccessToken =
-                TokenGenerator.generateAccessToken(
+                TokenGeneratorHelper.generateAccessToken(
                         "client-id-one", "issuer-id", scopes, signingKey);
         AccessToken accessToken = new BearerAccessToken(signedAccessToken.serialize());
         Subject subject = new Subject();

--- a/integration-tests/src/test/java/uk/gov/di/authentication/helpers/TokenGeneratorHelper.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/helpers/TokenGeneratorHelper.java
@@ -1,0 +1,82 @@
+package uk.gov.di.authentication.helpers;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.oauth2.sdk.id.Audience;
+import com.nimbusds.oauth2.sdk.id.Issuer;
+import com.nimbusds.oauth2.sdk.id.Subject;
+import com.nimbusds.openid.connect.sdk.claims.IDTokenClaimsSet;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+public class TokenGeneratorHelper {
+
+    public static SignedJWT generateIDToken(
+            String clientId, Subject subject, String issuerUrl, RSAKey signingKey) {
+        LocalDateTime localDateTime = LocalDateTime.now().plusMinutes(2);
+        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant());
+        IDTokenClaimsSet idTokenClaims =
+                new IDTokenClaimsSet(
+                        new Issuer(issuerUrl),
+                        subject,
+                        List.of(new Audience(clientId)),
+                        expiryDate,
+                        new Date());
+        JWSHeader jwsHeader =
+                new JWSHeader.Builder(JWSAlgorithm.RS512).keyID(signingKey.getKeyID()).build();
+        SignedJWT idToken;
+
+        try {
+            RSASSASigner signer = new RSASSASigner(signingKey);
+            idToken = new SignedJWT(jwsHeader, idTokenClaims.toJWTClaimsSet());
+            idToken.sign(signer);
+        } catch (JOSEException | ParseException e) {
+            throw new RuntimeException(e);
+        }
+        return idToken;
+    }
+
+    public static SignedJWT generateAccessToken(
+            String clientId, String issuerUrl, List<String> scopes, RSAKey signingKey) {
+
+        LocalDateTime localDateTime = LocalDateTime.now().plusMinutes(2);
+        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant());
+
+        JWTClaimsSet claimsSet =
+                new JWTClaimsSet.Builder()
+                        .claim("scope", scopes)
+                        .issuer(issuerUrl)
+                        .expirationTime(expiryDate)
+                        .issueTime(
+                                Date.from(
+                                        LocalDateTime.now()
+                                                .atZone(ZoneId.systemDefault())
+                                                .toInstant()))
+                        .claim("client_id", clientId)
+                        .jwtID(UUID.randomUUID().toString())
+                        .build();
+
+        JWSHeader jwsHeader =
+                new JWSHeader.Builder(JWSAlgorithm.RS512).keyID(signingKey.getKeyID()).build();
+        SignedJWT signedJWT;
+
+        try {
+            RSASSASigner signer = new RSASSASigner(signingKey);
+            signedJWT = new SignedJWT(jwsHeader, claimsSet);
+            signedJWT.sign(signer);
+        } catch (JOSEException e) {
+            throw new RuntimeException(e);
+        }
+        return signedJWT;
+    }
+}

--- a/serverless/lambda/build.gradle
+++ b/serverless/lambda/build.gradle
@@ -26,7 +26,7 @@ dependencies {
             "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${dependencyVersions.jackson_version}",
             "io.lettuce:lettuce-core:6.1.4.RELEASE",
             "uk.gov.service.notify:notifications-java-client:3.17.2-RELEASE",
-            "org.bouncycastle:bcprov-jdk15on:1.69",
+            "org.bouncycastle:bcpkix-jdk15on:1.68",
             "com.googlecode.libphonenumber:libphonenumber:8.12.28",
             project(":shared")
 

--- a/serverless/lambda/src/main/java/uk/gov/di/helpers/StateMachine.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/helpers/StateMachine.java
@@ -83,9 +83,7 @@ public class StateMachine<T> {
                         entry(
                                 VERIFY_PHONE_NUMBER_CODE_SENT,
                                 List.of(PHONE_NUMBER_CODE_VERIFIED, PHONE_NUMBER_CODE_NOT_VALID)),
-                        entry(
-                                PHONE_NUMBER_CODE_VERIFIED,
-                                List.of(AUTHENTICATED)),
+                        entry(PHONE_NUMBER_CODE_VERIFIED, List.of(AUTHENTICATED)),
                         entry(
                                 PHONE_NUMBER_CODE_NOT_VALID,
                                 List.of(

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/JwksHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/JwksHandler.java
@@ -7,6 +7,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import com.nimbusds.jose.jwk.JWKSet;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.services.RedisConnectionService;
+import uk.gov.di.services.TokenGeneratorService;
 import uk.gov.di.services.TokenService;
 
 import static uk.gov.di.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
@@ -26,7 +27,9 @@ public class JwksHandler
         this.configurationService = new ConfigurationService();
         this.tokenService =
                 new TokenService(
-                        configurationService, new RedisConnectionService(configurationService));
+                        configurationService,
+                        new RedisConnectionService(configurationService),
+                        new TokenGeneratorService(configurationService));
     }
 
     @Override

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/TokenHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/TokenHandler.java
@@ -23,6 +23,7 @@ import uk.gov.di.services.ClientSessionService;
 import uk.gov.di.services.DynamoClientService;
 import uk.gov.di.services.DynamoService;
 import uk.gov.di.services.RedisConnectionService;
+import uk.gov.di.services.TokenGeneratorService;
 import uk.gov.di.services.TokenService;
 
 import java.util.Map;
@@ -69,7 +70,9 @@ public class TokenHandler
                         configurationService.getDynamoEndpointUri());
         tokenService =
                 new TokenService(
-                        configurationService, new RedisConnectionService(configurationService));
+                        configurationService,
+                        new RedisConnectionService(configurationService),
+                        new TokenGeneratorService(configurationService));
         this.authenticationService =
                 new DynamoService(
                         configurationService.getAwsRegion(),

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/UserInfoHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/UserInfoHandler.java
@@ -17,6 +17,7 @@ import uk.gov.di.entity.UserProfile;
 import uk.gov.di.services.AuthenticationService;
 import uk.gov.di.services.DynamoService;
 import uk.gov.di.services.RedisConnectionService;
+import uk.gov.di.services.TokenGeneratorService;
 import uk.gov.di.services.TokenService;
 
 import java.text.ParseException;
@@ -50,7 +51,9 @@ public class UserInfoHandler
         configurationService = new ConfigurationService();
         tokenService =
                 new TokenService(
-                        configurationService, new RedisConnectionService(configurationService));
+                        configurationService,
+                        new RedisConnectionService(configurationService),
+                        new TokenGeneratorService(configurationService));
         authenticationService =
                 new DynamoService(
                         configurationService.getAwsRegion(),

--- a/serverless/lambda/src/main/java/uk/gov/di/services/TokenGeneratorService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/TokenGeneratorService.java
@@ -1,0 +1,137 @@
+package uk.gov.di.services;
+
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.kms.AWSKMS;
+import com.amazonaws.services.kms.AWSKMSClientBuilder;
+import com.amazonaws.services.kms.model.MessageType;
+import com.amazonaws.services.kms.model.SignRequest;
+import com.amazonaws.services.kms.model.SignResult;
+import com.amazonaws.services.kms.model.SigningAlgorithmSpec;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.util.Base64URL;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.id.Audience;
+import com.nimbusds.oauth2.sdk.id.Issuer;
+import com.nimbusds.oauth2.sdk.id.Subject;
+import com.nimbusds.openid.connect.sdk.claims.IDTokenClaimsSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+import java.nio.ByteBuffer;
+import java.text.ParseException;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+public class TokenGeneratorService {
+
+    private final AWSKMS kmsClient;
+    private final String keyId;
+    private static final Logger LOGGER = LoggerFactory.getLogger(TokenGeneratorService.class);
+
+    public TokenGeneratorService(ConfigurationService configurationService) {
+        if (configurationService.getLocalstackEndpointUri().isPresent()) {
+            LOGGER.info(
+                    "Localstack endpoint URI is present: "
+                            + configurationService.getLocalstackEndpointUri().get());
+            this.kmsClient =
+                    AWSKMSClientBuilder.standard()
+                            .withEndpointConfiguration(
+                                    new AwsClientBuilder.EndpointConfiguration(
+                                            configurationService.getLocalstackEndpointUri().get(),
+                                            configurationService.getAwsRegion()))
+                            .build();
+        } else {
+            this.kmsClient =
+                    AWSKMSClientBuilder.standard()
+                            .withRegion(configurationService.getAwsRegion())
+                            .build();
+        }
+        this.keyId = configurationService.getTokenSigningKeyId();
+    }
+
+    public SignedJWT generateSignedIdToken(String clientId, Subject subject, String issuerUrl) {
+        LocalDateTime localDateTime = LocalDateTime.now().plusMinutes(2);
+        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant());
+        IDTokenClaimsSet idTokenClaims =
+                new IDTokenClaimsSet(
+                        new Issuer(issuerUrl),
+                        subject,
+                        List.of(new Audience(clientId)),
+                        expiryDate,
+                        new Date());
+        JWSHeader jwsHeader = generateJWSHeader();
+
+        try {
+            Base64URL encodedHeader = jwsHeader.toBase64URL();
+            Base64URL encodedClaims = Base64URL.encode(idTokenClaims.toJWTClaimsSet().toString());
+            String message = encodedHeader + "." + encodedClaims;
+            ByteBuffer messageToSign = ByteBuffer.wrap(message.getBytes());
+            SignResult signResult = sign(messageToSign);
+            LOGGER.info("ID token has been signed successfully");
+            String signature = Base64URL.encode(signResult.getSignature().toString()).toString();
+            return SignedJWT.parse(message + "." + signature);
+        } catch (ParseException | com.nimbusds.oauth2.sdk.ParseException e) {
+            LOGGER.error("Exception thrown when trying to parse SignedJWT or JWTClaimSet", e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    public SignedJWT generateSignedAccessToken(
+            String clientId, String issuerUrl, List<String> scopes) {
+        LocalDateTime localDateTime = LocalDateTime.now().plusMinutes(2);
+        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant());
+
+        JWTClaimsSet claimsSet =
+                new JWTClaimsSet.Builder()
+                        .claim("scope", scopes)
+                        .issuer(issuerUrl)
+                        .expirationTime(expiryDate)
+                        .issueTime(
+                                Date.from(
+                                        LocalDateTime.now()
+                                                .atZone(ZoneId.systemDefault())
+                                                .toInstant()))
+                        .claim("client_id", clientId)
+                        .jwtID(UUID.randomUUID().toString())
+                        .build();
+        JWSHeader jwsHeader = generateJWSHeader();
+        try {
+            Base64URL encodedHeader = jwsHeader.toBase64URL();
+            Base64URL encodedClaims = Base64URL.encode(claimsSet.toString());
+            String message = encodedHeader + "." + encodedClaims;
+            ByteBuffer messageToSign = ByteBuffer.wrap(message.getBytes());
+            SignResult signResult = sign(messageToSign);
+            LOGGER.info("Access token has been signed successfully");
+            String signature = Base64URL.encode(signResult.getSignature().toString()).toString();
+            return SignedJWT.parse(message + "." + signature);
+        } catch (ParseException e) {
+            LOGGER.error("Exception thrown when trying to parse SignedJWT or JWTClaimSet", e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    private SignResult sign(ByteBuffer message) {
+        SignRequest signRequest = new SignRequest();
+        signRequest.setSigningAlgorithm(SigningAlgorithmSpec.ECDSA_SHA_256.toString());
+        signRequest.setKeyId(keyId);
+        signRequest.setMessage(message);
+        signRequest.setMessageType(MessageType.RAW.toString());
+        try {
+            LOGGER.info("Signing message with KMS");
+            return kmsClient.sign(signRequest);
+        } catch (Exception e) {
+            LOGGER.error("Exception thrown when attempting to sign with KMS", e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    private JWSHeader generateJWSHeader() {
+        return new JWSHeader.Builder(JWSAlgorithm.ES256).keyID(keyId).build();
+    }
+}

--- a/serverless/lambda/src/main/java/uk/gov/di/services/TokenService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/TokenService.java
@@ -94,7 +94,7 @@ public class TokenService {
     }
 
     public JWK getSigningKey() {
-        return signingKey;
+        return tokenGeneratorService.getPublicKey();
     }
 
     public Optional<ErrorObject> validateTokenRequestParams(String tokenRequestBody) {

--- a/serverless/lambda/src/main/java/uk/gov/di/services/TokenService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/TokenService.java
@@ -26,7 +26,6 @@ import com.nimbusds.openid.connect.sdk.token.OIDCTokens;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
-import uk.gov.di.helpers.TokenGenerator;
 
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
@@ -47,10 +46,13 @@ public class TokenService {
     private final RSAKey signingKey;
     private final ConfigurationService configService;
     private final RedisConnectionService redisConnectionService;
+    private final TokenGeneratorService tokenGeneratorService;
     private static final Logger LOG = LoggerFactory.getLogger(TokenService.class);
 
     public TokenService(
-            ConfigurationService configService, RedisConnectionService redisConnectionService) {
+            ConfigurationService configService,
+            RedisConnectionService redisConnectionService,
+            TokenGeneratorService tokenGeneratorService) {
         this.configService = configService;
         this.redisConnectionService = redisConnectionService;
         try {
@@ -58,6 +60,7 @@ public class TokenService {
         } catch (JOSEException e) {
             throw new RuntimeException(e);
         }
+        this.tokenGeneratorService = tokenGeneratorService;
     }
 
     public OIDCTokenResponse generateTokenResponse(
@@ -68,15 +71,15 @@ public class TokenService {
     }
 
     private SignedJWT generateIDToken(String clientId, Subject subject) {
-        return TokenGenerator.generateIDToken(
-                clientId, subject, configService.getBaseURL().get(), signingKey);
+        return tokenGeneratorService.generateSignedIdToken(
+                clientId, subject, configService.getBaseURL().get());
     }
 
     private AccessToken generateAndStoreAccessToken(
             String clientId, Subject subject, List<String> scopes) {
         SignedJWT signedJWT =
-                TokenGenerator.generateAccessToken(
-                        clientId, configService.getBaseURL().get(), scopes, signingKey);
+                tokenGeneratorService.generateSignedAccessToken(
+                        clientId, configService.getBaseURL().get(), scopes);
         AccessToken accessToken = new BearerAccessToken(signedJWT.serialize());
 
         redisConnectionService.saveWithExpiry(

--- a/serverless/lambda/src/test/java/uk/gov/di/helpers/TokenGeneratorHelper.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/helpers/TokenGeneratorHelper.java
@@ -19,7 +19,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
-public class TokenGenerator {
+public class TokenGeneratorHelper {
 
     public static SignedJWT generateIDToken(
             String clientId, Subject subject, String issuerUrl, RSAKey signingKey) {

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/LogoutHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/LogoutHandlerTest.java
@@ -17,7 +17,7 @@ import uk.gov.di.entity.ClientRegistry;
 import uk.gov.di.entity.ClientSession;
 import uk.gov.di.entity.ResponseHeaders;
 import uk.gov.di.entity.Session;
-import uk.gov.di.helpers.TokenGenerator;
+import uk.gov.di.helpers.TokenGeneratorHelper;
 import uk.gov.di.services.ClientSessionService;
 import uk.gov.di.services.DynamoClientService;
 import uk.gov.di.services.SessionService;
@@ -73,7 +73,7 @@ class LogoutHandlerTest {
         RSAKey signingKey =
                 new RSAKeyGenerator(2048).keyID(UUID.randomUUID().toString()).generate();
         signedIDToken =
-                TokenGenerator.generateIDToken(
+                TokenGeneratorHelper.generateIDToken(
                         "client-id", new Subject(), "http://localhost-rp", signingKey);
     }
 
@@ -196,7 +196,7 @@ class LogoutHandlerTest {
         RSAKey signingKey =
                 new RSAKeyGenerator(2048).keyID(UUID.randomUUID().toString()).generate();
         SignedJWT signedJWT =
-                TokenGenerator.generateIDToken(
+                TokenGeneratorHelper.generateIDToken(
                         "invalid-client-id", new Subject(), "http://localhost-rp", signingKey);
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setHeaders(Map.of(COOKIE, buildCookieString(CLIENT_SESSION_ID)));

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/TokenHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/TokenHandlerTest.java
@@ -57,7 +57,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.helpers.TokenGenerator.generateIDToken;
+import static uk.gov.di.helpers.TokenGeneratorHelper.generateIDToken;
 import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
 import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/UserInfoHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/UserInfoHandlerTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.entity.UserProfile;
-import uk.gov.di.helpers.TokenGenerator;
+import uk.gov.di.helpers.TokenGeneratorHelper;
 import uk.gov.di.services.AuthenticationService;
 import uk.gov.di.services.TokenService;
 
@@ -66,7 +66,8 @@ public class UserInfoHandlerTest {
         scopes.add("email");
         scopes.add("phone");
         SignedJWT signedAccessToken =
-                TokenGenerator.generateAccessToken("client-id", "issuer-url", scopes, signingKey);
+                TokenGeneratorHelper.generateAccessToken(
+                        "client-id", "issuer-url", scopes, signingKey);
         AccessToken accessToken = new BearerAccessToken(signedAccessToken.serialize());
         UserProfile userProfile =
                 new UserProfile()

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -81,12 +81,20 @@ public class ConfigurationService {
         return Optional.ofNullable(System.getenv("SQS_ENDPOINT"));
     }
 
+    public Optional<String> getLocalstackEndpointUri() {
+        return Optional.ofNullable(System.getenv("LOCALSTACK_ENDPOINT"));
+    }
+
     public Optional<String> getDynamoEndpointUri() {
         return Optional.ofNullable(System.getenv("DYNAMO_ENDPOINT"));
     }
 
     public String getDomainName() {
         return System.getenv("DOMAIN_NAME");
+    }
+
+    public String getTokenSigningKeyId() {
+        return System.getenv("TOKEN_SIGNING_KEY_ID");
     }
 
     public int getCodeMaxRetries() {


### PR DESCRIPTION
## What?

- Add terraform to generate KMS signing key for ID tokens
-  Sign ID tokens and access tokens using KMS
- Retrieve Public Key from KMS

## Why?

- We were previously using a signing key generated on the fly. Switch to using a signing key provided by KMS.
- So clients can verify the signing of the ID tokens using the JWKS lambda 


## Further work to do 
- Split out the permissions of signing and getting the public key into separate roles so that only the Lambdas who need to sign have permission to do so 
- Add some unit tests for the new service