### PR TITLE
BAU: Add Consent transactions for concurrent journeys

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/state/StateMachine.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/state/StateMachine.java
@@ -354,7 +354,16 @@ public class StateMachine<T, A, C> {
                 .when(CONSENT_REQUIRED)
                 .allow(
                         on(USER_HAS_ACTIONED_CONSENT).then(CONSENT_ADDED),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY).then(NEW),
+                        on(USER_HAS_STARTED_A_NEW_JOURNEY)
+                                .then(UPDATED_TERMS_AND_CONDITIONS)
+                                .ifCondition(
+                                        userHasNotAcceptedTermsAndConditionsVersion(
+                                                configurationService
+                                                        .getTermsAndConditionsVersion())),
+                        on(USER_HAS_STARTED_A_NEW_JOURNEY)
+                                .then(CONSENT_REQUIRED)
+                                .ifCondition(userHasNotGivenConsent()),
+                        on(USER_HAS_STARTED_A_NEW_JOURNEY).then(AUTHENTICATED),
                         on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED).then(NEW))
                 .when(CONSENT_ADDED)
                 .allow(


### PR DESCRIPTION
## What?

- Allow transition from `CONSENT_REQUIRED` to the correct states should the user start a concurrent journey before giving consent

## Why?

To close loopholes in the current state machine