### PR TITLE
GOVSI-791: redeploy api when authorizer lambda is updated

### DIFF
--- a/ci/terraform/account-management/api-gateway.tf
+++ b/ci/terraform/account-management/api-gateway.tf
@@ -163,6 +163,7 @@ resource "aws_api_gateway_deployment" "deployment" {
       module.update_phone_number.method_trigger_value,
       module.send_otp_notification.integration_trigger_value,
       module.send_otp_notification.method_trigger_value,
+      aws_lambda_alias.authorizer_alias.function_version
     ]))
   }
 


### PR DESCRIPTION
## What?

redeploy api when authorizer lambda is updated

## Why?

Make sure api calls get routed to the latest version of the authorizer.

## Related PRs

#509 