### PR TITLE
GOVSI-790 - Enforce API key authentication

### DIFF
--- a/ci/terraform/oidc/auth-code.tf
+++ b/ci/terraform/oidc/auth-code.tf
@@ -30,7 +30,6 @@ module "auth-code" {
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
   default_tags              = local.default_tags
-  api_key_required          = true
 
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"

--- a/ci/terraform/oidc/auth-code.tf
+++ b/ci/terraform/oidc/auth-code.tf
@@ -30,6 +30,7 @@ module "auth-code" {
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
   default_tags              = local.default_tags
+  api_key_required          = true
 
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"

--- a/ci/terraform/oidc/client-info.tf
+++ b/ci/terraform/oidc/client-info.tf
@@ -30,6 +30,7 @@ module "client-info" {
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
   default_tags              = local.default_tags
+  api_key_required          = true
 
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"

--- a/ci/terraform/oidc/login.tf
+++ b/ci/terraform/oidc/login.tf
@@ -29,6 +29,7 @@ module "login" {
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
   default_tags              = local.default_tags
+  api_key_required          = true
 
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"

--- a/ci/terraform/oidc/mfa.tf
+++ b/ci/terraform/oidc/mfa.tf
@@ -30,6 +30,7 @@ module "mfa" {
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
   default_tags              = local.default_tags
+  api_key_required          = true
 
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"

--- a/ci/terraform/oidc/send_notification.tf
+++ b/ci/terraform/oidc/send_notification.tf
@@ -28,6 +28,7 @@ module "send_notification" {
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
   default_tags              = local.default_tags
+  api_key_required          = true
 
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"

--- a/ci/terraform/oidc/signup.tf
+++ b/ci/terraform/oidc/signup.tf
@@ -30,6 +30,7 @@ module "signup" {
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
   default_tags              = local.default_tags
+  api_key_required          = true
 
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"

--- a/ci/terraform/oidc/update_profile.tf
+++ b/ci/terraform/oidc/update_profile.tf
@@ -31,6 +31,7 @@ module "update_profile" {
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
   default_tags              = local.default_tags
+  api_key_required          = true
 
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"

--- a/ci/terraform/oidc/userexists.tf
+++ b/ci/terraform/oidc/userexists.tf
@@ -30,6 +30,7 @@ module "userexists" {
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
   default_tags              = local.default_tags
+  api_key_required          = true
 
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"

--- a/ci/terraform/oidc/verify_code.tf
+++ b/ci/terraform/oidc/verify_code.tf
@@ -30,6 +30,7 @@ module "verify_code" {
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
   default_tags              = local.default_tags
+  api_key_required          = true
 
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientInfoIntegrationTest.java
@@ -47,7 +47,14 @@ public class ClientInfoIntegrationTest extends IntegrationTestEndpoints {
     public void shouldReturn400WhenClientSessionIdMissing() {
 
         Client client = ClientBuilder.newClient();
-        Response response = client.target(ROOT_RESOURCE_URL + CLIENTINFO_ENDPOINT).request().get();
+        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
+        headers.add("X-API-Key", API_KEY);
+
+        Response response =
+                client.target(ROOT_RESOURCE_URL + CLIENTINFO_ENDPOINT)
+                        .request()
+                        .headers(headers)
+                        .get();
         assertEquals(400, response.getStatus());
     }
 
@@ -71,6 +78,7 @@ public class ClientInfoIntegrationTest extends IntegrationTestEndpoints {
         MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
         headers.add("Session-Id", sessionId);
         headers.add("Client-Session-Id", CLIENT_SESSION_ID);
+        headers.add("X-API-Key", API_KEY);
 
         Client client = ClientBuilder.newClient();
         Response response =

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IntegrationTestEndpoints.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IntegrationTestEndpoints.java
@@ -11,6 +11,8 @@ public class IntegrationTestEndpoints {
             "http://localhost:45678/restapis/%s/local/_user_request_";
     protected static final String LOCAL_API_GATEWAY_ID =
             Optional.ofNullable(System.getenv().get("API_GATEWAY_ID")).orElse("");
+    protected static final String API_KEY =
+            Optional.ofNullable(System.getenv().get("API_KEY")).orElse("");
     public static final String ROOT_RESOURCE_URL =
             Optional.ofNullable(System.getenv().get("ROOT_RESOURCE_URL"))
                     .orElse(String.format(LOCAL_ENDPOINT_FORMAT, LOCAL_API_GATEWAY_ID));

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
@@ -1,6 +1,8 @@
 package uk.gov.di.authentication.api;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.frontendapi.entity.LoginRequest;
@@ -29,10 +31,11 @@ public class LoginIntegrationTest extends IntegrationTestEndpoints {
         DynamoHelper.addPhoneNumber(email, phoneNumber);
         String sessionId = RedisHelper.createSession();
         RedisHelper.setSessionState(sessionId, AUTHENTICATION_REQUIRED);
-
+        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
+        headers.add("Session-Id", sessionId);
+        headers.add("X-API-Key", API_KEY);
         Response response =
-                RequestHelper.requestWithSession(
-                        LOGIN_ENDPOINT, new LoginRequest(email, password), sessionId);
+                RequestHelper.request(LOGIN_ENDPOINT, new LoginRequest(email, password), headers);
 
         assertEquals(200, response.getStatus());
 
@@ -49,10 +52,12 @@ public class LoginIntegrationTest extends IntegrationTestEndpoints {
         DynamoHelper.signUp(email, "wrong-password");
         String sessionId = RedisHelper.createSession();
         RedisHelper.setSessionState(sessionId, AUTHENTICATION_REQUIRED);
+        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
+        headers.add("Session-Id", sessionId);
+        headers.add("X-API-Key", API_KEY);
 
         Response response =
-                RequestHelper.requestWithSession(
-                        LOGIN_ENDPOINT, new LoginRequest(email, password), sessionId);
+                RequestHelper.request(LOGIN_ENDPOINT, new LoginRequest(email, password), headers);
 
         assertEquals(401, response.getStatus());
     }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/SignupIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/SignupIntegrationTest.java
@@ -1,6 +1,8 @@
 package uk.gov.di.authentication.api;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.frontendapi.entity.SignupRequest;
@@ -29,8 +31,11 @@ public class SignupIntegrationTest extends IntegrationTestEndpoints {
 
         SignupRequest request =
                 new SignupRequest("joe.bloggs+5@digital.cabinet-office.gov.uk", "password-1");
+        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
+        headers.add("Session-Id", sessionId);
+        headers.add("X-API-Key", API_KEY);
 
-        Response response = RequestHelper.requestWithSession(SIGNUP_ENDPOINT, request, sessionId);
+        Response response = RequestHelper.request(SIGNUP_ENDPOINT, request, headers);
 
         assertEquals(200, response.getStatus());
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserExistsIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserExistsIntegrationTest.java
@@ -1,6 +1,8 @@
 package uk.gov.di.authentication.api;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.frontendapi.entity.CheckUserExistsResponse;
@@ -32,10 +34,12 @@ public class UserExistsIntegrationTest extends IntegrationTestEndpoints {
         DynamoHelper.signUp(emailAddress, "password-1");
         RedisHelper.setSessionState(sessionId, SessionState.NEW);
 
+        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
+        headers.add("Session-Id", sessionId);
+        headers.add("X-API-Key", API_KEY);
         UserWithEmailRequest request = new UserWithEmailRequest(emailAddress);
 
-        Response response =
-                RequestHelper.requestWithSession(USEREXISTS_ENDPOINT, request, sessionId);
+        Response response = RequestHelper.request(USEREXISTS_ENDPOINT, request, headers);
 
         assertEquals(200, response.getStatus());
         String responseString = response.readEntity(String.class);
@@ -51,10 +55,12 @@ public class UserExistsIntegrationTest extends IntegrationTestEndpoints {
             throws IOException {
         String emailAddress = "joe.bloggs+2@digital.cabinet-office.gov.uk";
         String sessionId = RedisHelper.createSession();
+        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
+        headers.add("Session-Id", sessionId);
+        headers.add("X-API-Key", API_KEY);
         RedisHelper.setSessionState(sessionId, SessionState.NEW);
         UserWithEmailRequest request = new UserWithEmailRequest(emailAddress);
-        Response response =
-                RequestHelper.requestWithSession(USEREXISTS_ENDPOINT, request, sessionId);
+        Response response = RequestHelper.request(USEREXISTS_ENDPOINT, request, headers);
 
         assertEquals(200, response.getStatus());
         String responseString = response.readEntity(String.class);
@@ -69,10 +75,12 @@ public class UserExistsIntegrationTest extends IntegrationTestEndpoints {
     public void shouldReturn400IfStateTransitionIsInvalid() throws IOException {
         String emailAddress = "joe.bloggs+2@digital.cabinet-office.gov.uk";
         String sessionId = RedisHelper.createSession();
+        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
+        headers.add("Session-Id", sessionId);
+        headers.add("X-API-Key", API_KEY);
         RedisHelper.setSessionState(sessionId, SessionState.AUTHENTICATED);
         UserWithEmailRequest request = new UserWithEmailRequest(emailAddress);
-        Response response =
-                RequestHelper.requestWithSession(USEREXISTS_ENDPOINT, request, sessionId);
+        Response response = RequestHelper.request(USEREXISTS_ENDPOINT, request, headers);
 
         assertEquals(400, response.getStatus());
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
@@ -1,6 +1,8 @@
 package uk.gov.di.authentication.api;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.frontendapi.entity.VerifyCodeRequest;
@@ -30,11 +32,13 @@ public class VerifyCodeIntegrationTest extends IntegrationTestEndpoints {
         RedisHelper.setSessionState(sessionId, SessionState.VERIFY_EMAIL_CODE_SENT);
         RedisHelper.addEmailToSession(sessionId, EMAIL_ADDRESS);
 
+        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
+        headers.add("Session-Id", sessionId);
+        headers.add("X-API-Key", API_KEY);
         String code = RedisHelper.generateAndSaveEmailCode(EMAIL_ADDRESS, 900);
         VerifyCodeRequest codeRequest = new VerifyCodeRequest(VERIFY_EMAIL, code);
 
-        Response response =
-                RequestHelper.requestWithSession(VERIFY_CODE_ENDPOINT, codeRequest, sessionId);
+        Response response = RequestHelper.request(VERIFY_CODE_ENDPOINT, codeRequest, headers);
 
         assertEquals(200, response.getStatus());
     }
@@ -50,9 +54,11 @@ public class VerifyCodeIntegrationTest extends IntegrationTestEndpoints {
         VerifyCodeRequest codeRequest = new VerifyCodeRequest(VERIFY_EMAIL, code);
 
         TimeUnit.SECONDS.sleep(3);
+        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
+        headers.add("Session-Id", sessionId);
+        headers.add("X-API-Key", API_KEY);
 
-        Response response =
-                RequestHelper.requestWithSession(VERIFY_CODE_ENDPOINT, codeRequest, sessionId);
+        Response response = RequestHelper.request(VERIFY_CODE_ENDPOINT, codeRequest, headers);
 
         assertEquals(200, response.getStatus());
         BaseAPIResponse codeResponse =
@@ -68,14 +74,15 @@ public class VerifyCodeIntegrationTest extends IntegrationTestEndpoints {
         RedisHelper.addEmailToSession(sessionId, EMAIL_ADDRESS);
         String code = RedisHelper.generateAndSaveEmailCode(EMAIL_ADDRESS, 900);
         VerifyCodeRequest codeRequest = new VerifyCodeRequest(VERIFY_EMAIL, code);
+        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
+        headers.add("Session-Id", sessionId);
+        headers.add("X-API-Key", API_KEY);
 
-        Response response =
-                RequestHelper.requestWithSession(VERIFY_CODE_ENDPOINT, codeRequest, sessionId);
+        Response response = RequestHelper.request(VERIFY_CODE_ENDPOINT, codeRequest, headers);
 
         assertEquals(200, response.getStatus());
 
-        Response response2 =
-                RequestHelper.requestWithSession(VERIFY_CODE_ENDPOINT, codeRequest, sessionId);
+        Response response2 = RequestHelper.request(VERIFY_CODE_ENDPOINT, codeRequest, headers);
 
         assertEquals(200, response2.getStatus());
 
@@ -89,14 +96,16 @@ public class VerifyCodeIntegrationTest extends IntegrationTestEndpoints {
         String sessionId = RedisHelper.createSession();
         RedisHelper.addEmailToSession(sessionId, EMAIL_ADDRESS);
         RedisHelper.setSessionState(sessionId, SessionState.VERIFY_PHONE_NUMBER_CODE_SENT);
+        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
+        headers.add("Session-Id", sessionId);
+        headers.add("X-API-Key", API_KEY);
 
         String code = RedisHelper.generateAndSavePhoneNumberCode(EMAIL_ADDRESS, 900);
         VerifyCodeRequest codeRequest =
                 new VerifyCodeRequest(NotificationType.VERIFY_PHONE_NUMBER, code);
         DynamoHelper.signUp(EMAIL_ADDRESS, "password");
 
-        Response response =
-                RequestHelper.requestWithSession(VERIFY_CODE_ENDPOINT, codeRequest, sessionId);
+        Response response = RequestHelper.request(VERIFY_CODE_ENDPOINT, codeRequest, headers);
 
         assertEquals(200, response.getStatus());
     }
@@ -108,6 +117,9 @@ public class VerifyCodeIntegrationTest extends IntegrationTestEndpoints {
         String sessionId = RedisHelper.createSession();
         RedisHelper.addEmailToSession(sessionId, EMAIL_ADDRESS);
         RedisHelper.setSessionState(sessionId, SessionState.VERIFY_PHONE_NUMBER_CODE_SENT);
+        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
+        headers.add("Session-Id", sessionId);
+        headers.add("X-API-Key", API_KEY);
 
         String code = RedisHelper.generateAndSavePhoneNumberCode(EMAIL_ADDRESS, 2);
         VerifyCodeRequest codeRequest =
@@ -115,8 +127,7 @@ public class VerifyCodeIntegrationTest extends IntegrationTestEndpoints {
 
         TimeUnit.SECONDS.sleep(3);
 
-        Response response =
-                RequestHelper.requestWithSession(VERIFY_CODE_ENDPOINT, codeRequest, sessionId);
+        Response response = RequestHelper.request(VERIFY_CODE_ENDPOINT, codeRequest, headers);
 
         assertEquals(200, response.getStatus());
 
@@ -131,12 +142,14 @@ public class VerifyCodeIntegrationTest extends IntegrationTestEndpoints {
         RedisHelper.addEmailToSession(sessionId, EMAIL_ADDRESS);
         RedisHelper.setSessionState(sessionId, SessionState.PHONE_NUMBER_CODE_NOT_VALID);
         RedisHelper.blockPhoneCode(EMAIL_ADDRESS, sessionId);
+        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
+        headers.add("Session-Id", sessionId);
+        headers.add("X-API-Key", API_KEY);
 
         VerifyCodeRequest codeRequest =
                 new VerifyCodeRequest(NotificationType.VERIFY_PHONE_NUMBER, "123456");
 
-        Response response =
-                RequestHelper.requestWithSession(VERIFY_CODE_ENDPOINT, codeRequest, sessionId);
+        Response response = RequestHelper.request(VERIFY_CODE_ENDPOINT, codeRequest, headers);
 
         assertEquals(200, response.getStatus());
 
@@ -152,11 +165,13 @@ public class VerifyCodeIntegrationTest extends IntegrationTestEndpoints {
         RedisHelper.setSessionState(sessionId, SessionState.EMAIL_CODE_NOT_VALID);
         RedisHelper.addEmailToSession(sessionId, EMAIL_ADDRESS);
         RedisHelper.blockPhoneCode(EMAIL_ADDRESS, sessionId);
+        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
+        headers.add("Session-Id", sessionId);
+        headers.add("X-API-Key", API_KEY);
 
         VerifyCodeRequest codeRequest = new VerifyCodeRequest(VERIFY_EMAIL, "123456");
 
-        Response response =
-                RequestHelper.requestWithSession(VERIFY_CODE_ENDPOINT, codeRequest, sessionId);
+        Response response = RequestHelper.request(VERIFY_CODE_ENDPOINT, codeRequest, headers);
 
         assertEquals(200, response.getStatus());
 
@@ -170,12 +185,14 @@ public class VerifyCodeIntegrationTest extends IntegrationTestEndpoints {
         String sessionId = RedisHelper.createSession();
         RedisHelper.setSessionState(sessionId, SessionState.NEW);
         RedisHelper.addEmailToSession(sessionId, EMAIL_ADDRESS);
+        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
+        headers.add("Session-Id", sessionId);
+        headers.add("X-API-Key", API_KEY);
 
         String code = RedisHelper.generateAndSaveEmailCode(EMAIL_ADDRESS, 900);
         VerifyCodeRequest codeRequest = new VerifyCodeRequest(VERIFY_EMAIL, code);
 
-        Response response =
-                RequestHelper.requestWithSession(VERIFY_CODE_ENDPOINT, codeRequest, sessionId);
+        Response response = RequestHelper.request(VERIFY_CODE_ENDPOINT, codeRequest, headers);
 
         assertEquals(400, response.getStatus());
         assertEquals(
@@ -188,14 +205,16 @@ public class VerifyCodeIntegrationTest extends IntegrationTestEndpoints {
         String sessionId = RedisHelper.createSession();
         RedisHelper.setSessionState(sessionId, SessionState.NEW);
         RedisHelper.addEmailToSession(sessionId, EMAIL_ADDRESS);
+        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
+        headers.add("Session-Id", sessionId);
+        headers.add("X-API-Key", API_KEY);
 
         String code = RedisHelper.generateAndSavePhoneNumberCode(EMAIL_ADDRESS, 900);
         VerifyCodeRequest codeRequest =
                 new VerifyCodeRequest(NotificationType.VERIFY_PHONE_NUMBER, code);
         DynamoHelper.signUp(EMAIL_ADDRESS, "password");
 
-        Response response =
-                RequestHelper.requestWithSession(VERIFY_CODE_ENDPOINT, codeRequest, sessionId);
+        Response response = RequestHelper.request(VERIFY_CODE_ENDPOINT, codeRequest, headers);
 
         assertEquals(400, response.getStatus());
         assertEquals(
@@ -208,12 +227,14 @@ public class VerifyCodeIntegrationTest extends IntegrationTestEndpoints {
         String sessionId = RedisHelper.createSession();
         RedisHelper.addEmailToSession(sessionId, EMAIL_ADDRESS);
         RedisHelper.setSessionState(sessionId, SessionState.MFA_SMS_CODE_SENT);
+        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
+        headers.add("Session-Id", sessionId);
+        headers.add("X-API-Key", API_KEY);
 
         String code = RedisHelper.generateAndSaveEmailCode(EMAIL_ADDRESS, 900);
         VerifyCodeRequest codeRequest = new VerifyCodeRequest(NotificationType.MFA_SMS, code);
 
-        Response response =
-                RequestHelper.requestWithSession(VERIFY_CODE_ENDPOINT, codeRequest, sessionId);
+        Response response = RequestHelper.request(VERIFY_CODE_ENDPOINT, codeRequest, headers);
 
         assertEquals(200, response.getStatus());
     }
@@ -223,12 +244,14 @@ public class VerifyCodeIntegrationTest extends IntegrationTestEndpoints {
         String sessionId = RedisHelper.createSession();
         RedisHelper.setSessionState(sessionId, SessionState.NEW);
         RedisHelper.addEmailToSession(sessionId, EMAIL_ADDRESS);
+        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
+        headers.add("Session-Id", sessionId);
+        headers.add("X-API-Key", API_KEY);
 
         String code = RedisHelper.generateAndSaveEmailCode(EMAIL_ADDRESS, 900);
         VerifyCodeRequest codeRequest = new VerifyCodeRequest(NotificationType.MFA_SMS, code);
 
-        Response response =
-                RequestHelper.requestWithSession(VERIFY_CODE_ENDPOINT, codeRequest, sessionId);
+        Response response = RequestHelper.request(VERIFY_CODE_ENDPOINT, codeRequest, headers);
 
         assertEquals(400, response.getStatus());
         assertEquals(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/helpers/RequestHelper.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/helpers/RequestHelper.java
@@ -14,15 +14,10 @@ public class RequestHelper {
     public static Response requestWithSession(String endpoint, Object body, String sessionId) {
         MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
         headers.add("Session-Id", sessionId);
-        return buildRequest(endpoint, body, headers);
+        return request(endpoint, body, headers);
     }
 
-    public static Response buildRequest(String endpoint, Object body) {
-        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
-        return buildRequest(endpoint, body, headers);
-    }
-
-    private static Response buildRequest(
+    public static Response request(
             String endpoint, Object body, MultivaluedMap<String, Object> headers) {
         return ClientBuilder.newClient()
                 .target(ROOT_RESOURCE_URL + endpoint)

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -97,6 +97,7 @@ run-integration-tests() {
   export API_GATEWAY_ID="$(terraform output -raw api_gateway_root_id)"
   export TOKEN_SIGNING_KEY_ALIAS="$(terraform output -raw token_signing_key_alias)"
   export BASE_URL="$(terraform output -raw base_url)"
+  export API_KEY="$(terraform output -raw frontend_api_key)"
   popd >/dev/null
   if [[ -z ${IN_GITHUB_ACTIONS+x} ||  ${IN_GITHUB_ACTIONS} -eq 0 ]]; then
     ./gradlew --no-daemon integration-tests:test


### PR DESCRIPTION
## What?

- Enforce api key authentication for the apis that are only called by our frontend app.
- These are the following: client-info, login, mfa, send_notification, signup, update_profile, userexists, verify_code


## Why?

- So these APIs can only be called from our frontend app