### PR TITLE
BAU - Retrieve the UserProfile using the PublicSubjectID

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandler.java
@@ -14,6 +14,8 @@ import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.accountmanagement.entity.RemoveAccountRequest;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.helpers.RequestBodyHelper;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
@@ -22,7 +24,6 @@ import java.util.Map;
 
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
-import static uk.gov.di.authentication.shared.helpers.RequestBodyHelper.validatePrincipal;
 import static uk.gov.di.authentication.shared.helpers.WarmerHelper.isWarming;
 
 public class RemoveAccountHandler
@@ -68,11 +69,13 @@ public class RemoveAccountHandler
 
                                 String email = removeAccountRequest.getEmail();
 
-                                Subject subjectFromEmail =
-                                        authenticationService.getSubjectFromEmail(email);
+                                UserProfile userProfile =
+                                        authenticationService.getUserProfileByEmail(email);
                                 Map<String, Object> authorizerParams =
                                         input.getRequestContext().getAuthorizer();
-                                validatePrincipal(subjectFromEmail, authorizerParams);
+                                RequestBodyHelper.validatePrincipal(
+                                        new Subject(userProfile.getPublicSubjectID()),
+                                        authorizerParams);
 
                                 authenticationService.removeAccount(email);
                                 LOGGER.info("User account removed. Adding message to SQS queue");

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
@@ -15,6 +15,7 @@ import uk.gov.di.accountmanagement.entity.UpdateEmailRequest;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.RequestBodyHelper;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
@@ -104,13 +105,14 @@ public class UpdateEmailHandler
                                     return generateApiGatewayProxyErrorResponse(
                                             400, ErrorResponse.ERROR_1009);
                                 }
-                                Subject subjectFromEmail =
-                                        dynamoService.getSubjectFromEmail(
+                                UserProfile userProfile =
+                                        dynamoService.getUserProfileByEmail(
                                                 updateInfoRequest.getExistingEmailAddress());
                                 Map<String, Object> authorizerParams =
                                         input.getRequestContext().getAuthorizer();
                                 RequestBodyHelper.validatePrincipal(
-                                        subjectFromEmail, authorizerParams);
+                                        new Subject(userProfile.getPublicSubjectID()),
+                                        authorizerParams);
                                 dynamoService.updateEmail(
                                         updateInfoRequest.getExistingEmailAddress(),
                                         updateInfoRequest.getReplacementEmailAddress());

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandler.java
@@ -14,6 +14,7 @@ import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.accountmanagement.entity.UpdatePasswordRequest;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.RequestBodyHelper;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
@@ -64,14 +65,15 @@ public class UpdatePasswordHandler
                                         objectMapper.readValue(
                                                 input.getBody(), UpdatePasswordRequest.class);
 
-                                Subject subjectFromEmail =
-                                        dynamoService.getSubjectFromEmail(
+                                UserProfile userProfile =
+                                        dynamoService.getUserProfileByEmail(
                                                 updatePasswordRequest.getEmail());
                                 Map<String, Object> authorizerParams =
                                         input.getRequestContext().getAuthorizer();
 
                                 RequestBodyHelper.validatePrincipal(
-                                        subjectFromEmail, authorizerParams);
+                                        new Subject(userProfile.getPublicSubjectID()),
+                                        authorizerParams);
 
                                 dynamoService.updatePassword(
                                         updatePasswordRequest.getEmail(),

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandler.java
@@ -15,6 +15,7 @@ import uk.gov.di.accountmanagement.entity.UpdatePhoneNumberRequest;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.RequestBodyHelper;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
@@ -93,13 +94,14 @@ public class UpdatePhoneNumberHandler
                                     return generateApiGatewayProxyErrorResponse(
                                             400, phoneValidationErrors.get());
                                 }
-                                Subject subjectFromEmail =
-                                        dynamoService.getSubjectFromEmail(
+                                UserProfile userProfile =
+                                        dynamoService.getUserProfileByEmail(
                                                 updatePhoneNumberRequest.getEmail());
                                 Map<String, Object> authorizerParams =
                                         input.getRequestContext().getAuthorizer();
                                 RequestBodyHelper.validatePrincipal(
-                                        subjectFromEmail, authorizerParams);
+                                        new Subject(userProfile.getPublicSubjectID()),
+                                        authorizerParams);
                                 dynamoService.updatePhoneNumber(
                                         updatePhoneNumberRequest.getEmail(),
                                         updatePhoneNumberRequest.getPhoneNumber());

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandlerTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
+import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 
 import java.util.HashMap;
@@ -40,7 +41,8 @@ class RemoveAccountHandlerTest {
 
     @Test
     public void shouldReturn200IfAccountRemovalIsSuccessful() throws JsonProcessingException {
-        when(authenticationService.getSubjectFromEmail(EMAIL)).thenReturn(SUBJECT);
+        UserProfile userProfile = new UserProfile().setPublicSubjectID(SUBJECT.getValue());
+        when(authenticationService.getUserProfileByEmail(EMAIL)).thenReturn(userProfile);
         APIGatewayProxyRequestEvent.ProxyRequestContext proxyRequestContext =
                 new APIGatewayProxyRequestEvent.ProxyRequestContext();
         Map<String, Object> authorizerParams = new HashMap<>();

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandlerTest.java
@@ -12,6 +12,7 @@ import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.ValidationService;
 
@@ -54,7 +55,8 @@ class UpdateEmailHandlerTest {
 
     @Test
     public void shouldReturn200ForValidUpdateEmailRequest() throws JsonProcessingException {
-        when(dynamoService.getSubjectFromEmail(EXISTING_EMAIL_ADDRESS)).thenReturn(SUBJECT);
+        UserProfile userProfile = new UserProfile().setPublicSubjectID(SUBJECT.getValue());
+        when(dynamoService.getUserProfileByEmail(EXISTING_EMAIL_ADDRESS)).thenReturn(userProfile);
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setBody(
                 format(

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandlerTest.java
@@ -12,6 +12,7 @@ import uk.gov.di.accountmanagement.entity.NotificationType;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.services.DynamoService;
 
 import java.util.HashMap;
@@ -43,7 +44,8 @@ class UpdatePasswordHandlerTest {
 
     @Test
     public void shouldReturn200ForValidRequest() throws JsonProcessingException {
-        when(dynamoService.getSubjectFromEmail(EXISTING_EMAIL_ADDRESS)).thenReturn(SUBJECT);
+        UserProfile userProfile = new UserProfile().setPublicSubjectID(SUBJECT.getValue());
+        when(dynamoService.getUserProfileByEmail(EXISTING_EMAIL_ADDRESS)).thenReturn(userProfile);
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setBody(
                 format(

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandlerTest.java
@@ -12,6 +12,7 @@ import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.ValidationService;
 
@@ -54,7 +55,8 @@ class UpdatePhoneNumberHandlerTest {
 
     @Test
     public void shouldReturn200ForValidUpdatePhoneNumberRequest() throws JsonProcessingException {
-        when(dynamoService.getSubjectFromEmail(EMAIL_ADDRESS)).thenReturn(SUBJECT);
+        UserProfile userProfile = new UserProfile().setPublicSubjectID(SUBJECT.getValue());
+        when(dynamoService.getUserProfileByEmail(EMAIL_ADDRESS)).thenReturn(userProfile);
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setBody(
                 format(

--- a/ci/terraform/oidc/dynamodb.tf
+++ b/ci/terraform/oidc/dynamodb.tf
@@ -41,9 +41,20 @@ resource "aws_dynamodb_table" "user_profile_table" {
     type = "S"
   }
 
+  attribute {
+    name = "PublicSubjectID"
+    type = "S"
+  }
+
   global_secondary_index {
     name            = "SubjectIDIndex"
     hash_key        = "SubjectID"
+    projection_type = "ALL"
+  }
+
+  global_secondary_index {
+    name            = "PublicSubjectIDIndex"
+    hash_key        = "PublicSubjectID"
     projection_type = "ALL"
   }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/helpers/DynamoHelper.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/helpers/DynamoHelper.java
@@ -51,6 +51,10 @@ public class DynamoHelper {
         DYNAMO_SERVICE.signUp(email, password, subject, termsAndConditions);
     }
 
+    public static UserProfile getByPublicSubject(String subject) {
+        return DYNAMO_SERVICE.getUserProfileFromPublicSubject(subject);
+    }
+
     public static void addPhoneNumber(String email, String phoneNumber) {
         DYNAMO_SERVICE.updatePhoneNumber(email, phoneNumber);
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/UserProfile.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/UserProfile.java
@@ -120,7 +120,9 @@ public class UserProfile {
         return this;
     }
 
-    @DynamoDBAttribute(attributeName = "PublicSubjectID")
+    @DynamoDBIndexHashKey(
+            globalSecondaryIndexName = "PublicSubjectIDIndex",
+            attributeName = "PublicSubjectID")
     public String getPublicSubjectID() {
         return publicSubjectID;
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthenticationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthenticationService.java
@@ -35,6 +35,8 @@ public interface AuthenticationService {
 
     UserProfile getUserProfileFromSubject(String subject);
 
+    UserProfile getUserProfileFromPublicSubject(String subject);
+
     void updateTermsAndConditions(String email, String version);
 
     void updateEmail(String currentEmail, String newEmail);

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
@@ -233,6 +233,21 @@ public class DynamoService implements AuthenticationService {
         return getUserProfile(queryExpression);
     }
 
+    @Override
+    public UserProfile getUserProfileFromPublicSubject(String subject) {
+        Map<String, AttributeValue> eav = new HashMap<>();
+        eav.put(":val1", new AttributeValue().withS(subject));
+
+        DynamoDBQueryExpression<UserProfile> queryExpression =
+                new DynamoDBQueryExpression<UserProfile>()
+                        .withIndexName("PublicSubjectIDIndex")
+                        .withKeyConditionExpression("PublicSubjectID= :val1")
+                        .withExpressionAttributeValues(eav)
+                        .withConsistentRead(false);
+
+        return getUserProfile(queryExpression);
+    }
+
     private UserProfile getUserProfile(DynamoDBQueryExpression<UserProfile> queryExpression) {
         QueryResultPage<UserProfile> scanPage =
                 userProfileMapper.queryPage(UserProfile.class, queryExpression);


### PR DESCRIPTION
## What?

- We now store the Public SubjectID in the AccessToken and no longer use the InternalSubjectID in the token. This means the current logic in the authorizer will not work as it is expecting the Internal Subject ID. Refactor the Authoriser to check if the user exists via the PublicSubjectId.
- Validate the principal as before. We can assume the Subject type is always public for the client as it is used internally and therefore we do not expect it to be pairwise and can avoid calculating the SubjectID.
- Validate that the ClientID is a valid client in the authorizer


## Why?

- Because we no longer store the internal subject ID in the access token and need to refactor the authorizer to use the public subject ID. 