### PR TITLE
GOVSI-735: Add env var for events SNS topic ARN

### DIFF
--- a/ci/terraform/oidc/auth-code.tf
+++ b/ci/terraform/oidc/auth-code.tf
@@ -6,13 +6,14 @@ module "auth-code" {
   endpoint_method = "GET"
 
   handler_environment_variables = {
-    BASE_URL        = local.api_base_url
-    REDIS_HOST      = var.use_localstack ? var.external_redis_host : aws_elasticache_replication_group.sessions_store[0].primary_endpoint_address
-    REDIS_PORT      = var.use_localstack ? var.external_redis_port : aws_elasticache_replication_group.sessions_store[0].port
-    REDIS_PASSWORD  = var.use_localstack ? var.external_redis_password : random_password.redis_password.result
-    REDIS_TLS       = var.redis_use_tls
-    ENVIRONMENT     = var.environment
-    DYNAMO_ENDPOINT = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    BASE_URL             = local.api_base_url
+    EVENTS_SNS_TOPIC_ARN = aws_sns_topic.events.arn
+    REDIS_HOST           = var.use_localstack ? var.external_redis_host : aws_elasticache_replication_group.sessions_store[0].primary_endpoint_address
+    REDIS_PORT           = var.use_localstack ? var.external_redis_port : aws_elasticache_replication_group.sessions_store[0].port
+    REDIS_PASSWORD       = var.use_localstack ? var.external_redis_password : random_password.redis_password.result
+    REDIS_TLS            = var.redis_use_tls
+    ENVIRONMENT          = var.environment
+    DYNAMO_ENDPOINT      = var.use_localstack ? var.lambda_dynamo_endpoint : null
   }
   handler_function_name = "uk.gov.di.lambdas.AuthCodeHandler::handleRequest"
 

--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -7,15 +7,16 @@ module "authorize" {
   environment     = var.environment
 
   handler_environment_variables = {
-    BASE_URL        = local.api_base_url
-    DOMAIN_NAME     = "${var.environment}.${var.service_domain_name}"
-    LOGIN_URI       = var.use_localstack ? "http://localhost:3000/" : "https://front.${var.environment}.${var.service_domain_name}/"
-    REDIS_HOST      = var.use_localstack ? var.external_redis_host : aws_elasticache_replication_group.sessions_store[0].primary_endpoint_address
-    REDIS_PORT      = var.use_localstack ? var.external_redis_port : aws_elasticache_replication_group.sessions_store[0].port
-    REDIS_PASSWORD  = var.use_localstack ? var.external_redis_password : random_password.redis_password.result
-    REDIS_TLS       = var.redis_use_tls
-    ENVIRONMENT     = var.environment
-    DYNAMO_ENDPOINT = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    BASE_URL             = local.api_base_url
+    DOMAIN_NAME          = "${var.environment}.${var.service_domain_name}"
+    EVENTS_SNS_TOPIC_ARN = aws_sns_topic.events.arn
+    LOGIN_URI            = var.use_localstack ? "http://localhost:3000/" : "https://front.${var.environment}.${var.service_domain_name}/"
+    REDIS_HOST           = var.use_localstack ? var.external_redis_host : aws_elasticache_replication_group.sessions_store[0].primary_endpoint_address
+    REDIS_PORT           = var.use_localstack ? var.external_redis_port : aws_elasticache_replication_group.sessions_store[0].port
+    REDIS_PASSWORD       = var.use_localstack ? var.external_redis_password : random_password.redis_password.result
+    REDIS_TLS            = var.redis_use_tls
+    ENVIRONMENT          = var.environment
+    DYNAMO_ENDPOINT      = var.use_localstack ? var.lambda_dynamo_endpoint : null
   }
   handler_function_name = "uk.gov.di.lambdas.AuthorisationHandler::handleRequest"
 

--- a/ci/terraform/oidc/client-info.tf
+++ b/ci/terraform/oidc/client-info.tf
@@ -7,13 +7,14 @@ module "client-info" {
   environment     = var.environment
 
   handler_environment_variables = {
-    BASE_URL        = local.api_base_url
-    REDIS_HOST      = var.use_localstack ? var.external_redis_host : aws_elasticache_replication_group.sessions_store[0].primary_endpoint_address
-    REDIS_PORT      = var.use_localstack ? var.external_redis_port : aws_elasticache_replication_group.sessions_store[0].port
-    REDIS_PASSWORD  = var.use_localstack ? var.external_redis_password : random_password.redis_password.result
-    REDIS_TLS       = var.redis_use_tls
-    ENVIRONMENT     = var.environment
-    DYNAMO_ENDPOINT = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    BASE_URL             = local.api_base_url
+    EVENTS_SNS_TOPIC_ARN = aws_sns_topic.events.arn
+    REDIS_HOST           = var.use_localstack ? var.external_redis_host : aws_elasticache_replication_group.sessions_store[0].primary_endpoint_address
+    REDIS_PORT           = var.use_localstack ? var.external_redis_port : aws_elasticache_replication_group.sessions_store[0].port
+    REDIS_PASSWORD       = var.use_localstack ? var.external_redis_password : random_password.redis_password.result
+    REDIS_TLS            = var.redis_use_tls
+    ENVIRONMENT          = var.environment
+    DYNAMO_ENDPOINT      = var.use_localstack ? var.lambda_dynamo_endpoint : null
   }
   handler_function_name = "uk.gov.di.lambdas.ClientInfoHandler::handleRequest"
 

--- a/ci/terraform/oidc/jwks.tf
+++ b/ci/terraform/oidc/jwks.tf
@@ -7,8 +7,9 @@ module "jwks" {
   environment     = var.environment
 
   handler_environment_variables = {
-    BASE_URL = local.api_base_url
-    LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
+    BASE_URL             = local.api_base_url
+    EVENTS_SNS_TOPIC_ARN = aws_sns_topic.events.arn
+    LOCALSTACK_ENDPOINT  = var.use_localstack ? var.localstack_endpoint : null
     TOKEN_SIGNING_KEY_ID = aws_kms_key.id_token_signing_key.key_id
   }
   handler_function_name = "uk.gov.di.lambdas.JwksHandler::handleRequest"

--- a/ci/terraform/oidc/login.tf
+++ b/ci/terraform/oidc/login.tf
@@ -5,13 +5,14 @@ module "login" {
   path_part       = "login"
   endpoint_method = "POST"
   handler_environment_variables = {
-    ENVIRONMENT     = var.environment
-    BASE_URL        = local.api_base_url
-    REDIS_HOST      = var.use_localstack ? var.external_redis_host : aws_elasticache_replication_group.sessions_store[0].primary_endpoint_address
-    REDIS_PORT      = var.use_localstack ? var.external_redis_port : aws_elasticache_replication_group.sessions_store[0].port
-    REDIS_PASSWORD  = var.use_localstack ? var.external_redis_password : random_password.redis_password.result
-    REDIS_TLS       = var.redis_use_tls
-    DYNAMO_ENDPOINT = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    ENVIRONMENT          = var.environment
+    BASE_URL             = local.api_base_url
+    EVENTS_SNS_TOPIC_ARN = aws_sns_topic.events.arn
+    REDIS_HOST           = var.use_localstack ? var.external_redis_host : aws_elasticache_replication_group.sessions_store[0].primary_endpoint_address
+    REDIS_PORT           = var.use_localstack ? var.external_redis_port : aws_elasticache_replication_group.sessions_store[0].port
+    REDIS_PASSWORD       = var.use_localstack ? var.external_redis_password : random_password.redis_password.result
+    REDIS_TLS            = var.redis_use_tls
+    DYNAMO_ENDPOINT      = var.use_localstack ? var.lambda_dynamo_endpoint : null
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.LoginHandler::handleRequest"
 

--- a/ci/terraform/oidc/logout.tf
+++ b/ci/terraform/oidc/logout.tf
@@ -7,16 +7,17 @@ module "logout" {
   environment     = var.environment
 
   handler_environment_variables = {
-    DEFAULT_LOGOUT_URI = "https://di-authentication-frontend.london.cloudapps.digital/signed-out"
-    BASE_URL           = local.api_base_url
-    REDIS_HOST         = var.use_localstack ? var.external_redis_host : aws_elasticache_replication_group.sessions_store[0].primary_endpoint_address
-    REDIS_PORT         = var.use_localstack ? var.external_redis_port : aws_elasticache_replication_group.sessions_store[0].port
-    REDIS_PASSWORD     = var.use_localstack ? var.external_redis_password : random_password.redis_password.result
-    REDIS_TLS          = var.redis_use_tls
-    ENVIRONMENT        = var.environment
-    DYNAMO_ENDPOINT    = var.use_localstack ? var.lambda_dynamo_endpoint : null
-    TOKEN_SIGNING_KEY_ID    = aws_kms_key.id_token_signing_key.key_id
-    LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
+    DEFAULT_LOGOUT_URI   = "https://di-authentication-frontend.london.cloudapps.digital/signed-out"
+    BASE_URL             = local.api_base_url
+    EVENTS_SNS_TOPIC_ARN = aws_sns_topic.events.arn
+    REDIS_HOST           = var.use_localstack ? var.external_redis_host : aws_elasticache_replication_group.sessions_store[0].primary_endpoint_address
+    REDIS_PORT           = var.use_localstack ? var.external_redis_port : aws_elasticache_replication_group.sessions_store[0].port
+    REDIS_PASSWORD       = var.use_localstack ? var.external_redis_password : random_password.redis_password.result
+    REDIS_TLS            = var.redis_use_tls
+    ENVIRONMENT          = var.environment
+    DYNAMO_ENDPOINT      = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    TOKEN_SIGNING_KEY_ID = aws_kms_key.id_token_signing_key.key_id
+    LOCALSTACK_ENDPOINT  = var.use_localstack ? var.localstack_endpoint : null
   }
   handler_function_name = "uk.gov.di.lambdas.LogoutHandler::handleRequest"
 

--- a/ci/terraform/oidc/mfa.tf
+++ b/ci/terraform/oidc/mfa.tf
@@ -7,13 +7,14 @@ module "mfa" {
   environment     = var.environment
 
   handler_environment_variables = {
-    ENVIRONMENT     = var.environment
-    EMAIL_QUEUE_URL = aws_sqs_queue.email_queue.id
-    REDIS_HOST      = var.use_localstack ? var.external_redis_host : aws_elasticache_replication_group.sessions_store[0].primary_endpoint_address
-    REDIS_PORT      = var.use_localstack ? var.external_redis_port : aws_elasticache_replication_group.sessions_store[0].port
-    REDIS_PASSWORD  = var.use_localstack ? var.external_redis_password : random_password.redis_password.result
-    REDIS_TLS       = var.redis_use_tls
-    DYNAMO_ENDPOINT = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    ENVIRONMENT          = var.environment
+    EMAIL_QUEUE_URL      = aws_sqs_queue.email_queue.id
+    EVENTS_SNS_TOPIC_ARN = aws_sns_topic.events.arn
+    REDIS_HOST           = var.use_localstack ? var.external_redis_host : aws_elasticache_replication_group.sessions_store[0].primary_endpoint_address
+    REDIS_PORT           = var.use_localstack ? var.external_redis_port : aws_elasticache_replication_group.sessions_store[0].port
+    REDIS_PASSWORD       = var.use_localstack ? var.external_redis_password : random_password.redis_password.result
+    REDIS_TLS            = var.redis_use_tls
+    DYNAMO_ENDPOINT      = var.use_localstack ? var.lambda_dynamo_endpoint : null
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.MfaHandler::handleRequest"
 

--- a/ci/terraform/oidc/register.tf
+++ b/ci/terraform/oidc/register.tf
@@ -6,9 +6,10 @@ module "register" {
   endpoint_method = "POST"
 
   handler_environment_variables = {
-    ENVIRONMENT     = var.environment
-    BASE_URL        = local.api_base_url
-    DYNAMO_ENDPOINT = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    ENVIRONMENT          = var.environment
+    BASE_URL             = local.api_base_url
+    DYNAMO_ENDPOINT      = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    EVENTS_SNS_TOPIC_ARN = aws_sns_topic.events.arn
   }
   handler_function_name = "uk.gov.di.lambdas.ClientRegistrationHandler::handleRequest"
 

--- a/ci/terraform/oidc/send_notification.tf
+++ b/ci/terraform/oidc/send_notification.tf
@@ -7,11 +7,12 @@ module "send_notification" {
   environment     = var.environment
 
   handler_environment_variables = {
-    EMAIL_QUEUE_URL = aws_sqs_queue.email_queue.id
-    REDIS_HOST      = var.use_localstack ? var.external_redis_host : aws_elasticache_replication_group.sessions_store[0].primary_endpoint_address
-    REDIS_PORT      = var.use_localstack ? var.external_redis_port : aws_elasticache_replication_group.sessions_store[0].port
-    REDIS_PASSWORD  = var.use_localstack ? var.external_redis_password : random_password.redis_password.result
-    REDIS_TLS       = var.redis_use_tls
+    EMAIL_QUEUE_URL      = aws_sqs_queue.email_queue.id
+    EVENTS_SNS_TOPIC_ARN = aws_sns_topic.events.arn
+    REDIS_HOST           = var.use_localstack ? var.external_redis_host : aws_elasticache_replication_group.sessions_store[0].primary_endpoint_address
+    REDIS_PORT           = var.use_localstack ? var.external_redis_port : aws_elasticache_replication_group.sessions_store[0].port
+    REDIS_PASSWORD       = var.use_localstack ? var.external_redis_password : random_password.redis_password.result
+    REDIS_TLS            = var.redis_use_tls
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.SendNotificationHandler::handleRequest"
 

--- a/ci/terraform/oidc/signup.tf
+++ b/ci/terraform/oidc/signup.tf
@@ -7,13 +7,14 @@ module "signup" {
   environment     = var.environment
 
   handler_environment_variables = {
-    ENVIRONMENT     = var.environment
-    BASE_URL        = local.api_base_url
-    REDIS_HOST      = var.use_localstack ? var.external_redis_host : aws_elasticache_replication_group.sessions_store[0].primary_endpoint_address
-    REDIS_PORT      = var.use_localstack ? var.external_redis_port : aws_elasticache_replication_group.sessions_store[0].port
-    REDIS_PASSWORD  = var.use_localstack ? var.external_redis_password : random_password.redis_password.result
-    REDIS_TLS       = var.redis_use_tls
-    DYNAMO_ENDPOINT = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    ENVIRONMENT          = var.environment
+    BASE_URL             = local.api_base_url
+    EVENTS_SNS_TOPIC_ARN = aws_sns_topic.events.arn
+    REDIS_HOST           = var.use_localstack ? var.external_redis_host : aws_elasticache_replication_group.sessions_store[0].primary_endpoint_address
+    REDIS_PORT           = var.use_localstack ? var.external_redis_port : aws_elasticache_replication_group.sessions_store[0].port
+    REDIS_PASSWORD       = var.use_localstack ? var.external_redis_password : random_password.redis_password.result
+    REDIS_TLS            = var.redis_use_tls
+    DYNAMO_ENDPOINT      = var.use_localstack ? var.lambda_dynamo_endpoint : null
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.SignUpHandler::handleRequest"
 

--- a/ci/terraform/oidc/token.tf
+++ b/ci/terraform/oidc/token.tf
@@ -7,15 +7,16 @@ module "token" {
   environment     = var.environment
 
   handler_environment_variables = {
-    ENVIRONMENT             = var.environment
-    BASE_URL                = local.api_base_url
-    DYNAMO_ENDPOINT         = var.use_localstack ? var.lambda_dynamo_endpoint : null
-    REDIS_HOST              = var.use_localstack ? var.external_redis_host : aws_elasticache_replication_group.sessions_store[0].primary_endpoint_address
-    REDIS_PORT              = var.use_localstack ? var.external_redis_port : aws_elasticache_replication_group.sessions_store[0].port
-    REDIS_PASSWORD          = var.use_localstack ? var.external_redis_password : random_password.redis_password.result
-    REDIS_TLS               = var.redis_use_tls
-    TOKEN_SIGNING_KEY_ID    = aws_kms_key.id_token_signing_key.key_id
-    LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
+    ENVIRONMENT          = var.environment
+    BASE_URL             = local.api_base_url
+    DYNAMO_ENDPOINT      = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    EVENTS_SNS_TOPIC_ARN = aws_sns_topic.events.arn
+    REDIS_HOST           = var.use_localstack ? var.external_redis_host : aws_elasticache_replication_group.sessions_store[0].primary_endpoint_address
+    REDIS_PORT           = var.use_localstack ? var.external_redis_port : aws_elasticache_replication_group.sessions_store[0].port
+    REDIS_PASSWORD       = var.use_localstack ? var.external_redis_password : random_password.redis_password.result
+    REDIS_TLS            = var.redis_use_tls
+    TOKEN_SIGNING_KEY_ID = aws_kms_key.id_token_signing_key.key_id
+    LOCALSTACK_ENDPOINT  = var.use_localstack ? var.localstack_endpoint : null
   }
   handler_function_name = "uk.gov.di.lambdas.TokenHandler::handleRequest"
 

--- a/ci/terraform/oidc/update.tf
+++ b/ci/terraform/oidc/update.tf
@@ -8,9 +8,10 @@ module "update" {
   integration_request_parameters = { "integration.request.path.clientId" = "method.request.path.clientId" }
 
   handler_environment_variables = {
-    ENVIRONMENT     = var.environment
-    BASE_URL        = local.api_base_url
-    DYNAMO_ENDPOINT = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    ENVIRONMENT          = var.environment
+    BASE_URL             = local.api_base_url
+    DYNAMO_ENDPOINT      = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    EVENTS_SNS_TOPIC_ARN = aws_sns_topic.events.arn
   }
   handler_function_name = "uk.gov.di.lambdas.UpdateClientConfigHandler::handleRequest"
 

--- a/ci/terraform/oidc/update_profile.tf
+++ b/ci/terraform/oidc/update_profile.tf
@@ -9,6 +9,7 @@ module "update_profile" {
   handler_environment_variables = {
     ENVIRONMENT              = var.environment
     BASE_URL                 = var.api_base_url
+    EVENTS_SNS_TOPIC_ARN     = aws_sns_topic.events.arn
     REDIS_HOST               = var.use_localstack ? var.external_redis_host : aws_elasticache_replication_group.sessions_store[0].primary_endpoint_address
     REDIS_PORT               = var.use_localstack ? var.external_redis_port : aws_elasticache_replication_group.sessions_store[0].port
     REDIS_PASSWORD           = var.use_localstack ? var.external_redis_password : random_password.redis_password.result

--- a/ci/terraform/oidc/userexists.tf
+++ b/ci/terraform/oidc/userexists.tf
@@ -7,13 +7,14 @@ module "userexists" {
   environment     = var.environment
 
   handler_environment_variables = {
-    ENVIRONMENT     = var.environment
-    BASE_URL        = local.api_base_url
-    REDIS_HOST      = var.use_localstack ? var.external_redis_host : aws_elasticache_replication_group.sessions_store[0].primary_endpoint_address
-    REDIS_PORT      = var.use_localstack ? var.external_redis_port : aws_elasticache_replication_group.sessions_store[0].port
-    REDIS_PASSWORD  = var.use_localstack ? var.external_redis_password : random_password.redis_password.result
-    REDIS_TLS       = var.redis_use_tls
-    DYNAMO_ENDPOINT = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    ENVIRONMENT          = var.environment
+    BASE_URL             = local.api_base_url
+    EVENTS_SNS_TOPIC_ARN = aws_sns_topic.events.arn
+    REDIS_HOST           = var.use_localstack ? var.external_redis_host : aws_elasticache_replication_group.sessions_store[0].primary_endpoint_address
+    REDIS_PORT           = var.use_localstack ? var.external_redis_port : aws_elasticache_replication_group.sessions_store[0].port
+    REDIS_PASSWORD       = var.use_localstack ? var.external_redis_password : random_password.redis_password.result
+    REDIS_TLS            = var.redis_use_tls
+    DYNAMO_ENDPOINT      = var.use_localstack ? var.lambda_dynamo_endpoint : null
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.CheckUserExistsHandler::handleRequest"
 

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -7,13 +7,14 @@ module "userinfo" {
   environment     = var.environment
 
   handler_environment_variables = {
-    ENVIRONMENT     = var.environment
-    BASE_URL        = local.api_base_url
-    REDIS_HOST      = var.use_localstack ? var.external_redis_host : aws_elasticache_replication_group.sessions_store[0].primary_endpoint_address
-    REDIS_PORT      = var.use_localstack ? var.external_redis_port : aws_elasticache_replication_group.sessions_store[0].port
-    REDIS_PASSWORD  = var.use_localstack ? var.external_redis_password : random_password.redis_password.result
-    REDIS_TLS       = var.redis_use_tls
-    DYNAMO_ENDPOINT = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    ENVIRONMENT          = var.environment
+    BASE_URL             = local.api_base_url
+    EVENTS_SNS_TOPIC_ARN = aws_sns_topic.events.arn
+    REDIS_HOST           = var.use_localstack ? var.external_redis_host : aws_elasticache_replication_group.sessions_store[0].primary_endpoint_address
+    REDIS_PORT           = var.use_localstack ? var.external_redis_port : aws_elasticache_replication_group.sessions_store[0].port
+    REDIS_PASSWORD       = var.use_localstack ? var.external_redis_password : random_password.redis_password.result
+    REDIS_TLS            = var.redis_use_tls
+    DYNAMO_ENDPOINT      = var.use_localstack ? var.lambda_dynamo_endpoint : null
   }
   handler_function_name = "uk.gov.di.lambdas.UserInfoHandler::handleRequest"
 

--- a/ci/terraform/oidc/verify_code.tf
+++ b/ci/terraform/oidc/verify_code.tf
@@ -7,13 +7,14 @@ module "verify_code" {
   environment     = var.environment
 
   handler_environment_variables = {
-    ENVIRONMENT     = var.environment
-    BASE_URL        = local.api_base_url
-    REDIS_HOST      = var.use_localstack ? var.external_redis_host : aws_elasticache_replication_group.sessions_store[0].primary_endpoint_address
-    REDIS_PORT      = var.use_localstack ? var.external_redis_port : aws_elasticache_replication_group.sessions_store[0].port
-    REDIS_PASSWORD  = var.use_localstack ? var.external_redis_password : random_password.redis_password.result
-    REDIS_TLS       = var.redis_use_tls
-    DYNAMO_ENDPOINT = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    ENVIRONMENT          = var.environment
+    BASE_URL             = local.api_base_url
+    EVENTS_SNS_TOPIC_ARN = aws_sns_topic.events.arn
+    REDIS_HOST           = var.use_localstack ? var.external_redis_host : aws_elasticache_replication_group.sessions_store[0].primary_endpoint_address
+    REDIS_PORT           = var.use_localstack ? var.external_redis_port : aws_elasticache_replication_group.sessions_store[0].port
+    REDIS_PASSWORD       = var.use_localstack ? var.external_redis_password : random_password.redis_password.result
+    REDIS_TLS            = var.redis_use_tls
+    DYNAMO_ENDPOINT      = var.use_localstack ? var.lambda_dynamo_endpoint : null
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.VerifyCodeHandler::handleRequest"
 

--- a/ci/terraform/oidc/wellknown.tf
+++ b/ci/terraform/oidc/wellknown.tf
@@ -7,7 +7,8 @@ module "openid_configuration_discovery" {
   environment     = var.environment
 
   handler_environment_variables = {
-    BASE_URL = local.api_base_url
+    BASE_URL             = local.api_base_url
+    EVENTS_SNS_TOPIC_ARN = aws_sns_topic.events.arn
   }
   handler_function_name = "uk.gov.di.lambdas.WellknownHandler::handleRequest"
 


### PR DESCRIPTION
## What?

Add environment variable in Terraform for the events SNS topic ARN.

I've added it for all lambdas; I'm on the fence about whether this is sensible.  I don't want people to get caught out by the environment variable being missing if they add event auditing somewhere, but it's probably overkill.  On the other hand, it won't really do any harm, apart maybe from cluttering up the .tfs a bit?

## Why?

Needed so that Java can see the ARN.  

## Related PRs

#361 