### PR TITLE
GOVSI-719 - Give authorizer permission to secondary index

### DIFF
--- a/ci/terraform/account-management/lambda-roles.tf
+++ b/ci/terraform/account-management/lambda-roles.tf
@@ -187,6 +187,7 @@ data "aws_iam_policy_document" "dynamo_policy_document" {
     resources = [
       data.aws_dynamodb_table.user_credentials_table.arn,
       data.aws_dynamodb_table.user_profile_table.arn,
+      "${data.aws_dynamodb_table.user_profile_table.arn}/index/*",
     ]
   }
 }


### PR DESCRIPTION
## What?

 - Give authorizer permission to secondary index

## Why?

- To use the secondary index to query the database