### PR TITLE
BAU: `VerifyCodeHandler` refactoring

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -88,113 +88,91 @@ public class VerifyCodeHandler extends BaseFrontendHandler
             VerifyCodeRequest codeRequest =
                     objectMapper.readValue(input.getBody(), VerifyCodeRequest.class);
 
+            var session = userContext.getSession();
+
             switch (codeRequest.getNotificationType()) {
                 case VERIFY_EMAIL:
                     if (codeStorageService.isCodeBlockedForSession(
-                            userContext.getSession().getEmailAddress(),
-                            userContext.getSession().getSessionId())) {
+                            session.getEmailAddress(), session.getSessionId())) {
                         sessionService.save(
-                                userContext
-                                        .getSession()
-                                        .setState(
-                                                stateMachine.transition(
-                                                        userContext.getSession().getState(),
-                                                        USER_ENTERED_INVALID_EMAIL_VERIFICATION_CODE_TOO_MANY_TIMES,
-                                                        userContext)));
+                                session.setState(
+                                        stateMachine.transition(
+                                                session.getState(),
+                                                USER_ENTERED_INVALID_EMAIL_VERIFICATION_CODE_TOO_MANY_TIMES,
+                                                userContext)));
                     } else {
                         Optional<String> emailCode =
                                 codeStorageService.getOtpCode(
-                                        userContext.getSession().getEmailAddress(),
+                                        session.getEmailAddress(),
                                         codeRequest.getNotificationType());
                         sessionService.save(
-                                userContext
-                                        .getSession()
-                                        .setState(
-                                                stateMachine.transition(
-                                                        userContext.getSession().getState(),
-                                                        validationService
-                                                                .validateEmailVerificationCode(
-                                                                        emailCode,
-                                                                        codeRequest.getCode(),
-                                                                        userContext.getSession(),
-                                                                        configurationService
-                                                                                .getCodeMaxRetries()),
-                                                        userContext)));
-                        processCodeSessionState(
-                                userContext.getSession(), codeRequest.getNotificationType());
+                                session.setState(
+                                        stateMachine.transition(
+                                                session.getState(),
+                                                validationService.validateEmailVerificationCode(
+                                                        emailCode,
+                                                        codeRequest.getCode(),
+                                                        session,
+                                                        configurationService.getCodeMaxRetries()),
+                                                userContext)));
+                        processCodeSessionState(session, codeRequest.getNotificationType());
                     }
-                    return generateSuccessResponse(userContext.getSession());
+                    return generateSuccessResponse(session);
                 case VERIFY_PHONE_NUMBER:
                     if (codeStorageService.isCodeBlockedForSession(
-                            userContext.getSession().getEmailAddress(),
-                            userContext.getSession().getSessionId())) {
+                            session.getEmailAddress(), session.getSessionId())) {
                         sessionService.save(
-                                userContext
-                                        .getSession()
-                                        .setState(
-                                                stateMachine.transition(
-                                                        userContext.getSession().getState(),
-                                                        USER_ENTERED_INVALID_PHONE_VERIFICATION_CODE_TOO_MANY_TIMES,
-                                                        userContext)));
+                                session.setState(
+                                        stateMachine.transition(
+                                                session.getState(),
+                                                USER_ENTERED_INVALID_PHONE_VERIFICATION_CODE_TOO_MANY_TIMES,
+                                                userContext)));
                     } else {
                         Optional<String> phoneNumberCode =
                                 codeStorageService.getOtpCode(
-                                        userContext.getSession().getEmailAddress(),
+                                        session.getEmailAddress(),
                                         codeRequest.getNotificationType());
                         sessionService.save(
-                                userContext
-                                        .getSession()
-                                        .setState(
-                                                stateMachine.transition(
-                                                        userContext.getSession().getState(),
-                                                        validationService
-                                                                .validatePhoneVerificationCode(
-                                                                        phoneNumberCode,
-                                                                        codeRequest.getCode(),
-                                                                        userContext.getSession(),
-                                                                        configurationService
-                                                                                .getCodeMaxRetries()),
-                                                        userContext)));
-                        processCodeSessionState(
-                                userContext.getSession(), codeRequest.getNotificationType());
+                                session.setState(
+                                        stateMachine.transition(
+                                                session.getState(),
+                                                validationService.validatePhoneVerificationCode(
+                                                        phoneNumberCode,
+                                                        codeRequest.getCode(),
+                                                        session,
+                                                        configurationService.getCodeMaxRetries()),
+                                                userContext)));
+                        processCodeSessionState(session, codeRequest.getNotificationType());
                     }
-                    return generateSuccessResponse(userContext.getSession());
+                    return generateSuccessResponse(session);
                 case MFA_SMS:
                     if (codeStorageService.isCodeBlockedForSession(
-                            userContext.getSession().getEmailAddress(),
-                            userContext.getSession().getSessionId())) {
+                            session.getEmailAddress(), session.getSessionId())) {
                         sessionService.save(
-                                userContext
-                                        .getSession()
-                                        .setState(
-                                                stateMachine.transition(
-                                                        userContext.getSession().getState(),
-                                                        USER_ENTERED_INVALID_MFA_CODE_TOO_MANY_TIMES,
-                                                        userContext)));
+                                session.setState(
+                                        stateMachine.transition(
+                                                session.getState(),
+                                                USER_ENTERED_INVALID_MFA_CODE_TOO_MANY_TIMES,
+                                                userContext)));
                     } else {
                         Optional<String> mfaCode =
                                 codeStorageService.getOtpCode(
-                                        userContext.getSession().getEmailAddress(),
+                                        session.getEmailAddress(),
                                         codeRequest.getNotificationType());
 
                         sessionService.save(
-                                userContext
-                                        .getSession()
-                                        .setState(
-                                                stateMachine.transition(
-                                                        userContext.getSession().getState(),
-                                                        validationService
-                                                                .validateMfaVerificationCode(
-                                                                        mfaCode,
-                                                                        codeRequest.getCode(),
-                                                                        userContext.getSession(),
-                                                                        configurationService
-                                                                                .getCodeMaxRetries()),
-                                                        userContext)));
-                        processCodeSessionState(
-                                userContext.getSession(), codeRequest.getNotificationType());
+                                session.setState(
+                                        stateMachine.transition(
+                                                session.getState(),
+                                                validationService.validateMfaVerificationCode(
+                                                        mfaCode,
+                                                        codeRequest.getCode(),
+                                                        session,
+                                                        configurationService.getCodeMaxRetries()),
+                                                userContext)));
+                        processCodeSessionState(session, codeRequest.getNotificationType());
                     }
-                    return generateSuccessResponse(userContext.getSession());
+                    return generateSuccessResponse(session);
             }
         } catch (JsonProcessingException e) {
             LOG.error("Error parsing request", e);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -95,22 +95,12 @@ public class VerifyCodeHandler extends BaseFrontendHandler
 
             var session = userContext.getSession();
 
-            var blockedCodeBehaviour =
-                    Map.ofEntries(
-                            entry(
-                                    VERIFY_EMAIL,
-                                    USER_ENTERED_INVALID_EMAIL_VERIFICATION_CODE_TOO_MANY_TIMES),
-                            entry(
-                                    VERIFY_PHONE_NUMBER,
-                                    USER_ENTERED_INVALID_PHONE_VERIFICATION_CODE_TOO_MANY_TIMES),
-                            entry(MFA_SMS, USER_ENTERED_INVALID_MFA_CODE_TOO_MANY_TIMES));
-
             if (isCodeBlockedForSession(session)) {
                 sessionService.save(
                         session.setState(
                                 stateMachine.transition(
                                         session.getState(),
-                                        blockedCodeBehaviour.get(codeRequest.getNotificationType()),
+                                        blockedCodeBehaviour(codeRequest),
                                         userContext)));
                 return generateSuccessResponse(session);
             }
@@ -177,6 +167,18 @@ public class VerifyCodeHandler extends BaseFrontendHandler
                 "Encountered unexpected error while processing session {}",
                 userContext.getSession().getSessionId());
         return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1002);
+    }
+
+    private SessionAction blockedCodeBehaviour(VerifyCodeRequest codeRequest) {
+        return Map.ofEntries(
+                        entry(
+                                VERIFY_EMAIL,
+                                USER_ENTERED_INVALID_EMAIL_VERIFICATION_CODE_TOO_MANY_TIMES),
+                        entry(
+                                VERIFY_PHONE_NUMBER,
+                                USER_ENTERED_INVALID_PHONE_VERIFICATION_CODE_TOO_MANY_TIMES),
+                        entry(MFA_SMS, USER_ENTERED_INVALID_MFA_CODE_TOO_MANY_TIMES))
+                .get(codeRequest.getNotificationType());
     }
 
     private boolean isCodeBlockedForSession(Session session) {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -92,8 +92,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler
 
             switch (codeRequest.getNotificationType()) {
                 case VERIFY_EMAIL:
-                    if (codeStorageService.isCodeBlockedForSession(
-                            session.getEmailAddress(), session.getSessionId())) {
+                    if (isCodeBlockedForSession(session)) {
                         sessionService.save(
                                 session.setState(
                                         stateMachine.transition(
@@ -119,8 +118,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler
                     }
                     return generateSuccessResponse(session);
                 case VERIFY_PHONE_NUMBER:
-                    if (codeStorageService.isCodeBlockedForSession(
-                            session.getEmailAddress(), session.getSessionId())) {
+                    if (isCodeBlockedForSession(session)) {
                         sessionService.save(
                                 session.setState(
                                         stateMachine.transition(
@@ -146,8 +144,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler
                     }
                     return generateSuccessResponse(session);
                 case MFA_SMS:
-                    if (codeStorageService.isCodeBlockedForSession(
-                            session.getEmailAddress(), session.getSessionId())) {
+                    if (isCodeBlockedForSession(session)) {
                         sessionService.save(
                                 session.setState(
                                         stateMachine.transition(
@@ -185,6 +182,11 @@ public class VerifyCodeHandler extends BaseFrontendHandler
                 "Encountered unexpected error while processing session {}",
                 userContext.getSession().getSessionId());
         return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1002);
+    }
+
+    private boolean isCodeBlockedForSession(Session session) {
+        return codeStorageService.isCodeBlockedForSession(
+                session.getEmailAddress(), session.getSessionId());
     }
 
     private APIGatewayProxyResponseEvent generateSuccessResponse(Session session)

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -28,7 +28,6 @@ import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import static java.util.Map.entry;
 import static uk.gov.di.authentication.shared.entity.NotificationType.MFA_SMS;
@@ -105,17 +104,18 @@ public class VerifyCodeHandler extends BaseFrontendHandler
                 return generateSuccessResponse(session);
             }
 
+            var code =
+                    codeStorageService.getOtpCode(
+                            session.getEmailAddress(), codeRequest.getNotificationType());
+
             switch (codeRequest.getNotificationType()) {
                 case VERIFY_EMAIL:
-                    Optional<String> emailCode =
-                            codeStorageService.getOtpCode(
-                                    session.getEmailAddress(), codeRequest.getNotificationType());
                     sessionService.save(
                             session.setState(
                                     stateMachine.transition(
                                             session.getState(),
                                             validationService.validateEmailVerificationCode(
-                                                    emailCode,
+                                                    code,
                                                     codeRequest.getCode(),
                                                     session,
                                                     configurationService.getCodeMaxRetries()),
@@ -123,15 +123,12 @@ public class VerifyCodeHandler extends BaseFrontendHandler
                     processCodeSessionState(session, codeRequest.getNotificationType());
                     return generateSuccessResponse(session);
                 case VERIFY_PHONE_NUMBER:
-                    Optional<String> phoneNumberCode =
-                            codeStorageService.getOtpCode(
-                                    session.getEmailAddress(), codeRequest.getNotificationType());
                     sessionService.save(
                             session.setState(
                                     stateMachine.transition(
                                             session.getState(),
                                             validationService.validatePhoneVerificationCode(
-                                                    phoneNumberCode,
+                                                    code,
                                                     codeRequest.getCode(),
                                                     session,
                                                     configurationService.getCodeMaxRetries()),
@@ -139,16 +136,12 @@ public class VerifyCodeHandler extends BaseFrontendHandler
                     processCodeSessionState(session, codeRequest.getNotificationType());
                     return generateSuccessResponse(session);
                 case MFA_SMS:
-                    Optional<String> mfaCode =
-                            codeStorageService.getOtpCode(
-                                    session.getEmailAddress(), codeRequest.getNotificationType());
-
                     sessionService.save(
                             session.setState(
                                     stateMachine.transition(
                                             session.getState(),
                                             validationService.validateMfaVerificationCode(
-                                                    mfaCode,
+                                                    code,
                                                     codeRequest.getCode(),
                                                     session,
                                                     configurationService.getCodeMaxRetries()),

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeRequestHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeRequestHandlerTest.java
@@ -167,8 +167,12 @@ class VerifyCodeRequestHandlerTest {
         when(configurationService.getCodeMaxRetries()).thenReturn(5);
         when(codeStorageService.getOtpCode(TEST_EMAIL_ADDRESS, VERIFY_EMAIL))
                 .thenReturn(Optional.of(CODE));
-        when(validationService.validateEmailVerificationCode(
-                        eq(Optional.of(CODE)), eq(CODE), any(Session.class), eq(5)))
+        when(validationService.validateVerificationCode(
+                        eq(VERIFY_EMAIL),
+                        eq(Optional.of(CODE)),
+                        eq(CODE),
+                        any(Session.class),
+                        eq(5)))
                 .thenReturn(USER_ENTERED_VALID_EMAIL_VERIFICATION_CODE);
         APIGatewayProxyResponseEvent result = makeCallWithCode(CODE, VERIFY_EMAIL.toString());
 
@@ -183,8 +187,13 @@ class VerifyCodeRequestHandlerTest {
     public void shouldReturn200ForValidVerifyPhoneNumberRequest() throws JsonProcessingException {
         session.setState(VERIFY_PHONE_NUMBER_CODE_SENT);
         when(configurationService.getCodeMaxRetries()).thenReturn(5);
-        when(validationService.validatePhoneVerificationCode(
-                        eq(Optional.of(CODE)), eq(CODE), any(Session.class), eq(5)))
+
+        when(validationService.validateVerificationCode(
+                        eq(VERIFY_PHONE_NUMBER),
+                        eq(Optional.of(CODE)),
+                        eq(CODE),
+                        any(Session.class),
+                        eq(5)))
                 .thenReturn(USER_ENTERED_VALID_PHONE_VERIFICATION_CODE);
         when(codeStorageService.getOtpCode(TEST_EMAIL_ADDRESS, VERIFY_PHONE_NUMBER))
                 .thenReturn(Optional.of(CODE));
@@ -206,8 +215,12 @@ class VerifyCodeRequestHandlerTest {
         when(configurationService.getCodeMaxRetries()).thenReturn(5);
         when(codeStorageService.getOtpCode(TEST_EMAIL_ADDRESS, VERIFY_EMAIL))
                 .thenReturn(Optional.of(CODE));
-        when(validationService.validateEmailVerificationCode(
-                        eq(Optional.of(CODE)), eq("123457"), any(Session.class), eq(5)))
+        when(validationService.validateVerificationCode(
+                        eq(VERIFY_EMAIL),
+                        eq(Optional.of(CODE)),
+                        eq("123457"),
+                        any(Session.class),
+                        eq(5)))
                 .thenReturn(USER_ENTERED_INVALID_EMAIL_VERIFICATION_CODE);
 
         APIGatewayProxyResponseEvent result = makeCallWithCode("123457", VERIFY_EMAIL.toString());
@@ -223,8 +236,13 @@ class VerifyCodeRequestHandlerTest {
             throws JsonProcessingException {
         session.setState(VERIFY_PHONE_NUMBER_CODE_SENT);
         when(configurationService.getCodeMaxRetries()).thenReturn(5);
-        when(validationService.validatePhoneVerificationCode(
-                        eq(Optional.of(CODE)), eq(CODE), any(Session.class), eq(5)))
+
+        when(validationService.validateVerificationCode(
+                        eq(VERIFY_PHONE_NUMBER),
+                        eq(Optional.of(CODE)),
+                        eq(CODE),
+                        any(Session.class),
+                        eq(5)))
                 .thenReturn(USER_ENTERED_INVALID_PHONE_VERIFICATION_CODE);
         when(codeStorageService.getOtpCode(TEST_EMAIL_ADDRESS, VERIFY_PHONE_NUMBER))
                 .thenReturn(Optional.of(CODE));
@@ -277,8 +295,13 @@ class VerifyCodeRequestHandlerTest {
         session.setState(PHONE_NUMBER_CODE_NOT_VALID);
         when(configurationService.getCodeMaxRetries()).thenReturn(5);
         when(configurationService.getCodeExpiry()).thenReturn(900L);
-        when(validationService.validatePhoneVerificationCode(
-                        eq(Optional.of(CODE)), eq(USER_INPUT), any(Session.class), eq(5)))
+
+        when(validationService.validateVerificationCode(
+                        eq(VERIFY_PHONE_NUMBER),
+                        eq(Optional.of(CODE)),
+                        eq(USER_INPUT),
+                        any(Session.class),
+                        eq(5)))
                 .thenReturn(USER_ENTERED_INVALID_PHONE_VERIFICATION_CODE_TOO_MANY_TIMES);
         when(codeStorageService.getOtpCode(TEST_EMAIL_ADDRESS, VERIFY_PHONE_NUMBER))
                 .thenReturn(Optional.of(CODE));
@@ -324,8 +347,12 @@ class VerifyCodeRequestHandlerTest {
         final String USER_INPUT = "123456";
         when(configurationService.getCodeMaxRetries()).thenReturn(5);
         when(configurationService.getCodeExpiry()).thenReturn(900L);
-        when(validationService.validateEmailVerificationCode(
-                        eq(Optional.of(CODE)), eq(USER_INPUT), any(Session.class), eq(5)))
+        when(validationService.validateVerificationCode(
+                        eq(VERIFY_EMAIL),
+                        eq(Optional.of(CODE)),
+                        eq(USER_INPUT),
+                        any(Session.class),
+                        eq(5)))
                 .thenReturn(USER_ENTERED_INVALID_EMAIL_VERIFICATION_CODE_TOO_MANY_TIMES);
         when(codeStorageService.getOtpCode(TEST_EMAIL_ADDRESS, VERIFY_EMAIL))
                 .thenReturn(Optional.of(CODE));
@@ -364,8 +391,8 @@ class VerifyCodeRequestHandlerTest {
         when(configurationService.getCodeMaxRetries()).thenReturn(5);
         when(codeStorageService.getOtpCode(TEST_EMAIL_ADDRESS, MFA_SMS))
                 .thenReturn(Optional.of(CODE));
-        when(validationService.validateMfaVerificationCode(
-                        eq(Optional.of(CODE)), eq(CODE), any(Session.class), eq(5)))
+        when(validationService.validateVerificationCode(
+                        eq(MFA_SMS), eq(Optional.of(CODE)), eq(CODE), any(Session.class), eq(5)))
                 .thenReturn(USER_ENTERED_VALID_MFA_CODE);
 
         when(stateMachine.transition(
@@ -391,8 +418,8 @@ class VerifyCodeRequestHandlerTest {
         when(configurationService.getCodeMaxRetries()).thenReturn(5);
         when(codeStorageService.getOtpCode(TEST_EMAIL_ADDRESS, MFA_SMS))
                 .thenReturn(Optional.of(CODE));
-        when(validationService.validateMfaVerificationCode(
-                        eq(Optional.of(CODE)), eq(CODE), any(Session.class), eq(5)))
+        when(validationService.validateVerificationCode(
+                        eq(MFA_SMS), eq(Optional.of(CODE)), eq(CODE), any(Session.class), eq(5)))
                 .thenReturn(USER_ENTERED_VALID_MFA_CODE);
 
         when(stateMachine.transition(
@@ -417,8 +444,12 @@ class VerifyCodeRequestHandlerTest {
         when(configurationService.getCodeMaxRetries()).thenReturn(5);
         when(codeStorageService.getOtpCode(TEST_EMAIL_ADDRESS, MFA_SMS))
                 .thenReturn(Optional.of(CODE));
-        when(validationService.validateMfaVerificationCode(
-                        eq(Optional.of(CODE)), eq("123457"), any(Session.class), eq(5)))
+        when(validationService.validateVerificationCode(
+                        eq(MFA_SMS),
+                        eq(Optional.of(CODE)),
+                        eq("123457"),
+                        any(Session.class),
+                        eq(5)))
                 .thenReturn(USER_ENTERED_INVALID_MFA_CODE);
 
         APIGatewayProxyResponseEvent result = makeCallWithCode("123457", MFA_SMS.toString());
@@ -436,8 +467,12 @@ class VerifyCodeRequestHandlerTest {
         final String USER_INPUT = "123456";
         when(configurationService.getCodeMaxRetries()).thenReturn(5);
         when(configurationService.getCodeExpiry()).thenReturn(900L);
-        when(validationService.validateMfaVerificationCode(
-                        eq(Optional.of(CODE)), eq(USER_INPUT), any(Session.class), eq(5)))
+        when(validationService.validateVerificationCode(
+                        eq(MFA_SMS),
+                        eq(Optional.of(CODE)),
+                        eq(USER_INPUT),
+                        any(Session.class),
+                        eq(5)))
                 .thenReturn(USER_ENTERED_INVALID_MFA_CODE_TOO_MANY_TIMES);
         when(codeStorageService.getOtpCode(TEST_EMAIL_ADDRESS, MFA_SMS))
                 .thenReturn(Optional.of(CODE));
@@ -475,8 +510,12 @@ class VerifyCodeRequestHandlerTest {
         when(configurationService.getCodeMaxRetries()).thenReturn(5);
         when(codeStorageService.getOtpCode(TEST_EMAIL_ADDRESS, VERIFY_EMAIL))
                 .thenReturn(Optional.of(CODE));
-        when(validationService.validateEmailVerificationCode(
-                        eq(Optional.of(CODE)), eq(CODE), any(Session.class), eq(5)))
+        when(validationService.validateVerificationCode(
+                        eq(VERIFY_EMAIL),
+                        eq(Optional.of(CODE)),
+                        eq(CODE),
+                        any(Session.class),
+                        eq(5)))
                 .thenReturn(USER_ENTERED_VALID_EMAIL_VERIFICATION_CODE);
         when(stateMachine.transition(
                         eq(NEW),

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ValidationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ValidationService.java
@@ -76,48 +76,6 @@ public class ValidationService {
         }
     }
 
-    public SessionAction validatePhoneVerificationCode(
-            Optional<String> phoneNumberCode, String input, Session session, int maxRetries) {
-        if (phoneNumberCode.isEmpty() || !phoneNumberCode.get().equals(input)) {
-            session.incrementRetryCount();
-            if (session.getRetryCount() > maxRetries) {
-                return USER_ENTERED_INVALID_PHONE_VERIFICATION_CODE_TOO_MANY_TIMES;
-            } else {
-                return USER_ENTERED_INVALID_PHONE_VERIFICATION_CODE;
-            }
-        }
-        session.resetCodeRequestCount();
-        return USER_ENTERED_VALID_PHONE_VERIFICATION_CODE;
-    }
-
-    public SessionAction validateMfaVerificationCode(
-            Optional<String> mfaCode, String input, Session session, int maxRetries) {
-        if (mfaCode.isEmpty() || !mfaCode.get().equals(input)) {
-            session.incrementRetryCount();
-            if (session.getRetryCount() > maxRetries) {
-                return USER_ENTERED_INVALID_MFA_CODE_TOO_MANY_TIMES;
-            } else {
-                return USER_ENTERED_INVALID_MFA_CODE;
-            }
-        }
-        session.resetCodeRequestCount();
-        return USER_ENTERED_VALID_MFA_CODE;
-    }
-
-    public SessionAction validateEmailVerificationCode(
-            Optional<String> emailCode, String input, Session session, int maxRetries) {
-        if (emailCode.isEmpty() || !emailCode.get().equals(input)) {
-            session.incrementRetryCount();
-            if (session.getRetryCount() > maxRetries) {
-                return USER_ENTERED_INVALID_EMAIL_VERIFICATION_CODE_TOO_MANY_TIMES;
-            } else {
-                return USER_ENTERED_INVALID_EMAIL_VERIFICATION_CODE;
-            }
-        }
-        session.resetCodeRequestCount();
-        return USER_ENTERED_VALID_EMAIL_VERIFICATION_CODE;
-    }
-
     public SessionAction validateVerificationCode(
             NotificationType type,
             Optional<String> code,

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/ValidationServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/ValidationServiceTest.java
@@ -11,6 +11,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.shared.entity.NotificationType.MFA_SMS;
+import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_EMAIL;
+import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_PHONE_NUMBER;
 
 public class ValidationServiceTest {
 
@@ -120,16 +123,20 @@ public class ValidationServiceTest {
     public void shouldReturnCorrectStateWhenPhoneCodeMatchesStored() {
         assertEquals(
                 SessionAction.USER_ENTERED_VALID_PHONE_VERIFICATION_CODE,
-                validationService.validatePhoneVerificationCode(
-                        Optional.of("123456"), "123456", mock(Session.class), 5));
+                validationService.validateVerificationCode(
+                        VERIFY_PHONE_NUMBER,
+                        Optional.of("123456"),
+                        "123456",
+                        mock(Session.class),
+                        5));
     }
 
     @Test
     public void shouldReturnCorrectStateWhenStoredPhoneCodeIsEmpty() {
         assertEquals(
                 SessionAction.USER_ENTERED_INVALID_PHONE_VERIFICATION_CODE,
-                validationService.validatePhoneVerificationCode(
-                        Optional.empty(), "123456", mock(Session.class), 5));
+                validationService.validateVerificationCode(
+                        VERIFY_PHONE_NUMBER, Optional.empty(), "123456", mock(Session.class), 5));
     }
 
     @Test
@@ -139,8 +146,8 @@ public class ValidationServiceTest {
         when(session.getRetryCount()).thenReturn(1);
         assertEquals(
                 SessionAction.USER_ENTERED_INVALID_PHONE_VERIFICATION_CODE,
-                validationService.validatePhoneVerificationCode(
-                        Optional.of("654321"), "123456", session, 5));
+                validationService.validateVerificationCode(
+                        VERIFY_PHONE_NUMBER, Optional.of("654321"), "123456", session, 5));
     }
 
     @Test
@@ -150,24 +157,24 @@ public class ValidationServiceTest {
         when(session.getRetryCount()).thenReturn(6);
         assertEquals(
                 SessionAction.USER_ENTERED_INVALID_PHONE_VERIFICATION_CODE_TOO_MANY_TIMES,
-                validationService.validatePhoneVerificationCode(
-                        Optional.of("654321"), "123456", session, 5));
+                validationService.validateVerificationCode(
+                        VERIFY_PHONE_NUMBER, Optional.of("654321"), "123456", session, 5));
     }
 
     @Test
     public void shouldReturnCorrectStateWhenEmailCodeMatchesStored() {
         assertEquals(
                 SessionAction.USER_ENTERED_VALID_EMAIL_VERIFICATION_CODE,
-                validationService.validateEmailVerificationCode(
-                        Optional.of("123456"), "123456", mock(Session.class), 5));
+                validationService.validateVerificationCode(
+                        VERIFY_EMAIL, Optional.of("123456"), "123456", mock(Session.class), 5));
     }
 
     @Test
     public void shouldReturnCorrectStateWhenStoredEmailCodeIsEmpty() {
         assertEquals(
                 SessionAction.USER_ENTERED_INVALID_EMAIL_VERIFICATION_CODE,
-                validationService.validateEmailVerificationCode(
-                        Optional.empty(), "123456", mock(Session.class), 5));
+                validationService.validateVerificationCode(
+                        VERIFY_EMAIL, Optional.empty(), "123456", mock(Session.class), 5));
     }
 
     @Test
@@ -177,8 +184,8 @@ public class ValidationServiceTest {
         when(session.getRetryCount()).thenReturn(1);
         assertEquals(
                 SessionAction.USER_ENTERED_INVALID_EMAIL_VERIFICATION_CODE,
-                validationService.validateEmailVerificationCode(
-                        Optional.of("654321"), "123456", session, 5));
+                validationService.validateVerificationCode(
+                        VERIFY_EMAIL, Optional.of("654321"), "123456", session, 5));
     }
 
     @Test
@@ -188,24 +195,24 @@ public class ValidationServiceTest {
         when(session.getRetryCount()).thenReturn(6);
         assertEquals(
                 SessionAction.USER_ENTERED_INVALID_EMAIL_VERIFICATION_CODE_TOO_MANY_TIMES,
-                validationService.validateEmailVerificationCode(
-                        Optional.of("654321"), "123456", session, 5));
+                validationService.validateVerificationCode(
+                        VERIFY_EMAIL, Optional.of("654321"), "123456", session, 5));
     }
 
     @Test
     public void shouldReturnCorrectStateWhenMfaCodeMatchesStored() {
         assertEquals(
                 SessionAction.USER_ENTERED_VALID_MFA_CODE,
-                validationService.validateMfaVerificationCode(
-                        Optional.of("123456"), "123456", mock(Session.class), 5));
+                validationService.validateVerificationCode(
+                        MFA_SMS, Optional.of("123456"), "123456", mock(Session.class), 5));
     }
 
     @Test
     public void shouldReturnCorrectStateWhenStoredMfaCodeIsEmpty() {
         assertEquals(
                 SessionAction.USER_ENTERED_INVALID_MFA_CODE,
-                validationService.validateMfaVerificationCode(
-                        Optional.empty(), "123456", mock(Session.class), 5));
+                validationService.validateVerificationCode(
+                        MFA_SMS, Optional.empty(), "123456", mock(Session.class), 5));
     }
 
     @Test
@@ -215,8 +222,8 @@ public class ValidationServiceTest {
         when(session.getRetryCount()).thenReturn(1);
         assertEquals(
                 SessionAction.USER_ENTERED_INVALID_MFA_CODE,
-                validationService.validateMfaVerificationCode(
-                        Optional.of("654321"), "123456", session, 5));
+                validationService.validateVerificationCode(
+                        MFA_SMS, Optional.of("654321"), "123456", session, 5));
     }
 
     @Test
@@ -226,8 +233,8 @@ public class ValidationServiceTest {
         when(session.getRetryCount()).thenReturn(6);
         assertEquals(
                 SessionAction.USER_ENTERED_INVALID_MFA_CODE_TOO_MANY_TIMES,
-                validationService.validateMfaVerificationCode(
-                        Optional.of("654321"), "123456", session, 5));
+                validationService.validateVerificationCode(
+                        MFA_SMS, Optional.of("654321"), "123456", session, 5));
     }
 
     @Test


### PR DESCRIPTION
This is an attempt to break apart the large switch statement in `VerifyCodeHandler`.

It does this by pulling out logic into other places, primarily `ValidationService`, and removing duplication with early returns.

Feedback on the approach appreciated.
