### PR TITLE
GOVSI-642: pass frontend url to backend in the pipeline

### DIFF
--- a/ci/tasks/deploy-oidc-api.yml
+++ b/ci/tasks/deploy-oidc-api.yml
@@ -10,6 +10,9 @@ params:
   DEPLOYER_ROLE_ARN: ((deployer-role-arn-non-prod))
   DEPLOY_ENVIRONMENT: build
   NOTIFY_API_KEY: ((build-notify-api-key))
+  DNS_DEPLOYER_ROLE_ARN: ((deployer-role-arn-production))
+  DNS_STATE_BUCKET: ((dns-state-bucket))
+  DNS_STATE_KEY: ((dns-state-key))
 inputs:
   - name: api-src
   - name: oidc-api-release
@@ -42,5 +45,8 @@ run:
         -var 'logging_endpoint_enabled=true' \
         -var 'logging_endpoint_arn=arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod' \
         -var-file ${DEPLOY_ENVIRONMENT}-stub-clients.tfvars \
+        -var "dns_state_bucket=${DNS_STATE_BUCKET}" \
+        -var "dns_state_key=${DNS_STATE_KEY}" \
+        -var "dns_state_role=${DNS_DEPLOYER_ROLE_ARN}" \
 
       terraform output --json > ../../../../terraform-outputs/${DEPLOY_ENVIRONMENT}-terraform-outputs.json

--- a/ci/terraform/oidc/dns.tf
+++ b/ci/terraform/oidc/dns.tf
@@ -1,0 +1,14 @@
+data "terraform_remote_state" "dns" {
+  count   = var.use_localstack ? 0 : 1
+  backend = "s3"
+  config = {
+    bucket   = var.dns_state_bucket
+    key      = var.dns_state_key
+    role_arn = var.dns_state_role
+    region   = var.aws_region
+  }
+}
+
+locals {
+  frontend_base_url = var.use_localstack ? var.frontend_base_url : lookup(data.terraform_remote_state.dns[0].outputs, "${var.environment}_frontend_url", "")
+}

--- a/ci/terraform/oidc/localstack.tfvars
+++ b/ci/terraform/oidc/localstack.tfvars
@@ -6,3 +6,6 @@ redis_use_tls             = "false"
 external_redis_password   = "redis"
 api_deployment_stage_name = "local"
 keep_lambdas_warm         = false
+dns_state_bucket          = null
+dns_state_key             = null
+dns_state_role            = null

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -144,3 +144,20 @@ variable "keep_lambdas_warm" {
   default = true
   type    = bool
 }
+
+variable "frontend_base_url" {
+  type    = string
+  default = ""
+}
+
+variable "dns_state_bucket" {
+  type = string
+}
+
+variable "dns_state_key" {
+  type = string
+}
+
+variable "dns_state_role" {
+  type = string
+}


### PR DESCRIPTION
## What?

Pass frontend url to backend in the pipeline

## Why?

So that the url generated by reset password request is always the correct one for the environment
