### PR TITLE
Govsi 622 java warmer

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
@@ -26,6 +26,7 @@ import java.util.Optional;
 
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
+import static uk.gov.di.authentication.shared.helpers.WarmerHelper.isWarming;
 
 public class UpdateEmailHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -64,54 +65,72 @@ public class UpdateEmailHandler
     @Override
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
-        LOGGER.info("UpdateEmailHandler received request");
-        LOGGER.info(
-                "Authorizer parameters received: {}", input.getRequestContext().getAuthorizer());
-        try {
-            UpdateEmailRequest updateInfoRequest =
-                    objectMapper.readValue(input.getBody(), UpdateEmailRequest.class);
-            boolean isValidOtpCode =
-                    codeStorageService.isValidOtpCode(
-                            updateInfoRequest.getExistingEmailAddress(),
-                            updateInfoRequest.getOtp(),
-                            NotificationType.VERIFY_EMAIL);
-            if (!isValidOtpCode) {
-                LOGGER.error("Invalid OTP code sent in request");
-                return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1020);
-            }
-            Optional<ErrorResponse> emailValidationErrors =
-                    validationService.validateEmailAddressUpdate(
-                            updateInfoRequest.getExistingEmailAddress(),
-                            updateInfoRequest.getReplacementEmailAddress());
-            if (emailValidationErrors.isPresent()) {
-                LOGGER.error(
-                        "Invalid email address with error: {}",
-                        emailValidationErrors.get().getMessage());
-                return generateApiGatewayProxyErrorResponse(400, emailValidationErrors.get());
-            }
-            if (dynamoService.userExists(updateInfoRequest.getReplacementEmailAddress())) {
-                LOGGER.error("An account with this email address already exists");
-                return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1009);
-            }
-            Subject subjectFromEmail =
-                    dynamoService.getSubjectFromEmail(updateInfoRequest.getExistingEmailAddress());
-            Map<String, Object> authorizerParams = input.getRequestContext().getAuthorizer();
-            RequestBodyHelper.validatePrincipal(subjectFromEmail, authorizerParams);
-            dynamoService.updateEmail(
-                    updateInfoRequest.getExistingEmailAddress(),
-                    updateInfoRequest.getReplacementEmailAddress());
-            LOGGER.info("Email has successfully been updated. Adding message to SQS queue");
-            NotifyRequest notifyRequest =
-                    new NotifyRequest(
-                            updateInfoRequest.getReplacementEmailAddress(),
-                            NotificationType.EMAIL_UPDATED);
-            sqsClient.send(objectMapper.writeValueAsString((notifyRequest)));
-            LOGGER.info(
-                    "Message successfully added to queue. Generating successful gateway response");
-            return generateApiGatewayProxyResponse(200, "");
-        } catch (JsonProcessingException | IllegalArgumentException e) {
-            LOGGER.error("UpdateInfo request is missing or contains invalid parameters.", e);
-            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
-        }
+        return isWarming(input)
+                .orElseGet(
+                        () -> {
+                            LOGGER.info("UpdateEmailHandler received request");
+                            LOGGER.info(
+                                    "Authorizer parameters received: {}",
+                                    input.getRequestContext().getAuthorizer());
+                            try {
+                                UpdateEmailRequest updateInfoRequest =
+                                        objectMapper.readValue(
+                                                input.getBody(), UpdateEmailRequest.class);
+                                boolean isValidOtpCode =
+                                        codeStorageService.isValidOtpCode(
+                                                updateInfoRequest.getExistingEmailAddress(),
+                                                updateInfoRequest.getOtp(),
+                                                NotificationType.VERIFY_EMAIL);
+                                if (!isValidOtpCode) {
+                                    LOGGER.error("Invalid OTP code sent in request");
+                                    return generateApiGatewayProxyErrorResponse(
+                                            400, ErrorResponse.ERROR_1020);
+                                }
+                                Optional<ErrorResponse> emailValidationErrors =
+                                        validationService.validateEmailAddressUpdate(
+                                                updateInfoRequest.getExistingEmailAddress(),
+                                                updateInfoRequest.getReplacementEmailAddress());
+                                if (emailValidationErrors.isPresent()) {
+                                    LOGGER.error(
+                                            "Invalid email address with error: {}",
+                                            emailValidationErrors.get().getMessage());
+                                    return generateApiGatewayProxyErrorResponse(
+                                            400, emailValidationErrors.get());
+                                }
+                                if (dynamoService.userExists(
+                                        updateInfoRequest.getReplacementEmailAddress())) {
+                                    LOGGER.error(
+                                            "An account with this email address already exists");
+                                    return generateApiGatewayProxyErrorResponse(
+                                            400, ErrorResponse.ERROR_1009);
+                                }
+                                Subject subjectFromEmail =
+                                        dynamoService.getSubjectFromEmail(
+                                                updateInfoRequest.getExistingEmailAddress());
+                                Map<String, Object> authorizerParams =
+                                        input.getRequestContext().getAuthorizer();
+                                RequestBodyHelper.validatePrincipal(
+                                        subjectFromEmail, authorizerParams);
+                                dynamoService.updateEmail(
+                                        updateInfoRequest.getExistingEmailAddress(),
+                                        updateInfoRequest.getReplacementEmailAddress());
+                                LOGGER.info(
+                                        "Email has successfully been updated. Adding message to SQS queue");
+                                NotifyRequest notifyRequest =
+                                        new NotifyRequest(
+                                                updateInfoRequest.getReplacementEmailAddress(),
+                                                NotificationType.EMAIL_UPDATED);
+                                sqsClient.send(objectMapper.writeValueAsString((notifyRequest)));
+                                LOGGER.info(
+                                        "Message successfully added to queue. Generating successful gateway response");
+                                return generateApiGatewayProxyResponse(200, "");
+                            } catch (JsonProcessingException | IllegalArgumentException e) {
+                                LOGGER.error(
+                                        "UpdateInfo request is missing or contains invalid parameters.",
+                                        e);
+                                return generateApiGatewayProxyErrorResponse(
+                                        400, ErrorResponse.ERROR_1001);
+                            }
+                        });
     }
 }

--- a/ci/terraform/oidc/client-info.tf
+++ b/ci/terraform/oidc/client-info.tf
@@ -31,6 +31,10 @@ module "client-info" {
   logging_endpoint_arn      = var.logging_endpoint_arn
   default_tags              = local.default_tags
 
+  keep_lambda_warm             = var.keep_lambdas_warm
+  warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
+  warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+
   use_localstack = var.use_localstack
 
   depends_on = [

--- a/ci/terraform/oidc/login.tf
+++ b/ci/terraform/oidc/login.tf
@@ -30,5 +30,9 @@ module "login" {
   logging_endpoint_arn      = var.logging_endpoint_arn
   default_tags              = local.default_tags
 
+  keep_lambda_warm             = var.keep_lambdas_warm
+  warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
+  warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+
   use_localstack = var.use_localstack
 }

--- a/ci/terraform/oidc/mfa.tf
+++ b/ci/terraform/oidc/mfa.tf
@@ -31,6 +31,10 @@ module "mfa" {
   logging_endpoint_arn      = var.logging_endpoint_arn
   default_tags              = local.default_tags
 
+  keep_lambda_warm             = var.keep_lambdas_warm
+  warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
+  warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+
   use_localstack = var.use_localstack
 
   depends_on = [

--- a/ci/terraform/oidc/register.tf
+++ b/ci/terraform/oidc/register.tf
@@ -27,6 +27,10 @@ module "register" {
   logging_endpoint_arn      = var.logging_endpoint_arn
   default_tags              = local.default_tags
 
+  keep_lambda_warm             = var.keep_lambdas_warm
+  warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
+  warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+
   use_localstack = var.use_localstack
 
   depends_on = [

--- a/ci/terraform/oidc/send_notification.tf
+++ b/ci/terraform/oidc/send_notification.tf
@@ -29,6 +29,10 @@ module "send_notification" {
   logging_endpoint_arn      = var.logging_endpoint_arn
   default_tags              = local.default_tags
 
+  keep_lambda_warm             = var.keep_lambdas_warm
+  warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
+  warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+
   use_localstack = var.use_localstack
 
   depends_on = [

--- a/ci/terraform/oidc/signup.tf
+++ b/ci/terraform/oidc/signup.tf
@@ -31,6 +31,10 @@ module "signup" {
   logging_endpoint_arn      = var.logging_endpoint_arn
   default_tags              = local.default_tags
 
+  keep_lambda_warm             = var.keep_lambdas_warm
+  warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
+  warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+
   use_localstack = var.use_localstack
 
   depends_on = [

--- a/ci/terraform/oidc/update.tf
+++ b/ci/terraform/oidc/update.tf
@@ -29,6 +29,10 @@ module "update" {
   logging_endpoint_arn      = var.logging_endpoint_arn
   default_tags              = local.default_tags
 
+  keep_lambda_warm             = var.keep_lambdas_warm
+  warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
+  warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+
   use_localstack = var.use_localstack
 
   depends_on = [

--- a/ci/terraform/oidc/update_profile.tf
+++ b/ci/terraform/oidc/update_profile.tf
@@ -32,6 +32,10 @@ module "update_profile" {
   logging_endpoint_arn      = var.logging_endpoint_arn
   default_tags              = local.default_tags
 
+  keep_lambda_warm             = var.keep_lambdas_warm
+  warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
+  warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+
   use_localstack = var.use_localstack
 
   depends_on = [

--- a/ci/terraform/oidc/userexists.tf
+++ b/ci/terraform/oidc/userexists.tf
@@ -31,6 +31,10 @@ module "userexists" {
   logging_endpoint_arn      = var.logging_endpoint_arn
   default_tags              = local.default_tags
 
+  keep_lambda_warm             = var.keep_lambdas_warm
+  warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
+  warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+
   use_localstack = var.use_localstack
 
   depends_on = [

--- a/ci/terraform/oidc/verify_code.tf
+++ b/ci/terraform/oidc/verify_code.tf
@@ -31,6 +31,10 @@ module "verify_code" {
   logging_endpoint_arn      = var.logging_endpoint_arn
   default_tags              = local.default_tags
 
+  keep_lambda_warm             = var.keep_lambdas_warm
+  warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
+  warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+
   use_localstack = var.use_localstack
 
   depends_on = [

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
+import static uk.gov.di.authentication.shared.helpers.WarmerHelper.isWarming;
 
 public class LoginHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -53,53 +54,78 @@ public class LoginHandler
     @Override
     public APIGatewayProxyResponseEvent handleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
-        LOGGER.info("Request received to the LoginHandler");
-        Optional<Session> session = sessionService.getSessionFromRequestHeaders(input.getHeaders());
-        if (session.isEmpty()) {
-            LOGGER.error("Unable to find session");
-            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1000);
-        } else {
-            LOGGER.info("LoginHandler processing session with ID {}", session.get().getSessionId());
-        }
+        return isWarming(input)
+                .orElseGet(
+                        () -> {
+                            LOGGER.info("Request received to the LoginHandler");
+                            Optional<Session> session =
+                                    sessionService.getSessionFromRequestHeaders(input.getHeaders());
+                            if (session.isEmpty()) {
+                                LOGGER.error("Unable to find session");
+                                return generateApiGatewayProxyErrorResponse(
+                                        400, ErrorResponse.ERROR_1000);
+                            } else {
+                                LOGGER.info(
+                                        "LoginHandler processing session with ID {}",
+                                        session.get().getSessionId());
+                            }
 
-        try {
-            StateMachine.validateStateTransition(session.get(), SessionState.LOGGED_IN);
+                            try {
+                                StateMachine.validateStateTransition(
+                                        session.get(), SessionState.LOGGED_IN);
 
-            LoginRequest loginRequest = objectMapper.readValue(input.getBody(), LoginRequest.class);
-            boolean userHasAccount = authenticationService.userExists(loginRequest.getEmail());
-            if (!userHasAccount) {
-                LOGGER.error("The user does not have an account");
-                return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1010);
-            }
-            boolean hasValidCredentials =
-                    authenticationService.login(
-                            loginRequest.getEmail(), loginRequest.getPassword());
-            if (!hasValidCredentials) {
-                LOGGER.error("Invalid login credentials entered");
-                return generateApiGatewayProxyErrorResponse(401, ErrorResponse.ERROR_1008);
-            }
-            String phoneNumber =
-                    authenticationService.getPhoneNumber(loginRequest.getEmail()).orElse(null);
+                                LoginRequest loginRequest =
+                                        objectMapper.readValue(input.getBody(), LoginRequest.class);
+                                boolean userHasAccount =
+                                        authenticationService.userExists(loginRequest.getEmail());
+                                if (!userHasAccount) {
+                                    LOGGER.error("The user does not have an account");
+                                    return generateApiGatewayProxyErrorResponse(
+                                            400, ErrorResponse.ERROR_1010);
+                                }
+                                boolean hasValidCredentials =
+                                        authenticationService.login(
+                                                loginRequest.getEmail(),
+                                                loginRequest.getPassword());
+                                if (!hasValidCredentials) {
+                                    LOGGER.error("Invalid login credentials entered");
+                                    return generateApiGatewayProxyErrorResponse(
+                                            401, ErrorResponse.ERROR_1008);
+                                }
+                                String phoneNumber =
+                                        authenticationService
+                                                .getPhoneNumber(loginRequest.getEmail())
+                                                .orElse(null);
 
-            if (phoneNumber == null) {
-                LOGGER.error("No Phone Number has been registered for this user");
-                return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1014);
-            }
-            String concatPhoneNumber = RedactPhoneNumberHelper.redactPhoneNumber(phoneNumber);
-            sessionService.save(session.get().setState(SessionState.LOGGED_IN));
-            LOGGER.info(
-                    "User has successfully Logged in. Generating successful LoginResponse for session with ID {}",
-                    session.get().getSessionId());
-            return generateApiGatewayProxyResponse(
-                    200, new LoginResponse(concatPhoneNumber, session.get().getState()));
-        } catch (JsonProcessingException e) {
-            LOGGER.error(
-                    "Request is missing parameters. The body present in request: {}",
-                    input.getBody());
-            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
-        } catch (StateMachine.InvalidStateTransitionException e) {
-            LOGGER.error("Invalid transition in user journey. Unable to Login user", e);
-            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1017);
-        }
+                                if (phoneNumber == null) {
+                                    LOGGER.error(
+                                            "No Phone Number has been registered for this user");
+                                    return generateApiGatewayProxyErrorResponse(
+                                            400, ErrorResponse.ERROR_1014);
+                                }
+                                String concatPhoneNumber =
+                                        RedactPhoneNumberHelper.redactPhoneNumber(phoneNumber);
+                                sessionService.save(session.get().setState(SessionState.LOGGED_IN));
+                                LOGGER.info(
+                                        "User has successfully Logged in. Generating successful LoginResponse for session with ID {}",
+                                        session.get().getSessionId());
+                                return generateApiGatewayProxyResponse(
+                                        200,
+                                        new LoginResponse(
+                                                concatPhoneNumber, session.get().getState()));
+                            } catch (JsonProcessingException e) {
+                                LOGGER.error(
+                                        "Request is missing parameters. The body present in request: {}",
+                                        input.getBody());
+                                return generateApiGatewayProxyErrorResponse(
+                                        400, ErrorResponse.ERROR_1001);
+                            } catch (StateMachine.InvalidStateTransitionException e) {
+                                LOGGER.error(
+                                        "Invalid transition in user journey. Unable to Login user",
+                                        e);
+                                return generateApiGatewayProxyErrorResponse(
+                                        400, ErrorResponse.ERROR_1017);
+                            }
+                        });
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -56,7 +56,10 @@ public class AuthorisationIntegrationTest extends IntegrationTestEndpoints {
     public void shouldReturnUnmetAuthenticationRequirementsErrorWhenUsingInvalidClient() {
         Response response =
                 doAuthorisationRequest(
-                        Optional.of(INVALID_CLIENT_ID), Optional.empty(), Optional.empty(), "openid");
+                        Optional.of(INVALID_CLIENT_ID),
+                        Optional.empty(),
+                        Optional.empty(),
+                        "openid");
         assertEquals(302, response.getStatus());
         assertThat(
                 getHeaderValueByParamName(response, ResponseHeaders.LOCATION),
@@ -98,8 +101,8 @@ public class AuthorisationIntegrationTest extends IntegrationTestEndpoints {
         assertEquals(302, response.getStatus());
         assertThat(
                 getHeaderValueByParamName(response, ResponseHeaders.LOCATION),
-                containsString("error=invalid_scope&error_description=Invalid%2C+unknown+or+malformed+scope")
-        );
+                containsString(
+                        "error=invalid_scope&error_description=Invalid%2C+unknown+or+malformed+scope"));
     }
 
     @Test

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
@@ -23,8 +23,6 @@ import java.util.List;
 import java.util.UUID;
 
 import static com.nimbusds.oauth2.sdk.token.BearerTokenError.INVALID_TOKEN;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -71,16 +69,18 @@ public class UserInfoIntegrationTest extends IntegrationTestEndpoints {
                         .header("Authorization", accessToken.toAuthorizationHeader())
                         .get();
 
-//        Commented out due to same reason as LogoutIntegration test. It's an issue with KSM running inside localstack which causes the Caused by: java.security.NoSuchAlgorithmException: EC KeyFactory not available error. 
-//        assertEquals(200, response.getStatus());
+        //        Commented out due to same reason as LogoutIntegration test. It's an issue with KSM
+        // running inside localstack which causes the Caused by:
+        // java.security.NoSuchAlgorithmException: EC KeyFactory not available error.
+        //        assertEquals(200, response.getStatus());
         UserInfo expectedUserInfoResponse = new UserInfo(subject);
         expectedUserInfoResponse.setEmailAddress(TEST_EMAIL_ADDRESS);
         expectedUserInfoResponse.setEmailVerified(true);
         expectedUserInfoResponse.setPhoneNumber(TEST_PHONE_NUMBER);
         expectedUserInfoResponse.setPhoneNumberVerified(true);
-//        assertThat(
-//                response.readEntity(String.class),
-//                equalTo(expectedUserInfoResponse.toJSONString()));
+        //        assertThat(
+        //                response.readEntity(String.class),
+        //                equalTo(expectedUserInfoResponse.toJSONString()));
     }
 
     @Test

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandler.java
@@ -102,7 +102,9 @@ public class UserInfoHandler
                                 return generateApiGatewayProxyResponse(
                                         401,
                                         "",
-                                        new UserInfoErrorResponse(INVALID_TOKEN).toHTTPResponse().getHeaderMap());
+                                        new UserInfoErrorResponse(INVALID_TOKEN)
+                                                .toHTTPResponse()
+                                                .getHeaderMap());
                             }
                             Optional<String> subjectFromAccessToken =
                                     getSubjectWithAccessToken(accessToken);


### PR DESCRIPTION
## What?

- Add warmup handling to all Lambdas in all APIs
- Configure Terraform to enable warm-up handling in `client-registry-api` and `frontend-api` (`account-management-api` will follow in different PR).
- Create new base class that handles the logic to determine if the Lambda is responding to a "warmer" request
- Make all endpoint lambda extend this new base class to reduce repeated code

## Why?

We have a working warmer, lets enable all Lambda's to use it.

## Related PRs

#473 