### PR TITLE
GOVSI-628 - Give permissions to delete item in DynamoDB

### DIFF
--- a/ci/terraform/oidc/dynamodb.tf
+++ b/ci/terraform/oidc/dynamodb.tf
@@ -88,6 +88,7 @@ data "aws_iam_policy_document" "dynamo_policy_document" {
       "dynamodb:BatchGetItem",
       "dynamodb:DescribeStream",
       "dynamodb:DescribeTable",
+      "dynamodb:DeleteItem",
       "dynamodb:Get*",
       "dynamodb:Query",
       "dynamodb:Scan",


### PR DESCRIPTION
## What?

- Give permissions to delete item in DynamoDB

## Why?

- So we can delete items