### PR TITLE
BAU - Set time of expiry to 15 mins in the future

### DIFF
--- a/ci/terraform/account-management/lambda-roles.tf
+++ b/ci/terraform/account-management/lambda-roles.tf
@@ -152,6 +152,10 @@ data "aws_dynamodb_table" "user_profile_table" {
   name = "${var.environment}-user-profile"
 }
 
+data "aws_dynamodb_table" "client_registry_table" {
+  name = "${var.environment}-client-registry"
+}
+
 data "aws_iam_policy_document" "dynamo_policy_document" {
   count = var.use_localstack ? 0 : 1
   statement {
@@ -168,6 +172,7 @@ data "aws_iam_policy_document" "dynamo_policy_document" {
     resources = [
       data.aws_dynamodb_table.user_credentials_table.arn,
       data.aws_dynamodb_table.user_profile_table.arn,
+      data.aws_dynamodb_table.client_registry_table.arn,
       "${data.aws_dynamodb_table.user_profile_table.arn}/index/*",
     ]
   }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandler.java
@@ -14,7 +14,10 @@ import uk.gov.di.authentication.shared.services.NotificationService;
 import uk.gov.service.notify.NotificationClient;
 import uk.gov.service.notify.NotificationClientException;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -123,10 +126,13 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
     }
 
     private String buildResetPasswordLink(String code) {
+        LocalDateTime localDateTime =
+                LocalDateTime.now().plusMinutes(configService.getCodeExpiry());
+        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
         return configService.getFrontendBaseUrl()
                 + configService.getResetPasswordRoute()
                 + code
                 + "."
-                + System.currentTimeMillis();
+                + expiryDate.toInstant().toEpochMilli();
     }
 }


### PR DESCRIPTION


## What?

 - Set time of expiry to 15 mins in the future

## Why?

- So the frontend can determine when the token has expired and the API is the source of trust