### PR TITLE
GOVSI-617: Add DynamoDB permissions to Acct Mgmt lambda role

### DIFF
--- a/ci/terraform/account-management/lambda-roles.tf
+++ b/ci/terraform/account-management/lambda-roles.tf
@@ -33,7 +33,6 @@ data "aws_iam_policy_document" "endpoint_logging_policy" {
       "logs:CreateLogGroup",
       "logs:CreateLogStream",
       "logs:PutLogEvents",
-      "logs:CreateLogGroup"
     ]
 
     resources = [
@@ -110,4 +109,44 @@ resource "aws_iam_policy" "endpoint_networking_policy" {
 resource "aws_iam_role_policy_attachment" "lambda_networking" {
   role       = aws_iam_role.lambda_iam_role.name
   policy_arn = aws_iam_policy.endpoint_networking_policy.arn
+}
+
+data "aws_dynamodb_table" "user_credentials_table" {
+  name = "${var.environment}-user-credentials"
+}
+
+data "aws_dynamodb_table" "user_profile_table" {
+  name = "${var.environment}-user-profile"
+}
+
+data "aws_iam_policy_document" "dynamo_policy_document" {
+  count = var.use_localstack ? 0 : 1
+  statement {
+    sid = "AllowAccessToDynamoTables"
+    effect = "Allow"
+
+    actions = [
+      "dynamodb:GetItem",
+      "dynamodb:UpdateItem",
+    ]
+    resources = [
+      data.aws_dynamodb_table.user_credentials_table.arn,
+      data.aws_dynamodb_table.user_profile_table.arn,
+    ]
+  }
+}
+
+resource "aws_iam_policy" "lambda_dynamo_policy" {
+  count       = var.use_localstack ? 0 : 1
+  name        = "${var.environment}-account-management-lambda-dynamo-policy"
+  path        = "/"
+  description = "IAM policy for managing Dynamo connection for an account management lambdas"
+
+  policy = data.aws_iam_policy_document.dynamo_policy_document[0].json
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_dynamo" {
+  count      = var.use_localstack ? 0 : 1
+  role       = aws_iam_role.lambda_iam_role.name
+  policy_arn = aws_iam_policy.lambda_dynamo_policy[0].arn
 }


### PR DESCRIPTION
## What?

- The account management API will be interacting directly with the user-profile and user-credentials tables, lets grant that access by default.
- Only grant permissions to get and update items by hash key (e-mail address) as the account management API shouldn't need to do anything else.

## Why?

The lambda will need Dynamo access.

## Related PRs

#357 