### PR TITLE
GOVSI-818: Check for Updated T&Cs when no MFA required

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/LoginRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/LoginRequest.java
@@ -2,15 +2,14 @@ package uk.gov.di.authentication.frontendapi.entity;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class LoginRequest {
+public class LoginRequest extends UserWithEmailRequest {
 
-    private String email;
     private String password;
 
     public LoginRequest(
             @JsonProperty(required = true, value = "email") String email,
             @JsonProperty(required = true, value = "password") String password) {
-        this.email = email;
+        super(email);
         this.password = password;
     }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/UserWithEmailRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/UserWithEmailRequest.java
@@ -1,9 +1,10 @@
 package uk.gov.di.authentication.frontendapi.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class UserWithEmailRequest {
-
     protected String email;
 
     public UserWithEmailRequest(@JsonProperty(required = true, value = "email") String email) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/state/StateMachine.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/state/StateMachine.java
@@ -61,6 +61,7 @@ import static uk.gov.di.authentication.shared.entity.SessionState.UPDATED_TERMS_
 import static uk.gov.di.authentication.shared.entity.SessionState.USER_NOT_FOUND;
 import static uk.gov.di.authentication.shared.entity.SessionState.VERIFY_EMAIL_CODE_SENT;
 import static uk.gov.di.authentication.shared.entity.SessionState.VERIFY_PHONE_NUMBER_CODE_SENT;
+import static uk.gov.di.authentication.shared.state.conditions.AggregateCondition.and;
 import static uk.gov.di.authentication.shared.state.conditions.ClientDoesNotRequireMfa.clientDoesNotRequireMfa;
 import static uk.gov.di.authentication.shared.state.conditions.TermsAndConditionsVersionNotAccepted.userHasNotAcceptedTermsAndConditionsVersion;
 
@@ -176,6 +177,14 @@ public class StateMachine<T, A, C> {
                 .finalState()
                 .when(AUTHENTICATION_REQUIRED)
                 .allow(
+                        on(USER_ENTERED_VALID_CREDENTIALS)
+                                .ifCondition(
+                                        and(
+                                                clientDoesNotRequireMfa(),
+                                                userHasNotAcceptedTermsAndConditionsVersion(
+                                                        configurationService
+                                                                .getTermsAndConditionsVersion())))
+                                .then(UPDATED_TERMS_AND_CONDITIONS),
                         on(USER_ENTERED_VALID_CREDENTIALS)
                                 .ifCondition(clientDoesNotRequireMfa())
                                 .then(AUTHENTICATED),

--- a/shared/src/main/java/uk/gov/di/authentication/shared/state/UserContext.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/state/UserContext.java
@@ -9,12 +9,17 @@ import java.util.Optional;
 public class UserContext {
     private final Session session;
     private final Optional<UserProfile> userProfile;
+    private final boolean userAuthenticated;
     private final Optional<ClientRegistry> client;
 
     protected UserContext(
-            Session session, Optional<UserProfile> userProfile, Optional<ClientRegistry> client) {
+            Session session,
+            Optional<UserProfile> userProfile,
+            boolean userAuthenticated,
+            Optional<ClientRegistry> client) {
         this.session = session;
         this.userProfile = userProfile;
+        this.userAuthenticated = userAuthenticated;
         this.client = client;
     }
 
@@ -24,6 +29,10 @@ public class UserContext {
 
     public Optional<UserProfile> getUserProfile() {
         return userProfile;
+    }
+
+    public boolean isUserAuthenticated() {
+        return userAuthenticated;
     }
 
     public Optional<ClientRegistry> getClient() {
@@ -37,6 +46,7 @@ public class UserContext {
     public static class Builder {
         private Session session;
         private Optional<UserProfile> userProfile = Optional.empty();
+        private boolean userAuthenticated = false;
         private Optional<ClientRegistry> client = Optional.empty();
 
         protected Builder(Session session) {
@@ -52,6 +62,11 @@ public class UserContext {
             return this;
         }
 
+        public Builder withUserAuthenticated(boolean userAuthenticated) {
+            this.userAuthenticated = userAuthenticated;
+            return this;
+        }
+
         public Builder withClient(ClientRegistry client) {
             return withClient(Optional.of(client));
         }
@@ -62,7 +77,7 @@ public class UserContext {
         }
 
         public UserContext build() {
-            return new UserContext(session, userProfile, client);
+            return new UserContext(session, userProfile, userAuthenticated, client);
         }
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/state/conditions/AggregateCondition.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/state/conditions/AggregateCondition.java
@@ -1,0 +1,26 @@
+package uk.gov.di.authentication.shared.state.conditions;
+
+import uk.gov.di.authentication.shared.state.Condition;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+public class AggregateCondition<T> implements Condition<T> {
+
+    private final List<Condition<T>> conditions;
+
+    public AggregateCondition(Condition<T>... conditions) {
+        this.conditions = Arrays.asList(conditions);
+    }
+
+    @Override
+    public boolean isMet(Optional<T> context) {
+        return conditions.stream().allMatch(c -> c.isMet(context));
+    }
+
+    @SafeVarargs
+    public static <T> AggregateCondition<T> and(Condition<T>... conditions) {
+        return new AggregateCondition<>(conditions);
+    }
+}

--- a/shared/src/test/java/uk/gov/di/authentication/shared/state/conditions/AggregateConditionTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/state/conditions/AggregateConditionTest.java
@@ -14,25 +14,18 @@ class AggregateConditionTest {
 
     private static final Condition<Object> FALSE_CONDITION = context -> false;
 
-
     @Test
     public void shouldReturnTrueIfAllConditionsAreTrue() {
-        AggregateCondition<Object> condition = new AggregateCondition<>(
-                TRUE_CONDITION,
-                TRUE_CONDITION,
-                TRUE_CONDITION
-        );
+        AggregateCondition<Object> condition =
+                new AggregateCondition<>(TRUE_CONDITION, TRUE_CONDITION, TRUE_CONDITION);
 
         assertThat(condition.isMet(Optional.empty()), equalTo(true));
     }
 
     @Test
     public void shouldReturnFalseIfAnyConditionIsFalse() {
-        AggregateCondition<Object> condition = new AggregateCondition<>(
-                TRUE_CONDITION,
-                FALSE_CONDITION,
-                TRUE_CONDITION
-        );
+        AggregateCondition<Object> condition =
+                new AggregateCondition<>(TRUE_CONDITION, FALSE_CONDITION, TRUE_CONDITION);
 
         assertThat(condition.isMet(Optional.empty()), equalTo(false));
     }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/state/conditions/AggregateConditionTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/state/conditions/AggregateConditionTest.java
@@ -1,0 +1,39 @@
+package uk.gov.di.authentication.shared.state.conditions;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.state.Condition;
+
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class AggregateConditionTest {
+
+    private static final Condition<Object> TRUE_CONDITION = context -> true;
+
+    private static final Condition<Object> FALSE_CONDITION = context -> false;
+
+
+    @Test
+    public void shouldReturnTrueIfAllConditionsAreTrue() {
+        AggregateCondition<Object> condition = new AggregateCondition<>(
+                TRUE_CONDITION,
+                TRUE_CONDITION,
+                TRUE_CONDITION
+        );
+
+        assertThat(condition.isMet(Optional.empty()), equalTo(true));
+    }
+
+    @Test
+    public void shouldReturnFalseIfAnyConditionIsFalse() {
+        AggregateCondition<Object> condition = new AggregateCondition<>(
+                TRUE_CONDITION,
+                FALSE_CONDITION,
+                TRUE_CONDITION
+        );
+
+        assertThat(condition.isMet(Optional.empty()), equalTo(false));
+    }
+}


### PR DESCRIPTION
## What?

Please include a summary of the change.

## Why?

- Add a new condition type that can take multiple other conditions as parameters and returns `true` if they are ALL `true`
- When in the LoginHandler, the session is not yet assigned to user, extract the e-mail address from the request to populate the `UserContext` object
- Update the state machine to check for updated T&Cs

## Related PRs

#565 