### PR TITLE
GOVSI-735: Rename 'audit' SNS topic ARN to 'events'

### DIFF
--- a/ci/terraform/oidc/events-sns.tf
+++ b/ci/terraform/oidc/events-sns.tf
@@ -1,16 +1,16 @@
-resource "aws_sns_topic" "audit" {
-  name              = "${var.environment}-audit"
+resource "aws_sns_topic" "events" {
+  name              = "${var.environment}-events"
   kms_master_key_id = "alias/aws/sns"
   tags              = local.default_tags
 }
 
-data "aws_iam_policy_document" "audit_policy_document" {
+data "aws_iam_policy_document" "events_policy_document" {
   version   = "2008-10-17"
-  policy_id = "${var.environment}-audit-sns-topic-policy"
+  policy_id = "${var.environment}-events-sns-topic-policy"
 
   statement {
     effect = "Allow"
-    sid    = "${var.environment}-audit-sns-topic-policy-publish"
+    sid    = "${var.environment}-events-sns-topic-policy-publish"
     principals {
       type        = "AWS"
       identifiers = ["*"]
@@ -26,7 +26,7 @@ data "aws_iam_policy_document" "audit_policy_document" {
       "SNS:AddPermission",
       "SNS:Subscribe"
     ]
-    resources = [aws_sns_topic.audit.arn]
+    resources = [aws_sns_topic.events.arn]
     condition {
       test     = "StringEquals"
       variable = "AWS:SourceOwner"
@@ -35,7 +35,7 @@ data "aws_iam_policy_document" "audit_policy_document" {
   }
   statement {
     effect = "Allow"
-    sid    = "${var.environment}-audit-sns-topic-policy-subscribe"
+    sid    = "${var.environment}-events-sns-topic-policy-subscribe"
     principals {
       type        = "AWS"
       identifiers = ["*"]
@@ -44,11 +44,11 @@ data "aws_iam_policy_document" "audit_policy_document" {
       "SNS:Subscribe",
       "SNS:Receive"
     ]
-    resources = [aws_sns_topic.audit.arn]
+    resources = [aws_sns_topic.events.arn]
   }
 }
 
-resource "aws_sns_topic_policy" "audit" {
-  policy = data.aws_iam_policy_document.audit_policy_document.json
-  arn    = aws_sns_topic.audit.arn
+resource "aws_sns_topic_policy" "events" {
+  policy = data.aws_iam_policy_document.events_policy_document.json
+  arn    = aws_sns_topic.events.arn
 }


### PR DESCRIPTION
## What?

Rename 'audit' SNS topic ARN to 'events'

## Why?

This brings it into line with ADR-003.

## Related PRs

#361