### PR TITLE
GOVSI-716: Tag OIDC resources and better API deployment trigger

### DIFF
--- a/ci/terraform/oidc/auth-code.tf
+++ b/ci/terraform/oidc/auth-code.tf
@@ -27,6 +27,7 @@ module "auth-code" {
   environment               = var.environment
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
+  default_tags              = local.default_tags
 
   use_localstack = var.use_localstack
   depends_on = [

--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -29,6 +29,7 @@ module "authorize" {
   lambda_role_arn           = aws_iam_role.lambda_iam_role.arn
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
+  default_tags              = local.default_tags
 
   use_localstack = var.use_localstack
   depends_on = [

--- a/ci/terraform/oidc/client-info.tf
+++ b/ci/terraform/oidc/client-info.tf
@@ -27,6 +27,7 @@ module "client-info" {
   lambda_role_arn           = aws_iam_role.lambda_iam_role.arn
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
+  default_tags              = local.default_tags
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/dynamodb.tf
+++ b/ci/terraform/oidc/dynamodb.tf
@@ -22,6 +22,8 @@ resource "aws_dynamodb_table" "user_credentials_table" {
   server_side_encryption {
     enabled = true
   }
+
+  tags = local.default_tags
 }
 
 resource "aws_dynamodb_table" "user_profile_table" {
@@ -48,6 +50,8 @@ resource "aws_dynamodb_table" "user_profile_table" {
   server_side_encryption {
     enabled = true
   }
+
+  tags = local.default_tags
 }
 
 resource "aws_dynamodb_table" "client_registry_table" {
@@ -70,12 +74,14 @@ resource "aws_dynamodb_table" "client_registry_table" {
     hash_key        = "ClientName"
     projection_type = "ALL"
   }
+
+  tags = local.default_tags
 }
 
 data "aws_iam_policy_document" "dynamo_policy_document" {
   count = var.use_localstack ? 0 : 1
   statement {
-    sid    = "AllowAccessToDynamoTables"
+    sid = "AllowAccessToDynamoTables"
     effect = "Allow"
 
     actions = [

--- a/ci/terraform/oidc/ecr.tf
+++ b/ci/terraform/oidc/ecr.tf
@@ -7,4 +7,6 @@ resource "aws_ecr_repository" "authentication" {
   image_scanning_configuration {
     scan_on_push = true
   }
+
+  tags = local.default_tags
 }

--- a/ci/terraform/oidc/jwks.tf
+++ b/ci/terraform/oidc/jwks.tf
@@ -23,6 +23,7 @@ module "jwks" {
   lambda_role_arn           = aws_iam_role.lambda_iam_role.arn
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
+  default_tags              = local.default_tags
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/kms.tf
+++ b/ci/terraform/oidc/kms.tf
@@ -3,6 +3,8 @@ resource "aws_kms_key" "id_token_signing_key" {
   deletion_window_in_days = 30
   key_usage               = "SIGN_VERIFY"
   customer_master_key_spec = "ECC_NIST_P256"
+
+  tags = local.default_tags
 }
 
 resource "aws_kms_alias" "id_token_signing_key_alias" {

--- a/ci/terraform/oidc/lambda-roles.tf
+++ b/ci/terraform/oidc/lambda-roles.tf
@@ -21,9 +21,7 @@ resource "aws_iam_role" "lambda_iam_role" {
 
   assume_role_policy = data.aws_iam_policy_document.lambda_can_assume_policy.json
 
-  tags = {
-    environment = var.environment
-  }
+  tags = local.default_tags
 }
 
 data "aws_iam_policy_document" "endpoint_logging_policy" {

--- a/ci/terraform/oidc/login.tf
+++ b/ci/terraform/oidc/login.tf
@@ -26,7 +26,7 @@ module "login" {
   lambda_role_arn           = aws_iam_role.lambda_iam_role.arn
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
+  default_tags              = local.default_tags
 
   use_localstack = var.use_localstack
-
 }

--- a/ci/terraform/oidc/logout.tf
+++ b/ci/terraform/oidc/logout.tf
@@ -28,6 +28,7 @@ module "logout" {
   lambda_role_arn           = aws_iam_role.lambda_iam_role.arn
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
+  default_tags              = local.default_tags
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/mfa.tf
+++ b/ci/terraform/oidc/mfa.tf
@@ -27,6 +27,7 @@ module "mfa" {
   lambda_role_arn           = aws_iam_role.dynamo_sqs_lambda_iam_role.arn
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
+  default_tags              = local.default_tags
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/redis.tf
+++ b/ci/terraform/oidc/redis.tf
@@ -47,9 +47,7 @@ resource "aws_elasticache_replication_group" "sessions_store" {
     ]
   }
 
-  tags = {
-    environment = var.environment
-  }
+  tags = local.default_tags
 
   depends_on = [
     aws_vpc.authentication,

--- a/ci/terraform/oidc/register.tf
+++ b/ci/terraform/oidc/register.tf
@@ -23,6 +23,7 @@ module "register" {
   environment               = var.environment
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
+  default_tags              = local.default_tags
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/send_notification.tf
+++ b/ci/terraform/oidc/send_notification.tf
@@ -25,6 +25,7 @@ module "send_notification" {
   lambda_role_arn           = aws_iam_role.sqs_lambda_iam_role.arn
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
+  default_tags              = local.default_tags
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/signup.tf
+++ b/ci/terraform/oidc/signup.tf
@@ -27,6 +27,7 @@ module "signup" {
   lambda_role_arn           = aws_iam_role.lambda_iam_role.arn
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
+  default_tags              = local.default_tags
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/site.tf
+++ b/ci/terraform/oidc/site.tf
@@ -52,3 +52,11 @@ provider "aws" {
     dynamodb    = var.aws_dynamodb_endpoint
   }
 }
+
+locals {
+  // Using a local rather than the default_tags option on the AWS provider, as the latter has known issues which produce errors on apply.
+  default_tags = {
+    environment = var.environment
+    application = "oidc-api"
+  }
+}

--- a/ci/terraform/oidc/sqs.tf
+++ b/ci/terraform/oidc/sqs.tf
@@ -3,9 +3,7 @@ resource "aws_iam_role" "email_lambda_iam_role" {
 
   assume_role_policy = data.aws_iam_policy_document.lambda_can_assume_policy.json
 
-  tags = {
-    environment = var.environment
-  }
+  tags = local.default_tags
 }
 
 resource "aws_iam_role_policy_attachment" "emaiL_lambda_logging_policy" {
@@ -35,9 +33,7 @@ resource "aws_sqs_queue" "email_queue" {
   message_retention_seconds = 1209600
   receive_wait_time_seconds = 10
 
-  tags = {
-    environment = var.environment
-  }
+  tags = local.default_tags
 }
 
 resource "time_sleep" "wait_60_seconds" {
@@ -143,9 +139,7 @@ resource "aws_lambda_function" "email_sqs_lambda" {
     }
   }
 
-  tags = {
-    environment = var.environment
-  }
+  tags = local.default_tags
 
   depends_on = [
     aws_iam_role.lambda_iam_role,

--- a/ci/terraform/oidc/token.tf
+++ b/ci/terraform/oidc/token.tf
@@ -29,6 +29,7 @@ module "token" {
   lambda_role_arn           = aws_iam_role.token_lambda_iam_role.arn
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
+  default_tags              = local.default_tags
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/update.tf
+++ b/ci/terraform/oidc/update.tf
@@ -25,6 +25,7 @@ module "update" {
   environment               = var.environment
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
+  default_tags              = local.default_tags
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/update_profile.tf
+++ b/ci/terraform/oidc/update_profile.tf
@@ -28,6 +28,7 @@ module "update_profile" {
   lambda_role_arn           = aws_iam_role.lambda_iam_role.arn
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
+  default_tags              = local.default_tags
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/userexists.tf
+++ b/ci/terraform/oidc/userexists.tf
@@ -27,6 +27,7 @@ module "userexists" {
   lambda_role_arn           = aws_iam_role.lambda_iam_role.arn
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
+  default_tags              = local.default_tags
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -27,6 +27,7 @@ module "userinfo" {
   lambda_role_arn           = aws_iam_role.lambda_iam_role.arn
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
+  default_tags              = local.default_tags
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/verify_code.tf
+++ b/ci/terraform/oidc/verify_code.tf
@@ -27,6 +27,7 @@ module "verify_code" {
   lambda_role_arn           = aws_iam_role.lambda_iam_role.arn
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
+  default_tags              = local.default_tags
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/wellknown.tf
+++ b/ci/terraform/oidc/wellknown.tf
@@ -21,6 +21,7 @@ module "openid_configuration_discovery" {
   lambda_role_arn           = aws_iam_role.lambda_iam_role.arn
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
+  default_tags              = local.default_tags
 
   use_localstack = var.use_localstack
 


### PR DESCRIPTION
## What?

- Lifecycle trigger for API gateway deployment wasn't always guaranteed to trigger a new deployment. Ensure the trigger includes all elements of the deployment.
- Ensure all AWS resources that can be tagged are tagged with, at least, both an environment and application name. 

## Why?

We have multiple Terraform stacks deploying to our environments, it is probably a good practice to add some tags to the resources so we know which part of the application they belong to.

## Related PRs

#357 