### PR TITLE
GOVSI-562: Remove unnecessary IAM permissions

### DIFF
--- a/ci/terraform/shared/lambda-roles.tf
+++ b/ci/terraform/shared/lambda-roles.tf
@@ -90,8 +90,6 @@ data "aws_iam_policy_document" "endpoint_networking_policy" {
       "ec2:DescribeNetworkInterfaces",
       "ec2:CreateNetworkInterface",
       "ec2:DeleteNetworkInterface",
-      "ec2:DescribeInstances",
-      "ec2:AttachNetworkInterface",
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
## What?

Adjust the execution role for the Lambdas to only have the following permissions:

```
"ec2:DescribeNetworkInterfaces",
"ec2:CreateNetworkInterface",
"ec2:DeleteNetworkInterface",
```

## Why?

The ITHC report suggested the original perms were to pervasive, according to https://docs.aws.amazon.com/lambda/latest/dg/configuration-vpc.html, the above is all that is required
