### PR TITLE
GOVSI-818: Refactor context for state machine

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -14,13 +14,13 @@ import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.SessionAction;
 import uk.gov.di.authentication.shared.entity.SessionState;
-import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.services.ValidationService;
 import uk.gov.di.authentication.shared.state.StateMachine;
+import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.util.Optional;
 
@@ -40,7 +40,7 @@ public class CheckUserExistsHandler
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final AuthenticationService authenticationService;
     private final SessionService sessionService;
-    private final StateMachine<SessionState, SessionAction, UserProfile> stateMachine =
+    private final StateMachine<SessionState, SessionAction, UserContext> stateMachine =
             userJourneyStateMachine();
 
     public CheckUserExistsHandler(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -15,12 +15,12 @@ import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.SessionAction;
 import uk.gov.di.authentication.shared.entity.SessionState;
-import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.state.StateMachine;
+import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.util.Optional;
 
@@ -38,7 +38,7 @@ public class LoginHandler
     private final AuthenticationService authenticationService;
     private final SessionService sessionService;
     private final ObjectMapper objectMapper = new ObjectMapper();
-    private final StateMachine<SessionState, SessionAction, UserProfile> stateMachine =
+    private final StateMachine<SessionState, SessionAction, UserContext> stateMachine =
             userJourneyStateMachine();
 
     public LoginHandler(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
@@ -15,7 +15,6 @@ import uk.gov.di.authentication.shared.entity.NotifyRequest;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.SessionAction;
 import uk.gov.di.authentication.shared.entity.SessionState;
-import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.CodeGeneratorService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
@@ -24,6 +23,7 @@ import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
 import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.state.StateMachine;
+import uk.gov.di.authentication.shared.state.UserContext;
 
 import static uk.gov.di.authentication.shared.entity.ErrorResponse.ERROR_1000;
 import static uk.gov.di.authentication.shared.entity.ErrorResponse.ERROR_1001;
@@ -48,7 +48,7 @@ public class MfaHandler
     private final AuthenticationService authenticationService;
     private final AwsSqsClient sqsClient;
     private final ObjectMapper objectMapper = new ObjectMapper();
-    private final StateMachine<SessionState, SessionAction, UserProfile> stateMachine =
+    private final StateMachine<SessionState, SessionAction, UserContext> stateMachine =
             userJourneyStateMachine();
 
     public MfaHandler(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
@@ -18,7 +18,6 @@ import uk.gov.di.authentication.shared.entity.NotifyRequest;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.SessionAction;
 import uk.gov.di.authentication.shared.entity.SessionState;
-import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.CodeGeneratorService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
@@ -28,6 +27,7 @@ import uk.gov.di.authentication.shared.services.RedisConnectionService;
 import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.services.ValidationService;
 import uk.gov.di.authentication.shared.state.StateMachine;
+import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.util.Optional;
 
@@ -53,7 +53,7 @@ public class ResetPasswordRequestHandler
     private final CodeStorageService codeStorageService;
     private final AuthenticationService authenticationService;
     private final ObjectMapper objectMapper = new ObjectMapper();
-    private final StateMachine<SessionState, SessionAction, UserProfile> stateMachine =
+    private final StateMachine<SessionState, SessionAction, UserContext> stateMachine =
             userJourneyStateMachine();
 
     public ResetPasswordRequestHandler(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
@@ -18,7 +18,6 @@ import uk.gov.di.authentication.shared.entity.NotifyRequest;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.SessionAction;
 import uk.gov.di.authentication.shared.entity.SessionState;
-import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.services.CodeGeneratorService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -26,6 +25,7 @@ import uk.gov.di.authentication.shared.services.RedisConnectionService;
 import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.services.ValidationService;
 import uk.gov.di.authentication.shared.state.StateMachine;
+import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.util.Optional;
 
@@ -51,7 +51,7 @@ public class SendNotificationHandler
     private final CodeGeneratorService codeGeneratorService;
     private final CodeStorageService codeStorageService;
     private final ObjectMapper objectMapper = new ObjectMapper();
-    private final StateMachine<SessionState, SessionAction, UserProfile> stateMachine =
+    private final StateMachine<SessionState, SessionAction, UserContext> stateMachine =
             userJourneyStateMachine();
 
     public SendNotificationHandler(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
@@ -16,13 +16,13 @@ import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.SessionAction;
 import uk.gov.di.authentication.shared.entity.SessionState;
 import uk.gov.di.authentication.shared.entity.TermsAndConditions;
-import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.services.ValidationService;
 import uk.gov.di.authentication.shared.state.StateMachine;
+import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.time.Instant;
 import java.util.Optional;
@@ -43,7 +43,7 @@ public class SignUpHandler
     private final SessionService sessionService;
     private final ConfigurationService configurationService;
     private final ObjectMapper objectMapper = new ObjectMapper();
-    private final StateMachine<SessionState, SessionAction, UserProfile> stateMachine =
+    private final StateMachine<SessionState, SessionAction, UserContext> stateMachine =
             userJourneyStateMachine();
 
     public SignUpHandler(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandlerTest.java
@@ -21,7 +21,6 @@ import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.SessionAction;
 import uk.gov.di.authentication.shared.entity.SessionState;
-import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.exceptions.ClientNotFoundException;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
@@ -31,6 +30,7 @@ import uk.gov.di.authentication.shared.services.ClientSessionService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.state.StateMachine;
+import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.net.URI;
 import java.time.LocalDateTime;
@@ -80,7 +80,7 @@ class UpdateProfileHandlerTest {
     private final AuditService auditService = mock(AuditService.class);
     private final AuthorisationCodeService authorisationCodeService =
             mock(AuthorisationCodeService.class);
-    private final StateMachine<SessionState, SessionAction, UserProfile> stateMachine =
+    private final StateMachine<SessionState, SessionAction, UserContext> stateMachine =
             userJourneyStateMachine();
 
     private final String TERMS_AND_CONDITIONS_VERSION =

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeRequestHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeRequestHandlerTest.java
@@ -152,8 +152,7 @@ class VerifyCodeRequestHandlerTest {
     }
 
     private ArgumentMatcher<UserContext> isContextWithUserProfile(UserProfile userProfile) {
-        return userContext ->
-                userContext.getUserProfile().map(p -> p.equals(userProfile)).orElse(false);
+        return userContext -> userContext.getUserProfile().filter(userProfile::equals).isPresent();
     }
 
     @Test

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeRequestHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeRequestHandlerTest.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatcher;
 import uk.gov.di.authentication.shared.entity.BaseAPIResponse;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.Session;
@@ -19,6 +20,7 @@ import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.services.ValidationService;
 import uk.gov.di.authentication.shared.state.StateMachine;
+import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.util.Map;
 import java.util.Optional;
@@ -27,6 +29,7 @@ import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -71,7 +74,7 @@ class VerifyCodeRequestHandlerTest {
     private final DynamoService dynamoService = mock(DynamoService.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final ValidationService validationService = mock(ValidationService.class);
-    private final StateMachine<SessionState, SessionAction, UserProfile> stateMachine =
+    private final StateMachine<SessionState, SessionAction, UserContext> stateMachine =
             mock(StateMachine.class);
     private final UserProfile userProfile = mock(UserProfile.class);
     private final Session session =
@@ -97,55 +100,60 @@ class VerifyCodeRequestHandlerTest {
         when(stateMachine.transition(
                         eq(VERIFY_EMAIL_CODE_SENT),
                         eq(USER_ENTERED_VALID_EMAIL_VERIFICATION_CODE),
-                        eq(Optional.of(userProfile))))
+                        argThat(isContextWithUserProfile(userProfile))))
                 .thenReturn(EMAIL_CODE_VERIFIED);
         when(stateMachine.transition(
                         eq(VERIFY_EMAIL_CODE_SENT),
                         eq(USER_ENTERED_INVALID_EMAIL_VERIFICATION_CODE),
-                        eq(Optional.of(userProfile))))
+                        argThat(isContextWithUserProfile(userProfile))))
                 .thenReturn(EMAIL_CODE_NOT_VALID);
         when(stateMachine.transition(
                         eq(EMAIL_CODE_NOT_VALID),
                         eq(USER_ENTERED_INVALID_EMAIL_VERIFICATION_CODE_TOO_MANY_TIMES),
-                        eq(Optional.of(userProfile))))
+                        argThat(isContextWithUserProfile(userProfile))))
                 .thenReturn(EMAIL_CODE_MAX_RETRIES_REACHED);
 
         when(stateMachine.transition(
                         eq(VERIFY_PHONE_NUMBER_CODE_SENT),
                         eq(USER_ENTERED_VALID_PHONE_VERIFICATION_CODE),
-                        eq(Optional.of(userProfile))))
+                        argThat(isContextWithUserProfile(userProfile))))
                 .thenReturn(PHONE_NUMBER_CODE_VERIFIED);
         when(stateMachine.transition(
                         eq(VERIFY_PHONE_NUMBER_CODE_SENT),
                         eq(USER_ENTERED_INVALID_PHONE_VERIFICATION_CODE),
-                        eq(Optional.of(userProfile))))
+                        argThat(isContextWithUserProfile(userProfile))))
                 .thenReturn(PHONE_NUMBER_CODE_NOT_VALID);
         when(stateMachine.transition(
                         eq(PHONE_NUMBER_CODE_NOT_VALID),
                         eq(USER_ENTERED_INVALID_PHONE_VERIFICATION_CODE_TOO_MANY_TIMES),
-                        eq(Optional.of(userProfile))))
+                        argThat(isContextWithUserProfile(userProfile))))
                 .thenReturn(PHONE_NUMBER_CODE_MAX_RETRIES_REACHED);
 
         when(stateMachine.transition(
                         eq(MFA_SMS_CODE_SENT),
                         eq(USER_ENTERED_INVALID_MFA_CODE),
-                        eq(Optional.of(userProfile))))
+                        argThat(isContextWithUserProfile(userProfile))))
                 .thenReturn(MFA_CODE_NOT_VALID);
         when(stateMachine.transition(
                         eq(MFA_CODE_NOT_VALID),
                         eq(USER_ENTERED_VALID_MFA_CODE),
-                        eq(Optional.of(userProfile))))
+                        argThat(isContextWithUserProfile(userProfile))))
                 .thenReturn(MFA_CODE_VERIFIED);
         when(stateMachine.transition(
                         eq(MFA_CODE_NOT_VALID),
                         eq(USER_ENTERED_INVALID_MFA_CODE),
-                        eq(Optional.of(userProfile))))
+                        argThat(isContextWithUserProfile(userProfile))))
                 .thenReturn(MFA_CODE_NOT_VALID);
         when(stateMachine.transition(
                         eq(MFA_CODE_NOT_VALID),
                         eq(USER_ENTERED_INVALID_MFA_CODE_TOO_MANY_TIMES),
-                        eq(Optional.of(userProfile))))
+                        argThat(isContextWithUserProfile(userProfile))))
                 .thenReturn(MFA_CODE_MAX_RETRIES_REACHED);
+    }
+
+    private ArgumentMatcher<UserContext> isContextWithUserProfile(UserProfile userProfile) {
+        return userContext ->
+                userContext.getUserProfile().map(p -> p.equals(userProfile)).orElse(false);
     }
 
     @Test
@@ -355,7 +363,7 @@ class VerifyCodeRequestHandlerTest {
         when(stateMachine.transition(
                         eq(MFA_SMS_CODE_SENT),
                         eq(USER_ENTERED_VALID_MFA_CODE),
-                        eq(Optional.of(userProfile))))
+                        argThat(isContextWithUserProfile(userProfile))))
                 .thenReturn(MFA_CODE_VERIFIED);
 
         APIGatewayProxyResponseEvent result = makeCallWithCode(CODE, MFA_SMS.toString());
@@ -382,7 +390,7 @@ class VerifyCodeRequestHandlerTest {
         when(stateMachine.transition(
                         eq(MFA_SMS_CODE_SENT),
                         eq(USER_ENTERED_VALID_MFA_CODE),
-                        eq(Optional.of(userProfile))))
+                        argThat(isContextWithUserProfile(userProfile))))
                 .thenReturn(UPDATED_TERMS_AND_CONDITIONS);
 
         APIGatewayProxyResponseEvent result = makeCallWithCode(CODE, MFA_SMS.toString());
@@ -465,7 +473,7 @@ class VerifyCodeRequestHandlerTest {
         when(stateMachine.transition(
                         eq(NEW),
                         eq(USER_ENTERED_VALID_EMAIL_VERIFICATION_CODE),
-                        eq(Optional.of(userProfile))))
+                        argThat(isContextWithUserProfile(userProfile))))
                 .thenThrow(new StateMachine.InvalidStateTransitionException());
 
         APIGatewayProxyResponseEvent result = makeCallWithCode(CODE, VERIFY_EMAIL.toString());

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -17,7 +17,6 @@ import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.SessionAction;
 import uk.gov.di.authentication.shared.entity.SessionState;
-import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.exceptions.ClientNotFoundException;
 import uk.gov.di.authentication.shared.helpers.CookieHelper;
 import uk.gov.di.authentication.shared.helpers.CookieHelper.SessionCookieIds;
@@ -27,6 +26,7 @@ import uk.gov.di.authentication.shared.services.ClientSessionService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.state.StateMachine;
+import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.util.List;
 import java.util.Map;
@@ -45,7 +45,7 @@ public class AuthCodeHandler
     private final ConfigurationService configurationService;
     private final AuthorizationService authorizationService;
     private final ClientSessionService clientSessionService;
-    private final StateMachine<SessionState, SessionAction, UserProfile> stateMachine =
+    private final StateMachine<SessionState, SessionAction, UserContext> stateMachine =
             userJourneyStateMachine();
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AuthCodeHandler.class);

--- a/shared/src/main/java/uk/gov/di/authentication/shared/state/UserContext.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/state/UserContext.java
@@ -1,0 +1,51 @@
+package uk.gov.di.authentication.shared.state;
+
+import uk.gov.di.authentication.shared.entity.Session;
+import uk.gov.di.authentication.shared.entity.UserProfile;
+
+import java.util.Optional;
+
+public class UserContext {
+    private final Session session;
+    private final Optional<UserProfile> userProfile;
+
+    protected UserContext(Session session, Optional<UserProfile> userProfile) {
+        this.session = session;
+        this.userProfile = userProfile;
+    }
+
+    public Session getSession() {
+        return session;
+    }
+
+    public Optional<UserProfile> getUserProfile() {
+        return userProfile;
+    }
+
+    public static Builder builder(Session session) {
+        return new Builder(session);
+    }
+
+    public static class Builder {
+        private Session session;
+        private Optional<UserProfile> userProfile = Optional.empty();
+
+        protected Builder(Session session) {
+            this.session = session;
+        }
+
+        public Builder withUserProfile(UserProfile userProfile) {
+            this.userProfile = Optional.of(userProfile);
+            return this;
+        }
+
+        public Builder withUserProfile(Optional<UserProfile> userProfile) {
+            this.userProfile = userProfile;
+            return this;
+        }
+
+        public UserContext build() {
+            return new UserContext(session, userProfile);
+        }
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/state/conditions/TermsAndConditionsVersionNotAccepted.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/state/conditions/TermsAndConditionsVersionNotAccepted.java
@@ -1,11 +1,11 @@
 package uk.gov.di.authentication.shared.state.conditions;
 
-import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.state.Condition;
+import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.util.Optional;
 
-public class TermsAndConditionsVersionNotAccepted implements Condition<UserProfile> {
+public class TermsAndConditionsVersionNotAccepted implements Condition<UserContext> {
 
     private final String latestVersion;
 
@@ -14,10 +14,18 @@ public class TermsAndConditionsVersionNotAccepted implements Condition<UserProfi
     }
 
     @Override
-    public boolean isMet(Optional<UserProfile> context) {
+    public boolean isMet(Optional<UserContext> context) {
         if (latestVersion == null) return false;
-        return context.map(u -> !latestVersion.equals(u.getTermsAndConditions().getVersion()))
-                .orElse(true);
+        return context.map(
+                        c ->
+                                c.getUserProfile()
+                                        .map(
+                                                u ->
+                                                        !latestVersion.equals(
+                                                                u.getTermsAndConditions()
+                                                                        .getVersion()))
+                                        .orElseThrow())
+                .orElseThrow();
     }
 
     public static TermsAndConditionsVersionNotAccepted userHasNotAcceptedTermsAndConditionsVersion(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/state/conditions/TermsAndConditionsVersionNotAccepted.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/state/conditions/TermsAndConditionsVersionNotAccepted.java
@@ -18,7 +18,7 @@ public class TermsAndConditionsVersionNotAccepted implements Condition<UserConte
     @Override
     public boolean isMet(Optional<UserContext> context) {
         if (latestVersion == null) return false;
-        return context.flatMap(UserContext::getUserProfile)
+        return !context.flatMap(UserContext::getUserProfile)
                 .map(UserProfile::getTermsAndConditions)
                 .map(TermsAndConditions::getVersion)
                 .map(latestVersion::equals)

--- a/shared/src/main/java/uk/gov/di/authentication/shared/state/conditions/TermsAndConditionsVersionNotAccepted.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/state/conditions/TermsAndConditionsVersionNotAccepted.java
@@ -1,5 +1,7 @@
 package uk.gov.di.authentication.shared.state.conditions;
 
+import uk.gov.di.authentication.shared.entity.TermsAndConditions;
+import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.state.Condition;
 import uk.gov.di.authentication.shared.state.UserContext;
 
@@ -16,15 +18,10 @@ public class TermsAndConditionsVersionNotAccepted implements Condition<UserConte
     @Override
     public boolean isMet(Optional<UserContext> context) {
         if (latestVersion == null) return false;
-        return context.map(
-                        c ->
-                                c.getUserProfile()
-                                        .map(
-                                                u ->
-                                                        !latestVersion.equals(
-                                                                u.getTermsAndConditions()
-                                                                        .getVersion()))
-                                        .orElseThrow())
+        return context.flatMap(UserContext::getUserProfile)
+                .map(UserProfile::getTermsAndConditions)
+                .map(TermsAndConditions::getVersion)
+                .map(latestVersion::equals)
                 .orElseThrow();
     }
 

--- a/shared/src/test/java/uk/gov/di/authentication/shared/state/StateMachineTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/state/StateMachineTest.java
@@ -65,14 +65,13 @@ public class StateMachineTest {
     @Test
     public void returnsCorrectNextStateForConditionalTransition() {
         assertThat(
-                stateMachine.transition(STATE_3, CONDITIONAL_MOVE, Optional.of(Boolean.TRUE)),
-                equalTo(STATE_4));
+                stateMachine.transition(STATE_3, CONDITIONAL_MOVE, Boolean.TRUE), equalTo(STATE_4));
     }
 
     @Test
     public void returnsDefaultNextStateForConditionalTransitionWhenNoOtherConditionMatches() {
         assertThat(
-                stateMachine.transition(STATE_3, CONDITIONAL_MOVE, Optional.of(Boolean.FALSE)),
+                stateMachine.transition(STATE_3, CONDITIONAL_MOVE, Boolean.FALSE),
                 equalTo(STATE_5));
     }
 

--- a/shared/src/test/java/uk/gov/di/authentication/shared/state/conditions/TermsAndConditionsVersionNotAcceptedTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/state/conditions/TermsAndConditionsVersionNotAcceptedTest.java
@@ -1,13 +1,17 @@
 package uk.gov.di.authentication.shared.state.conditions;
 
 import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.TermsAndConditions;
 import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.state.UserContext;
 
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -21,8 +25,9 @@ class TermsAndConditionsVersionNotAcceptedTest {
         when(termsAndConditions.getVersion()).thenReturn("1.0");
         TermsAndConditionsVersionNotAccepted condition =
                 new TermsAndConditionsVersionNotAccepted("2.0");
-
-        assertThat(condition.isMet(Optional.of(userProfile)), equalTo(true));
+        UserContext userContext =
+                UserContext.builder(mock(Session.class)).withUserProfile(userProfile).build();
+        assertThat(condition.isMet(Optional.of(userContext)), equalTo(true));
     }
 
     @Test
@@ -33,7 +38,17 @@ class TermsAndConditionsVersionNotAcceptedTest {
         when(termsAndConditions.getVersion()).thenReturn("1.0");
         TermsAndConditionsVersionNotAccepted condition =
                 new TermsAndConditionsVersionNotAccepted("1.0");
+        UserContext userContext =
+                UserContext.builder(mock(Session.class)).withUserProfile(userProfile).build();
 
-        assertThat(condition.isMet(Optional.of(userProfile)), equalTo(false));
+        assertThat(condition.isMet(Optional.of(userContext)), equalTo(false));
+    }
+
+    @Test
+    void shouldThrowIfUserProfileNotPresent() {
+        TermsAndConditionsVersionNotAccepted condition =
+                new TermsAndConditionsVersionNotAccepted("1.0");
+        UserContext userContext = UserContext.builder(mock(Session.class)).build();
+        assertThrows(NoSuchElementException.class, () -> condition.isMet(Optional.of(userContext)));
     }
 }


### PR DESCRIPTION
## What?

- Add `UserContext` class which includes both the the `UserProfile` and the `Session` as this going to be required for the VoT work
- Add a builder to the `UserContext` class
- Refactor state machine so `transition()` does not need to be called with an `Optional<C>`, this aids readability

## Why?

Pre-cursor to the VoT state machine handling
