### PR TITLE
GOVSI-622: Warm the account-management API authoriser

### DIFF
--- a/ci/terraform/account-management/authoriser-warmer.tf
+++ b/ci/terraform/account-management/authoriser-warmer.tf
@@ -1,0 +1,132 @@
+data "aws_iam_policy_document" "warmer_can_execute_endpoint_lambda" {
+  statement {
+    sid = "AllowExecutionFromWarmer"
+    actions = [
+      "lambda:InvokeFunction"
+    ]
+    resources = [
+      aws_lambda_function.authorizer.arn
+    ]
+    effect = "Allow"
+  }
+}
+
+resource "aws_iam_role" "lambda_warmer_role" {
+  count = var.keep_lambdas_warm ? 1 : 0
+
+  name               = "${aws_lambda_function.authorizer.function_name}-warmer-role"
+  assume_role_policy = data.aws_iam_policy_document.lambda_can_assume_policy.json
+}
+
+resource "aws_iam_policy" "lambda_warmer_policy" {
+  count = var.keep_lambdas_warm ? 1 : 0
+
+  name        = "${aws_lambda_function.authorizer.function_name}-warmer-policy"
+  policy      = data.aws_iam_policy_document.warmer_can_execute_endpoint_lambda.json
+  description = "Allow warmer to invoke its related function"
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_warmer_execution" {
+  count = var.keep_lambdas_warm ? 1 : 0
+
+  role       = aws_iam_role.lambda_warmer_role[0].name
+  policy_arn = aws_iam_policy.lambda_warmer_policy[0].arn
+}
+
+data "aws_iam_policy_document" "lambda_logging_policy" {
+  version = "2012-10-17"
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+
+    resources = [
+      "arn:aws:logs:*:*:*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "lambda_warmer_logging_policy" {
+  count = var.keep_lambdas_warm ? 1 : 0
+
+  name        = "${aws_lambda_function.authorizer.function_name}-warmer-policy-logging"
+  path        = "/"
+  description = "IAM policy for logging from a warmer lambda"
+
+  policy = data.aws_iam_policy_document.lambda_logging_policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_warmer_logs" {
+  count = var.keep_lambdas_warm  ? 1 : 0
+
+  role       = aws_iam_role.lambda_warmer_role[0].name
+  policy_arn = aws_iam_policy.lambda_warmer_logging_policy[0].arn
+}
+
+resource "aws_lambda_function" "warmer_function" {
+  count = var.keep_lambdas_warm ? 1 : 0
+
+  filename      = var.lambda_warmer_zip_file
+  function_name = "${aws_lambda_function.authorizer.function_name}-lambda-warmer"
+  role          = aws_iam_role.lambda_warmer_role[0].arn
+  handler       = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
+  timeout       = 60
+  memory_size   = 1024
+
+  tracing_config {
+    mode = "Active"
+  }
+
+  source_code_hash = filebase64sha256(var.lambda_warmer_zip_file)
+
+  environment {
+    variables = {
+      LAMBDA_ARN       = aws_lambda_function.authorizer.arn
+      LAMBDA_QUALIFIER = aws_lambda_function.authorizer.version
+      LAMBDA_TYPE      = "AUTHORIZER"
+    }
+  }
+
+  runtime = "java11"
+
+  tags = merge(local.default_tags, {
+    lambda = "warmer"
+  })
+}
+
+resource "aws_cloudwatch_log_group" "warmer_lambda_log_group" {
+  count = var.keep_lambdas_warm ? 1 : 0
+
+  name = "/aws/lambda/${aws_lambda_function.warmer_function[0].function_name}"
+  tags = merge(local.default_tags, {
+    lambda = "warmer"
+  })
+}
+
+resource "aws_cloudwatch_event_rule" "warmer_schedule_rule" {
+  count = var.keep_lambdas_warm ? 1 : 0
+
+  name                = "${aws_lambda_function.warmer_function[0].function_name}-schedule"
+  schedule_expression = "cron(0/5 * * * ? *)"
+  is_enabled          = true
+}
+
+resource "aws_cloudwatch_event_target" "warmer_schedule_target" {
+  count = var.keep_lambdas_warm ? 1 : 0
+
+  arn  = aws_lambda_function.warmer_function[0].arn
+  rule = aws_cloudwatch_event_rule.warmer_schedule_rule[0].name
+}
+
+resource "aws_lambda_permission" "allow_cloudwatch_to_call_warmer_lambda" {
+  count = var.keep_lambdas_warm ? 1 : 0
+
+  statement_id  = "AllowExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.warmer_function[0].function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.warmer_schedule_rule[0].arn
+}

--- a/lambda-warmer/src/main/java/uk/gov/di/lambdawarmer/lambda/ConfigurationService.java
+++ b/lambda-warmer/src/main/java/uk/gov/di/lambdawarmer/lambda/ConfigurationService.java
@@ -12,7 +12,17 @@ public class ConfigurationService {
         return System.getenv().get("LAMBDA_QUALIFIER");
     }
 
+    public LambdaType getLambdaType() {
+        return Enum.valueOf(
+                LambdaType.class, System.getenv().getOrDefault("LAMBDA_TYPE", "ENDPOINT"));
+    }
+
     public int getMinConcurrency() {
         return Integer.parseInt(System.getenv().getOrDefault("LAMBDA_MIN_CONCURRENCY", "10"));
+    }
+
+    public enum LambdaType {
+        ENDPOINT,
+        AUTHORIZER
     }
 }

--- a/lambda-warmer/src/test/java/uk/gov/di/lambdawarmer/lambda/LambdaWarmerHandlerTest.java
+++ b/lambda-warmer/src/test/java/uk/gov/di/lambdawarmer/lambda/LambdaWarmerHandlerTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.lambdawarmer.lambda.ConfigurationService.LambdaType.ENDPOINT;
 
 class LambdaWarmerHandlerTest {
 
@@ -25,6 +26,7 @@ class LambdaWarmerHandlerTest {
     @Test
     void shouldExecuteTheSpecifiedNumberOfTimes() {
         when(configurationService.getLambdaArn()).thenReturn("a-function-arn");
+        when(configurationService.getLambdaType()).thenReturn(ENDPOINT);
         when(configurationService.getMinConcurrency()).thenReturn(5);
         when(lambda.invoke(any(InvokeRequest.class)))
                 .thenReturn(
@@ -42,6 +44,7 @@ class LambdaWarmerHandlerTest {
 
     void shouldExecuteTheDefaultNumberOfTimes() {
         when(configurationService.getLambdaArn()).thenReturn("a-function-arn");
+        when(configurationService.getLambdaType()).thenReturn(ENDPOINT);
         when(lambda.invoke(any(InvokeRequest.class)))
                 .thenReturn(
                         new InvokeResult()


### PR DESCRIPTION
## What?

- Add configuration option to `LambdaWarmer` to differentiate lambda type
- Warm the authoriser lambda with the correct payload
- Add code to authoriser to detect warming request and sleep then exit early.

## Why?

The account management API is has warm lambdas but there is still a delay when calling that API as the authoriser isn't warm.