### PR TITLE
GOVSI-735: Create SNS topic for audit

### DIFF
--- a/ci/terraform/oidc/audit-sns.tf
+++ b/ci/terraform/oidc/audit-sns.tf
@@ -1,0 +1,50 @@
+resource "aws_sns_topic" "audit" {
+  name              = "${var.environment}-audit"
+  kms_master_key_id = "alias/aws/sns"
+  tags              = local.default_tags
+}
+
+data "aws_iam_policy_document" "audit_policy_document" {
+  version = "2008-10-17"
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+    actions = [
+      "SNS:Publish",
+      "SNS:RemovePermission",
+      "SNS:SetTopicAttributes",
+      "SNS:DeleteTopic",
+      "SNS:ListSubscriptionsByTopic",
+      "SNS:GetTopicAttributes",
+      "SNS:Receive",
+      "SNS:AddPermission",
+      "SNS:Subscribe"
+    ]
+    resources = [aws_sns_topic.audit.arn]
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceOwner"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+  }
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+    actions = [
+      "SNS:Subscribe",
+      "SNS:Receive"
+    ]
+    resources = [aws_sns_topic.audit.arn]
+  }
+}
+
+resource "aws_sns_topic_policy" "audit" {
+  policy = data.aws_iam_policy_document.audit_policy_document.json
+  arn    = aws_sns_topic.audit.arn
+}

--- a/ci/terraform/oidc/site.tf
+++ b/ci/terraform/oidc/site.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">= 3.54.0"
     }
     time = {
@@ -50,6 +50,7 @@ provider "aws" {
     elasticache = var.aws_endpoint
     kms         = var.aws_endpoint
     dynamodb    = var.aws_dynamodb_endpoint
+    sns         = var.aws_endpoint
   }
 }
 
@@ -60,3 +61,5 @@ locals {
     application = "oidc-api"
   }
 }
+
+data "aws_caller_identity" "current" {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: docker
       dockerfile: localstack.Dockerfile
     environment:
-      SERVICES: lambda, apigateway, iam, ec2, sqs, s3, sts, kms
+      SERVICES: lambda, apigateway, iam, ec2, sqs, s3, sts, kms, sns
       EDGE_PORT: "45678"
       EXTERNAL_HOSTNAME: localhost
       DEFAULT_REGION: eu-west-2


### PR DESCRIPTION
## What?

Create SNS topic for audit.

Access policy (for the moment): account owner can send, anyone can receive

## Why?

Precursor to writing code to distribute audit events.