### PR TITLE
Make stub RP's use public subject id

### DIFF
--- a/ci/terraform/oidc/stub-rp-clients.tf
+++ b/ci/terraform/oidc/stub-rp-clients.tf
@@ -66,5 +66,8 @@ resource "aws_dynamodb_table_item" "stub_rp_client" {
     ServiceType = {
       S = "MANDATORY"
     }
+    SubjectType = {
+      S = "public"
+    }
   })
 }


### PR DESCRIPTION
## What?

Make RP's use public subject type

## Why?

To fix the stubs as currently they have no value for this and throw a null pointer exception 

