### PR TITLE
GOVSI-766: Log SessionID in all relevant lambdas

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -80,6 +80,8 @@ public class AuthCodeHandler
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1000);
         }
 
+        LOGGER.info("AuthCodeHandler processing request for session {}", session.getSessionId());
+
         try {
             validateStateTransition(session, AUTHENTICATED);
         } catch (StateMachine.InvalidStateTransitionException e) {

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
@@ -83,6 +83,8 @@ public class LogoutHandler
 
     private APIGatewayProxyResponseEvent processLogoutRequest(
             Session session, APIGatewayProxyRequestEvent input, Optional<String> state) {
+        LOG.info("LogoutHandler processing request for session {}", session.getSessionId());
+
         Map<String, String> queryStringParameters = input.getQueryStringParameters();
         Optional<CookieHelper.SessionCookieIds> sessionCookieIds =
                 CookieHelper.parseSessionCookie(input.getHeaders());


### PR DESCRIPTION
## What?

Log SessionID in all relevant lambdas.

* Needed in AuthCodeHandler and LogoutHandler.
* Already done in AuthorisationHandler.
* Not relevant in other lambdas.

## Why?

We need this so we can trace sessions when debugging.