### PR TITLE
GOVSI-822: Add environment sizing files

### DIFF
--- a/ci/tasks/deploy-acct-mgmt-api.yml
+++ b/ci/tasks/deploy-acct-mgmt-api.yml
@@ -10,6 +10,7 @@ params:
   DEPLOYER_ROLE_ARN: ((deployer-role-arn-non-prod))
   DEPLOY_ENVIRONMENT: build
   NOTIFY_API_KEY: ((build-notify-api-key))
+  STATE_BUCKET: digital-identity-dev-tfstate
 inputs:
   - name: api-src
   - name: api-release
@@ -24,7 +25,7 @@ run:
       cd "api-src/ci/terraform/account-management"
       terraform init -input=false \
         -backend-config "role_arn=${DEPLOYER_ROLE_ARN}" \
-        -backend-config "bucket=digital-identity-dev-tfstate" \
+        -backend-config "bucket=${STATE_BUCKET}" \
         -backend-config "key=${DEPLOY_ENVIRONMENT}-account-managment-api-terraform.tfstate" \
         -backend-config "encrypt=true" \
         -backend-config "region=eu-west-2"

--- a/ci/tasks/deploy-oidc-api.yml
+++ b/ci/tasks/deploy-oidc-api.yml
@@ -13,6 +13,7 @@ params:
   DNS_DEPLOYER_ROLE_ARN: ((deployer-role-arn-production))
   DNS_STATE_BUCKET: ((dns-state-bucket))
   DNS_STATE_KEY: ((dns-state-key))
+  STATE_BUCKET: digital-identity-dev-tfstate
 inputs:
   - name: api-src
   - name: oidc-api-release
@@ -30,7 +31,7 @@ run:
       cd "api-src/ci/terraform/oidc"
       terraform init -input=false \
         -backend-config "role_arn=${DEPLOYER_ROLE_ARN}" \
-        -backend-config "bucket=digital-identity-dev-tfstate" \
+        -backend-config "bucket=${STATE_BUCKET}" \
         -backend-config "key=${DEPLOY_ENVIRONMENT}-terraform.tfstate" \
         -backend-config "encrypt=true" \
         -backend-config "region=eu-west-2"
@@ -48,6 +49,6 @@ run:
         -var "dns_state_bucket=${DNS_STATE_BUCKET}" \
         -var "dns_state_key=${DNS_STATE_KEY}" \
         -var "dns_state_role=${DNS_DEPLOYER_ROLE_ARN}" \
-        -var "shared_state_bucket=digital-identity-dev-tfstate" \
+        -var "shared_state_bucket=${STATE_BUCKET}" \
 
       terraform output --json > ../../../../terraform-outputs/${DEPLOY_ENVIRONMENT}-terraform-outputs.json

--- a/ci/tasks/deploy-shared-api.yml
+++ b/ci/tasks/deploy-shared-api.yml
@@ -10,6 +10,7 @@ params:
   DEPLOYER_ROLE_ARN: ((deployer-role-arn-non-prod))
   DEPLOY_ENVIRONMENT: build
   NOTIFY_API_KEY: ((build-notify-api-key))
+  STATE_BUCKET: digital-identity-dev-tfstate
 inputs:
   - name: api-src
   - name: oidc-api-release
@@ -25,7 +26,7 @@ run:
       cd "api-src/ci/terraform/shared"
       terraform init -input=false \
         -backend-config "role_arn=${DEPLOYER_ROLE_ARN}" \
-        -backend-config "bucket=digital-identity-dev-tfstate" \
+        -backend-config "bucket=${STATE_BUCKET}" \
         -backend-config "key=${DEPLOY_ENVIRONMENT}-shared-terraform.tfstate" \
         -backend-config "encrypt=true" \
         -backend-config "region=eu-west-2"
@@ -36,5 +37,6 @@ run:
         -var 'logging_endpoint_enabled=true' \
         -var 'logging_endpoint_arn=arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod' \
         -var-file ${DEPLOY_ENVIRONMENT}-stub-clients.tfvars \
+        -var-file ${DEPLOY_ENVIRONMENT}-sizing.tfvars \
 
       terraform output --json > ../../../../terraform-outputs/${DEPLOY_ENVIRONMENT}-shared-terraform-outputs.json

--- a/ci/tasks/terraform-taint.yml
+++ b/ci/tasks/terraform-taint.yml
@@ -9,6 +9,7 @@ image_resource:
 params:
   DEPLOYER_ROLE_ARN: ((deployer-role-arn-non-prod))
   DEPLOY_ENVIRONMENT: build
+  STATE_BUCKET: digital-identity-dev-tfstate
 inputs:
   - name: api-release
 outputs:
@@ -23,7 +24,7 @@ run:
       cd "src/ci/terraform/oidc"
       terraform init -input=false \
         -backend-config "role_arn=${DEPLOYER_ROLE_ARN}" \
-        -backend-config "bucket=digital-identity-dev-tfstate" \
+        -backend-config "bucket=${STATE_BUCKET}" \
         -backend-config "key=${DEPLOY_ENVIRONMENT}-terraform.tfstate" \
         -backend-config "encrypt=true" \
         -backend-config "region=eu-west-2"

--- a/ci/terraform/shared/build-sizing.tfvars
+++ b/ci/terraform/shared/build-sizing.tfvars
@@ -1,0 +1,2 @@
+redis_node_size  = "cache.t2.small"
+provision_dynamo = false

--- a/ci/terraform/shared/integration-sizing.tfvars
+++ b/ci/terraform/shared/integration-sizing.tfvars
@@ -1,0 +1,2 @@
+redis_node_size  = "cache.t2.small"
+provision_dynamo = false

--- a/ci/terraform/shared/production-sizing.tfvars
+++ b/ci/terraform/shared/production-sizing.tfvars
@@ -1,0 +1,4 @@
+redis_node_size               = "cache.m4.xlarge"
+provision_dynamo              = true
+dynamo_default_read_capacity  = 20
+dynamo_default_write_capacity = 20

--- a/ci/terraform/shared/production-stub-clients.tfvars
+++ b/ci/terraform/shared/production-stub-clients.tfvars
@@ -1,0 +1,9 @@
+stub_rp_clients = [
+  {
+    client_name = "di-auth-stub-relying-party-production"
+    callback_urls = [
+      "https://di-auth-stub-relying-party-production.london.cloudapps.digital/oidc/authorization-code/callback",
+    ]
+    logout_urls = []
+  },
+]


### PR DESCRIPTION
## What?

- Add a `.tfvars` per environment to define Redis and Dynamo sizing
- Inject correct file into terraform apply during shared deployment task
- Ensure state bucket name is configurable on Terraform deployment tasks (will be different for production)
- Add a (temporary) stub client for production

## Why?

Preparation for deploying a production environment
