### PR TITLE
BAU: github actions unit test optimisation

### DIFF
--- a/.github/workflows/pre-merge-checks-am.yml
+++ b/.github/workflows/pre-merge-checks-am.yml
@@ -20,7 +20,7 @@ jobs:
           java-version: '11'
           distribution: 'adopt'
       - name: Run Unit Tests
-        run: ./gradlew build -x integration-tests:test -x account-management-integration-tests:test
+        run: ./gradlew test -x integration-tests:test -x account-management-integration-tests:test -x spotlessApply spotlessCheck
 
   integration-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -20,7 +20,7 @@ jobs:
           java-version: '11'
           distribution: 'adopt'
       - name: Run Unit Tests
-        run: ./gradlew build -x integration-tests:test -x account-management-integration-tests:test
+        run: ./gradlew test -x integration-tests:test -x account-management-integration-tests:test -x spotlessApply spotlessCheck
 
   integration-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What?

Small optimisation to remove the gradle 'assemble' and 'spotlessApply' tasks when running unit tests.

## Why?

There is no need to build any distributable packages in this case, so 'test' rather than 'build' does the trick.