### PR TITLE
GOVSI-622 - Give lambdas permission to ListKeys in KMS

### DIFF
--- a/ci/terraform/modules/endpoint-module/lambda.tf
+++ b/ci/terraform/modules/endpoint-module/lambda.tf
@@ -4,7 +4,7 @@ resource "aws_lambda_function" "endpoint_lambda" {
   role          = var.lambda_role_arn
   handler       = var.handler_function_name
   timeout       = 30
-  memory_size   = 6144
+  memory_size   = 4096
   publish       = true
 
   tracing_config {

--- a/ci/terraform/oidc/kms.tf
+++ b/ci/terraform/oidc/kms.tf
@@ -20,6 +20,7 @@ data "aws_iam_policy_document" "kms_policy_document" {
 
     actions = [
       "kms:GetPublicKey",
+      "kms:ListKeys",
     ]
     resources = [
       aws_kms_key.id_token_signing_key.arn,
@@ -35,6 +36,7 @@ data "aws_iam_policy_document" "kms_signing_policy_document" {
 
     actions = [
       "kms:Sign",
+      "kms:ListKeys",
     ]
     resources = [
       aws_kms_key.id_token_signing_key.arn,


### PR DESCRIPTION


## What and Why

- We call the ListKeys method when we warmup the lambda
- Bring the memory down to 4gb
