### PR TITLE
GOVSI-719 - Set the environment variable for the authorization lambda

### DIFF
--- a/ci/terraform/account-management/api-gateway.tf
+++ b/ci/terraform/account-management/api-gateway.tf
@@ -88,6 +88,7 @@ resource "aws_lambda_function" "authorizer" {
   environment {
     variables = {
       TOKEN_SIGNING_KEY_ALIAS = data.aws_kms_key.id_token_public_key.key_id
+      ENVIRONMENT             = var.environment
     }
   }
 }


### PR DESCRIPTION
## What?

- Set the environment variable for the authorization lambda

## Why?

- So it can find the correct dynamodb table