### PR TITLE
GOVSI-623 - Restrict signing permissions to the Token Lambda

### DIFF
--- a/ci/terraform/aws/dynamodb.tf
+++ b/ci/terraform/aws/dynamodb.tf
@@ -113,6 +113,12 @@ resource "aws_iam_role_policy_attachment" "lambda_dynamo" {
   policy_arn = aws_iam_policy.lambda_dynamo_policy[0].arn
 }
 
+resource "aws_iam_role_policy_attachment" "token_lambda_dynamo" {
+  count      = var.use_localstack ? 0 : 1
+  role       = aws_iam_role.token_lambda_iam_role.name
+  policy_arn = aws_iam_policy.lambda_dynamo_policy[0].arn
+}
+
 resource "aws_iam_role_policy_attachment" "lambda_sqs_dynamo" {
   count      = var.use_localstack ? 0 : 1
   role       = aws_iam_role.dynamo_sqs_lambda_iam_role.name

--- a/ci/terraform/aws/lambda-roles.tf
+++ b/ci/terraform/aws/lambda-roles.tf
@@ -151,3 +151,21 @@ resource "aws_iam_role_policy_attachment" "dynamo_sqs_lambda_networking" {
   role       = aws_iam_role.dynamo_sqs_lambda_iam_role.name
   policy_arn = aws_iam_policy.endpoint_networking_policy.arn
 }
+
+resource "aws_iam_role" "token_lambda_iam_role" {
+  name = "${var.environment}-token-lambda-role"
+  assume_role_policy = data.aws_iam_policy_document.lambda_can_assume_policy.json
+  tags = {
+    environment = var.environment
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "token_lambda_logs" {
+  role       = aws_iam_role.token_lambda_iam_role.name
+  policy_arn = aws_iam_policy.endpoint_logging_policy.arn
+}
+
+resource "aws_iam_role_policy_attachment" "token_lambda_networking" {
+  role       = aws_iam_role.token_lambda_iam_role.name
+  policy_arn = aws_iam_policy.endpoint_networking_policy.arn
+}

--- a/ci/terraform/aws/token.tf
+++ b/ci/terraform/aws/token.tf
@@ -26,7 +26,7 @@ module "token" {
   lambda_zip_file           = var.lambda_zip_file
   security_group_id         = aws_vpc.authentication.default_security_group_id
   subnet_id                 = aws_subnet.authentication.*.id
-  lambda_role_arn           = aws_iam_role.lambda_iam_role.arn
+  lambda_role_arn           = aws_iam_role.token_lambda_iam_role.arn
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
 


### PR DESCRIPTION
## What?

- Ensure that the token lambda is the only lambda which has permissions to sign.
- Give all other lambda permissions to retrieve the public key.

## Why?

-  Currently the token lambda is the only lambda which needs to sign so we should ensure are permissions cater for this.
- The public key is not a secret 

