### PR TITLE
GOVSI-712: Add capability to add context data to audit events

### DIFF
--- a/serverless/lambda/src/main/java/uk/gov/di/domain/OidcAuditableEvent.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/domain/OidcAuditableEvent.java
@@ -3,5 +3,6 @@ package uk.gov.di.domain;
 import uk.gov.di.authentication.shared.domain.AuditableEvent;
 
 public enum OidcAuditableEvent implements AuditableEvent {
+    AUTHORISATION_REQUEST_ERROR,
     AUTHORISATION_REQUEST_RECEIVED
 }

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/AuthorisationHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/AuthorisationHandler.java
@@ -34,6 +34,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static java.lang.String.format;
+import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
 import static uk.gov.di.entity.SessionState.AUTHENTICATED;
 import static uk.gov.di.entity.SessionState.AUTHENTICATION_REQUIRED;
 
@@ -222,6 +223,11 @@ public class AuthorisationHandler
 
     private APIGatewayProxyResponseEvent generateErrorResponse(
             URI redirectUri, State state, ResponseMode responseMode, ErrorObject errorObject) {
+
+        auditService.submitAuditEvent(
+                OidcAuditableEvent.AUTHORISATION_REQUEST_ERROR,
+                pair("description", errorObject.getDescription()));
+
         LOGGER.error(
                 "Returning error response: {} {}",
                 errorObject.getCode(),

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/AuthorisationHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/AuthorisationHandlerTest.java
@@ -7,6 +7,7 @@ import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import com.nimbusds.openid.connect.sdk.OIDCError;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.shared.services.AuditService;
@@ -33,7 +34,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
+import static uk.gov.di.domain.OidcAuditableEvent.AUTHORISATION_REQUEST_ERROR;
 import static uk.gov.di.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 class AuthorisationHandlerTest {
@@ -61,6 +65,11 @@ class AuthorisationHandlerTest {
                         clientSessionService,
                         authorizationService,
                         auditService);
+    }
+
+    @AfterEach
+    public void afterEach() {
+        verifyNoMoreInteractions(auditService);
     }
 
     @Test
@@ -118,6 +127,13 @@ class AuthorisationHandlerTest {
                 "http://localhost:8080?error=invalid_request&error_description=Invalid+request%3A+Missing+response_type+parameter&state="
                         + state,
                 response.getHeaders().get(ResponseHeaders.LOCATION));
+
+        verify(auditService)
+                .submitAuditEvent(
+                        AUTHORISATION_REQUEST_ERROR,
+                        pair(
+                                "description",
+                                "Invalid request: Missing response_type parameter"));
     }
 
     @Test
@@ -138,6 +154,13 @@ class AuthorisationHandlerTest {
         assertEquals(
                 "http://localhost:8080?error=invalid_scope&error_description=Invalid%2C+unknown+or+malformed+scope",
                 response.getHeaders().get(ResponseHeaders.LOCATION));
+
+        verify(auditService)
+                .submitAuditEvent(
+                        AUTHORISATION_REQUEST_ERROR,
+                        pair(
+                                "description",
+                                OAuth2Error.INVALID_SCOPE.getDescription()));
     }
 
     @Test
@@ -196,6 +219,13 @@ class AuthorisationHandlerTest {
         assertThat(
                 getHeaderValueByParamName(response, ResponseHeaders.LOCATION),
                 containsString("error=login_required"));
+
+        verify(auditService)
+                .submitAuditEvent(
+                        AUTHORISATION_REQUEST_ERROR,
+                        pair(
+                                "description",
+                                OIDCError.LOGIN_REQUIRED.getDescription()));
     }
 
     @Test
@@ -275,6 +305,13 @@ class AuthorisationHandlerTest {
         assertEquals(
                 "http://localhost:8080?error=invalid_request&error_description=Invalid+request%3A+Invalid+prompt+parameter%3A+Unknown+prompt+type%3A+unrecognised&state=some-state",
                 response.getHeaders().get(ResponseHeaders.LOCATION));
+
+        verify(auditService)
+                .submitAuditEvent(
+                        AUTHORISATION_REQUEST_ERROR,
+                        pair(
+                                "description",
+                                "Invalid request: Invalid prompt parameter: Unknown prompt type: unrecognised"));
     }
 
     @Test
@@ -287,6 +324,13 @@ class AuthorisationHandlerTest {
         assertEquals(
                 "http://localhost:8080?error=invalid_request&error_description=Invalid+request%3A+Invalid+prompt+parameter%3A+Invalid+prompt%3A+none+login&state=some-state",
                 response.getHeaders().get(ResponseHeaders.LOCATION));
+
+        verify(auditService)
+                .submitAuditEvent(
+                        AUTHORISATION_REQUEST_ERROR,
+                        pair(
+                                "description",
+                                "Invalid request: Invalid prompt parameter: Invalid prompt: none login"));
     }
 
     @Test
@@ -299,6 +343,13 @@ class AuthorisationHandlerTest {
         assertThat(
                 getHeaderValueByParamName(response, ResponseHeaders.LOCATION),
                 containsString(OIDCError.UNMET_AUTHENTICATION_REQUIREMENTS_CODE));
+
+        verify(auditService)
+                .submitAuditEvent(
+                        AUTHORISATION_REQUEST_ERROR,
+                        pair(
+                                "description",
+                                OIDCError.UNMET_AUTHENTICATION_REQUIREMENTS.getDescription()));
     }
 
     @Test
@@ -311,6 +362,13 @@ class AuthorisationHandlerTest {
         assertThat(
                 getHeaderValueByParamName(response, ResponseHeaders.LOCATION),
                 containsString(OIDCError.UNMET_AUTHENTICATION_REQUIREMENTS_CODE));
+
+        verify(auditService)
+                .submitAuditEvent(
+                        AUTHORISATION_REQUEST_ERROR,
+                        pair(
+                                "description",
+                                OIDCError.UNMET_AUTHENTICATION_REQUIREMENTS.getDescription()));
     }
 
     @Test
@@ -323,6 +381,14 @@ class AuthorisationHandlerTest {
         assertThat(
                 getHeaderValueByParamName(response, ResponseHeaders.LOCATION),
                 containsString(OIDCError.UNMET_AUTHENTICATION_REQUIREMENTS_CODE));
+
+
+        verify(auditService)
+                .submitAuditEvent(
+                        AUTHORISATION_REQUEST_ERROR,
+                        pair(
+                                "description",
+                                OIDCError.UNMET_AUTHENTICATION_REQUIREMENTS.getDescription()));
     }
 
     @Test

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
@@ -9,6 +9,10 @@ public class AuditService {
     private static final Logger LOGGER = LoggerFactory.getLogger(AuditService.class);
 
     public void submitAuditEvent(AuditableEvent event) {
-        LOGGER.info("Emitting audit event - " + event);
+        LOGGER.info(generateLogLine(event));
+    }
+
+    String generateLogLine(AuditableEvent event) {
+        return "Emitting audit event - " + event;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
@@ -4,15 +4,62 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.di.authentication.shared.domain.AuditableEvent;
 
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
 public class AuditService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AuditService.class);
 
-    public void submitAuditEvent(AuditableEvent event) {
-        LOGGER.info(generateLogLine(event));
+    public void submitAuditEvent(AuditableEvent event, MetadataPair... metadataPairs) {
+        LOGGER.info(generateLogLine(event, metadataPairs));
     }
 
-    String generateLogLine(AuditableEvent event) {
-        return "Emitting audit event - " + event;
+    String generateLogLine(AuditableEvent event, MetadataPair... metadataPairs) {
+        var baseLogLine = "Emitting audit event - " + event;
+
+        if (metadataPairs.length == 0) {
+            return baseLogLine;
+        }
+
+        var keyValuePairs =
+                Arrays.stream(metadataPairs)
+                        .map(MetadataPair::toString)
+                        .collect(Collectors.joining(", "));
+
+        return baseLogLine + " => " + keyValuePairs;
+    }
+
+    public static class MetadataPair {
+        private final String key;
+        private final Object value;
+
+        private MetadataPair(String key, Object value) {
+            this.key = key;
+            this.value = value;
+        }
+
+        public static MetadataPair pair(String key, Object value) {
+            return new MetadataPair(key, value);
+        }
+
+        @Override
+        public String toString() {
+            return String.format("[%s: %s]", key, value);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            MetadataPair that = (MetadataPair) o;
+            return Objects.equals(key, that.key) && Objects.equals(value, that.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(key, value);
+        }
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
@@ -1,0 +1,23 @@
+package uk.gov.di.authentication.shared.services;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.domain.AuditableEvent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static uk.gov.di.authentication.shared.services.AuditServiceTest.TestEvents.TEST_EVENT_ONE;
+
+class AuditServiceTest {
+
+    enum TestEvents implements AuditableEvent {
+        TEST_EVENT_ONE
+    }
+
+    @Test
+    void shouldLogAuditEvent() {
+        var auditService = new AuditService();
+
+        assertEquals(
+                auditService.generateLogLine(TEST_EVENT_ONE),
+                "Emitting audit event - TEST_EVENT_ONE");
+    }
+}

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.shared.domain.AuditableEvent;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
 import static uk.gov.di.authentication.shared.services.AuditServiceTest.TestEvents.TEST_EVENT_ONE;
 
 class AuditServiceTest {
@@ -19,5 +20,15 @@ class AuditServiceTest {
         assertEquals(
                 auditService.generateLogLine(TEST_EVENT_ONE),
                 "Emitting audit event - TEST_EVENT_ONE");
+    }
+
+    @Test
+    void shouldLogAuditEventWithMetadataPairsAttached() {
+        var auditService = new AuditService();
+
+        assertEquals(
+                auditService.generateLogLine(
+                        TEST_EVENT_ONE, pair("key", "value"), pair("key2", "value2")),
+                "Emitting audit event - TEST_EVENT_ONE => [key: value], [key2: value2]");
     }
 }


### PR DESCRIPTION
## What?

This adds the option to add arbitrary key-value pairs to audit events. At the moment, this is consumed into a logline, but it will eventually be transformed into messages for our as-yet-to-be-decided audit transport mechanism.

## Why?

Audit events need to have metadata attached which is best decided at the call-site.

This is currently only implemented for one case, error handling for `AuthorisationHandler` but can be rolled out more widely at the discretion of the team.

## Related PRs

#312 

