### PR TITLE
BAU: Provision Stub Clients with a ServiceType

### DIFF
--- a/ci/terraform/aws/stub-rp-clients.tf
+++ b/ci/terraform/aws/stub-rp-clients.tf
@@ -63,5 +63,8 @@ resource "aws_dynamodb_table_item" "stub_rp_client" {
         tls_private_key.stub_rp_client_private_key[count.index].public_key_pem, "-----BEGIN PUBLIC KEY-----", ""),
       "-----END PUBLIC KEY-----", ""), "\n", "")
     }
+    ServiceType = {
+      S = "MANDATORY"
+    }
   })
 }


### PR DESCRIPTION
## What?

- Provision stub RP clients with `ServiceType` of `MANDATORY`

## Why?

The auto-provisioning of clients currently doesn't include this field so may break the stub journeys.