### PR TITLE
GOVSI-790 - Generate API key

### DIFF
--- a/ci/terraform/modules/endpoint-module/api-gateway.tf
+++ b/ci/terraform/modules/endpoint-module/api-gateway.tf
@@ -10,7 +10,7 @@ resource "aws_api_gateway_method" "endpoint_method" {
   http_method   = var.endpoint_method
   authorization = "NONE"
   request_parameters   = var.method_request_parameters
-
+  api_key_required = var.api_key_required
   depends_on = [
     aws_api_gateway_resource.endpoint_resource
   ]

--- a/ci/terraform/modules/endpoint-module/variables.tf
+++ b/ci/terraform/modules/endpoint-module/variables.tf
@@ -11,6 +11,11 @@ variable "method_request_parameters" {
   default = {}
 }
 
+variable "api_key_required" {
+  type = bool
+  default = false
+}
+
 variable "integration_request_parameters" {
   type    = map(string)
   default = {}

--- a/ci/terraform/oidc/api-gateway.tf
+++ b/ci/terraform/oidc/api-gateway.tf
@@ -64,6 +64,29 @@ resource "aws_api_gateway_rest_api" "di_authentication_api" {
   tags = local.default_tags
 }
 
+resource "aws_api_gateway_usage_plan" "di_auth_usage_plan" {
+  name = "${var.environment}-di-auth-usage-plan"
+
+  api_stages {
+    api_id = aws_api_gateway_rest_api.di_authentication_api.id
+    stage  = aws_api_gateway_stage.endpoint_stage.stage_name
+  }
+  depends_on = [
+    aws_api_gateway_stage.endpoint_stage,
+    aws_api_gateway_rest_api.di_authentication_api,
+  ]
+}
+
+resource "aws_api_gateway_api_key" "di_auth_api_key" {
+  name = "${var.environment}-di-auth-api-key"
+}
+
+resource "aws_api_gateway_usage_plan_key" "di_auth_usage_plan_key" {
+  key_id        = aws_api_gateway_api_key.di_auth_api_key.id
+  key_type      = "API_KEY"
+  usage_plan_id = aws_api_gateway_usage_plan.di_auth_usage_plan.id
+}
+
 resource "aws_api_gateway_resource" "wellknown_resource" {
   rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
   parent_id   = aws_api_gateway_rest_api.di_authentication_api.root_resource_id

--- a/ci/terraform/oidc/outputs.tf
+++ b/ci/terraform/oidc/outputs.tf
@@ -19,3 +19,8 @@ output "stub_rp_client_credentials" {
   }]
   sensitive = true
 }
+
+output "frontend_api_key" {
+  value = aws_api_gateway_api_key.di_auth_api_key.value
+  sensitive = true
+}


### PR DESCRIPTION
## What?

- Generate an API key which will eventually be required to access any of the frontend apis.
- Add this in as an environment variable which is consumed by the api-gateway-method and default to false for now.
- Output the api key as a sensitive value so it can be picked up by the pipeline

## Why?

- To authenticate the frontend app to use the frontend apis. 


**Next steps**
- Set the `api_key_required` variable to true for the apis we want to authenticate 