### PR TITLE
BAU: Stop request tracing in all environments

### DIFF
--- a/ci/terraform/account-management/api-gateway.tf
+++ b/ci/terraform/account-management/api-gateway.tf
@@ -204,7 +204,7 @@ resource "aws_api_gateway_method_settings" "api_gateway_logging_settings" {
 
   settings {
     metrics_enabled    = false
-    data_trace_enabled = true
+    data_trace_enabled = var.enable_api_gateway_execution_request_tracing && local.request_tracing_allowed
     logging_level      = "INFO"
   }
   depends_on = [

--- a/ci/terraform/account-management/site.tf
+++ b/ci/terraform/account-management/site.tf
@@ -47,4 +47,6 @@ locals {
     environment = var.environment
     application = "account-management-api"
   }
+
+  request_tracing_allowed = contains(["build", "sandpit"], var.environment)
 }

--- a/ci/terraform/account-management/variables.tf
+++ b/ci/terraform/account-management/variables.tf
@@ -54,7 +54,12 @@ variable "service_domain_name" {
 
 variable "enable_api_gateway_execution_logging" {
   default     = true
-  description = "Whether to enable logging of API gateway runs (including capturing of requests/responses)"
+  description = "Whether to enable logging of API gateway runs"
+}
+
+variable "enable_api_gateway_execution_request_tracing" {
+  default     = false
+  description = "Whether to enable capturing of requests/responses from API gateway runs (ONLY ENABLE IN NON-PROD ENVIRONMENTS)"
 }
 
 variable "lambda_zip_file" {

--- a/ci/terraform/oidc/api-gateway.tf
+++ b/ci/terraform/oidc/api-gateway.tf
@@ -226,7 +226,7 @@ resource "aws_api_gateway_method_settings" "api_gateway_logging_settings" {
 
   settings {
     metrics_enabled    = false
-    data_trace_enabled = true
+    data_trace_enabled = var.enable_api_gateway_execution_request_tracing && local.request_tracing_allowed
     logging_level      = "INFO"
   }
   depends_on = [

--- a/ci/terraform/oidc/sandpit.tfvars
+++ b/ci/terraform/oidc/sandpit.tfvars
@@ -1,3 +1,5 @@
 environment       = "sandpit"
 notify_api_key    = "123456"
 keep_lambdas_warm = false
+
+enable_api_gateway_execution_request_tracing = true

--- a/ci/terraform/oidc/site.tf
+++ b/ci/terraform/oidc/site.tf
@@ -60,6 +60,8 @@ locals {
     environment = var.environment
     application = "oidc-api"
   }
+
+  request_tracing_allowed = contains(["build", "sandpit"], var.environment)
 }
 
 data "aws_caller_identity" "current" {}

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -110,7 +110,12 @@ variable "service_domain_name" {
 
 variable "enable_api_gateway_execution_logging" {
   default     = true
-  description = "Whether to enable logging of API gateway runs (including capturing of requests/responses)"
+  description = "Whether to enable logging of API gateway runs"
+}
+
+variable "enable_api_gateway_execution_request_tracing" {
+  default     = false
+  description = "Whether to enable capturing of requests/responses from API gateway runs (ONLY ENABLE IN NON-PROD ENVIRONMENTS)"
 }
 
 variable "logging_endpoint_enabled" {


### PR DESCRIPTION
## What?

- Stop request tracing by default, this should be optional per environment
- Only allow request tracing in `build` and `sandpit` environments

## Why?

Some request contain sensitive data, we really don't want to log this in other upstream environments, particularly production (when we get there).
