### PR TITLE
GOVSI-622: Use correct filename for Lambda warmer dist

### DIFF
--- a/ci/tasks/deploy-oidc-api.yml
+++ b/ci/tasks/deploy-oidc-api.yml
@@ -35,7 +35,7 @@ run:
         -var 'oidc_api_lambda_zip_file=../../../../oidc-api-release/oidc-api.zip' \
         -var 'frontend_api_lambda_zip_file=../../../../frontend-api-release/frontend-api.zip' \
         -var 'client_registry_api_lambda_zip_file=../../../../client-registry-api-release/client-registry-api.zip' \
-        -var 'lambda_warmer_zip_file=../../../../lambda-warmer-release/lambda-warmer-api.zip' \
+        -var 'lambda_warmer_zip_file=../../../../lambda-warmer-release/lambda-warmer.zip' \
         -var "deployer_role_arn=${DEPLOYER_ROLE_ARN}" \
         -var "notify_api_key=${NOTIFY_API_KEY}" \
         -var "environment=${DEPLOY_ENVIRONMENT}" \


### PR DESCRIPTION
## What?

- Correct filename is deploy task to `lambda-warmer.zip` rather than `lambda-warmer-api.zip`

## Why?

Pipeline is failing to deploy.

## Related PRs

#480 