### PR TITLE
BAU: Add missing `break` statements

### DIFF
--- a/lambda-warmer/src/main/java/uk/gov/di/lambdawarmer/lambda/LambdaWarmerHandler.java
+++ b/lambda-warmer/src/main/java/uk/gov/di/lambdawarmer/lambda/LambdaWarmerHandler.java
@@ -81,15 +81,19 @@ public class LambdaWarmerHandler implements RequestHandler<ScheduledEvent, Strin
                         .withInvocationType(InvocationType.RequestResponse);
         switch (configurationService.getLambdaType()) {
             case ENDPOINT:
+                LOGGER.info("Using ENDPOINT payload");
                 invokeRequest.setPayload(
                         format(
                                 "'{' \"headers\": '{' \"{0}\": \"{1}\" '}}'",
                                 WARMUP_HEADER, warmupRequestId));
+                break;
             case AUTHORIZER:
+                LOGGER.info("Using AUTHORIZER payload");
                 invokeRequest.setPayload(
                         format(
                                 "'{' \"type\": \"{0}\", \"authorizationToken\": \"{1}\" '}'",
                                 WARMUP_HEADER, warmupRequestId));
+                break;
         }
         try {
             LOGGER.info("Invoking warmup request with ID {}", warmupRequestId);


### PR DESCRIPTION
## What?

- Add missing `break` statements in Lambda warmer payload `switch` block

## Why?

The warmer was submitting the wrong payload to the endpoint lambda due to a missing `break` in the `switch` statement.
