### PR TITLE
GOVSI-716: Fix typo in the name of the lamdba passed to Terraform

### DIFF
--- a/ci/tasks/deploy-acct-mgmt-api.yml
+++ b/ci/tasks/deploy-acct-mgmt-api.yml
@@ -31,6 +31,6 @@ run:
       terraform apply -auto-approve \
         -var "deployer_role_arn=${DEPLOYER_ROLE_ARN}" \
         -var "environment=${DEPLOY_ENVIRONMENT}" \
-        -var 'lambda_zip_file=../../../../api-release/account-managment-api.zip' \
+        -var 'lambda_zip_file=../../../../api-release/account-management-api.zip' \
 
       terraform output --json > ../../../../terraform-outputs/${DEPLOY_ENVIRONMENT}-account-managment-api-terraform-outputs.json


### PR DESCRIPTION
## What?

- The `deploy-acct-mgmt-api.yml` task is missing the 'e' in the ZIP file path name passed to `terraform apply`

## Why?

The pipeline is erroring

## Related PRs

#357 