### PR TITLE
GOVSI-719 - Add query permission to Account mgmt IAM role

### DIFF
--- a/ci/terraform/account-management/lambda-roles.tf
+++ b/ci/terraform/account-management/lambda-roles.tf
@@ -182,6 +182,7 @@ data "aws_iam_policy_document" "dynamo_policy_document" {
       "dynamodb:UpdateItem",
       "dynamodb:DescribeTable",
       "dynamodb:DeleteItem",
+      "dynamodb:Query",
     ]
     resources = [
       data.aws_dynamodb_table.user_credentials_table.arn,


### PR DESCRIPTION
## What?

- Add query permission to Account mgmt IAM role


## Why?

- The authorizer needs to be able to use query when using the SubjectID to retrieve the user profile