### PR TITLE
GOVSI-718 -  Change how we store Refresh and Access tokens

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
@@ -17,8 +17,8 @@ import uk.gov.di.authentication.helpers.DynamoHelper;
 import uk.gov.di.authentication.helpers.KeyPairHelper;
 import uk.gov.di.authentication.helpers.KmsHelper;
 import uk.gov.di.authentication.helpers.RedisHelper;
-import uk.gov.di.authentication.shared.entity.AccessTokenStore;
 import uk.gov.di.authentication.shared.entity.ServiceType;
+import uk.gov.di.authentication.shared.entity.TokenStore;
 
 import java.security.KeyPair;
 import java.time.LocalDateTime;
@@ -69,8 +69,8 @@ public class UserInfoIntegrationTest extends IntegrationTestEndpoints {
                         .build();
         SignedJWT signedJWT = KmsHelper.signAccessToken(claimsSet);
         AccessToken accessToken = new BearerAccessToken(signedJWT.serialize());
-        AccessTokenStore accessTokenStore =
-                new AccessTokenStore(accessToken.getValue(), internalSubject.getValue());
+        TokenStore accessTokenStore =
+                new TokenStore(accessToken.getValue(), internalSubject.getValue());
         String accessTokenStoreString = new ObjectMapper().writeValueAsString(accessTokenStore);
         RedisHelper.addToRedis(
                 ACCESS_TOKEN_PREFIX + CLIENT_ID + "." + publicSubject,

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
@@ -1,5 +1,7 @@
 package uk.gov.di.authentication.api;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.id.Subject;
@@ -12,17 +14,23 @@ import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.helpers.DynamoHelper;
+import uk.gov.di.authentication.helpers.KeyPairHelper;
 import uk.gov.di.authentication.helpers.KmsHelper;
 import uk.gov.di.authentication.helpers.RedisHelper;
+import uk.gov.di.authentication.shared.entity.AccessTokenStore;
+import uk.gov.di.authentication.shared.entity.ServiceType;
 
+import java.security.KeyPair;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
 import static com.nimbusds.oauth2.sdk.token.BearerTokenError.INVALID_TOKEN;
+import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -32,15 +40,19 @@ public class UserInfoIntegrationTest extends IntegrationTestEndpoints {
     private static final String TEST_EMAIL_ADDRESS = "joe.bloggs@digital.cabinet-office.gov.uk";
     private static final String TEST_PHONE_NUMBER = "01234567890";
     private static final String TEST_PASSWORD = "password-1";
+    private static final String CLIENT_ID = "client-id-one";
+    private static final String ACCESS_TOKEN_PREFIX = "ACCESS_TOKEN:";
 
     @Test
-    public void shouldCallUserInfoWithAccessTokenAndReturn200() {
+    public void shouldCallUserInfoWithAccessTokenAndReturn200() throws JsonProcessingException {
+        Subject internalSubject = new Subject();
+        Subject publicSubject = new Subject();
         LocalDateTime localDateTime = LocalDateTime.now().plusMinutes(10);
         Date expiryDate = Date.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant());
         List<String> scopes = new ArrayList<>();
         scopes.add("email");
         scopes.add("phone");
-        scopes.add("oidc");
+        scopes.add("openid");
         JWTClaimsSet claimsSet =
                 new JWTClaimsSet.Builder()
                         .claim("scope", scopes)
@@ -52,16 +64,19 @@ public class UserInfoIntegrationTest extends IntegrationTestEndpoints {
                                                 .atZone(ZoneId.systemDefault())
                                                 .toInstant()))
                         .claim("client_id", "client-id-one")
-                        .subject(new Subject().getValue())
+                        .subject(publicSubject.getValue())
                         .jwtID(UUID.randomUUID().toString())
                         .build();
         SignedJWT signedJWT = KmsHelper.signAccessToken(claimsSet);
         AccessToken accessToken = new BearerAccessToken(signedJWT.serialize());
-        Subject subject = new Subject();
-        RedisHelper.addToRedis(accessToken.toJSONString(), subject.toString(), 300L);
-        DynamoHelper.signUp(TEST_EMAIL_ADDRESS, TEST_PASSWORD, subject);
-        DynamoHelper.addPhoneNumber(TEST_EMAIL_ADDRESS, TEST_PHONE_NUMBER);
-        DynamoHelper.setPhoneNumberVerified(TEST_EMAIL_ADDRESS, true);
+        AccessTokenStore accessTokenStore =
+                new AccessTokenStore(accessToken.getValue(), internalSubject.getValue());
+        String accessTokenStoreString = new ObjectMapper().writeValueAsString(accessTokenStore);
+        RedisHelper.addToRedis(
+                ACCESS_TOKEN_PREFIX + CLIENT_ID + "." + publicSubject,
+                accessTokenStoreString,
+                300L);
+        setUpDynamo(internalSubject);
         Client client = ClientBuilder.newClient();
         Response response =
                 client.target(ROOT_RESOURCE_URL + USERINFO_ENDPOINT)
@@ -72,8 +87,8 @@ public class UserInfoIntegrationTest extends IntegrationTestEndpoints {
         //        Commented out due to same reason as LogoutIntegration test. It's an issue with KSM
         // running inside localstack which causes the Caused by:
         // java.security.NoSuchAlgorithmException: EC KeyFactory not available error.
-        //        assertEquals(200, response.getStatus());
-        UserInfo expectedUserInfoResponse = new UserInfo(subject);
+        //                assertEquals(200, response.getStatus());
+        UserInfo expectedUserInfoResponse = new UserInfo(publicSubject);
         expectedUserInfoResponse.setEmailAddress(TEST_EMAIL_ADDRESS);
         expectedUserInfoResponse.setEmailVerified(true);
         expectedUserInfoResponse.setPhoneNumber(TEST_PHONE_NUMBER);
@@ -100,5 +115,23 @@ public class UserInfoIntegrationTest extends IntegrationTestEndpoints {
                                         .toHTTPResponse()
                                         .getHeaderMap()
                                         .get("WWW-Authenticate")));
+    }
+
+    private void setUpDynamo(Subject internalSubject) {
+        DynamoHelper.signUp(TEST_EMAIL_ADDRESS, TEST_PASSWORD, internalSubject);
+        DynamoHelper.addPhoneNumber(TEST_EMAIL_ADDRESS, TEST_PHONE_NUMBER);
+        DynamoHelper.setPhoneNumberVerified(TEST_EMAIL_ADDRESS, true);
+        KeyPair keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        DynamoHelper.registerClient(
+                CLIENT_ID,
+                "test-client",
+                singletonList("redirect-url"),
+                singletonList(TEST_EMAIL_ADDRESS),
+                List.of("openid", "email", "phone"),
+                Base64.getMimeEncoder().encodeToString(keyPair.getPublic().getEncoded()),
+                singletonList("http://localhost/post-redirect-logout"),
+                String.valueOf(ServiceType.MANDATORY),
+                "https://test.com",
+                "public");
     }
 }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/UserInfoService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/UserInfoService.java
@@ -1,0 +1,144 @@
+package uk.gov.di.authentication.oidc.services;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.OAuth2Error;
+import com.nimbusds.oauth2.sdk.id.Subject;
+import com.nimbusds.oauth2.sdk.token.AccessToken;
+import com.nimbusds.oauth2.sdk.token.AccessTokenType;
+import com.nimbusds.oauth2.sdk.token.BearerTokenError;
+import com.nimbusds.openid.connect.sdk.claims.UserInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.di.authentication.shared.entity.AccessTokenStore;
+import uk.gov.di.authentication.shared.entity.ClientRegistry;
+import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.entity.ValidScopes;
+import uk.gov.di.authentication.shared.exceptions.UserInfoValidationException;
+import uk.gov.di.authentication.shared.services.AuthenticationService;
+import uk.gov.di.authentication.shared.services.DynamoClientService;
+import uk.gov.di.authentication.shared.services.RedisConnectionService;
+import uk.gov.di.authentication.shared.services.TokenValidationService;
+
+import java.text.ParseException;
+import java.util.List;
+import java.util.Optional;
+
+public class UserInfoService {
+
+    private final RedisConnectionService redisConnectionService;
+    private final AuthenticationService authenticationService;
+    private final TokenValidationService tokenValidationService;
+    private final DynamoClientService clientService;
+    private static final String ACCESS_TOKEN_PREFIX = "ACCESS_TOKEN:";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(UserInfoService.class);
+
+    public UserInfoService(
+            RedisConnectionService redisConnectionService,
+            AuthenticationService authenticationService,
+            TokenValidationService tokenValidationService,
+            DynamoClientService clientService) {
+        this.redisConnectionService = redisConnectionService;
+        this.authenticationService = authenticationService;
+        this.tokenValidationService = tokenValidationService;
+        this.clientService = clientService;
+    }
+
+    public UserInfo processUserInfoRequest(String authorizationHeader)
+            throws UserInfoValidationException {
+        LOGGER.info("Processing UserInfo request");
+        AccessToken accessToken;
+        try {
+            accessToken = AccessToken.parse(authorizationHeader, AccessTokenType.BEARER);
+        } catch (com.nimbusds.oauth2.sdk.ParseException e) {
+            LOGGER.error("Unable to parse AccessToken", e);
+            throw new UserInfoValidationException(
+                    "Unable to parse AccessToken", BearerTokenError.INVALID_TOKEN);
+        }
+        SignedJWT signedJWT;
+        try {
+            signedJWT = SignedJWT.parse(accessToken.getValue());
+
+            if (!tokenValidationService.validateAccessTokenSignature(accessToken)) {
+                LOGGER.error("Unable to validate AccessToken signature");
+                throw new UserInfoValidationException(
+                        "Unable to validate AccessToken signature", BearerTokenError.INVALID_TOKEN);
+            }
+            String clientID = signedJWT.getJWTClaimsSet().getStringClaim("client_id");
+            Optional<ClientRegistry> client = clientService.getClient(clientID);
+            if (client.isEmpty()) {
+                LOGGER.error("Client not found with given ClientID: {}", clientID);
+                throw new UserInfoValidationException(
+                        "Client not found with given ClientID", BearerTokenError.INVALID_TOKEN);
+            }
+            List<String> scopes = (List<String>) signedJWT.getJWTClaimsSet().getClaim("scope");
+            if (!areScopesValid(scopes) || !client.get().getScopes().containsAll(scopes)) {
+                LOGGER.error("Invalid Scopes: {}", scopes);
+                throw new UserInfoValidationException("Invalid Scopes", OAuth2Error.INVALID_SCOPE);
+            }
+            String subject = signedJWT.getJWTClaimsSet().getSubject();
+            Optional<AccessTokenStore> accessTokenStore = getAccessTokenStore(clientID, subject);
+            if (accessTokenStore.isEmpty()) {
+                LOGGER.error("Access Token Store is empty");
+                throw new UserInfoValidationException(
+                        "Invalid Access Token", BearerTokenError.INVALID_TOKEN);
+            }
+            if (!accessTokenStore.get().getAccessToken().equals(accessToken.getValue())) {
+                LOGGER.error(
+                        "Access Token in Access Token Store is different to Access Token sent in request");
+                throw new UserInfoValidationException(
+                        "Invalid Access Token", BearerTokenError.INVALID_TOKEN);
+            }
+            deleteAccessTokenStore(clientID, subject);
+            UserProfile userProfile =
+                    authenticationService.getUserProfileFromSubject(
+                            accessTokenStore.get().getInternalSubjectId());
+            return populateUserInfo(userProfile, subject, scopes);
+        } catch (ParseException e) {
+            LOGGER.error("Unable to parse AccessToken to SignedJWT", e);
+            throw new UserInfoValidationException(
+                    "Unable to parse AccessToken to SignedJWT", BearerTokenError.INVALID_TOKEN);
+        }
+    }
+
+    private UserInfo populateUserInfo(
+            UserProfile userProfile, String subject, List<String> scopes) {
+        UserInfo userInfo = new UserInfo(new Subject(subject));
+        if (scopes.contains("email")) {
+            userInfo.setEmailAddress(userProfile.getEmail());
+            userInfo.setEmailVerified(userProfile.isEmailVerified());
+        }
+        if (scopes.contains("phone")) {
+            userInfo.setPhoneNumber(userProfile.getPhoneNumber());
+            userInfo.setPhoneNumberVerified(userProfile.isPhoneNumberVerified());
+        }
+        return userInfo;
+    }
+
+    private Optional<AccessTokenStore> getAccessTokenStore(String clientId, String subjectId) {
+        String result =
+                redisConnectionService.getValue(ACCESS_TOKEN_PREFIX + clientId + "." + subjectId);
+        try {
+            return Optional.of(new ObjectMapper().readValue(result, AccessTokenStore.class));
+        } catch (JsonProcessingException | IllegalArgumentException e) {
+            LOGGER.error("Error getting AccessToken from Redis");
+            return Optional.empty();
+        }
+        //        TODO - delete access token after use
+    }
+
+    private void deleteAccessTokenStore(String clientId, String subjectId) {
+        redisConnectionService.deleteValue(ACCESS_TOKEN_PREFIX + clientId + "." + subjectId);
+    }
+
+    private boolean areScopesValid(List<String> scopes) {
+        for (String scope : scopes) {
+            if (ValidScopes.getAllValidScopes().stream().noneMatch((t) -> t.equals(scope))) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
@@ -1,0 +1,250 @@
+package uk.gov.di.authentication.oidc.services;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.OAuth2Error;
+import com.nimbusds.oauth2.sdk.id.Subject;
+import com.nimbusds.oauth2.sdk.token.AccessToken;
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
+import com.nimbusds.oauth2.sdk.token.BearerTokenError;
+import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
+import com.nimbusds.openid.connect.sdk.claims.UserInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.entity.AccessTokenStore;
+import uk.gov.di.authentication.shared.entity.ClientRegistry;
+import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.exceptions.UserInfoValidationException;
+import uk.gov.di.authentication.shared.helpers.TokenGeneratorHelper;
+import uk.gov.di.authentication.shared.services.AuthenticationService;
+import uk.gov.di.authentication.shared.services.DynamoClientService;
+import uk.gov.di.authentication.shared.services.RedisConnectionService;
+import uk.gov.di.authentication.shared.services.TokenValidationService;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class UserInfoServiceTest {
+
+    private UserInfoService userInfoService;
+    private final RedisConnectionService redisConnectionService =
+            mock(RedisConnectionService.class);
+    private final AuthenticationService authenticationService = mock(AuthenticationService.class);
+    private final TokenValidationService tokenValidationService =
+            mock(TokenValidationService.class);
+    private final DynamoClientService clientService = mock(DynamoClientService.class);
+    private static final Subject INTERNAL_SUBJECT = new Subject("internal-subject");
+    private static final Subject SUBJECT = new Subject("some-subject");
+    private static final List<String> SCOPES =
+            List.of(
+                    OIDCScopeValue.OPENID.getValue(),
+                    OIDCScopeValue.EMAIL.getValue(),
+                    OIDCScopeValue.PHONE.getValue());
+    private static final String CLIENT_ID = "client-id";
+    private static final String EMAIL = "joe.bloggs@digital.cabinet-office.gov.uk";
+    private static final String PHONE_NUMBER = "01234567891";
+    private static final String BASE_URL = "http://example.com";
+    private static final String KEY_ID = "14342354354353";
+    private static final String ACCESS_TOKEN_PREFIX = "ACCESS_TOKEN:";
+    private AccessToken accessToken;
+
+    @BeforeEach
+    public void setUp() throws JOSEException {
+        userInfoService =
+                new UserInfoService(
+                        redisConnectionService,
+                        authenticationService,
+                        tokenValidationService,
+                        clientService);
+        accessToken = createSignedAccessToken();
+    }
+
+    @Test
+    public void shouldSuccessfullyProcessUserInfoRequest()
+            throws JsonProcessingException, UserInfoValidationException {
+        when(tokenValidationService.validateAccessTokenSignature(accessToken)).thenReturn(true);
+        when(clientService.getClient(CLIENT_ID))
+                .thenReturn(Optional.of(generateClientRegistry(SCOPES)));
+        when(redisConnectionService.getValue(ACCESS_TOKEN_PREFIX + CLIENT_ID + "." + SUBJECT))
+                .thenReturn(
+                        new ObjectMapper()
+                                .writeValueAsString(
+                                        new AccessTokenStore(
+                                                accessToken.getValue(),
+                                                INTERNAL_SUBJECT.getValue())));
+        when(authenticationService.getUserProfileFromSubject(INTERNAL_SUBJECT.getValue()))
+                .thenReturn(generateUserprofile());
+
+        UserInfo userInfo =
+                userInfoService.processUserInfoRequest(accessToken.toAuthorizationHeader());
+        assertEquals(userInfo.getEmailAddress(), EMAIL);
+        assertEquals(userInfo.getEmailVerified(), true);
+        assertEquals(userInfo.getPhoneNumber(), PHONE_NUMBER);
+        assertEquals(userInfo.getPhoneNumberVerified(), true);
+        verify(redisConnectionService, times(1))
+                .deleteValue(ACCESS_TOKEN_PREFIX + CLIENT_ID + "." + SUBJECT);
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenTokenSignatureIsInvalid() {
+        when(tokenValidationService.validateAccessTokenSignature(accessToken)).thenReturn(false);
+
+        UserInfoValidationException userInfoValidationException =
+                assertThrows(
+                        UserInfoValidationException.class,
+                        () ->
+                                userInfoService.processUserInfoRequest(
+                                        accessToken.toAuthorizationHeader()),
+                        "Expected to throw UserInfoValidationException");
+
+        assertEquals(
+                userInfoValidationException.getMessage(),
+                "Unable to validate AccessToken signature");
+        assertEquals(userInfoValidationException.getError(), BearerTokenError.INVALID_TOKEN);
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenClientIsNotFoundInClientRegistry() {
+        when(tokenValidationService.validateAccessTokenSignature(accessToken)).thenReturn(true);
+        when(clientService.getClient(CLIENT_ID)).thenReturn(Optional.empty());
+
+        UserInfoValidationException userInfoValidationException =
+                assertThrows(
+                        UserInfoValidationException.class,
+                        () ->
+                                userInfoService.processUserInfoRequest(
+                                        accessToken.toAuthorizationHeader()),
+                        "Expected to throw UserInfoValidationException");
+
+        assertEquals(
+                userInfoValidationException.getMessage(), "Client not found with given ClientID");
+        assertEquals(userInfoValidationException.getError(), BearerTokenError.INVALID_TOKEN);
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenScopesAreInvalid() {
+        List<String> scopes =
+                List.of(OIDCScopeValue.OPENID.getValue(), OIDCScopeValue.ADDRESS.getValue());
+        when(tokenValidationService.validateAccessTokenSignature(accessToken)).thenReturn(true);
+        when(clientService.getClient(CLIENT_ID))
+                .thenReturn(Optional.of(generateClientRegistry(scopes)));
+
+        UserInfoValidationException userInfoValidationException =
+                assertThrows(
+                        UserInfoValidationException.class,
+                        () ->
+                                userInfoService.processUserInfoRequest(
+                                        accessToken.toAuthorizationHeader()),
+                        "Expected to throw UserInfoValidationException");
+
+        assertEquals(userInfoValidationException.getMessage(), "Invalid Scopes");
+        assertEquals(userInfoValidationException.getError(), OAuth2Error.INVALID_SCOPE);
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenAccessTokenNotFoundInRedis() {
+        when(tokenValidationService.validateAccessTokenSignature(accessToken)).thenReturn(true);
+        when(clientService.getClient(CLIENT_ID))
+                .thenReturn(Optional.of(generateClientRegistry(SCOPES)));
+        when(redisConnectionService.getValue(ACCESS_TOKEN_PREFIX + CLIENT_ID + "." + SUBJECT))
+                .thenReturn(null);
+
+        UserInfoValidationException userInfoValidationException =
+                assertThrows(
+                        UserInfoValidationException.class,
+                        () ->
+                                userInfoService.processUserInfoRequest(
+                                        accessToken.toAuthorizationHeader()),
+                        "Expected to throw UserInfoValidationException");
+
+        assertEquals(userInfoValidationException.getMessage(), "Invalid Access Token");
+        assertEquals(userInfoValidationException.getError(), BearerTokenError.INVALID_TOKEN);
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenAccessTokenSentIsNotTheSameAsInRedis()
+            throws JsonProcessingException, JOSEException {
+        when(tokenValidationService.validateAccessTokenSignature(accessToken)).thenReturn(true);
+        when(clientService.getClient(CLIENT_ID))
+                .thenReturn(Optional.of(generateClientRegistry(SCOPES)));
+        when(redisConnectionService.getValue(ACCESS_TOKEN_PREFIX + CLIENT_ID + "." + SUBJECT))
+                .thenReturn(
+                        new ObjectMapper()
+                                .writeValueAsString(
+                                        new AccessTokenStore(
+                                                createSignedAccessToken().getValue(),
+                                                INTERNAL_SUBJECT.getValue())));
+
+        UserInfoValidationException userInfoValidationException =
+                assertThrows(
+                        UserInfoValidationException.class,
+                        () ->
+                                userInfoService.processUserInfoRequest(
+                                        accessToken.toAuthorizationHeader()),
+                        "Expected to throw UserInfoValidationException");
+
+        assertEquals(userInfoValidationException.getMessage(), "Invalid Access Token");
+        assertEquals(userInfoValidationException.getError(), BearerTokenError.INVALID_TOKEN);
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenUnableToParseAccessToken() {
+        UserInfoValidationException userInfoValidationException =
+                assertThrows(
+                        UserInfoValidationException.class,
+                        () -> userInfoService.processUserInfoRequest("rubbish-access-token"),
+                        "Expected to throw UserInfoValidationException");
+
+        assertEquals(userInfoValidationException.getMessage(), "Unable to parse AccessToken");
+        assertEquals(userInfoValidationException.getError(), BearerTokenError.INVALID_TOKEN);
+    }
+
+    private AccessToken createSignedAccessToken() throws JOSEException {
+        ECKey ecSigningKey =
+                new ECKeyGenerator(Curve.P_256)
+                        .keyID(KEY_ID)
+                        .algorithm(JWSAlgorithm.ES256)
+                        .generate();
+        ECDSASigner signer = new ECDSASigner(ecSigningKey);
+        SignedJWT signedJWT =
+                TokenGeneratorHelper.generateSignedToken(
+                        CLIENT_ID, BASE_URL, SCOPES, signer, SUBJECT, ecSigningKey.getKeyID());
+        return new BearerAccessToken(signedJWT.serialize());
+    }
+
+    private ClientRegistry generateClientRegistry(List<String> scopes) {
+        return new ClientRegistry()
+                .setRedirectUrls(singletonList("http://localhost/redirect"))
+                .setClientID(CLIENT_ID)
+                .setContacts(singletonList("joe.bloggs@digital.cabinet-office.gov.uk"))
+                .setPublicKey(null)
+                .setScopes(scopes);
+    }
+
+    private UserProfile generateUserprofile() {
+        return new UserProfile()
+                .setEmail("joe.bloggs@digital.cabinet-office.gov.uk")
+                .setEmailVerified(true)
+                .setPhoneNumber(PHONE_NUMBER)
+                .setPhoneNumberVerified(true)
+                .setSubjectID(SUBJECT.toString())
+                .setCreated(LocalDateTime.now().toString())
+                .setUpdated(LocalDateTime.now().toString());
+    }
+}

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
@@ -18,8 +18,8 @@ import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import uk.gov.di.authentication.shared.entity.AccessTokenStore;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
+import uk.gov.di.authentication.shared.entity.TokenStore;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.exceptions.UserInfoValidationException;
 import uk.gov.di.authentication.shared.helpers.TokenGeneratorHelper;
@@ -85,7 +85,7 @@ class UserInfoServiceTest {
                 .thenReturn(
                         new ObjectMapper()
                                 .writeValueAsString(
-                                        new AccessTokenStore(
+                                        new TokenStore(
                                                 accessToken.getValue(),
                                                 INTERNAL_SUBJECT.getValue())));
         when(authenticationService.getUserProfileFromSubject(INTERNAL_SUBJECT.getValue()))
@@ -187,7 +187,7 @@ class UserInfoServiceTest {
                 .thenReturn(
                         new ObjectMapper()
                                 .writeValueAsString(
-                                        new AccessTokenStore(
+                                        new TokenStore(
                                                 createSignedAccessToken().getValue(),
                                                 INTERNAL_SUBJECT.getValue())));
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AccessTokenStore.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AccessTokenStore.java
@@ -1,0 +1,28 @@
+package uk.gov.di.authentication.shared.entity;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class AccessTokenStore {
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("internal_subject_id")
+    private String internalSubjectId;
+
+    public AccessTokenStore(
+            @JsonProperty(required = true, value = "access_token") String accessToken,
+            @JsonProperty(required = true, value = "internal_subject_id")
+                    String internalSubjectId) {
+        this.accessToken = accessToken;
+        this.internalSubjectId = internalSubjectId;
+    }
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public String getInternalSubjectId() {
+        return internalSubjectId;
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/TokenStore.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/TokenStore.java
@@ -2,24 +2,24 @@ package uk.gov.di.authentication.shared.entity;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class AccessTokenStore {
+public class TokenStore {
 
-    @JsonProperty("access_token")
-    private String accessToken;
+    @JsonProperty("token")
+    private String token;
 
     @JsonProperty("internal_subject_id")
     private String internalSubjectId;
 
-    public AccessTokenStore(
-            @JsonProperty(required = true, value = "access_token") String accessToken,
+    public TokenStore(
+            @JsonProperty(required = true, value = "token") String token,
             @JsonProperty(required = true, value = "internal_subject_id")
                     String internalSubjectId) {
-        this.accessToken = accessToken;
+        this.token = token;
         this.internalSubjectId = internalSubjectId;
     }
 
-    public String getAccessToken() {
-        return accessToken;
+    public String getToken() {
+        return token;
     }
 
     public String getInternalSubjectId() {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/UserInfoValidationException.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/UserInfoValidationException.java
@@ -1,0 +1,17 @@
+package uk.gov.di.authentication.shared.exceptions;
+
+import com.nimbusds.oauth2.sdk.ErrorObject;
+
+public class UserInfoValidationException extends Exception {
+
+    private final ErrorObject error;
+
+    public UserInfoValidationException(String message, ErrorObject error) {
+        super(message);
+        this.error = error;
+    }
+
+    public ErrorObject getError() {
+        return error;
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ApiGatewayResponseHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ApiGatewayResponseHelper.java
@@ -3,23 +3,12 @@ package uk.gov.di.authentication.shared.helpers;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.nimbusds.jwt.SignedJWT;
-import com.nimbusds.oauth2.sdk.id.Subject;
-import com.nimbusds.oauth2.sdk.token.AccessToken;
-import com.nimbusds.openid.connect.sdk.UserInfoErrorResponse;
-import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
-import uk.gov.di.authentication.shared.entity.UserProfile;
-import uk.gov.di.authentication.shared.services.AuthenticationService;
 
-import java.text.ParseException;
 import java.util.List;
 import java.util.Map;
-
-import static com.nimbusds.oauth2.sdk.token.BearerTokenError.INVALID_TOKEN;
-import static java.lang.String.format;
 
 public class ApiGatewayResponseHelper {
 
@@ -57,37 +46,5 @@ public class ApiGatewayResponseHelper {
             apiGatewayProxyResponseEvent.setMultiValueHeaders(multiValueHeaders);
         }
         return apiGatewayProxyResponseEvent;
-    }
-
-    public static APIGatewayProxyResponseEvent validateScopesAndRetrieveUserInfo(
-            String subject,
-            AccessToken accessToken,
-            AuthenticationService authenticationService,
-            Map<String, String> headers) {
-        UserProfile userProfile = authenticationService.getUserProfileFromSubject(subject);
-        List<String> scopes;
-        try {
-            SignedJWT signedAccessToken = SignedJWT.parse(accessToken.getValue());
-            scopes = (List<String>) signedAccessToken.getJWTClaimsSet().getClaim("scope");
-        } catch (ParseException e) {
-            LOGGER.error(
-                    format(
-                            "Unable to parse JWT on AccessToken with headers: %s.\n\n Exception thrown: %s",
-                            headers, e));
-            return generateApiGatewayProxyResponse(
-                    401,
-                    "",
-                    new UserInfoErrorResponse(INVALID_TOKEN).toHTTPResponse().getHeaderMap());
-        }
-        UserInfo userInfo = new UserInfo(new Subject(subject));
-        if (scopes.contains("email")) {
-            userInfo.setEmailAddress(userProfile.getEmail());
-            userInfo.setEmailVerified(userProfile.isEmailVerified());
-        }
-        if (scopes.contains("phone")) {
-            userInfo.setPhoneNumber(userProfile.getPhoneNumber());
-            userInfo.setPhoneNumberVerified(userProfile.isPhoneNumberVerified());
-        }
-        return generateApiGatewayProxyResponse(200, userInfo.toJSONString());
     }
 }


### PR DESCRIPTION
## What?

- Change how we retrieve the AccessToken from Redis by using the key of the Public subjectID and Client ID. This will retrieve the access token which we compare to the access token sent in the request. It will also retrieve the InternalSubjectID which is required to query the UserProfile table and populate the UserInfo with the information relevant to that particular User.
- Store the RefreshToken in Redis as part of its own TokenStore object alongside the internal SubjectID. The key is "REFRESH_TOKEN:client_id.public_subject_id" We need to store it like this as the public subject ID will be populated in the tokens. When a refresh token request comes in we need to access the InternalSubjectID so we can store it alongside the AccessToken for the reasons mentioned above. The best way to do this is to store the InternalSubjectID alongside the RefreshToken so we can have access to it.
- Store the AccessToken in Redis as part of the TokenStore object alongside the internal SubjectID. The key is "ACCESS_TOKEN:client_id.public_subject_id". We need to store the internal subject ID alongside the AccessToken so it can be used at UserInfo to retrieve the UserProfile.
-  Add extra validation to the UserInfo endpoint

## Why?
- We were currently populating the Access and Refresh tokens with the internal subject ID however these need to be populated with the Public Subject ID.
- We need a way to retrieve the user profile on the userinfo endpoint. 
- To invalidate AccessTokens when a new one is generated 