### PR TITLE
BAU: add sandpit vars for sandpit users

### DIFF
--- a/ci/terraform/account-management/sandpit.tfvars
+++ b/ci/terraform/account-management/sandpit.tfvars
@@ -1,2 +1,3 @@
 environment    = "sandpit"
-
+use_localstack = false
+notify_api_key = 123456


### PR DESCRIPTION
## What?

Add sandpit vars for sandpit users.

## Why?

So that the right things are applied for remote and local terraform usage.