### PR TITLE
GOVSI-774: Fix `count` variable on warmer log group

### DIFF
--- a/ci/terraform/modules/endpoint-module/warmer.tf
+++ b/ci/terraform/modules/endpoint-module/warmer.tf
@@ -26,7 +26,7 @@ resource "aws_lambda_function" "warmer_function" {
 }
 
 resource "aws_cloudwatch_log_group" "warmer_lambda_log_group" {
-  count = var.use_localstack ? 0 : 1
+  count = var.warmer_handler_function_name == null ? 0 : 1
 
   name  = "/aws/lambda/${aws_lambda_function.warmer_function[0].function_name}"
   tags = merge(var.default_tags, {


### PR DESCRIPTION
## What?

Fix `count` variable on warmer log group

## Why?

This should depend on the `warmer_handler_function_name` variable rather than `use_localstack`, as such the deployment is failing.

## Related PRs

#448 