### PR TITLE
BAU - Validate the mandatory scopes and expiry times in AccessTokens

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
@@ -47,7 +47,7 @@ public class LogoutIntegrationTest extends IntegrationTestEndpoints {
         String sessionId = "session-id";
         String clientSessionId = "client-session-id";
         LocalDateTime localDateTime = LocalDateTime.now().plusMinutes(10);
-        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant());
+        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
         IDTokenClaimsSet idTokenClaims =
                 new IDTokenClaimsSet(
                         new Issuer(BASE_URL),

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
@@ -171,17 +171,14 @@ public class TokenIntegrationTest extends IntegrationTestEndpoints {
 
     private SignedJWT generateSignedRefreshToken(Scope scope, Subject publicSubject) {
         LocalDateTime localDateTime = LocalDateTime.now().plusMinutes(60);
-        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant());
+        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
         JWTClaimsSet claimsSet =
                 new JWTClaimsSet.Builder()
                         .claim("scope", scope.toStringList())
                         .issuer("issuer-id")
                         .expirationTime(expiryDate)
                         .issueTime(
-                                Date.from(
-                                        LocalDateTime.now()
-                                                .atZone(ZoneId.systemDefault())
-                                                .toInstant()))
+                                Date.from(LocalDateTime.now().atZone(ZoneId.of("UTC")).toInstant()))
                         .claim("client_id", CLIENT_ID)
                         .subject(publicSubject.getValue())
                         .jwtID(UUID.randomUUID().toString())

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
@@ -48,7 +48,7 @@ public class UserInfoIntegrationTest extends IntegrationTestEndpoints {
         Subject internalSubject = new Subject();
         Subject publicSubject = new Subject();
         LocalDateTime localDateTime = LocalDateTime.now().plusMinutes(10);
-        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant());
+        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
         List<String> scopes = new ArrayList<>();
         scopes.add("email");
         scopes.add("phone");
@@ -59,10 +59,7 @@ public class UserInfoIntegrationTest extends IntegrationTestEndpoints {
                         .issuer("issuer-id")
                         .expirationTime(expiryDate)
                         .issueTime(
-                                Date.from(
-                                        LocalDateTime.now()
-                                                .atZone(ZoneId.systemDefault())
-                                                .toInstant()))
+                                Date.from(LocalDateTime.now().atZone(ZoneId.of("UTC")).toInstant()))
                         .claim("client_id", "client-id-one")
                         .subject(publicSubject.getValue())
                         .jwtID(UUID.randomUUID().toString())

--- a/integration-tests/src/test/java/uk/gov/di/authentication/helpers/TokenGeneratorHelper.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/helpers/TokenGeneratorHelper.java
@@ -24,7 +24,7 @@ public class TokenGeneratorHelper {
     public static SignedJWT generateIDToken(
             String clientId, Subject subject, String issuerUrl, RSAKey signingKey) {
         LocalDateTime localDateTime = LocalDateTime.now().plusMinutes(2);
-        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant());
+        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
         IDTokenClaimsSet idTokenClaims =
                 new IDTokenClaimsSet(
                         new Issuer(issuerUrl),
@@ -50,7 +50,7 @@ public class TokenGeneratorHelper {
             String clientId, String issuerUrl, List<String> scopes, RSAKey signingKey) {
 
         LocalDateTime localDateTime = LocalDateTime.now().plusMinutes(2);
-        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant());
+        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
 
         JWTClaimsSet claimsSet =
                 new JWTClaimsSet.Builder()
@@ -58,10 +58,7 @@ public class TokenGeneratorHelper {
                         .issuer(issuerUrl)
                         .expirationTime(expiryDate)
                         .issueTime(
-                                Date.from(
-                                        LocalDateTime.now()
-                                                .atZone(ZoneId.systemDefault())
-                                                .toInstant()))
+                                Date.from(LocalDateTime.now().atZone(ZoneId.of("UTC")).toInstant()))
                         .claim("client_id", clientId)
                         .jwtID(UUID.randomUUID().toString())
                         .build();

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/TokenGeneratorHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/TokenGeneratorHelper.java
@@ -27,7 +27,7 @@ public class TokenGeneratorHelper {
     public static SignedJWT generateIDToken(
             String clientId, Subject subject, String issuerUrl, RSAKey signingKey) {
         LocalDateTime localDateTime = LocalDateTime.now().plusMinutes(2);
-        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant());
+        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
         IDTokenClaimsSet idTokenClaims =
                 new IDTokenClaimsSet(
                         new Issuer(issuerUrl),
@@ -63,7 +63,7 @@ public class TokenGeneratorHelper {
     public static SignedJWT generateIDToken(
             String clientId, Subject subject, String issuerUrl, JWSSigner signer, String keyId) {
         LocalDateTime localDateTime = LocalDateTime.now().plusMinutes(2);
-        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant());
+        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
         IDTokenClaimsSet idTokenClaims =
                 new IDTokenClaimsSet(
                         new Issuer(issuerUrl),
@@ -92,7 +92,19 @@ public class TokenGeneratorHelper {
             String keyId) {
 
         LocalDateTime localDateTime = LocalDateTime.now().plusMinutes(2);
-        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant());
+        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
+
+        return generateSignedToken(clientId, issuerUrl, scopes, signer, subject, keyId, expiryDate);
+    }
+
+    public static SignedJWT generateSignedToken(
+            String clientId,
+            String issuerUrl,
+            List<String> scopes,
+            JWSSigner signer,
+            Subject subject,
+            String keyId,
+            Date expiryDate) {
 
         JWTClaimsSet claimsSet =
                 new JWTClaimsSet.Builder()
@@ -100,10 +112,7 @@ public class TokenGeneratorHelper {
                         .issuer(issuerUrl)
                         .expirationTime(expiryDate)
                         .issueTime(
-                                Date.from(
-                                        LocalDateTime.now()
-                                                .atZone(ZoneId.systemDefault())
-                                                .toInstant()))
+                                Date.from(LocalDateTime.now().atZone(ZoneId.of("UTC")).toInstant()))
                         .claim("client_id", clientId)
                         .subject(subject.getValue())
                         .jwtID(UUID.randomUUID().toString())

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
@@ -186,7 +186,7 @@ public class TokenService {
             AccessTokenHash accessTokenHash) {
         LOGGER.info("Generating IdToken for ClientId: {}", clientId);
         LocalDateTime localDateTime = LocalDateTime.now().plusMinutes(2);
-        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant());
+        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
         IDTokenClaimsSet idTokenClaims =
                 new IDTokenClaimsSet(
                         new Issuer(configService.getBaseURL().get()),
@@ -209,7 +209,7 @@ public class TokenService {
         LOGGER.info("Generating AccessToken for ClientId: {}", clientId);
         LocalDateTime localDateTime =
                 LocalDateTime.now().plusSeconds(configService.getAccessTokenExpiry());
-        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant());
+        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
 
         JWTClaimsSet claimsSet =
                 new JWTClaimsSet.Builder()
@@ -217,10 +217,7 @@ public class TokenService {
                         .issuer(configService.getBaseURL().get())
                         .expirationTime(expiryDate)
                         .issueTime(
-                                Date.from(
-                                        LocalDateTime.now()
-                                                .atZone(ZoneId.systemDefault())
-                                                .toInstant()))
+                                Date.from(LocalDateTime.now().atZone(ZoneId.of("UTC")).toInstant()))
                         .claim("client_id", clientId)
                         .subject(publicSubject.getValue())
                         .jwtID(UUID.randomUUID().toString())
@@ -248,17 +245,14 @@ public class TokenService {
         LOGGER.info("Generating RefreshToken for ClientId: {}", clientId);
         LocalDateTime localDateTime =
                 LocalDateTime.now().plusSeconds(configService.getSessionExpiry());
-        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant());
+        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
         JWTClaimsSet claimsSet =
                 new JWTClaimsSet.Builder()
                         .claim("scope", scopes)
                         .issuer(configService.getBaseURL().get())
                         .expirationTime(expiryDate)
                         .issueTime(
-                                Date.from(
-                                        LocalDateTime.now()
-                                                .atZone(ZoneId.systemDefault())
-                                                .toInstant()))
+                                Date.from(LocalDateTime.now().atZone(ZoneId.of("UTC")).toInstant()))
                         .claim("client_id", clientId)
                         .subject(publicSubject.getValue())
                         .jwtID(UUID.randomUUID().toString())


### PR DESCRIPTION
## What?

- When we validate the access tokens we should check if they are expired and whether or not they contain the claims we expect.
- Set all timezones to use UTC so make them all explicit and not rely on what timezone the server is running on


## Why?

- So we can be confident that only valid access tokens pass through
- So we don't rely on whatever timezone the server is running on 