### PR TITLE
GOVSI-830: Send basic audit payload to SNS topic

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/matchers/AuditMessageMatcher.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/matchers/AuditMessageMatcher.java
@@ -1,0 +1,70 @@
+package uk.gov.di.authentication.shared.matchers;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+import uk.gov.di.audit.AuditPayload;
+
+import java.nio.charset.StandardCharsets;
+import java.util.function.Function;
+
+public class AuditMessageMatcher<T> extends TypeSafeDiagnosingMatcher<String> {
+
+    private final String name;
+    private final Function<String, T> mapper;
+    private final T expected;
+
+    private AuditMessageMatcher(
+            String name, Function<AuditPayload.AuditEvent, T> mapper, T expected) {
+        this.name = name;
+        this.expected = expected;
+
+        Function<String, AuditPayload.AuditEvent>
+                annoyingInterimVariableBecauseFPIsANightmareInJava = this::deserialiseAuditEvent;
+        this.mapper = annoyingInterimVariableBecauseFPIsANightmareInJava.andThen(mapper);
+    }
+
+    public static AuditMessageMatcher<String> hasEventName(String eventName) {
+        return new AuditMessageMatcher<>(
+                "event name", AuditPayload.AuditEvent::getEventName, eventName);
+    }
+
+    public static AuditMessageMatcher<String> hasTimestamp(String timestampAsString) {
+        return new AuditMessageMatcher<>(
+                "timestamp", AuditPayload.AuditEvent::getTimestamp, timestampAsString);
+    }
+
+    @Override
+    protected boolean matchesSafely(
+            String serialisedAuditMessage, Description mismatchDescription) {
+        var actual = mapper.apply(serialisedAuditMessage);
+
+        boolean matched = actual.equals(expected);
+
+        if (!matched) {
+            mismatchDescription.appendText(description(actual));
+        }
+
+        return matched;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText(description(expected));
+    }
+
+    private String description(T value) {
+        return "an audit message with " + name + ": " + value;
+    }
+
+    private AuditPayload.AuditEvent deserialiseAuditEvent(String serialisedMessage) {
+        try {
+            var signedAuditEvent =
+                    AuditPayload.SignedAuditEvent.parseFrom(
+                            serialisedMessage.getBytes(StandardCharsets.UTF_8));
+
+            return AuditPayload.AuditEvent.parseFrom(signedAuditEvent.getPayload());
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
@@ -1,6 +1,7 @@
 package uk.gov.di.authentication.shared.services;
 
-import uk.gov.di.audit.AuditPayload;
+import uk.gov.di.audit.AuditPayload.AuditEvent;
+import uk.gov.di.audit.AuditPayload.SignedAuditEvent;
 import uk.gov.di.authentication.shared.domain.AuditableEvent;
 
 import java.time.Clock;
@@ -28,12 +29,12 @@ public class AuditService {
     String generateLogLine(AuditableEvent eventEnum, MetadataPair... metadataPairs) {
         var timestamp = clock.instant().toString();
 
-        var eventBuilder = AuditPayload.AuditEvent.newBuilder();
+        var eventBuilder = AuditEvent.newBuilder();
         eventBuilder.setEventName(eventEnum.toString());
         eventBuilder.setTimestamp(timestamp);
         // TODO - Extract other values from the metadataPairs argument.
 
-        var signedEventBuilder = AuditPayload.SignedAuditEvent.newBuilder();
+        var signedEventBuilder = SignedAuditEvent.newBuilder();
         signedEventBuilder.setPayload(eventBuilder.build().toByteString());
         // TODO - We need to sign the event at this point, but we don't yet have the infrastructure
         // in place to do that.

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
@@ -1,24 +1,23 @@
 package uk.gov.di.authentication.shared.services;
 
-import com.google.protobuf.ByteString;
-import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.MockitoAnnotations;
-import uk.gov.di.audit.AuditPayload;
 import uk.gov.di.authentication.shared.domain.AuditableEvent;
 
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
 
-import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static uk.gov.di.authentication.shared.matchers.AuditMessageMatcher.hasEventName;
+import static uk.gov.di.authentication.shared.matchers.AuditMessageMatcher.hasTimestamp;
 import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
 import static uk.gov.di.authentication.shared.services.AuditServiceTest.TestEvents.TEST_EVENT_ONE;
 
@@ -47,40 +46,28 @@ class AuditServiceTest {
     }
 
     @Test
-    void shouldLogAuditEvent() throws Exception {
+    void shouldLogAuditEvent() {
         var auditService = new AuditService(FIXED_CLOCK, snsService);
 
         auditService.submitAuditEvent(TEST_EVENT_ONE);
 
         verify(snsService).publishAuditMessage(messageCaptor.capture());
+        var serialisedAuditMessage = messageCaptor.getValue();
 
-        var signedAuditEvent =
-                AuditPayload.SignedAuditEvent.parseFrom(
-                        ByteString.copyFromUtf8(messageCaptor.getValue()));
-        var auditEvent = AuditPayload.AuditEvent.parseFrom(signedAuditEvent.getPayload());
-
-        MatcherAssert.assertThat(auditEvent.getTimestamp(), equalTo(FIXED_TIMESTAMP));
-
-        MatcherAssert.assertThat(
-                auditEvent.getEventNameBytes().toStringUtf8(), equalTo(TEST_EVENT_ONE.toString()));
+        assertThat(serialisedAuditMessage, hasTimestamp(FIXED_TIMESTAMP));
+        assertThat(serialisedAuditMessage, hasEventName(TEST_EVENT_ONE.toString()));
     }
 
     @Test
-    void shouldLogAuditEventWithMetadataPairsAttached() throws Exception {
+    void shouldLogAuditEventWithMetadataPairsAttached() {
         var auditService = new AuditService(FIXED_CLOCK, snsService);
 
         auditService.submitAuditEvent(TEST_EVENT_ONE, pair("key", "value"), pair("key2", "value2"));
 
         verify(snsService).publishAuditMessage(messageCaptor.capture());
+        var serialisedAuditMessage = messageCaptor.getValue();
 
-        var signedAuditEvent =
-                AuditPayload.SignedAuditEvent.parseFrom(
-                        ByteString.copyFromUtf8(messageCaptor.getValue()));
-        var auditEvent = AuditPayload.AuditEvent.parseFrom(signedAuditEvent.getPayload());
-
-        MatcherAssert.assertThat(auditEvent.getTimestamp(), equalTo(FIXED_TIMESTAMP));
-
-        MatcherAssert.assertThat(
-                auditEvent.getEventNameBytes().toStringUtf8(), equalTo(TEST_EVENT_ONE.toString()));
+        assertThat(serialisedAuditMessage, hasTimestamp(FIXED_TIMESTAMP));
+        assertThat(serialisedAuditMessage, hasEventName(TEST_EVENT_ONE.toString()));
     }
 }


### PR DESCRIPTION
## What?

Send a basic audit payload to the SNS topic, rather than sending a string.

* For the moment, the payload consists only of the event name and a timestamp; we'll add other fields in a subsequent PR
* Although we're using a protobuf container called SignedAuditEvent, we're not yet actually signing it (signature will be dealt with in a later task)

## Why?

Using a structured format should help make the audit logs more searchable.

## Special exercise for reviewer

Can you spot the moment when my patience snapped and I gave up on trying to work out the 'right' way to compose a method reference and a function in Java?  I really wish GDS would let us use a modern language (Kotlin, Scala).

Open to suggestions about renaming the offending variable, or, better yet, what obscure syntax I can use to get rid of the need for it.