### PR TITLE
Increase memory for optional performance

### DIFF
--- a/ci/terraform/modules/endpoint-module/lambda.tf
+++ b/ci/terraform/modules/endpoint-module/lambda.tf
@@ -4,7 +4,7 @@ resource "aws_lambda_function" "endpoint_lambda" {
   role          = var.lambda_role_arn
   handler       = var.handler_function_name
   timeout       = 30
-  memory_size   = 2048
+  memory_size   = 4096
   publish       = true
 
   tracing_config {


### PR DESCRIPTION
## What?

Increase aws lambda memory

## Why?

After some research 4gig seems the optimal space for the best ratio of performance/cost

