### PR TITLE
BAU: enable gradle cache in github actions

### DIFF
--- a/.github/workflows/pre-merge-checks-am.yml
+++ b/.github/workflows/pre-merge-checks-am.yml
@@ -19,8 +19,17 @@ jobs:
         with:
           java-version: '11'
           distribution: 'adopt'
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
       - name: Run Unit Tests
-        run: ./gradlew test -x integration-tests:test -x account-management-integration-tests:test -x spotlessApply spotlessCheck
+        run: ./gradlew --no-daemon test -x integration-tests:test -x account-management-integration-tests:test -x spotlessApply spotlessCheck
 
   integration-tests:
     runs-on: ubuntu-latest
@@ -32,5 +41,14 @@ jobs:
         with:
           java-version: '11'
           distribution: 'adopt'
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
       - name: Run Integration Tests
         run: ./pre-commit.sh -tg

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -19,8 +19,17 @@ jobs:
         with:
           java-version: '11'
           distribution: 'adopt'
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
       - name: Run Unit Tests
-        run: ./gradlew test -x integration-tests:test -x account-management-integration-tests:test -x spotlessApply spotlessCheck
+        run: ./gradlew --no-daemon test -x integration-tests:test -x account-management-integration-tests:test -x spotlessApply spotlessCheck
 
   integration-tests:
     runs-on: ubuntu-latest
@@ -32,5 +41,14 @@ jobs:
         with:
           java-version: '11'
           distribution: 'adopt'
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
       - name: Run Integration Tests
         run: ./pre-commit.sh -ig

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -98,7 +98,11 @@ run-integration-tests() {
   export TOKEN_SIGNING_KEY_ALIAS="$(terraform output -raw token_signing_key_alias)"
   export BASE_URL="$(terraform output -raw base_url)"
   popd >/dev/null
-  ./gradlew integration-tests:test
+  if [[ -z ${IN_GITHUB_ACTIONS+x} ||  ${IN_GITHUB_ACTIONS} -eq 0 ]]; then
+    ./gradlew --no-daemon integration-tests:test
+  else
+    ./gradlew integration-tests:test
+  fi
 }
 
 run-account-management-integration-tests() {
@@ -106,5 +110,9 @@ run-account-management-integration-tests() {
   export API_GATEWAY_ID="$(terraform output -raw api_gateway_root_id)"
   export BASE_URL="$(terraform output -raw base_url)"
   popd >/dev/null
-  ./gradlew account-management-integration-tests:test
+  if [[ -z ${IN_GITHUB_ACTIONS+x} ||  ${IN_GITHUB_ACTIONS} -eq 0 ]]; then
+    ./gradlew --no-daemon account-management-integration-tests:test
+  else
+    ./gradlew account-management-integration-tests:test
+  fi
 }


### PR DESCRIPTION
## What?

Enable gradle cache in github actions.

## Why?

See if this will speed up the test runs.

https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows

Gradle daemon switched off to allow the cache package to be created:

https://github.com/actions/cache/blob/main/examples.md#java---gradle