### PR TITLE
GOVSI-628 - Add transition from AUTHENTICATION_REQUIRED to USER_NOT_FOUND

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/StateMachine.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/StateMachine.java
@@ -94,7 +94,7 @@ public class StateMachine<T> {
                                         PHONE_NUMBER_CODE_NOT_VALID,
                                         PHONE_NUMBER_CODE_MAX_RETRIES_REACHED)),
                         entry(PHONE_NUMBER_CODE_MAX_RETRIES_REACHED, Collections.emptyList()),
-                        entry(AUTHENTICATION_REQUIRED, List.of(LOGGED_IN)),
+                        entry(AUTHENTICATION_REQUIRED, List.of(LOGGED_IN, USER_NOT_FOUND)),
                         entry(LOGGED_IN, List.of(MFA_SMS_CODE_SENT)),
                         entry(
                                 MFA_SMS_CODE_SENT,


### PR DESCRIPTION
## What?

- Add transition from AUTHENTICATION_REQUIRED to USER_NOT_FOUND

## Why?

- This is so when the UserExists lambda is called and the user is not found then the correct state can be set