### PR TITLE
GOVSI-622 - Create warmup methods for all connections

### DIFF
--- a/ci/terraform/oidc/dynamodb.tf
+++ b/ci/terraform/oidc/dynamodb.tf
@@ -94,6 +94,7 @@ data "aws_iam_policy_document" "dynamo_policy_document" {
       "dynamodb:BatchWriteItem",
       "dynamodb:UpdateItem",
       "dynamodb:PutItem",
+      "dynamodb:ListTables",
     ]
     resources = [
       aws_dynamodb_table.user_credentials_table.arn,

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoClientService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoClientService.java
@@ -17,9 +17,10 @@ public class DynamoClientService implements ClientService {
 
     private static final String CLIENT_REGISTRY_TABLE = "client-registry";
     private final DynamoDBMapper clientRegistryMapper;
+    private final AmazonDynamoDB dynamoDB;
 
     public DynamoClientService(String region, String environment, Optional<String> dynamoEndpoint) {
-        AmazonDynamoDB dynamoDB =
+        dynamoDB =
                 dynamoEndpoint
                         .map(
                                 t ->
@@ -38,7 +39,7 @@ public class DynamoClientService implements ClientService {
                         .build();
 
         this.clientRegistryMapper = new DynamoDBMapper(dynamoDB, clientRegistryConfig);
-        this.clientRegistryMapper.load(ClientRegistry.class, "testkey1");
+        warmUp();
     }
 
     @Override
@@ -94,5 +95,9 @@ public class DynamoClientService implements ClientService {
     @Override
     public ClientID generateClientID() {
         return new ClientID(IdGenerator.generate());
+    }
+
+    private void warmUp() {
+        dynamoDB.listTables();
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
@@ -31,9 +31,10 @@ public class DynamoService implements AuthenticationService {
     private final DynamoDBMapper userProfileMapper;
     private static final String USER_CREDENTIALS_TABLE = "user-credentials";
     private static final String USER_PROFILE_TABLE = "user-profile";
+    private final AmazonDynamoDB dynamoDB;
 
     public DynamoService(String region, String environment, Optional<String> dynamoEndpoint) {
-        AmazonDynamoDB dynamoDB =
+        dynamoDB =
                 dynamoEndpoint
                         .map(
                                 t ->
@@ -58,8 +59,7 @@ public class DynamoService implements AuthenticationService {
                         .build();
         this.userCredentialsMapper = new DynamoDBMapper(dynamoDB, userCredentialsConfig);
         this.userProfileMapper = new DynamoDBMapper(dynamoDB, userProfileConfig);
-        this.userProfileMapper.load(UserProfile.class, "TestKey1");
-        this.userProfileMapper.load(UserProfile.class, "TestKey1");
+        warmUp();
     }
 
     @Override
@@ -169,6 +169,10 @@ public class DynamoService implements AuthenticationService {
                             scanPage.getResults().size()));
         }
         return scanPage.getResults().get(0);
+    }
+
+    private void warmUp() {
+        dynamoDB.listTables();
     }
 
     private static String hashPassword(String password) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/KmsConnectionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/KmsConnectionService.java
@@ -33,6 +33,7 @@ public class KmsConnectionService {
         } else {
             this.kmsClient = AWSKMSClientBuilder.standard().withRegion(awsRegion).build();
         }
+        warmUp();
     }
 
     public GetPublicKeyResult getPublicKey(GetPublicKeyRequest getPublicKeyRequest) {
@@ -43,5 +44,9 @@ public class KmsConnectionService {
     public SignResult sign(SignRequest signRequest) {
         LOGGER.info("Calling KMS with SignRequest and KeyId {}", signRequest.getKeyId());
         return kmsClient.sign(signRequest);
+    }
+
+    private void warmUp() {
+        kmsClient.listKeys();
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/RedisConnectionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/RedisConnectionService.java
@@ -26,6 +26,7 @@ public class RedisConnectionService implements AutoCloseable {
         this.pool =
                 ConnectionPoolSupport.createGenericObjectPool(
                         client::connect, new GenericObjectPoolConfig());
+        warmUp();
     }
 
     public RedisConnectionService(ConfigurationService configurationService) {
@@ -78,6 +79,14 @@ public class RedisConnectionService implements AutoCloseable {
             return result.get(0);
         } catch (Exception e) {
             return null;
+        }
+    }
+
+    private void warmUp() {
+        try (StatefulRedisConnection<String, String> connection = pool.borrowObject()) {
+            boolean keyExists = connection.sync().exists("test-key") == 1;
+        } catch (Exception e) {
+
         }
     }
 


### PR DESCRIPTION

## What?

- Create warmup methods for all connections

## Why?

- When one of the services that establishes a connection is called, call a warmup method which will initalize a connection. This is so that when the lamdas are called we can maintain a quicker connection to any of the AWS services that we use


## Related PRs

Please include links to PRs in other repositories relevant to this PR.
Delete this section if not needed.