### PR TITLE
BAU - Allow transition from RESET_PASSWORD_LINK_SENT to action USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/state/StateMachine.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/state/StateMachine.java
@@ -71,6 +71,8 @@ public class StateMachine<T, A, C> {
         return StateMachine.<SessionState, SessionAction, UserProfile>builder()
                 .when(NEW)
                 .allow(on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND))
+                .when(RESET_PASSWORD_LINK_SENT)
+                .allow(on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND))
                 .when(USER_NOT_FOUND)
                 .allow(
                         on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND),


### PR DESCRIPTION
## What?

- Once a user has reset their password we should allow that user to open another tab and start another journey

## Why?

- So a user does not need to open another browser to start a new session and a journey 

