### PR TITLE
GOVSI-720 - Make State and Nonce mandatory in the Auth Request

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
@@ -5,6 +5,7 @@ import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+import com.nimbusds.openid.connect.sdk.Nonce;
 import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
@@ -61,9 +62,11 @@ public class AuthCodeIntegrationTest extends IntegrationTestEndpoints {
         ResponseType responseType = new ResponseType(ResponseType.Value.CODE);
         State state = new State();
         Scope scope = new Scope();
+        Nonce nonce = new Nonce();
         scope.add(OIDCScopeValue.OPENID);
         return new AuthenticationRequest.Builder(responseType, scope, CLIENT_ID, REDIRECT_URI)
                 .state(state)
+                .nonce(nonce)
                 .build();
     }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -1,6 +1,7 @@
 package uk.gov.di.authentication.api;
 
 import com.nimbusds.oauth2.sdk.OAuth2Error;
+import com.nimbusds.openid.connect.sdk.Nonce;
 import com.nimbusds.openid.connect.sdk.OIDCError;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
@@ -217,12 +218,13 @@ public class AuthorisationIntegrationTest extends IntegrationTestEndpoints {
     private Response doAuthorisationRequest(
             Optional<String> clientId, Optional<Cookie> cookie, Optional<String> prompt) {
         Client client = ClientBuilder.newClient();
-
+        Nonce nonce = new Nonce();
         WebTarget webTarget =
                 client.target(ROOT_RESOURCE_URL + AUTHORIZE_ENDPOINT)
                         .queryParam("response_type", "code")
                         .queryParam("redirect_uri", "localhost")
                         .queryParam("state", "8VAVNSxHO1HwiNDhwchQKdd7eOUK3ltKfQzwPDxu9LU")
+                        .queryParam("nonce", nonce.getValue())
                         .queryParam("client_id", clientId.orElse("test-client"))
                         .queryParam("scope", "openid")
                         .property(ClientProperties.FOLLOW_REDIRECTS, Boolean.FALSE);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientInfoIntegrationTest.java
@@ -5,6 +5,7 @@ import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+import com.nimbusds.openid.connect.sdk.Nonce;
 import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
@@ -61,6 +62,7 @@ public class ClientInfoIntegrationTest extends IntegrationTestEndpoints {
                                 scope,
                                 new ClientID(CLIENT_ID),
                                 URI.create("http://localhost/redirect"))
+                        .nonce(new Nonce())
                         .build();
         RedisHelper.createClientSession(CLIENT_SESSION_ID, authRequest.toParameters());
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
@@ -10,6 +10,7 @@ import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+import com.nimbusds.openid.connect.sdk.Nonce;
 import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
@@ -96,6 +97,7 @@ public class LogoutIntegrationTest extends IntegrationTestEndpoints {
                         new ClientID("test-client"),
                         URI.create("http://localhost:8080/redirect"))
                 .state(state)
+                .nonce(new Nonce())
                 .build();
     }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
@@ -10,6 +10,7 @@ import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.oauth2.sdk.util.URLUtils;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+import com.nimbusds.openid.connect.sdk.Nonce;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.client.Entity;
@@ -104,12 +105,14 @@ public class TokenIntegrationTest extends IntegrationTestEndpoints {
         scopeValues.add("openid");
         ResponseType responseType = new ResponseType(ResponseType.Value.CODE);
         State state = new State();
+        Nonce nonce = new Nonce();
         return new AuthenticationRequest.Builder(
                         responseType,
                         scopeValues,
                         new ClientID(CLIENT_ID),
                         URI.create("http://localhost/redirect"))
                 .state(state)
+                .nonce(nonce)
                 .build();
     }
 }

--- a/serverless/lambda/src/main/java/uk/gov/di/services/AuthorizationService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/AuthorizationService.java
@@ -85,6 +85,18 @@ public class AuthorizationService {
                 || !client.get().getScopes().containsAll(authRequest.getScope().toStringList())) {
             return Optional.of(OAuth2Error.INVALID_SCOPE);
         }
+        if (authRequest.getNonce() == null) {
+            return Optional.of(
+                    new ErrorObject(
+                            OAuth2Error.INVALID_REQUEST_CODE,
+                            "Request is missing nonce parameter"));
+        }
+        if (authRequest.getState() == null) {
+            return Optional.of(
+                    new ErrorObject(
+                            OAuth2Error.INVALID_REQUEST_CODE,
+                            "Request is missing state parameter"));
+        }
         return Optional.empty();
     }
 

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/AuthCodeHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/AuthCodeHandlerTest.java
@@ -13,6 +13,7 @@ import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.openid.connect.sdk.AuthenticationErrorResponse;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import com.nimbusds.openid.connect.sdk.AuthenticationSuccessResponse;
+import com.nimbusds.openid.connect.sdk.Nonce;
 import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -229,10 +230,12 @@ class AuthCodeHandlerTest {
             ClientID clientID, State state) {
         ResponseType responseType = new ResponseType(ResponseType.Value.CODE);
         Scope scope = new Scope();
+        Nonce nonce = new Nonce();
         scope.add(OIDCScopeValue.OPENID);
         AuthenticationRequest authRequest =
                 new AuthenticationRequest.Builder(responseType, scope, clientID, REDIRECT_URI)
                         .state(state)
+                        .nonce(nonce)
                         .build();
         generateValidSession(authRequest.toParameters());
         return authRequest;

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/ClientInfoHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/ClientInfoHandlerTest.java
@@ -10,6 +10,7 @@ import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+import com.nimbusds.openid.connect.sdk.Nonce;
 import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -137,6 +138,7 @@ public class ClientInfoHandlerTest {
                                 new ClientID(clientId),
                                 URI.create("http://localhost/redirect"))
                         .state(state)
+                        .nonce(new Nonce())
                         .build();
         return Optional.of(new ClientSession(authRequest.toParameters(), null));
     }

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/TokenHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/TokenHandlerTest.java
@@ -20,6 +20,7 @@ import com.nimbusds.oauth2.sdk.id.Subject;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.oauth2.sdk.util.URLUtils;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+import com.nimbusds.openid.connect.sdk.Nonce;
 import com.nimbusds.openid.connect.sdk.OIDCTokenResponse;
 import com.nimbusds.openid.connect.sdk.token.OIDCTokens;
 import org.junit.jupiter.api.BeforeEach;
@@ -53,6 +54,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -128,7 +130,7 @@ public class TokenHandlerTest {
                                 generateAuthRequest().toParameters(), LocalDateTime.now()));
         when(authenticationService.getSubjectFromEmail(eq(TEST_EMAIL))).thenReturn(TEST_SUBJECT);
         when(tokenService.generateTokenResponse(
-                        eq(CLIENT_ID), any(Subject.class), eq(SCOPES), eq(Collections.emptyMap())))
+                        eq(CLIENT_ID), any(Subject.class), eq(SCOPES), anyMap()))
                 .thenReturn(tokenResponse);
 
         APIGatewayProxyResponseEvent result = generateApiGatewayRequest(privateKeyJWT, authCode);
@@ -282,6 +284,7 @@ public class TokenHandlerTest {
                         new ClientID(CLIENT_ID),
                         URI.create(REDIRECT_URI))
                 .state(state)
+                .nonce(new Nonce())
                 .build();
     }
 

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/UpdateProfileHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/UpdateProfileHandlerTest.java
@@ -10,6 +10,7 @@ import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import com.nimbusds.openid.connect.sdk.AuthenticationSuccessResponse;
+import com.nimbusds.openid.connect.sdk.Nonce;
 import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -212,6 +213,7 @@ class UpdateProfileHandlerTest {
         AuthenticationRequest authRequest =
                 new AuthenticationRequest.Builder(responseType, scope, clientID, REDIRECT_URI)
                         .state(state)
+                        .nonce(new Nonce())
                         .build();
         ClientSession clientSession =
                 new ClientSession(authRequest.toParameters(), LocalDateTime.now());


### PR DESCRIPTION
## What?

 - Make State and Nonce mandatory in the Auth Request

## Why?

- State will help protect us from cross site request forgery attacks. This allows a client to validate that the auth response has not been altered to the one sent in the original auth request.
- Nonce will help mitigate replay attacks by linking a client session and ID token together.