### PR TITLE
GOVSI-628 - Validate email addresses and OTP code

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
@@ -13,9 +13,12 @@ import uk.gov.di.accountmanagement.entity.NotificationType;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.accountmanagement.entity.UpdateEmailRequest;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
+import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.helpers.RequestBodyHelper;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
+import uk.gov.di.authentication.shared.services.RedisConnectionService;
 import uk.gov.di.authentication.shared.services.ValidationService;
 
 import java.util.Map;
@@ -31,6 +34,7 @@ public class UpdateEmailHandler
     private final DynamoService dynamoService;
     private final AwsSqsClient sqsClient;
     private final ValidationService validationService;
+    private final CodeStorageService codeStorageService;
     private static final Logger LOGGER = LoggerFactory.getLogger(UpdateEmailHandler.class);
 
     public UpdateEmailHandler() {
@@ -42,15 +46,19 @@ public class UpdateEmailHandler
                         configurationService.getEmailQueueUri(),
                         configurationService.getSqsEndpointUri());
         this.validationService = new ValidationService();
+        this.codeStorageService =
+                new CodeStorageService(new RedisConnectionService(configurationService));
     }
 
     public UpdateEmailHandler(
             DynamoService dynamoService,
             AwsSqsClient sqsClient,
-            ValidationService validationService) {
+            ValidationService validationService,
+            CodeStorageService codeStorageService) {
         this.dynamoService = dynamoService;
         this.sqsClient = sqsClient;
         this.validationService = validationService;
+        this.codeStorageService = codeStorageService;
     }
 
     @Override
@@ -62,6 +70,16 @@ public class UpdateEmailHandler
         try {
             UpdateEmailRequest updateInfoRequest =
                     objectMapper.readValue(input.getBody(), UpdateEmailRequest.class);
+            boolean isValidOtpCode =
+                    codeStorageService.isValidOtpCode(
+                            updateInfoRequest.getExistingEmailAddress(),
+                            updateInfoRequest.getOtp(),
+                            NotificationType.VERIFY_EMAIL);
+            if (!isValidOtpCode) {
+                LOGGER.error(
+                        "Invalid OTP code sent in request");
+                return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1020);
+            }
             Optional<ErrorResponse> emailValidationErrors =
                     validationService.validateEmailAddressUpdate(
                             updateInfoRequest.getExistingEmailAddress(),
@@ -75,17 +93,7 @@ public class UpdateEmailHandler
             Subject subjectFromEmail =
                     dynamoService.getSubjectFromEmail(updateInfoRequest.getExistingEmailAddress());
             Map<String, Object> authorizerParams = input.getRequestContext().getAuthorizer();
-
-            if (!authorizerParams.containsKey("principalId")) {
-                LOGGER.error("principalId is missing");
-                throw new RuntimeException("principalId is missing");
-            } else if (!subjectFromEmail.getValue().equals(authorizerParams.get("principalId"))) {
-                LOGGER.error(
-                        "Subject ID: {} does not match principalId: {}",
-                        subjectFromEmail,
-                        authorizerParams.get("principalId"));
-                throw new RuntimeException("Subject ID does not match principalId");
-            }
+            RequestBodyHelper.validatePrincipal(subjectFromEmail, authorizerParams);
             dynamoService.updateEmail(
                     updateInfoRequest.getExistingEmailAddress(),
                     updateInfoRequest.getReplacementEmailAddress());

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/CodeStorageService.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/CodeStorageService.java
@@ -1,11 +1,16 @@
 package uk.gov.di.accountmanagement.services;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import uk.gov.di.accountmanagement.entity.NotificationType;
 import uk.gov.di.authentication.shared.helpers.HashHelper;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
 
+import static java.lang.String.format;
+
 public class CodeStorageService {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(CodeStorageService.class);
     private final RedisConnectionService redisConnectionService;
     private static final String EMAIL_KEY_PREFIX = "email-code:";
 
@@ -26,6 +31,29 @@ public class CodeStorageService {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public void deleteOtpCode(String emailAddress, NotificationType notificationType) {
+        String prefix = getPrefixForNotificationType(notificationType);
+        long numberOfKeysRemoved =
+                redisConnectionService.deleteValue(
+                        prefix + HashHelper.hashSha256String(emailAddress));
+
+        if (numberOfKeysRemoved == 0) {
+            LOGGER.info(format("No %s key was deleted for: %s", prefix, emailAddress));
+        }
+    }
+
+    public boolean isValidOtpCode(
+            String emailAddress, String code, NotificationType notificationType) {
+        String prefix = getPrefixForNotificationType(notificationType);
+        String codeFromRedis =
+                redisConnectionService.getValue(prefix + HashHelper.hashSha256String(emailAddress));
+        if (code.equals(codeFromRedis)) {
+            deleteOtpCode(emailAddress, notificationType);
+            return true;
+        }
+        return false;
     }
 
     private String getPrefixForNotificationType(NotificationType notificationType) {

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/CodeStorageServiceTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/services/CodeStorageServiceTest.java
@@ -1,0 +1,63 @@
+package uk.gov.di.accountmanagement.services;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.services.RedisConnectionService;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.accountmanagement.entity.NotificationType.VERIFY_EMAIL;
+
+class CodeStorageServiceTest {
+
+    private static final String TEST_EMAIL = "test@test.com";
+    private static final String CODE = "123456";
+    private final RedisConnectionService redisConnectionService =
+            mock(RedisConnectionService.class);
+    private final CodeStorageService codeStorageService =
+            new CodeStorageService(redisConnectionService);
+    private static final String REDIS_EMAIL_KEY =
+            "email-code:f660ab912ec121d1b1e928a0bb4bc61b15f5ad44d5efdc4e1c92a25e99b8e44a";
+    private static final long CODE_EXPIRY_TIME = 900;
+
+    @Test
+    public void shouldCallRedisWithValidEmailCodeAndHashedEmail() {
+        codeStorageService.saveOtpCode(TEST_EMAIL, CODE, CODE_EXPIRY_TIME, VERIFY_EMAIL);
+
+        verify(redisConnectionService).saveWithExpiry(REDIS_EMAIL_KEY, CODE, CODE_EXPIRY_TIME);
+    }
+
+    @Test
+    public void shouldCallRedisToDeleteEmailCodeWithHashedEmail() {
+        codeStorageService.deleteOtpCode(TEST_EMAIL, VERIFY_EMAIL);
+
+        verify(redisConnectionService).deleteValue(REDIS_EMAIL_KEY);
+    }
+
+    @Test
+    public void shouldSuccessfullyValidateOtpCodeAndDelete() {
+        when(redisConnectionService.getValue(REDIS_EMAIL_KEY)).thenReturn(CODE);
+
+        assertTrue(codeStorageService.isValidOtpCode(TEST_EMAIL, CODE, VERIFY_EMAIL));
+        verify(redisConnectionService).deleteValue(REDIS_EMAIL_KEY);
+    }
+
+    @Test
+    public void shouldReturnFalseWhenOtpCodeNotFound() {
+        when(redisConnectionService.getValue(REDIS_EMAIL_KEY)).thenReturn(null);
+
+        assertFalse(codeStorageService.isValidOtpCode(TEST_EMAIL, CODE, VERIFY_EMAIL));
+        verify(redisConnectionService, times(0)).deleteValue(REDIS_EMAIL_KEY);
+    }
+
+    @Test
+    public void shouldReturnFalseWhenOtpFoundButCodeDoesNotMatch() {
+        when(redisConnectionService.getValue(REDIS_EMAIL_KEY)).thenReturn(CODE);
+
+        assertFalse(codeStorageService.isValidOtpCode(TEST_EMAIL, "1234", VERIFY_EMAIL));
+        verify(redisConnectionService, times(0)).deleteValue(REDIS_EMAIL_KEY);
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
@@ -24,7 +24,7 @@ public enum ErrorResponse {
     ERROR_1016(1016, "Invalid Redirect URI"),
     ERROR_1017(1017, "Invalid transition in user journey"),
     ERROR_1018(1018, "Client-Session-Id is missing or invalid"),
-    ERROR_1019(1018, "Invalid updateInfoType sent in request");
+    ERROR_1019(1019, "Email addresses are the same");
 
     @JsonProperty("code")
     private int code;

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
@@ -24,7 +24,8 @@ public enum ErrorResponse {
     ERROR_1016(1016, "Invalid Redirect URI"),
     ERROR_1017(1017, "Invalid transition in user journey"),
     ERROR_1018(1018, "Client-Session-Id is missing or invalid"),
-    ERROR_1019(1019, "Email addresses are the same");
+    ERROR_1019(1019, "Email addresses are the same"),
+    ERROR_1020(1020, "Invalid OTP code");
 
     @JsonProperty("code")
     private int code;

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ValidationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ValidationService.java
@@ -14,6 +14,18 @@ public class ValidationService {
     private static final Pattern EMAIL_REGEX = Pattern.compile("[^@]+@[^@]+\\.[^@]*");
     private static final Pattern PASSWORD_REGEX = Pattern.compile(".*\\d.*");
 
+    public Optional<ErrorResponse> validateEmailAddressUpdate(
+            String existingEmail, String replacementEmail) {
+        if (existingEmail.equals(replacementEmail)) {
+            return Optional.of(ErrorResponse.ERROR_1019);
+        }
+        Optional<ErrorResponse> existingEmailError = validateEmailAddress(existingEmail);
+        if (existingEmailError.isPresent()) {
+            return existingEmailError;
+        }
+        return validateEmailAddress(replacementEmail);
+    }
+
     public Optional<ErrorResponse> validateEmailAddress(String email) {
         if (email.isBlank()) {
             return Optional.of(ErrorResponse.ERROR_1003);

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/ValidationServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/ValidationServiceTest.java
@@ -229,4 +229,30 @@ public class ValidationServiceTest {
                 validationService.validateMfaVerificationCode(
                         Optional.of("654321"), "123456", session, 5));
     }
+
+    @Test
+    public void shouldReturnErrorWhenEmailAddressesAreTheSame() {
+        String email = "joe.bloggs@digital.cabinet-office.gov.uk";
+        assertEquals(
+                Optional.of(ErrorResponse.ERROR_1019),
+                validationService.validateEmailAddressUpdate(email, email));
+    }
+
+    @Test
+    public void shouldReturnErrorWhenExistingEmailIsInvalid() {
+        String existingEmail = "joe.bloggs";
+        String replacementEmail = "joe.bloggs@digital.cabinet-office.gov.uk";
+        assertEquals(
+                Optional.of(ErrorResponse.ERROR_1004),
+                validationService.validateEmailAddressUpdate(existingEmail, replacementEmail));
+    }
+
+    @Test
+    public void shouldReturnErrorWhenReplacementEmailIsInvalid() {
+        String existingEmail = "joe.bloggs@digital.cabinet-office.gov.uk";
+        String replacementEmail = "joe.bloggs";
+        assertEquals(
+                Optional.of(ErrorResponse.ERROR_1004),
+                validationService.validateEmailAddressUpdate(existingEmail, replacementEmail));
+    }
 }


### PR DESCRIPTION
## What?

- Validate the emails are in the correct format and are different from one another. 
- If the OTP code is valid then delete it and return true
- If the OTP code is not valid then return an error response

## Why?

- Although some email validation will be carried out on the frontend it gives us extra protection 
- By validating the OTP code we can be confident that emails are only updated for the intended party
