### PR TITLE
GOVSI-774: Add Cloudwatch triggers for lambda warmers

### DIFF
--- a/ci/terraform/modules/endpoint-module/variables.tf
+++ b/ci/terraform/modules/endpoint-module/variables.tf
@@ -7,12 +7,12 @@ variable "path_part" {
 }
 
 variable "method_request_parameters" {
-  type = map(bool)
+  type    = map(bool)
   default = {}
 }
 
 variable "integration_request_parameters" {
-  type = map(string)
+  type    = map(string)
   default = {}
 }
 
@@ -50,7 +50,7 @@ variable "execution_arn" {
 }
 
 variable "environment" {
-  type    = string
+  type = string
 }
 
 variable "api_deployment_stage_name" {
@@ -59,12 +59,12 @@ variable "api_deployment_stage_name" {
 }
 
 variable "security_group_id" {
-  type = string
+  type        = string
   description = "The id of the security for the lambda"
 }
 
 variable "subnet_id" {
-  type = list(string)
+  type        = list(string)
   description = "The id of the subnets for the lambda"
 }
 
@@ -85,11 +85,36 @@ variable "logging_endpoint_arn" {
 }
 
 variable "use_localstack" {
-  type    = bool
+  type = bool
 }
 
 variable "default_tags" {
   default     = {}
   type        = map(string)
   description = "Default tags to apply to all resources"
+}
+
+variable "warmer_lambda_zip_file" {
+  type    = string
+  default = null
+}
+
+variable "warmer_handler_function_name" {
+  type    = string
+  default = null
+}
+
+variable "warmer_handler_environment_variables" {
+  type    = map(string)
+  default = null
+}
+
+variable "warmer_handler_runtime" {
+  type    = string
+  default = "java11"
+}
+
+variable "warmer_lambda_role_arn" {
+  type    = string
+  default = null
 }

--- a/ci/terraform/modules/endpoint-module/warmer.tf
+++ b/ci/terraform/modules/endpoint-module/warmer.tf
@@ -5,7 +5,7 @@ resource "aws_lambda_function" "warmer_function" {
   function_name = replace("${var.environment}-${var.endpoint_name}-lambda-warmer", ".", "")
   role          = var.warmer_lambda_role_arn
   handler       = var.warmer_handler_function_name
-  timeout       = 30
+  timeout       = 60
   memory_size   = 4096
 
   tracing_config {

--- a/ci/terraform/modules/endpoint-module/warmer.tf
+++ b/ci/terraform/modules/endpoint-module/warmer.tf
@@ -1,0 +1,60 @@
+resource "aws_lambda_function" "warmer_function" {
+  count = var.warmer_handler_function_name == null ? 0 : 1
+
+  filename      = var.warmer_lambda_zip_file
+  function_name = replace("${var.environment}-${var.endpoint_name}-lambda-warmer", ".", "")
+  role          = var.warmer_lambda_role_arn
+  handler       = var.warmer_handler_function_name
+  timeout       = 30
+  memory_size   = 4096
+
+  tracing_config {
+    mode = "Active"
+  }
+
+  source_code_hash = filebase64sha256(var.warmer_lambda_zip_file)
+
+  environment {
+    variables = var.warmer_handler_environment_variables
+  }
+
+  runtime = var.warmer_handler_runtime
+
+  tags = merge(var.default_tags, {
+    lambda = "warmer"
+  })
+}
+
+resource "aws_cloudwatch_log_group" "warmer_lambda_log_group" {
+  count = var.use_localstack ? 0 : 1
+
+  name  = "/aws/lambda/${aws_lambda_function.warmer_function[0].function_name}"
+  tags = merge(var.default_tags, {
+    lambda = "warmer"
+  })
+}
+
+resource "aws_cloudwatch_event_rule" "warmer_schedule_rule" {
+  count = var.warmer_handler_function_name == null ? 0 : 1
+
+  name                = "${aws_lambda_function.warmer_function[0].function_name}-schedule"
+  schedule_expression = "cron(0/5 * * * ? *)"
+  is_enabled          = true
+}
+
+resource "aws_cloudwatch_event_target" "warmer_schedule_target" {
+  count = var.warmer_handler_function_name == null ? 0 : 1
+
+  arn       = aws_lambda_function.warmer_function[0].arn
+  rule      = aws_cloudwatch_event_rule.warmer_schedule_rule[0].name
+}
+
+resource "aws_lambda_permission" "allow_cloudwatch_to_call_warmer_lambda" {
+  count = var.warmer_handler_function_name == null ? 0 : 1
+
+  statement_id  = "AllowExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.warmer_function[0].function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.warmer_schedule_rule[0].arn
+}


### PR DESCRIPTION
## What?

- Add an, optional, CloudWatch trigger for each endpoint that triggers a warmer lambda every 5 mins

## Why?

We want keep some, if not all, lambdas "warm". This trigger will be used to trigger an execution of a warmer function.