### PR TITLE
GOVSI-623 - Fix BaseURL for Token endpoint

### DIFF
--- a/ci/terraform/aws/token.tf
+++ b/ci/terraform/aws/token.tf
@@ -8,7 +8,7 @@ module "token" {
 
   handler_environment_variables = {
     ENVIRONMENT      = var.environment
-    BASE_URL         = "${local.api_base_url}/token"
+    BASE_URL         = local.api_base_url
     DYNAMO_ENDPOINT  = var.use_localstack ? var.lambda_dynamo_endpoint : null
     REDIS_HOST       = var.use_localstack ? var.external_redis_host : aws_elasticache_replication_group.sessions_store[0].primary_endpoint_address
     REDIS_PORT       = var.use_localstack ? var.external_redis_port : aws_elasticache_replication_group.sessions_store[0].port

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/TokenHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/TokenHandler.java
@@ -45,6 +45,7 @@ public class TokenHandler
     private final ConfigurationService configurationService;
     private final AuthorisationCodeService authorisationCodeService;
     private final ClientSessionService clientSessionService;
+    private static final String TOKEN_PATH = "/token";
 
     public TokenHandler(
             ClientService clientService,
@@ -103,12 +104,11 @@ public class TokenHandler
             return generateApiGatewayProxyResponse(
                     400, OAuth2Error.INVALID_CLIENT.toJSONObject().toJSONString());
         }
-
+        String baseUrl = configurationService.getBaseURL().orElseThrow();
+        String tokenUrl = baseUrl + TOKEN_PATH;
         Optional<ErrorObject> invalidPrivateKeyJwtError =
                 tokenService.validatePrivateKeyJWT(
-                        input.getBody(),
-                        client.getPublicKey(),
-                        configurationService.getBaseURL().orElseThrow());
+                        input.getBody(), client.getPublicKey(), tokenUrl);
         if (invalidPrivateKeyJwtError.isPresent()) {
             LOG.error("Private Key JWT is not valid for Client ID {}", clientID);
             return generateApiGatewayProxyResponse(

--- a/serverless/lambda/src/main/java/uk/gov/di/services/TokenService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/TokenService.java
@@ -129,7 +129,7 @@ public class TokenService {
     }
 
     public Optional<ErrorObject> validatePrivateKeyJWT(
-            String requestString, String publicKey, String baseUrl) {
+            String requestString, String publicKey, String tokenUrl) {
         PrivateKeyJWT privateKeyJWT;
         try {
             privateKeyJWT = PrivateKeyJWT.parse(requestString);
@@ -140,7 +140,7 @@ public class TokenService {
         ClientAuthenticationVerifier<?> authenticationVerifier =
                 new ClientAuthenticationVerifier<>(
                         generateClientCredentialsSelector(publicKey),
-                        Collections.singleton(new Audience(baseUrl)));
+                        Collections.singleton(new Audience(tokenUrl)));
         try {
             authenticationVerifier.verify(privateKeyJWT, null, null);
         } catch (InvalidClientException | JOSEException e) {

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/TokenHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/TokenHandlerTest.java
@@ -68,7 +68,8 @@ public class TokenHandlerTest {
     private static final Subject TEST_SUBJECT = new Subject();
     private static final String CLIENT_ID = "test-id";
     private static final List<String> SCOPES = List.of("openid");
-    private static final String ENDPOINT_URI = "http://localhost/token";
+    private static final String BASE_URI = "http://localhost";
+    private static final String TOKEN_URI = "http://localhost/token";
     public static final String CLIENT_SESSION_ID = "a-client-session-id";
     private final Context context = mock(Context.class);
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
@@ -82,7 +83,7 @@ public class TokenHandlerTest {
 
     @BeforeEach
     public void setUp() {
-        when(configurationService.getBaseURL()).thenReturn(Optional.of(ENDPOINT_URI));
+        when(configurationService.getBaseURL()).thenReturn(Optional.of(BASE_URI));
         handler =
                 new TokenHandler(
                         clientService,
@@ -111,7 +112,7 @@ public class TokenHandlerTest {
         when(tokenService.validateTokenRequestParams(anyString())).thenReturn(Optional.empty());
         when(clientService.getClient(eq(CLIENT_ID))).thenReturn(Optional.of(clientRegistry));
         when(tokenService.validatePrivateKeyJWT(
-                        anyString(), eq(clientRegistry.getPublicKey()), eq(ENDPOINT_URI)))
+                        anyString(), eq(clientRegistry.getPublicKey()), eq(BASE_URI)))
                 .thenReturn(Optional.empty());
         String authCode = new AuthorizationCode().toString();
         when(authorisationCodeService.getExchangeDataForCode(authCode))
@@ -168,10 +169,9 @@ public class TokenHandlerTest {
         KeyPair keyPairTwo = generateRsaKeyPair();
         ClientRegistry clientRegistry = generateClientRegistry(keyPairTwo);
         PrivateKeyJWT privateKeyJWT = generatePrivateKeyJWT(keyPairOne.getPrivate());
-        when(clientService.getClient(eq(CLIENT_ID))).thenReturn(Optional.empty());
         when(clientService.getClient(eq(CLIENT_ID))).thenReturn(Optional.of(clientRegistry));
         when(tokenService.validatePrivateKeyJWT(
-                        anyString(), eq(clientRegistry.getPublicKey()), eq(ENDPOINT_URI)))
+                        anyString(), eq(clientRegistry.getPublicKey()), eq(TOKEN_URI)))
                 .thenReturn(Optional.of(OAuth2Error.INVALID_CLIENT));
 
         APIGatewayProxyResponseEvent result =
@@ -190,7 +190,7 @@ public class TokenHandlerTest {
         when(tokenService.validateTokenRequestParams(anyString())).thenReturn(Optional.empty());
         when(clientService.getClient(eq(CLIENT_ID))).thenReturn(Optional.of(clientRegistry));
         when(tokenService.validatePrivateKeyJWT(
-                        anyString(), eq(clientRegistry.getPublicKey()), eq(ENDPOINT_URI)))
+                        anyString(), eq(clientRegistry.getPublicKey()), eq(BASE_URI)))
                 .thenReturn(Optional.empty());
         String authCode = new AuthorizationCode().toString();
         when(authorisationCodeService.getExchangeDataForCode(authCode))
@@ -211,7 +211,7 @@ public class TokenHandlerTest {
         when(tokenService.validateTokenRequestParams(anyString())).thenReturn(Optional.empty());
         when(clientService.getClient(eq(CLIENT_ID))).thenReturn(Optional.of(clientRegistry));
         when(tokenService.validatePrivateKeyJWT(
-                        anyString(), eq(clientRegistry.getPublicKey()), eq(ENDPOINT_URI)))
+                        anyString(), eq(clientRegistry.getPublicKey()), eq(BASE_URI)))
                 .thenReturn(Optional.empty());
         String authCode = new AuthorizationCode().toString();
         when(authorisationCodeService.getExchangeDataForCode(authCode))
@@ -234,7 +234,7 @@ public class TokenHandlerTest {
     private PrivateKeyJWT generatePrivateKeyJWT(PrivateKey privateKey) throws JOSEException {
         return new PrivateKeyJWT(
                 new ClientID(CLIENT_ID),
-                URI.create(ENDPOINT_URI),
+                URI.create(TOKEN_URI),
                 JWSAlgorithm.RS256,
                 (RSAPrivateKey) privateKey,
                 null,


### PR DESCRIPTION
## What?

- Fix BaseURL for Token endpoint

## Why?


- The issuer of the ID token should just be the baseurl without the token path however the audience of the privatekeyjwt should be the baseurl with the token path
