### PR TITLE
GOVSI-820: Save effective VTR for auth-request in client session

### DIFF
--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/helpers/RedisHelper.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/helpers/RedisHelper.java
@@ -10,6 +10,7 @@ import uk.gov.di.authentication.shared.entity.AuthCodeExchangeData;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.SessionState;
+import uk.gov.di.authentication.shared.entity.VectorOfTrust;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.services.CodeGeneratorService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
@@ -63,7 +64,8 @@ public class RedisHelper {
             redis.saveWithExpiry(
                     CLIENT_SESSION_PREFIX.concat(clientSessionId),
                     OBJECT_MAPPER.writeValueAsString(
-                            new ClientSession(authRequest, LocalDateTime.now())),
+                            new ClientSession(
+                                    authRequest, LocalDateTime.now(), VectorOfTrust.getDefaults())),
                     3600);
 
         } catch (IOException e) {
@@ -181,7 +183,8 @@ public class RedisHelper {
             redis.saveWithExpiry(
                     CLIENT_SESSION_PREFIX.concat(clientSessionId),
                     OBJECT_MAPPER.writeValueAsString(
-                            new ClientSession(authRequest, LocalDateTime.now())),
+                            new ClientSession(
+                                    authRequest, LocalDateTime.now(), VectorOfTrust.getDefaults())),
                     300);
         } catch (IOException e) {
             throw new RuntimeException(e);
@@ -195,7 +198,8 @@ public class RedisHelper {
             redis.saveWithExpiry(
                     CLIENT_SESSION_PREFIX.concat(clientSessionId),
                     OBJECT_MAPPER.writeValueAsString(
-                            new ClientSession(authRequest, LocalDateTime.now())),
+                            new ClientSession(
+                                    authRequest, LocalDateTime.now(), VectorOfTrust.getDefaults())),
                     300);
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/ClientInfoHandlerTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/ClientInfoHandlerTest.java
@@ -19,6 +19,7 @@ import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.Session;
+import uk.gov.di.authentication.shared.entity.VectorOfTrust;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -140,6 +141,7 @@ public class ClientInfoHandlerTest {
                         .state(state)
                         .nonce(new Nonce())
                         .build();
-        return Optional.of(new ClientSession(authRequest.toParameters(), null));
+        return Optional.of(
+                new ClientSession(authRequest.toParameters(), null, mock(VectorOfTrust.class)));
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandlerTest.java
@@ -21,6 +21,7 @@ import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.SessionAction;
 import uk.gov.di.authentication.shared.entity.SessionState;
+import uk.gov.di.authentication.shared.entity.VectorOfTrust;
 import uk.gov.di.authentication.shared.exceptions.ClientNotFoundException;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
@@ -248,7 +249,8 @@ class UpdateProfileHandlerTest {
                         .nonce(new Nonce())
                         .build();
         ClientSession clientSession =
-                new ClientSession(authRequest.toParameters(), LocalDateTime.now());
+                new ClientSession(
+                        authRequest.toParameters(), LocalDateTime.now(), mock(VectorOfTrust.class));
         when(clientSessionService.getClientSessionFromRequestHeaders(anyMap()))
                 .thenReturn(Optional.of(clientSession));
         return authRequest;

--- a/integration-tests/src/test/java/uk/gov/di/authentication/helpers/RedisHelper.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/helpers/RedisHelper.java
@@ -10,6 +10,7 @@ import uk.gov.di.authentication.shared.entity.AuthCodeExchangeData;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.SessionState;
+import uk.gov.di.authentication.shared.entity.VectorOfTrust;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.services.CodeGeneratorService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
@@ -65,7 +66,8 @@ public class RedisHelper {
             redis.saveWithExpiry(
                     CLIENT_SESSION_PREFIX.concat(clientSessionId),
                     OBJECT_MAPPER.writeValueAsString(
-                            new ClientSession(authRequest, LocalDateTime.now())),
+                            new ClientSession(
+                                    authRequest, LocalDateTime.now(), VectorOfTrust.getDefaults())),
                     3600);
 
         } catch (IOException e) {
@@ -204,7 +206,8 @@ public class RedisHelper {
             redis.saveWithExpiry(
                     CLIENT_SESSION_PREFIX.concat(clientSessionId),
                     OBJECT_MAPPER.writeValueAsString(
-                            new ClientSession(authRequest, LocalDateTime.now())),
+                            new ClientSession(
+                                    authRequest, LocalDateTime.now(), VectorOfTrust.getDefaults())),
                     300);
         } catch (IOException e) {
             throw new RuntimeException(e);
@@ -218,7 +221,8 @@ public class RedisHelper {
             redis.saveWithExpiry(
                     CLIENT_SESSION_PREFIX.concat(clientSessionId),
                     OBJECT_MAPPER.writeValueAsString(
-                            new ClientSession(authRequest, LocalDateTime.now())),
+                            new ClientSession(
+                                    authRequest, LocalDateTime.now(), VectorOfTrust.getDefaults())),
                     300);
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -22,6 +22,7 @@ import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.SessionState;
+import uk.gov.di.authentication.shared.entity.VectorOfTrust;
 import uk.gov.di.authentication.shared.exceptions.ClientNotFoundException;
 import uk.gov.di.authentication.shared.services.AuthorisationCodeService;
 import uk.gov.di.authentication.shared.services.AuthorizationService;
@@ -243,7 +244,9 @@ class AuthCodeHandlerTest {
     private void generateValidSession(Map<String, List<String>> authRequest) {
         when(sessionService.readSessionFromRedis(SESSION_ID)).thenReturn(Optional.of(session));
         when(clientSessionService.getClientSession(CLIENT_SESSION_ID))
-                .thenReturn(new ClientSession(authRequest, LocalDateTime.now()));
+                .thenReturn(
+                        new ClientSession(
+                                authRequest, LocalDateTime.now(), mock(VectorOfTrust.class)));
     }
 
     private String buildCookieString() {

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/LogoutHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/LogoutHandlerTest.java
@@ -18,6 +18,7 @@ import uk.gov.di.authentication.oidc.entity.ResponseHeaders;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.Session;
+import uk.gov.di.authentication.shared.entity.VectorOfTrust;
 import uk.gov.di.authentication.shared.helpers.TokenGeneratorHelper;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -274,7 +275,8 @@ class LogoutHandlerTest {
                                 List.of("code"),
                                 "state",
                                 List.of("some-state")),
-                        LocalDateTime.now());
+                        LocalDateTime.now(),
+                        mock(VectorOfTrust.class));
         clientSession.setIdTokenHint(idToken.serialize());
         when(clientSessionService.getClientSession(CLIENT_SESSION_ID)).thenReturn(clientSession);
     }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
@@ -38,6 +38,7 @@ import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.TokenStore;
 import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.entity.VectorOfTrust;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.TokenGeneratorHelper;
 import uk.gov.di.authentication.shared.services.AuthorisationCodeService;
@@ -156,7 +157,9 @@ public class TokenHandlerTest {
         when(clientSessionService.getClientSession(CLIENT_SESSION_ID))
                 .thenReturn(
                         new ClientSession(
-                                generateAuthRequest().toParameters(), LocalDateTime.now()));
+                                generateAuthRequest().toParameters(),
+                                LocalDateTime.now(),
+                                mock(VectorOfTrust.class)));
         when(dynamoService.getSubjectFromEmail(eq(TEST_EMAIL))).thenReturn(INTERNAL_SUBJECT);
         when(dynamoService.getUserProfileByEmail(eq(TEST_EMAIL))).thenReturn(userProfile);
         when(tokenService.generateTokenResponse(
@@ -300,7 +303,9 @@ public class TokenHandlerTest {
         when(clientSessionService.getClientSession(CLIENT_SESSION_ID))
                 .thenReturn(
                         new ClientSession(
-                                generateAuthRequest().toParameters(), LocalDateTime.now()));
+                                generateAuthRequest().toParameters(),
+                                LocalDateTime.now(),
+                                mock(VectorOfTrust.class)));
 
         APIGatewayProxyResponseEvent result =
                 generateApiGatewayRequest(privateKeyJWT, authCode, "http://invalid-redirect-uri");

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ClientSession.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ClientSession.java
@@ -17,12 +17,18 @@ public class ClientSession {
     @JsonProperty("creation_date")
     private LocalDateTime creationDate;
 
+    @JsonProperty("effective_vector_of_trust")
+    private VectorOfTrust effectiveVectorOfTrust;
+
     public ClientSession(
             @JsonProperty(required = true, value = "auth_request_params")
                     Map<String, List<String>> authRequestParams,
-            @JsonProperty(required = true, value = "creation_date") LocalDateTime creationDate) {
+            @JsonProperty(required = true, value = "creation_date") LocalDateTime creationDate,
+            @JsonProperty(required = true, value = "effective_vector_of_trust")
+                    VectorOfTrust effectiveVectorOfTrust) {
         this.authRequestParams = authRequestParams;
         this.creationDate = creationDate;
+        this.effectiveVectorOfTrust = effectiveVectorOfTrust;
     }
 
     public ClientSession setIdTokenHint(String idTokenHint) {
@@ -40,5 +46,9 @@ public class ClientSession {
 
     public LocalDateTime getCreationDate() {
         return creationDate;
+    }
+
+    public VectorOfTrust getEffectiveVectorOfTrust() {
+        return effectiveVectorOfTrust;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/VectorOfTrust.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/VectorOfTrust.java
@@ -1,19 +1,33 @@
 package uk.gov.di.authentication.shared.entity;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
 public class VectorOfTrust {
 
+    @JsonProperty("credential_trust_level")
     private final CredentialTrustLevel credentialTrustLevel;
 
-    private VectorOfTrust(CredentialTrustLevel credentialTrustLevel) {
+    @JsonCreator
+    private VectorOfTrust(
+            @JsonProperty(required = true, value = "credential_trust_level")
+                    CredentialTrustLevel credentialTrustLevel) {
         this.credentialTrustLevel = credentialTrustLevel;
     }
 
     public CredentialTrustLevel getCredentialTrustLevel() {
         return credentialTrustLevel;
+    }
+
+    public static VectorOfTrust parse(List<String> vtr, VectorOfTrust clientDefaults) {
+        if (Objects.isNull(vtr)) {
+            return clientDefaults;
+        }
+        return parse(String.join(".", vtr), clientDefaults.getCredentialTrustLevel());
     }
 
     public static final VectorOfTrust parse(List<String> vtr) {
@@ -36,5 +50,9 @@ public class VectorOfTrust {
             }
         }
         return new VectorOfTrust(credentialTrustLevel);
+    }
+
+    public static VectorOfTrust getDefaults() {
+        return new VectorOfTrust(CredentialTrustLevel.getDefault());
     }
 }


### PR DESCRIPTION
## What?

- Calculate effective `vtr` based on request and client defaults
- Save this into the `ClientSession` object during the `authorize` process

## Why?

We need to save the effective VoT for the authorisation request in order to apply it later and use it to determine if uplift is required.