### PR TITLE
BAU: Fix Notify Stub and cache generated key-pair

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/helpers/KeyPairHelper.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/helpers/KeyPairHelper.java
@@ -4,18 +4,25 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 
+import static java.util.Objects.isNull;
+
 public class KeyPairHelper {
 
     private KeyPairHelper() {}
 
+    private static KeyPair cachedKeyPair = null;
+
     public static final KeyPair GENERATE_RSA_KEY_PAIR() {
-        KeyPairGenerator kpg;
-        try {
-            kpg = KeyPairGenerator.getInstance("RSA");
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException();
+        if (isNull(KeyPairHelper.cachedKeyPair)) {
+            KeyPairGenerator kpg;
+            try {
+                kpg = KeyPairGenerator.getInstance("RSA");
+            } catch (NoSuchAlgorithmException e) {
+                throw new RuntimeException();
+            }
+            kpg.initialize(2048);
+            KeyPairHelper.cachedKeyPair = kpg.generateKeyPair();
         }
-        kpg.initialize(2048);
-        return kpg.generateKeyPair();
+        return KeyPairHelper.cachedKeyPair;
     }
 }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/NotifyStubExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/NotifyStubExtension.java
@@ -40,16 +40,15 @@ public class NotifyStubExtension extends HttpStubExtension {
                         + "  }"
                         + "}");
         register(
-                "/v2/notifications/email",
+                "/v2/notifications/sms",
                 201,
                 "application/json",
                 "{"
                         + "  \"id\": \"740e5834-3a29-46b4-9a6f-16142fde533a\","
                         + "  \"reference\": \"STRING\","
                         + "  \"content\": {"
-                        + "    \"subject\": \"SUBJECT TEXT\","
                         + "    \"body\": \"MESSAGE TEXT\",\n"
-                        + "    \"from_email\": \"SENDER EMAIL\""
+                        + "    \"from_number\": \"SENDER\""
                         + "  },"
                         + "  \"uri\": \"http://localhost:8888/v2/notifications/a-message-id\","
                         + "  \"template\": {"


### PR DESCRIPTION
## What?

- Cache the KeyPair generated by `GENERATE_RSA_KEY_PAIR()`
- Fix SMS endpoint on StubNotifyExtension 

## Why?

The `GENERATE_RSA_KEY_PAIR()` static method takes 15-20 seconds to execute and it runs 6 times in the course of the integration tests. As we don't need unique keys for the tests, we should cache the keys a re-use them where required.

The `StubNotifyExtension` was incorrectly registering the `email` endpoint twice rather than the `sms` and `email` end points. This is causing random integration test failures.
