### PR TITLE
BAU - Configure lambdas with environment env var

### DIFF
--- a/ci/terraform/oidc/send_notification.tf
+++ b/ci/terraform/oidc/send_notification.tf
@@ -7,6 +7,7 @@ module "send_notification" {
   environment     = var.environment
 
   handler_environment_variables = {
+    ENVIRONMENT          = var.environment
     EMAIL_QUEUE_URL      = aws_sqs_queue.email_queue.id
     EVENTS_SNS_TOPIC_ARN = aws_sns_topic.events.arn
     LOCALSTACK_ENDPOINT  = var.use_localstack ? var.localstack_endpoint : null

--- a/ci/terraform/oidc/wellknown.tf
+++ b/ci/terraform/oidc/wellknown.tf
@@ -7,6 +7,7 @@ module "openid_configuration_discovery" {
   environment     = var.environment
 
   handler_environment_variables = {
+    ENVIRONMENT          = var.environment
     BASE_URL             = local.api_base_url
     EVENTS_SNS_TOPIC_ARN = aws_sns_topic.events.arn
     LOCALSTACK_ENDPOINT  = var.use_localstack ? var.localstack_endpoint : null


### PR DESCRIPTION
## What?

- Configure lambdas with environment env var

## Why?

- All frontend lambdas require the ENVIRONMENT env var to be configured as they inherit the BaseFrontendHandler