### PR TITLE
GOVSI-628 - Set Subject claim in AccessToken

### DIFF
--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandlerTest.java
@@ -68,7 +68,7 @@ public class UserInfoHandlerTest {
         scopes.add("phone");
         SignedJWT signedAccessToken =
                 TokenGeneratorHelper.generateAccessToken(
-                        "client-id", "issuer-url", scopes, ecSigningKey);
+                        "client-id", "issuer-url", scopes, ecSigningKey, SUBJECT);
         AccessToken accessToken = new BearerAccessToken(signedAccessToken.serialize());
         UserProfile userProfile =
                 new UserProfile()

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/TokenGeneratorHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/TokenGeneratorHelper.java
@@ -83,7 +83,11 @@ public class TokenGeneratorHelper {
     }
 
     public static SignedJWT generateAccessToken(
-            String clientId, String issuerUrl, List<String> scopes, ECKey signingKey) {
+            String clientId,
+            String issuerUrl,
+            List<String> scopes,
+            ECKey signingKey,
+            Subject subject) {
 
         LocalDateTime localDateTime = LocalDateTime.now().plusMinutes(2);
         Date expiryDate = Date.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant());
@@ -99,6 +103,7 @@ public class TokenGeneratorHelper {
                                                 .atZone(ZoneId.systemDefault())
                                                 .toInstant()))
                         .claim("client_id", clientId)
+                        .subject(subject.getValue())
                         .jwtID(UUID.randomUUID().toString())
                         .build();
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
@@ -272,6 +272,7 @@ public class TokenService {
                                                 .atZone(ZoneId.systemDefault())
                                                 .toInstant()))
                         .claim("client_id", clientId)
+                        .subject(subject.getValue())
                         .jwtID(UUID.randomUUID().toString())
                         .build();
         SignedJWT signedJWT = generateSignedJWT(claimsSet);

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
@@ -318,7 +318,8 @@ public class TokenServiceTest {
                         .keyID(KEY_ID)
                         .algorithm(JWSAlgorithm.ES256)
                         .generate();
-        return TokenGeneratorHelper.generateAccessToken(CLIENT_ID, BASE_URL, SCOPES, ecSigningKey);
+        return TokenGeneratorHelper.generateAccessToken(
+                CLIENT_ID, BASE_URL, SCOPES, ecSigningKey, SUBJECT);
     }
 
     private KeyPair generateRsaKeyPair() {


### PR DESCRIPTION
## What?

- Set Subject claim in AccessToken
## Why?

- It is required by the authorizer so it can set the principalId