### PR TITLE
GOVSI-562: Restrict Lambda networking connection to specific VPC

### DIFF
--- a/ci/terraform/account-management/lambda-roles.tf
+++ b/ci/terraform/account-management/lambda-roles.tf
@@ -90,10 +90,13 @@ data "aws_iam_policy_document" "endpoint_networking_policy" {
       "ec2:DescribeNetworkInterfaces",
       "ec2:CreateNetworkInterface",
       "ec2:DeleteNetworkInterface",
-      "ec2:DescribeInstances",
-      "ec2:AttachNetworkInterface",
     ]
     resources = ["*"]
+    condition {
+      test     = "ArnLikeIfExists"
+      variable = "ec2:Vpc"
+      values   = [aws_vpc.account_management_vpc.arn]
+    }
   }
 }
 

--- a/ci/terraform/shared/lambda-roles.tf
+++ b/ci/terraform/shared/lambda-roles.tf
@@ -92,6 +92,11 @@ data "aws_iam_policy_document" "endpoint_networking_policy" {
       "ec2:DeleteNetworkInterface",
     ]
     resources = ["*"]
+    condition {
+      test     = "ArnLikeIfExists"
+      variable = "ec2:Vpc"
+      values   = [aws_vpc.authentication.arn]
+    }
   }
 }
 


### PR DESCRIPTION
## What?

- Further restrict the execution privileges of the endpoint lambdas so they can only connect to our VPC
- Add same restriction to account management lambdas

## Why?

Tightening up privileges before deploying a production environment

## Related PRs

#638 