### PR TITLE
GOVSI-719 - Validate AccessToken signature in UserInfo

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthoriseAccessTokenHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthoriseAccessTokenHandler.java
@@ -14,30 +14,30 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.KmsConnectionService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
-import uk.gov.di.authentication.shared.services.TokenService;
+import uk.gov.di.authentication.shared.services.TokenValidationService;
 
 public class AuthoriseAccessTokenHandler
         implements RequestHandler<TokenAuthorizerContext, AuthPolicy> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AuthoriseAccessTokenHandler.class);
 
-    private final TokenService tokenService;
+    private final TokenValidationService tokenValidationService;
     private final ConfigurationService configurationService;
     private final DynamoService dynamoService;
 
     public AuthoriseAccessTokenHandler(
-            TokenService tokenService,
+            TokenValidationService tokenValidationService,
             ConfigurationService configurationService,
             DynamoService dynamoService) {
-        this.tokenService = tokenService;
+        this.tokenValidationService = tokenValidationService;
         this.configurationService = configurationService;
         this.dynamoService = dynamoService;
     }
 
     public AuthoriseAccessTokenHandler() {
         configurationService = new ConfigurationService();
-        tokenService =
-                new TokenService(
+        tokenValidationService =
+                new TokenValidationService(
                         configurationService,
                         new RedisConnectionService(configurationService),
                         new KmsConnectionService(configurationService));
@@ -54,7 +54,7 @@ public class AuthoriseAccessTokenHandler
             accessToken = AccessToken.parse(token, AccessTokenType.BEARER);
             String subject = SignedJWT.parse(accessToken.getValue()).getJWTClaimsSet().getSubject();
             boolean isAccessTokenSignatureValid =
-                    tokenService.validateAccessTokenSignature(accessToken);
+                    tokenValidationService.validateAccessTokenSignature(accessToken);
             if (!isAccessTokenSignatureValid) {
                 LOGGER.error("Access Token signature is not valid");
                 throw new RuntimeException("Unauthorized");

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/AuthoriseAccessTokenHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/AuthoriseAccessTokenHandlerTest.java
@@ -17,7 +17,7 @@ import uk.gov.di.accountmanagement.entity.TokenAuthorizerContext;
 import uk.gov.di.authentication.shared.helpers.TokenGeneratorHelper;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
-import uk.gov.di.authentication.shared.services.TokenService;
+import uk.gov.di.authentication.shared.services.TokenValidationService;
 
 import java.util.List;
 
@@ -31,7 +31,8 @@ import static org.mockito.Mockito.when;
 
 class AuthoriseAccessTokenHandlerTest {
 
-    private final TokenService tokenService = mock(TokenService.class);
+    private final TokenValidationService tokenValidationServicen =
+            mock(TokenValidationService.class);
     private final DynamoService dynamoService = mock(DynamoService.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private AuthoriseAccessTokenHandler handler;
@@ -46,7 +47,8 @@ class AuthoriseAccessTokenHandlerTest {
     @BeforeEach
     public void setUp() {
         handler =
-                new AuthoriseAccessTokenHandler(tokenService, configurationService, dynamoService);
+                new AuthoriseAccessTokenHandler(
+                        tokenValidationServicen, configurationService, dynamoService);
     }
 
     @Test
@@ -56,7 +58,8 @@ class AuthoriseAccessTokenHandlerTest {
         TokenAuthorizerContext tokenAuthorizerContext =
                 new TokenAuthorizerContext(
                         TOKEN_TYPE, signedAccessToken.toAuthorizationHeader(), METHOD_ARN);
-        when(tokenService.validateAccessTokenSignature(signedAccessToken)).thenReturn(true);
+        when(tokenValidationServicen.validateAccessTokenSignature(signedAccessToken))
+                .thenReturn(true);
         AuthPolicy authPolicy = handler.handleRequest(tokenAuthorizerContext, context);
 
         assertThat(authPolicy.getPrincipalId(), equalTo(SUBJECT.getValue()));
@@ -70,7 +73,8 @@ class AuthoriseAccessTokenHandlerTest {
         TokenAuthorizerContext tokenAuthorizerContext =
                 new TokenAuthorizerContext(
                         TOKEN_TYPE, signedAccessToken.toAuthorizationHeader(), METHOD_ARN);
-        when(tokenService.validateAccessTokenSignature(signedAccessToken)).thenReturn(false);
+        when(tokenValidationServicen.validateAccessTokenSignature(signedAccessToken))
+                .thenReturn(false);
 
         RuntimeException exception =
                 assertThrows(
@@ -88,7 +92,8 @@ class AuthoriseAccessTokenHandlerTest {
         TokenAuthorizerContext tokenAuthorizerContext =
                 new TokenAuthorizerContext(
                         TOKEN_TYPE, signedAccessToken.toAuthorizationHeader(), METHOD_ARN);
-        when(tokenService.validateAccessTokenSignature(signedAccessToken)).thenReturn(true);
+        when(tokenValidationServicen.validateAccessTokenSignature(signedAccessToken))
+                .thenReturn(true);
         when(dynamoService.getUserProfileFromSubject(SUBJECT.getValue()))
                 .thenThrow(RuntimeException.class);
 

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/AuthoriseAccessTokenHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/AuthoriseAccessTokenHandlerTest.java
@@ -38,19 +38,24 @@ class AuthoriseAccessTokenHandlerTest {
     private final Context context = mock(Context.class);
     private static final String KEY_ID = "14342354354353";
     private static final String TOKEN_TYPE = "TOKEN";
-    private static final String METHOD_ARN = "arn:aws:execute-api:eu-west-2:123456789012:ymy8tbxw7b/*/POST/";
+    private static final String METHOD_ARN =
+            "arn:aws:execute-api:eu-west-2:123456789012:ymy8tbxw7b/*/POST/";
     private static final List<String> SCOPES = List.of("openid", "email", "phone", "am");
     private static final Subject SUBJECT = new Subject("some-subject");
 
     @BeforeEach
     public void setUp() {
-        handler = new AuthoriseAccessTokenHandler(tokenService, configurationService, dynamoService);
+        handler =
+                new AuthoriseAccessTokenHandler(tokenService, configurationService, dynamoService);
     }
 
     @Test
     public void shouldReturnAuthPolicyForSuccessfulRequest() throws JOSEException {
-        BearerAccessToken signedAccessToken = new BearerAccessToken(createSignedAccessToken().serialize());
-        TokenAuthorizerContext tokenAuthorizerContext = new TokenAuthorizerContext(TOKEN_TYPE, signedAccessToken.toAuthorizationHeader(), METHOD_ARN);
+        BearerAccessToken signedAccessToken =
+                new BearerAccessToken(createSignedAccessToken().serialize());
+        TokenAuthorizerContext tokenAuthorizerContext =
+                new TokenAuthorizerContext(
+                        TOKEN_TYPE, signedAccessToken.toAuthorizationHeader(), METHOD_ARN);
         when(tokenService.validateAccessTokenSignature(signedAccessToken)).thenReturn(true);
         AuthPolicy authPolicy = handler.handleRequest(tokenAuthorizerContext, context);
 
@@ -60,8 +65,11 @@ class AuthoriseAccessTokenHandlerTest {
 
     @Test
     public void shouldThrowExceptionWhenAccessTokenHasInvalidSignature() throws JOSEException {
-        BearerAccessToken signedAccessToken = new BearerAccessToken(createSignedAccessToken().serialize());
-        TokenAuthorizerContext tokenAuthorizerContext = new TokenAuthorizerContext(TOKEN_TYPE, signedAccessToken.toAuthorizationHeader(), METHOD_ARN);
+        BearerAccessToken signedAccessToken =
+                new BearerAccessToken(createSignedAccessToken().serialize());
+        TokenAuthorizerContext tokenAuthorizerContext =
+                new TokenAuthorizerContext(
+                        TOKEN_TYPE, signedAccessToken.toAuthorizationHeader(), METHOD_ARN);
         when(tokenService.validateAccessTokenSignature(signedAccessToken)).thenReturn(false);
 
         RuntimeException exception =
@@ -70,16 +78,19 @@ class AuthoriseAccessTokenHandlerTest {
                         () -> handler.handleRequest(tokenAuthorizerContext, context),
                         "Expected to throw exception");
 
-        assertEquals(
-                "Unauthorized", exception.getMessage());
+        assertEquals("Unauthorized", exception.getMessage());
     }
 
     @Test
     public void shouldThrowExceptionWhenSubjectIdCannotBeLinkedToAUser() throws JOSEException {
-        BearerAccessToken signedAccessToken = new BearerAccessToken(createSignedAccessToken().serialize());
-        TokenAuthorizerContext tokenAuthorizerContext = new TokenAuthorizerContext(TOKEN_TYPE, signedAccessToken.toAuthorizationHeader(), METHOD_ARN);
+        BearerAccessToken signedAccessToken =
+                new BearerAccessToken(createSignedAccessToken().serialize());
+        TokenAuthorizerContext tokenAuthorizerContext =
+                new TokenAuthorizerContext(
+                        TOKEN_TYPE, signedAccessToken.toAuthorizationHeader(), METHOD_ARN);
         when(tokenService.validateAccessTokenSignature(signedAccessToken)).thenReturn(true);
-        when(dynamoService.getUserProfileFromSubject(SUBJECT.getValue())).thenThrow(RuntimeException.class);
+        when(dynamoService.getUserProfileFromSubject(SUBJECT.getValue()))
+                .thenThrow(RuntimeException.class);
 
         RuntimeException exception =
                 assertThrows(
@@ -87,14 +98,14 @@ class AuthoriseAccessTokenHandlerTest {
                         () -> handler.handleRequest(tokenAuthorizerContext, context),
                         "Expected to throw exception");
 
-        assertEquals(
-                "Unauthorized", exception.getMessage());
+        assertEquals("Unauthorized", exception.getMessage());
     }
 
     @Test
     public void shouldThrowExceptionWhenInvalidAccessTokenIsSentInRequest() throws JOSEException {
         String invalidAccessToken = createSignedAccessToken().serialize();
-        TokenAuthorizerContext tokenAuthorizerContext = new TokenAuthorizerContext(TOKEN_TYPE, invalidAccessToken, METHOD_ARN);
+        TokenAuthorizerContext tokenAuthorizerContext =
+                new TokenAuthorizerContext(TOKEN_TYPE, invalidAccessToken, METHOD_ARN);
 
         RuntimeException exception =
                 assertThrows(
@@ -102,13 +113,14 @@ class AuthoriseAccessTokenHandlerTest {
                         () -> handler.handleRequest(tokenAuthorizerContext, context),
                         "Expected to throw exception");
 
-        assertEquals(
-                "Unauthorized", exception.getMessage());
+        assertEquals("Unauthorized", exception.getMessage());
     }
 
     @Test
     public void shouldThrowExceptionWhenAccessTokenHasNotBeenSigned() throws JOSEException {
-        TokenAuthorizerContext tokenAuthorizerContext = new TokenAuthorizerContext(TOKEN_TYPE, new BearerAccessToken().toAuthorizationHeader(), METHOD_ARN);
+        TokenAuthorizerContext tokenAuthorizerContext =
+                new TokenAuthorizerContext(
+                        TOKEN_TYPE, new BearerAccessToken().toAuthorizationHeader(), METHOD_ARN);
 
         RuntimeException exception =
                 assertThrows(
@@ -116,8 +128,7 @@ class AuthoriseAccessTokenHandlerTest {
                         () -> handler.handleRequest(tokenAuthorizerContext, context),
                         "Expected to throw exception");
 
-        assertEquals(
-                "Unauthorized", exception.getMessage());
+        assertEquals("Unauthorized", exception.getMessage());
     }
 
     private SignedJWT createSignedAccessToken() throws JOSEException {
@@ -126,5 +137,4 @@ class AuthoriseAccessTokenHandlerTest {
         return TokenGeneratorHelper.generateAccessToken(
                 "client-id", "http://example.com", SCOPES, signer, SUBJECT, "14342354354353");
     }
-
 }

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -16,6 +16,7 @@ module "userinfo" {
     REDIS_PASSWORD       = var.use_localstack ? var.external_redis_password : random_password.redis_password.result
     REDIS_TLS            = var.redis_use_tls
     DYNAMO_ENDPOINT      = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    TOKEN_SIGNING_KEY_ALIAS = aws_kms_alias.id_token_signing_key_alias.name
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.UserInfoHandler::handleRequest"
 

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/JwksHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/JwksHandlerTest.java
@@ -10,7 +10,7 @@ import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
-import uk.gov.di.authentication.shared.services.TokenService;
+import uk.gov.di.authentication.shared.services.TokenValidationService;
 
 import java.util.UUID;
 
@@ -23,19 +23,20 @@ import static uk.gov.di.authentication.shared.matchers.APIGatewayProxyResponseEv
 class JwksHandlerTest {
 
     private final Context context = mock(Context.class);
-    private final TokenService tokenService = mock(TokenService.class);
+    private final TokenValidationService tokenValidationService =
+            mock(TokenValidationService.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private JwksHandler handler;
 
     @BeforeEach
     public void setUp() {
-        handler = new JwksHandler(tokenService, configurationService);
+        handler = new JwksHandler(tokenValidationService, configurationService);
     }
 
     @Test
     public void shouldReturn200WhenRequestIsSuccessful() throws JOSEException {
         JWK signingKey = new RSAKeyGenerator(2048).keyID(UUID.randomUUID().toString()).generate();
-        when(tokenService.getPublicJwk()).thenReturn(signingKey);
+        when(tokenValidationService.getPublicJwk()).thenReturn(signingKey);
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
@@ -48,7 +49,7 @@ class JwksHandlerTest {
 
     @Test
     public void shouldReturn500WhenSigningKeyIsNotPresent() {
-        when(tokenService.getPublicJwk()).thenReturn(null);
+        when(tokenValidationService.getPublicJwk()).thenReturn(null);
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandlerTest.java
@@ -22,13 +22,12 @@ import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.TokenGeneratorHelper;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
-import uk.gov.di.authentication.shared.services.TokenService;
+import uk.gov.di.authentication.shared.services.RedisConnectionService;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import static com.nimbusds.oauth2.sdk.token.BearerTokenError.INVALID_TOKEN;
 import static com.nimbusds.oauth2.sdk.token.BearerTokenError.MISSING_TOKEN;
@@ -36,7 +35,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.shared.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
@@ -47,7 +46,8 @@ public class UserInfoHandlerTest {
     private static final String PHONE_NUMBER = "01234567890";
     private static final Subject SUBJECT = new Subject();
     private final Context context = mock(Context.class);
-    private final TokenService tokenService = mock(TokenService.class);
+    private final RedisConnectionService redisConnectionService =
+            mock(RedisConnectionService.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
     private static final Map<String, List<String>> INVALID_TOKEN_RESPONSE =
@@ -56,7 +56,9 @@ public class UserInfoHandlerTest {
 
     @BeforeEach
     public void setUp() {
-        handler = new UserInfoHandler(tokenService, configurationService, authenticationService);
+        handler =
+                new UserInfoHandler(
+                        configurationService, authenticationService, redisConnectionService);
     }
 
     @Test
@@ -85,8 +87,8 @@ public class UserInfoHandlerTest {
                         .setSubjectID(SUBJECT.toString())
                         .setCreated(LocalDateTime.now().toString())
                         .setUpdated(LocalDateTime.now().toString());
-        when(tokenService.getSubjectWithAccessToken(accessToken))
-                .thenReturn(Optional.of(SUBJECT.toString()));
+        when(redisConnectionService.getValue(accessToken.toJSONString()))
+                .thenReturn(SUBJECT.toString());
         when(authenticationService.getUserProfileFromSubject(SUBJECT.toString()))
                 .thenReturn(userProfile);
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
@@ -128,8 +130,7 @@ public class UserInfoHandlerTest {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setHeaders(Map.of("Authorization", new BearerAccessToken().toAuthorizationHeader()));
 
-        when(tokenService.getSubjectWithAccessToken(any(BearerAccessToken.class)))
-                .thenReturn(Optional.empty());
+        when(redisConnectionService.getValue(anyString())).thenReturn(null);
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(401));

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
@@ -1,24 +1,12 @@
 package uk.gov.di.authentication.shared.services;
 
-import com.amazonaws.services.kms.model.GetPublicKeyRequest;
-import com.amazonaws.services.kms.model.GetPublicKeyResult;
 import com.amazonaws.services.kms.model.SignRequest;
 import com.amazonaws.services.kms.model.SignResult;
 import com.amazonaws.services.kms.model.SigningAlgorithmSpec;
-import com.nimbusds.jose.Algorithm;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
-import com.nimbusds.jose.JWSVerifier;
-import com.nimbusds.jose.crypto.ECDSAVerifier;
 import com.nimbusds.jose.crypto.impl.ECDSA;
-import com.nimbusds.jose.jwk.Curve;
-import com.nimbusds.jose.jwk.ECKey;
-import com.nimbusds.jose.jwk.JWK;
-import com.nimbusds.jose.jwk.JWKSet;
-import com.nimbusds.jose.jwk.KeyUse;
-import com.nimbusds.jose.proc.BadJOSEException;
-import com.nimbusds.jose.proc.JWSKeySelector;
 import com.nimbusds.jose.util.Base64URL;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
@@ -41,11 +29,6 @@ import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.openid.connect.sdk.OIDCTokenResponse;
 import com.nimbusds.openid.connect.sdk.claims.IDTokenClaimsSet;
 import com.nimbusds.openid.connect.sdk.token.OIDCTokens;
-import com.nimbusds.openid.connect.sdk.validators.IDTokenValidator;
-import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.bouncycastle.openssl.PEMException;
-import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.di.authentication.shared.helpers.RequestBodyHelper;
@@ -53,9 +36,7 @@ import uk.gov.di.authentication.shared.helpers.RequestBodyHelper;
 import java.nio.ByteBuffer;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
-import java.security.Provider;
 import java.security.PublicKey;
-import java.security.interfaces.ECPublicKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.X509EncodedKeySpec;
 import java.time.LocalDateTime;
@@ -92,84 +73,6 @@ public class TokenService {
         AccessToken accessToken = generateAndStoreAccessToken(clientID, subject, scopes);
         SignedJWT idToken = generateIDToken(clientID, subject, additionalTokenClaims);
         return new OIDCTokenResponse(new OIDCTokens(idToken, accessToken, null));
-    }
-
-    public boolean validateIdTokenSignature(String idTokenHint) {
-        try {
-            LOGGER.info("Validating ID token signature");
-            LOGGER.info("IDTokenHint: " + idTokenHint);
-            LOGGER.info("TokenSigningKeyID: " + configService.getTokenSigningKeyAlias());
-            SignedJWT idToken = SignedJWT.parse(idTokenHint);
-            LOGGER.info("ClientID:" + idToken.getJWTClaimsSet().getAudience().get(0));
-            LOGGER.info("Issuer: " + configService.getBaseURL().get());
-            JWK publicJwk = getPublicJwk();
-            LOGGER.info("PublicJWK: " + publicJwk.toString());
-            JWKSet jwkSet = new JWKSet(publicJwk);
-            LOGGER.info("JWKSET: " + jwkSet);
-            IDTokenValidator validator =
-                    new IDTokenValidator(
-                            new Issuer(configService.getBaseURL().get()),
-                            new ClientID(idToken.getJWTClaimsSet().getAudience().get(0)),
-                            JWSAlgorithm.ES256,
-                            jwkSet);
-            JWSKeySelector jwsKeySelector = validator.getJWSKeySelector();
-            LOGGER.info("KEYSELECTOR: " + jwsKeySelector.selectJWSKeys(idToken.getHeader(), null));
-            validator.validate(idToken, null);
-        } catch (java.text.ParseException | JOSEException | BadJOSEException e) {
-            LOGGER.error("Unable to validate Signature of ID token", e);
-            return false;
-        }
-        return true;
-    }
-
-    public boolean validateAccessTokenSignature(AccessToken accessToken) {
-        boolean isVerified;
-        try {
-            LOGGER.info("Validating Access Token signature");
-            LOGGER.info("TokenSigningKeyID: " + configService.getTokenSigningKeyAlias());
-            SignedJWT signedJwt = SignedJWT.parse(accessToken.getValue());
-            JWSVerifier verifier = new ECDSAVerifier(getPublicJwk().toECKey());
-            isVerified = signedJwt.verify(verifier);
-        } catch (JOSEException | java.text.ParseException e) {
-            LOGGER.error("Unable to validate Signature of Access token", e);
-            return false;
-        }
-        return isVerified;
-    }
-
-    public PublicKey getPublicKey() {
-        LOGGER.info("Creating GetPublicKeyRequest to retrieve PublicKey from KMS");
-        Provider bcProvider = new BouncyCastleProvider();
-        GetPublicKeyRequest getPublicKeyRequest = new GetPublicKeyRequest();
-        getPublicKeyRequest.setKeyId(configService.getTokenSigningKeyAlias());
-        GetPublicKeyResult publicKeyResult = kmsConnectionService.getPublicKey(getPublicKeyRequest);
-        try {
-            LOGGER.info("PUBLICKEYRESULT: " + publicKeyResult.toString());
-            SubjectPublicKeyInfo subjectKeyInfo =
-                    SubjectPublicKeyInfo.getInstance(publicKeyResult.getPublicKey().array());
-            return new JcaPEMKeyConverter().setProvider(bcProvider).getPublicKey(subjectKeyInfo);
-        } catch (PEMException e) {
-            LOGGER.error("Error getting the PublicKey using the JcaPEMKeyConverter", e);
-            throw new RuntimeException();
-        }
-    }
-
-    public JWK getPublicJwk() {
-        try {
-            PublicKey publicKey = getPublicKey();
-            ECKey jwk =
-                    new ECKey.Builder(Curve.P_256, (ECPublicKey) publicKey)
-                            .keyID(configService.getTokenSigningKeyAlias())
-                            .keyUse(KeyUse.SIGNATURE)
-                            .algorithm(new Algorithm(JWSAlgorithm.ES256.getName()))
-                            .build();
-            LOGGER.info("ECKey: " + jwk.toJSONString());
-            LOGGER.info("ECKey KeyID: " + jwk.getKeyID());
-            return JWK.parse(jwk.toJSONObject());
-        } catch (java.text.ParseException e) {
-            LOGGER.error("Error parsing the ECKey to JWK", e);
-            throw new RuntimeException(e);
-        }
     }
 
     public Optional<ErrorObject> validateTokenRequestParams(String tokenRequestBody) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
@@ -94,10 +94,6 @@ public class TokenService {
         return new OIDCTokenResponse(new OIDCTokens(idToken, accessToken, null));
     }
 
-    public Optional<String> getSubjectWithAccessToken(AccessToken token) {
-        return Optional.ofNullable(redisConnectionService.getValue(token.toJSONString()));
-    }
-
     public boolean validateIdTokenSignature(String idTokenHint) {
         try {
             LOGGER.info("Validating ID token signature");

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenValidationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenValidationService.java
@@ -1,0 +1,126 @@
+package uk.gov.di.authentication.shared.services;
+
+import com.amazonaws.services.kms.model.GetPublicKeyRequest;
+import com.amazonaws.services.kms.model.GetPublicKeyResult;
+import com.nimbusds.jose.Algorithm;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSVerifier;
+import com.nimbusds.jose.crypto.ECDSAVerifier;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jose.proc.BadJOSEException;
+import com.nimbusds.jose.proc.JWSKeySelector;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.id.Issuer;
+import com.nimbusds.oauth2.sdk.token.AccessToken;
+import com.nimbusds.openid.connect.sdk.validators.IDTokenValidator;
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.openssl.PEMException;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.security.Provider;
+import java.security.PublicKey;
+import java.security.interfaces.ECPublicKey;
+
+public class TokenValidationService {
+
+    private final ConfigurationService configService;
+    private final RedisConnectionService redisConnectionService;
+    private final KmsConnectionService kmsConnectionService;
+    private static final Logger LOGGER = LoggerFactory.getLogger(TokenValidationService.class);
+
+    public TokenValidationService(
+            ConfigurationService configService,
+            RedisConnectionService redisConnectionService,
+            KmsConnectionService kmsConnectionService) {
+        this.configService = configService;
+        this.redisConnectionService = redisConnectionService;
+        this.kmsConnectionService = kmsConnectionService;
+    }
+
+    public boolean validateIdTokenSignature(String idTokenHint) {
+        try {
+            LOGGER.info("Validating ID token signature");
+            LOGGER.info("IDTokenHint: " + idTokenHint);
+            LOGGER.info("TokenSigningKeyID: " + configService.getTokenSigningKeyAlias());
+            SignedJWT idToken = SignedJWT.parse(idTokenHint);
+            LOGGER.info("ClientID:" + idToken.getJWTClaimsSet().getAudience().get(0));
+            LOGGER.info("Issuer: " + configService.getBaseURL().get());
+            JWK publicJwk = getPublicJwk();
+            LOGGER.info("PublicJWK: " + publicJwk.toString());
+            JWKSet jwkSet = new JWKSet(publicJwk);
+            LOGGER.info("JWKSET: " + jwkSet);
+            IDTokenValidator validator =
+                    new IDTokenValidator(
+                            new Issuer(configService.getBaseURL().get()),
+                            new ClientID(idToken.getJWTClaimsSet().getAudience().get(0)),
+                            JWSAlgorithm.ES256,
+                            jwkSet);
+            JWSKeySelector jwsKeySelector = validator.getJWSKeySelector();
+            LOGGER.info("KEYSELECTOR: " + jwsKeySelector.selectJWSKeys(idToken.getHeader(), null));
+            validator.validate(idToken, null);
+        } catch (java.text.ParseException | JOSEException | BadJOSEException e) {
+            LOGGER.error("Unable to validate Signature of ID token", e);
+            return false;
+        }
+        return true;
+    }
+
+    public boolean validateAccessTokenSignature(AccessToken accessToken) {
+        boolean isVerified;
+        try {
+            LOGGER.info("Validating Access Token signature");
+            LOGGER.info("TokenSigningKeyID: " + configService.getTokenSigningKeyAlias());
+            SignedJWT signedJwt = SignedJWT.parse(accessToken.getValue());
+            JWSVerifier verifier = new ECDSAVerifier(getPublicJwk().toECKey());
+            isVerified = signedJwt.verify(verifier);
+        } catch (JOSEException | java.text.ParseException e) {
+            LOGGER.error("Unable to validate Signature of Access token", e);
+            return false;
+        }
+        return isVerified;
+    }
+
+    public PublicKey getPublicKey() {
+        LOGGER.info("Creating GetPublicKeyRequest to retrieve PublicKey from KMS");
+        Provider bcProvider = new BouncyCastleProvider();
+        GetPublicKeyRequest getPublicKeyRequest = new GetPublicKeyRequest();
+        getPublicKeyRequest.setKeyId(configService.getTokenSigningKeyAlias());
+        GetPublicKeyResult publicKeyResult = kmsConnectionService.getPublicKey(getPublicKeyRequest);
+        try {
+            LOGGER.info("PUBLICKEYRESULT: " + publicKeyResult.toString());
+            SubjectPublicKeyInfo subjectKeyInfo =
+                    SubjectPublicKeyInfo.getInstance(publicKeyResult.getPublicKey().array());
+            return new JcaPEMKeyConverter().setProvider(bcProvider).getPublicKey(subjectKeyInfo);
+        } catch (PEMException e) {
+            LOGGER.error("Error getting the PublicKey using the JcaPEMKeyConverter", e);
+            throw new RuntimeException();
+        }
+    }
+
+    public JWK getPublicJwk() {
+        try {
+            PublicKey publicKey = getPublicKey();
+            ECKey jwk =
+                    new ECKey.Builder(Curve.P_256, (ECPublicKey) publicKey)
+                            .keyID(configService.getTokenSigningKeyAlias())
+                            .keyUse(KeyUse.SIGNATURE)
+                            .algorithm(new Algorithm(JWSAlgorithm.ES256.getName()))
+                            .build();
+            LOGGER.info("ECKey: " + jwk.toJSONString());
+            LOGGER.info("ECKey KeyID: " + jwk.getKeyID());
+            return JWK.parse(jwk.toJSONObject());
+        } catch (java.text.ParseException e) {
+            LOGGER.error("Error parsing the ECKey to JWK", e);
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenValidationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenValidationService.java
@@ -117,7 +117,7 @@ public class TokenValidationService {
                             .build();
             LOGGER.info("ECKey: " + jwk.toJSONString());
             LOGGER.info("ECKey KeyID: " + jwk.getKeyID());
-            return JWK.parse(jwk.toJSONObject());
+            return JWK.parse(jwk.toString());
         } catch (java.text.ParseException e) {
             LOGGER.error("Error parsing the ECKey to JWK", e);
             throw new RuntimeException(e);

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
@@ -284,12 +284,4 @@ public class TokenServiceTest {
         kpg.initialize(2048);
         return kpg.generateKeyPair();
     }
-
-    private ECKey generateECKeyPair() {
-        try {
-            return new ECKeyGenerator(Curve.P_256).keyID(KEY_ID).generate();
-        } catch (JOSEException e) {
-            throw new RuntimeException();
-        }
-    }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenValidationServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenValidationServiceTest.java
@@ -1,0 +1,133 @@
+package uk.gov.di.authentication.shared.services;
+
+import com.amazonaws.services.kms.model.GetPublicKeyRequest;
+import com.amazonaws.services.kms.model.GetPublicKeyResult;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.id.Subject;
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.helpers.TokenGeneratorHelper;
+
+import java.nio.ByteBuffer;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class TokenValidationServiceTest {
+
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private final RedisConnectionService redisConnectionService =
+            mock(RedisConnectionService.class);
+    private final KmsConnectionService kmsConnectionService = mock(KmsConnectionService.class);
+    private final TokenValidationService tokenValidationService =
+            new TokenValidationService(
+                    configurationService, redisConnectionService, kmsConnectionService);
+    private static final Subject SUBJECT = new Subject("some-subject");
+    private static final List<String> SCOPES = List.of("openid", "email", "phone");
+    private static final String CLIENT_ID = "client-id";
+    private static final String BASE_URL = "http://example.com";
+    private static final String KEY_ID = "14342354354353";
+
+    @BeforeEach
+    public void setUp() {
+        Optional<String> baseUrl = Optional.of(BASE_URL);
+        when(configurationService.getBaseURL()).thenReturn(baseUrl);
+    }
+
+    @Test
+    public void shouldSuccessfullyValidateIDToken() throws JOSEException {
+        ECKey ecJWK = generateECKeyPair();
+        ECKey ecPublicJWK = ecJWK.toPublicJWK();
+        JWSSigner signer = new ECDSASigner(ecJWK);
+        when(configurationService.getTokenSigningKeyAlias()).thenReturn(KEY_ID);
+        GetPublicKeyResult getPublicKeyResult = new GetPublicKeyResult();
+        getPublicKeyResult.setKeyUsage("SIGN_VERIFY");
+        getPublicKeyResult.setKeyId(KEY_ID);
+        getPublicKeyResult.setSigningAlgorithms(
+                Collections.singletonList(JWSAlgorithm.ES256.getName()));
+        getPublicKeyResult.setPublicKey(ByteBuffer.wrap(ecPublicJWK.toECPublicKey().getEncoded()));
+        when(kmsConnectionService.getPublicKey(any(GetPublicKeyRequest.class)))
+                .thenReturn(getPublicKeyResult);
+
+        SignedJWT signedIdToken = createSignedIdToken(signer);
+        assertTrue(tokenValidationService.validateIdTokenSignature(signedIdToken.serialize()));
+    }
+
+    @Test
+    public void shouldSuccessfullyValidateAccessToken() throws JOSEException {
+        ECKey ecJWK = generateECKeyPair();
+        ECKey ecPublicJWK = ecJWK.toPublicJWK();
+        JWSSigner signer = new ECDSASigner(ecJWK);
+        when(configurationService.getTokenSigningKeyAlias()).thenReturn(KEY_ID);
+        GetPublicKeyResult getPublicKeyResult = new GetPublicKeyResult();
+        getPublicKeyResult.setKeyUsage("SIGN_VERIFY");
+        getPublicKeyResult.setKeyId(KEY_ID);
+        getPublicKeyResult.setSigningAlgorithms(
+                Collections.singletonList(JWSAlgorithm.ES256.getName()));
+        getPublicKeyResult.setPublicKey(ByteBuffer.wrap(ecPublicJWK.toECPublicKey().getEncoded()));
+        when(kmsConnectionService.getPublicKey(any(GetPublicKeyRequest.class)))
+                .thenReturn(getPublicKeyResult);
+
+        SignedJWT signedAccessToken = createSignedAccessToken(signer);
+        assertTrue(
+                tokenValidationService.validateAccessTokenSignature(
+                        new BearerAccessToken(signedAccessToken.serialize())));
+    }
+
+    @Test
+    public void shouldRetrievePublicKeyfromKmsAndParseToJwk() {
+        String keyId = "3423543t5435345";
+        byte[] publicKey =
+                Base64.getDecoder()
+                        .decode(
+                                "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEpRm+QZsh2IkUWcqXUhBI9ulOzO8dz0Z8HIS6m77tI4eWoZgKYUcbByshDtN4gWPql7E5mN4uCLsg5+6SDXlQcA==");
+        when(configurationService.getTokenSigningKeyAlias()).thenReturn(keyId);
+        GetPublicKeyResult getPublicKeyResult = new GetPublicKeyResult();
+        getPublicKeyResult.setKeyUsage("SIGN_VERIFY");
+        getPublicKeyResult.setKeyId(keyId);
+        getPublicKeyResult.setSigningAlgorithms(
+                Collections.singletonList(JWSAlgorithm.ES256.getName()));
+        getPublicKeyResult.setPublicKey(ByteBuffer.wrap(publicKey));
+        when(kmsConnectionService.getPublicKey(any(GetPublicKeyRequest.class)))
+                .thenReturn(getPublicKeyResult);
+        JWK publicKeyJwk = tokenValidationService.getPublicJwk();
+        assertEquals(publicKeyJwk.getKeyID(), keyId);
+        assertEquals(publicKeyJwk.getAlgorithm(), JWSAlgorithm.ES256);
+        assertEquals(publicKeyJwk.getKeyUse(), KeyUse.SIGNATURE);
+    }
+
+    private ECKey generateECKeyPair() {
+        try {
+            return new ECKeyGenerator(Curve.P_256).keyID(KEY_ID).generate();
+        } catch (JOSEException e) {
+            throw new RuntimeException();
+        }
+    }
+
+    private SignedJWT createSignedIdToken(JWSSigner signer) {
+        return TokenGeneratorHelper.generateIDToken(CLIENT_ID, SUBJECT, BASE_URL, signer, KEY_ID);
+    }
+
+    private SignedJWT createSignedAccessToken(JWSSigner signer) {
+
+        return TokenGeneratorHelper.generateAccessToken(
+                CLIENT_ID, BASE_URL, SCOPES, signer, SUBJECT, KEY_ID);
+    }
+}


### PR DESCRIPTION
## What?

- Move token validation into a separate service
- Validate AccessToken signature in UserInfo

## Why?

- The TokenService is getting heavy with a lot of stuff. Simplify that by moving out the Token validation logic into a TokenValidationService
- So only valid AccessTokens can retrieve userinfo