### PR TITLE
GOVSI-830: Send audit payloads to SNS (1)

### DIFF
--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandler.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandler.java
@@ -58,7 +58,8 @@ public class ClientRegistrationHandler
         return isWarming(input)
                 .orElseGet(
                         () -> {
-                            auditService.submitAuditEvent(REGISTER_CLIENT_REQUEST_RECEIVED);
+                            auditService.submitAuditEvent(
+                                    REGISTER_CLIENT_REQUEST_RECEIVED, context.getAwsRequestId());
 
                             try {
                                 ClientRegistrationRequest clientRegistrationRequest =
@@ -68,7 +69,9 @@ public class ClientRegistrationHandler
                                         validationService.validateClientRegistrationConfig(
                                                 clientRegistrationRequest);
                                 if (errorResponse.isPresent()) {
-                                    auditService.submitAuditEvent(REGISTER_CLIENT_REQUEST_ERROR);
+                                    auditService.submitAuditEvent(
+                                            REGISTER_CLIENT_REQUEST_ERROR,
+                                            context.getAwsRequestId());
 
                                     return generateApiGatewayProxyResponse(
                                             400, errorResponse.get().toJSONObject().toJSONString());
@@ -102,7 +105,8 @@ public class ClientRegistrationHandler
                                 return generateApiGatewayProxyResponse(
                                         200, clientRegistrationResponse);
                             } catch (JsonProcessingException e) {
-                                auditService.submitAuditEvent(REGISTER_CLIENT_REQUEST_ERROR);
+                                auditService.submitAuditEvent(
+                                        REGISTER_CLIENT_REQUEST_ERROR, context.getAwsRequestId());
 
                                 return generateApiGatewayProxyResponse(
                                         400,

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandler.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandler.java
@@ -59,7 +59,9 @@ public class ClientRegistrationHandler
                 .orElseGet(
                         () -> {
                             auditService.submitAuditEvent(
-                                    REGISTER_CLIENT_REQUEST_RECEIVED, context.getAwsRequestId());
+                                    REGISTER_CLIENT_REQUEST_RECEIVED,
+                                    context.getAwsRequestId(),
+                                    "");
 
                             try {
                                 ClientRegistrationRequest clientRegistrationRequest =
@@ -71,7 +73,8 @@ public class ClientRegistrationHandler
                                 if (errorResponse.isPresent()) {
                                     auditService.submitAuditEvent(
                                             REGISTER_CLIENT_REQUEST_ERROR,
-                                            context.getAwsRequestId());
+                                            context.getAwsRequestId(),
+                                            "");
 
                                     return generateApiGatewayProxyResponse(
                                             400, errorResponse.get().toJSONObject().toJSONString());
@@ -106,7 +109,9 @@ public class ClientRegistrationHandler
                                         200, clientRegistrationResponse);
                             } catch (JsonProcessingException e) {
                                 auditService.submitAuditEvent(
-                                        REGISTER_CLIENT_REQUEST_ERROR, context.getAwsRequestId());
+                                        REGISTER_CLIENT_REQUEST_ERROR,
+                                        context.getAwsRequestId(),
+                                        "");
 
                                 return generateApiGatewayProxyResponse(
                                         400,

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandler.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandler.java
@@ -61,7 +61,8 @@ public class UpdateClientConfigHandler
         return isWarming(input)
                 .orElseGet(
                         () -> {
-                            auditService.submitAuditEvent(UPDATE_CLIENT_REQUEST_RECEIVED);
+                            auditService.submitAuditEvent(
+                                    UPDATE_CLIENT_REQUEST_RECEIVED, context.getAwsRequestId());
 
                             try {
                                 String clientId = input.getPathParameters().get("clientId");
@@ -70,7 +71,8 @@ public class UpdateClientConfigHandler
                                         objectMapper.readValue(
                                                 input.getBody(), UpdateClientConfigRequest.class);
                                 if (!clientService.isValidClient(clientId)) {
-                                    auditService.submitAuditEvent(UPDATE_CLIENT_REQUEST_ERROR);
+                                    auditService.submitAuditEvent(
+                                            UPDATE_CLIENT_REQUEST_ERROR, context.getAwsRequestId());
                                     LOGGER.error("Client with ClientId {} is not valid", clientId);
                                     return generateApiGatewayProxyResponse(
                                             400,
@@ -82,7 +84,8 @@ public class UpdateClientConfigHandler
                                         validationService.validateClientUpdateConfig(
                                                 updateClientConfigRequest);
                                 if (errorResponse.isPresent()) {
-                                    auditService.submitAuditEvent(UPDATE_CLIENT_REQUEST_ERROR);
+                                    auditService.submitAuditEvent(
+                                            UPDATE_CLIENT_REQUEST_ERROR, context.getAwsRequestId());
                                     return generateApiGatewayProxyResponse(
                                             400, errorResponse.get().toJSONObject().toJSONString());
                                 }
@@ -102,7 +105,8 @@ public class UpdateClientConfigHandler
                                 return generateApiGatewayProxyResponse(
                                         200, clientRegistrationResponse);
                             } catch (JsonProcessingException | NullPointerException e) {
-                                auditService.submitAuditEvent(UPDATE_CLIENT_REQUEST_ERROR);
+                                auditService.submitAuditEvent(
+                                        UPDATE_CLIENT_REQUEST_ERROR, context.getAwsRequestId());
                                 LOGGER.error(
                                         "Request with path parameters {} is missing request parameters",
                                         input.getPathParameters());

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandler.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandler.java
@@ -62,7 +62,7 @@ public class UpdateClientConfigHandler
                 .orElseGet(
                         () -> {
                             auditService.submitAuditEvent(
-                                    UPDATE_CLIENT_REQUEST_RECEIVED, context.getAwsRequestId());
+                                    UPDATE_CLIENT_REQUEST_RECEIVED, context.getAwsRequestId(), "");
 
                             try {
                                 String clientId = input.getPathParameters().get("clientId");
@@ -72,7 +72,9 @@ public class UpdateClientConfigHandler
                                                 input.getBody(), UpdateClientConfigRequest.class);
                                 if (!clientService.isValidClient(clientId)) {
                                     auditService.submitAuditEvent(
-                                            UPDATE_CLIENT_REQUEST_ERROR, context.getAwsRequestId());
+                                            UPDATE_CLIENT_REQUEST_ERROR,
+                                            context.getAwsRequestId(),
+                                            "");
                                     LOGGER.error("Client with ClientId {} is not valid", clientId);
                                     return generateApiGatewayProxyResponse(
                                             400,
@@ -85,7 +87,9 @@ public class UpdateClientConfigHandler
                                                 updateClientConfigRequest);
                                 if (errorResponse.isPresent()) {
                                     auditService.submitAuditEvent(
-                                            UPDATE_CLIENT_REQUEST_ERROR, context.getAwsRequestId());
+                                            UPDATE_CLIENT_REQUEST_ERROR,
+                                            context.getAwsRequestId(),
+                                            "");
                                     return generateApiGatewayProxyResponse(
                                             400, errorResponse.get().toJSONObject().toJSONString());
                                 }
@@ -106,7 +110,7 @@ public class UpdateClientConfigHandler
                                         200, clientRegistrationResponse);
                             } catch (JsonProcessingException | NullPointerException e) {
                                 auditService.submitAuditEvent(
-                                        UPDATE_CLIENT_REQUEST_ERROR, context.getAwsRequestId());
+                                        UPDATE_CLIENT_REQUEST_ERROR, context.getAwsRequestId(), "");
                                 LOGGER.error(
                                         "Request with path parameters {} is missing request parameters",
                                         input.getPathParameters());

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandlerTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandlerTest.java
@@ -114,7 +114,7 @@ class ClientRegistrationHandlerTest {
         assertThat(result, hasStatus(400));
         assertThat(result, hasBody(OAuth2Error.INVALID_REQUEST.toJSONObject().toJSONString()));
 
-        verify(auditService).submitAuditEvent(REGISTER_CLIENT_REQUEST_ERROR, "request-id");
+        verify(auditService).submitAuditEvent(REGISTER_CLIENT_REQUEST_ERROR, "request-id", "");
     }
 
     @Test
@@ -130,7 +130,7 @@ class ClientRegistrationHandlerTest {
         assertThat(result, hasStatus(400));
         assertThat(result, hasBody(INVALID_PUBLIC_KEY.toJSONObject().toJSONString()));
 
-        verify(auditService).submitAuditEvent(REGISTER_CLIENT_REQUEST_ERROR, "request-id");
+        verify(auditService).submitAuditEvent(REGISTER_CLIENT_REQUEST_ERROR, "request-id", "");
     }
 
     @Test
@@ -146,13 +146,13 @@ class ClientRegistrationHandlerTest {
         assertThat(result, hasStatus(400));
         assertThat(result, hasBody(INVALID_SCOPE.toJSONObject().toJSONString()));
 
-        verify(auditService).submitAuditEvent(REGISTER_CLIENT_REQUEST_ERROR, "request-id");
+        verify(auditService).submitAuditEvent(REGISTER_CLIENT_REQUEST_ERROR, "request-id", "");
     }
 
     private APIGatewayProxyResponseEvent makeHandlerRequest(APIGatewayProxyRequestEvent event) {
         var response = handler.handleRequest(event, context);
 
-        verify(auditService).submitAuditEvent(REGISTER_CLIENT_REQUEST_RECEIVED, "request-id");
+        verify(auditService).submitAuditEvent(REGISTER_CLIENT_REQUEST_RECEIVED, "request-id", "");
 
         return response;
     }

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandlerTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandlerTest.java
@@ -49,6 +49,7 @@ class ClientRegistrationHandlerTest {
 
     @BeforeEach
     public void setup() {
+        when(context.getAwsRequestId()).thenReturn("request-id");
         handler =
                 new ClientRegistrationHandler(clientService, configValidationService, auditService);
     }
@@ -113,7 +114,7 @@ class ClientRegistrationHandlerTest {
         assertThat(result, hasStatus(400));
         assertThat(result, hasBody(OAuth2Error.INVALID_REQUEST.toJSONObject().toJSONString()));
 
-        verify(auditService).submitAuditEvent(REGISTER_CLIENT_REQUEST_ERROR);
+        verify(auditService).submitAuditEvent(REGISTER_CLIENT_REQUEST_ERROR, "request-id");
     }
 
     @Test
@@ -129,7 +130,7 @@ class ClientRegistrationHandlerTest {
         assertThat(result, hasStatus(400));
         assertThat(result, hasBody(INVALID_PUBLIC_KEY.toJSONObject().toJSONString()));
 
-        verify(auditService).submitAuditEvent(REGISTER_CLIENT_REQUEST_ERROR);
+        verify(auditService).submitAuditEvent(REGISTER_CLIENT_REQUEST_ERROR, "request-id");
     }
 
     @Test
@@ -145,13 +146,13 @@ class ClientRegistrationHandlerTest {
         assertThat(result, hasStatus(400));
         assertThat(result, hasBody(INVALID_SCOPE.toJSONObject().toJSONString()));
 
-        verify(auditService).submitAuditEvent(REGISTER_CLIENT_REQUEST_ERROR);
+        verify(auditService).submitAuditEvent(REGISTER_CLIENT_REQUEST_ERROR, "request-id");
     }
 
     private APIGatewayProxyResponseEvent makeHandlerRequest(APIGatewayProxyRequestEvent event) {
         var response = handler.handleRequest(event, context);
 
-        verify(auditService).submitAuditEvent(REGISTER_CLIENT_REQUEST_RECEIVED);
+        verify(auditService).submitAuditEvent(REGISTER_CLIENT_REQUEST_RECEIVED, "request-id");
 
         return response;
     }

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandlerTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandlerTest.java
@@ -53,6 +53,7 @@ class UpdateClientConfigHandlerTest {
 
     @BeforeEach
     public void setUp() {
+        when(context.getAwsRequestId()).thenReturn("request-id");
         handler =
                 new UpdateClientConfigHandler(clientService, clientValidationService, auditService);
     }
@@ -95,7 +96,7 @@ class UpdateClientConfigHandlerTest {
         assertThat(result, hasStatus(400));
         assertThat(result, hasBody(OAuth2Error.INVALID_REQUEST.toJSONObject().toJSONString()));
 
-        verify(auditService).submitAuditEvent(UPDATE_CLIENT_REQUEST_ERROR);
+        verify(auditService).submitAuditEvent(UPDATE_CLIENT_REQUEST_ERROR, "request-id");
     }
 
     @Test
@@ -107,7 +108,7 @@ class UpdateClientConfigHandlerTest {
         assertThat(result, hasStatus(400));
         assertThat(result, hasBody(OAuth2Error.INVALID_REQUEST.toJSONObject().toJSONString()));
 
-        verify(auditService).submitAuditEvent(UPDATE_CLIENT_REQUEST_ERROR);
+        verify(auditService).submitAuditEvent(UPDATE_CLIENT_REQUEST_ERROR, "request-id");
     }
 
     @Test
@@ -121,7 +122,7 @@ class UpdateClientConfigHandlerTest {
         assertThat(result, hasStatus(400));
         assertThat(result, hasBody(OAuth2Error.INVALID_CLIENT.toJSONObject().toJSONString()));
 
-        verify(auditService).submitAuditEvent(UPDATE_CLIENT_REQUEST_ERROR);
+        verify(auditService).submitAuditEvent(UPDATE_CLIENT_REQUEST_ERROR, "request-id");
     }
 
     @Test
@@ -142,7 +143,7 @@ class UpdateClientConfigHandlerTest {
         assertThat(result, hasStatus(400));
         assertThat(result, hasBody(INVALID_PUBLIC_KEY.toJSONObject().toJSONString()));
 
-        verify(auditService).submitAuditEvent(UPDATE_CLIENT_REQUEST_ERROR);
+        verify(auditService).submitAuditEvent(UPDATE_CLIENT_REQUEST_ERROR, "request-id");
     }
 
     @Test
@@ -160,7 +161,7 @@ class UpdateClientConfigHandlerTest {
         assertThat(result, hasStatus(400));
         assertThat(result, hasBody(INVALID_SCOPE.toJSONObject().toJSONString()));
 
-        verify(auditService).submitAuditEvent(UPDATE_CLIENT_REQUEST_ERROR);
+        verify(auditService).submitAuditEvent(UPDATE_CLIENT_REQUEST_ERROR, "request-id");
     }
 
     private ClientRegistry createClientRegistry() {
@@ -179,7 +180,7 @@ class UpdateClientConfigHandlerTest {
     private APIGatewayProxyResponseEvent makeHandlerRequest(APIGatewayProxyRequestEvent event) {
         var response = handler.handleRequest(event, context);
 
-        verify(auditService).submitAuditEvent(UPDATE_CLIENT_REQUEST_RECEIVED);
+        verify(auditService).submitAuditEvent(UPDATE_CLIENT_REQUEST_RECEIVED, "request-id");
 
         return response;
     }

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandlerTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandlerTest.java
@@ -96,7 +96,7 @@ class UpdateClientConfigHandlerTest {
         assertThat(result, hasStatus(400));
         assertThat(result, hasBody(OAuth2Error.INVALID_REQUEST.toJSONObject().toJSONString()));
 
-        verify(auditService).submitAuditEvent(UPDATE_CLIENT_REQUEST_ERROR, "request-id");
+        verify(auditService).submitAuditEvent(UPDATE_CLIENT_REQUEST_ERROR, "request-id", "");
     }
 
     @Test
@@ -108,7 +108,7 @@ class UpdateClientConfigHandlerTest {
         assertThat(result, hasStatus(400));
         assertThat(result, hasBody(OAuth2Error.INVALID_REQUEST.toJSONObject().toJSONString()));
 
-        verify(auditService).submitAuditEvent(UPDATE_CLIENT_REQUEST_ERROR, "request-id");
+        verify(auditService).submitAuditEvent(UPDATE_CLIENT_REQUEST_ERROR, "request-id", "");
     }
 
     @Test
@@ -122,7 +122,7 @@ class UpdateClientConfigHandlerTest {
         assertThat(result, hasStatus(400));
         assertThat(result, hasBody(OAuth2Error.INVALID_CLIENT.toJSONObject().toJSONString()));
 
-        verify(auditService).submitAuditEvent(UPDATE_CLIENT_REQUEST_ERROR, "request-id");
+        verify(auditService).submitAuditEvent(UPDATE_CLIENT_REQUEST_ERROR, "request-id", "");
     }
 
     @Test
@@ -143,7 +143,7 @@ class UpdateClientConfigHandlerTest {
         assertThat(result, hasStatus(400));
         assertThat(result, hasBody(INVALID_PUBLIC_KEY.toJSONObject().toJSONString()));
 
-        verify(auditService).submitAuditEvent(UPDATE_CLIENT_REQUEST_ERROR, "request-id");
+        verify(auditService).submitAuditEvent(UPDATE_CLIENT_REQUEST_ERROR, "request-id", "");
     }
 
     @Test
@@ -161,7 +161,7 @@ class UpdateClientConfigHandlerTest {
         assertThat(result, hasStatus(400));
         assertThat(result, hasBody(INVALID_SCOPE.toJSONObject().toJSONString()));
 
-        verify(auditService).submitAuditEvent(UPDATE_CLIENT_REQUEST_ERROR, "request-id");
+        verify(auditService).submitAuditEvent(UPDATE_CLIENT_REQUEST_ERROR, "request-id", "");
     }
 
     private ClientRegistry createClientRegistry() {
@@ -180,7 +180,7 @@ class UpdateClientConfigHandlerTest {
     private APIGatewayProxyResponseEvent makeHandlerRequest(APIGatewayProxyRequestEvent event) {
         var response = handler.handleRequest(event, context);
 
-        verify(auditService).submitAuditEvent(UPDATE_CLIENT_REQUEST_RECEIVED, "request-id");
+        verify(auditService).submitAuditEvent(UPDATE_CLIENT_REQUEST_RECEIVED, "request-id", "");
 
         return response;
     }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/BaseFrontendHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/BaseFrontendHandler.java
@@ -78,9 +78,9 @@ public abstract class BaseFrontendHandler<T>
         return isWarming(input).orElseGet(() -> validateAndHandleRequest(input, context));
     }
 
-    public void onRequestReceived() {}
+    public void onRequestReceived(Context context) {}
 
-    public void onRequestValidationError() {}
+    public void onRequestValidationError(Context context) {}
 
     public abstract APIGatewayProxyResponseEvent handleRequestWithUserContext(
             APIGatewayProxyRequestEvent input,
@@ -90,7 +90,7 @@ public abstract class BaseFrontendHandler<T>
 
     private APIGatewayProxyResponseEvent validateAndHandleRequest(
             APIGatewayProxyRequestEvent input, Context context) {
-        onRequestReceived();
+        onRequestReceived(context);
         Optional<Session> session = sessionService.getSessionFromRequestHeaders(input.getHeaders());
         Optional<ClientSession> clientSession =
                 clientSessionService.getClientSessionFromRequestHeaders(input.getHeaders());
@@ -105,7 +105,7 @@ public abstract class BaseFrontendHandler<T>
             LOG.error(
                     "Request is missing parameters. The body present in request: {}",
                     input.getBody());
-            onRequestValidationError();
+            onRequestValidationError(context);
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
         }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
@@ -97,12 +97,13 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
 
     @Override
     public void onRequestReceived(Context context) {
-        auditService.submitAuditEvent(ACCOUNT_MANAGEMENT_REQUEST_RECEIVED);
+        auditService.submitAuditEvent(
+                ACCOUNT_MANAGEMENT_REQUEST_RECEIVED, context.getAwsRequestId());
     }
 
     @Override
     public void onRequestValidationError(Context context) {
-        auditService.submitAuditEvent(ACCOUNT_MANAGEMENT_REQUEST_ERROR);
+        auditService.submitAuditEvent(ACCOUNT_MANAGEMENT_REQUEST_ERROR, context.getAwsRequestId());
     }
 
     @Override
@@ -129,7 +130,8 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
                                         session.getState(), USER_ENTERED_A_NEW_PHONE_NUMBER);
                         authenticationService.updatePhoneNumber(
                                 request.getEmail(), request.getProfileInformation());
-                        auditService.submitAuditEvent(ACCOUNT_MANAGEMENT_PHONE_NUMBER_UPDATED);
+                        auditService.submitAuditEvent(
+                                ACCOUNT_MANAGEMENT_PHONE_NUMBER_UPDATED, context.getAwsRequestId());
                         sessionService.save(session.setState(nextState));
                         LOGGER.info(
                                 "Phone number updated and session state changed. Session state {}",
@@ -174,7 +176,8 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
 
                         sessionService.save(session.setState(nextState));
 
-                        auditService.submitAuditEvent(ACCOUNT_MANAGEMENT_CONSENT_UPDATED);
+                        auditService.submitAuditEvent(
+                                ACCOUNT_MANAGEMENT_CONSENT_UPDATED, context.getAwsRequestId());
 
                         LOGGER.info(
                                 "Consent updated for ClientID {} and session state changed. Session state {}",
@@ -190,7 +193,8 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
                                 configurationService.getTermsAndConditionsVersion());
 
                         auditService.submitAuditEvent(
-                                ACCOUNT_MANAGEMENT_TERMS_CONDS_ACCEPTANCE_UPDATED);
+                                ACCOUNT_MANAGEMENT_TERMS_CONDS_ACCEPTANCE_UPDATED,
+                                context.getAwsRequestId());
                         LOGGER.info(
                                 "Updated terms and conditions. Email {} for Version {}",
                                 request.getEmail(),

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
@@ -98,12 +98,13 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
     @Override
     public void onRequestReceived(Context context) {
         auditService.submitAuditEvent(
-                ACCOUNT_MANAGEMENT_REQUEST_RECEIVED, context.getAwsRequestId());
+                ACCOUNT_MANAGEMENT_REQUEST_RECEIVED, context.getAwsRequestId(), "");
     }
 
     @Override
     public void onRequestValidationError(Context context) {
-        auditService.submitAuditEvent(ACCOUNT_MANAGEMENT_REQUEST_ERROR, context.getAwsRequestId());
+        auditService.submitAuditEvent(
+                ACCOUNT_MANAGEMENT_REQUEST_ERROR, context.getAwsRequestId(), "");
     }
 
     @Override
@@ -131,7 +132,9 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
                         authenticationService.updatePhoneNumber(
                                 request.getEmail(), request.getProfileInformation());
                         auditService.submitAuditEvent(
-                                ACCOUNT_MANAGEMENT_PHONE_NUMBER_UPDATED, context.getAwsRequestId());
+                                ACCOUNT_MANAGEMENT_PHONE_NUMBER_UPDATED,
+                                context.getAwsRequestId(),
+                                session.getSessionId());
                         sessionService.save(session.setState(nextState));
                         LOGGER.info(
                                 "Phone number updated and session state changed. Session state {}",
@@ -177,7 +180,9 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
                         sessionService.save(session.setState(nextState));
 
                         auditService.submitAuditEvent(
-                                ACCOUNT_MANAGEMENT_CONSENT_UPDATED, context.getAwsRequestId());
+                                ACCOUNT_MANAGEMENT_CONSENT_UPDATED,
+                                context.getAwsRequestId(),
+                                session.getSessionId());
 
                         LOGGER.info(
                                 "Consent updated for ClientID {} and session state changed. Session state {}",
@@ -194,7 +199,8 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
 
                         auditService.submitAuditEvent(
                                 ACCOUNT_MANAGEMENT_TERMS_CONDS_ACCEPTANCE_UPDATED,
-                                context.getAwsRequestId());
+                                context.getAwsRequestId(),
+                                session.getSessionId());
                         LOGGER.info(
                                 "Updated terms and conditions. Email {} for Version {}",
                                 request.getEmail(),

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandlerTest.java
@@ -140,7 +140,10 @@ class UpdateProfileHandlerTest {
         assertThat(result, hasStatus(200));
 
         verify(auditService)
-                .submitAuditEvent(ACCOUNT_MANAGEMENT_PHONE_NUMBER_UPDATED, "request-id");
+                .submitAuditEvent(
+                        ACCOUNT_MANAGEMENT_PHONE_NUMBER_UPDATED,
+                        "request-id",
+                        session.getSessionId());
     }
 
     @Test
@@ -170,7 +173,10 @@ class UpdateProfileHandlerTest {
         assertThat(result, hasStatus(200));
 
         verify(auditService)
-                .submitAuditEvent(ACCOUNT_MANAGEMENT_TERMS_CONDS_ACCEPTANCE_UPDATED, "request-id");
+                .submitAuditEvent(
+                        ACCOUNT_MANAGEMENT_TERMS_CONDS_ACCEPTANCE_UPDATED,
+                        "request-id",
+                        session.getSessionId());
     }
 
     @Test
@@ -213,7 +219,9 @@ class UpdateProfileHandlerTest {
 
         assertThat(result, hasStatus(200));
 
-        verify(auditService).submitAuditEvent(ACCOUNT_MANAGEMENT_CONSENT_UPDATED, "request-id");
+        verify(auditService)
+                .submitAuditEvent(
+                        ACCOUNT_MANAGEMENT_CONSENT_UPDATED, "request-id", session.getSessionId());
         BaseAPIResponse codeResponse =
                 new ObjectMapper().readValue(result.getBody(), BaseAPIResponse.class);
         assertThat(codeResponse.getSessionState(), equalTo(CONSENT_ADDED));
@@ -236,7 +244,7 @@ class UpdateProfileHandlerTest {
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1001));
 
-        verify(auditService).submitAuditEvent(ACCOUNT_MANAGEMENT_REQUEST_ERROR, "request-id");
+        verify(auditService).submitAuditEvent(ACCOUNT_MANAGEMENT_REQUEST_ERROR, "request-id", "");
     }
 
     @Test
@@ -254,7 +262,7 @@ class UpdateProfileHandlerTest {
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1017));
 
-        verify(auditService).submitAuditEvent(ACCOUNT_MANAGEMENT_REQUEST_ERROR, "request-id");
+        verify(auditService).submitAuditEvent(ACCOUNT_MANAGEMENT_REQUEST_ERROR, "request-id", "");
     }
 
     private void usingValidSession() {
@@ -281,7 +289,8 @@ class UpdateProfileHandlerTest {
     private APIGatewayProxyResponseEvent makeHandlerRequest(APIGatewayProxyRequestEvent event) {
         var response = handler.handleRequest(event, context);
 
-        verify(auditService).submitAuditEvent(ACCOUNT_MANAGEMENT_REQUEST_RECEIVED, "request-id");
+        verify(auditService)
+                .submitAuditEvent(ACCOUNT_MANAGEMENT_REQUEST_RECEIVED, "request-id", "");
 
         return response;
     }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandlerTest.java
@@ -107,6 +107,7 @@ class UpdateProfileHandlerTest {
 
     @BeforeEach
     public void setUp() {
+        when(context.getAwsRequestId()).thenReturn("request-id");
         handler =
                 new UpdateProfileHandler(
                         authenticationService,
@@ -138,7 +139,8 @@ class UpdateProfileHandlerTest {
 
         assertThat(result, hasStatus(200));
 
-        verify(auditService).submitAuditEvent(ACCOUNT_MANAGEMENT_PHONE_NUMBER_UPDATED);
+        verify(auditService)
+                .submitAuditEvent(ACCOUNT_MANAGEMENT_PHONE_NUMBER_UPDATED, "request-id");
     }
 
     @Test
@@ -167,7 +169,8 @@ class UpdateProfileHandlerTest {
 
         assertThat(result, hasStatus(200));
 
-        verify(auditService).submitAuditEvent(ACCOUNT_MANAGEMENT_TERMS_CONDS_ACCEPTANCE_UPDATED);
+        verify(auditService)
+                .submitAuditEvent(ACCOUNT_MANAGEMENT_TERMS_CONDS_ACCEPTANCE_UPDATED, "request-id");
     }
 
     @Test
@@ -210,7 +213,7 @@ class UpdateProfileHandlerTest {
 
         assertThat(result, hasStatus(200));
 
-        verify(auditService).submitAuditEvent(ACCOUNT_MANAGEMENT_CONSENT_UPDATED);
+        verify(auditService).submitAuditEvent(ACCOUNT_MANAGEMENT_CONSENT_UPDATED, "request-id");
         BaseAPIResponse codeResponse =
                 new ObjectMapper().readValue(result.getBody(), BaseAPIResponse.class);
         assertThat(codeResponse.getSessionState(), equalTo(CONSENT_ADDED));
@@ -233,7 +236,7 @@ class UpdateProfileHandlerTest {
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1001));
 
-        verify(auditService).submitAuditEvent(ACCOUNT_MANAGEMENT_REQUEST_ERROR);
+        verify(auditService).submitAuditEvent(ACCOUNT_MANAGEMENT_REQUEST_ERROR, "request-id");
     }
 
     @Test
@@ -251,7 +254,7 @@ class UpdateProfileHandlerTest {
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1017));
 
-        verify(auditService).submitAuditEvent(ACCOUNT_MANAGEMENT_REQUEST_ERROR);
+        verify(auditService).submitAuditEvent(ACCOUNT_MANAGEMENT_REQUEST_ERROR, "request-id");
     }
 
     private void usingValidSession() {
@@ -278,7 +281,7 @@ class UpdateProfileHandlerTest {
     private APIGatewayProxyResponseEvent makeHandlerRequest(APIGatewayProxyRequestEvent event) {
         var response = handler.handleRequest(event, context);
 
-        verify(auditService).submitAuditEvent(ACCOUNT_MANAGEMENT_REQUEST_RECEIVED);
+        verify(auditService).submitAuditEvent(ACCOUNT_MANAGEMENT_REQUEST_RECEIVED, "request-id");
 
         return response;
     }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -91,7 +91,8 @@ public class AuthorisationHandler
                         () -> {
                             auditService.submitAuditEvent(
                                     OidcAuditableEvent.AUTHORISATION_REQUEST_RECEIVED,
-                                    context.getAwsRequestId());
+                                    context.getAwsRequestId(),
+                                    "");
                             LOGGER.info("Received authentication request");
 
                             Map<String, List<String>> queryStringParameters =
@@ -300,6 +301,7 @@ public class AuthorisationHandler
         auditService.submitAuditEvent(
                 OidcAuditableEvent.AUTHORISATION_REQUEST_ERROR,
                 context.getAwsRequestId(),
+                "",
                 pair("description", errorObject.getDescription()));
 
         LOGGER.error(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -90,7 +90,8 @@ public class AuthorisationHandler
                 .orElseGet(
                         () -> {
                             auditService.submitAuditEvent(
-                                    OidcAuditableEvent.AUTHORISATION_REQUEST_RECEIVED);
+                                    OidcAuditableEvent.AUTHORISATION_REQUEST_RECEIVED,
+                                    context.getAwsRequestId());
                             LOGGER.info("Received authentication request");
 
                             Map<String, List<String>> queryStringParameters =
@@ -113,12 +114,13 @@ public class AuthorisationHandler
                                         e.getRedirectionURI(),
                                         e.getState(),
                                         e.getResponseMode(),
-                                        e.getErrorObject());
+                                        e.getErrorObject(),
+                                        context);
                             }
                             Optional<ErrorObject> error =
                                     authorizationService.validateAuthRequest(authRequest);
 
-                            return error.map(e -> generateErrorResponse(authRequest, e))
+                            return error.map(e -> generateErrorResponse(authRequest, e, context))
                                     .orElseGet(
                                             () ->
                                                     getOrCreateSessionAndRedirect(
@@ -126,24 +128,29 @@ public class AuthorisationHandler
                                                             sessionService
                                                                     .getSessionFromSessionCookie(
                                                                             input.getHeaders()),
-                                                            authRequest));
+                                                            authRequest,
+                                                            context));
                         });
     }
 
     private APIGatewayProxyResponseEvent getOrCreateSessionAndRedirect(
             Map<String, List<String>> authRequestParameters,
             Optional<Session> existingSession,
-            AuthenticationRequest authenticationRequest) {
+            AuthenticationRequest authenticationRequest,
+            Context context) {
         final SessionAction sessionAction;
         if (authenticationRequest.getPrompt() != null) {
             if (authenticationRequest.getPrompt().contains(Prompt.Type.CONSENT)
                     || authenticationRequest.getPrompt().contains(Prompt.Type.SELECT_ACCOUNT)) {
                 return generateErrorResponse(
-                        authenticationRequest, OIDCError.UNMET_AUTHENTICATION_REQUIREMENTS);
+                        authenticationRequest,
+                        OIDCError.UNMET_AUTHENTICATION_REQUIREMENTS,
+                        context);
             }
             if (authenticationRequest.getPrompt().contains(Prompt.Type.NONE)
                     && !isUserAuthenticated(existingSession)) {
-                return generateErrorResponse(authenticationRequest, OIDCError.LOGIN_REQUIRED);
+                return generateErrorResponse(
+                        authenticationRequest, OIDCError.LOGIN_REQUIRED, context);
             }
             if (authenticationRequest.getPrompt().contains(Prompt.Type.LOGIN)
                     && isUserAuthenticated(existingSession)) {
@@ -273,20 +280,26 @@ public class AuthorisationHandler
     }
 
     private APIGatewayProxyResponseEvent generateErrorResponse(
-            AuthenticationRequest authRequest, ErrorObject errorObject) {
+            AuthenticationRequest authRequest, ErrorObject errorObject, Context context) {
 
         return generateErrorResponse(
                 authRequest.getRedirectionURI(),
                 authRequest.getState(),
                 authRequest.getResponseMode(),
-                errorObject);
+                errorObject,
+                context);
     }
 
     private APIGatewayProxyResponseEvent generateErrorResponse(
-            URI redirectUri, State state, ResponseMode responseMode, ErrorObject errorObject) {
+            URI redirectUri,
+            State state,
+            ResponseMode responseMode,
+            ErrorObject errorObject,
+            Context context) {
 
         auditService.submitAuditEvent(
                 OidcAuditableEvent.AUTHORISATION_REQUEST_ERROR,
+                context.getAwsRequestId(),
                 pair("description", errorObject.getDescription()));
 
         LOGGER.error(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -70,6 +70,7 @@ class AuthorisationHandlerTest {
 
     @BeforeEach
     public void setUp() {
+        when(context.getAwsRequestId()).thenReturn("request-id");
         handler =
                 new AuthorisationHandler(
                         configService,
@@ -164,6 +165,7 @@ class AuthorisationHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         AUTHORISATION_REQUEST_ERROR,
+                        "request-id",
                         pair("description", "Invalid request: Missing response_type parameter"));
     }
 
@@ -189,6 +191,7 @@ class AuthorisationHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         AUTHORISATION_REQUEST_ERROR,
+                        "request-id",
                         pair("description", OAuth2Error.INVALID_SCOPE.getDescription()));
     }
 
@@ -254,6 +257,7 @@ class AuthorisationHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         AUTHORISATION_REQUEST_ERROR,
+                        "request-id",
                         pair("description", OIDCError.LOGIN_REQUIRED.getDescription()));
     }
 
@@ -345,6 +349,7 @@ class AuthorisationHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         AUTHORISATION_REQUEST_ERROR,
+                        "request-id",
                         pair(
                                 "description",
                                 "Invalid request: Invalid prompt parameter: Unknown prompt type: unrecognised"));
@@ -364,6 +369,7 @@ class AuthorisationHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         AUTHORISATION_REQUEST_ERROR,
+                        "request-id",
                         pair(
                                 "description",
                                 "Invalid request: Invalid prompt parameter: Invalid prompt: none login"));
@@ -383,6 +389,7 @@ class AuthorisationHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         AUTHORISATION_REQUEST_ERROR,
+                        "request-id",
                         pair(
                                 "description",
                                 OIDCError.UNMET_AUTHENTICATION_REQUIREMENTS.getDescription()));
@@ -402,6 +409,7 @@ class AuthorisationHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         AUTHORISATION_REQUEST_ERROR,
+                        "request-id",
                         pair(
                                 "description",
                                 OIDCError.UNMET_AUTHENTICATION_REQUIREMENTS.getDescription()));
@@ -421,6 +429,7 @@ class AuthorisationHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         AUTHORISATION_REQUEST_ERROR,
+                        "request-id",
                         pair(
                                 "description",
                                 OIDCError.UNMET_AUTHENTICATION_REQUIREMENTS.getDescription()));
@@ -477,7 +486,8 @@ class AuthorisationHandlerTest {
     private APIGatewayProxyResponseEvent makeHandlerRequest(APIGatewayProxyRequestEvent event) {
         var response = handler.handleRequest(event, context);
 
-        verify(auditService).submitAuditEvent(OidcAuditableEvent.AUTHORISATION_REQUEST_RECEIVED);
+        verify(auditService)
+                .submitAuditEvent(OidcAuditableEvent.AUTHORISATION_REQUEST_RECEIVED, "request-id");
 
         return response;
     }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -166,6 +166,7 @@ class AuthorisationHandlerTest {
                 .submitAuditEvent(
                         AUTHORISATION_REQUEST_ERROR,
                         "request-id",
+                        "",
                         pair("description", "Invalid request: Missing response_type parameter"));
     }
 
@@ -192,6 +193,7 @@ class AuthorisationHandlerTest {
                 .submitAuditEvent(
                         AUTHORISATION_REQUEST_ERROR,
                         "request-id",
+                        "",
                         pair("description", OAuth2Error.INVALID_SCOPE.getDescription()));
     }
 
@@ -258,6 +260,7 @@ class AuthorisationHandlerTest {
                 .submitAuditEvent(
                         AUTHORISATION_REQUEST_ERROR,
                         "request-id",
+                        "",
                         pair("description", OIDCError.LOGIN_REQUIRED.getDescription()));
     }
 
@@ -350,6 +353,7 @@ class AuthorisationHandlerTest {
                 .submitAuditEvent(
                         AUTHORISATION_REQUEST_ERROR,
                         "request-id",
+                        "",
                         pair(
                                 "description",
                                 "Invalid request: Invalid prompt parameter: Unknown prompt type: unrecognised"));
@@ -370,6 +374,7 @@ class AuthorisationHandlerTest {
                 .submitAuditEvent(
                         AUTHORISATION_REQUEST_ERROR,
                         "request-id",
+                        "",
                         pair(
                                 "description",
                                 "Invalid request: Invalid prompt parameter: Invalid prompt: none login"));
@@ -390,6 +395,7 @@ class AuthorisationHandlerTest {
                 .submitAuditEvent(
                         AUTHORISATION_REQUEST_ERROR,
                         "request-id",
+                        "",
                         pair(
                                 "description",
                                 OIDCError.UNMET_AUTHENTICATION_REQUIREMENTS.getDescription()));
@@ -410,6 +416,7 @@ class AuthorisationHandlerTest {
                 .submitAuditEvent(
                         AUTHORISATION_REQUEST_ERROR,
                         "request-id",
+                        "",
                         pair(
                                 "description",
                                 OIDCError.UNMET_AUTHENTICATION_REQUIREMENTS.getDescription()));
@@ -430,6 +437,7 @@ class AuthorisationHandlerTest {
                 .submitAuditEvent(
                         AUTHORISATION_REQUEST_ERROR,
                         "request-id",
+                        "",
                         pair(
                                 "description",
                                 OIDCError.UNMET_AUTHENTICATION_REQUIREMENTS.getDescription()));
@@ -487,7 +495,8 @@ class AuthorisationHandlerTest {
         var response = handler.handleRequest(event, context);
 
         verify(auditService)
-                .submitAuditEvent(OidcAuditableEvent.AUTHORISATION_REQUEST_RECEIVED, "request-id");
+                .submitAuditEvent(
+                        OidcAuditableEvent.AUTHORISATION_REQUEST_RECEIVED, "request-id", "");
 
         return response;
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/matchers/AuditMessageMatcher.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/matchers/AuditMessageMatcher.java
@@ -28,6 +28,10 @@ public class AuditMessageMatcher<T> extends TypeSafeDiagnosingMatcher<String> {
         return new AuditMessageMatcher<>("timestamp", AuditEvent::getTimestamp, timestampAsString);
     }
 
+    public static AuditMessageMatcher<String> hasRequestId(String requestId) {
+        return new AuditMessageMatcher<>("request ID", AuditEvent::getRequestId, requestId);
+    }
+
     @Override
     protected boolean matchesSafely(
             String serialisedAuditMessage, Description mismatchDescription) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/matchers/AuditMessageMatcher.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/matchers/AuditMessageMatcher.java
@@ -32,6 +32,10 @@ public class AuditMessageMatcher<T> extends TypeSafeDiagnosingMatcher<String> {
         return new AuditMessageMatcher<>("request ID", AuditEvent::getRequestId, requestId);
     }
 
+    public static AuditMessageMatcher<String> hasSessionId(String sessionId) {
+        return new AuditMessageMatcher<>("session ID", AuditEvent::getSessionId, sessionId);
+    }
+
     @Override
     protected boolean matchesSafely(
             String serialisedAuditMessage, Description mismatchDescription) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
@@ -23,18 +23,25 @@ public class AuditService {
     }
 
     public void submitAuditEvent(
-            AuditableEvent event, String requestId, MetadataPair... metadataPairs) {
-        snsService.publishAuditMessage(generateLogLine(event, requestId, metadataPairs));
+            AuditableEvent event,
+            String requestId,
+            String sessionId,
+            MetadataPair... metadataPairs) {
+        snsService.publishAuditMessage(generateLogLine(event, requestId, sessionId, metadataPairs));
     }
 
     String generateLogLine(
-            AuditableEvent eventEnum, String requestId, MetadataPair... metadataPairs) {
+            AuditableEvent eventEnum,
+            String requestId,
+            String sessionId,
+            MetadataPair... metadataPairs) {
         var timestamp = clock.instant().toString();
 
         var eventBuilder = AuditEvent.newBuilder();
         eventBuilder.setEventName(eventEnum.toString());
         eventBuilder.setTimestamp(timestamp);
         eventBuilder.setRequestId(requestId);
+        eventBuilder.setSessionId(sessionId);
         // TODO - Extract other values from the metadataPairs argument.
 
         var signedEventBuilder = SignedAuditEvent.newBuilder();

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
@@ -22,16 +22,19 @@ public class AuditService {
         this.snsService = new SnsService(new ConfigurationService());
     }
 
-    public void submitAuditEvent(AuditableEvent event, MetadataPair... metadataPairs) {
-        snsService.publishAuditMessage(generateLogLine(event, metadataPairs));
+    public void submitAuditEvent(
+            AuditableEvent event, String requestId, MetadataPair... metadataPairs) {
+        snsService.publishAuditMessage(generateLogLine(event, requestId, metadataPairs));
     }
 
-    String generateLogLine(AuditableEvent eventEnum, MetadataPair... metadataPairs) {
+    String generateLogLine(
+            AuditableEvent eventEnum, String requestId, MetadataPair... metadataPairs) {
         var timestamp = clock.instant().toString();
 
         var eventBuilder = AuditEvent.newBuilder();
         eventBuilder.setEventName(eventEnum.toString());
         eventBuilder.setTimestamp(timestamp);
+        eventBuilder.setRequestId(requestId);
         // TODO - Extract other values from the metadataPairs argument.
 
         var signedEventBuilder = SignedAuditEvent.newBuilder();

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
@@ -6,6 +6,7 @@ import uk.gov.di.authentication.shared.domain.AuditableEvent;
 
 import java.time.Clock;
 import java.util.Objects;
+import java.util.Optional;
 
 public class AuditService {
 
@@ -41,8 +42,8 @@ public class AuditService {
                 AuditEvent.newBuilder()
                         .setEventName(eventEnum.toString())
                         .setTimestamp(timestamp)
-                        .setRequestId(requestId)
-                        .setSessionId(sessionId);
+                        .setRequestId(Optional.ofNullable(requestId).orElse(""))
+                        .setSessionId(Optional.ofNullable(sessionId).orElse(""));
         // TODO - Extract other values from the metadataPairs argument.
 
         var signedEventBuilder = SignedAuditEvent.newBuilder();

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
@@ -37,11 +37,12 @@ public class AuditService {
             MetadataPair... metadataPairs) {
         var timestamp = clock.instant().toString();
 
-        var eventBuilder = AuditEvent.newBuilder();
-        eventBuilder.setEventName(eventEnum.toString());
-        eventBuilder.setTimestamp(timestamp);
-        eventBuilder.setRequestId(requestId);
-        eventBuilder.setSessionId(sessionId);
+        var eventBuilder =
+                AuditEvent.newBuilder()
+                        .setEventName(eventEnum.toString())
+                        .setTimestamp(timestamp)
+                        .setRequestId(requestId)
+                        .setSessionId(sessionId);
         // TODO - Extract other values from the metadataPairs argument.
 
         var signedEventBuilder = SignedAuditEvent.newBuilder();

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static uk.gov.di.authentication.shared.matchers.AuditMessageMatcher.hasEventName;
+import static uk.gov.di.authentication.shared.matchers.AuditMessageMatcher.hasRequestId;
 import static uk.gov.di.authentication.shared.matchers.AuditMessageMatcher.hasTimestamp;
 import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
 import static uk.gov.di.authentication.shared.services.AuditServiceTest.TestEvents.TEST_EVENT_ONE;
@@ -49,20 +50,22 @@ class AuditServiceTest {
     void shouldLogAuditEvent() {
         var auditService = new AuditService(FIXED_CLOCK, snsService);
 
-        auditService.submitAuditEvent(TEST_EVENT_ONE);
+        auditService.submitAuditEvent(TEST_EVENT_ONE, "request-id");
 
         verify(snsService).publishAuditMessage(messageCaptor.capture());
         var serialisedAuditMessage = messageCaptor.getValue();
 
         assertThat(serialisedAuditMessage, hasTimestamp(FIXED_TIMESTAMP));
         assertThat(serialisedAuditMessage, hasEventName(TEST_EVENT_ONE.toString()));
+        assertThat(serialisedAuditMessage, hasRequestId("request-id"));
     }
 
     @Test
     void shouldLogAuditEventWithMetadataPairsAttached() {
         var auditService = new AuditService(FIXED_CLOCK, snsService);
 
-        auditService.submitAuditEvent(TEST_EVENT_ONE, pair("key", "value"), pair("key2", "value2"));
+        auditService.submitAuditEvent(
+                TEST_EVENT_ONE, "request-id", pair("key", "value"), pair("key2", "value2"));
 
         verify(snsService).publishAuditMessage(messageCaptor.capture());
         var serialisedAuditMessage = messageCaptor.getValue();

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static uk.gov.di.authentication.shared.matchers.AuditMessageMatcher.hasEventName;
 import static uk.gov.di.authentication.shared.matchers.AuditMessageMatcher.hasRequestId;
+import static uk.gov.di.authentication.shared.matchers.AuditMessageMatcher.hasSessionId;
 import static uk.gov.di.authentication.shared.matchers.AuditMessageMatcher.hasTimestamp;
 import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
 import static uk.gov.di.authentication.shared.services.AuditServiceTest.TestEvents.TEST_EVENT_ONE;
@@ -50,7 +51,7 @@ class AuditServiceTest {
     void shouldLogAuditEvent() {
         var auditService = new AuditService(FIXED_CLOCK, snsService);
 
-        auditService.submitAuditEvent(TEST_EVENT_ONE, "request-id");
+        auditService.submitAuditEvent(TEST_EVENT_ONE, "request-id", "session-id");
 
         verify(snsService).publishAuditMessage(messageCaptor.capture());
         var serialisedAuditMessage = messageCaptor.getValue();
@@ -58,6 +59,7 @@ class AuditServiceTest {
         assertThat(serialisedAuditMessage, hasTimestamp(FIXED_TIMESTAMP));
         assertThat(serialisedAuditMessage, hasEventName(TEST_EVENT_ONE.toString()));
         assertThat(serialisedAuditMessage, hasRequestId("request-id"));
+        assertThat(serialisedAuditMessage, hasSessionId("session-id"));
     }
 
     @Test
@@ -65,7 +67,11 @@ class AuditServiceTest {
         var auditService = new AuditService(FIXED_CLOCK, snsService);
 
         auditService.submitAuditEvent(
-                TEST_EVENT_ONE, "request-id", pair("key", "value"), pair("key2", "value2"));
+                TEST_EVENT_ONE,
+                "request-id",
+                "session-id",
+                pair("key", "value"),
+                pair("key2", "value2"));
 
         verify(snsService).publishAuditMessage(messageCaptor.capture());
         var serialisedAuditMessage = messageCaptor.getValue();


### PR DESCRIPTION
## What?

Send AWS Request ID and Session ID to the audit service

## Why?

They are needed by our performance analysts and our monitoring.

## Notes

This is the first PR of a few that will incrementally add data to the payload
