### PR TITLE
GOVSI-790 - Add triggers for accountmgnt api gateway resources

### DIFF
--- a/ci/terraform/account-management/api-gateway.tf
+++ b/ci/terraform/account-management/api-gateway.tf
@@ -141,8 +141,18 @@ resource "aws_api_gateway_deployment" "deployment" {
 
   triggers = {
     redeployment = sha1(jsonencode([
-      module.update_email.integration_trigger_value,
       module.authenticate.integration_trigger_value,
+      module.authenticate.method_trigger_value,
+      module.delete_account.integration_trigger_value,
+      module.delete_account.method_trigger_value,
+      module.update_email.integration_trigger_value,
+      module.update_email.method_trigger_value,
+      module.update_password.integration_trigger_value,
+      module.update_password.method_trigger_value,
+      module.update_phone_number.integration_trigger_value,
+      module.update_phone_number.method_trigger_value,
+      module.send_otp_notification.integration_trigger_value,
+      module.send_otp_notification.method_trigger_value,
     ]))
   }
 


### PR DESCRIPTION
## What?

- When we make changes to a aws_api_gateway_integration or aws_api_gateway_method we want to generate a new aws_api_gateway_deployment. This is similar to what we do in the `/oidc` directory
- It's common issue that the aws_api_gateway_deployment doesn't get updated after to changes to any aws_api_gateway_* hashicorp/terraform-provider-aws#162. 

## Why?

- Add a trigger to kick off an aws_api_gateway_deployment when there has been a change to the gateway method or integration, this will prevent us from having to manually deploy stuff in the console.