### PR TITLE
BAU: add new scope for account management: 'am'

### DIFF
--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationService.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationService.java
@@ -105,8 +105,7 @@ public class ClientConfigValidationService {
 
     private boolean areScopesValid(List<String> scopes) {
         for (String scope : scopes) {
-            if (ValidScopes.getAllValidScopes().stream()
-                    .noneMatch((t) -> t.getValue().equals(scope))) {
+            if (ValidScopes.getPublicValidScopes().stream().noneMatch((t) -> t.equals(scope))) {
                 return false;
             }
         }

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationServiceTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationServiceTest.java
@@ -90,6 +90,19 @@ class ClientConfigValidationServiceTest {
     }
 
     @Test
+    public void shouldReturnErrorForPrivateScopeInRegistrationRequest() {
+        Optional<ErrorObject> errorResponse =
+                validationService.validateClientRegistrationConfig(
+                        generateClientRegRequest(
+                                singletonList("http://localhost:1000/redirect"),
+                                VALID_PUBLIC_CERT,
+                                List.of("openid", "am"),
+                                singletonList("http://localhost/post-redirect-logout"),
+                                String.valueOf(MANDATORY)));
+        assertThat(errorResponse, equalTo(Optional.of(INVALID_SCOPE)));
+    }
+
+    @Test
     public void shouldPassValidationForValidUpdateRequest() {
         Optional<ErrorObject> errorResponse =
                 validationService.validateClientUpdateConfig(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -135,7 +135,7 @@ class AuthorisationHandlerTest {
     }
 
     @Test
-    void shouldReturn400WhenAuthorisationRequestContainsInvalidData() {
+    void shouldReturn400WhenAuthorisationRequestContainsInvalidScope() {
         when(authorizationService.validateAuthRequest(any(AuthenticationRequest.class)))
                 .thenReturn(Optional.of(OAuth2Error.INVALID_SCOPE));
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/CustomScopeValue.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/CustomScopeValue.java
@@ -1,0 +1,41 @@
+package uk.gov.di.authentication.shared.entity;
+
+import com.nimbusds.oauth2.sdk.Scope;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+public class CustomScopeValue extends Scope.Value {
+
+    public static final CustomScopeValue ACCOUNT_MANAGEMENT =
+            new CustomScopeValue("am", Requirement.OPTIONAL, new String[] {"read", "write"}, true);
+
+    private final String[] claims;
+
+    private boolean privateScope = true;
+
+    private CustomScopeValue(
+            final String value,
+            final Requirement requirement,
+            final String[] claims,
+            boolean privateScope) {
+        super(value, requirement);
+        this.claims = claims;
+        this.privateScope = privateScope;
+    }
+
+    public Set<String> getClaimNames() {
+        Set<String> targetSet = new HashSet<>();
+        Collections.addAll(targetSet, claims);
+        return targetSet;
+    }
+
+    public boolean isPrivateScope() {
+        return privateScope;
+    }
+
+    public boolean isPublicScope() {
+        return !privateScope;
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthorizationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthorizationService.java
@@ -115,8 +115,7 @@ public class AuthorizationService {
 
     private boolean areScopesValid(List<String> scopes) {
         for (String scope : scopes) {
-            if (ValidScopes.getAllValidScopes().stream()
-                    .noneMatch((t) -> t.getValue().equals(scope))) {
+            if (ValidScopes.getAllValidScopes().stream().noneMatch((t) -> t.equals(scope))) {
                 return false;
             }
         }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/ValidScopesTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/ValidScopesTest.java
@@ -1,0 +1,94 @@
+package uk.gov.di.authentication.shared.entity;
+
+import com.nimbusds.oauth2.sdk.Scope;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ValidScopesTest {
+
+    @Test
+    void shouldReturnCorrectClaimsForOpenidScope() {
+        assertThat(ValidScopes.getClaimsForListOfScopes(List.of("openid")), contains("sub"));
+        assertEquals(ValidScopes.getClaimsForListOfScopes(List.of("openid")).size(), 1);
+    }
+
+    @Test
+    void shouldReturnCorrectClaimsForEmailScope() {
+        assertThat(
+                ValidScopes.getClaimsForListOfScopes(List.of("email")),
+                containsInAnyOrder("email", "email_verified"));
+        assertEquals(ValidScopes.getClaimsForListOfScopes(List.of("email")).size(), 2);
+    }
+
+    @Test
+    void shouldReturnCorrectClaimsForPhoneScope() {
+        assertThat(
+                ValidScopes.getClaimsForListOfScopes(List.of("phone")),
+                containsInAnyOrder("phone_number", "phone_number_verified"));
+        assertEquals(ValidScopes.getClaimsForListOfScopes(List.of("phone")).size(), 2);
+    }
+
+    @Test
+    void shouldReturnCorrectClaimsForAmScope() {
+        assertThat(
+                ValidScopes.getClaimsForListOfScopes(List.of("am")),
+                containsInAnyOrder("read", "write"));
+        assertEquals(ValidScopes.getClaimsForListOfScopes(List.of("am")).size(), 2);
+    }
+
+    @Test
+    void shouldReturnCorrectClaimsForOIDCAndCustomScopes() {
+        assertThat(
+                ValidScopes.getClaimsForListOfScopes(List.of("openid", "am")),
+                containsInAnyOrder("sub", "read", "write"));
+        assertEquals(ValidScopes.getClaimsForListOfScopes(List.of("openid", "am")).size(), 3);
+    }
+
+    @Test
+    void shouldReturnCorrectClaimsForAllOIDCAndCustomScopes() {
+        assertThat(
+                ValidScopes.getClaimsForListOfScopes(List.of("openid", "email", "phone", "am")),
+                containsInAnyOrder(
+                        "sub",
+                        "email",
+                        "email_verified",
+                        "phone_number",
+                        "phone_number_verified",
+                        "read",
+                        "write"));
+        assertEquals(
+                ValidScopes.getClaimsForListOfScopes(List.of("openid", "email", "phone", "am"))
+                        .size(),
+                7);
+    }
+
+    @Test
+    void shouldReturnAllValidScopesInCorrectOrder() {
+        assertThat(ValidScopes.getAllValidScopes(), contains("openid", "email", "phone", "am"));
+    }
+
+    @Test
+    void shouldReturnCorrectNumberOfValidScopes() {
+        assertEquals(ValidScopes.getAllValidScopes().size(), 4);
+    }
+
+    @Test
+    void shouldNotReturnPrivateScopesWhenPublicRequested() {
+        assertEquals(ValidScopes.getPublicValidScopes().size(), 3);
+        assertThat(ValidScopes.getPublicValidScopes(), contains("openid", "email", "phone"));
+        assertThat(ValidScopes.getPublicValidScopes(), not(contains("am")));
+    }
+
+    @Test
+    void shouldReturnOIDCScopesForWellKnown() {
+        Scope scope = ValidScopes.getScopesForWellKnownHandler();
+        assertEquals(scope.toString(), "openid,email,phone");
+    }
+}


### PR DESCRIPTION
## What?

Add new scope for account management: 'am'

- Add support for custom (non-OIDC scopes).
- Expand scope validation to check for custom scopes.
- These custom scopes are private by default, meaning that it's not possible to for public users to register them against their clients using the public API.  Only we can add these scopes to clients via the database.
- Return an error is a client tries to register a private scope.
- Allow clients with private scopes to authorize.  In practice for the moment this will only be allowed for the Account Management application.

## Why?

Restrict usage of the Account Management application to our private/internal client.

