### PR TITLE
GOVSI-728 - Update Consent model

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateProfileIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateProfileIntegrationTest.java
@@ -1,22 +1,41 @@
 package uk.gov.di.authentication.api;
 
+import com.nimbusds.oauth2.sdk.ResponseType;
+import com.nimbusds.oauth2.sdk.Scope;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.id.State;
+import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+import com.nimbusds.openid.connect.sdk.Nonce;
+import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.helpers.DynamoHelper;
 import uk.gov.di.authentication.helpers.RedisHelper;
+import uk.gov.di.entity.ClientConsent;
 import uk.gov.di.entity.SessionState;
 import uk.gov.di.entity.UpdateProfileRequest;
+import uk.gov.di.helpers.IdGenerator;
 
 import java.io.IOException;
+import java.net.URI;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.authentication.helpers.RequestHelper.requestWithSession;
 import static uk.gov.di.entity.UpdateProfileType.ADD_PHONE_NUMBER;
+import static uk.gov.di.entity.UpdateProfileType.CAPTURE_CONSENT;
 
 public class UpdateProfileIntegrationTest extends IntegrationTestEndpoints {
 
     private static final String UPDATE_PROFILE_ENDPOINT = "/update-profile";
     private static final String EMAIL_ADDRESS = "test@test.com";
+    private static final String CLIENT_ID = "test-id";
 
     @Test
     public void shouldCallUpdateProfileEndpointAndReturn200() throws IOException {
@@ -31,5 +50,57 @@ public class UpdateProfileIntegrationTest extends IntegrationTestEndpoints {
         Response response = requestWithSession(UPDATE_PROFILE_ENDPOINT, request, sessionId);
 
         assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    public void shouldCallUpdateProfileToUpdateConsentAndReturn200() throws IOException {
+        String sessionId = RedisHelper.createSession();
+        String clientSessionId = IdGenerator.generate();
+        RedisHelper.addEmailToSession(sessionId, EMAIL_ADDRESS);
+        RedisHelper.setSessionState(sessionId, SessionState.TWO_FACTOR_REQUIRED);
+        RedisHelper.createClientSession(clientSessionId, generateAuthRequest().toParameters());
+        DynamoHelper.signUp(EMAIL_ADDRESS, "password-1");
+
+        UpdateProfileRequest request =
+                new UpdateProfileRequest(EMAIL_ADDRESS, CAPTURE_CONSENT, String.valueOf(true));
+
+        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
+        headers.add("Session-Id", sessionId);
+        headers.add("Client-Session-Id", clientSessionId);
+
+        Response response =
+                ClientBuilder.newClient()
+                        .target(ROOT_RESOURCE_URL + UPDATE_PROFILE_ENDPOINT)
+                        .request(MediaType.APPLICATION_JSON)
+                        .headers(headers)
+                        .post(Entity.entity(request, MediaType.APPLICATION_JSON));
+
+        assertEquals(200, response.getStatus());
+        Optional<ClientConsent> consent =
+                DynamoHelper.getUserConsents(EMAIL_ADDRESS)
+                        .flatMap(
+                                list ->
+                                        list.stream()
+                                                .filter(c -> c.getClientId().equals(CLIENT_ID))
+                                                .findFirst());
+        assertTrue(consent.get().getClaims().containsAll(OIDCScopeValue.OPENID.getClaimNames()));
+        assertTrue(consent.get().getClaims().containsAll(OIDCScopeValue.EMAIL.getClaimNames()));
+    }
+
+    private AuthenticationRequest generateAuthRequest() {
+        Scope scopeValues = new Scope();
+        scopeValues.add("openid");
+        scopeValues.add("email");
+        ResponseType responseType = new ResponseType(ResponseType.Value.CODE);
+        State state = new State();
+        Nonce nonce = new Nonce();
+        return new AuthenticationRequest.Builder(
+                        responseType,
+                        scopeValues,
+                        new ClientID(CLIENT_ID),
+                        URI.create("http://localhost/redirect"))
+                .state(state)
+                .nonce(nonce)
+                .build();
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/helpers/DynamoHelper.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/helpers/DynamoHelper.java
@@ -7,6 +7,7 @@ import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.ScanRequest;
 import com.amazonaws.services.dynamodbv2.model.ScanResult;
 import com.nimbusds.oauth2.sdk.id.Subject;
+import uk.gov.di.entity.ClientConsent;
 import uk.gov.di.services.DynamoClientService;
 import uk.gov.di.services.DynamoService;
 
@@ -19,7 +20,6 @@ public class DynamoHelper {
     private static final String ENVIRONMENT = System.getenv().getOrDefault("ENVIRONMENT", "local");
     private static final String DYNAMO_ENDPOINT =
             System.getenv().getOrDefault("DYNAMO_ENDPOINT", "http://localhost:8000");
-
     private static final DynamoService DYNAMO_SERVICE =
             new DynamoService(REGION, ENVIRONMENT, Optional.of(DYNAMO_ENDPOINT));
 
@@ -44,6 +44,10 @@ public class DynamoHelper {
 
     public static void setPhoneNumberVerified(String email, boolean isVerified) {
         DYNAMO_SERVICE.updatePhoneNumberVerifiedStatus(email, isVerified);
+    }
+
+    public static Optional<List<ClientConsent>> getUserConsents(String email) {
+        return DYNAMO_SERVICE.getUserConsents(email);
     }
 
     public static void registerClient(

--- a/serverless/lambda/src/main/java/uk/gov/di/entity/ClientConsent.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/entity/ClientConsent.java
@@ -1,0 +1,68 @@
+package uk.gov.di.entity;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBAttribute;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBDocument;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+@DynamoDBDocument
+public class ClientConsent {
+
+    private String clientId;
+    private String updatedTimestamp;
+    private Set<String> claims;
+
+    public ClientConsent() {}
+
+    public ClientConsent(String clientId, Set<String> claims, String updatedTimestamp) {
+        this.clientId = clientId;
+        this.claims = claims;
+        this.updatedTimestamp = updatedTimestamp;
+    }
+
+    @DynamoDBAttribute(attributeName = "ClientId")
+    public String getClientId() {
+        return clientId;
+    }
+
+    @DynamoDBAttribute(attributeName = "UpdatedTimestamp")
+    public String getUpdatedTimestamp() {
+        return updatedTimestamp;
+    }
+
+    @DynamoDBAttribute(attributeName = "Claims")
+    public Set<String> getClaims() {
+        return claims;
+    }
+
+    public ClientConsent setClaims(Set<String> claims) {
+        this.claims = claims;
+        this.updatedTimestamp = LocalDateTime.now().toString();
+        return this;
+    }
+
+    public ClientConsent setClientId(String clientId) {
+        this.clientId = clientId;
+        return this;
+    }
+
+    public ClientConsent setUpdatedTimestamp(String updatedTimestamp) {
+        this.updatedTimestamp = updatedTimestamp;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return "ClientConsent{"
+                + "clientId='"
+                + clientId
+                + '\''
+                + ", updatedTimestamp='"
+                + updatedTimestamp
+                + '\''
+                + ", claims="
+                + claims
+                + '}';
+    }
+}

--- a/serverless/lambda/src/main/java/uk/gov/di/entity/UserProfile.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/entity/UserProfile.java
@@ -5,7 +5,6 @@ import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBIndexHashKey;
 
 import java.util.List;
-import java.util.Map;
 
 public class UserProfile {
 
@@ -13,8 +12,7 @@ public class UserProfile {
     private String subjectID;
     private boolean emailVerified;
     private String phoneNumber;
-    private String consent;
-    private Map<String, List<String>> clientConsents;
+    private List<ClientConsent> clientConsent;
     private boolean phoneNumberVerified;
     private String created;
     private String updated;
@@ -62,16 +60,6 @@ public class UserProfile {
         return this;
     }
 
-    @DynamoDBAttribute(attributeName = "Consent")
-    public String getConsent() {
-        return consent;
-    }
-
-    public UserProfile setConsent(String consent) {
-        this.consent = consent;
-        return this;
-    }
-
     @DynamoDBAttribute(attributeName = "PhoneNumberVerified")
     public boolean isPhoneNumberVerified() {
         return phoneNumberVerified;
@@ -102,16 +90,6 @@ public class UserProfile {
         return this;
     }
 
-    @DynamoDBAttribute(attributeName = "ClientConsents")
-    public Map<String, List<String>> getClientConsents() {
-        return clientConsents;
-    }
-
-    public UserProfile setClientConsents(Map<String, List<String>> clientConsents) {
-        this.clientConsents = clientConsents;
-        return this;
-    }
-
     @DynamoDBAttribute(attributeName = "termsAndConditions")
     public TermsAndConditions getTermsAndConditions() {
         return termsAndConditions;
@@ -119,6 +97,25 @@ public class UserProfile {
 
     public UserProfile setTermsAndConditions(TermsAndConditions termsAndConditions) {
         this.termsAndConditions = termsAndConditions;
+        return this;
+    }
+
+    @DynamoDBAttribute(attributeName = "ClientConsent")
+    public List<ClientConsent> getClientConsent() {
+        return clientConsent;
+    }
+
+    public UserProfile setClientConsent(List<ClientConsent> clientConsent) {
+        this.clientConsent = clientConsent;
+        return this;
+    }
+
+    public UserProfile setClientConsent(ClientConsent consent) {
+        if (this.clientConsent == null) {
+            this.clientConsent = List.of(consent);
+        } else {
+            this.clientConsent.add(consent);
+        }
         return this;
     }
 }

--- a/serverless/lambda/src/main/java/uk/gov/di/entity/ValidScopes.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/entity/ValidScopes.java
@@ -1,11 +1,45 @@
 package uk.gov.di.entity;
 
-public enum ValidScopes {
-    OPENID,
-    PHONE,
-    EMAIL;
+import com.nimbusds.oauth2.sdk.Scope;
+import com.nimbusds.oauth2.sdk.id.Identifier;
+import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 
-    public String scopesLowerCase() {
-        return name().toLowerCase();
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class ValidScopes {
+
+    private static final List<OIDCScopeValue> allowedScopes =
+            List.of(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL, OIDCScopeValue.PHONE);
+
+    private ValidScopes() {}
+
+    public static Set<String> getClaimsForScope(String scope) {
+        for (OIDCScopeValue scopeValue : allowedScopes) {
+            if (scopeValue.getValue().equals(scope)) {
+                return scopeValue.getClaimNames();
+            }
+        }
+        return Collections.emptySet();
+    }
+
+    public static Set<String> getClaimsForListOfScopes(List<String> scopes) {
+        Set<String> claims = new HashSet<>();
+        for (String scope : scopes) {
+            claims.addAll(ValidScopes.getClaimsForScope(scope));
+        }
+        return claims;
+    }
+
+    public static List<OIDCScopeValue> getAllValidScopes() {
+        return allowedScopes;
+    }
+
+    public static Scope getScopesForWellKnownHandler() {
+        return new Scope(
+                allowedScopes.stream().map(Identifier::getValue).collect(Collectors.joining(",")));
     }
 }

--- a/serverless/lambda/src/main/java/uk/gov/di/lambdas/WellknownHandler.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/lambdas/WellknownHandler.java
@@ -7,14 +7,13 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.oauth2.sdk.GrantType;
 import com.nimbusds.oauth2.sdk.ResponseType;
-import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod;
 import com.nimbusds.oauth2.sdk.id.Issuer;
-import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import com.nimbusds.openid.connect.sdk.SubjectType;
 import com.nimbusds.openid.connect.sdk.claims.ClaimType;
 import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.entity.ValidScopes;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -54,8 +53,7 @@ public class WellknownHandler
             providerMetadata.setRegistrationEndpointURI(buildURI("/connect/register", baseUrl));
             providerMetadata.setTokenEndpointAuthMethods(
                     List.of(ClientAuthenticationMethod.PRIVATE_KEY_JWT));
-            providerMetadata.setScopes(
-                    new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL, OIDCScopeValue.PHONE));
+            providerMetadata.setScopes(ValidScopes.getScopesForWellKnownHandler());
             providerMetadata.setResponseTypes(List.of(new ResponseType("code")));
             providerMetadata.setGrantTypes(List.of(GrantType.AUTHORIZATION_CODE));
             providerMetadata.setClaimTypes(List.of(ClaimType.NORMAL));

--- a/serverless/lambda/src/main/java/uk/gov/di/services/AuthenticationService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/AuthenticationService.java
@@ -1,10 +1,10 @@
 package uk.gov.di.services;
 
 import com.nimbusds.oauth2.sdk.id.Subject;
+import uk.gov.di.entity.ClientConsent;
 import uk.gov.di.entity.UserProfile;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 public interface AuthenticationService {
@@ -20,9 +20,9 @@ public interface AuthenticationService {
 
     void updatePhoneNumber(String email, String profileInformation);
 
-    void updateConsent(String email, Map<String, List<String>> clientConsents);
+    void updateConsent(String email, ClientConsent clientConsent);
 
-    Optional<Map<String, List<String>>> getUserConsents(String email);
+    Optional<List<ClientConsent>> getUserConsents(String email);
 
     void updatePhoneNumberVerifiedStatus(String email, boolean verifiedStatus);
 

--- a/serverless/lambda/src/main/java/uk/gov/di/services/AuthorizationService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/AuthorizationService.java
@@ -17,7 +17,6 @@ import uk.gov.di.entity.ValidScopes;
 import uk.gov.di.exceptions.ClientNotFoundException;
 
 import java.net.URI;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -117,8 +116,8 @@ public class AuthorizationService {
 
     private boolean areScopesValid(List<String> scopes) {
         for (String scope : scopes) {
-            if (Arrays.stream(ValidScopes.values())
-                    .noneMatch((t) -> t.scopesLowerCase().equals(scope))) {
+            if (ValidScopes.getAllValidScopes().stream()
+                    .noneMatch((t) -> t.getValue().equals(scope))) {
                 return false;
             }
         }

--- a/serverless/lambda/src/main/java/uk/gov/di/services/ClientConfigValidationService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/ClientConfigValidationService.java
@@ -11,7 +11,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.security.KeyFactory;
 import java.security.spec.X509EncodedKeySpec;
-import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
 import java.util.Optional;
@@ -104,8 +103,8 @@ public class ClientConfigValidationService {
 
     private boolean areScopesValid(List<String> scopes) {
         for (String scope : scopes) {
-            if (Arrays.stream(ValidScopes.values())
-                    .noneMatch((t) -> t.scopesLowerCase().equals(scope))) {
+            if (ValidScopes.getAllValidScopes().stream()
+                    .noneMatch((t) -> t.getValue().equals(scope))) {
                 return false;
             }
         }

--- a/serverless/lambda/src/main/java/uk/gov/di/services/DynamoService.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/services/DynamoService.java
@@ -10,6 +10,7 @@ import com.amazonaws.services.dynamodbv2.datamodeling.QueryResultPage;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.amazonaws.util.Base64;
 import com.nimbusds.oauth2.sdk.id.Subject;
+import uk.gov.di.entity.ClientConsent;
 import uk.gov.di.entity.TermsAndConditions;
 import uk.gov.di.entity.UserCredentials;
 import uk.gov.di.entity.UserProfile;
@@ -109,9 +110,9 @@ public class DynamoService implements AuthenticationService {
     }
 
     @Override
-    public void updateConsent(String email, Map<String, List<String>> clientConsents) {
+    public void updateConsent(String email, ClientConsent clientConsent) {
         userProfileMapper.save(
-                userProfileMapper.load(UserProfile.class, email).setClientConsents(clientConsents));
+                userProfileMapper.load(UserProfile.class, email).setClientConsent(clientConsent));
     }
 
     @Override
@@ -126,9 +127,9 @@ public class DynamoService implements AuthenticationService {
     }
 
     @Override
-    public Optional<Map<String, List<String>>> getUserConsents(String email) {
+    public Optional<List<ClientConsent>> getUserConsents(String email) {
         return Optional.ofNullable(
-                userProfileMapper.load(UserProfile.class, email).getClientConsents());
+                userProfileMapper.load(UserProfile.class, email).getClientConsent());
     }
 
     @Override

--- a/serverless/lambda/src/test/java/uk/gov/di/lambdas/UpdateProfileHandlerTest.java
+++ b/serverless/lambda/src/test/java/uk/gov/di/lambdas/UpdateProfileHandlerTest.java
@@ -15,6 +15,7 @@ import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.entity.ClientConsent;
 import uk.gov.di.entity.ClientSession;
 import uk.gov.di.entity.ErrorResponse;
 import uk.gov.di.entity.Session;
@@ -28,7 +29,6 @@ import uk.gov.di.services.SessionService;
 
 import java.net.URI;
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -128,8 +128,6 @@ class UpdateProfileHandlerTest {
         ClientID clientID = new ClientID();
         AuthorizationCode authorizationCode = new AuthorizationCode();
         AuthenticationRequest authRequest = generateValidClientSessionAndAuthRequest(clientID);
-        var consentMap =
-                Map.of(authRequest.getClientID().getValue(), List.of(String.valueOf(true)));
 
         AuthenticationSuccessResponse authSuccessResponse =
                 new AuthenticationSuccessResponse(
@@ -158,7 +156,8 @@ class UpdateProfileHandlerTest {
 
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
-        verify(authenticationService).updateConsent(eq(TEST_EMAIL_ADDRESS), eq(consentMap));
+        verify(authenticationService)
+                .updateConsent(eq(TEST_EMAIL_ADDRESS), any(ClientConsent.class));
 
         assertThat(result, hasStatus(200));
     }


### PR DESCRIPTION
## What and Why?

- Update how we store Consent in the UserProfile table. This will now be stores as a List of the ClientConsent DynamoDocument object. This is because there will be different consent for a user on different services.
- Have a single source of truth for how we specify the Scopes we support
- Add an integration test to ensure that the consent is updated correctly

