### PR TITLE
GOVSI-622 - Retrieve public key when initalizing KmsConnectingService

### DIFF
--- a/ci/terraform/oidc/kms.tf
+++ b/ci/terraform/oidc/kms.tf
@@ -20,7 +20,6 @@ data "aws_iam_policy_document" "kms_policy_document" {
 
     actions = [
       "kms:GetPublicKey",
-      "kms:ListKeys",
     ]
     resources = [
       aws_kms_key.id_token_signing_key.arn,
@@ -36,7 +35,7 @@ data "aws_iam_policy_document" "kms_signing_policy_document" {
 
     actions = [
       "kms:Sign",
-      "kms:ListKeys",
+      "kms:GetPublicKey",
     ]
     resources = [
       aws_kms_key.id_token_signing_key.arn,

--- a/integration-tests/src/test/java/uk/gov/di/authentication/helpers/KmsHelper.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/helpers/KmsHelper.java
@@ -24,7 +24,8 @@ public class KmsHelper {
     private static final String TOKEN_SIGNING_KEY_ID = System.getenv().get("TOKEN_SIGNING_KEY_ID");
 
     private static final KmsConnectionService KMS_CONNECTION_SERVICE =
-            new KmsConnectionService(Optional.of(LOCALSTACK_ENDPOINT), REGION);
+            new KmsConnectionService(
+                    Optional.of(LOCALSTACK_ENDPOINT), REGION, TOKEN_SIGNING_KEY_ID);
 
     public static SignedJWT signIdToken(JWTClaimsSet claimsSet) {
         try {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoClientService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoClientService.java
@@ -5,7 +5,6 @@ import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperConfig;
-import com.amazonaws.services.dynamodbv2.model.ListTablesRequest;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.UpdateClientConfigRequest;


### PR DESCRIPTION
## What?

- Retrieve public key when initalizing KmsConnectingService

## Why?

- So the lambdas can obtain a quicker connection to KMS