### PR TITLE
GOVSI-642: add timestamp to password reset link

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandler.java
@@ -86,9 +86,7 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                             Map<String, Object> resetPasswordPersonalisation = new HashMap<>();
                             resetPasswordPersonalisation.put(
                                     "reset-password-link",
-                                    configService.getFrontendBaseUrl()
-                                            + configService.getResetPasswordRoute()
-                                            + notifyRequest.getCode());
+                                    buildResetPasswordLink(notifyRequest.getCode()));
                             notificationService.sendEmail(
                                     notifyRequest.getDestination(),
                                     resetPasswordPersonalisation,
@@ -113,5 +111,13 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
             }
         }
         return null;
+    }
+
+    private String buildResetPasswordLink(String code) {
+        return configService.getFrontendBaseUrl()
+                + configService.getResetPasswordRoute()
+                + code
+                + "."
+                + System.currentTimeMillis();
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/SendNotificationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/SendNotificationIntegrationTest.java
@@ -16,7 +16,7 @@ import java.util.Optional;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -119,7 +119,7 @@ public class SendNotificationIntegrationTest {
 
         JsonNode request = objectMapper.readTree(notifyStub.getLastRequest().getEntity());
         JsonNode personalisation = request.get("personalisation");
-        assertThat(personalisation.get("reset-password-link").asText(), endsWith(code));
+        assertThat(personalisation.get("reset-password-link").asText(), containsString(code));
         assertThat(
                 personalisation.get("reset-password-link").asText(),
                 startsWith("http://localhost:3000/reset-password?code="));


### PR DESCRIPTION
## What?

Add timestamp to password reset link

## Why?

So that a quick validity check can be applied to the link when clicked to see if it is within the 15 min time window.
