### PR TITLE
BAU - Add extra logging and remove userexists check

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandler.java
@@ -14,7 +14,6 @@ import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.accountmanagement.entity.RemoveAccountRequest;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
-import uk.gov.di.authentication.shared.helpers.StateMachine;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
@@ -58,32 +57,28 @@ public class RemoveAccountHandler
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
         try {
+            LOGGER.info("RemoveAccountHandler received request");
             RemoveAccountRequest removeAccountRequest =
                     objectMapper.readValue(input.getBody(), RemoveAccountRequest.class);
 
             String email = removeAccountRequest.getEmail();
+
             Subject subjectFromEmail = authenticationService.getSubjectFromEmail(email);
             Map<String, Object> authorizerParams = input.getRequestContext().getAuthorizer();
-
             validatePrincipal(subjectFromEmail, authorizerParams);
 
-            if (!authenticationService.userExists(email)) {
-                LOGGER.info("User account does not exist");
-                return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1010);
-            }
-
             authenticationService.removeAccount(email);
-            LOGGER.info("User account removed");
+            LOGGER.info("User account removed. Adding message to SQS queue");
 
             NotifyRequest notifyRequest = new NotifyRequest(email, NotificationType.DELETE_ACCOUNT);
             sqsClient.send(objectMapper.writeValueAsString((notifyRequest)));
-            LOGGER.info("Remove account message successfully added to queue.");
-
+            LOGGER.info(
+                    "Remove account message successfully added to queue. Generating successful gateway response");
             return generateApiGatewayProxyResponse(200, "");
         } catch (JsonProcessingException e) {
+            LOGGER.error(
+                    "RemoveAccountRequest request is missing or contains invalid parameters.", e);
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
-        } catch (StateMachine.InvalidStateTransitionException e) {
-            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1017);
         }
     }
 }


### PR DESCRIPTION

## What?

 - Add extra logging and remove userexists check

## Why?

- We can do a userexists check in the authorizer so we don't need to duplicate this in each lambda.
- Add extra logging so it is easier to debug
