### PR TITLE
GOVSI-628 - Delete the original entry once email has been updated

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
@@ -138,8 +138,10 @@ public class DynamoService implements AuthenticationService {
     public void updateEmail(String currentEmail, String newEmail) {
         userProfileMapper.save(
                 userProfileMapper.load(UserProfile.class, currentEmail).setEmail(newEmail));
+        userProfileMapper.delete(userProfileMapper.load(UserProfile.class, currentEmail));
         userCredentialsMapper.save(
                 userCredentialsMapper.load(UserCredentials.class, currentEmail).setEmail(newEmail));
+        userCredentialsMapper.delete(userCredentialsMapper.load(UserCredentials.class, currentEmail));
     }
 
     @Override


### PR DESCRIPTION
## What?

- Delete the original entry once email has been updated

## Why?

- The current logic did not update the existing row but created a new row with a different hash key leaving the entry there with the old email. Turns out a hashkey can't be updated so we need to explicitly delete it. https://stackoverflow.com/questions/37854710/is-it-possible-to-update-a-hash-key-in-amazon-dynamo-db