### PR TITLE
GOVSI-818: Add `client` to `UserContext` and refactor its construction

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/BaseFrontendHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/BaseFrontendHandler.java
@@ -1,0 +1,108 @@
+package uk.gov.di.authentication.frontendapi.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.di.authentication.shared.entity.ClientSession;
+import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.Session;
+import uk.gov.di.authentication.shared.services.AuthenticationService;
+import uk.gov.di.authentication.shared.services.ClientService;
+import uk.gov.di.authentication.shared.services.ClientSessionService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.DynamoClientService;
+import uk.gov.di.authentication.shared.services.DynamoService;
+import uk.gov.di.authentication.shared.services.SessionService;
+import uk.gov.di.authentication.shared.state.UserContext;
+
+import java.util.Optional;
+
+import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
+import static uk.gov.di.authentication.shared.helpers.WarmerHelper.isWarming;
+
+public abstract class BaseFrontendHandler
+        implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BaseFrontendHandler.class);
+    protected final ConfigurationService configurationService;
+    protected final SessionService sessionService;
+    protected final ClientSessionService clientSessionService;
+    protected final ClientService clientService;
+    protected final AuthenticationService authenticationService;
+
+    protected BaseFrontendHandler(
+            ConfigurationService configurationService,
+            SessionService sessionService,
+            ClientSessionService clientSessionService,
+            ClientService clientService,
+            AuthenticationService authenticationService) {
+        this.configurationService = configurationService;
+        this.sessionService = sessionService;
+        this.clientSessionService = clientSessionService;
+        this.clientService = clientService;
+        this.authenticationService = authenticationService;
+    }
+
+    protected BaseFrontendHandler(ConfigurationService configurationService) {
+        this.configurationService = configurationService;
+        this.sessionService = new SessionService(configurationService);
+        this.clientSessionService = new ClientSessionService(configurationService);
+        this.clientService =
+                new DynamoClientService(
+                        configurationService.getAwsRegion(),
+                        configurationService.getEnvironment(),
+                        configurationService.getDynamoEndpointUri());
+        this.authenticationService =
+                new DynamoService(
+                        configurationService.getAwsRegion(),
+                        configurationService.getEnvironment(),
+                        configurationService.getDynamoEndpointUri());
+    }
+
+    @Override
+    public APIGatewayProxyResponseEvent handleRequest(
+            APIGatewayProxyRequestEvent input, Context context) {
+        return isWarming(input)
+                .orElseGet(
+                        () -> {
+                            Optional<Session> session =
+                                    sessionService.getSessionFromRequestHeaders(input.getHeaders());
+                            Optional<ClientSession> clientSession =
+                                    clientSessionService.getClientSessionFromRequestHeaders(
+                                            input.getHeaders());
+                            if (session.isPresent()) {
+                                UserContext.Builder userContextBuilder =
+                                        UserContext.builder(session.get());
+                                clientSession.ifPresent(
+                                        cs ->
+                                                userContextBuilder.withClient(
+                                                        clientService.getClient(
+                                                                cs
+                                                                        .getAuthRequestParams()
+                                                                        .get("client_id")
+                                                                        .stream()
+                                                                        .findFirst()
+                                                                        .orElseThrow())));
+                                session.ifPresent(
+                                        s ->
+                                                userContextBuilder.withUserProfile(
+                                                        authenticationService
+                                                                .getUserProfileFromEmail(
+                                                                        s.getEmailAddress())));
+
+                                return handleRequestWithUserContext(
+                                        input, context, userContextBuilder.build());
+                            } else {
+                                LOG.error("Session cannot be found");
+                                return generateApiGatewayProxyErrorResponse(
+                                        400, ErrorResponse.ERROR_1000);
+                            }
+                        });
+    }
+
+    public abstract APIGatewayProxyResponseEvent handleRequestWithUserContext(
+            APIGatewayProxyRequestEvent input, Context context, UserContext userContext);
+}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -16,8 +16,9 @@ import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.SessionAction;
 import uk.gov.di.authentication.shared.entity.SessionState;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
+import uk.gov.di.authentication.shared.services.ClientService;
+import uk.gov.di.authentication.shared.services.ClientSessionService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
-import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.state.StateMachine;
 import uk.gov.di.authentication.shared.state.UserContext;
@@ -27,113 +28,86 @@ import java.util.Optional;
 import static uk.gov.di.authentication.shared.entity.SessionAction.USER_ENTERED_VALID_CREDENTIALS;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
-import static uk.gov.di.authentication.shared.helpers.WarmerHelper.isWarming;
 import static uk.gov.di.authentication.shared.state.StateMachine.userJourneyStateMachine;
 
-public class LoginHandler
+public class LoginHandler extends BaseFrontendHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LoginHandler.class);
 
-    private final AuthenticationService authenticationService;
-    private final SessionService sessionService;
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final StateMachine<SessionState, SessionAction, UserContext> stateMachine =
             userJourneyStateMachine();
 
     public LoginHandler(
-            SessionService sessionService, AuthenticationService authenticationService) {
-        this.sessionService = sessionService;
-        this.authenticationService = authenticationService;
+            ConfigurationService configurationService,
+            SessionService sessionService,
+            AuthenticationService authenticationService,
+            ClientSessionService clientSessionService,
+            ClientService clientService) {
+        super(
+                configurationService,
+                sessionService,
+                clientSessionService,
+                clientService,
+                authenticationService);
     }
 
     public LoginHandler() {
-        ConfigurationService configurationService = new ConfigurationService();
-        this.sessionService = new SessionService(configurationService);
-        this.authenticationService =
-                new DynamoService(
-                        configurationService.getAwsRegion(),
-                        configurationService.getEnvironment(),
-                        configurationService.getDynamoEndpointUri());
+        super(ConfigurationService.getInstance());
     }
 
     @Override
-    public APIGatewayProxyResponseEvent handleRequest(
-            APIGatewayProxyRequestEvent input, Context context) {
-        return isWarming(input)
-                .orElseGet(
-                        () -> {
-                            LOGGER.info("Request received to the LoginHandler");
-                            Optional<Session> session =
-                                    sessionService.getSessionFromRequestHeaders(input.getHeaders());
-                            if (session.isEmpty()) {
-                                LOGGER.error("Unable to find session");
-                                return generateApiGatewayProxyErrorResponse(
-                                        400, ErrorResponse.ERROR_1000);
-                            } else {
-                                LOGGER.info(
-                                        "LoginHandler processing session with ID {}",
-                                        session.get().getSessionId());
-                            }
+    public APIGatewayProxyResponseEvent handleRequestWithUserContext(
+            APIGatewayProxyRequestEvent input, Context context, UserContext userContext) {
+        LOGGER.info("Request received to the LoginHandler");
+        Optional<Session> session = sessionService.getSessionFromRequestHeaders(input.getHeaders());
+        if (session.isEmpty()) {
+            LOGGER.error("Unable to find session");
+            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1000);
+        } else {
+            LOGGER.info("LoginHandler processing session with ID {}", session.get().getSessionId());
+        }
 
-                            try {
-                                var nextState =
-                                        stateMachine.transition(
-                                                session.get().getState(),
-                                                USER_ENTERED_VALID_CREDENTIALS);
+        try {
+            var nextState =
+                    stateMachine.transition(
+                            session.get().getState(), USER_ENTERED_VALID_CREDENTIALS, userContext);
+            LoginRequest loginRequest = objectMapper.readValue(input.getBody(), LoginRequest.class);
+            boolean userHasAccount = authenticationService.userExists(loginRequest.getEmail());
+            if (!userHasAccount) {
+                LOGGER.error("The user does not have an account");
+                return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1010);
+            }
+            boolean hasValidCredentials =
+                    authenticationService.login(
+                            loginRequest.getEmail(), loginRequest.getPassword());
+            if (!hasValidCredentials) {
+                LOGGER.error("Invalid login credentials entered");
+                return generateApiGatewayProxyErrorResponse(401, ErrorResponse.ERROR_1008);
+            }
+            String phoneNumber =
+                    authenticationService.getPhoneNumber(loginRequest.getEmail()).orElse(null);
 
-                                LoginRequest loginRequest =
-                                        objectMapper.readValue(input.getBody(), LoginRequest.class);
-                                boolean userHasAccount =
-                                        authenticationService.userExists(loginRequest.getEmail());
-                                if (!userHasAccount) {
-                                    LOGGER.error("The user does not have an account");
-                                    return generateApiGatewayProxyErrorResponse(
-                                            400, ErrorResponse.ERROR_1010);
-                                }
-                                boolean hasValidCredentials =
-                                        authenticationService.login(
-                                                loginRequest.getEmail(),
-                                                loginRequest.getPassword());
-                                if (!hasValidCredentials) {
-                                    LOGGER.error("Invalid login credentials entered");
-                                    return generateApiGatewayProxyErrorResponse(
-                                            401, ErrorResponse.ERROR_1008);
-                                }
-                                String phoneNumber =
-                                        authenticationService
-                                                .getPhoneNumber(loginRequest.getEmail())
-                                                .orElse(null);
-
-                                if (phoneNumber == null) {
-                                    LOGGER.error(
-                                            "No Phone Number has been registered for this user");
-                                    return generateApiGatewayProxyErrorResponse(
-                                            400, ErrorResponse.ERROR_1014);
-                                }
-                                String concatPhoneNumber =
-                                        RedactPhoneNumberHelper.redactPhoneNumber(phoneNumber);
-                                sessionService.save(session.get().setState(nextState));
-                                LOGGER.info(
-                                        "User has successfully Logged in. Generating successful LoginResponse for session with ID {}",
-                                        session.get().getSessionId());
-                                return generateApiGatewayProxyResponse(
-                                        200,
-                                        new LoginResponse(
-                                                concatPhoneNumber, session.get().getState()));
-                            } catch (JsonProcessingException e) {
-                                LOGGER.error(
-                                        "Request is missing parameters. The body present in request: {}",
-                                        input.getBody());
-                                return generateApiGatewayProxyErrorResponse(
-                                        400, ErrorResponse.ERROR_1001);
-                            } catch (StateMachine.InvalidStateTransitionException e) {
-                                LOGGER.error(
-                                        "Invalid transition in user journey. Unable to Login user",
-                                        e);
-                                return generateApiGatewayProxyErrorResponse(
-                                        400, ErrorResponse.ERROR_1017);
-                            }
-                        });
+            if (phoneNumber == null) {
+                LOGGER.error("No Phone Number has been registered for this user");
+                return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1014);
+            }
+            String concatPhoneNumber = RedactPhoneNumberHelper.redactPhoneNumber(phoneNumber);
+            sessionService.save(session.get().setState(nextState));
+            LOGGER.info(
+                    "User has successfully Logged in. Generating successful LoginResponse for session with ID {}",
+                    session.get().getSessionId());
+            return generateApiGatewayProxyResponse(
+                    200, new LoginResponse(concatPhoneNumber, session.get().getState()));
+        } catch (JsonProcessingException e) {
+            LOGGER.error(
+                    "Request is missing parameters. The body present in request: {}",
+                    input.getBody());
+            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
+        } catch (StateMachine.InvalidStateTransitionException e) {
+            LOGGER.error("Invalid transition in user journey. Unable to Login user", e);
+            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1017);
+        }
     }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -15,10 +15,11 @@ import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.SessionAction;
 import uk.gov.di.authentication.shared.entity.SessionState;
-import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.services.AuthenticationService;
+import uk.gov.di.authentication.shared.services.ClientService;
+import uk.gov.di.authentication.shared.services.ClientSessionService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
-import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
 import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.services.ValidationService;
@@ -39,212 +40,173 @@ import static uk.gov.di.authentication.shared.entity.SessionState.PHONE_NUMBER_C
 import static uk.gov.di.authentication.shared.entity.SessionState.UPDATED_TERMS_AND_CONDITIONS;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
-import static uk.gov.di.authentication.shared.helpers.WarmerHelper.isWarming;
 import static uk.gov.di.authentication.shared.state.StateMachine.userJourneyStateMachine;
 
-public class VerifyCodeHandler
+public class VerifyCodeHandler extends BaseFrontendHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     private static final Logger LOG = LoggerFactory.getLogger(VerifyCodeHandler.class);
 
     private final ObjectMapper objectMapper = new ObjectMapper();
-    private final SessionService sessionService;
     private final CodeStorageService codeStorageService;
-    private final DynamoService dynamoService;
-    private final ConfigurationService configurationService;
     private final ValidationService validationService;
     private final StateMachine<SessionState, SessionAction, UserContext> stateMachine;
 
-    public VerifyCodeHandler(
-            SessionService sessionService,
-            CodeStorageService codeStorageService,
-            DynamoService dynamoService,
+    protected VerifyCodeHandler(
             ConfigurationService configurationService,
+            SessionService sessionService,
+            ClientSessionService clientSessionService,
+            ClientService clientService,
+            AuthenticationService authenticationService,
+            CodeStorageService codeStorageService,
             ValidationService validationService,
             StateMachine<SessionState, SessionAction, UserContext> stateMachine) {
-        this.sessionService = sessionService;
+        super(
+                configurationService,
+                sessionService,
+                clientSessionService,
+                clientService,
+                authenticationService);
         this.codeStorageService = codeStorageService;
-        this.dynamoService = dynamoService;
-        this.configurationService = configurationService;
         this.validationService = validationService;
         this.stateMachine = stateMachine;
     }
 
     public VerifyCodeHandler() {
-        this.configurationService = new ConfigurationService();
-        this.sessionService = new SessionService(configurationService);
+        super(ConfigurationService.getInstance());
         this.codeStorageService =
-                new CodeStorageService(new RedisConnectionService(configurationService));
-        this.dynamoService =
-                new DynamoService(
-                        configurationService.getAwsRegion(),
-                        configurationService.getEnvironment(),
-                        configurationService.getDynamoEndpointUri());
+                new CodeStorageService(
+                        new RedisConnectionService(ConfigurationService.getInstance()));
         this.validationService = new ValidationService();
         this.stateMachine = userJourneyStateMachine();
     }
 
     @Override
-    public APIGatewayProxyResponseEvent handleRequest(
-            APIGatewayProxyRequestEvent input, Context context) {
-        return isWarming(input)
-                .orElseGet(
-                        () -> {
-                            Optional<Session> session =
-                                    sessionService.getSessionFromRequestHeaders(input.getHeaders());
-                            if (session.isEmpty()) {
-                                return generateApiGatewayProxyErrorResponse(
-                                        400, ErrorResponse.ERROR_1000);
-                            } else {
-                                LOG.info(
-                                        "VerifyCodeHandler processing request for session {}",
-                                        session.get().getSessionId());
-                            }
+    public APIGatewayProxyResponseEvent handleRequestWithUserContext(
+            APIGatewayProxyRequestEvent input, Context context, UserContext userContext) {
+        try {
+            VerifyCodeRequest codeRequest =
+                    objectMapper.readValue(input.getBody(), VerifyCodeRequest.class);
 
-                            try {
-                                VerifyCodeRequest codeRequest =
-                                        objectMapper.readValue(
-                                                input.getBody(), VerifyCodeRequest.class);
-                                Optional<UserProfile> userProfile =
-                                        dynamoService.getUserProfileFromEmail(
-                                                session.get().getEmailAddress());
-                                UserContext userContext =
-                                        UserContext.builder(session.get())
-                                                .withUserProfile(userProfile)
-                                                .build();
+            switch (codeRequest.getNotificationType()) {
+                case VERIFY_EMAIL:
+                    if (codeStorageService.isCodeBlockedForSession(
+                            userContext.getSession().getEmailAddress(),
+                            userContext.getSession().getSessionId())) {
+                        sessionService.save(
+                                userContext
+                                        .getSession()
+                                        .setState(
+                                                stateMachine.transition(
+                                                        userContext.getSession().getState(),
+                                                        USER_ENTERED_INVALID_EMAIL_VERIFICATION_CODE_TOO_MANY_TIMES,
+                                                        userContext)));
+                    } else {
+                        Optional<String> emailCode =
+                                codeStorageService.getOtpCode(
+                                        userContext.getSession().getEmailAddress(),
+                                        codeRequest.getNotificationType());
+                        sessionService.save(
+                                userContext
+                                        .getSession()
+                                        .setState(
+                                                stateMachine.transition(
+                                                        userContext.getSession().getState(),
+                                                        validationService
+                                                                .validateEmailVerificationCode(
+                                                                        emailCode,
+                                                                        codeRequest.getCode(),
+                                                                        userContext.getSession(),
+                                                                        configurationService
+                                                                                .getCodeMaxRetries()),
+                                                        userContext)));
+                        processCodeSessionState(
+                                userContext.getSession(), codeRequest.getNotificationType());
+                    }
+                    return generateSuccessResponse(userContext.getSession());
+                case VERIFY_PHONE_NUMBER:
+                    if (codeStorageService.isCodeBlockedForSession(
+                            userContext.getSession().getEmailAddress(),
+                            userContext.getSession().getSessionId())) {
+                        sessionService.save(
+                                userContext
+                                        .getSession()
+                                        .setState(
+                                                stateMachine.transition(
+                                                        userContext.getSession().getState(),
+                                                        USER_ENTERED_INVALID_PHONE_VERIFICATION_CODE_TOO_MANY_TIMES,
+                                                        userContext)));
+                    } else {
+                        Optional<String> phoneNumberCode =
+                                codeStorageService.getOtpCode(
+                                        userContext.getSession().getEmailAddress(),
+                                        codeRequest.getNotificationType());
+                        sessionService.save(
+                                userContext
+                                        .getSession()
+                                        .setState(
+                                                stateMachine.transition(
+                                                        userContext.getSession().getState(),
+                                                        validationService
+                                                                .validatePhoneVerificationCode(
+                                                                        phoneNumberCode,
+                                                                        codeRequest.getCode(),
+                                                                        userContext.getSession(),
+                                                                        configurationService
+                                                                                .getCodeMaxRetries()),
+                                                        userContext)));
+                        processCodeSessionState(
+                                userContext.getSession(), codeRequest.getNotificationType());
+                    }
+                    return generateSuccessResponse(userContext.getSession());
+                case MFA_SMS:
+                    if (codeStorageService.isCodeBlockedForSession(
+                            userContext.getSession().getEmailAddress(),
+                            userContext.getSession().getSessionId())) {
+                        sessionService.save(
+                                userContext
+                                        .getSession()
+                                        .setState(
+                                                stateMachine.transition(
+                                                        userContext.getSession().getState(),
+                                                        USER_ENTERED_INVALID_MFA_CODE_TOO_MANY_TIMES,
+                                                        userContext)));
+                    } else {
+                        Optional<String> mfaCode =
+                                codeStorageService.getOtpCode(
+                                        userContext.getSession().getEmailAddress(),
+                                        codeRequest.getNotificationType());
 
-                                switch (codeRequest.getNotificationType()) {
-                                    case VERIFY_EMAIL:
-                                        if (codeStorageService.isCodeBlockedForSession(
-                                                session.get().getEmailAddress(),
-                                                session.get().getSessionId())) {
-                                            sessionService.save(
-                                                    session.get()
-                                                            .setState(
-                                                                    stateMachine.transition(
-                                                                            session.get()
-                                                                                    .getState(),
-                                                                            USER_ENTERED_INVALID_EMAIL_VERIFICATION_CODE_TOO_MANY_TIMES,
-                                                                            userContext)));
-                                        } else {
-                                            Optional<String> emailCode =
-                                                    codeStorageService.getOtpCode(
-                                                            session.get().getEmailAddress(),
-                                                            codeRequest.getNotificationType());
-                                            sessionService.save(
-                                                    session.get()
-                                                            .setState(
-                                                                    stateMachine.transition(
-                                                                            session.get()
-                                                                                    .getState(),
-                                                                            validationService
-                                                                                    .validateEmailVerificationCode(
-                                                                                            emailCode,
-                                                                                            codeRequest
-                                                                                                    .getCode(),
-                                                                                            session
-                                                                                                    .get(),
-                                                                                            configurationService
-                                                                                                    .getCodeMaxRetries()),
-                                                                            userContext)));
-                                            processCodeSessionState(
-                                                    session.get(),
-                                                    codeRequest.getNotificationType());
-                                        }
-                                        return generateSuccessResponse(session.get());
-                                    case VERIFY_PHONE_NUMBER:
-                                        if (codeStorageService.isCodeBlockedForSession(
-                                                session.get().getEmailAddress(),
-                                                session.get().getSessionId())) {
-                                            sessionService.save(
-                                                    session.get()
-                                                            .setState(
-                                                                    stateMachine.transition(
-                                                                            session.get()
-                                                                                    .getState(),
-                                                                            USER_ENTERED_INVALID_PHONE_VERIFICATION_CODE_TOO_MANY_TIMES,
-                                                                            userContext)));
-                                        } else {
-                                            Optional<String> phoneNumberCode =
-                                                    codeStorageService.getOtpCode(
-                                                            session.get().getEmailAddress(),
-                                                            codeRequest.getNotificationType());
-                                            sessionService.save(
-                                                    session.get()
-                                                            .setState(
-                                                                    stateMachine.transition(
-                                                                            session.get()
-                                                                                    .getState(),
-                                                                            validationService
-                                                                                    .validatePhoneVerificationCode(
-                                                                                            phoneNumberCode,
-                                                                                            codeRequest
-                                                                                                    .getCode(),
-                                                                                            session
-                                                                                                    .get(),
-                                                                                            configurationService
-                                                                                                    .getCodeMaxRetries()),
-                                                                            userContext)));
-                                            processCodeSessionState(
-                                                    session.get(),
-                                                    codeRequest.getNotificationType());
-                                        }
-                                        return generateSuccessResponse(session.get());
-                                    case MFA_SMS:
-                                        if (codeStorageService.isCodeBlockedForSession(
-                                                session.get().getEmailAddress(),
-                                                session.get().getSessionId())) {
-                                            sessionService.save(
-                                                    session.get()
-                                                            .setState(
-                                                                    stateMachine.transition(
-                                                                            session.get()
-                                                                                    .getState(),
-                                                                            USER_ENTERED_INVALID_MFA_CODE_TOO_MANY_TIMES,
-                                                                            userContext)));
-                                        } else {
-                                            Optional<String> mfaCode =
-                                                    codeStorageService.getOtpCode(
-                                                            session.get().getEmailAddress(),
-                                                            codeRequest.getNotificationType());
-
-                                            sessionService.save(
-                                                    session.get()
-                                                            .setState(
-                                                                    stateMachine.transition(
-                                                                            session.get()
-                                                                                    .getState(),
-                                                                            validationService
-                                                                                    .validateMfaVerificationCode(
-                                                                                            mfaCode,
-                                                                                            codeRequest
-                                                                                                    .getCode(),
-                                                                                            session
-                                                                                                    .get(),
-                                                                                            configurationService
-                                                                                                    .getCodeMaxRetries()),
-                                                                            userContext)));
-                                            processCodeSessionState(
-                                                    session.get(),
-                                                    codeRequest.getNotificationType());
-                                        }
-                                        return generateSuccessResponse(session.get());
-                                }
-                            } catch (JsonProcessingException e) {
-                                LOG.error("Error parsing request", e);
-                                return generateApiGatewayProxyErrorResponse(
-                                        400, ErrorResponse.ERROR_1001);
-                            } catch (StateMachine.InvalidStateTransitionException e) {
-                                LOG.error("Invalid transition in user journey", e);
-                                return generateApiGatewayProxyErrorResponse(
-                                        400, ErrorResponse.ERROR_1017);
-                            }
-                            LOG.error(
-                                    "Encountered unexpected error while processing session {}",
-                                    session.get().getSessionId());
-                            return generateApiGatewayProxyErrorResponse(
-                                    400, ErrorResponse.ERROR_1002);
-                        });
+                        sessionService.save(
+                                userContext
+                                        .getSession()
+                                        .setState(
+                                                stateMachine.transition(
+                                                        userContext.getSession().getState(),
+                                                        validationService
+                                                                .validateMfaVerificationCode(
+                                                                        mfaCode,
+                                                                        codeRequest.getCode(),
+                                                                        userContext.getSession(),
+                                                                        configurationService
+                                                                                .getCodeMaxRetries()),
+                                                        userContext)));
+                        processCodeSessionState(
+                                userContext.getSession(), codeRequest.getNotificationType());
+                    }
+                    return generateSuccessResponse(userContext.getSession());
+            }
+        } catch (JsonProcessingException e) {
+            LOG.error("Error parsing request", e);
+            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
+        } catch (StateMachine.InvalidStateTransitionException e) {
+            LOG.error("Invalid transition in user journey", e);
+            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1017);
+        }
+        LOG.error(
+                "Encountered unexpected error while processing session {}",
+                userContext.getSession().getSessionId());
+        return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1002);
     }
 
     private APIGatewayProxyResponseEvent generateSuccessResponse(Session session)
@@ -267,7 +229,7 @@ public class VerifyCodeHandler
     private void processCodeSessionState(Session session, NotificationType notificationType) {
         if (session.getState().equals(SessionState.PHONE_NUMBER_CODE_VERIFIED)) {
             codeStorageService.deleteOtpCode(session.getEmailAddress(), notificationType);
-            dynamoService.updatePhoneNumberVerifiedStatus(session.getEmailAddress(), true);
+            authenticationService.updatePhoneNumberVerifiedStatus(session.getEmailAddress(), true);
         } else if (List.of(EMAIL_CODE_VERIFIED, MFA_CODE_VERIFIED, UPDATED_TERMS_AND_CONDITIONS)
                 .contains(session.getState())) {
             codeStorageService.deleteOtpCode(session.getEmailAddress(), notificationType);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
@@ -13,6 +13,9 @@ import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
+import uk.gov.di.authentication.shared.services.ClientService;
+import uk.gov.di.authentication.shared.services.ClientSessionService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SessionService;
 
 import java.util.Map;
@@ -37,14 +40,24 @@ class LoginHandlerTest {
     private static final String PHONE_NUMBER = "01234567890";
     private LoginHandler handler;
     private final Context context = mock(Context.class);
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
     private final SessionService sessionService = mock(SessionService.class);
+    private final ClientSessionService clientSessionService = mock(ClientSessionService.class);
+    private final ClientService clientService = mock(ClientService.class);
+
     private final Session session =
             new Session(IdGenerator.generate()).setState(AUTHENTICATION_REQUIRED);
 
     @BeforeEach
     public void setUp() {
-        handler = new LoginHandler(sessionService, authenticationService);
+        handler =
+                new LoginHandler(
+                        configurationService,
+                        sessionService,
+                        authenticationService,
+                        clientSessionService,
+                        clientService);
     }
 
     @Test

--- a/shared/src/main/java/uk/gov/di/authentication/shared/state/UserContext.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/state/UserContext.java
@@ -1,5 +1,6 @@
 package uk.gov.di.authentication.shared.state;
 
+import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 
@@ -8,10 +9,13 @@ import java.util.Optional;
 public class UserContext {
     private final Session session;
     private final Optional<UserProfile> userProfile;
+    private final Optional<ClientRegistry> client;
 
-    protected UserContext(Session session, Optional<UserProfile> userProfile) {
+    protected UserContext(
+            Session session, Optional<UserProfile> userProfile, Optional<ClientRegistry> client) {
         this.session = session;
         this.userProfile = userProfile;
+        this.client = client;
     }
 
     public Session getSession() {
@@ -22,6 +26,10 @@ public class UserContext {
         return userProfile;
     }
 
+    public Optional<ClientRegistry> getClient() {
+        return client;
+    }
+
     public static Builder builder(Session session) {
         return new Builder(session);
     }
@@ -29,14 +37,14 @@ public class UserContext {
     public static class Builder {
         private Session session;
         private Optional<UserProfile> userProfile = Optional.empty();
+        private Optional<ClientRegistry> client = Optional.empty();
 
         protected Builder(Session session) {
             this.session = session;
         }
 
         public Builder withUserProfile(UserProfile userProfile) {
-            this.userProfile = Optional.of(userProfile);
-            return this;
+            return withUserProfile(Optional.of(userProfile));
         }
 
         public Builder withUserProfile(Optional<UserProfile> userProfile) {
@@ -44,8 +52,17 @@ public class UserContext {
             return this;
         }
 
+        public Builder withClient(ClientRegistry client) {
+            return withClient(Optional.of(client));
+        }
+
+        public Builder withClient(Optional<ClientRegistry> client) {
+            this.client = client;
+            return this;
+        }
+
         public UserContext build() {
-            return new UserContext(session, userProfile);
+            return new UserContext(session, userProfile, client);
         }
     }
 }


### PR DESCRIPTION
## What?

- Add the `ClientRegistry` object to the `UserContext`, required by optional MFA and VoT
- The `UserContext` that is required by the state machine is going to need to be constructed in multiple lambdas, create a base class that handles this
- Also include the shared warming logic in the base class

## Why?

The client object will be required in various state machine conditions, constructing it in a shared class keeps the the main lambda code clean.