### PR TITLE
GOVSI-719

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthoriseAccessTokenHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthoriseAccessTokenHandler.java
@@ -9,8 +9,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.di.accountmanagement.entity.AuthPolicy;
 import uk.gov.di.accountmanagement.entity.TokenAuthorizerContext;
-import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.KmsConnectionService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
 import uk.gov.di.authentication.shared.services.TokenService;
@@ -22,13 +22,15 @@ public class AuthoriseAccessTokenHandler
 
     private final TokenService tokenService;
     private final ConfigurationService configurationService;
+    private final DynamoService dynamoService;
 
     public AuthoriseAccessTokenHandler(
             TokenService tokenService,
-            AuthenticationService authenticationService,
-            ConfigurationService configurationService) {
+            ConfigurationService configurationService,
+            DynamoService dynamoService) {
         this.tokenService = tokenService;
         this.configurationService = configurationService;
+        this.dynamoService = dynamoService;
     }
 
     public AuthoriseAccessTokenHandler() {
@@ -38,6 +40,7 @@ public class AuthoriseAccessTokenHandler
                         configurationService,
                         new RedisConnectionService(configurationService),
                         new KmsConnectionService(configurationService));
+        dynamoService = new DynamoService(configurationService);
     }
 
     @Override
@@ -57,6 +60,12 @@ public class AuthoriseAccessTokenHandler
             //            }
             LOGGER.info("Successfully validated Access Token signature");
             String subject = SignedJWT.parse(accessToken.getValue()).getJWTClaimsSet().getSubject();
+            try {
+                dynamoService.getUserProfileFromSubject(subject);
+            } catch (Exception e) {
+                LOGGER.error("Unable to retrieve UserProfile from Dynamo with given SubjectID: {}", subject, e);
+                throw new RuntimeException("Unable to retrieve UserProfile from Dynamo with given SubjectID", e);
+            }
             String methodArn = input.getMethodArn();
             String[] arnPartials = methodArn.split(":");
             String region = arnPartials[3];


### PR DESCRIPTION

## What?

 - Check in the authorizer whether the user already exists. If a userprofile is unable to be found the dynamo service getUserProfileFromSubject method will throw an exception which we can handle here. 

## Why?

- To prevent us having to do a check in each lambda in account management whether a user exists, do a check in the authorizer by using the SubjectID in the access token
