### PR TITLE
BAU - Check user exists before sending OTP to new email address

### DIFF
--- a/ci/terraform/account-management/lambda-roles.tf
+++ b/ci/terraform/account-management/lambda-roles.tf
@@ -97,25 +97,6 @@ data "aws_iam_policy_document" "endpoint_networking_policy" {
   }
 }
 
-resource "aws_iam_role" "sqs_lambda_iam_role" {
-  name = "${var.environment}-account-management-sqs-lambda-role"
-
-  assume_role_policy = data.aws_iam_policy_document.lambda_can_assume_policy.json
-  tags = {
-    environment = var.environment
-  }
-}
-
-resource "aws_iam_role_policy_attachment" "sqs_lambda_logs" {
-  role       = aws_iam_role.sqs_lambda_iam_role.name
-  policy_arn = aws_iam_policy.endpoint_logging_policy.arn
-}
-
-resource "aws_iam_role_policy_attachment" "sqs_lambda_networking" {
-  role       = aws_iam_role.sqs_lambda_iam_role.name
-  policy_arn = aws_iam_policy.endpoint_networking_policy.arn
-}
-
 resource "aws_iam_policy" "endpoint_networking_policy" {
   name        = "${var.environment}-account-management-standard-lambda-networking"
   path        = "/"

--- a/ci/terraform/account-management/send_otp_notification.tf
+++ b/ci/terraform/account-management/send_otp_notification.tf
@@ -7,7 +7,9 @@ module "send_otp_notification" {
   environment     = var.environment
 
   handler_environment_variables = {
+    ENVIRONMENT = var.environment
     EMAIL_QUEUE_URL      = aws_sqs_queue.email_queue.id
+    DYNAMO_ENDPOINT      = var.use_localstack ? var.lambda_dynamo_endpoint : null
     REDIS_HOST           = var.use_localstack ? var.external_redis_host : aws_elasticache_replication_group.account_management_sessions_store[0].primary_endpoint_address
     REDIS_PORT           = var.use_localstack ? var.external_redis_port : aws_elasticache_replication_group.account_management_sessions_store[0].port
     REDIS_PASSWORD       = var.use_localstack ? var.external_redis_password : random_password.redis_password.result
@@ -22,7 +24,7 @@ module "send_otp_notification" {
   lambda_zip_file           = var.lambda_zip_file
   security_group_id         = aws_vpc.account_management_vpc.default_security_group_id
   subnet_id                 = aws_subnet.account_management_subnets.*.id
-  lambda_role_arn           = aws_iam_role.sqs_lambda_iam_role.arn
+  lambda_role_arn           = aws_iam_role.dynamo_sqs_lambda_iam_role.arn
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
   default_tags              = local.default_tags

--- a/ci/terraform/account-management/sqs.tf
+++ b/ci/terraform/account-management/sqs.tf
@@ -50,7 +50,7 @@ data "aws_iam_policy_document" "email_queue_policy_document" {
 
     principals {
       type        = "AWS"
-      identifiers = [aws_iam_role.sqs_lambda_iam_role.arn, aws_iam_role.dynamo_sqs_lambda_iam_role.arn]
+      identifiers = [aws_iam_role.dynamo_sqs_lambda_iam_role.arn]
     }
 
     actions = [
@@ -87,7 +87,6 @@ data "aws_iam_policy_document" "email_queue_policy_document" {
   depends_on = [
     time_sleep.wait_60_seconds,
     aws_iam_role.account_management_sqs_iam_role,
-    aws_iam_role.sqs_lambda_iam_role,
     aws_iam_role.dynamo_sqs_lambda_iam_role,
   ]
 }


### PR DESCRIPTION

## What?

 - Check user exists before sending OTP to new email address when user updates email

## Why?

- When a user changes their email address we need to send an OTP to that email. We should make sure this email is not already registered to an account.
- Remove the aws_iam_role.sqs_lambda_iam_role.arn permission as the send-otp lambda also needs permission to dynamo and therefore this role can be removed completely as it is not used elsewhere
