### PR TITLE
reduce lambda memory to 4gig and make api gateway deploy version of l…

### DIFF
--- a/ci/terraform/modules/endpoint-module/api-gateway.tf
+++ b/ci/terraform/modules/endpoint-module/api-gateway.tf
@@ -24,7 +24,7 @@ resource "aws_api_gateway_integration" "endpoint_integration" {
 
   integration_http_method = "POST"
   type                    = "AWS_PROXY"
-  uri                     = aws_lambda_function.endpoint_lambda.invoke_arn
+  uri                     = aws_lambda_alias.endpoint_lambda.invoke_arn
 
   depends_on = [
     aws_api_gateway_resource.endpoint_resource,

--- a/ci/terraform/modules/endpoint-module/lambda.tf
+++ b/ci/terraform/modules/endpoint-module/lambda.tf
@@ -4,7 +4,7 @@ resource "aws_lambda_function" "endpoint_lambda" {
   role          = var.lambda_role_arn
   handler       = var.handler_function_name
   timeout       = 30
-  memory_size   = 6144
+  memory_size   = 4096
   publish       = true
 
   tracing_config {
@@ -50,4 +50,11 @@ resource "aws_cloudwatch_log_subscription_filter" "log_subscription" {
   log_group_name  = aws_cloudwatch_log_group.lambda_log_group[0].name
   filter_pattern  = ""
   destination_arn = var.logging_endpoint_arn
+}
+
+resource "aws_lambda_alias" "endpoint_lambda"{
+  name = "endpoint_lambda_version"
+  description = "Versioned alias"
+  function_name = aws_lambda_function.endpoint_lambda.arn
+  function_version = aws_lambda_function.endpoint_lambda.version
 }


### PR DESCRIPTION
## What?

Reduce lambda to 4gig and make api gateway point to published version of lambda.

## Why?

The size difference doesn't equate to much of a performance improvement and the provisioned concurrency is not being used as the right version of lambda is not being invoked.

