### PR TITLE
BAU - Create a new Session when the sessionState is not AUTHENTICATED 

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/SessionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/SessionService.java
@@ -56,7 +56,6 @@ public class SessionService {
 
     public void updateSessionId(Session session) {
         try {
-
             String oldSessionId = session.getSessionId();
             session.setSessionId(IdGenerator.generate());
             save(session);


### PR DESCRIPTION
## What?

- Currently when a user who has an existing session hits authorize then they are given a new session_id however their existing session is copied across to correspond with this new session_id. What this means is that if a user is in the middle of a flow and hits a state such as MFA_CODE_NOT_VALID, and they attempt to start a new journey they will not be able to as the STATE machine will throw an invalid transition error. We want to allow users to be able to start a new session if they wish and dispose of their existing session information to allow this to happen.
- If a user is on a session where the state is either AUTHENTICATED  we want to leave them as they are so they can skip login

## Why?

- To allow users to start new journeys even if they are in a middle of a previous journey