### PR TITLE
GOVSI-368 -  Add consent and t&c checks for SSO

### DIFF
--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/helpers/DynamoHelper.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/helpers/DynamoHelper.java
@@ -12,7 +12,8 @@ import uk.gov.di.authentication.shared.entity.TermsAndConditions;
 import uk.gov.di.authentication.shared.services.DynamoClientService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 
-import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -38,7 +39,7 @@ public class DynamoHelper {
 
     public static void signUp(String email, String password, Subject subject) {
         TermsAndConditions termsAndConditions =
-                new TermsAndConditions("1.0", String.valueOf(Instant.now().getEpochSecond()));
+                new TermsAndConditions("1.0", LocalDateTime.now(ZoneId.of("UTC")).toString());
         DYNAMO_SERVICE.signUp(email, password, subject, termsAndConditions);
     }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
@@ -24,7 +24,8 @@ import uk.gov.di.authentication.shared.services.ValidationService;
 import uk.gov.di.authentication.shared.state.StateMachine;
 import uk.gov.di.authentication.shared.state.UserContext;
 
-import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Optional;
 
 import static uk.gov.di.authentication.shared.entity.SessionAction.USER_HAS_CREATED_A_PASSWORD;
@@ -115,8 +116,8 @@ public class SignUpHandler
                                             new TermsAndConditions(
                                                     configurationService
                                                             .getTermsAndConditionsVersion(),
-                                                    String.valueOf(
-                                                            Instant.now().getEpochSecond())));
+                                                    LocalDateTime.now(ZoneId.of("UTC"))
+                                                            .toString()));
 
                                     sessionService.save(
                                             session.get()

--- a/integration-tests/src/test/java/uk/gov/di/authentication/helpers/DynamoHelper.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/helpers/DynamoHelper.java
@@ -13,7 +13,8 @@ import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.services.DynamoClientService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 
-import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -47,7 +48,7 @@ public class DynamoHelper {
 
     public static void signUp(String email, String password, Subject subject) {
         TermsAndConditions termsAndConditions =
-                new TermsAndConditions("1.0", String.valueOf(Instant.now().getEpochSecond()));
+                new TermsAndConditions("1.0", LocalDateTime.now(ZoneId.of("UTC")).toString());
         DYNAMO_SERVICE.signUp(email, password, subject, termsAndConditions);
     }
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -51,7 +51,6 @@ public class AuthorisationHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AuthorisationHandler.class);
-    public static final String VTR = "vtr";
 
     private final SessionService sessionService;
     private final ConfigurationService configurationService;
@@ -184,8 +183,7 @@ public class AuthorisationHandler
                         LocalDateTime.now(),
                         authorizationService.getEffectiveVectorOfTrust(authenticationRequest));
         String clientSessionID = clientSessionService.generateClientSession(clientSession);
-        UserContext userContext =
-                UserContext.builder(session).withClientSession(clientSession).build();
+        UserContext userContext = authorizationService.buildUserContext(session, clientSession);
         SessionState nextState =
                 stateMachine.transition(session.getState(), sessionAction, userContext);
         URI redirectUri;

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -57,6 +57,7 @@ class AuthorisationHandlerTest {
     private final SessionService sessionService = mock(SessionService.class);
     private final ClientSessionService clientSessionService = mock(ClientSessionService.class);
     private final AuthorizationService authorizationService = mock(AuthorizationService.class);
+    private final UserContext userContext = mock(UserContext.class);
     private final AuditService auditService = mock(AuditService.class);
     private final StateMachine<SessionState, SessionAction, UserContext> stateMachine =
             mock(StateMachine.class);
@@ -225,6 +226,8 @@ class AuthorisationHandlerTest {
 
         whenLoggedIn(session, loginUrl);
         when(configService.getAuthCodeURI()).thenReturn(authCodeUri);
+        when(authorizationService.buildUserContext(eq(session), any(ClientSession.class)))
+                .thenReturn(userContext);
 
         APIGatewayProxyResponseEvent response = makeHandlerRequest(withRequestEvent());
         URI uri = URI.create(response.getHeaders().get(ResponseHeaders.LOCATION));
@@ -264,6 +267,8 @@ class AuthorisationHandlerTest {
 
         whenLoggedIn(session, loginUrl);
         when(configService.getAuthCodeURI()).thenReturn(authCodeUri);
+        when(authorizationService.buildUserContext(eq(session), any(ClientSession.class)))
+                .thenReturn(userContext);
 
         APIGatewayProxyResponseEvent response = makeHandlerRequest(withPromptRequestEvent("none"));
         URI uri = URI.create(response.getHeaders().get(ResponseHeaders.LOCATION));
@@ -314,6 +319,8 @@ class AuthorisationHandlerTest {
                         session.getSessionId());
 
         whenLoggedIn(session, loginUrl);
+        when(authorizationService.buildUserContext(eq(session), any(ClientSession.class)))
+                .thenReturn(userContext);
 
         APIGatewayProxyResponseEvent response = makeHandlerRequest(withPromptRequestEvent("login"));
         URI uri = URI.create(response.getHeaders().get(ResponseHeaders.LOCATION));
@@ -455,7 +462,8 @@ class AuthorisationHandlerTest {
                 format(
                         "gs=%s.client-session-id; Max-Age=3600; Domain=auth.ida.digital.cabinet-office.gov.uk; Secure; HttpOnly;",
                         session.getSessionId());
-
+        when(authorizationService.buildUserContext(eq(session), any(ClientSession.class)))
+                .thenReturn(userContext);
         APIGatewayProxyResponseEvent response = makeHandlerRequest(withRequestEvent());
         URI uri = URI.create(response.getHeaders().get(ResponseHeaders.LOCATION));
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/SessionState.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/SessionState.java
@@ -37,5 +37,6 @@ public enum SessionState {
     ACCOUNT_TEMPORARILY_LOCKED,
     UPLIFT_REQUIRED_CM;
 
-    public static List<SessionState> INTERRUPT_STATES = List.of(UPLIFT_REQUIRED_CM);
+    public static List<SessionState> INTERRUPT_STATES =
+            List.of(UPLIFT_REQUIRED_CM, CONSENT_REQUIRED, UPDATED_TERMS_AND_CONDITIONS);
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/UserProfile.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/UserProfile.java
@@ -115,6 +115,7 @@ public class UserProfile {
         if (this.clientConsent == null) {
             this.clientConsent = List.of(consent);
         } else {
+            this.clientConsent.removeIf(t -> t.getClientId().equals(consent.getClientId()));
             this.clientConsent.add(consent);
         }
         return this;

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
@@ -16,8 +16,8 @@ import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.Argon2Helper;
 
-import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -136,8 +136,8 @@ public class DynamoService implements AuthenticationService {
 
     @Override
     public void updateTermsAndConditions(String email, String version) {
-        String epochTime = String.valueOf(Instant.now().getEpochSecond());
-        TermsAndConditions termsAndConditions = new TermsAndConditions(version, epochTime);
+        TermsAndConditions termsAndConditions =
+                new TermsAndConditions(version, LocalDateTime.now(ZoneId.of("UTC")).toString());
 
         userProfileMapper.save(
                 userProfileMapper

--- a/shared/src/main/java/uk/gov/di/authentication/shared/state/StateMachine.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/state/StateMachine.java
@@ -300,6 +300,9 @@ public class StateMachine<T, A, C> {
                                         userHasNotAcceptedTermsAndConditionsVersion(
                                                 configurationService
                                                         .getTermsAndConditionsVersion())),
+                        on(USER_ENTERED_VALID_MFA_CODE)
+                                .then(CONSENT_REQUIRED)
+                                .ifCondition(userHasNotGivenConsent()),
                         on(USER_ENTERED_VALID_MFA_CODE).then(MFA_CODE_VERIFIED).byDefault(),
                         on(USER_ENTERED_INVALID_MFA_CODE).then(MFA_CODE_NOT_VALID),
                         on(USER_HAS_STARTED_A_NEW_JOURNEY).then(NEW),
@@ -364,6 +367,15 @@ public class StateMachine<T, A, C> {
                         on(USER_HAS_STARTED_A_NEW_JOURNEY)
                                 .ifCondition(and(upliftRequired(), requestedLevelOfTrustIsCm()))
                                 .then(UPLIFT_REQUIRED_CM),
+                        on(USER_HAS_STARTED_A_NEW_JOURNEY)
+                                .then(UPDATED_TERMS_AND_CONDITIONS)
+                                .ifCondition(
+                                        userHasNotAcceptedTermsAndConditionsVersion(
+                                                configurationService
+                                                        .getTermsAndConditionsVersion())),
+                        on(USER_HAS_STARTED_A_NEW_JOURNEY)
+                                .then(CONSENT_REQUIRED)
+                                .ifCondition(userHasNotGivenConsent()),
                         on(USER_HAS_STARTED_A_NEW_JOURNEY).then(AUTHENTICATED),
                         on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED)
                                 .then(AUTHENTICATION_REQUIRED))


### PR DESCRIPTION
## What and Why?

- Update terms and conditions time to be consistent with times of the other data in dynamo
- When a client consent already exists with a client ID rather avoid creating a duplicate entry with the same client ID and just update what is already there
- Build the user context in authorize so that we can check if a user requires consent or needs to approve terms and conditions from an SSO journey
- Add extra tests