### PR TITLE
GOVSI-628 - Give account management lambda role permissions to delete item in dynamo

### DIFF
--- a/ci/terraform/account-management/lambda-roles.tf
+++ b/ci/terraform/account-management/lambda-roles.tf
@@ -128,6 +128,7 @@ data "aws_iam_policy_document" "dynamo_policy_document" {
       "dynamodb:GetItem",
       "dynamodb:UpdateItem",
       "dynamodb:DescribeTable",
+      "dynamodb:DeleteItem",
     ]
     resources = [
       data.aws_dynamodb_table.user_credentials_table.arn,

--- a/ci/terraform/oidc/dynamodb.tf
+++ b/ci/terraform/oidc/dynamodb.tf
@@ -88,7 +88,6 @@ data "aws_iam_policy_document" "dynamo_policy_document" {
       "dynamodb:BatchGetItem",
       "dynamodb:DescribeStream",
       "dynamodb:DescribeTable",
-      "dynamodb:DeleteItem",
       "dynamodb:Get*",
       "dynamodb:Query",
       "dynamodb:Scan",


### PR DESCRIPTION
## What?

- Give account management lambda role permissions to delete item in dynamo


