### PR TITLE
BAU - Specify Alias as a qualifier to lambda permission

### DIFF
--- a/ci/terraform/modules/endpoint-module/api-gateway.tf
+++ b/ci/terraform/modules/endpoint-module/api-gateway.tf
@@ -38,6 +38,7 @@ resource "aws_lambda_permission" "endpoint_execution_permission" {
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.endpoint_lambda.function_name
   principal     = "apigateway.amazonaws.com"
+  qualifier     = aws_lambda_alias.endpoint_lambda.name
 
   # The "/*/*" portion grants access from any method on any resource
   # within the API Gateway REST API.


### PR DESCRIPTION
## What?

- Specify Alias as a qualifier to lambda permission

## Why?

- So that the API gateway has the correct permissions 

