### PR TITLE
GOVSI-644 - Allow a user to start a journey if they have maxed out password reset requests

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/state/StateMachine.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/state/StateMachine.java
@@ -78,7 +78,9 @@ public class StateMachine<T, A, C> {
                                 .then(RESET_PASSWORD_LINK_MAX_RETRIES_REACHED),
                         on(SYSTEM_HAS_SENT_RESET_PASSWORD_LINK).then(RESET_PASSWORD_LINK_SENT))
                 .when(RESET_PASSWORD_LINK_MAX_RETRIES_REACHED)
-                .allow(on(SYSTEM_HAS_SENT_RESET_PASSWORD_LINK).then(RESET_PASSWORD_LINK_SENT))
+                .allow(
+                        on(SYSTEM_HAS_SENT_RESET_PASSWORD_LINK).then(RESET_PASSWORD_LINK_SENT),
+                        on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND))
                 .when(USER_NOT_FOUND)
                 .allow(
                         on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND),


### PR DESCRIPTION
## What?

- Allow a user to start a journey if the have maxed out password reset requests

## Why?

- If a user has maxed out there password request limit (more than 5 times) then they should be able to start a journey. This may be because they have suddenly remembered their password or have managed to access the last password reset link which was set.
