### PR TITLE
GOVSI-791: use latest version of the lambda authorizer in account management

### DIFF
--- a/ci/terraform/account-management/api-gateway.tf
+++ b/ci/terraform/account-management/api-gateway.tf
@@ -48,7 +48,7 @@ data "aws_iam_policy_document" "api_gateway_logging_policy" {
 resource "aws_api_gateway_authorizer" "di_account_management_api" {
   name                             = "${var.environment}-authorise-access-token"
   rest_api_id                      = aws_api_gateway_rest_api.di_account_management_api.id
-  authorizer_uri                   = aws_lambda_function.authorizer.invoke_arn
+  authorizer_uri                   = aws_lambda_alias.authorizer_alias.invoke_arn
   authorizer_credentials           = aws_iam_role.invocation_role.arn
   authorizer_result_ttl_in_seconds = 0
 }
@@ -64,7 +64,10 @@ resource "aws_iam_role_policy" "invocation_policy" {
     {
       "Action": "lambda:InvokeFunction",
       "Effect": "Allow",
-      "Resource": "${aws_lambda_function.authorizer.arn}"
+      "Resource": [
+          "${aws_lambda_function.authorizer.arn}",
+          "${aws_lambda_alias.authorizer_alias.arn}"
+        ]
     }
   ]
 }
@@ -98,6 +101,13 @@ resource "aws_iam_role" "invocation_role" {
   path = "/"
 
   assume_role_policy = data.aws_iam_policy_document.api_gateway_can_assume_policy.json
+}
+
+resource "aws_lambda_alias" "authorizer_alias" {
+  name             = "${var.environment}-authorizer-alias-lambda-active"
+  description      = "Alias pointing at active version of Lambda"
+  function_name    = aws_lambda_function.authorizer.arn
+  function_version = aws_lambda_function.authorizer.version
 }
 
 resource "aws_cloudwatch_log_group" "lambda_log_group" {

--- a/ci/terraform/account-management/authoriser-warmer.tf
+++ b/ci/terraform/account-management/authoriser-warmer.tf
@@ -85,7 +85,7 @@ resource "aws_lambda_function" "warmer_function" {
   environment {
     variables = {
       LAMBDA_ARN       = aws_lambda_function.authorizer.arn
-      LAMBDA_QUALIFIER = aws_lambda_function.authorizer.version
+      LAMBDA_QUALIFIER = aws_lambda_alias.authorizer_alias.name
       LAMBDA_TYPE      = "AUTHORIZER"
     }
   }


### PR DESCRIPTION
## What?

Use latest version of the lambda authorizer in account management.

## Why?

Warmer was running against one lambda version, whereas the authorizer was running against another, so the authorizer had longer cold starts.