### PR TITLE
GOVSI-458: modify state machine to allow multiple calls to userExists in a single session

### DIFF
--- a/serverless/lambda/src/main/java/uk/gov/di/helpers/StateMachine.java
+++ b/serverless/lambda/src/main/java/uk/gov/di/helpers/StateMachine.java
@@ -60,7 +60,7 @@ public class StateMachine<T> {
                         entry(NEW, List.of(USER_NOT_FOUND)),
                         entry(
                                 USER_NOT_FOUND,
-                                List.of(AUTHENTICATION_REQUIRED, VERIFY_EMAIL_CODE_SENT)),
+                                List.of(USER_NOT_FOUND, AUTHENTICATION_REQUIRED, VERIFY_EMAIL_CODE_SENT)),
                         entry(
                                 VERIFY_EMAIL_CODE_SENT,
                                 List.of(EMAIL_CODE_VERIFIED, EMAIL_CODE_NOT_VALID)),


### PR DESCRIPTION
## What?

Modify state machine to allow multiple calls to userExists in a single session.
Now able to transition from USER_NOT_FOUND to USER_NOT_FOUND again.

## Why?

User journey is changing to allow a single user to check whether accounts exist for multiple emails.  Before it was only possible to check a single email within a single session.