### PR TITLE
BAU: Extend all frontend handlers from BaseFrontendHandler

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/BaseFrontendRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/BaseFrontendRequest.java
@@ -4,19 +4,14 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class UserWithEmailRequest {
+public class BaseFrontendRequest {
     protected String email;
 
-    public UserWithEmailRequest(@JsonProperty(required = true, value = "email") String email) {
+    public BaseFrontendRequest(@JsonProperty(required = true, value = "email") String email) {
         this.email = email;
     }
 
     public String getEmail() {
         return email;
-    }
-
-    @Override
-    public String toString() {
-        return "CheckUserExistsRequest{" + "email='" + email + '\'' + '}';
     }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/CheckUserExistsRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/CheckUserExistsRequest.java
@@ -1,0 +1,14 @@
+package uk.gov.di.authentication.frontendapi.entity;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class CheckUserExistsRequest extends BaseFrontendRequest {
+    public CheckUserExistsRequest(@JsonProperty(required = true, value = "email") String email) {
+        super(email);
+    }
+
+    @Override
+    public String toString() {
+        return "CheckUserExistsRequest{" + "email='" + email + '\'' + '}';
+    }
+}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/LoginRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/LoginRequest.java
@@ -2,7 +2,7 @@ package uk.gov.di.authentication.frontendapi.entity;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class LoginRequest extends UserWithEmailRequest {
+public class LoginRequest extends BaseFrontendRequest {
 
     private String password;
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/MfaRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/MfaRequest.java
@@ -1,0 +1,10 @@
+package uk.gov.di.authentication.frontendapi.entity;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class MfaRequest extends BaseFrontendRequest {
+
+    public MfaRequest(@JsonProperty(required = true, value = "email") String email) {
+        super(email);
+    }
+}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/ResetPasswordRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/ResetPasswordRequest.java
@@ -2,7 +2,7 @@ package uk.gov.di.authentication.frontendapi.entity;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class ResetPasswordRequest extends UserWithEmailRequest {
+public class ResetPasswordRequest extends BaseFrontendRequest {
 
     public ResetPasswordRequest(@JsonProperty(required = true, value = "email") String email) {
         super(email);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/SendNotificationRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/SendNotificationRequest.java
@@ -3,7 +3,7 @@ package uk.gov.di.authentication.frontendapi.entity;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 
-public class SendNotificationRequest extends UserWithEmailRequest {
+public class SendNotificationRequest extends BaseFrontendRequest {
 
     private final NotificationType notificationType;
     private final String phoneNumber;

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/SignupRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/SignupRequest.java
@@ -2,15 +2,14 @@ package uk.gov.di.authentication.frontendapi.entity;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class SignupRequest {
+public class SignupRequest extends BaseFrontendRequest {
 
-    private String email;
     private String password;
 
     public SignupRequest(
             @JsonProperty(required = true, value = "email") String email,
             @JsonProperty(required = true, value = "password") String password) {
-        this.email = email;
+        super(email);
         this.password = password;
     }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/UpdateProfileRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/UpdateProfileRequest.java
@@ -2,9 +2,8 @@ package uk.gov.di.authentication.frontendapi.entity;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class UpdateProfileRequest {
+public class UpdateProfileRequest extends BaseFrontendRequest {
 
-    private String email;
     private UpdateProfileType updateProfileType;
     private String profileInformation;
 
@@ -14,7 +13,7 @@ public class UpdateProfileRequest {
                     UpdateProfileType updateProfileType,
             @JsonProperty(required = true, value = "profileInformation")
                     String profileInformation) {
-        this.email = email;
+        super(email);
         this.updateProfileType = updateProfileType;
         this.profileInformation = profileInformation;
     }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/BaseFrontendHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/BaseFrontendHandler.java
@@ -78,6 +78,10 @@ public abstract class BaseFrontendHandler<T>
         return isWarming(input).orElseGet(() -> validateAndHandleRequest(input, context));
     }
 
+    public void onRequestReceived() {}
+
+    public void onRequestValidationError() {}
+
     public abstract APIGatewayProxyResponseEvent handleRequestWithUserContext(
             APIGatewayProxyRequestEvent input,
             Context context,
@@ -86,6 +90,7 @@ public abstract class BaseFrontendHandler<T>
 
     private APIGatewayProxyResponseEvent validateAndHandleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
+        onRequestReceived();
         Optional<Session> session = sessionService.getSessionFromRequestHeaders(input.getHeaders());
         Optional<ClientSession> clientSession =
                 clientSessionService.getClientSessionFromRequestHeaders(input.getHeaders());
@@ -100,6 +105,7 @@ public abstract class BaseFrontendHandler<T>
             LOG.error(
                     "Request is missing parameters. The body present in request: {}",
                     input.getBody());
+            onRequestValidationError();
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
         }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -8,15 +8,15 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.di.authentication.frontendapi.entity.BaseFrontendRequest;
+import uk.gov.di.authentication.frontendapi.entity.CheckUserExistsRequest;
 import uk.gov.di.authentication.frontendapi.entity.CheckUserExistsResponse;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
-import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.SessionAction;
 import uk.gov.di.authentication.shared.entity.SessionState;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
+import uk.gov.di.authentication.shared.services.ClientService;
+import uk.gov.di.authentication.shared.services.ClientSessionService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
-import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.services.ValidationService;
 import uk.gov.di.authentication.shared.state.StateMachine;
@@ -28,113 +28,97 @@ import static uk.gov.di.authentication.shared.entity.SessionAction.USER_ENTERED_
 import static uk.gov.di.authentication.shared.entity.SessionAction.USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
-import static uk.gov.di.authentication.shared.helpers.WarmerHelper.isWarming;
 import static uk.gov.di.authentication.shared.state.StateMachine.userJourneyStateMachine;
 
-public class CheckUserExistsHandler
+public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsRequest>
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     private static final Logger LOG = LoggerFactory.getLogger(CheckUserExistsHandler.class);
 
     private final ValidationService validationService;
     private final ObjectMapper objectMapper = new ObjectMapper();
-    private final AuthenticationService authenticationService;
-    private final SessionService sessionService;
     private final StateMachine<SessionState, SessionAction, UserContext> stateMachine =
             userJourneyStateMachine();
 
     public CheckUserExistsHandler(
-            ValidationService validationService,
+            ConfigurationService configurationService,
+            SessionService sessionService,
+            ClientSessionService clientSessionService,
+            ClientService clientService,
             AuthenticationService authenticationService,
-            SessionService sessionService) {
+            ValidationService validationService) {
+        super(
+                CheckUserExistsRequest.class,
+                configurationService,
+                sessionService,
+                clientSessionService,
+                clientService,
+                authenticationService);
         this.validationService = validationService;
-        this.authenticationService = authenticationService;
-        this.sessionService = sessionService;
     }
 
     public CheckUserExistsHandler() {
-        ConfigurationService configurationService = new ConfigurationService();
+        super(CheckUserExistsRequest.class, ConfigurationService.getInstance());
         this.validationService = new ValidationService();
-        this.sessionService = new SessionService(configurationService);
-        this.authenticationService =
-                new DynamoService(
-                        configurationService.getAwsRegion(),
-                        configurationService.getEnvironment(),
-                        configurationService.getDynamoEndpointUri());
     }
 
     @Override
-    public APIGatewayProxyResponseEvent handleRequest(
-            APIGatewayProxyRequestEvent input, Context context) {
-        return isWarming(input)
-                .orElseGet(
-                        () -> {
-                            try {
-                                Optional<Session> session =
-                                        sessionService.getSessionFromRequestHeaders(
-                                                input.getHeaders());
-                                if (session.isPresent()) {
-                                    LOG.info(
-                                            "CheckUserExistsHandler processing request for session {}",
-                                            session.get().getSessionId());
+    public APIGatewayProxyResponseEvent handleRequestWithUserContext(
+            APIGatewayProxyRequestEvent input,
+            Context context,
+            CheckUserExistsRequest request,
+            UserContext userContext) {
+        try {
+            LOG.info(
+                    "CheckUserExistsHandler processing request for session {}",
+                    userContext.getSession().getSessionId());
 
-                                    session.get()
-                                            .setState(
-                                                    stateMachine.transition(
-                                                            session.get().getState(),
-                                                            USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS));
+            userContext
+                    .getSession()
+                    .setState(
+                            stateMachine.transition(
+                                    userContext.getSession().getState(),
+                                    USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS,
+                                    userContext));
 
-                                    BaseFrontendRequest userExistsRequest =
-                                            objectMapper.readValue(
-                                                    input.getBody(), BaseFrontendRequest.class);
-                                    String emailAddress = userExistsRequest.getEmail();
-                                    Optional<ErrorResponse> errorResponse =
-                                            validationService.validateEmailAddress(emailAddress);
-                                    if (errorResponse.isPresent()) {
-                                        LOG.error(
-                                                "Encountered an error while processing request for session {}; errorResponse is {}",
-                                                session.get().getSessionId(),
-                                                errorResponse.get());
-                                        return generateApiGatewayProxyErrorResponse(
-                                                400, errorResponse.get());
-                                    }
-                                    boolean userExists =
-                                            authenticationService.userExists(emailAddress);
-                                    session.get().setEmailAddress(emailAddress);
-                                    if (userExists) {
-                                        session.get()
-                                                .setState(
-                                                        stateMachine.transition(
-                                                                session.get().getState(),
-                                                                USER_ENTERED_REGISTERED_EMAIL_ADDRESS));
-                                    }
-                                    CheckUserExistsResponse checkUserExistsResponse =
-                                            new CheckUserExistsResponse(
-                                                    emailAddress,
-                                                    userExists,
-                                                    session.get().getState());
-                                    sessionService.save(session.get());
+            String emailAddress = request.getEmail();
+            Optional<ErrorResponse> errorResponse =
+                    validationService.validateEmailAddress(emailAddress);
+            if (errorResponse.isPresent()) {
+                LOG.error(
+                        "Encountered an error while processing request for session {}; errorResponse is {}",
+                        userContext.getSession().getSessionId(),
+                        errorResponse.get());
+                return generateApiGatewayProxyErrorResponse(400, errorResponse.get());
+            }
+            boolean userExists = authenticationService.userExists(emailAddress);
+            userContext.getSession().setEmailAddress(emailAddress);
+            if (userExists) {
+                userContext
+                        .getSession()
+                        .setState(
+                                stateMachine.transition(
+                                        userContext.getSession().getState(),
+                                        USER_ENTERED_REGISTERED_EMAIL_ADDRESS,
+                                        userContext));
+            }
+            CheckUserExistsResponse checkUserExistsResponse =
+                    new CheckUserExistsResponse(
+                            emailAddress, userExists, userContext.getSession().getState());
+            sessionService.save(userContext.getSession());
 
-                                    LOG.info(
-                                            "CheckUserExistsHandler successfully processed request for session {}",
-                                            session.get().getSessionId());
+            LOG.info(
+                    "CheckUserExistsHandler successfully processed request for session {}",
+                    userContext.getSession().getSessionId());
 
-                                    return generateApiGatewayProxyResponse(
-                                            200, checkUserExistsResponse);
-                                } else {
-                                    LOG.error("Session cannot be found");
-                                    return generateApiGatewayProxyErrorResponse(
-                                            400, ErrorResponse.ERROR_1000);
-                                }
-                            } catch (JsonProcessingException e) {
-                                LOG.error("Error parsing request", e);
-                                return generateApiGatewayProxyErrorResponse(
-                                        400, ErrorResponse.ERROR_1001);
-                            } catch (StateMachine.InvalidStateTransitionException e) {
-                                LOG.error("Invalid transition in user journey", e);
-                                return generateApiGatewayProxyErrorResponse(
-                                        400, ErrorResponse.ERROR_1017);
-                            }
-                        });
+            return generateApiGatewayProxyResponse(200, checkUserExistsResponse);
+
+        } catch (JsonProcessingException e) {
+            LOG.error("Error parsing request", e);
+            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
+        } catch (StateMachine.InvalidStateTransitionException e) {
+            LOG.error("Invalid transition in user journey", e);
+            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1017);
+        }
     }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -8,8 +8,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.di.authentication.frontendapi.entity.BaseFrontendRequest;
 import uk.gov.di.authentication.frontendapi.entity.CheckUserExistsResponse;
-import uk.gov.di.authentication.frontendapi.entity.UserWithEmailRequest;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.SessionAction;
@@ -84,9 +84,9 @@ public class CheckUserExistsHandler
                                                             session.get().getState(),
                                                             USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS));
 
-                                    UserWithEmailRequest userExistsRequest =
+                                    BaseFrontendRequest userExistsRequest =
                                             objectMapper.readValue(
-                                                    input.getBody(), UserWithEmailRequest.class);
+                                                    input.getBody(), BaseFrontendRequest.class);
                                     String emailAddress = userExistsRequest.getEmail();
                                     Optional<ErrorResponse> errorResponse =
                                             validationService.validateEmailAddress(emailAddress);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -5,7 +5,6 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.di.authentication.frontendapi.entity.CheckUserExistsRequest;
@@ -36,7 +35,6 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
     private static final Logger LOG = LoggerFactory.getLogger(CheckUserExistsHandler.class);
 
     private final ValidationService validationService;
-    private final ObjectMapper objectMapper = new ObjectMapper();
     private final StateMachine<SessionState, SessionAction, UserContext> stateMachine =
             userJourneyStateMachine();
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -5,7 +5,6 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.di.authentication.frontendapi.entity.LoginRequest;
@@ -39,7 +38,6 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LoginHandler.class);
     private final CodeStorageService codeStorageService;
-    private final ObjectMapper objectMapper = new ObjectMapper();
     private final StateMachine<SessionState, SessionAction, UserContext> stateMachine =
             userJourneyStateMachine();
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
@@ -5,7 +5,6 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.di.authentication.frontendapi.entity.BaseFrontendRequest;
@@ -47,7 +46,6 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
     private final CodeGeneratorService codeGeneratorService;
     private final CodeStorageService codeStorageService;
     private final AwsSqsClient sqsClient;
-    private final ObjectMapper objectMapper = new ObjectMapper();
     private final StateMachine<SessionState, SessionAction, UserContext> stateMachine =
             userJourneyStateMachine();
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.gov.di.authentication.frontendapi.entity.UserWithEmailRequest;
+import uk.gov.di.authentication.frontendapi.entity.BaseFrontendRequest;
 import uk.gov.di.authentication.frontendapi.services.AwsSqsClient;
 import uk.gov.di.authentication.shared.entity.BaseAPIResponse;
 import uk.gov.di.authentication.shared.entity.NotifyRequest;
@@ -110,9 +110,9 @@ public class MfaHandler
                                         stateMachine.transition(
                                                 session.getState(), SYSTEM_HAS_SENT_MFA_CODE);
 
-                                UserWithEmailRequest userWithEmailRequest =
+                                BaseFrontendRequest userWithEmailRequest =
                                         objectMapper.readValue(
-                                                input.getBody(), UserWithEmailRequest.class);
+                                                input.getBody(), BaseFrontendRequest.class);
                                 boolean codeRequestValid =
                                         validateCodeRequestAttempts(
                                                 userWithEmailRequest.getEmail(), session);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.di.authentication.frontendapi.entity.BaseFrontendRequest;
+import uk.gov.di.authentication.frontendapi.entity.MfaRequest;
 import uk.gov.di.authentication.frontendapi.services.AwsSqsClient;
 import uk.gov.di.authentication.shared.entity.BaseAPIResponse;
 import uk.gov.di.authentication.shared.entity.NotifyRequest;
@@ -16,10 +17,11 @@ import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.SessionAction;
 import uk.gov.di.authentication.shared.entity.SessionState;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
+import uk.gov.di.authentication.shared.services.ClientService;
+import uk.gov.di.authentication.shared.services.ClientSessionService;
 import uk.gov.di.authentication.shared.services.CodeGeneratorService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
-import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
 import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.state.StateMachine;
@@ -35,19 +37,15 @@ import static uk.gov.di.authentication.shared.entity.SessionAction.SYSTEM_HAS_SE
 import static uk.gov.di.authentication.shared.entity.SessionAction.SYSTEM_IS_BLOCKED_FROM_SENDING_ANY_MFA_VERIFICATION_CODES;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
-import static uk.gov.di.authentication.shared.helpers.WarmerHelper.isWarming;
 import static uk.gov.di.authentication.shared.state.StateMachine.userJourneyStateMachine;
 
-public class MfaHandler
+public class MfaHandler extends BaseFrontendHandler<MfaRequest>
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MfaHandler.class);
 
-    private final ConfigurationService configurationService;
-    private final SessionService sessionService;
     private final CodeGeneratorService codeGeneratorService;
     private final CodeStorageService codeStorageService;
-    private final AuthenticationService authenticationService;
     private final AwsSqsClient sqsClient;
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final StateMachine<SessionState, SessionAction, UserContext> stateMachine =
@@ -58,27 +56,27 @@ public class MfaHandler
             SessionService sessionService,
             CodeGeneratorService codeGeneratorService,
             CodeStorageService codeStorageService,
+            ClientSessionService clientSessionService,
+            ClientService clientService,
             AuthenticationService authenticationService,
             AwsSqsClient sqsClient) {
-        this.configurationService = configurationService;
-        this.sessionService = sessionService;
+        super(MfaRequest.class,
+                configurationService,
+                sessionService,
+                clientSessionService,
+                clientService,
+                authenticationService);
         this.codeGeneratorService = codeGeneratorService;
         this.codeStorageService = codeStorageService;
-        this.authenticationService = authenticationService;
         this.sqsClient = sqsClient;
     }
 
     public MfaHandler() {
-        this.configurationService = new ConfigurationService();
-        this.sessionService = new SessionService(configurationService);
+        super(MfaRequest.class,
+                ConfigurationService.getInstance());
         this.codeGeneratorService = new CodeGeneratorService();
         this.codeStorageService =
                 new CodeStorageService(new RedisConnectionService(configurationService));
-        this.authenticationService =
-                new DynamoService(
-                        configurationService.getAwsRegion(),
-                        configurationService.getEnvironment(),
-                        configurationService.getDynamoEndpointUri());
         this.sqsClient =
                 new AwsSqsClient(
                         configurationService.getAwsRegion(),
@@ -87,81 +85,64 @@ public class MfaHandler
     }
 
     @Override
-    public APIGatewayProxyResponseEvent handleRequest(
-            APIGatewayProxyRequestEvent input, Context context) {
-        return isWarming(input)
-                .orElseGet(
-                        () -> {
-                            Session session =
-                                    sessionService
-                                            .getSessionFromRequestHeaders(input.getHeaders())
-                                            .orElse(null);
-                            if (session == null) {
-                                LOGGER.error("Session cannot be found");
-                                return generateApiGatewayProxyErrorResponse(400, ERROR_1000);
-                            } else {
-                                LOGGER.info(
-                                        "MfaHandler processing request for session {}",
-                                        session.getSessionId());
-                            }
+    public APIGatewayProxyResponseEvent handleRequestWithUserContext(
+            APIGatewayProxyRequestEvent input, Context context, MfaRequest request, UserContext userContext) {
+        try {
+            var nextState =
+                    stateMachine.transition(
+                            userContext.getSession().getState(), SYSTEM_HAS_SENT_MFA_CODE);
 
-                            try {
-                                var nextState =
-                                        stateMachine.transition(
-                                                session.getState(), SYSTEM_HAS_SENT_MFA_CODE);
+            BaseFrontendRequest userWithEmailRequest =
+                    objectMapper.readValue(
+                            input.getBody(), BaseFrontendRequest.class);
+            boolean codeRequestValid =
+                    validateCodeRequestAttempts(
+                            userWithEmailRequest.getEmail(), userContext.getSession());
+            if (!codeRequestValid) {
+                return generateApiGatewayProxyResponse(
+                        400, new BaseAPIResponse(userContext.getSession().getState()));
+            }
+            if (!userContext.getSession().validateSession(userWithEmailRequest.getEmail())) {
+                LOGGER.error(
+                        "Email in session does not match Email in Request");
+                return generateApiGatewayProxyErrorResponse(400, ERROR_1000);
+            }
+            String phoneNumber =
+                    authenticationService
+                            .getPhoneNumber(userWithEmailRequest.getEmail())
+                            .orElse(null);
 
-                                BaseFrontendRequest userWithEmailRequest =
-                                        objectMapper.readValue(
-                                                input.getBody(), BaseFrontendRequest.class);
-                                boolean codeRequestValid =
-                                        validateCodeRequestAttempts(
-                                                userWithEmailRequest.getEmail(), session);
-                                if (!codeRequestValid) {
-                                    return generateApiGatewayProxyResponse(
-                                            400, new BaseAPIResponse(session.getState()));
-                                }
-                                if (!session.validateSession(userWithEmailRequest.getEmail())) {
-                                    LOGGER.error(
-                                            "Email in session does not match Email in Request");
-                                    return generateApiGatewayProxyErrorResponse(400, ERROR_1000);
-                                }
-                                String phoneNumber =
-                                        authenticationService
-                                                .getPhoneNumber(userWithEmailRequest.getEmail())
-                                                .orElse(null);
+            if (phoneNumber == null) {
+                LOGGER.error("PhoneNumber is null");
+                return generateApiGatewayProxyErrorResponse(400, ERROR_1014);
+            }
+            String code = codeGeneratorService.sixDigitCode();
+            codeStorageService.saveOtpCode(
+                    userWithEmailRequest.getEmail(),
+                    code,
+                    configurationService.getCodeExpiry(),
+                    MFA_SMS);
+            sessionService.save(
+                    userContext.getSession().setState(nextState).incrementCodeRequestCount());
+            NotifyRequest notifyRequest =
+                    new NotifyRequest(phoneNumber, MFA_SMS, code);
+            sqsClient.send(objectMapper.writeValueAsString(notifyRequest));
 
-                                if (phoneNumber == null) {
-                                    LOGGER.error("PhoneNumber is null");
-                                    return generateApiGatewayProxyErrorResponse(400, ERROR_1014);
-                                }
-                                String code = codeGeneratorService.sixDigitCode();
-                                codeStorageService.saveOtpCode(
-                                        userWithEmailRequest.getEmail(),
-                                        code,
-                                        configurationService.getCodeExpiry(),
-                                        MFA_SMS);
-                                sessionService.save(
-                                        session.setState(nextState).incrementCodeRequestCount());
-                                NotifyRequest notifyRequest =
-                                        new NotifyRequest(phoneNumber, MFA_SMS, code);
-                                sqsClient.send(objectMapper.writeValueAsString(notifyRequest));
+            LOGGER.info(
+                    "MfaHandler successfully processed request for session {}",
+                    userContext.getSession().getSessionId());
 
-                                LOGGER.info(
-                                        "MfaHandler successfully processed request for session {}",
-                                        session.getSessionId());
-
-                                return generateApiGatewayProxyResponse(
-                                        200, new BaseAPIResponse(session.getState()));
-                            } catch (JsonProcessingException e) {
-                                LOGGER.error(
-                                        "Request is missing parameters. Request Body: {}",
-                                        input.getBody());
-                                return generateApiGatewayProxyErrorResponse(400, ERROR_1001);
-                            } catch (StateMachine.InvalidStateTransitionException e) {
-                                LOGGER.error("Invalid transition in user journey", e);
-                                return generateApiGatewayProxyErrorResponse(400, ERROR_1017);
-                            }
-                        });
+            return generateApiGatewayProxyResponse(
+                    200, new BaseAPIResponse(userContext.getSession().getState()));
+        } catch (JsonProcessingException e) {
+            LOGGER.error(
+                    "Request is missing parameters. Request Body: {}",
+                    input.getBody());
+            return generateApiGatewayProxyErrorResponse(400, ERROR_1001);
+        } catch (StateMachine.InvalidStateTransitionException e) {
+            LOGGER.error("Invalid transition in user journey", e);
+            return generateApiGatewayProxyErrorResponse(400, ERROR_1017);
+        }
     }
 
     private boolean validateCodeRequestAttempts(String email, Session session) {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
@@ -97,21 +97,21 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
 
     @Override
     public APIGatewayProxyResponseEvent handleRequestWithUserContext(
-            APIGatewayProxyRequestEvent input, Context context, SendNotificationRequest request, UserContext userContext) {
+            APIGatewayProxyRequestEvent input,
+            Context context,
+            SendNotificationRequest request,
+            UserContext userContext) {
         try {
-            if (!userContext.getSession()
-                    .validateSession(request.getEmail())) {
-                LOGGER.info(
-                        "Invalid session. Email {}",
-                        request.getEmail());
-                return generateApiGatewayProxyErrorResponse(
-                        400, ErrorResponse.ERROR_1000);
+            if (!userContext.getSession().validateSession(request.getEmail())) {
+                LOGGER.info("Invalid session. Email {}", request.getEmail());
+                return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1000);
             }
             boolean codeRequestValid =
                     isCodeRequestAttemptValid(
                             request.getEmail(),
                             userContext.getSession(),
-                            request.getNotificationType(), userContext);
+                            request.getNotificationType(),
+                            userContext);
             if (!codeRequestValid) {
                 return generateApiGatewayProxyResponse(
                         400, new BaseAPIResponse(userContext.getSession().getState()));
@@ -122,18 +122,17 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
                     nextState =
                             stateMachine.transition(
                                     userContext.getSession().getState(),
-                                    SYSTEM_HAS_SENT_EMAIL_VERIFICATION_CODE, userContext);
+                                    SYSTEM_HAS_SENT_EMAIL_VERIFICATION_CODE,
+                                    userContext);
 
                     Optional<ErrorResponse> emailErrorResponse =
-                            validationService.validateEmailAddress(
-                                    request.getEmail());
+                            validationService.validateEmailAddress(request.getEmail());
                     if (emailErrorResponse.isPresent()) {
                         LOGGER.error(
                                 "Session: {} encountered emailErrorResponse: {}",
                                 userContext.getSession().getSessionId(),
                                 emailErrorResponse.get());
-                        return generateApiGatewayProxyErrorResponse(
-                                400, emailErrorResponse.get());
+                        return generateApiGatewayProxyErrorResponse(400, emailErrorResponse.get());
                     }
                     return handleNotificationRequest(
                             request.getEmail(),
@@ -153,14 +152,11 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
                                 userContext.getSession().getSessionId());
                         return generateApiGatewayProxyResponse(400, ERROR_1011);
                     }
-                    String phoneNumber =
-                            removeWhitespaceFromPhoneNumber(
-                                    request.getPhoneNumber());
+                    String phoneNumber = removeWhitespaceFromPhoneNumber(request.getPhoneNumber());
                     Optional<ErrorResponse> errorResponse =
                             validationService.validatePhoneNumber(phoneNumber);
                     if (errorResponse.isPresent()) {
-                        return generateApiGatewayProxyErrorResponse(
-                                400, errorResponse.get());
+                        return generateApiGatewayProxyErrorResponse(400, errorResponse.get());
                     }
                     return handleNotificationRequest(
                             phoneNumber,
@@ -171,8 +167,7 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
             return generateApiGatewayProxyErrorResponse(400, ERROR_1002);
         } catch (SdkClientException ex) {
             LOGGER.error("Error sending message to queue", ex);
-            return generateApiGatewayProxyResponse(
-                    500, "Error sending message to queue");
+            return generateApiGatewayProxyResponse(500, "Error sending message to queue");
         } catch (JsonProcessingException e) {
             LOGGER.error("Error parsing request", e);
             return generateApiGatewayProxyErrorResponse(400, ERROR_1001);
@@ -209,7 +204,10 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
     }
 
     private boolean isCodeRequestAttemptValid(
-            String email, Session session, NotificationType notificationType, UserContext userContext) {
+            String email,
+            Session session,
+            NotificationType notificationType,
+            UserContext userContext) {
         if (session.getCodeRequestCount() == configurationService.getCodeMaxRetries()) {
             LOGGER.error(
                     "User has requested too many OTP codes for session {}", session.getSessionId());

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
@@ -18,6 +18,9 @@ import uk.gov.di.authentication.shared.entity.NotifyRequest;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.SessionAction;
 import uk.gov.di.authentication.shared.entity.SessionState;
+import uk.gov.di.authentication.shared.services.AuthenticationService;
+import uk.gov.di.authentication.shared.services.ClientService;
+import uk.gov.di.authentication.shared.services.ClientSessionService;
 import uk.gov.di.authentication.shared.services.CodeGeneratorService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -34,24 +37,22 @@ import static uk.gov.di.authentication.shared.entity.ErrorResponse.ERROR_1002;
 import static uk.gov.di.authentication.shared.entity.ErrorResponse.ERROR_1011;
 import static uk.gov.di.authentication.shared.entity.ErrorResponse.ERROR_1017;
 import static uk.gov.di.authentication.shared.entity.SessionAction.SYSTEM_HAS_SENT_EMAIL_VERIFICATION_CODE;
+import static uk.gov.di.authentication.shared.entity.SessionAction.SYSTEM_HAS_SENT_PHONE_VERIFICATION_CODE;
 import static uk.gov.di.authentication.shared.entity.SessionAction.SYSTEM_HAS_SENT_TOO_MANY_EMAIL_VERIFICATION_CODES;
 import static uk.gov.di.authentication.shared.entity.SessionAction.SYSTEM_HAS_SENT_TOO_MANY_PHONE_VERIFICATION_CODES;
 import static uk.gov.di.authentication.shared.entity.SessionAction.SYSTEM_IS_BLOCKED_FROM_SENDING_ANY_EMAIL_VERIFICATION_CODES;
 import static uk.gov.di.authentication.shared.entity.SessionAction.SYSTEM_IS_BLOCKED_FROM_SENDING_ANY_PHONE_VERIFICATION_CODES;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
-import static uk.gov.di.authentication.shared.helpers.WarmerHelper.isWarming;
 import static uk.gov.di.authentication.shared.state.StateMachine.userJourneyStateMachine;
 
-public class SendNotificationHandler
+public class SendNotificationHandler extends BaseFrontendHandler<SendNotificationRequest>
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SendNotificationHandler.class);
 
-    private final ConfigurationService configurationService;
     private final ValidationService validationService;
     private final AwsSqsClient sqsClient;
-    private final SessionService sessionService;
     private final CodeGeneratorService codeGeneratorService;
     private final CodeStorageService codeStorageService;
     private final ObjectMapper objectMapper = new ObjectMapper();
@@ -60,135 +61,125 @@ public class SendNotificationHandler
 
     public SendNotificationHandler(
             ConfigurationService configurationService,
+            SessionService sessionService,
+            ClientSessionService clientSessionService,
+            ClientService clientService,
+            AuthenticationService authenticationService,
             ValidationService validationService,
             AwsSqsClient sqsClient,
-            SessionService sessionService,
             CodeGeneratorService codeGeneratorService,
             CodeStorageService codeStorageService) {
-        this.configurationService = configurationService;
+        super(
+                SendNotificationRequest.class,
+                configurationService,
+                sessionService,
+                clientSessionService,
+                clientService,
+                authenticationService);
         this.validationService = validationService;
         this.sqsClient = sqsClient;
-        this.sessionService = sessionService;
         this.codeGeneratorService = codeGeneratorService;
         this.codeStorageService = codeStorageService;
     }
 
     public SendNotificationHandler() {
-        this.configurationService = new ConfigurationService();
+        super(SendNotificationRequest.class, ConfigurationService.getInstance());
         this.sqsClient =
                 new AwsSqsClient(
                         configurationService.getAwsRegion(),
                         configurationService.getEmailQueueUri(),
                         configurationService.getSqsEndpointUri());
         this.validationService = new ValidationService();
-        sessionService = new SessionService(configurationService);
         this.codeGeneratorService = new CodeGeneratorService();
         this.codeStorageService =
                 new CodeStorageService(new RedisConnectionService(configurationService));
     }
 
     @Override
-    public APIGatewayProxyResponseEvent handleRequest(
-            APIGatewayProxyRequestEvent input, Context context) {
-        return isWarming(input)
-                .orElseGet(
-                        () -> {
-                            Optional<Session> session =
-                                    sessionService.getSessionFromRequestHeaders(input.getHeaders());
-                            if (session.isEmpty()) {
-                                return generateApiGatewayProxyErrorResponse(
-                                        400, ErrorResponse.ERROR_1000);
-                            } else {
-                                LOGGER.info(
-                                        "SendNotificationHandler processing request for session {}",
-                                        session.get().getSessionId());
-                            }
-                            try {
-                                SendNotificationRequest sendNotificationRequest =
-                                        objectMapper.readValue(
-                                                input.getBody(), SendNotificationRequest.class);
-                                if (!session.get()
-                                        .validateSession(sendNotificationRequest.getEmail())) {
-                                    LOGGER.info(
-                                            "Invalid session. Email {}",
-                                            sendNotificationRequest.getEmail());
-                                    return generateApiGatewayProxyErrorResponse(
-                                            400, ErrorResponse.ERROR_1000);
-                                }
-                                boolean codeRequestValid =
-                                        isCodeRequestAttemptValid(
-                                                sendNotificationRequest.getEmail(),
-                                                session.get(),
-                                                sendNotificationRequest.getNotificationType());
-                                if (!codeRequestValid) {
-                                    return generateApiGatewayProxyResponse(
-                                            400, new BaseAPIResponse(session.get().getState()));
-                                }
-                                SessionState nextState;
-                                switch (sendNotificationRequest.getNotificationType()) {
-                                    case VERIFY_EMAIL:
-                                        nextState =
-                                                stateMachine.transition(
-                                                        session.get().getState(),
-                                                        SYSTEM_HAS_SENT_EMAIL_VERIFICATION_CODE);
+    public APIGatewayProxyResponseEvent handleRequestWithUserContext(
+            APIGatewayProxyRequestEvent input, Context context, SendNotificationRequest request, UserContext userContext) {
+        try {
+            if (!userContext.getSession()
+                    .validateSession(request.getEmail())) {
+                LOGGER.info(
+                        "Invalid session. Email {}",
+                        request.getEmail());
+                return generateApiGatewayProxyErrorResponse(
+                        400, ErrorResponse.ERROR_1000);
+            }
+            boolean codeRequestValid =
+                    isCodeRequestAttemptValid(
+                            request.getEmail(),
+                            userContext.getSession(),
+                            request.getNotificationType(), userContext);
+            if (!codeRequestValid) {
+                return generateApiGatewayProxyResponse(
+                        400, new BaseAPIResponse(userContext.getSession().getState()));
+            }
+            SessionState nextState;
+            switch (request.getNotificationType()) {
+                case VERIFY_EMAIL:
+                    nextState =
+                            stateMachine.transition(
+                                    userContext.getSession().getState(),
+                                    SYSTEM_HAS_SENT_EMAIL_VERIFICATION_CODE, userContext);
 
-                                        Optional<ErrorResponse> emailErrorResponse =
-                                                validationService.validateEmailAddress(
-                                                        sendNotificationRequest.getEmail());
-                                        if (emailErrorResponse.isPresent()) {
-                                            LOGGER.error(
-                                                    "Session: {} encountered emailErrorResponse: {}",
-                                                    session.get().getSessionId(),
-                                                    emailErrorResponse.get());
-                                            return generateApiGatewayProxyErrorResponse(
-                                                    400, emailErrorResponse.get());
-                                        }
-                                        return handleNotificationRequest(
-                                                sendNotificationRequest.getEmail(),
-                                                sendNotificationRequest.getNotificationType(),
-                                                session.get(),
-                                                nextState);
-                                    case VERIFY_PHONE_NUMBER:
-                                        nextState =
-                                                stateMachine.transition(
-                                                        session.get().getState(),
-                                                        SessionAction
-                                                                .SYSTEM_HAS_SENT_PHONE_VERIFICATION_CODE);
+                    Optional<ErrorResponse> emailErrorResponse =
+                            validationService.validateEmailAddress(
+                                    request.getEmail());
+                    if (emailErrorResponse.isPresent()) {
+                        LOGGER.error(
+                                "Session: {} encountered emailErrorResponse: {}",
+                                userContext.getSession().getSessionId(),
+                                emailErrorResponse.get());
+                        return generateApiGatewayProxyErrorResponse(
+                                400, emailErrorResponse.get());
+                    }
+                    return handleNotificationRequest(
+                            request.getEmail(),
+                            request.getNotificationType(),
+                            userContext.getSession(),
+                            nextState);
+                case VERIFY_PHONE_NUMBER:
+                    nextState =
+                            stateMachine.transition(
+                                    userContext.getSession().getState(),
+                                    SYSTEM_HAS_SENT_PHONE_VERIFICATION_CODE,
+                                    userContext);
 
-                                        if (sendNotificationRequest.getPhoneNumber() == null) {
-                                            LOGGER.error(
-                                                    "No phone number provided for session {}",
-                                                    session.get().getSessionId());
-                                            return generateApiGatewayProxyResponse(400, ERROR_1011);
-                                        }
-                                        String phoneNumber =
-                                                removeWhitespaceFromPhoneNumber(
-                                                        sendNotificationRequest.getPhoneNumber());
-                                        Optional<ErrorResponse> errorResponse =
-                                                validationService.validatePhoneNumber(phoneNumber);
-                                        if (errorResponse.isPresent()) {
-                                            return generateApiGatewayProxyErrorResponse(
-                                                    400, errorResponse.get());
-                                        }
-                                        return handleNotificationRequest(
-                                                phoneNumber,
-                                                sendNotificationRequest.getNotificationType(),
-                                                session.get(),
-                                                nextState);
-                                }
-                                return generateApiGatewayProxyErrorResponse(400, ERROR_1002);
-                            } catch (SdkClientException ex) {
-                                LOGGER.error("Error sending message to queue", ex);
-                                return generateApiGatewayProxyResponse(
-                                        500, "Error sending message to queue");
-                            } catch (JsonProcessingException e) {
-                                LOGGER.error("Error parsing request", e);
-                                return generateApiGatewayProxyErrorResponse(400, ERROR_1001);
-                            } catch (StateMachine.InvalidStateTransitionException e) {
-                                LOGGER.error("Invalid transition in user journey", e);
-                                return generateApiGatewayProxyErrorResponse(400, ERROR_1017);
-                            }
-                        });
+                    if (request.getPhoneNumber() == null) {
+                        LOGGER.error(
+                                "No phone number provided for session {}",
+                                userContext.getSession().getSessionId());
+                        return generateApiGatewayProxyResponse(400, ERROR_1011);
+                    }
+                    String phoneNumber =
+                            removeWhitespaceFromPhoneNumber(
+                                    request.getPhoneNumber());
+                    Optional<ErrorResponse> errorResponse =
+                            validationService.validatePhoneNumber(phoneNumber);
+                    if (errorResponse.isPresent()) {
+                        return generateApiGatewayProxyErrorResponse(
+                                400, errorResponse.get());
+                    }
+                    return handleNotificationRequest(
+                            phoneNumber,
+                            request.getNotificationType(),
+                            userContext.getSession(),
+                            nextState);
+            }
+            return generateApiGatewayProxyErrorResponse(400, ERROR_1002);
+        } catch (SdkClientException ex) {
+            LOGGER.error("Error sending message to queue", ex);
+            return generateApiGatewayProxyResponse(
+                    500, "Error sending message to queue");
+        } catch (JsonProcessingException e) {
+            LOGGER.error("Error parsing request", e);
+            return generateApiGatewayProxyErrorResponse(400, ERROR_1001);
+        } catch (StateMachine.InvalidStateTransitionException e) {
+            LOGGER.error("Invalid transition in user journey", e);
+            return generateApiGatewayProxyErrorResponse(400, ERROR_1017);
+        }
     }
 
     private String removeWhitespaceFromPhoneNumber(String phoneNumber) {
@@ -218,7 +209,7 @@ public class SendNotificationHandler
     }
 
     private boolean isCodeRequestAttemptValid(
-            String email, Session session, NotificationType notificationType) {
+            String email, Session session, NotificationType notificationType, UserContext userContext) {
         if (session.getCodeRequestCount() == configurationService.getCodeMaxRetries()) {
             LOGGER.error(
                     "User has requested too many OTP codes for session {}", session.getSessionId());
@@ -227,7 +218,8 @@ public class SendNotificationHandler
             SessionState nextState =
                     stateMachine.transition(
                             session.getState(),
-                            getSessionActionForCodeRequestLimitReached(notificationType));
+                            getSessionActionForCodeRequestLimitReached(notificationType),
+                            userContext);
             sessionService.save(session.setState(nextState).resetCodeRequestCount());
             return false;
         }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
@@ -5,7 +5,6 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.core.exception.SdkClientException;
@@ -55,7 +54,6 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
     private final AwsSqsClient sqsClient;
     private final CodeGeneratorService codeGeneratorService;
     private final CodeStorageService codeStorageService;
-    private final ObjectMapper objectMapper = new ObjectMapper();
     private final StateMachine<SessionState, SessionAction, UserContext> stateMachine =
             userJourneyStateMachine();
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
@@ -65,7 +65,10 @@ public class SignUpHandler extends BaseFrontendHandler<SignupRequest>
 
     @Override
     public APIGatewayProxyResponseEvent handleRequestWithUserContext(
-            APIGatewayProxyRequestEvent input, Context context, SignupRequest request, UserContext userContext) {
+            APIGatewayProxyRequestEvent input,
+            Context context,
+            SignupRequest request,
+            UserContext userContext) {
         try {
             var nextState =
                     stateMachine.transition(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
@@ -5,20 +5,19 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.di.authentication.frontendapi.entity.SignupRequest;
 import uk.gov.di.authentication.shared.entity.BaseAPIResponse;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
-import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.SessionAction;
 import uk.gov.di.authentication.shared.entity.SessionState;
 import uk.gov.di.authentication.shared.entity.TermsAndConditions;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
+import uk.gov.di.authentication.shared.services.ClientService;
+import uk.gov.di.authentication.shared.services.ClientSessionService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
-import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.services.ValidationService;
 import uk.gov.di.authentication.shared.state.StateMachine;
@@ -31,118 +30,98 @@ import java.util.Optional;
 import static uk.gov.di.authentication.shared.entity.SessionAction.USER_HAS_CREATED_A_PASSWORD;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
-import static uk.gov.di.authentication.shared.helpers.WarmerHelper.isWarming;
 import static uk.gov.di.authentication.shared.state.StateMachine.userJourneyStateMachine;
 
-public class SignUpHandler
+public class SignUpHandler extends BaseFrontendHandler<SignupRequest>
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     private static final Logger LOG = LoggerFactory.getLogger(SignUpHandler.class);
 
-    private final AuthenticationService authenticationService;
     private final ValidationService validationService;
-    private final SessionService sessionService;
-    private final ConfigurationService configurationService;
-    private final ObjectMapper objectMapper = new ObjectMapper();
     private final StateMachine<SessionState, SessionAction, UserContext> stateMachine =
             userJourneyStateMachine();
 
     public SignUpHandler(
-            AuthenticationService authenticationService,
-            ValidationService validationService,
+            ConfigurationService configurationService,
             SessionService sessionService,
-            ConfigurationService configurationService) {
-        this.authenticationService = authenticationService;
+            ClientSessionService clientSessionService,
+            ClientService clientService,
+            AuthenticationService authenticationService,
+            ValidationService validationService) {
+        super(
+                SignupRequest.class,
+                configurationService,
+                sessionService,
+                clientSessionService,
+                clientService,
+                authenticationService);
         this.validationService = validationService;
-        this.sessionService = sessionService;
-        this.configurationService = configurationService;
     }
 
     public SignUpHandler() {
-        this.configurationService = new ConfigurationService();
-        this.authenticationService =
-                new DynamoService(
-                        configurationService.getAwsRegion(),
-                        configurationService.getEnvironment(),
-                        configurationService.getDynamoEndpointUri());
+        super(SignupRequest.class, ConfigurationService.getInstance());
         this.validationService = new ValidationService();
-        sessionService = new SessionService(configurationService);
     }
 
     @Override
-    public APIGatewayProxyResponseEvent handleRequest(
-            APIGatewayProxyRequestEvent input, Context context) {
-        return isWarming(input)
-                .orElseGet(
-                        () -> {
-                            Optional<Session> session =
-                                    sessionService.getSessionFromRequestHeaders(input.getHeaders());
-                            if (session.isEmpty()) {
-                                return generateApiGatewayProxyErrorResponse(
-                                        400, ErrorResponse.ERROR_1000);
-                            } else {
-                                LOG.info(
-                                        "SignUpHandler processing request for session {}",
-                                        session.get().getSessionId());
-                            }
+    public APIGatewayProxyResponseEvent handleRequestWithUserContext(
+            APIGatewayProxyRequestEvent input, Context context, SignupRequest request, UserContext userContext) {
+        try {
+            var nextState =
+                    stateMachine.transition(
+                            userContext.getSession().getState(),
+                            USER_HAS_CREATED_A_PASSWORD);
 
-                            try {
-                                var nextState =
-                                        stateMachine.transition(
-                                                session.get().getState(),
-                                                USER_HAS_CREATED_A_PASSWORD);
+            SignupRequest signupRequest =
+                    objectMapper.readValue(
+                            input.getBody(), SignupRequest.class);
 
-                                SignupRequest signupRequest =
-                                        objectMapper.readValue(
-                                                input.getBody(), SignupRequest.class);
+            Optional<ErrorResponse> passwordValidationErrors =
+                    validationService.validatePassword(
+                            signupRequest.getPassword());
 
-                                Optional<ErrorResponse> passwordValidationErrors =
-                                        validationService.validatePassword(
-                                                signupRequest.getPassword());
+            if (passwordValidationErrors.isEmpty()) {
+                if (authenticationService.userExists(
+                        signupRequest.getEmail())) {
+                    LOG.error(
+                            "User with email {} already exists",
+                            signupRequest.getEmail());
+                    return generateApiGatewayProxyErrorResponse(
+                            400, ErrorResponse.ERROR_1009);
+                }
+                authenticationService.signUp(
+                        signupRequest.getEmail(),
+                        signupRequest.getPassword(),
+                        new Subject(),
+                        new TermsAndConditions(
+                                configurationService
+                                        .getTermsAndConditionsVersion(),
+                                LocalDateTime.now(ZoneId.of("UTC"))
+                                        .toString()));
 
-                                if (passwordValidationErrors.isEmpty()) {
-                                    if (authenticationService.userExists(
-                                            signupRequest.getEmail())) {
-                                        LOG.error(
-                                                "User with email {} already exists",
-                                                signupRequest.getEmail());
-                                        return generateApiGatewayProxyErrorResponse(
-                                                400, ErrorResponse.ERROR_1009);
-                                    }
-                                    authenticationService.signUp(
-                                            signupRequest.getEmail(),
-                                            signupRequest.getPassword(),
-                                            new Subject(),
-                                            new TermsAndConditions(
-                                                    configurationService
-                                                            .getTermsAndConditionsVersion(),
-                                                    LocalDateTime.now(ZoneId.of("UTC"))
-                                                            .toString()));
+                sessionService.save(
+                        userContext.getSession()
+                                .setState(nextState)
+                                .setEmailAddress(signupRequest.getEmail()));
 
-                                    sessionService.save(
-                                            session.get()
-                                                    .setState(nextState)
-                                                    .setEmailAddress(signupRequest.getEmail()));
+                LOG.info(
+                        "SignUpHandler successfully processed request for session {}",
+                        userContext.getSession().getSessionId());
 
-                                    LOG.info(
-                                            "SignUpHandler successfully processed request for session {}",
-                                            session.get().getSessionId());
-
-                                    return generateApiGatewayProxyResponse(
-                                            200, new BaseAPIResponse(session.get().getState()));
-                                } else {
-                                    return generateApiGatewayProxyErrorResponse(
-                                            400, passwordValidationErrors.get());
-                                }
-                            } catch (JsonProcessingException e) {
-                                LOG.error("Error parsing request", e);
-                                return generateApiGatewayProxyErrorResponse(
-                                        400, ErrorResponse.ERROR_1001);
-                            } catch (StateMachine.InvalidStateTransitionException e) {
-                                LOG.error("Invalid transition in user journey", e);
-                                return generateApiGatewayProxyErrorResponse(
-                                        400, ErrorResponse.ERROR_1017);
-                            }
-                        });
+                return generateApiGatewayProxyResponse(
+                        200, new BaseAPIResponse(userContext.getSession().getState()));
+            } else {
+                return generateApiGatewayProxyErrorResponse(
+                        400, passwordValidationErrors.get());
+            }
+        } catch (JsonProcessingException e) {
+            LOG.error("Error parsing request", e);
+            return generateApiGatewayProxyErrorResponse(
+                    400, ErrorResponse.ERROR_1001);
+        } catch (StateMachine.InvalidStateTransitionException e) {
+            LOG.error("Invalid transition in user journey", e);
+            return generateApiGatewayProxyErrorResponse(
+                    400, ErrorResponse.ERROR_1017);
+        }
     }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
@@ -48,10 +48,9 @@ import static uk.gov.di.authentication.shared.entity.SessionAction.USER_HAS_ACTI
 import static uk.gov.di.authentication.shared.entity.SessionState.ADDED_UNVERIFIED_PHONE_NUMBER;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
-import static uk.gov.di.authentication.shared.helpers.WarmerHelper.isWarming;
 import static uk.gov.di.authentication.shared.state.StateMachine.userJourneyStateMachine;
 
-public class UpdateProfileHandler extends BaseFrontendHandler
+public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileRequest>
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(UpdateProfileHandler.class);
@@ -72,6 +71,7 @@ public class UpdateProfileHandler extends BaseFrontendHandler
             ClientService clientService,
             StateMachine<SessionState, SessionAction, UserContext> stateMachine) {
         super(
+                UpdateProfileRequest.class,
                 configurationService,
                 sessionService,
                 clientSessionService,
@@ -85,7 +85,7 @@ public class UpdateProfileHandler extends BaseFrontendHandler
     }
 
     public UpdateProfileHandler() {
-        super(ConfigurationService.getInstance());
+        super(UpdateProfileRequest.class, ConfigurationService.getInstance());
         configurationService = new ConfigurationService();
         this.authenticationService =
                 new DynamoService(
@@ -99,147 +99,119 @@ public class UpdateProfileHandler extends BaseFrontendHandler
 
     @Override
     public APIGatewayProxyResponseEvent handleRequestWithUserContext(
-            APIGatewayProxyRequestEvent input, Context context, UserContext userContext) {
-        return isWarming(input)
-                .orElseGet(
-                        () -> {
-                            auditService.submitAuditEvent(ACCOUNT_MANAGEMENT_REQUEST_RECEIVED);
+            APIGatewayProxyRequestEvent input,
+            Context context,
+            UpdateProfileRequest request,
+            UserContext userContext) {
+        auditService.submitAuditEvent(ACCOUNT_MANAGEMENT_REQUEST_RECEIVED);
 
-                            Session session = userContext.getSession();
+        Session session = userContext.getSession();
 
+        LOGGER.info(
+                "UpdateProfileHandler processing request for session {}", session.getSessionId());
+
+        try {
+            if (!session.validateSession(request.getEmail())) {
+                LOGGER.info("Invalid session. Email {}", request.getEmail());
+                return generateErrorResponse(ErrorResponse.ERROR_1000);
+            }
+            switch (request.getUpdateProfileType()) {
+                case ADD_PHONE_NUMBER:
+                    {
+                        var nextState =
+                                stateMachine.transition(
+                                        session.getState(), USER_ENTERED_A_NEW_PHONE_NUMBER);
+                        authenticationService.updatePhoneNumber(
+                                request.getEmail(), request.getProfileInformation());
+                        auditService.submitAuditEvent(ACCOUNT_MANAGEMENT_PHONE_NUMBER_UPDATED);
+                        sessionService.save(session.setState(nextState));
+                        LOGGER.info(
+                                "Phone number updated and session state changed. Session state {}",
+                                ADDED_UNVERIFIED_PHONE_NUMBER);
+                        return generateSuccessResponse(session);
+                    }
+                case CAPTURE_CONSENT:
+                    {
+                        ClientSession clientSession = userContext.getClientSession();
+
+                        if (clientSession == null) {
+                            LOGGER.info("ClientSession not found");
+                            return generateErrorResponse(ErrorResponse.ERROR_1000);
+                        }
+                        AuthenticationRequest authorizationRequest;
+                        try {
+                            authorizationRequest =
+                                    AuthenticationRequest.parse(
+                                            clientSession.getAuthRequestParams());
+                        } catch (ParseException e) {
                             LOGGER.info(
-                                    "UpdateProfileHandler processing request for session {}",
-                                    session.getSessionId());
+                                    "Cannot retrieve auth request params from client session id.");
+                            return generateErrorResponse(ErrorResponse.ERROR_1001);
+                        }
+                        String clientId = authorizationRequest.getClientID().getValue();
+                        Set<String> claimsConsented;
 
-                            try {
-                                UpdateProfileRequest profileRequest =
-                                        objectMapper.readValue(
-                                                input.getBody(), UpdateProfileRequest.class);
-                                if (!session.validateSession(profileRequest.getEmail())) {
-                                    LOGGER.info(
-                                            "Invalid session. Email {}", profileRequest.getEmail());
-                                    return generateErrorResponse(ErrorResponse.ERROR_1000);
-                                }
-                                switch (profileRequest.getUpdateProfileType()) {
-                                    case ADD_PHONE_NUMBER:
-                                        {
-                                            var nextState =
-                                                    stateMachine.transition(
-                                                            session.getState(),
-                                                            USER_ENTERED_A_NEW_PHONE_NUMBER);
-                                            authenticationService.updatePhoneNumber(
-                                                    profileRequest.getEmail(),
-                                                    profileRequest.getProfileInformation());
-                                            auditService.submitAuditEvent(
-                                                    ACCOUNT_MANAGEMENT_PHONE_NUMBER_UPDATED);
-                                            sessionService.save(session.setState(nextState));
-                                            LOGGER.info(
-                                                    "Phone number updated and session state changed. Session state {}",
-                                                    ADDED_UNVERIFIED_PHONE_NUMBER);
-                                            return generateSuccessResponse(session);
-                                        }
-                                    case CAPTURE_CONSENT:
-                                        {
-                                            ClientSession clientSession =
-                                                    userContext.getClientSession();
+                        if (!Boolean.parseBoolean(request.getProfileInformation())) {
+                            claimsConsented = OIDCScopeValue.OPENID.getClaimNames();
+                        } else {
+                            claimsConsented =
+                                    ValidScopes.getClaimsForListOfScopes(
+                                            authorizationRequest.getScope().toStringList());
+                        }
 
-                                            if (clientSession == null) {
-                                                LOGGER.info("ClientSession not found");
-                                                return generateErrorResponse(
-                                                        ErrorResponse.ERROR_1000);
-                                            }
-                                            AuthenticationRequest authorizationRequest;
-                                            try {
-                                                authorizationRequest =
-                                                        AuthenticationRequest.parse(
-                                                                clientSession
-                                                                        .getAuthRequestParams());
-                                            } catch (ParseException e) {
-                                                LOGGER.info(
-                                                        "Cannot retrieve auth request params from client session id.");
-                                                return generateErrorResponse(
-                                                        ErrorResponse.ERROR_1001);
-                                            }
-                                            String clientId =
-                                                    authorizationRequest.getClientID().getValue();
-                                            Set<String> claimsConsented;
+                        processAndUpdateClientConsent(
+                                request.getEmail(), userContext, clientId, claimsConsented);
 
-                                            if (!Boolean.parseBoolean(
-                                                    profileRequest.getProfileInformation())) {
-                                                claimsConsented =
-                                                        OIDCScopeValue.OPENID.getClaimNames();
-                                            } else {
-                                                claimsConsented =
-                                                        ValidScopes.getClaimsForListOfScopes(
-                                                                authorizationRequest
-                                                                        .getScope()
-                                                                        .toStringList());
-                                            }
+                        var nextState =
+                                stateMachine.transition(
+                                        session.getState(), USER_HAS_ACTIONED_CONSENT);
 
-                                            processAndUpdateClientConsent(
-                                                    profileRequest.getEmail(),
-                                                    userContext,
-                                                    clientId,
-                                                    claimsConsented);
+                        sessionService.save(session.setState(nextState));
 
-                                            var nextState =
-                                                    stateMachine.transition(
-                                                            session.getState(),
-                                                            USER_HAS_ACTIONED_CONSENT);
+                        auditService.submitAuditEvent(ACCOUNT_MANAGEMENT_CONSENT_UPDATED);
 
-                                            sessionService.save(session.setState(nextState));
+                        LOGGER.info(
+                                "Consent updated for ClientID {} and session state changed. Session state {}",
+                                clientId,
+                                nextState);
 
-                                            auditService.submitAuditEvent(
-                                                    ACCOUNT_MANAGEMENT_CONSENT_UPDATED);
+                        return generateSuccessResponse(session);
+                    }
+                case UPDATE_TERMS_CONDS:
+                    {
+                        authenticationService.updateTermsAndConditions(
+                                request.getEmail(),
+                                configurationService.getTermsAndConditionsVersion());
 
-                                            LOGGER.info(
-                                                    "Consent updated for ClientID {} and session state changed. Session state {}",
-                                                    clientId,
-                                                    nextState);
+                        auditService.submitAuditEvent(
+                                ACCOUNT_MANAGEMENT_TERMS_CONDS_ACCEPTANCE_UPDATED);
+                        LOGGER.info(
+                                "Updated terms and conditions. Email {} for Version {}",
+                                request.getEmail(),
+                                configurationService.getTermsAndConditionsVersion());
 
-                                            return generateSuccessResponse(session);
-                                        }
-                                    case UPDATE_TERMS_CONDS:
-                                        {
-                                            authenticationService.updateTermsAndConditions(
-                                                    profileRequest.getEmail(),
-                                                    configurationService
-                                                            .getTermsAndConditionsVersion());
+                        var nextState =
+                                stateMachine.transition(
+                                        session.getState(),
+                                        USER_ACCEPTS_TERMS_AND_CONDITIONS,
+                                        userContext);
+                        sessionService.save(session.setState(nextState));
 
-                                            auditService.submitAuditEvent(
-                                                    ACCOUNT_MANAGEMENT_TERMS_CONDS_ACCEPTANCE_UPDATED);
-                                            LOGGER.info(
-                                                    "Updated terms and conditions. Email {} for Version {}",
-                                                    profileRequest.getEmail(),
-                                                    configurationService
-                                                            .getTermsAndConditionsVersion());
+                        LOGGER.info("Updated terms and conditions. Session state {}", nextState);
 
-                                            var nextState =
-                                                    stateMachine.transition(
-                                                            session.getState(),
-                                                            USER_ACCEPTS_TERMS_AND_CONDITIONS,
-                                                            userContext);
-                                            sessionService.save(session.setState(nextState));
-
-                                            LOGGER.info(
-                                                    "Updated terms and conditions. Session state {}",
-                                                    nextState);
-
-                                            return generateSuccessResponse(session);
-                                        }
-                                }
-                            } catch (JsonProcessingException e) {
-                                LOGGER.error("Error parsing request", e);
-                                return generateErrorResponse(ErrorResponse.ERROR_1001);
-                            } catch (InvalidStateTransitionException e) {
-                                LOGGER.error("Invalid transition in user journey", e);
-                                return generateErrorResponse(ErrorResponse.ERROR_1017);
-                            }
-                            LOGGER.error(
-                                    "Encountered unexpected error while processing session {}",
-                                    session.getSessionId());
-                            return generateErrorResponse(ErrorResponse.ERROR_1013);
-                        });
+                        return generateSuccessResponse(session);
+                    }
+            }
+        } catch (JsonProcessingException e) {
+            LOGGER.error("Error parsing request", e);
+            return generateErrorResponse(ErrorResponse.ERROR_1001);
+        } catch (InvalidStateTransitionException e) {
+            LOGGER.error("Invalid transition in user journey", e);
+            return generateErrorResponse(ErrorResponse.ERROR_1017);
+        }
+        LOGGER.error(
+                "Encountered unexpected error while processing session {}", session.getSessionId());
+        return generateErrorResponse(ErrorResponse.ERROR_1013);
     }
 
     private void processAndUpdateClientConsent(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -46,7 +46,7 @@ import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.g
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.authentication.shared.state.StateMachine.userJourneyStateMachine;
 
-public class VerifyCodeHandler extends BaseFrontendHandler
+public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     private static final Logger LOG = LoggerFactory.getLogger(VerifyCodeHandler.class);
@@ -66,6 +66,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler
             ValidationService validationService,
             StateMachine<SessionState, SessionAction, UserContext> stateMachine) {
         super(
+                VerifyCodeRequest.class,
                 configurationService,
                 sessionService,
                 clientSessionService,
@@ -77,7 +78,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler
     }
 
     public VerifyCodeHandler() {
-        super(ConfigurationService.getInstance());
+        super(VerifyCodeRequest.class, ConfigurationService.getInstance());
         this.codeStorageService =
                 new CodeStorageService(
                         new RedisConnectionService(ConfigurationService.getInstance()));
@@ -87,7 +88,10 @@ public class VerifyCodeHandler extends BaseFrontendHandler
 
     @Override
     public APIGatewayProxyResponseEvent handleRequestWithUserContext(
-            APIGatewayProxyRequestEvent input, Context context, UserContext userContext) {
+            APIGatewayProxyRequestEvent input,
+            Context context,
+            VerifyCodeRequest request,
+            UserContext userContext) {
         try {
             VerifyCodeRequest codeRequest =
                     objectMapper.readValue(input.getBody(), VerifyCodeRequest.class);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
@@ -13,6 +13,9 @@ import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.SessionState;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
+import uk.gov.di.authentication.shared.services.ClientService;
+import uk.gov.di.authentication.shared.services.ClientSessionService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.services.ValidationService;
 
@@ -36,6 +39,10 @@ class CheckUserExistsHandlerTest {
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
     private final ValidationService validationService = mock(ValidationService.class);
     private final SessionService sessionService = mock(SessionService.class);
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private final ClientSessionService clientSessionService = mock(ClientSessionService.class);
+    private final ClientService clientService = mock(ClientService.class);
+
     private CheckUserExistsHandler handler;
     private ObjectMapper objectMapper = new ObjectMapper();
 
@@ -45,7 +52,12 @@ class CheckUserExistsHandlerTest {
     public void setup() {
         handler =
                 new CheckUserExistsHandler(
-                        validationService, authenticationService, sessionService);
+                        configurationService,
+                        sessionService,
+                        clientSessionService,
+                        clientService,
+                        authenticationService,
+                        validationService);
         reset(authenticationService);
     }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
@@ -14,6 +14,8 @@ import uk.gov.di.authentication.shared.entity.NotifyRequest;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.SessionState;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
+import uk.gov.di.authentication.shared.services.ClientService;
+import uk.gov.di.authentication.shared.services.ClientSessionService;
 import uk.gov.di.authentication.shared.services.CodeGeneratorService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -50,6 +52,8 @@ public class MfaHandlerTest {
     private final CodeGeneratorService codeGeneratorService = mock(CodeGeneratorService.class);
     private final CodeStorageService codeStorageService = mock(CodeStorageService.class);
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
+    private final ClientSessionService clientSessionService = mock(ClientSessionService.class);
+    private final ClientService clientService = mock(ClientService.class);
     private final AwsSqsClient sqsClient = mock(AwsSqsClient.class);
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final Session session =
@@ -67,6 +71,8 @@ public class MfaHandlerTest {
                         sessionService,
                         codeGeneratorService,
                         codeStorageService,
+                        clientSessionService,
+                        clientService,
                         authenticationService,
                         sqsClient);
     }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
@@ -18,6 +18,8 @@ import uk.gov.di.authentication.shared.entity.NotifyRequest;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
+import uk.gov.di.authentication.shared.services.ClientService;
+import uk.gov.di.authentication.shared.services.ClientSessionService;
 import uk.gov.di.authentication.shared.services.CodeGeneratorService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -62,22 +64,25 @@ class ResetPasswordRequestHandlerTest {
     private final CodeGeneratorService codeGeneratorService = mock(CodeGeneratorService.class);
     private final CodeStorageService codeStorageService = mock(CodeStorageService.class);
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
+    private final ClientSessionService clientSessionService = mock(ClientSessionService.class);
+    private final ClientService clientService = mock(ClientService.class);
     private final Context context = mock(Context.class);
 
     private final Session session =
             new Session(IdGenerator.generate())
                     .setEmailAddress(TEST_EMAIL_ADDRESS)
                     .setState(AUTHENTICATION_REQUIRED);
-
     private final ResetPasswordRequestHandler handler =
             new ResetPasswordRequestHandler(
                     configurationService,
+                    sessionService,
+                    clientSessionService,
+                    clientService,
+                    authenticationService,
                     validationService,
                     awsSqsClient,
-                    sessionService,
                     codeGeneratorService,
-                    codeStorageService,
-                    authenticationService);
+                    codeStorageService);
 
     @BeforeEach
     void setup() {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
@@ -17,6 +17,9 @@ import uk.gov.di.authentication.shared.entity.NotifyRequest;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.SessionState;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
+import uk.gov.di.authentication.shared.services.AuthenticationService;
+import uk.gov.di.authentication.shared.services.ClientService;
+import uk.gov.di.authentication.shared.services.ClientSessionService;
 import uk.gov.di.authentication.shared.services.CodeGeneratorService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -62,6 +65,10 @@ class SendNotificationHandlerTest {
     private final SessionService sessionService = mock(SessionService.class);
     private final CodeGeneratorService codeGeneratorService = mock(CodeGeneratorService.class);
     private final CodeStorageService codeStorageService = mock(CodeStorageService.class);
+    private final ClientSessionService clientSessionService = mock(ClientSessionService.class);
+    private final ClientService clientService = mock(ClientService.class);
+    private final AuthenticationService authenticationService = mock(AuthenticationService.class);
+
     private final Context context = mock(Context.class);
     private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -73,9 +80,12 @@ class SendNotificationHandlerTest {
     private final SendNotificationHandler handler =
             new SendNotificationHandler(
                     configurationService,
+                    sessionService,
+                    clientSessionService,
+                    clientService,
+                    authenticationService,
                     validationService,
                     awsSqsClient,
-                    sessionService,
                     codeGeneratorService,
                     codeStorageService);
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandlerTest.java
@@ -15,6 +15,8 @@ import uk.gov.di.authentication.shared.entity.SessionState;
 import uk.gov.di.authentication.shared.entity.TermsAndConditions;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
+import uk.gov.di.authentication.shared.services.ClientService;
+import uk.gov.di.authentication.shared.services.ClientSessionService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.services.ValidationService;
@@ -44,6 +46,9 @@ class SignUpHandlerTest {
     private final ValidationService validationService = mock(ValidationService.class);
     private final SessionService sessionService = mock(SessionService.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private final ClientSessionService clientSessionService = mock(ClientSessionService.class);
+    private final ClientService clientService = mock(ClientService.class);
+
     private SignUpHandler handler;
 
     private final Session session =
@@ -54,10 +59,12 @@ class SignUpHandlerTest {
         when(configurationService.getTermsAndConditionsVersion()).thenReturn("1.0");
         handler =
                 new SignUpHandler(
-                        authenticationService,
-                        validationService,
+                        configurationService,
                         sessionService,
-                        configurationService);
+                        clientSessionService,
+                        clientService,
+                        authenticationService,
+                        validationService);
     }
 
     @Test

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserExistsIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserExistsIntegrationTest.java
@@ -5,8 +5,8 @@ import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.frontendapi.entity.BaseFrontendRequest;
 import uk.gov.di.authentication.frontendapi.entity.CheckUserExistsResponse;
-import uk.gov.di.authentication.frontendapi.entity.UserWithEmailRequest;
 import uk.gov.di.authentication.helpers.DynamoHelper;
 import uk.gov.di.authentication.helpers.RedisHelper;
 import uk.gov.di.authentication.helpers.RequestHelper;
@@ -37,7 +37,7 @@ public class UserExistsIntegrationTest extends IntegrationTestEndpoints {
         MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
         headers.add("Session-Id", sessionId);
         headers.add("X-API-Key", API_KEY);
-        UserWithEmailRequest request = new UserWithEmailRequest(emailAddress);
+        BaseFrontendRequest request = new BaseFrontendRequest(emailAddress);
 
         Response response = RequestHelper.request(USEREXISTS_ENDPOINT, request, headers);
 
@@ -59,7 +59,7 @@ public class UserExistsIntegrationTest extends IntegrationTestEndpoints {
         headers.add("Session-Id", sessionId);
         headers.add("X-API-Key", API_KEY);
         RedisHelper.setSessionState(sessionId, SessionState.NEW);
-        UserWithEmailRequest request = new UserWithEmailRequest(emailAddress);
+        BaseFrontendRequest request = new BaseFrontendRequest(emailAddress);
         Response response = RequestHelper.request(USEREXISTS_ENDPOINT, request, headers);
 
         assertEquals(200, response.getStatus());
@@ -79,7 +79,7 @@ public class UserExistsIntegrationTest extends IntegrationTestEndpoints {
         headers.add("Session-Id", sessionId);
         headers.add("X-API-Key", API_KEY);
         RedisHelper.setSessionState(sessionId, SessionState.AUTHENTICATED);
-        UserWithEmailRequest request = new UserWithEmailRequest(emailAddress);
+        BaseFrontendRequest request = new BaseFrontendRequest(emailAddress);
         Response response = RequestHelper.request(USEREXISTS_ENDPOINT, request, headers);
 
         assertEquals(400, response.getStatus());


### PR DESCRIPTION
## What?

- Amend `BaseFrontendHandler` to be generic taking the type of request
- Base class should handle deserialisation of request and pass it to delegate in handler
- Amend all frontend API handlers (except `PasswordResetHandler`) to extend `BaseFrontendHandler`
- Ensure all calls to `StateMachine.transition()` use the `UserContext` constructed in `BaseFrontendHandler`

## Why?

Reduces the amount of 'boiler plate' code in handlers, and indentation levels. Ensures consistency across handlers.
