### PR TITLE
GOVSI-839 - Change State machine to account for drop offs

### DIFF
--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
@@ -192,7 +192,7 @@ class LoginHandlerTest {
     }
 
     @Test
-    public void shouldReturn400IfUserTransitionsFromWrongState() throws JsonProcessingException {
+    public void shouldReturn400IfUserTransitionsFromWrongState() {
         when(authenticationService.userExists(EMAIL)).thenReturn(true);
         when(authenticationService.login(EMAIL, PASSWORD)).thenReturn(true);
         when(authenticationService.getPhoneNumber(EMAIL)).thenReturn(Optional.of(PHONE_NUMBER));

--- a/integration-tests/src/test/java/uk/gov/di/authentication/helpers/DynamoHelper.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/helpers/DynamoHelper.java
@@ -57,6 +57,7 @@ public class DynamoHelper {
 
     public static void addPhoneNumber(String email, String phoneNumber) {
         DYNAMO_SERVICE.updatePhoneNumber(email, phoneNumber);
+        DYNAMO_SERVICE.updatePhoneNumberVerifiedStatus(email, true);
     }
 
     public static void setPhoneNumberVerified(String email, boolean isVerified) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/state/StateMachine.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/state/StateMachine.java
@@ -78,6 +78,7 @@ import static uk.gov.di.authentication.shared.entity.SessionState.VERIFY_EMAIL_C
 import static uk.gov.di.authentication.shared.entity.SessionState.VERIFY_PHONE_NUMBER_CODE_SENT;
 import static uk.gov.di.authentication.shared.state.conditions.AggregateCondition.and;
 import static uk.gov.di.authentication.shared.state.conditions.ClientDoesNotRequireMfa.clientDoesNotRequireMfa;
+import static uk.gov.di.authentication.shared.state.conditions.PhoneNumberUnverified.phoneNumberUnverified;
 import static uk.gov.di.authentication.shared.state.conditions.TermsAndConditionsVersionNotAccepted.userHasNotAcceptedTermsAndConditionsVersion;
 
 public class StateMachine<T, A, C> {
@@ -215,6 +216,9 @@ public class StateMachine<T, A, C> {
                 .allow(on(SYSTEM_HAS_SENT_RESET_PASSWORD_LINK).then(RESET_PASSWORD_LINK_SENT))
                 .when(AUTHENTICATION_REQUIRED)
                 .allow(
+                        on(USER_ENTERED_VALID_CREDENTIALS)
+                                .ifCondition(phoneNumberUnverified())
+                                .then(TWO_FACTOR_REQUIRED),
                         on(USER_ENTERED_VALID_CREDENTIALS)
                                 .ifCondition(
                                         and(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/state/conditions/PhoneNumberUnverified.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/state/conditions/PhoneNumberUnverified.java
@@ -1,0 +1,20 @@
+package uk.gov.di.authentication.shared.state.conditions;
+
+import uk.gov.di.authentication.shared.state.Condition;
+import uk.gov.di.authentication.shared.state.UserContext;
+
+import java.util.Optional;
+
+public class PhoneNumberUnverified implements Condition<UserContext> {
+
+    @Override
+    public boolean isMet(Optional<UserContext> context) {
+        return context.flatMap(UserContext::getUserProfile)
+                .map(t -> !t.isPhoneNumberVerified())
+                .orElse(false);
+    }
+
+    public static PhoneNumberUnverified phoneNumberUnverified() {
+        return new PhoneNumberUnverified();
+    }
+}


### PR DESCRIPTION
## What?

- Before transitioning the user state after a successful login, check to see if the phone number has been verified. If it hasn't then return the TWO_FACTOR_REQUIRED back to the frontend. 

## Why?

- When a user starts a sign up journey but either doesn't enter their phone number or doesn't verify their phone number and then drop offs, we need to ensure that next time they log in we redirect them back to the register their phone number screen on the sign up journey. This prevents a user entering an incorrect phone number which hasn't been verified and therefore gives them the chance to enter it and confirm it before it is used for MFA