### PR TITLE
GOVSI-818: Optional MFA in state machine

### DIFF
--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    testImplementation "org.junit.jupiter:junit-jupiter-api:${dependencyVersions.junit}",
+    testImplementation configurations.tests,
             "com.nimbusds:nimbus-jose-jwt:9.13",
             "com.nimbusds:oauth2-oidc-sdk:9.15",
             "org.glassfish.jersey.core:jersey-client:${dependencyVersions.glassfish_version}",

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
@@ -1,29 +1,58 @@
 package uk.gov.di.authentication.api;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.oauth2.sdk.ResponseType;
+import com.nimbusds.oauth2.sdk.Scope;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+import com.nimbusds.openid.connect.sdk.Nonce;
+import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.authentication.frontendapi.entity.LoginRequest;
 import uk.gov.di.authentication.frontendapi.entity.LoginResponse;
 import uk.gov.di.authentication.helpers.DynamoHelper;
 import uk.gov.di.authentication.helpers.RedisHelper;
 import uk.gov.di.authentication.helpers.RequestHelper;
+import uk.gov.di.authentication.shared.entity.AuthenticationValues;
+import uk.gov.di.authentication.shared.entity.ServiceType;
+import uk.gov.di.authentication.shared.entity.SessionState;
 
 import java.io.IOException;
+import java.net.URI;
+import java.util.Base64;
+import java.util.stream.Stream;
 
+import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static uk.gov.di.authentication.helpers.KeyPairHelper.GENERATE_RSA_KEY_PAIR;
+import static uk.gov.di.authentication.shared.entity.AuthenticationValues.HIGH_LEVEL;
+import static uk.gov.di.authentication.shared.entity.AuthenticationValues.LOW_LEVEL;
+import static uk.gov.di.authentication.shared.entity.AuthenticationValues.MEDIUM_LEVEL;
+import static uk.gov.di.authentication.shared.entity.AuthenticationValues.VERY_HIGH_LEVEL;
+import static uk.gov.di.authentication.shared.entity.SessionState.AUTHENTICATED;
 import static uk.gov.di.authentication.shared.entity.SessionState.AUTHENTICATION_REQUIRED;
 import static uk.gov.di.authentication.shared.entity.SessionState.LOGGED_IN;
 
 public class LoginIntegrationTest extends IntegrationTestEndpoints {
 
     private static final String LOGIN_ENDPOINT = "/login";
+    private static final String CLIENT_ID = "test-client-id";
+    private static final String REDIRECT_URI = "http://localhost/redirect";
+    public static final String CLIENT_SESSION_ID = "a-client-session-id";
+    public static final String TEST_CLIENT_NAME = "test-client-name";
+
     private final ObjectMapper objectMapper = new ObjectMapper();
 
-    @Test
-    public void shouldCallLoginEndpointAndReturn200WhenLoginIsSuccessful() throws IOException {
+    @ParameterizedTest
+    @MethodSource("vectorOfTrustEndStates")
+    public void shouldReturnCorrectStateForClientsTrustLevel(
+            AuthenticationValues level, SessionState expectedState) throws IOException {
         String email = "joe.bloggs+3@digital.cabinet-office.gov.uk";
         String password = "password-1";
         String phoneNumber = "01234567890";
@@ -31,9 +60,36 @@ public class LoginIntegrationTest extends IntegrationTestEndpoints {
         DynamoHelper.addPhoneNumber(email, phoneNumber);
         String sessionId = RedisHelper.createSession();
         RedisHelper.setSessionState(sessionId, AUTHENTICATION_REQUIRED);
+
+        Scope scope = new Scope();
+        scope.add(OIDCScopeValue.OPENID);
+        AuthenticationRequest authRequest =
+                new AuthenticationRequest.Builder(
+                                ResponseType.CODE,
+                                scope,
+                                new ClientID(CLIENT_ID),
+                                URI.create(REDIRECT_URI))
+                        .nonce(new Nonce())
+                        .build();
+        RedisHelper.createClientSession(CLIENT_SESSION_ID, authRequest.toParameters());
+        DynamoHelper.registerClient(
+                CLIENT_ID,
+                "The test client",
+                singletonList(REDIRECT_URI),
+                singletonList("test-client@test.com"),
+                singletonList(scope.toString()),
+                Base64.getMimeEncoder()
+                        .encodeToString(GENERATE_RSA_KEY_PAIR().getPublic().getEncoded()),
+                singletonList("http://localhost/post-redirect-logout"),
+                String.valueOf(ServiceType.MANDATORY),
+                "https://test.com",
+                "public",
+                level == null ? null : level.getValue());
+
         MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
         headers.add("Session-Id", sessionId);
         headers.add("X-API-Key", API_KEY);
+        headers.add("Client-Session-Id", CLIENT_SESSION_ID);
         Response response =
                 RequestHelper.request(LOGIN_ENDPOINT, new LoginRequest(email, password), headers);
 
@@ -41,7 +97,16 @@ public class LoginIntegrationTest extends IntegrationTestEndpoints {
 
         String responseString = response.readEntity(String.class);
         LoginResponse loginResponse = objectMapper.readValue(responseString, LoginResponse.class);
-        assertEquals(LOGGED_IN, loginResponse.getSessionState());
+        assertEquals(expectedState, loginResponse.getSessionState());
+    }
+
+    private static Stream<Arguments> vectorOfTrustEndStates() {
+        return Stream.of(
+                Arguments.of(null, LOGGED_IN),
+                Arguments.of(LOW_LEVEL, AUTHENTICATED),
+                Arguments.of(MEDIUM_LEVEL, LOGGED_IN),
+                Arguments.of(HIGH_LEVEL, LOGGED_IN),
+                Arguments.of(VERY_HIGH_LEVEL, LOGGED_IN));
     }
 
     @Test

--- a/shared/src/main/java/uk/gov/di/authentication/shared/state/StateMachine.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/state/StateMachine.java
@@ -61,6 +61,7 @@ import static uk.gov.di.authentication.shared.entity.SessionState.UPDATED_TERMS_
 import static uk.gov.di.authentication.shared.entity.SessionState.USER_NOT_FOUND;
 import static uk.gov.di.authentication.shared.entity.SessionState.VERIFY_EMAIL_CODE_SENT;
 import static uk.gov.di.authentication.shared.entity.SessionState.VERIFY_PHONE_NUMBER_CODE_SENT;
+import static uk.gov.di.authentication.shared.state.conditions.ClientDoesNotRequireMfa.clientDoesNotRequireMfa;
 import static uk.gov.di.authentication.shared.state.conditions.TermsAndConditionsVersionNotAccepted.userHasNotAcceptedTermsAndConditionsVersion;
 
 public class StateMachine<T, A, C> {
@@ -175,6 +176,9 @@ public class StateMachine<T, A, C> {
                 .finalState()
                 .when(AUTHENTICATION_REQUIRED)
                 .allow(
+                        on(USER_ENTERED_VALID_CREDENTIALS)
+                                .ifCondition(clientDoesNotRequireMfa())
+                                .then(AUTHENTICATED),
                         on(USER_ENTERED_VALID_CREDENTIALS).then(LOGGED_IN),
                         on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND),
                         on(SYSTEM_HAS_SENT_RESET_PASSWORD_LINK).then(RESET_PASSWORD_LINK_SENT))

--- a/shared/src/main/java/uk/gov/di/authentication/shared/state/conditions/ClientDoesNotRequireMfa.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/state/conditions/ClientDoesNotRequireMfa.java
@@ -11,10 +11,13 @@ import static uk.gov.di.authentication.shared.entity.AuthenticationValues.LOW_LE
 public class ClientDoesNotRequireMfa implements Condition<UserContext> {
     @Override
     public boolean isMet(Optional<UserContext> context) {
-        return context
-                .flatMap(UserContext::getClient)
+        return context.flatMap(UserContext::getClient)
                 .map(ClientRegistry::getVectorsOfTrust)
                 .map(LOW_LEVEL.getValue()::equals)
                 .orElse(false);
+    }
+
+    public static ClientDoesNotRequireMfa clientDoesNotRequireMfa() {
+        return new ClientDoesNotRequireMfa();
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/state/conditions/ClientDoesNotRequireMfa.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/state/conditions/ClientDoesNotRequireMfa.java
@@ -1,0 +1,20 @@
+package uk.gov.di.authentication.shared.state.conditions;
+
+import uk.gov.di.authentication.shared.entity.ClientRegistry;
+import uk.gov.di.authentication.shared.state.Condition;
+import uk.gov.di.authentication.shared.state.UserContext;
+
+import java.util.Optional;
+
+import static uk.gov.di.authentication.shared.entity.AuthenticationValues.LOW_LEVEL;
+
+public class ClientDoesNotRequireMfa implements Condition<UserContext> {
+    @Override
+    public boolean isMet(Optional<UserContext> context) {
+        return context
+                .flatMap(UserContext::getClient)
+                .map(ClientRegistry::getVectorsOfTrust)
+                .map(LOW_LEVEL.getValue()::equals)
+                .orElse(false);
+    }
+}

--- a/shared/src/test/java/uk/gov/di/authentication/shared/state/conditions/ClientDoesNotRequireMfaTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/state/conditions/ClientDoesNotRequireMfaTest.java
@@ -1,0 +1,55 @@
+package uk.gov.di.authentication.shared.state.conditions;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.entity.ClientRegistry;
+import uk.gov.di.authentication.shared.state.UserContext;
+
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.shared.entity.AuthenticationValues.LOW_LEVEL;
+import static uk.gov.di.authentication.shared.entity.AuthenticationValues.MEDIUM_LEVEL;
+
+
+class ClientDoesNotRequireMfaTest {
+    private final ClientDoesNotRequireMfa condition = new ClientDoesNotRequireMfa();
+    private UserContext userContext = mock(UserContext.class);
+    private ClientRegistry client = mock(ClientRegistry.class);
+
+    @BeforeEach
+    public void setup() {
+        when(userContext.getClient()).thenReturn(Optional.of(client));
+    }
+
+    @Test
+    public void shouldReturnTrueIfLowLevelOfTrust() {
+        when(client.getVectorsOfTrust()).thenReturn(LOW_LEVEL.getValue());
+
+        assertThat(condition.isMet(Optional.of(userContext)), equalTo(true));
+    }
+
+    @Test
+    public void shouldReturnFalseIfNotLowLevelOfTrust() {
+        when(client.getVectorsOfTrust()).thenReturn(MEDIUM_LEVEL.getValue());
+
+        assertThat(condition.isMet(Optional.of(userContext)), equalTo(false));
+    }
+
+    @Test
+    public void shouldReturnFalseIfNoClientHasNoSpecifiedVectorOfTrust() {
+        when(client.getVectorsOfTrust()).thenReturn(null);
+
+        assertThat(condition.isMet(Optional.of(userContext)), equalTo(false));
+    }
+
+    @Test
+    public void shouldReturnFalseIfClientDoesNotExistInContext() {
+        when(userContext.getClient()).thenReturn(Optional.empty());
+
+        assertThat(condition.isMet(Optional.of(userContext)), equalTo(false));
+    }
+}

--- a/shared/src/test/java/uk/gov/di/authentication/shared/state/conditions/ClientDoesNotRequireMfaTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/state/conditions/ClientDoesNotRequireMfaTest.java
@@ -14,7 +14,6 @@ import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.shared.entity.AuthenticationValues.LOW_LEVEL;
 import static uk.gov.di.authentication.shared.entity.AuthenticationValues.MEDIUM_LEVEL;
 
-
 class ClientDoesNotRequireMfaTest {
     private final ClientDoesNotRequireMfa condition = new ClientDoesNotRequireMfa();
     private UserContext userContext = mock(UserContext.class);


### PR DESCRIPTION
## What?

- Add a condition that inspects the client stored in the `UserContext` and returns `true` if the client has a `LOW_LEVEL` vector of trust, otherwise `false`.
- Assume a higher-lever VoT if none specified
- Amend the state machine rules to allow transition straight from `AUTHENTICATION_REQUIRED` to `AUTHENTICATED` if user correctly enters their credentials and the client does not require MFA

## Why?

Some RPs will not require MFA. If they register with a lower level of trust we will allow them to skip the MFA step.