### PR TITLE
GOVSI-622: Pass Lambda release as parameter in pipeline

### DIFF
--- a/ci/tasks/deploy-oidc-api.yml
+++ b/ci/tasks/deploy-oidc-api.yml
@@ -15,6 +15,7 @@ inputs:
   - name: oidc-api-release
   - name: frontend-api-release
   - name: client-registry-api-release
+  - name: lambda-warmer-release
 outputs:
   - name: terraform-outputs
 run:
@@ -34,6 +35,7 @@ run:
         -var 'oidc_api_lambda_zip_file=../../../../oidc-api-release/oidc-api.zip' \
         -var 'frontend_api_lambda_zip_file=../../../../frontend-api-release/frontend-api.zip' \
         -var 'client_registry_api_lambda_zip_file=../../../../client-registry-api-release/client-registry-api.zip' \
+        -var 'lambda_warmer_zip_file=../../../../lambda-warmer-release/lambda-warmer-api.zip' \
         -var "deployer_role_arn=${DEPLOYER_ROLE_ARN}" \
         -var "notify_api_key=${NOTIFY_API_KEY}" \
         -var "environment=${DEPLOY_ENVIRONMENT}" \


### PR DESCRIPTION
## What?

- Pass additional Terraform variable, the path to lambda warmer release, to the deploy task in the pipeline.

## Why?

The pipeline is failing.