### PR TITLE
GOVSI-771: Use json format for logs.

### DIFF
--- a/account-management-api/src/main/resources/log4j2.xml
+++ b/account-management-api/src/main/resources/log4j2.xml
@@ -1,9 +1,7 @@
 <Configuration status="WARN">
     <Appenders>
         <Lambda name="Lambda">
-            <PatternLayout>
-                <pattern>RequestId = %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
-            </PatternLayout>
+            <JsonLayout compact="true" eventEol="true" />
         </Lambda>
     </Appenders>
     <Loggers>

--- a/client-registry-api/src/main/resources/log4j2.xml
+++ b/client-registry-api/src/main/resources/log4j2.xml
@@ -1,9 +1,7 @@
 <Configuration status="WARN">
     <Appenders>
         <Lambda name="Lambda">
-            <PatternLayout>
-                <pattern>RequestId = %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
-            </PatternLayout>
+            <JsonLayout compact="true" eventEol="true" />
         </Lambda>
     </Appenders>
     <Loggers>

--- a/frontend-api/src/main/resources/log4j2.xml
+++ b/frontend-api/src/main/resources/log4j2.xml
@@ -1,9 +1,7 @@
 <Configuration status="WARN">
     <Appenders>
         <Lambda name="Lambda">
-            <PatternLayout>
-                <pattern>RequestId = %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
-            </PatternLayout>
+            <JsonLayout compact="true" eventEol="true" />
         </Lambda>
     </Appenders>
     <Loggers>

--- a/lambda-warmer/src/main/resources/log4j2.xml
+++ b/lambda-warmer/src/main/resources/log4j2.xml
@@ -1,9 +1,7 @@
 <Configuration status="WARN">
     <Appenders>
         <Lambda name="Lambda">
-            <PatternLayout>
-                <pattern>RequestId = %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
-            </PatternLayout>
+            <JsonLayout compact="true" eventEol="true" />
         </Lambda>
     </Appenders>
     <Loggers>

--- a/lambda-warmer/src/test/resources/log4j2.xml
+++ b/lambda-warmer/src/test/resources/log4j2.xml
@@ -1,9 +1,7 @@
 <Configuration status="WARN">
     <Appenders>
         <Lambda name="Lambda">
-            <PatternLayout>
-                <pattern>RequestId = %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
-            </PatternLayout>
+            <JsonLayout compact="true" eventEol="true" />
         </Lambda>
     </Appenders>
     <Loggers>

--- a/oidc-api/src/main/resources/log4j2.xml
+++ b/oidc-api/src/main/resources/log4j2.xml
@@ -1,9 +1,7 @@
 <Configuration status="WARN">
     <Appenders>
         <Lambda name="Lambda">
-            <PatternLayout>
-                <pattern>RequestId = %X{AWSRequestId} %-5p %c{1} - %m%n</pattern>
-            </PatternLayout>
+            <JsonLayout compact="true" eventEol="true" />
         </Lambda>
     </Appenders>
     <Loggers>


### PR DESCRIPTION
## What?

Use json format for logs.

## Why?

Using a structured format will make the logs more searchable.

## Notes:

* We're not sure whether the AWSRequestId will come through automatically or whether we'll need to configure it as an additional field.  In any case, we're not sure that Localstack provides it when we test locally, so we won't be able to see how this is behaving until this PR is deployed.
* We've gone with JSON Layout (https://logging.apache.org/log4j/2.x/manual/layouts.html#JSONLayout) as it seems like the most straightforward way to meet our needs, but JSON Template Layout is a potential alternative (https://logging.apache.org/log4j/2.x/manual/json-template-layout.html).