### PR TITLE
GOVSI-185: add switch to apply account-management terraform to localstack

### DIFF
--- a/ci/terraform/account-management/localstack.hcl
+++ b/ci/terraform/account-management/localstack.hcl
@@ -1,0 +1,10 @@
+bucket       = "terraform-state"
+key          = "localstack-account-management.tfstate"
+region       = "eu-west-2"
+endpoint     = "http://localhost:45678"
+iam_endpoint = "http://localhost:45678"
+sts_endpoint = "http://localhost:45678"
+
+skip_credentials_validation = true
+skip_metadata_api_check     = true
+force_path_style            = true

--- a/ci/terraform/account-management/localstack.tfvars
+++ b/ci/terraform/account-management/localstack.tfvars
@@ -1,0 +1,5 @@
+environment               = "local"
+aws_endpoint              = "http://localhost:45678"
+aws_dynamodb_endpoint     = "http://localhost:8000"
+use_localstack            = true
+api_deployment_stage_name = "local"

--- a/ci/terraform/account-management/outputs.tf
+++ b/ci/terraform/account-management/outputs.tf
@@ -1,0 +1,7 @@
+output "base_url" {
+  value = local.api_base_url
+}
+
+output "api_gateway_root_id" {
+  value = aws_api_gateway_rest_api.di_account_management_api.id
+}

--- a/ci/terraform/account-management/site.tf
+++ b/ci/terraform/account-management/site.tf
@@ -18,8 +18,29 @@ provider "aws" {
   assume_role {
     role_arn = var.deployer_role_arn
   }
-}
 
+  insecure = var.use_localstack
+
+  s3_force_path_style = var.use_localstack
+  skip_credentials_validation = var.use_localstack
+  skip_metadata_api_check = var.use_localstack
+  skip_requesting_account_id = var.use_localstack
+
+  endpoints {
+    apigateway = var.aws_endpoint
+    ecr = var.aws_endpoint
+    iam = var.aws_endpoint
+    lambda = var.aws_endpoint
+    s3 = var.aws_endpoint
+    ec2 = var.aws_endpoint
+    sqs = var.aws_endpoint
+    sts = var.aws_endpoint
+    elasticache = var.aws_endpoint
+    kms = var.aws_endpoint
+    dynamodb = var.aws_dynamodb_endpoint
+    sns = var.aws_endpoint
+  }
+}
 locals {
   // Using a local rather than the default_tags option on the AWS provider, as the latter has known issues which produce errors on apply.
   default_tags = {

--- a/ci/terraform/account-management/variables.tf
+++ b/ci/terraform/account-management/variables.tf
@@ -22,6 +22,11 @@ variable "aws_endpoint" {
   default = null
 }
 
+variable "aws_dynamodb_endpoint" {
+  type    = string
+  default = null
+}
+
 variable "service_domain_name" {
   default = "auth.ida.digital.cabinet-office.gov.uk"
 }

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -16,18 +16,20 @@ function usage() {
     -u  run the unit tests
     -i  run the integration tests
     -g  running in GitHub actions
+    -t  terraform all modules
 USAGE
 }
 RUN_UNIT=0
 RUN_INTEGRATION=0
 IN_GITHUB_ACTIONS=0
+TF_ACCOUNT_MANAGEMENT=0
 
 if [[ $# -eq 0 ]] || [[ ( $# -eq 1 && ${1} == "-l" ) ]]; then
   RUN_UNIT=1
   RUN_INTEGRATION=1
 fi
 
-while getopts "uig" opt; do
+while getopts "uigt" opt; do
   case ${opt} in
     u)
       RUN_UNIT=1
@@ -37,6 +39,9 @@ while getopts "uig" opt; do
       ;;
     g)
       IN_GITHUB_ACTIONS=1
+      ;;
+    t)
+      TF_ACCOUNT_MANAGEMENT=1
       ;;
     *)
       usage

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -40,7 +40,7 @@ function run_terraform() {
   pushd "$1" >/dev/null
   rm -fr .terraform/ *.tfstate
   terraform init -backend-config=localstack.hcl
-  printf "\nRunning terraform apply quietly (output redirected to terraform.log)...\n"
+  printf "\nRunning terraform -> %s apply quietly (output redirected to terraform.log)...\n", "$1"
   set +e
   terraform apply -var-file=localstack.tfvars -auto-approve > terraform.log
   tf_exit_code=$?
@@ -82,6 +82,9 @@ startup() {
   printf "\nStarting Docker services...\n"
   startup_docker aws redis dynamodb
   run_terraform ci/terraform/oidc
+  if [[ ! -z ${TF_ACCOUNT_MANAGEMENT+x} && ${TF_ACCOUNT_MANAGEMENT} -eq 1 ]]; then
+    run_terraform ci/terraform/account-management
+  fi
   if [[ -z ${IN_GITHUB_ACTIONS+x} ||  ${IN_GITHUB_ACTIONS} -eq 0 ]]; then
     funky_started
   else


### PR DESCRIPTION
## What?

Add switch to apply account-management terraform to localstack.
Add required terraform files to support localstack deployment.

Will only be applied if the switch is set.
No extra terraform applied if working on the OIDC API only.
Note that account-management depends on dynamoDb, so all terraform needs to run if working on account-management.

## Why?

Ability to run integration tests and the end-to-end application locally.