### PR TITLE
GOVSI-623 - Add Nonce to ID token when it is included in Auth Request

### DIFF
--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/TokenHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/TokenHandler.java
@@ -26,6 +26,7 @@ import uk.gov.di.services.KmsConnectionService;
 import uk.gov.di.services.RedisConnectionService;
 import uk.gov.di.services.TokenService;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -144,9 +145,16 @@ public class TokenHandler
         }
         Subject subject =
                 authenticationService.getSubjectFromEmail(authCodeExchangeData.getEmail());
+        Map<String, Object> additionalTokenClaims = new HashMap<>();
+        if (authRequest.getNonce() != null) {
+            additionalTokenClaims.put("nonce", authRequest.getNonce());
+        }
         OIDCTokenResponse tokenResponse =
                 tokenService.generateTokenResponse(
-                        clientID, subject, authRequest.getScope().toStringList());
+                        clientID,
+                        subject,
+                        authRequest.getScope().toStringList(),
+                        additionalTokenClaims);
 
         clientSessionService.saveClientSession(
                 authCodeExchangeData.getClientSessionId(),

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/TokenHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/TokenHandlerTest.java
@@ -127,7 +127,8 @@ public class TokenHandlerTest {
                         new ClientSession(
                                 generateAuthRequest().toParameters(), LocalDateTime.now()));
         when(authenticationService.getSubjectFromEmail(eq(TEST_EMAIL))).thenReturn(TEST_SUBJECT);
-        when(tokenService.generateTokenResponse(eq(CLIENT_ID), any(Subject.class), eq(SCOPES)))
+        when(tokenService.generateTokenResponse(
+                        eq(CLIENT_ID), any(Subject.class), eq(SCOPES), eq(Collections.emptyMap())))
                 .thenReturn(tokenResponse);
 
         APIGatewayProxyResponseEvent result = generateApiGatewayRequest(privateKeyJWT, authCode);


### PR DESCRIPTION


## What?

- Add Nonce to ID token when it is included in Auth Request

## Why?

- To be compliant with 3.1.3.7 of the openid connect spec