### PR TITLE
GOVSI-680: Make `account_management_client_details` sensitive

### DIFF
--- a/ci/terraform/aws/outputs.tf
+++ b/ci/terraform/aws/outputs.tf
@@ -26,4 +26,5 @@ output "account_management_client_details" {
     KMS_KEY_ID            = aws_kms_key.account_management_jwt_key.id
     KMS_KEY_ALIAS         = aws_kms_alias.account_management_jwt_alias.name
   }
+  sensitive = true
 }


### PR DESCRIPTION
## What?

- Mark the `account_management_client_details` Terraform output as `sensitive` to stop it's values being output in the pipeline

## Why?

This contains sensitive data that is getting output in the pipeline, which is not good. All affected resources are being tainted to generate new values.
