### PR TITLE
GOVSI-642: update 'reset password request' lambda role

### DIFF
--- a/ci/terraform/oidc/reset-password-request.tf
+++ b/ci/terraform/oidc/reset-password-request.tf
@@ -27,7 +27,7 @@ module "reset-password-request" {
   lambda_zip_file           = var.frontend_api_lambda_zip_file
   security_group_id         = aws_vpc.authentication.default_security_group_id
   subnet_id                 = aws_subnet.authentication.*.id
-  lambda_role_arn           = aws_iam_role.sqs_lambda_iam_role.arn
+  lambda_role_arn           = aws_iam_role.dynamo_sqs_lambda_iam_role.arn
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
   default_tags              = local.default_tags


### PR DESCRIPTION

## What?

update 'reset password request' lambda role

## Why?

So it can access dynamo.

Resolves error:

  lambda is not authorized to perform: dynamodb:DescribeTable on resource

## Related PRs

#534 
