### PR TITLE
GOVSI-623: Convert KMS signature to JWT compatible signature

### DIFF
--- a/serverless/lambda/build.gradle
+++ b/serverless/lambda/build.gradle
@@ -27,6 +27,7 @@ dependencies {
             "io.lettuce:lettuce-core:6.1.4.RELEASE",
             "uk.gov.service.notify:notifications-java-client:3.17.2-RELEASE",
             "org.bouncycastle:bcpkix-jdk15on:1.68",
+            "org.bouncycastle:bcprov-jdk15on:1.69",
             "com.googlecode.libphonenumber:libphonenumber:8.12.28",
             project(":shared")
 


### PR DESCRIPTION
## What?

Convert KMS signature to JWT compatible signature

## Why?

KMS gives a signature in a format that is incompatible with JWT.