### PR TITLE
GOVSI-718 - Set Refresh Token expiry to 30 mins

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
@@ -267,7 +267,7 @@ public class TokenService {
                                             refreshToken.getValue(), internalSubject.getValue()));
             String redisKey = REFRESH_TOKEN_PREFIX + clientId + "." + publicSubject.getValue();
             redisConnectionService.saveWithExpiry(
-                    redisKey, tokenStoreString, configService.getAccessTokenExpiry());
+                    redisKey, tokenStoreString, configService.getSessionExpiry());
         } catch (JsonProcessingException e) {
             LOGGER.error("Unable to create new TokenStore with RefreshToken", e);
             throw new RuntimeException(e);

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
@@ -81,6 +81,8 @@ public class TokenServiceTest {
     public void setUp() {
         Optional<String> baseUrl = Optional.of(BASE_URL);
         when(configurationService.getBaseURL()).thenReturn(baseUrl);
+        when(configurationService.getAccessTokenExpiry()).thenReturn(300L);
+        when(configurationService.getSessionExpiry()).thenReturn(300L);
     }
 
     @Test
@@ -88,7 +90,6 @@ public class TokenServiceTest {
             throws ParseException, JOSEException, JsonProcessingException {
         Nonce nonce = new Nonce();
         when(configurationService.getTokenSigningKeyAlias()).thenReturn(KEY_ID);
-        when(configurationService.getAccessTokenExpiry()).thenReturn(300L);
         createSignedIdToken();
         createSignedAccessToken();
         Map<String, Object> additionalTokenClaims = new HashMap<>();


### PR DESCRIPTION
## What?

-  Set Refresh Token expiry to 30 mins

## Why?

- It was previously set as 3 mins which is too short