### PR TITLE
GOVSI-622: Publish Lambda versions

### DIFF
--- a/ci/terraform/aws/sqs.tf
+++ b/ci/terraform/aws/sqs.tf
@@ -126,6 +126,7 @@ resource "aws_lambda_function" "email_sqs_lambda" {
   timeout       = 30
   memory_size   = 512
   runtime       = "java11"
+  publish       = true
 
   source_code_hash = filebase64sha256(var.lambda_zip_file)
   vpc_config {

--- a/ci/terraform/modules/endpoint-module/lambda.tf
+++ b/ci/terraform/modules/endpoint-module/lambda.tf
@@ -5,6 +5,7 @@ resource "aws_lambda_function" "endpoint_lambda" {
   handler       = var.handler_function_name
   timeout       = 30
   memory_size   = 512
+  publish       = true
 
   tracing_config {
     mode = "Active"


### PR DESCRIPTION
## What?

- Ensure we publish lamdba functions to create new versions

## Why?

We cannot provision concurrency on un-versioned lambdas

## Related PRs

#297 