### PR TITLE
GOVSI-719 - Use Alias ID to retrieve key and configure account management with KMS

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthoriseAccessTokenHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthoriseAccessTokenHandler.java
@@ -63,8 +63,12 @@ public class AuthoriseAccessTokenHandler
             try {
                 dynamoService.getUserProfileFromSubject(subject);
             } catch (Exception e) {
-                LOGGER.error("Unable to retrieve UserProfile from Dynamo with given SubjectID: {}", subject, e);
-                throw new RuntimeException("Unable to retrieve UserProfile from Dynamo with given SubjectID", e);
+                LOGGER.error(
+                        "Unable to retrieve UserProfile from Dynamo with given SubjectID: {}",
+                        subject,
+                        e);
+                throw new RuntimeException(
+                        "Unable to retrieve UserProfile from Dynamo with given SubjectID", e);
             }
             String methodArn = input.getMethodArn();
             String[] arnPartials = methodArn.split(":");

--- a/ci/terraform/account-management/api-gateway.tf
+++ b/ci/terraform/account-management/api-gateway.tf
@@ -85,6 +85,11 @@ resource "aws_lambda_function" "authorizer" {
     security_group_ids = [aws_vpc.account_management_vpc.default_security_group_id]
     subnet_ids         = aws_subnet.account_management_subnets.*.id
   }
+  environment {
+    variables = {
+      TOKEN_SIGNING_KEY_ALIAS = data.aws_kms_key.id_token_public_key.key_id
+    }
+  }
 }
 
 resource "aws_iam_role" "invocation_role" {

--- a/ci/terraform/oidc/jwks.tf
+++ b/ci/terraform/oidc/jwks.tf
@@ -10,7 +10,7 @@ module "jwks" {
     BASE_URL             = local.api_base_url
     EVENTS_SNS_TOPIC_ARN = aws_sns_topic.events.arn
     LOCALSTACK_ENDPOINT  = var.use_localstack ? var.localstack_endpoint : null
-    TOKEN_SIGNING_KEY_ID = aws_kms_key.id_token_signing_key.key_id
+    TOKEN_SIGNING_KEY_ALIAS = aws_kms_alias.id_token_signing_key_alias.name
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.JwksHandler::handleRequest"
 

--- a/ci/terraform/oidc/logout.tf
+++ b/ci/terraform/oidc/logout.tf
@@ -17,7 +17,7 @@ module "logout" {
     REDIS_TLS            = var.redis_use_tls
     ENVIRONMENT          = var.environment
     DYNAMO_ENDPOINT      = var.use_localstack ? var.lambda_dynamo_endpoint : null
-    TOKEN_SIGNING_KEY_ID = aws_kms_key.id_token_signing_key.key_id
+    TOKEN_SIGNING_KEY_ALIAS = aws_kms_alias.id_token_signing_key_alias.name
     LOCALSTACK_ENDPOINT  = var.use_localstack ? var.localstack_endpoint : null
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.LogoutHandler::handleRequest"

--- a/ci/terraform/oidc/outputs.tf
+++ b/ci/terraform/oidc/outputs.tf
@@ -6,8 +6,8 @@ output "api_gateway_root_id" {
   value = aws_api_gateway_rest_api.di_authentication_api.id
 }
 
-output "token_signing_key_id" {
-  value = aws_kms_key.id_token_signing_key.key_id
+output "token_signing_key_alias" {
+  value = aws_kms_alias.id_token_signing_key_alias.name
 }
 
 output "stub_rp_client_credentials" {

--- a/ci/terraform/oidc/token.tf
+++ b/ci/terraform/oidc/token.tf
@@ -16,7 +16,7 @@ module "token" {
     REDIS_PORT           = var.use_localstack ? var.external_redis_port : aws_elasticache_replication_group.sessions_store[0].port
     REDIS_PASSWORD       = var.use_localstack ? var.external_redis_password : random_password.redis_password.result
     REDIS_TLS            = var.redis_use_tls
-    TOKEN_SIGNING_KEY_ID = aws_kms_key.id_token_signing_key.key_id
+    TOKEN_SIGNING_KEY_ALIAS =aws_kms_alias.id_token_signing_key_alias.name
     LOCALSTACK_ENDPOINT  = var.use_localstack ? var.localstack_endpoint : null
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.TokenHandler::handleRequest"

--- a/integration-tests/src/test/java/uk/gov/di/authentication/helpers/KmsHelper.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/helpers/KmsHelper.java
@@ -21,23 +21,26 @@ public class KmsHelper {
     private static final String BASE_URL = System.getenv().getOrDefault("BASE_URL", "rubbish");
     private static final String LOCALSTACK_ENDPOINT =
             System.getenv().getOrDefault("LOCALSTACK_ENDPOINT", "http://localhost:45678");
-    private static final String TOKEN_SIGNING_KEY_ID = System.getenv().get("TOKEN_SIGNING_KEY_ID");
+    private static final String TOKEN_SIGNING_KEY_ALIAS =
+            System.getenv().get("TOKEN_SIGNING_KEY_ALIAS");
 
     private static final KmsConnectionService KMS_CONNECTION_SERVICE =
             new KmsConnectionService(
-                    Optional.of(LOCALSTACK_ENDPOINT), REGION, TOKEN_SIGNING_KEY_ID);
+                    Optional.of(LOCALSTACK_ENDPOINT), REGION, TOKEN_SIGNING_KEY_ALIAS);
 
     public static SignedJWT signIdToken(JWTClaimsSet claimsSet) {
         try {
             JWSHeader jwsHeader =
-                    new JWSHeader.Builder(JWSAlgorithm.ES256).keyID(TOKEN_SIGNING_KEY_ID).build();
+                    new JWSHeader.Builder(JWSAlgorithm.ES256)
+                            .keyID(TOKEN_SIGNING_KEY_ALIAS)
+                            .build();
             Base64URL encodedHeader = jwsHeader.toBase64URL();
             Base64URL encodedClaims = Base64URL.encode(claimsSet.toString());
             String message = encodedHeader + "." + encodedClaims;
             ByteBuffer messageToSign = ByteBuffer.wrap(message.getBytes());
             SignRequest signRequest = new SignRequest();
             signRequest.setMessage(messageToSign);
-            signRequest.setKeyId(TOKEN_SIGNING_KEY_ID);
+            signRequest.setKeyId(TOKEN_SIGNING_KEY_ALIAS);
             signRequest.setSigningAlgorithm(SigningAlgorithmSpec.ECDSA_SHA_256.toString());
             SignResult signResult = KMS_CONNECTION_SERVICE.sign(signRequest);
             String signature =

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -95,7 +95,7 @@ startup() {
 run-integration-tests() {
   pushd ci/terraform/oidc >/dev/null
   export API_GATEWAY_ID="$(terraform output -raw api_gateway_root_id)"
-  export TOKEN_SIGNING_KEY_ID="$(terraform output -raw token_signing_key_id)"
+  export TOKEN_SIGNING_KEY_ALIAS="$(terraform output -raw token_signing_key_alias)"
   export BASE_URL="$(terraform output -raw base_url)"
   popd >/dev/null
   ./gradlew integration-tests:test

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -116,7 +116,7 @@ public class ConfigurationService {
         return System.getenv("TERMS_CONDITIONS_VERSION");
     }
 
-    public String getTokenSigningKeyId() {
-        return System.getenv("TOKEN_SIGNING_KEY_ID");
+    public String getTokenSigningKeyAlias() {
+        return System.getenv("TOKEN_SIGNING_KEY_ALIAS");
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/KmsConnectionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/KmsConnectionService.java
@@ -21,7 +21,7 @@ public class KmsConnectionService {
         this(
                 configurationService.getLocalstackEndpointUri(),
                 configurationService.getAwsRegion(),
-                configurationService.getTokenSigningKeyId());
+                configurationService.getTokenSigningKeyAlias());
     }
 
     public KmsConnectionService(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
@@ -103,7 +103,7 @@ public class TokenService {
         try {
             LOGGER.info("Validating ID token signature");
             LOGGER.info("IDTokenHint: " + idTokenHint);
-            LOGGER.info("TokenSigningKeyID: " + configService.getTokenSigningKeyId());
+            LOGGER.info("TokenSigningKeyID: " + configService.getTokenSigningKeyAlias());
             SignedJWT idToken = SignedJWT.parse(idTokenHint);
             LOGGER.info("ClientID:" + idToken.getJWTClaimsSet().getAudience().get(0));
             LOGGER.info("Issuer: " + configService.getBaseURL().get());
@@ -130,7 +130,7 @@ public class TokenService {
     public boolean validateAccessTokenSignature(AccessToken accessToken) {
         try {
             LOGGER.info("Validating Access Token signature");
-            LOGGER.info("TokenSigningKeyID: " + configService.getTokenSigningKeyId());
+            LOGGER.info("TokenSigningKeyID: " + configService.getTokenSigningKeyAlias());
             LOGGER.info("Issuer: " + configService.getBaseURL().get());
             JWK publicJwk = getPublicJwk();
             LOGGER.info("PublicJWK: " + publicJwk.toString());
@@ -150,7 +150,7 @@ public class TokenService {
         LOGGER.info("Creating GetPublicKeyRequest to retrieve PublicKey from KMS");
         Provider bcProvider = new BouncyCastleProvider();
         GetPublicKeyRequest getPublicKeyRequest = new GetPublicKeyRequest();
-        getPublicKeyRequest.setKeyId(configService.getTokenSigningKeyId());
+        getPublicKeyRequest.setKeyId(configService.getTokenSigningKeyAlias());
         GetPublicKeyResult publicKeyResult = kmsConnectionService.getPublicKey(getPublicKeyRequest);
         try {
             LOGGER.info("PUBLICKEYRESULT: " + publicKeyResult.toString());
@@ -168,7 +168,7 @@ public class TokenService {
             PublicKey publicKey = getPublicKey();
             ECKey jwk =
                     new ECKey.Builder(Curve.P_256, (ECPublicKey) publicKey)
-                            .keyID(configService.getTokenSigningKeyId())
+                            .keyID(configService.getTokenSigningKeyAlias())
                             .keyUse(KeyUse.SIGNATURE)
                             .algorithm(new Algorithm(JWSAlgorithm.ES256.getName()))
                             .build();
@@ -289,7 +289,7 @@ public class TokenService {
         try {
             JWSHeader jwsHeader =
                     new JWSHeader.Builder(JWSAlgorithm.ES256)
-                            .keyID(configService.getTokenSigningKeyId())
+                            .keyID(configService.getTokenSigningKeyAlias())
                             .build();
             Base64URL encodedHeader = jwsHeader.toBase64URL();
             Base64URL encodedClaims = Base64URL.encode(claimsSet.toString());
@@ -297,7 +297,7 @@ public class TokenService {
             ByteBuffer messageToSign = ByteBuffer.wrap(message.getBytes());
             SignRequest signRequest = new SignRequest();
             signRequest.setMessage(messageToSign);
-            signRequest.setKeyId(configService.getTokenSigningKeyId());
+            signRequest.setKeyId(configService.getTokenSigningKeyAlias());
             signRequest.setSigningAlgorithm(SigningAlgorithmSpec.ECDSA_SHA_256.toString());
             SignResult signResult = kmsConnectionService.sign(signRequest);
             LOGGER.info("Token has been signed successfully");

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
@@ -78,7 +78,7 @@ public class TokenServiceTest {
     @Test
     public void shouldSuccessfullyGenerateTokenResponse() throws ParseException, JOSEException {
         Nonce nonce = new Nonce();
-        when(configurationService.getTokenSigningKeyId()).thenReturn(KEY_ID);
+        when(configurationService.getTokenSigningKeyAlias()).thenReturn(KEY_ID);
         when(configurationService.getAccessTokenExpiry()).thenReturn(300L);
         SignedJWT signedIdToken = createSignedIdToken();
         SignedJWT signedAccessToken = createSignedAccessToken();
@@ -136,7 +136,7 @@ public class TokenServiceTest {
         ECDSASigner signer = new ECDSASigner(privateKey, Curve.P_256);
         ECPublicKey ecPublicKey = (ECPublicKey) keyPair.getPublic();
         byte[] encodedPublicKey = ecPublicKey.getEncoded();
-        when(configurationService.getTokenSigningKeyId()).thenReturn(KEY_ID);
+        when(configurationService.getTokenSigningKeyAlias()).thenReturn(KEY_ID);
         GetPublicKeyResult getPublicKeyResult = new GetPublicKeyResult();
         getPublicKeyResult.setKeyUsage("SIGN_VERIFY");
         getPublicKeyResult.setKeyId(KEY_ID);
@@ -183,7 +183,7 @@ public class TokenServiceTest {
                 Base64.getDecoder()
                         .decode(
                                 "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEpRm+QZsh2IkUWcqXUhBI9ulOzO8dz0Z8HIS6m77tI4eWoZgKYUcbByshDtN4gWPql7E5mN4uCLsg5+6SDXlQcA==");
-        when(configurationService.getTokenSigningKeyId()).thenReturn(keyId);
+        when(configurationService.getTokenSigningKeyAlias()).thenReturn(keyId);
         GetPublicKeyResult getPublicKeyResult = new GetPublicKeyResult();
         getPublicKeyResult.setKeyUsage("SIGN_VERIFY");
         getPublicKeyResult.setKeyId(keyId);


### PR DESCRIPTION
## What?

- Retrieve the key using the alias
- Reference the KMS key dataqsource in account management

## Why?

- By using the alias instead of the key_id, it ensures that we always retrieve the latest key. This will benefit us during key rotations as we can avoid having to restart our lambdas.
- We will need the public key in the authorizer so we can validate the signature of the access token