### PR TITLE
GOVSI-149 - Send change phone number email confirmation

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/NotificationHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/NotificationHandler.java
@@ -88,12 +88,22 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                             LOGGER.info("EMAIL_UPDATED email has been sent using Notify");
                             break;
                         case DELETE_ACCOUNT:
+                            LOGGER.info("Sending DELETE_ACCOUNT email using Notify");
                             notificationService.sendEmail(
                                     notifyRequest.getDestination(),
                                     new HashMap<>(),
                                     notificationService.getNotificationTemplateId(
                                             NotificationType.DELETE_ACCOUNT));
                             LOGGER.info("DELETE_ACCOUNT email has been sent using Notify");
+                            break;
+                        case PHONE_NUMBER_UPDATED:
+                            LOGGER.info("Sending PHONE_NUMBER_UPDATED email using Notify");
+                            notificationService.sendEmail(
+                                    notifyRequest.getDestination(),
+                                    Map.of(),
+                                    notificationService.getNotificationTemplateId(
+                                            NotificationType.PHONE_NUMBER_UPDATED));
+                            LOGGER.info("PHONE_NUMBER_UPDATED email has been sent using Notify");
                             break;
                     }
                 } catch (NotificationClientException e) {

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/NotificationService.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/NotificationService.java
@@ -34,6 +34,8 @@ public class NotificationService {
                 return System.getenv("EMAIL_UPDATED_TEMPLATE_ID");
             case DELETE_ACCOUNT:
                 return System.getenv("DELETE_ACCOUNT_TEMPLATE_ID");
+            case PHONE_NUMBER_UPDATED:
+                return System.getenv("PHONE_NUMBER_UPDATED_TEMPLATE_ID");
             default:
                 throw new RuntimeException("NotificationType template ID does not exist");
         }

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/NotificationHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/NotificationHandlerTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.accountmanagement.entity.NotificationType.EMAIL_UPDATED;
+import static uk.gov.di.accountmanagement.entity.NotificationType.PHONE_NUMBER_UPDATED;
 import static uk.gov.di.accountmanagement.entity.NotificationType.VERIFY_EMAIL;
 import static uk.gov.di.accountmanagement.entity.NotificationType.VERIFY_PHONE_NUMBER;
 
@@ -94,6 +95,21 @@ public class NotificationHandlerTest {
         personalisation.put("email-address", notifyRequest.getDestination());
 
         verify(notificationService).sendEmail(TEST_EMAIL_ADDRESS, personalisation, TEMPLATE_ID);
+    }
+
+    @Test
+    public void shouldSuccessfullyProcessUpdatePhoneNumberMessageFromSQSQueue()
+            throws JsonProcessingException, NotificationClientException {
+        when(notificationService.getNotificationTemplateId(PHONE_NUMBER_UPDATED))
+                .thenReturn(TEMPLATE_ID);
+
+        NotifyRequest notifyRequest = new NotifyRequest(TEST_EMAIL_ADDRESS, PHONE_NUMBER_UPDATED);
+        String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
+        SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
+
+        handler.handleRequest(sqsEvent, context);
+
+        verify(notificationService).sendEmail(TEST_EMAIL_ADDRESS, Map.of(), TEMPLATE_ID);
     }
 
     @Test

--- a/ci/terraform/account-management/sqs.tf
+++ b/ci/terraform/account-management/sqs.tf
@@ -131,12 +131,13 @@ resource "aws_lambda_function" "email_sqs_lambda" {
   }
   environment {
     variables = {
-      VERIFY_EMAIL_TEMPLATE_ID        = "b7dbb02f-941b-4d72-ad64-84cbe5d77c2e"
-      VERIFY_PHONE_NUMBER_TEMPLATE_ID = "7dd388f1-e029-4fe7-92ff-18496dcb53e9"
-      EMAIL_UPDATED_TEMPLATE_ID       = "0a200a63-97b2-4920-bc40-48e9a9e1121e"
-      DELETE_ACCOUNT_TEMPLATE_ID      = "0706adcc-b593-4d2d-afa6-c3da7149e426"
-      NOTIFY_API_KEY                  = var.notify_api_key
-      NOTIFY_URL                      = var.notify_url
+      VERIFY_EMAIL_TEMPLATE_ID              = "b7dbb02f-941b-4d72-ad64-84cbe5d77c2e"
+      VERIFY_PHONE_NUMBER_TEMPLATE_ID       = "7dd388f1-e029-4fe7-92ff-18496dcb53e9"
+      EMAIL_UPDATED_TEMPLATE_ID             = "0a200a63-97b2-4920-bc40-48e9a9e1121e"
+      DELETE_ACCOUNT_TEMPLATE_ID            = "0706adcc-b593-4d2d-afa6-c3da7149e426"
+      PHONE_NUMBER_UPDATED_TEMPLATE_ID      = "8274a2a3-5121-4630-a27e-e8578f8cba59"
+      NOTIFY_API_KEY                        = var.notify_api_key
+      NOTIFY_URL                            = var.notify_url
     }
   }
 


### PR DESCRIPTION
## What?

- Change the notification handler to pick the PHONE_NUMBER_UPDATED from the SQS queue and send an email confirming that the phone number has successfully been changed.

## Why?

- We need to send an email to the registered email address that the phone number has been changed