### PR TITLE
GOVSI-712: Create basic auditing component

### DIFF
--- a/serverless/lambda/src/main/java/uk/gov/di/domain/OidcAuditableEvent.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/domain/OidcAuditableEvent.java
@@ -1,0 +1,7 @@
+package uk.gov.di.domain;
+
+import uk.gov.di.authentication.shared.domain.AuditableEvent;
+
+public enum OidcAuditableEvent implements AuditableEvent {
+    AUTHORISATION_REQUEST_RECEIVED
+}

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/AuthorisationHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/AuthorisationHandler.java
@@ -15,7 +15,9 @@ import com.nimbusds.openid.connect.sdk.OIDCError;
 import com.nimbusds.openid.connect.sdk.Prompt;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.domain.OidcAuditableEvent;
 import uk.gov.di.entity.ClientSession;
 import uk.gov.di.entity.ResponseHeaders;
 import uk.gov.di.entity.Session;
@@ -44,16 +46,19 @@ public class AuthorisationHandler
     private final ConfigurationService configurationService;
     private final ClientSessionService clientSessionService;
     private final AuthorizationService authorizationService;
+    private final AuditService auditService;
 
     public AuthorisationHandler(
             ConfigurationService configurationService,
             SessionService sessionService,
             ClientSessionService clientSessionService,
-            AuthorizationService authorizationService) {
+            AuthorizationService authorizationService,
+            AuditService auditService) {
         this.configurationService = configurationService;
         this.sessionService = sessionService;
         this.clientSessionService = clientSessionService;
         this.authorizationService = authorizationService;
+        this.auditService = auditService;
     }
 
     public AuthorisationHandler() {
@@ -61,11 +66,13 @@ public class AuthorisationHandler
         this.sessionService = new SessionService(configurationService);
         this.clientSessionService = new ClientSessionService(configurationService);
         this.authorizationService = new AuthorizationService(configurationService);
+        this.auditService = new AuditService();
     }
 
     @Override
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
+        auditService.submitAuditEvent(OidcAuditableEvent.AUTHORISATION_REQUEST_RECEIVED);
         LOGGER.info("Received authentication request");
 
         Map<String, List<String>> queryStringParameters = getQueryStringParametersAsMap(input);
@@ -98,7 +105,6 @@ public class AuthorisationHandler
             Map<String, List<String>> authRequestParameters,
             Optional<Session> existingSession,
             AuthenticationRequest authenticationRequest) {
-
         if (authenticationRequest.getPrompt() != null) {
             if (authenticationRequest.getPrompt().contains(Prompt.Type.CONSENT)
                     || authenticationRequest.getPrompt().contains(Prompt.Type.SELECT_ACCOUNT)) {

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/AuthorisationHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/AuthorisationHandlerTest.java
@@ -7,9 +7,12 @@ import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import com.nimbusds.openid.connect.sdk.OIDCError;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.domain.OidcAuditableEvent;
 import uk.gov.di.entity.ClientSession;
 import uk.gov.di.entity.ResponseHeaders;
 import uk.gov.di.entity.Session;
@@ -41,6 +44,7 @@ class AuthorisationHandlerTest {
     private final SessionService sessionService = mock(SessionService.class);
     private final ClientSessionService clientSessionService = mock(ClientSessionService.class);
     private final AuthorizationService authorizationService = mock(AuthorizationService.class);
+    private final AuditService auditService = mock(AuditService.class);
 
     private static final String EXPECTED_COOKIE_STRING =
             "gs=a-session-id.client-session-id; Max-Age=1800; Domain=auth.ida.digital.cabinet-office.gov.uk; Secure; HttpOnly;";
@@ -53,7 +57,16 @@ class AuthorisationHandlerTest {
     public void setUp() {
         handler =
                 new AuthorisationHandler(
-                        configService, sessionService, clientSessionService, authorizationService);
+                        configService,
+                        sessionService,
+                        clientSessionService,
+                        authorizationService,
+                        auditService);
+    }
+
+    @AfterEach
+    public void validateAuditRequestReceived() {
+        verify(auditService).submitAuditEvent(OidcAuditableEvent.AUTHORISATION_REQUEST_RECEIVED);
     }
 
     @Test

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -10,6 +10,7 @@ repositories {
 }
 
 dependencies {
+    implementation "org.apache.logging.log4j:log4j-slf4j18-impl:2.13.0"
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/domain/AuditableEvent.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/domain/AuditableEvent.java
@@ -1,0 +1,3 @@
+package uk.gov.di.authentication.shared.domain;
+
+public interface AuditableEvent {}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
@@ -1,0 +1,14 @@
+package uk.gov.di.authentication.shared.services;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.di.authentication.shared.domain.AuditableEvent;
+
+public class AuditService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AuditService.class);
+
+    public void submitAuditEvent(AuditableEvent event) {
+        LOGGER.info("Emitting audit event - " + event);
+    }
+}


### PR DESCRIPTION
## What?

Create basic auditing component and use it to audit the receipt of authorisation requests.

## Why?

Proof of concept for an approach to publishing audit events.