### PR TITLE
GOVSI-628 - Configure NOTIFY_API_KEY with account management

### DIFF
--- a/ci/tasks/deploy-acct-mgmt-api.yml
+++ b/ci/tasks/deploy-acct-mgmt-api.yml
@@ -32,6 +32,7 @@ run:
         -var "deployer_role_arn=${DEPLOYER_ROLE_ARN}" \
         -var "environment=${DEPLOY_ENVIRONMENT}" \
         -var 'logging_endpoint_enabled=true' \
+        -var "notify_api_key=${NOTIFY_API_KEY}" \
         -var 'logging_endpoint_arn=arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod' \
         -var 'lambda_zip_file=../../../../api-release/account-management-api.zip' \
 


### PR DESCRIPTION
## What?

- Configure NOTIFY_API_KEY with account management

## Why?

- It is needed to use Notify