### PR TITLE
GOVSI-185: reset account management api stage name to match environment

### DIFF
--- a/ci/terraform/account-management/api-gateway.tf
+++ b/ci/terraform/account-management/api-gateway.tf
@@ -136,7 +136,7 @@ resource "aws_api_gateway_method_settings" "api_gateway_logging_settings" {
   count = var.enable_api_gateway_execution_logging ? 1 : 0
 
   rest_api_id = aws_api_gateway_rest_api.di_account_management_api.id
-  stage_name  = var.api_deployment_stage_name
+  stage_name  = var.environment
   method_path = "*/*"
 
   settings {


### PR DESCRIPTION
## What?

Reset account management api stage name to match environment.

## Why?

Updated to bring into line with the rest of the terraform, however seems to break the build.