### PR TITLE
GOVSI-871 - Refactor Vectors of Trust

### DIFF
--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/helpers/DynamoHelper.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/helpers/DynamoHelper.java
@@ -78,7 +78,7 @@ public class DynamoHelper {
                 serviceType,
                 sectorIdentifierUri,
                 subjectType,
-                vectorsOfTrust);
+                List.of(vectorsOfTrust));
     }
 
     public static boolean clientExists(String clientID) {

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/helpers/DynamoHelper.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/helpers/DynamoHelper.java
@@ -7,14 +7,11 @@ import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.ScanRequest;
 import com.amazonaws.services.dynamodbv2.model.ScanResult;
 import com.nimbusds.oauth2.sdk.id.Subject;
-import uk.gov.di.authentication.shared.entity.ClientConsent;
 import uk.gov.di.authentication.shared.entity.TermsAndConditions;
-import uk.gov.di.authentication.shared.services.DynamoClientService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -26,13 +23,6 @@ public class DynamoHelper {
     private static final DynamoService DYNAMO_SERVICE =
             new DynamoService(REGION, ENVIRONMENT, Optional.of(DYNAMO_ENDPOINT));
 
-    private static final DynamoClientService DYNAMO_CLIENT_SERVICE =
-            new DynamoClientService(REGION, ENVIRONMENT, Optional.of(DYNAMO_ENDPOINT));
-
-    public static boolean userExists(String email) {
-        return DYNAMO_SERVICE.userExists(email);
-    }
-
     public static void signUp(String email, String password) {
         signUp(email, password, new Subject());
     }
@@ -41,48 +31,6 @@ public class DynamoHelper {
         TermsAndConditions termsAndConditions =
                 new TermsAndConditions("1.0", LocalDateTime.now(ZoneId.of("UTC")).toString());
         DYNAMO_SERVICE.signUp(email, password, subject, termsAndConditions);
-    }
-
-    public static void addPhoneNumber(String email, String phoneNumber) {
-        DYNAMO_SERVICE.updatePhoneNumber(email, phoneNumber);
-    }
-
-    public static void setPhoneNumberVerified(String email, boolean isVerified) {
-        DYNAMO_SERVICE.updatePhoneNumberVerifiedStatus(email, isVerified);
-    }
-
-    public static Optional<List<ClientConsent>> getUserConsents(String email) {
-        return DYNAMO_SERVICE.getUserConsents(email);
-    }
-
-    public static void registerClient(
-            String clientID,
-            String clientName,
-            List<String> redirectUris,
-            List<String> contacts,
-            List<String> scopes,
-            String publicKey,
-            List<String> postLogoutRedirectUris,
-            String serviceType,
-            String sectorIdentifierUri,
-            String subjectType,
-            String vectorsOfTrust) {
-        DYNAMO_CLIENT_SERVICE.addClient(
-                clientID,
-                clientName,
-                redirectUris,
-                contacts,
-                scopes,
-                publicKey,
-                postLogoutRedirectUris,
-                serviceType,
-                sectorIdentifierUri,
-                subjectType,
-                List.of(vectorsOfTrust));
-    }
-
-    public static boolean clientExists(String clientID) {
-        return DYNAMO_CLIENT_SERVICE.isValidClient(clientID);
     }
 
     public static void flushData() {

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/entity/ClientRegistrationRequest.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/entity/ClientRegistrationRequest.java
@@ -36,7 +36,7 @@ public class ClientRegistrationRequest {
     private String subjectType;
 
     @JsonProperty("vectors_of_trust")
-    private String vectorsOfTrust;
+    private List<String> vectorsOfTrust;
 
     public ClientRegistrationRequest(
             @JsonProperty(required = true, value = "client_name") String clientName,
@@ -49,7 +49,7 @@ public class ClientRegistrationRequest {
             @JsonProperty(required = true, value = "sector_identifier_uri")
                     String sectorIdentifierUri,
             @JsonProperty(required = true, value = "subject_type") String subjectType,
-            @JsonProperty(required = false, value = "vectors_of_trust") String vectorsOfTrust) {
+            @JsonProperty(value = "vectors_of_trust") List<String> vectorsOfTrust) {
         this.clientName = clientName;
         this.redirectUris = redirectUris;
         this.contacts = contacts;
@@ -100,11 +100,11 @@ public class ClientRegistrationRequest {
         return subjectType;
     }
 
-    public String getVectorsOfTrust() {
+    public List<String> getVectorsOfTrust() {
         return vectorsOfTrust;
     }
 
-    public void setVectorsOfTrust(String vectorsOfTrust) {
+    public void setVectorsOfTrust(List<String> vectorsOfTrust) {
         this.vectorsOfTrust = vectorsOfTrust;
     }
 }

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/entity/ClientRegistrationRequest.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/entity/ClientRegistrationRequest.java
@@ -35,9 +35,6 @@ public class ClientRegistrationRequest {
     @JsonProperty("subject_type")
     private String subjectType;
 
-    @JsonProperty("vectors_of_trust")
-    private List<String> vectorsOfTrust;
-
     public ClientRegistrationRequest(
             @JsonProperty(required = true, value = "client_name") String clientName,
             @JsonProperty(required = true, value = "redirect_uris") List<String> redirectUris,
@@ -48,8 +45,7 @@ public class ClientRegistrationRequest {
             @JsonProperty(required = true, value = "service_type") String serviceType,
             @JsonProperty(required = true, value = "sector_identifier_uri")
                     String sectorIdentifierUri,
-            @JsonProperty(required = true, value = "subject_type") String subjectType,
-            @JsonProperty(value = "vectors_of_trust") List<String> vectorsOfTrust) {
+            @JsonProperty(required = true, value = "subject_type") String subjectType) {
         this.clientName = clientName;
         this.redirectUris = redirectUris;
         this.contacts = contacts;
@@ -61,7 +57,6 @@ public class ClientRegistrationRequest {
         this.serviceType = serviceType;
         this.sectorIdentifierUri = sectorIdentifierUri;
         this.subjectType = subjectType;
-        this.vectorsOfTrust = vectorsOfTrust;
     }
 
     public String getClientName() {
@@ -98,13 +93,5 @@ public class ClientRegistrationRequest {
 
     public String getSubjectType() {
         return subjectType;
-    }
-
-    public List<String> getVectorsOfTrust() {
-        return vectorsOfTrust;
-    }
-
-    public void setVectorsOfTrust(List<String> vectorsOfTrust) {
-        this.vectorsOfTrust = vectorsOfTrust;
     }
 }

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandler.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandler.java
@@ -94,8 +94,7 @@ public class ClientRegistrationHandler
                                         clientRegistrationRequest.getServiceType(),
                                         sanitiseUrl(
                                                 clientRegistrationRequest.getSectorIdentifierUri()),
-                                        clientRegistrationRequest.getSubjectType(),
-                                        clientRegistrationRequest.getVectorsOfTrust());
+                                        clientRegistrationRequest.getSubjectType());
 
                                 ClientRegistrationResponse clientRegistrationResponse =
                                         new ClientRegistrationResponse(

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationService.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationService.java
@@ -5,7 +5,6 @@ import com.nimbusds.oauth2.sdk.client.RegistrationError;
 import uk.gov.di.authentication.clientregistry.entity.ClientRegistrationRequest;
 import uk.gov.di.authentication.shared.entity.UpdateClientConfigRequest;
 import uk.gov.di.authentication.shared.entity.ValidScopes;
-import uk.gov.di.authentication.shared.entity.VectorOfTrust;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -28,8 +27,6 @@ public class ClientConfigValidationService {
             new ErrorObject("invalid_client_metadata", "Invalid Public Key");
     public static final ErrorObject INVALID_SERVICE_TYPE =
             new ErrorObject("invalid_client_metadata", "Invalid Service Type");
-    public static final ErrorObject INVALID_VECTOR_OF_TRUST =
-            new ErrorObject("invalid_client_metadata", "Invalid Vector of Trust");
 
     public Optional<ErrorObject> validateClientRegistrationConfig(
             ClientRegistrationRequest registrationRequest) {
@@ -49,11 +46,6 @@ public class ClientConfigValidationService {
         }
         if (!isValidServiceType(registrationRequest.getServiceType())) {
             return Optional.of(INVALID_SERVICE_TYPE);
-        }
-        if (!Optional.ofNullable(registrationRequest.getVectorsOfTrust())
-                .map(this::validateVectorsOfTrust)
-                .orElse(true)) {
-            return Optional.of(INVALID_VECTOR_OF_TRUST);
         }
         return Optional.empty();
     }
@@ -85,21 +77,7 @@ public class ClientConfigValidationService {
                 .orElse(true)) {
             return Optional.of(INVALID_SERVICE_TYPE);
         }
-        if (!Optional.ofNullable(registrationRequest.getVectorsOfTrust())
-                .map(this::validateVectorsOfTrust)
-                .orElse(true)) {
-            return Optional.of(INVALID_VECTOR_OF_TRUST);
-        }
         return Optional.empty();
-    }
-
-    private boolean validateVectorsOfTrust(List<String> vtr) {
-        try {
-            VectorOfTrust.parse(vtr);
-            return true;
-        } catch (IllegalArgumentException e) {
-            return false;
-        }
     }
 
     private boolean areUrisValid(List<String> uris) {

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationService.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationService.java
@@ -93,7 +93,7 @@ public class ClientConfigValidationService {
         return Optional.empty();
     }
 
-    private boolean validateVectorsOfTrust(String vtr) {
+    private boolean validateVectorsOfTrust(List<String> vtr) {
         try {
             VectorOfTrust.parse(vtr);
             return true;

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandlerTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandlerTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.clientregistry.entity.ClientRegistrationRequest;
 import uk.gov.di.authentication.clientregistry.entity.ClientRegistrationResponse;
 import uk.gov.di.authentication.clientregistry.services.ClientConfigValidationService;
-import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ClientService;
 
@@ -69,7 +68,6 @@ class ClientRegistrationHandlerTest {
         List<String> redirectUris = List.of("http://localhost:8080/redirect-uri");
         List<String> contacts = List.of("joe.bloggs@test.com");
         String serviceType = String.valueOf(MANDATORY);
-        String vectorsOfTrust = CredentialTrustLevel.MEDIUM_LEVEL.getValue();
         when(configValidationService.validateClientRegistrationConfig(
                         any(ClientRegistrationRequest.class)))
                 .thenReturn(Optional.empty());
@@ -78,7 +76,7 @@ class ClientRegistrationHandlerTest {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
 
         event.setBody(
-                "{ \"client_name\": \"test-client\", \"redirect_uris\": [\"http://localhost:8080/redirect-uri\"], \"contacts\": [\"joe.bloggs@test.com\"], \"scopes\": [\"openid\"],  \"public_key\": \"some-public-key\", \"post_logout_redirect_uris\": [\"http://localhost:8080/post-logout-redirect-uri\"], \"service_type\": \"MANDATORY\", \"sector_identifier_uri\": \"https://test.com\", \"subject_type\": \"public\", \"vectors_of_trust\": [\"Cl.Cm\"]}");
+                "{ \"client_name\": \"test-client\", \"redirect_uris\": [\"http://localhost:8080/redirect-uri\"], \"contacts\": [\"joe.bloggs@test.com\"], \"scopes\": [\"openid\"],  \"public_key\": \"some-public-key\", \"post_logout_redirect_uris\": [\"http://localhost:8080/post-logout-redirect-uri\"], \"service_type\": \"MANDATORY\", \"sector_identifier_uri\": \"https://test.com\", \"subject_type\": \"public\"}");
         APIGatewayProxyResponseEvent result = makeHandlerRequest(event);
 
         assertThat(result, hasStatus(200));
@@ -100,8 +98,7 @@ class ClientRegistrationHandlerTest {
                         singletonList("http://localhost:8080/post-logout-redirect-uri"),
                         serviceType,
                         sectorIdentifierUri,
-                        subjectType,
-                        List.of(vectorsOfTrust));
+                        subjectType);
     }
 
     @Test

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandlerTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandlerTest.java
@@ -78,7 +78,7 @@ class ClientRegistrationHandlerTest {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
 
         event.setBody(
-                "{ \"client_name\": \"test-client\", \"redirect_uris\": [\"http://localhost:8080/redirect-uri\"], \"contacts\": [\"joe.bloggs@test.com\"], \"scopes\": [\"openid\"],  \"public_key\": \"some-public-key\", \"post_logout_redirect_uris\": [\"http://localhost:8080/post-logout-redirect-uri\"], \"service_type\": \"MANDATORY\", \"sector_identifier_uri\": \"https://test.com\", \"subject_type\": \"public\", \"vectors_of_trust\": \"Cm\"}");
+                "{ \"client_name\": \"test-client\", \"redirect_uris\": [\"http://localhost:8080/redirect-uri\"], \"contacts\": [\"joe.bloggs@test.com\"], \"scopes\": [\"openid\"],  \"public_key\": \"some-public-key\", \"post_logout_redirect_uris\": [\"http://localhost:8080/post-logout-redirect-uri\"], \"service_type\": \"MANDATORY\", \"sector_identifier_uri\": \"https://test.com\", \"subject_type\": \"public\", \"vectors_of_trust\": [\"Cl.Cm\"]}");
         APIGatewayProxyResponseEvent result = makeHandlerRequest(event);
 
         assertThat(result, hasStatus(200));
@@ -101,7 +101,7 @@ class ClientRegistrationHandlerTest {
                         serviceType,
                         sectorIdentifierUri,
                         subjectType,
-                        vectorsOfTrust);
+                        List.of(vectorsOfTrust));
     }
 
     @Test

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationServiceTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationServiceTest.java
@@ -4,7 +4,6 @@ import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.client.RegistrationError;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.clientregistry.entity.ClientRegistrationRequest;
-import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.UpdateClientConfigRequest;
 
 import java.util.List;
@@ -36,8 +35,7 @@ class ClientConfigValidationServiceTest {
                                 singletonList("http://localhost/post-redirect-logout"),
                                 String.valueOf(MANDATORY),
                                 "http://test.com",
-                                "public",
-                                CredentialTrustLevel.MEDIUM_LEVEL.getValue()));
+                                "public"));
         assertThat(errorResponse, equalTo(Optional.empty()));
     }
 
@@ -52,8 +50,7 @@ class ClientConfigValidationServiceTest {
                                 singletonList("invalid-logout-uri"),
                                 String.valueOf(MANDATORY),
                                 "http://test.com",
-                                "public",
-                                CredentialTrustLevel.MEDIUM_LEVEL.getValue()));
+                                "public"));
         assertThat(errorResponse, equalTo(Optional.of(INVALID_POST_LOGOUT_URI)));
     }
 
@@ -68,8 +65,7 @@ class ClientConfigValidationServiceTest {
                                 singletonList("http://localhost/post-redirect-logout"),
                                 String.valueOf(MANDATORY),
                                 "http://test.com",
-                                "public",
-                                CredentialTrustLevel.MEDIUM_LEVEL.getValue()));
+                                "public"));
         assertThat(errorResponse, equalTo(Optional.of(RegistrationError.INVALID_REDIRECT_URI)));
     }
 
@@ -84,8 +80,7 @@ class ClientConfigValidationServiceTest {
                                 singletonList("http://localhost/post-redirect-logout"),
                                 String.valueOf(MANDATORY),
                                 "http://test.com",
-                                "public",
-                                CredentialTrustLevel.MEDIUM_LEVEL.getValue()));
+                                "public"));
         assertThat(errorResponse, equalTo(Optional.of(INVALID_PUBLIC_KEY)));
     }
 
@@ -100,8 +95,7 @@ class ClientConfigValidationServiceTest {
                                 singletonList("http://localhost/post-redirect-logout"),
                                 String.valueOf(MANDATORY),
                                 "http://test.com",
-                                "public",
-                                CredentialTrustLevel.MEDIUM_LEVEL.getValue()));
+                                "public"));
         assertThat(errorResponse, equalTo(Optional.of(INVALID_SCOPE)));
     }
 
@@ -116,8 +110,7 @@ class ClientConfigValidationServiceTest {
                                 singletonList("http://localhost/post-redirect-logout"),
                                 String.valueOf(MANDATORY),
                                 "http://test.com",
-                                "public",
-                                CredentialTrustLevel.MEDIUM_LEVEL.getValue()));
+                                "public"));
         assertThat(errorResponse, equalTo(Optional.of(INVALID_SCOPE)));
     }
 
@@ -200,8 +193,7 @@ class ClientConfigValidationServiceTest {
             List<String> postLogoutUris,
             String serviceType,
             String sectorIdentifierUri,
-            String subjectType,
-            String vectorsOfTrust) {
+            String subjectType) {
         return new ClientRegistrationRequest(
                 "The test client",
                 redirectUri,
@@ -211,8 +203,7 @@ class ClientConfigValidationServiceTest {
                 postLogoutUris,
                 serviceType,
                 sectorIdentifierUri,
-                subjectType,
-                List.of(vectorsOfTrust));
+                subjectType);
     }
 
     private UpdateClientConfigRequest generateClientUpdateRequest(

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationServiceTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationServiceTest.java
@@ -212,7 +212,7 @@ class ClientConfigValidationServiceTest {
                 serviceType,
                 sectorIdentifierUri,
                 subjectType,
-                vectorsOfTrust);
+                List.of(vectorsOfTrust));
     }
 
     private UpdateClientConfigRequest generateClientUpdateRequest(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
@@ -5,10 +5,18 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.oauth2.sdk.ResponseType;
+import com.nimbusds.oauth2.sdk.Scope;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.id.State;
+import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+import com.nimbusds.openid.connect.sdk.Nonce;
+import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.frontendapi.entity.LoginResponse;
 import uk.gov.di.authentication.frontendapi.helpers.RedactPhoneNumberHelper;
+import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
@@ -19,16 +27,21 @@ import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SessionService;
 
+import java.net.URI;
 import java.util.Map;
 import java.util.Optional;
 
 import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.authentication.shared.entity.SessionState.*;
+import static uk.gov.di.authentication.shared.entity.SessionState.ACCOUNT_TEMPORARILY_LOCKED;
+import static uk.gov.di.authentication.shared.entity.SessionState.AUTHENTICATION_REQUIRED;
+import static uk.gov.di.authentication.shared.entity.SessionState.LOGGED_IN;
+import static uk.gov.di.authentication.shared.entity.SessionState.NEW;
 import static uk.gov.di.authentication.shared.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 import static uk.gov.di.authentication.shared.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
@@ -44,6 +57,7 @@ class LoginHandlerTest {
     private final CodeStorageService codeStorageService = mock(CodeStorageService.class);
     private final SessionService sessionService = mock(SessionService.class);
     private final ClientSessionService clientSessionService = mock(ClientSessionService.class);
+    private final ClientSession clientSession = mock(ClientSession.class);
     private final ClientService clientService = mock(ClientService.class);
 
     private final Session session =
@@ -51,6 +65,8 @@ class LoginHandlerTest {
 
     @BeforeEach
     public void setUp() {
+        when(clientSessionService.getClientSessionFromRequestHeaders(any()))
+                .thenReturn(Optional.of(clientSession));
         handler =
                 new LoginHandler(
                         configurationService,
@@ -66,6 +82,8 @@ class LoginHandlerTest {
         when(authenticationService.userExists(EMAIL)).thenReturn(true);
         when(authenticationService.login(EMAIL, PASSWORD)).thenReturn(true);
         when(authenticationService.getPhoneNumber(EMAIL)).thenReturn(Optional.of(PHONE_NUMBER));
+        when(clientSession.getAuthRequestParams())
+                .thenReturn(generateAuthRequest(Optional.empty()).toParameters());
         usingValidSession();
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setHeaders(Map.of("Session-Id", session.getSessionId()));
@@ -121,6 +139,8 @@ class LoginHandlerTest {
 
         when(authenticationService.login(EMAIL, PASSWORD)).thenReturn(true);
         when(codeStorageService.hasEnteredPasswordIncorrectBefore(EMAIL)).thenReturn(true);
+        when(clientSession.getAuthRequestParams())
+                .thenReturn(generateAuthRequest(Optional.empty()).toParameters());
 
         APIGatewayProxyResponseEvent result2 = handler.handleRequest(event, context);
 
@@ -208,6 +228,22 @@ class LoginHandlerTest {
 
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1017));
+    }
+
+    private AuthenticationRequest generateAuthRequest(Optional<String> credentialTrustLevel) {
+        Scope scope = new Scope();
+        scope.add(OIDCScopeValue.OPENID);
+        AuthenticationRequest.Builder builder =
+                new AuthenticationRequest.Builder(
+                                ResponseType.CODE,
+                                scope,
+                                new ClientID(),
+                                URI.create("http://localhost/redirect"))
+                        .state(new State())
+                        .nonce(new Nonce());
+
+        credentialTrustLevel.ifPresent(t -> builder.customParameter("vtr", t));
+        return builder.build();
     }
 
     private void usingValidSession() {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.helpers.DynamoHelper;
 import uk.gov.di.authentication.helpers.KeyPairHelper;
 import uk.gov.di.authentication.helpers.RedisHelper;
-import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.shared.entity.SessionState;
 
@@ -83,8 +82,7 @@ public class AuthCodeIntegrationTest extends IntegrationTestEndpoints {
                 singletonList("http://localhost/post-redirect-logout"),
                 String.valueOf(ServiceType.MANDATORY),
                 "https://test.com",
-                "public",
-                CredentialTrustLevel.MEDIUM_LEVEL.getValue());
+                "public");
     }
 
     private String buildCookieString(String sessionID, String clientSessionID) {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -365,7 +365,6 @@ public class AuthorisationIntegrationTest extends IntegrationTestEndpoints {
                 singletonList("http://localhost/post-redirect-logout"),
                 String.valueOf(ServiceType.MANDATORY),
                 "https://test.com",
-                "public",
-                MEDIUM_LEVEL.getValue());
+                "public");
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -11,6 +11,7 @@ import jakarta.ws.rs.client.Invocation;
 import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.Cookie;
 import jakarta.ws.rs.core.Response;
+import net.minidev.json.JSONArray;
 import org.glassfish.jersey.client.ClientProperties;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -88,7 +89,11 @@ public class AuthorisationIntegrationTest extends IntegrationTestEndpoints {
     public void shouldRedirectToLoginWhenNoCookie() {
         Response response =
                 doAuthorisationRequest(
-                        Optional.of(CLIENT_ID), Optional.empty(), Optional.empty(), "openid");
+                        Optional.of(CLIENT_ID),
+                        Optional.empty(),
+                        Optional.empty(),
+                        "openid",
+                        Optional.of("Cl.Cm"));
 
         assertEquals(302, response.getStatus());
         assertThat(
@@ -317,6 +322,15 @@ public class AuthorisationIntegrationTest extends IntegrationTestEndpoints {
             Optional<Cookie> cookie,
             Optional<String> prompt,
             String scopes) {
+        return doAuthorisationRequest(clientId, cookie, prompt, scopes, Optional.empty());
+    }
+
+    private Response doAuthorisationRequest(
+            Optional<String> clientId,
+            Optional<Cookie> cookie,
+            Optional<String> prompt,
+            String scopes,
+            Optional<String> vtr) {
         Client client = ClientBuilder.newClient();
         Nonce nonce = new Nonce();
         WebTarget webTarget =
@@ -330,6 +344,11 @@ public class AuthorisationIntegrationTest extends IntegrationTestEndpoints {
                         .property(ClientProperties.FOLLOW_REDIRECTS, Boolean.FALSE);
         if (prompt.isPresent()) {
             webTarget = webTarget.queryParam("prompt", prompt.get());
+        }
+        if (vtr.isPresent()) {
+            JSONArray jsonArray = new JSONArray();
+            jsonArray.add(vtr.get());
+            webTarget = webTarget.queryParam("vtr", jsonArray.toJSONString());
         }
         Invocation.Builder builder = webTarget.request();
         cookie.ifPresent(builder::cookie);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientInfoIntegrationTest.java
@@ -18,7 +18,6 @@ import uk.gov.di.authentication.frontendapi.entity.ClientInfoResponse;
 import uk.gov.di.authentication.helpers.DynamoHelper;
 import uk.gov.di.authentication.helpers.KeyPairHelper;
 import uk.gov.di.authentication.helpers.RedisHelper;
-import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 
 import java.io.IOException;
@@ -112,7 +111,6 @@ public class ClientInfoIntegrationTest extends IntegrationTestEndpoints {
                 singletonList("http://localhost/post-redirect-logout"),
                 String.valueOf(ServiceType.MANDATORY),
                 "https://test.com",
-                "public",
-                CredentialTrustLevel.MEDIUM_LEVEL.getValue());
+                "public");
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientRegistrationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientRegistrationIntegrationTest.java
@@ -14,6 +14,8 @@ import uk.gov.di.authentication.helpers.DynamoHelper;
 import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 
+import java.util.List;
+
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -38,7 +40,7 @@ public class ClientRegistrationIntegrationTest extends IntegrationTestEndpoints 
                         String.valueOf(ServiceType.MANDATORY),
                         "https://test.com",
                         "public",
-                        CredentialTrustLevel.MEDIUM_LEVEL.getValue());
+                        List.of(CredentialTrustLevel.MEDIUM_LEVEL.getValue()));
 
         Response response =
                 ClientBuilder.newClient()

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientRegistrationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientRegistrationIntegrationTest.java
@@ -11,10 +11,7 @@ import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.clientregistry.entity.ClientRegistrationRequest;
 import uk.gov.di.authentication.clientregistry.entity.ClientRegistrationResponse;
 import uk.gov.di.authentication.helpers.DynamoHelper;
-import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.ServiceType;
-
-import java.util.List;
 
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -39,8 +36,7 @@ public class ClientRegistrationIntegrationTest extends IntegrationTestEndpoints 
                         singletonList("http://localhost/post-redirect-logout"),
                         String.valueOf(ServiceType.MANDATORY),
                         "https://test.com",
-                        "public",
-                        List.of(CredentialTrustLevel.MEDIUM_LEVEL.getValue()));
+                        "public");
 
         Response response =
                 ClientBuilder.newClient()

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
@@ -26,15 +26,15 @@ import uk.gov.di.authentication.shared.entity.SessionState;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Base64;
+import java.util.List;
 import java.util.stream.Stream;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static uk.gov.di.authentication.helpers.KeyPairHelper.GENERATE_RSA_KEY_PAIR;
-import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.HIGH_LEVEL;
 import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.LOW_LEVEL;
 import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.MEDIUM_LEVEL;
-import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.VERY_HIGH_LEVEL;
 import static uk.gov.di.authentication.shared.entity.SessionState.AUTHENTICATION_REQUIRED;
 import static uk.gov.di.authentication.shared.entity.SessionState.CONSENT_REQUIRED;
 import static uk.gov.di.authentication.shared.entity.SessionState.LOGGED_IN;
@@ -91,7 +91,7 @@ public class LoginIntegrationTest extends IntegrationTestEndpoints {
                 String.valueOf(ServiceType.MANDATORY),
                 "https://test.com",
                 "public",
-                level == null ? null : level.getValue());
+                level == null ? emptyList() : List.of(level.getValue()));
 
         MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
         headers.add("Session-Id", sessionId);
@@ -116,13 +116,9 @@ public class LoginIntegrationTest extends IntegrationTestEndpoints {
                 Arguments.of(null, CURRENT_TERMS_AND_CONDITIONS, LOGGED_IN),
                 Arguments.of(LOW_LEVEL, CURRENT_TERMS_AND_CONDITIONS, CONSENT_REQUIRED),
                 Arguments.of(MEDIUM_LEVEL, CURRENT_TERMS_AND_CONDITIONS, LOGGED_IN),
-                Arguments.of(HIGH_LEVEL, CURRENT_TERMS_AND_CONDITIONS, LOGGED_IN),
-                Arguments.of(VERY_HIGH_LEVEL, CURRENT_TERMS_AND_CONDITIONS, LOGGED_IN),
                 Arguments.of(null, OLD_TERMS_AND_CONDITIONS, LOGGED_IN),
                 Arguments.of(LOW_LEVEL, OLD_TERMS_AND_CONDITIONS, UPDATED_TERMS_AND_CONDITIONS),
-                Arguments.of(MEDIUM_LEVEL, OLD_TERMS_AND_CONDITIONS, LOGGED_IN),
-                Arguments.of(HIGH_LEVEL, OLD_TERMS_AND_CONDITIONS, LOGGED_IN),
-                Arguments.of(VERY_HIGH_LEVEL, OLD_TERMS_AND_CONDITIONS, LOGGED_IN));
+                Arguments.of(MEDIUM_LEVEL, OLD_TERMS_AND_CONDITIONS, LOGGED_IN));
     }
 
     @Test

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
@@ -10,6 +10,7 @@ import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
+import net.minidev.json.JSONArray;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -76,7 +77,9 @@ public class LoginIntegrationTest extends IntegrationTestEndpoints {
                                 URI.create(REDIRECT_URI))
                         .nonce(new Nonce());
         if (level != null) {
-            builder.customParameter("vtr", level.getValue());
+            JSONArray jsonArray = new JSONArray();
+            jsonArray.add(level.getValue());
+            builder.customParameter("vtr", jsonArray.toJSONString());
         }
         AuthenticationRequest authRequest = builder.build();
         RedisHelper.createClientSession(CLIENT_SESSION_ID, authRequest.toParameters());

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.helpers.DynamoHelper;
 import uk.gov.di.authentication.helpers.KmsHelper;
 import uk.gov.di.authentication.helpers.RedisHelper;
-import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 
 import java.io.IOException;
@@ -75,8 +74,7 @@ public class LogoutIntegrationTest extends IntegrationTestEndpoints {
                 singletonList("https://di-auth-stub-relying-party-build.london.cloudapps.digital/"),
                 String.valueOf(ServiceType.MANDATORY),
                 "https://test.com",
-                "public",
-                CredentialTrustLevel.MEDIUM_LEVEL.getValue());
+                "public");
         Client client = ClientBuilder.newClient();
         MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
         headers.add(COOKIE, buildCookieString(sessionId, clientSessionId));

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
@@ -36,7 +36,6 @@ import uk.gov.di.authentication.helpers.KeyPairHelper;
 import uk.gov.di.authentication.helpers.KmsHelper;
 import uk.gov.di.authentication.helpers.RedisHelper;
 import uk.gov.di.authentication.shared.entity.ClientConsent;
-import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.shared.entity.TokenStore;
 import uk.gov.di.authentication.shared.entity.ValidScopes;
@@ -201,8 +200,7 @@ public class TokenIntegrationTest extends IntegrationTestEndpoints {
                 singletonList("http://localhost/post-logout-redirect"),
                 String.valueOf(ServiceType.MANDATORY),
                 "https://test.com",
-                "public",
-                CredentialTrustLevel.MEDIUM_LEVEL.getValue());
+                "public");
         DynamoHelper.signUp(TEST_EMAIL, "password-1", internalSubject);
         Set<String> claims = ValidScopes.getClaimsForListOfScopes(scope.toStringList());
         ClientConsent clientConsent =

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateClientConfigIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateClientConfigIntegrationTest.java
@@ -11,7 +11,6 @@ import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.clientregistry.entity.ClientRegistrationResponse;
 import uk.gov.di.authentication.helpers.DynamoHelper;
-import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.shared.entity.UpdateClientConfigRequest;
 
@@ -38,8 +37,7 @@ public class UpdateClientConfigIntegrationTest extends IntegrationTestEndpoints 
                 singletonList("http://localhost/post-redirect-logout"),
                 String.valueOf(ServiceType.MANDATORY),
                 "https://test.com",
-                "public",
-                CredentialTrustLevel.MEDIUM_LEVEL.getValue());
+                "public");
 
         UpdateClientConfigRequest updateRequest = new UpdateClientConfigRequest();
         updateRequest.setClientName("new-client-name");

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateProfileIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateProfileIntegrationTest.java
@@ -20,7 +20,6 @@ import uk.gov.di.authentication.helpers.RedisHelper;
 import uk.gov.di.authentication.helpers.RequestHelper;
 import uk.gov.di.authentication.shared.entity.BaseAPIResponse;
 import uk.gov.di.authentication.shared.entity.ClientConsent;
-import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.shared.entity.SessionState;
 import uk.gov.di.authentication.shared.entity.ValidScopes;
@@ -166,8 +165,7 @@ public class UpdateProfileIntegrationTest extends IntegrationTestEndpoints {
                 singletonList("http://localhost/post-redirect-logout"),
                 String.valueOf(ServiceType.MANDATORY),
                 "https://test.com",
-                "public",
-                CredentialTrustLevel.MEDIUM_LEVEL.getValue());
+                "public");
         Set<String> claims = ValidScopes.getClaimsForListOfScopes(scope.toStringList());
         DynamoHelper.signUp(EMAIL_ADDRESS, "password");
         DynamoHelper.updateConsent(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
@@ -17,7 +17,6 @@ import uk.gov.di.authentication.helpers.DynamoHelper;
 import uk.gov.di.authentication.helpers.KeyPairHelper;
 import uk.gov.di.authentication.helpers.KmsHelper;
 import uk.gov.di.authentication.helpers.RedisHelper;
-import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.shared.entity.TokenStore;
 
@@ -130,7 +129,6 @@ public class UserInfoIntegrationTest extends IntegrationTestEndpoints {
                 singletonList("http://localhost/post-redirect-logout"),
                 String.valueOf(ServiceType.MANDATORY),
                 "https://test.com",
-                "public",
-                CredentialTrustLevel.MEDIUM_LEVEL.getValue());
+                "public");
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
@@ -18,7 +18,6 @@ import uk.gov.di.authentication.helpers.RedisHelper;
 import uk.gov.di.authentication.helpers.RequestHelper;
 import uk.gov.di.authentication.shared.entity.BaseAPIResponse;
 import uk.gov.di.authentication.shared.entity.ClientConsent;
-import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.ServiceType;
@@ -409,8 +408,7 @@ public class VerifyCodeIntegrationTest extends IntegrationTestEndpoints {
                 singletonList("http://localhost/post-redirect-logout"),
                 String.valueOf(ServiceType.MANDATORY),
                 "https://test.com",
-                "public",
-                CredentialTrustLevel.MEDIUM_LEVEL.getValue());
+                "public");
         DynamoHelper.signUp(EMAIL_ADDRESS, "password");
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/helpers/DynamoHelper.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/helpers/DynamoHelper.java
@@ -100,6 +100,32 @@ public class DynamoHelper {
                 serviceType,
                 sectorIdentifierUri,
                 subjectType,
+                List.of(vectorsOfTrust));
+    }
+
+    public static void registerClient(
+            String clientID,
+            String clientName,
+            List<String> redirectUris,
+            List<String> contacts,
+            List<String> scopes,
+            String publicKey,
+            List<String> postLogoutRedirectUris,
+            String serviceType,
+            String sectorIdentifierUri,
+            String subjectType,
+            List<String> vectorsOfTrust) {
+        DYNAMO_CLIENT_SERVICE.addClient(
+                clientID,
+                clientName,
+                redirectUris,
+                contacts,
+                scopes,
+                publicKey,
+                postLogoutRedirectUris,
+                serviceType,
+                sectorIdentifierUri,
+                subjectType,
                 vectorsOfTrust);
     }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/helpers/DynamoHelper.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/helpers/DynamoHelper.java
@@ -87,8 +87,7 @@ public class DynamoHelper {
             List<String> postLogoutRedirectUris,
             String serviceType,
             String sectorIdentifierUri,
-            String subjectType,
-            String vectorsOfTrust) {
+            String subjectType) {
         DYNAMO_CLIENT_SERVICE.addClient(
                 clientID,
                 clientName,
@@ -99,34 +98,7 @@ public class DynamoHelper {
                 postLogoutRedirectUris,
                 serviceType,
                 sectorIdentifierUri,
-                subjectType,
-                List.of(vectorsOfTrust));
-    }
-
-    public static void registerClient(
-            String clientID,
-            String clientName,
-            List<String> redirectUris,
-            List<String> contacts,
-            List<String> scopes,
-            String publicKey,
-            List<String> postLogoutRedirectUris,
-            String serviceType,
-            String sectorIdentifierUri,
-            String subjectType,
-            List<String> vectorsOfTrust) {
-        DYNAMO_CLIENT_SERVICE.addClient(
-                clientID,
-                clientName,
-                redirectUris,
-                contacts,
-                scopes,
-                publicKey,
-                postLogoutRedirectUris,
-                serviceType,
-                sectorIdentifierUri,
-                subjectType,
-                vectorsOfTrust);
+                subjectType);
     }
 
     public static boolean clientExists(String clientID) {

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
@@ -218,7 +218,11 @@ public class TokenHandler
                             if (authRequest.getNonce() != null) {
                                 additionalTokenClaims.put("nonce", authRequest.getNonce());
                             }
-                            String vot = client.getVectorsOfTrust();
+                            String vot =
+                                    clientSession
+                                            .getEffectiveVectorOfTrust()
+                                            .getCredentialTrustLevel()
+                                            .getValue();
 
                             OIDCTokenResponse tokenResponse =
                                     tokenService.generateTokenResponse(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
@@ -416,8 +416,7 @@ public class TokenHandlerTest {
                 .setPublicKey(
                         Base64.getMimeEncoder().encodeToString(keyPair.getPublic().getEncoded()))
                 .setSectorIdentifierUri("https://test.com")
-                .setSubjectType("public")
-                .setVectorsOfTrust(singletonList(VOT));
+                .setSubjectType("public");
     }
 
     private ClientRegistry generateClientRegistryPairwise(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
@@ -130,6 +130,8 @@ public class TokenHandlerTest {
 
     @Test
     public void shouldReturn200ForSuccessfulTokenRequest() throws JOSEException {
+        VectorOfTrust vot = mock(VectorOfTrust.class);
+        when(vot.getCredentialTrustLevel()).thenReturn(CredentialTrustLevel.MEDIUM_LEVEL);
         KeyPair keyPair = generateRsaKeyPair();
         UserProfile userProfile = generateUserProfile();
         SignedJWT signedJWT =
@@ -161,9 +163,7 @@ public class TokenHandlerTest {
         when(clientSessionService.getClientSession(CLIENT_SESSION_ID))
                 .thenReturn(
                         new ClientSession(
-                                generateAuthRequest().toParameters(),
-                                LocalDateTime.now(),
-                                mock(VectorOfTrust.class)));
+                                generateAuthRequest().toParameters(), LocalDateTime.now(), vot));
         when(dynamoService.getUserProfileByEmail(eq(TEST_EMAIL))).thenReturn(userProfile);
         when(tokenService.generateTokenResponse(
                         CLIENT_ID,
@@ -417,7 +417,7 @@ public class TokenHandlerTest {
                         Base64.getMimeEncoder().encodeToString(keyPair.getPublic().getEncoded()))
                 .setSectorIdentifierUri("https://test.com")
                 .setSubjectType("public")
-                .setVectorsOfTrust(VOT);
+                .setVectorsOfTrust(singletonList(VOT));
     }
 
     private ClientRegistry generateClientRegistryPairwise(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TrustMarkHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TrustMarkHandlerTest.java
@@ -39,11 +39,7 @@ class TrustMarkHandlerTest {
                 new TrustMarkResponse(
                         configurationService.getBaseURL().orElseThrow(),
                         configurationService.getBaseURL().orElseThrow(),
-                        List.of(
-                                CredentialTrustLevel.LOW_LEVEL,
-                                CredentialTrustLevel.MEDIUM_LEVEL,
-                                CredentialTrustLevel.HIGH_LEVEL,
-                                CredentialTrustLevel.VERY_HIGH_LEVEL));
+                        List.of(CredentialTrustLevel.LOW_LEVEL, CredentialTrustLevel.MEDIUM_LEVEL));
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ClientRegistry.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ClientRegistry.java
@@ -19,7 +19,7 @@ public class ClientRegistry {
     private String serviceType;
     private String sectorIdentifierUri;
     private String subjectType;
-    private String vectorsOfTrust;
+    private List<String> vectorsOfTrust;
 
     @DynamoDBHashKey(attributeName = "ClientID")
     public String getClientID() {
@@ -124,16 +124,16 @@ public class ClientRegistry {
     }
 
     @DynamoDBAttribute(attributeName = "VectorsOfTrust")
-    public String getVectorsOfTrust() {
+    public List<String> getVectorsOfTrust() {
         return vectorsOfTrust;
     }
 
-    public ClientRegistry setVectorsOfTrust(String vectorsOfTrust) {
+    public ClientRegistry setVectorsOfTrust(List<String> vectorsOfTrust) {
         this.vectorsOfTrust = vectorsOfTrust;
         return this;
     }
 
     public VectorOfTrust calculateEffectiveVectorOfTrust() {
-        return VectorOfTrust.parse(getVectorsOfTrust(), CredentialTrustLevel.getDefault());
+        return VectorOfTrust.parse(getVectorsOfTrust());
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ClientRegistry.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ClientRegistry.java
@@ -19,7 +19,6 @@ public class ClientRegistry {
     private String serviceType;
     private String sectorIdentifierUri;
     private String subjectType;
-    private List<String> vectorsOfTrust;
 
     @DynamoDBHashKey(attributeName = "ClientID")
     public String getClientID() {
@@ -121,19 +120,5 @@ public class ClientRegistry {
     public ClientRegistry setSubjectType(String subjectType) {
         this.subjectType = subjectType;
         return this;
-    }
-
-    @DynamoDBAttribute(attributeName = "VectorsOfTrust")
-    public List<String> getVectorsOfTrust() {
-        return vectorsOfTrust;
-    }
-
-    public ClientRegistry setVectorsOfTrust(List<String> vectorsOfTrust) {
-        this.vectorsOfTrust = vectorsOfTrust;
-        return this;
-    }
-
-    public VectorOfTrust calculateEffectiveVectorOfTrust() {
-        return VectorOfTrust.parse(getVectorsOfTrust());
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/CredentialTrustLevel.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/CredentialTrustLevel.java
@@ -1,6 +1,7 @@
 package uk.gov.di.authentication.shared.entity;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -21,7 +22,20 @@ public enum CredentialTrustLevel {
     public static CredentialTrustLevel retrieveCredentialTrustLevel(List<String> vtrSets) {
 
         return Arrays.stream(values())
-                .filter(c -> vtrSets.stream().anyMatch(c.getValue()::equals))
+                .filter(
+                        tl ->
+                                vtrSets.stream()
+                                        .anyMatch(
+                                                set ->
+                                                        new HashSet<>(
+                                                                        Arrays.asList(
+                                                                                set.split("\\.")))
+                                                                .equals(
+                                                                        new HashSet<>(
+                                                                                Arrays.asList(
+                                                                                        tl.getValue()
+                                                                                                .split(
+                                                                                                        "\\."))))))
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("Invalid CredentialTrustLevel"));
     }
@@ -29,7 +43,20 @@ public enum CredentialTrustLevel {
     public static List<CredentialTrustLevel> retrieveListOfCredentialTrustLevels(
             List<String> vtrSets) {
         return Arrays.stream(values())
-                .filter(c -> vtrSets.stream().anyMatch(c.getValue()::equals))
+                .filter(
+                        tl ->
+                                vtrSets.stream()
+                                        .anyMatch(
+                                                set ->
+                                                        new HashSet<>(
+                                                                        Arrays.asList(
+                                                                                set.split("\\.")))
+                                                                .equals(
+                                                                        new HashSet<>(
+                                                                                Arrays.asList(
+                                                                                        tl.getValue()
+                                                                                                .split(
+                                                                                                        "\\."))))))
                 .collect(Collectors.toList());
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/CredentialTrustLevel.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/CredentialTrustLevel.java
@@ -3,7 +3,6 @@ package uk.gov.di.authentication.shared.entity;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public enum CredentialTrustLevel {
     LOW_LEVEL("Cl"),
@@ -38,26 +37,6 @@ public enum CredentialTrustLevel {
                                                                                                         "\\."))))))
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("Invalid CredentialTrustLevel"));
-    }
-
-    public static List<CredentialTrustLevel> retrieveListOfCredentialTrustLevels(
-            List<String> vtrSets) {
-        return Arrays.stream(values())
-                .filter(
-                        tl ->
-                                vtrSets.stream()
-                                        .anyMatch(
-                                                set ->
-                                                        new HashSet<>(
-                                                                        Arrays.asList(
-                                                                                set.split("\\.")))
-                                                                .equals(
-                                                                        new HashSet<>(
-                                                                                Arrays.asList(
-                                                                                        tl.getValue()
-                                                                                                .split(
-                                                                                                        "\\."))))))
-                .collect(Collectors.toList());
     }
 
     public static CredentialTrustLevel getDefault() {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/CredentialTrustLevel.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/CredentialTrustLevel.java
@@ -1,12 +1,12 @@
 package uk.gov.di.authentication.shared.entity;
 
 import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public enum CredentialTrustLevel {
     LOW_LEVEL("Cl"),
-    MEDIUM_LEVEL("Cm"),
-    HIGH_LEVEL("Ch"),
-    VERY_HIGH_LEVEL("Cv");
+    MEDIUM_LEVEL("Cl.Cm");
 
     private String value;
 
@@ -18,14 +18,19 @@ public enum CredentialTrustLevel {
         return value;
     }
 
-    public static CredentialTrustLevel parseByValue(String value) {
+    public static CredentialTrustLevel retrieveCredentialTrustLevel(List<String> vtrSets) {
+
         return Arrays.stream(values())
-                .filter(c -> c.getValue().equals(value))
+                .filter(c -> vtrSets.stream().anyMatch(c.getValue()::equals))
                 .findFirst()
-                .orElseThrow(
-                        () ->
-                                new IllegalArgumentException(
-                                        value + " is not a valid CredentialTrustLevel"));
+                .orElseThrow(() -> new IllegalArgumentException("Invalid CredentialTrustLevel"));
+    }
+
+    public static List<CredentialTrustLevel> retrieveListOfCredentialTrustLevels(
+            List<String> vtrSets) {
+        return Arrays.stream(values())
+                .filter(c -> vtrSets.stream().anyMatch(c.getValue()::equals))
+                .collect(Collectors.toList());
     }
 
     public static CredentialTrustLevel getDefault() {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/UpdateClientConfigRequest.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/UpdateClientConfigRequest.java
@@ -30,9 +30,6 @@ public class UpdateClientConfigRequest {
     @JsonProperty("service_type")
     private String serviceType;
 
-    @JsonProperty("vectors_of_trust")
-    private List<String> vectorsOfTrust;
-
     public UpdateClientConfigRequest() {}
 
     public String getClientId() {
@@ -65,10 +62,6 @@ public class UpdateClientConfigRequest {
 
     public String getServiceType() {
         return serviceType;
-    }
-
-    public List<String> getVectorsOfTrust() {
-        return vectorsOfTrust;
     }
 
     public UpdateClientConfigRequest setClientId(String clientId) {
@@ -109,11 +102,6 @@ public class UpdateClientConfigRequest {
 
     public UpdateClientConfigRequest setServiceType(String serviceType) {
         this.serviceType = serviceType;
-        return this;
-    }
-
-    public UpdateClientConfigRequest setVectorsOfTrust(List<String> vectorsOfTrust) {
-        this.vectorsOfTrust = vectorsOfTrust;
         return this;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/UpdateClientConfigRequest.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/UpdateClientConfigRequest.java
@@ -31,7 +31,7 @@ public class UpdateClientConfigRequest {
     private String serviceType;
 
     @JsonProperty("vectors_of_trust")
-    private String vectorsOfTrust;
+    private List<String> vectorsOfTrust;
 
     public UpdateClientConfigRequest() {}
 
@@ -67,7 +67,7 @@ public class UpdateClientConfigRequest {
         return serviceType;
     }
 
-    public String getVectorsOfTrust() {
+    public List<String> getVectorsOfTrust() {
         return vectorsOfTrust;
     }
 
@@ -112,7 +112,7 @@ public class UpdateClientConfigRequest {
         return this;
     }
 
-    public UpdateClientConfigRequest setVectorsOfTrust(String vectorsOfTrust) {
+    public UpdateClientConfigRequest setVectorsOfTrust(List<String> vectorsOfTrust) {
         this.vectorsOfTrust = vectorsOfTrust;
         return this;
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/VectorOfTrust.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/VectorOfTrust.java
@@ -2,10 +2,14 @@ package uk.gov.di.authentication.shared.entity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import net.minidev.json.JSONArray;
+import net.minidev.json.parser.JSONParser;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import static net.minidev.json.parser.JSONParser.DEFAULT_PERMISSIVE_MODE;
 import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.retrieveCredentialTrustLevel;
 
 public class VectorOfTrust {
@@ -24,11 +28,22 @@ public class VectorOfTrust {
         return credentialTrustLevel;
     }
 
-    public static final VectorOfTrust parse(List<String> vtr) {
+    public static final VectorOfTrust parseFromAuthRequestAttribute(List<String> vtr) {
         if (Objects.isNull(vtr) || vtr.isEmpty()) {
             return new VectorOfTrust(CredentialTrustLevel.getDefault());
         }
-        return new VectorOfTrust(retrieveCredentialTrustLevel(vtr));
+        JSONParser parser = new JSONParser(DEFAULT_PERMISSIVE_MODE);
+        JSONArray vtrJsonArray;
+        try {
+            vtrJsonArray = (JSONArray) parser.parse(vtr.get(0));
+        } catch (net.minidev.json.parser.ParseException | ClassCastException e) {
+            throw new IllegalArgumentException("Invalid VTR attribute", e);
+        }
+        List<String> vtrSets = new ArrayList<>();
+        for (int i = 0; i < vtrJsonArray.size(); i++) {
+            vtrSets.add((String) vtrJsonArray.get(i));
+        }
+        return new VectorOfTrust(retrieveCredentialTrustLevel(vtrSets));
     }
 
     public static VectorOfTrust getDefaults() {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/VectorOfTrust.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/VectorOfTrust.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Objects;
 
 import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.retrieveCredentialTrustLevel;
-import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.retrieveListOfCredentialTrustLevels;
 
 public class VectorOfTrust {
 
@@ -23,25 +22,6 @@ public class VectorOfTrust {
 
     public CredentialTrustLevel getCredentialTrustLevel() {
         return credentialTrustLevel;
-    }
-
-    public static final VectorOfTrust parse(List<String> authRequestVtr, List<String> clientVtr) {
-        if (Objects.isNull(authRequestVtr)) {
-            return new VectorOfTrust(CredentialTrustLevel.getDefault());
-        }
-        VectorOfTrust vectorOfTrust =
-                new VectorOfTrust(retrieveCredentialTrustLevel(authRequestVtr));
-        if (!Objects.isNull(clientVtr)) {
-            List<CredentialTrustLevel> credentialTrustLevels =
-                    retrieveListOfCredentialTrustLevels(clientVtr);
-            if (credentialTrustLevels.contains(vectorOfTrust.getCredentialTrustLevel())) {
-                return vectorOfTrust;
-            } else {
-                throw new IllegalArgumentException(
-                        vectorOfTrust.getCredentialTrustLevel() + " is not registered with client");
-            }
-        }
-        return new VectorOfTrust(CredentialTrustLevel.getDefault());
     }
 
     public static final VectorOfTrust parse(List<String> vtr) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/VectorOfTrust.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/VectorOfTrust.java
@@ -3,9 +3,11 @@ package uk.gov.di.authentication.shared.entity;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+
+import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.retrieveCredentialTrustLevel;
+import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.retrieveListOfCredentialTrustLevels;
 
 public class VectorOfTrust {
 
@@ -23,33 +25,30 @@ public class VectorOfTrust {
         return credentialTrustLevel;
     }
 
-    public static VectorOfTrust parse(List<String> vtr, VectorOfTrust clientDefaults) {
-        if (Objects.isNull(vtr)) {
-            return clientDefaults;
+    public static final VectorOfTrust parse(List<String> authRequestVtr, List<String> clientVtr) {
+        if (Objects.isNull(authRequestVtr)) {
+            return new VectorOfTrust(CredentialTrustLevel.getDefault());
         }
-        return parse(String.join(".", vtr), clientDefaults.getCredentialTrustLevel());
+        VectorOfTrust vectorOfTrust =
+                new VectorOfTrust(retrieveCredentialTrustLevel(authRequestVtr));
+        if (!Objects.isNull(clientVtr)) {
+            List<CredentialTrustLevel> credentialTrustLevels =
+                    retrieveListOfCredentialTrustLevels(clientVtr);
+            if (credentialTrustLevels.contains(vectorOfTrust.getCredentialTrustLevel())) {
+                return vectorOfTrust;
+            } else {
+                throw new IllegalArgumentException(
+                        vectorOfTrust.getCredentialTrustLevel() + " is not registered with client");
+            }
+        }
+        return new VectorOfTrust(CredentialTrustLevel.getDefault());
     }
 
     public static final VectorOfTrust parse(List<String> vtr) {
-        return parse(String.join(".", vtr), null);
-    }
-
-    public static final VectorOfTrust parse(String vtr) {
-        return parse(vtr, null);
-    }
-
-    public static final VectorOfTrust parse(
-            String vtr, CredentialTrustLevel defaultCredentialsTrustLevel) {
-        CredentialTrustLevel credentialTrustLevel = defaultCredentialsTrustLevel;
-        if (Objects.nonNull(vtr)) {
-            List<String> vectors = Arrays.asList(vtr.split("\\."));
-            for (String vector : vectors) {
-                if (vector.startsWith(("C"))) {
-                    credentialTrustLevel = CredentialTrustLevel.parseByValue(vector);
-                }
-            }
+        if (Objects.isNull(vtr) || vtr.isEmpty()) {
+            return new VectorOfTrust(CredentialTrustLevel.getDefault());
         }
-        return new VectorOfTrust(credentialTrustLevel);
+        return new VectorOfTrust(retrieveCredentialTrustLevel(vtr));
     }
 
     public static VectorOfTrust getDefaults() {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/VectorOfTrust.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/VectorOfTrust.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import net.minidev.json.JSONArray;
 import net.minidev.json.parser.JSONParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -13,6 +15,8 @@ import static net.minidev.json.parser.JSONParser.DEFAULT_PERMISSIVE_MODE;
 import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.retrieveCredentialTrustLevel;
 
 public class VectorOfTrust {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(VectorOfTrust.class);
 
     @JsonProperty("credential_trust_level")
     private final CredentialTrustLevel credentialTrustLevel;
@@ -30,6 +34,9 @@ public class VectorOfTrust {
 
     public static final VectorOfTrust parseFromAuthRequestAttribute(List<String> vtr) {
         if (Objects.isNull(vtr) || vtr.isEmpty()) {
+            LOGGER.info(
+                    "VTR attribute is not present so defaulting to {}",
+                    CredentialTrustLevel.getDefault().getValue());
             return new VectorOfTrust(CredentialTrustLevel.getDefault());
         }
         JSONParser parser = new JSONParser(DEFAULT_PERMISSIVE_MODE);
@@ -37,13 +44,18 @@ public class VectorOfTrust {
         try {
             vtrJsonArray = (JSONArray) parser.parse(vtr.get(0));
         } catch (net.minidev.json.parser.ParseException | ClassCastException e) {
+            LOGGER.error("Error when parsing vtr attribute", e);
             throw new IllegalArgumentException("Invalid VTR attribute", e);
         }
         List<String> vtrSets = new ArrayList<>();
         for (int i = 0; i < vtrJsonArray.size(); i++) {
             vtrSets.add((String) vtrJsonArray.get(i));
         }
-        return new VectorOfTrust(retrieveCredentialTrustLevel(vtrSets));
+        CredentialTrustLevel credentialTrustLevel = retrieveCredentialTrustLevel(vtrSets);
+        LOGGER.info(
+                "VTR has been processed at credentialTrustLevel {}",
+                credentialTrustLevel.getValue());
+        return new VectorOfTrust(credentialTrustLevel);
     }
 
     public static VectorOfTrust getDefaults() {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthorizationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthorizationService.java
@@ -109,8 +109,7 @@ public class AuthorizationService {
         }
         List<String> authRequestVtr = authRequest.getCustomParameter(VTR);
         try {
-            List<String> clientVtr = client.get().getVectorsOfTrust();
-            VectorOfTrust vectorOfTrust = VectorOfTrust.parse(authRequestVtr, clientVtr);
+            VectorOfTrust vectorOfTrust = VectorOfTrust.parse(authRequestVtr);
         } catch (IllegalArgumentException e) {
             return Optional.of(
                     new ErrorObject(OAuth2Error.INVALID_REQUEST_CODE, "Request vtr not valid"));

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthorizationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthorizationService.java
@@ -107,14 +107,13 @@ public class AuthorizationService {
                             OAuth2Error.INVALID_REQUEST_CODE,
                             "Request is missing state parameter"));
         }
-        List<String> vtr = authRequest.getCustomParameter(VTR);
-        if (vtr != null) {
-            try {
-                VectorOfTrust vectorOfTrust = VectorOfTrust.parse(vtr);
-            } catch (IllegalArgumentException e) {
-                return Optional.of(
-                        new ErrorObject(OAuth2Error.INVALID_REQUEST_CODE, "Request vtr not valid"));
-            }
+        List<String> authRequestVtr = authRequest.getCustomParameter(VTR);
+        try {
+            List<String> clientVtr = client.get().getVectorsOfTrust();
+            VectorOfTrust vectorOfTrust = VectorOfTrust.parse(authRequestVtr, clientVtr);
+        } catch (IllegalArgumentException e) {
+            return Optional.of(
+                    new ErrorObject(OAuth2Error.INVALID_REQUEST_CODE, "Request vtr not valid"));
         }
         return Optional.empty();
     }
@@ -135,13 +134,8 @@ public class AuthorizationService {
     }
 
     public VectorOfTrust getEffectiveVectorOfTrust(AuthenticationRequest authenticationRequest) {
-        VectorOfTrust clientDefaults =
-                dynamoClientService
-                        .getClient(authenticationRequest.getClientID().getValue())
-                        .map(ClientRegistry::calculateEffectiveVectorOfTrust)
-                        .get();
 
-        return VectorOfTrust.parse(authenticationRequest.getCustomParameter(VTR), clientDefaults);
+        return VectorOfTrust.parse(authenticationRequest.getCustomParameter(VTR));
     }
 
     public UserContext buildUserContext(Session session, ClientSession clientSession) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthorizationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthorizationService.java
@@ -109,7 +109,8 @@ public class AuthorizationService {
         }
         List<String> authRequestVtr = authRequest.getCustomParameter(VTR);
         try {
-            VectorOfTrust vectorOfTrust = VectorOfTrust.parse(authRequestVtr);
+            VectorOfTrust vectorOfTrust =
+                    VectorOfTrust.parseFromAuthRequestAttribute(authRequestVtr);
         } catch (IllegalArgumentException e) {
             return Optional.of(
                     new ErrorObject(OAuth2Error.INVALID_REQUEST_CODE, "Request vtr not valid"));
@@ -133,8 +134,8 @@ public class AuthorizationService {
     }
 
     public VectorOfTrust getEffectiveVectorOfTrust(AuthenticationRequest authenticationRequest) {
-
-        return VectorOfTrust.parse(authenticationRequest.getCustomParameter(VTR));
+        return VectorOfTrust.parseFromAuthRequestAttribute(
+                authenticationRequest.getCustomParameter(VTR));
     }
 
     public UserContext buildUserContext(Session session, ClientSession clientSession) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ClientService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ClientService.java
@@ -22,7 +22,7 @@ public interface ClientService {
             String serviceType,
             String sectorIdentifierUri,
             String subjectType,
-            String vectorsOfTrust);
+            List<String> vectorsOfTrust);
 
     Optional<ClientRegistry> getClient(String clientId);
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ClientService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ClientService.java
@@ -21,8 +21,7 @@ public interface ClientService {
             List<String> postLogoutRedirectUris,
             String serviceType,
             String sectorIdentifierUri,
-            String subjectType,
-            List<String> vectorsOfTrust);
+            String subjectType);
 
     Optional<ClientRegistry> getClient(String clientId);
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoClientService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoClientService.java
@@ -59,8 +59,7 @@ public class DynamoClientService implements ClientService {
             List<String> postLogoutRedirectUris,
             String serviceType,
             String sectorIdentifierUri,
-            String subjectType,
-            List<String> vectorsOfTrust) {
+            String subjectType) {
         ClientRegistry clientRegistry =
                 new ClientRegistry()
                         .setClientID(clientID)
@@ -72,8 +71,7 @@ public class DynamoClientService implements ClientService {
                         .setPostLogoutRedirectUrls(postLogoutRedirectUris)
                         .setServiceType(serviceType)
                         .setSectorIdentifierUri(sectorIdentifierUri)
-                        .setSubjectType(subjectType)
-                        .setVectorsOfTrust(vectorsOfTrust);
+                        .setSubjectType(subjectType);
         clientRegistryMapper.save(clientRegistry);
     }
 
@@ -90,8 +88,6 @@ public class DynamoClientService implements ClientService {
         Optional.ofNullable(updateRequest.getPublicKey()).ifPresent(clientRegistry::setPublicKey);
         Optional.ofNullable(updateRequest.getServiceType())
                 .ifPresent(clientRegistry::setServiceType);
-        Optional.ofNullable(updateRequest.getVectorsOfTrust())
-                .ifPresent(clientRegistry::setVectorsOfTrust);
         clientRegistryMapper.save(clientRegistry);
         return clientRegistry;
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoClientService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoClientService.java
@@ -60,7 +60,7 @@ public class DynamoClientService implements ClientService {
             String serviceType,
             String sectorIdentifierUri,
             String subjectType,
-            String vectorsOfTrust) {
+            List<String> vectorsOfTrust) {
         ClientRegistry clientRegistry =
                 new ClientRegistry()
                         .setClientID(clientID)

--- a/shared/src/main/java/uk/gov/di/authentication/shared/state/StateMachine.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/state/StateMachine.java
@@ -85,7 +85,7 @@ import static uk.gov.di.authentication.shared.state.conditions.ClientDoesNotRequ
 import static uk.gov.di.authentication.shared.state.conditions.ConsentNotGiven.userHasNotGivenConsent;
 import static uk.gov.di.authentication.shared.state.conditions.CredentialTrustUpliftRequired.upliftRequired;
 import static uk.gov.di.authentication.shared.state.conditions.PhoneNumberUnverified.phoneNumberUnverified;
-import static uk.gov.di.authentication.shared.state.conditions.RequestedLevelOfTrustEquals.requestedLevelOfTrustIsCm;
+import static uk.gov.di.authentication.shared.state.conditions.RequestedLevelOfTrustEquals.requestedLevelOfTrustIsMedium;
 import static uk.gov.di.authentication.shared.state.conditions.TermsAndConditionsVersionNotAccepted.userHasNotAcceptedTermsAndConditionsVersion;
 
 public class StateMachine<T, A, C> {
@@ -374,7 +374,7 @@ public class StateMachine<T, A, C> {
                 .allow(
                         on(SYSTEM_HAS_ISSUED_AUTHORIZATION_CODE).then(AUTHENTICATED),
                         on(USER_HAS_STARTED_A_NEW_JOURNEY)
-                                .ifCondition(and(upliftRequired(), requestedLevelOfTrustIsCm()))
+                                .ifCondition(and(upliftRequired(), requestedLevelOfTrustIsMedium()))
                                 .then(UPLIFT_REQUIRED_CM),
                         on(USER_HAS_STARTED_A_NEW_JOURNEY)
                                 .then(UPDATED_TERMS_AND_CONDITIONS)

--- a/shared/src/main/java/uk/gov/di/authentication/shared/state/conditions/ClientDoesNotRequireMfa.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/state/conditions/ClientDoesNotRequireMfa.java
@@ -1,22 +1,46 @@
 package uk.gov.di.authentication.shared.state.conditions;
 
-import uk.gov.di.authentication.shared.entity.ClientRegistry;
+import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.VectorOfTrust;
 import uk.gov.di.authentication.shared.state.Condition;
 import uk.gov.di.authentication.shared.state.UserContext;
 
+import java.util.List;
 import java.util.Optional;
 
 import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.LOW_LEVEL;
 
 public class ClientDoesNotRequireMfa implements Condition<UserContext> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ClientDoesNotRequireMfa.class);
+
     @Override
     public boolean isMet(Optional<UserContext> context) {
-        return context.flatMap(UserContext::getClient)
-                .map(ClientRegistry::calculateEffectiveVectorOfTrust)
-                .map(VectorOfTrust::getCredentialTrustLevel)
-                .map(LOW_LEVEL::equals)
-                .orElse(false);
+        AuthenticationRequest authRequest =
+                context.map(UserContext::getClientSession)
+                        .map(ClientSession::getAuthRequestParams)
+                        .map(
+                                t -> {
+                                    try {
+                                        return AuthenticationRequest.parse(t);
+                                    } catch (ParseException e) {
+                                        LOG.error("Unable to parse AuthRequest", e);
+                                        throw new RuntimeException(e);
+                                    }
+                                })
+                        .orElseThrow();
+
+        List<String> vtr = authRequest.getCustomParameter("vtr");
+        VectorOfTrust vectorOfTrust = VectorOfTrust.parse(vtr);
+        if (vectorOfTrust.getCredentialTrustLevel().equals(LOW_LEVEL)) {
+            return true;
+        } else {
+            return false;
+        }
     }
 
     public static ClientDoesNotRequireMfa clientDoesNotRequireMfa() {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/state/conditions/ClientDoesNotRequireMfa.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/state/conditions/ClientDoesNotRequireMfa.java
@@ -35,7 +35,7 @@ public class ClientDoesNotRequireMfa implements Condition<UserContext> {
                         .orElseThrow();
 
         List<String> vtr = authRequest.getCustomParameter("vtr");
-        VectorOfTrust vectorOfTrust = VectorOfTrust.parse(vtr);
+        VectorOfTrust vectorOfTrust = VectorOfTrust.parseFromAuthRequestAttribute(vtr);
         if (vectorOfTrust.getCredentialTrustLevel().equals(LOW_LEVEL)) {
             return true;
         } else {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/state/conditions/ConsentNotGiven.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/state/conditions/ConsentNotGiven.java
@@ -12,6 +12,7 @@ import uk.gov.di.authentication.shared.entity.ValidScopes;
 import uk.gov.di.authentication.shared.state.Condition;
 import uk.gov.di.authentication.shared.state.UserContext;
 
+import java.util.List;
 import java.util.Optional;
 
 public class ConsentNotGiven implements Condition<UserContext> {
@@ -33,6 +34,8 @@ public class ConsentNotGiven implements Condition<UserContext> {
                                     }
                                 })
                         .orElseThrow();
+
+        List<String> authRequestVtr = authRequest.getCustomParameter("vtr");
 
         String clientID =
                 context.flatMap(UserContext::getClient)

--- a/shared/src/main/java/uk/gov/di/authentication/shared/state/conditions/RequestedLevelOfTrustEquals.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/state/conditions/RequestedLevelOfTrustEquals.java
@@ -27,7 +27,7 @@ public class RequestedLevelOfTrustEquals implements Condition<UserContext> {
                 .orElse(false);
     }
 
-    public static RequestedLevelOfTrustEquals requestedLevelOfTrustIsCm() {
+    public static RequestedLevelOfTrustEquals requestedLevelOfTrustIsMedium() {
         return new RequestedLevelOfTrustEquals(MEDIUM_LEVEL);
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/CredentialTrustLevelTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/CredentialTrustLevelTest.java
@@ -2,28 +2,34 @@ package uk.gov.di.authentication.shared.entity;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThan;
-import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.HIGH_LEVEL;
 import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.LOW_LEVEL;
 import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.MEDIUM_LEVEL;
-import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.VERY_HIGH_LEVEL;
 
 class CredentialTrustLevelTest {
 
     @Test
     void valuesShouldBeComparable() {
         assertThat(LOW_LEVEL, lessThan(MEDIUM_LEVEL));
-        assertThat(MEDIUM_LEVEL, lessThan(HIGH_LEVEL));
-        assertThat(HIGH_LEVEL, lessThan(VERY_HIGH_LEVEL));
     }
 
     @Test
     void valuesShouldBeParsable() {
-        assertThat(CredentialTrustLevel.parseByValue("Cl"), equalTo(LOW_LEVEL));
-        assertThat(CredentialTrustLevel.parseByValue("Cm"), equalTo(MEDIUM_LEVEL));
-        assertThat(CredentialTrustLevel.parseByValue("Ch"), equalTo(HIGH_LEVEL));
-        assertThat(CredentialTrustLevel.parseByValue("Cv"), equalTo(VERY_HIGH_LEVEL));
+        assertThat(
+                CredentialTrustLevel.retrieveCredentialTrustLevel(List.of("Cl")),
+                equalTo(LOW_LEVEL));
+        assertThat(
+                CredentialTrustLevel.retrieveCredentialTrustLevel(List.of("Cl.Cm")),
+                equalTo(MEDIUM_LEVEL));
+        assertThat(
+                CredentialTrustLevel.retrieveCredentialTrustLevel(List.of("Cl", "Cl.Cm")),
+                equalTo(LOW_LEVEL));
+        assertThat(
+                CredentialTrustLevel.retrieveCredentialTrustLevel(List.of("Cl.Cm", "Cl")),
+                equalTo(LOW_LEVEL));
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/CredentialTrustLevelTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/CredentialTrustLevelTest.java
@@ -31,5 +31,11 @@ class CredentialTrustLevelTest {
         assertThat(
                 CredentialTrustLevel.retrieveCredentialTrustLevel(List.of("Cl.Cm", "Cl")),
                 equalTo(LOW_LEVEL));
+        assertThat(
+                CredentialTrustLevel.retrieveCredentialTrustLevel(List.of("Cm.Cl")),
+                equalTo(MEDIUM_LEVEL));
+        assertThat(
+                CredentialTrustLevel.retrieveCredentialTrustLevel(List.of("Cm.Cl", "Cl")),
+                equalTo(LOW_LEVEL));
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/VectorOfTrustTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/VectorOfTrustTest.java
@@ -2,6 +2,8 @@ package uk.gov.di.authentication.shared.entity;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -11,24 +13,23 @@ import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.MEDIUM
 class VectorOfTrustTest {
     @Test
     public void shouldParseValidStringWithSingleVector() {
-        VectorOfTrust vectorOfTrust = VectorOfTrust.parse("Cm", null);
+        VectorOfTrust vectorOfTrust = VectorOfTrust.parse(List.of("Cl.Cm"));
         assertThat(vectorOfTrust.getCredentialTrustLevel(), equalTo(MEDIUM_LEVEL));
     }
 
     @Test
     public void shouldParseValidStringWithMultipleVectors() {
-        VectorOfTrust vectorOfTrust = VectorOfTrust.parse("Pa.Cm.Pb", null);
-        assertThat(vectorOfTrust.getCredentialTrustLevel(), equalTo(MEDIUM_LEVEL));
-    }
-
-    @Test
-    public void shouldParseValidStringAndReturnDefaultIfNoCredentialTrustPresent() {
-        VectorOfTrust vectorOfTrust = VectorOfTrust.parse("Pa.Pb", LOW_LEVEL);
+        VectorOfTrust vectorOfTrust = VectorOfTrust.parse(List.of("Cl"));
         assertThat(vectorOfTrust.getCredentialTrustLevel(), equalTo(LOW_LEVEL));
     }
 
     @Test
-    public void shouldParseThrowOnInvalidString() {
-        assertThrows(IllegalArgumentException.class, () -> VectorOfTrust.parse("Ck", null));
+    public void shouldParseValidStringAndReThrowIfInvalidValueIsPresent() {
+        assertThrows(IllegalArgumentException.class, () -> VectorOfTrust.parse(List.of("Pl.Pb")));
+    }
+
+    @Test
+    public void shouldThrowIfOnlyCmIsPresent() {
+        assertThrows(IllegalArgumentException.class, () -> VectorOfTrust.parse(List.of("Cm")));
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/VectorOfTrustTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/VectorOfTrustTest.java
@@ -2,6 +2,7 @@ package uk.gov.di.authentication.shared.entity;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -15,6 +16,20 @@ class VectorOfTrustTest {
     public void shouldParseValidStringWithSingleVector() {
         VectorOfTrust vectorOfTrust = VectorOfTrust.parse(List.of("Cl.Cm"));
         assertThat(vectorOfTrust.getCredentialTrustLevel(), equalTo(MEDIUM_LEVEL));
+    }
+
+    @Test
+    public void shouldReturnDefaultVectorWhenEmptyListIsPassedIn() {
+        VectorOfTrust vectorOfTrust = VectorOfTrust.parse(new ArrayList<>());
+        assertThat(
+                vectorOfTrust.getCredentialTrustLevel(),
+                equalTo(CredentialTrustLevel.getDefault()));
+    }
+
+    @Test
+    public void shouldReturnLowestVectorWhenMultipleSetsAreIsPassedIn() {
+        VectorOfTrust vectorOfTrust = VectorOfTrust.parse(List.of("Cl.Cm", "Cl"));
+        assertThat(vectorOfTrust.getCredentialTrustLevel(), equalTo(LOW_LEVEL));
     }
 
     @Test

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/VectorOfTrustTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/VectorOfTrustTest.java
@@ -1,9 +1,10 @@
 package uk.gov.di.authentication.shared.entity;
 
+import net.minidev.json.JSONArray;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
-import java.util.List;
+import java.util.Collections;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -14,13 +15,18 @@ import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.MEDIUM
 class VectorOfTrustTest {
     @Test
     public void shouldParseValidStringWithSingleVector() {
-        VectorOfTrust vectorOfTrust = VectorOfTrust.parse(List.of("Cl.Cm"));
+        JSONArray jsonArray = new JSONArray();
+        jsonArray.add("Cl.Cm");
+        VectorOfTrust vectorOfTrust =
+                VectorOfTrust.parseFromAuthRequestAttribute(
+                        Collections.singletonList(jsonArray.toJSONString()));
         assertThat(vectorOfTrust.getCredentialTrustLevel(), equalTo(MEDIUM_LEVEL));
     }
 
     @Test
     public void shouldReturnDefaultVectorWhenEmptyListIsPassedIn() {
-        VectorOfTrust vectorOfTrust = VectorOfTrust.parse(new ArrayList<>());
+        VectorOfTrust vectorOfTrust =
+                VectorOfTrust.parseFromAuthRequestAttribute(new ArrayList<>());
         assertThat(
                 vectorOfTrust.getCredentialTrustLevel(),
                 equalTo(CredentialTrustLevel.getDefault()));
@@ -28,23 +34,51 @@ class VectorOfTrustTest {
 
     @Test
     public void shouldReturnLowestVectorWhenMultipleSetsAreIsPassedIn() {
-        VectorOfTrust vectorOfTrust = VectorOfTrust.parse(List.of("Cl.Cm", "Cl"));
+        JSONArray jsonArray = new JSONArray();
+        jsonArray.add("Cl.Cm");
+        jsonArray.add("Cl");
+        VectorOfTrust vectorOfTrust =
+                VectorOfTrust.parseFromAuthRequestAttribute(
+                        Collections.singletonList(jsonArray.toJSONString()));
         assertThat(vectorOfTrust.getCredentialTrustLevel(), equalTo(LOW_LEVEL));
     }
 
     @Test
     public void shouldParseValidStringWithMultipleVectors() {
-        VectorOfTrust vectorOfTrust = VectorOfTrust.parse(List.of("Cl"));
+        JSONArray jsonArray = new JSONArray();
+        jsonArray.add("Cl");
+        VectorOfTrust vectorOfTrust =
+                VectorOfTrust.parseFromAuthRequestAttribute(
+                        Collections.singletonList(jsonArray.toJSONString()));
         assertThat(vectorOfTrust.getCredentialTrustLevel(), equalTo(LOW_LEVEL));
     }
 
     @Test
     public void shouldParseValidStringAndReThrowIfInvalidValueIsPresent() {
-        assertThrows(IllegalArgumentException.class, () -> VectorOfTrust.parse(List.of("Pl.Pb")));
+        JSONArray jsonArray = new JSONArray();
+        jsonArray.add("Pl.Pb");
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        VectorOfTrust.parseFromAuthRequestAttribute(
+                                Collections.singletonList(jsonArray.toJSONString())));
     }
 
     @Test
     public void shouldThrowIfOnlyCmIsPresent() {
-        assertThrows(IllegalArgumentException.class, () -> VectorOfTrust.parse(List.of("Cm")));
+        JSONArray jsonArray = new JSONArray();
+        jsonArray.add("Cm");
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        VectorOfTrust.parseFromAuthRequestAttribute(
+                                Collections.singletonList(jsonArray.toJSONString())));
+    }
+
+    @Test
+    public void shouldThrowIfEmptyListIsPresent() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> VectorOfTrust.parseFromAuthRequestAttribute(Collections.singletonList("")));
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuthorizationServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuthorizationServiceTest.java
@@ -355,6 +355,7 @@ class AuthorizationServiceTest {
                         responseType, scope, new ClientID(clientID), URI.create(redirectUri))
                 .state(state)
                 .nonce(new Nonce())
+                .customParameter("vtr", "Cl.Cm", "Cl")
                 .build();
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/state/conditions/ClientDoesNotRequireMfaTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/state/conditions/ClientDoesNotRequireMfaTest.java
@@ -1,11 +1,20 @@
 package uk.gov.di.authentication.shared.state.conditions;
 
+import com.nimbusds.oauth2.sdk.ResponseType;
+import com.nimbusds.oauth2.sdk.Scope;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.id.State;
+import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+import com.nimbusds.openid.connect.sdk.Nonce;
+import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
+import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.VectorOfTrust;
 import uk.gov.di.authentication.shared.state.UserContext;
 
+import java.net.URI;
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -19,16 +28,19 @@ class ClientDoesNotRequireMfaTest {
     private final ClientDoesNotRequireMfa condition = new ClientDoesNotRequireMfa();
     private UserContext userContext = mock(UserContext.class);
     private ClientRegistry client = mock(ClientRegistry.class);
+    private ClientSession clientSession = mock(ClientSession.class);
     private VectorOfTrust vectorOfTrust = mock(VectorOfTrust.class);
 
     @BeforeEach
     public void setup() {
         when(userContext.getClient()).thenReturn(Optional.of(client));
-        when(client.calculateEffectiveVectorOfTrust()).thenReturn(vectorOfTrust);
+        when(userContext.getClientSession()).thenReturn(clientSession);
     }
 
     @Test
     public void shouldReturnTrueIfLowLevelOfTrust() {
+        when(clientSession.getAuthRequestParams())
+                .thenReturn(generateAuthRequest(Optional.of("Cl")).toParameters());
         when(vectorOfTrust.getCredentialTrustLevel()).thenReturn(LOW_LEVEL);
 
         assertThat(condition.isMet(Optional.of(userContext)), equalTo(true));
@@ -36,15 +48,36 @@ class ClientDoesNotRequireMfaTest {
 
     @Test
     public void shouldReturnFalseIfNotLowLevelOfTrust() {
+        when(clientSession.getAuthRequestParams())
+                .thenReturn(generateAuthRequest(Optional.of("Cl.Cm")).toParameters());
         when(vectorOfTrust.getCredentialTrustLevel()).thenReturn(MEDIUM_LEVEL);
 
         assertThat(condition.isMet(Optional.of(userContext)), equalTo(false));
     }
 
     @Test
-    public void shouldReturnFalseIfClientDoesNotExistInContext() {
+    public void shouldReturnFalseIfAuthRequestDoesNotContainVtr() {
+        when(clientSession.getAuthRequestParams())
+                .thenReturn(generateAuthRequest(Optional.empty()).toParameters());
+
         when(userContext.getClient()).thenReturn(Optional.empty());
 
         assertThat(condition.isMet(Optional.of(userContext)), equalTo(false));
+    }
+
+    private AuthenticationRequest generateAuthRequest(Optional<String> credentialTrustLevel) {
+        Scope scope = new Scope();
+        scope.add(OIDCScopeValue.OPENID);
+        AuthenticationRequest.Builder builder =
+                new AuthenticationRequest.Builder(
+                                ResponseType.CODE,
+                                scope,
+                                new ClientID(),
+                                URI.create("http://localhost/redirect"))
+                        .state(new State())
+                        .nonce(new Nonce());
+
+        credentialTrustLevel.ifPresent(t -> builder.customParameter("vtr", t));
+        return builder.build();
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/state/conditions/ClientDoesNotRequireMfaTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/state/conditions/ClientDoesNotRequireMfaTest.java
@@ -7,6 +7,7 @@ import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import com.nimbusds.openid.connect.sdk.Nonce;
 import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
+import net.minidev.json.JSONArray;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
@@ -77,7 +78,12 @@ class ClientDoesNotRequireMfaTest {
                         .state(new State())
                         .nonce(new Nonce());
 
-        credentialTrustLevel.ifPresent(t -> builder.customParameter("vtr", t));
+        credentialTrustLevel.ifPresent(
+                t -> {
+                    JSONArray jsonArray = new JSONArray();
+                    jsonArray.add(t);
+                    builder.customParameter("vtr", jsonArray.toJSONString());
+                });
         return builder.build();
     }
 }


### PR DESCRIPTION
## What and Why?
- Previously we were accepting a single value against the VTR property in the authn request which was . seperated. Change this to allow a list of VTR values as an JSON array list such as "["cl", "cl.cm"]". [This reflects section 4.1 of the VTR RFC ](https://datatracker.ietf.org/doc/html/rfc8485#section-4.1)
- Change the TokenHandler to use the VTR set in the clientsession
- Stop storing the VTR in the ClientRegistry and rely on the authn request to decide what level the authn request is processed as. This VTR attribute is returned in the ID token to be validated by the client before they request UserInfo. 
- Validate the vtr attribute in the auth request with the following conditions.
1-If the vtr is empty then default it to our default 
2-If the vtr is present, ensure that all values are valid by checking against the CredentialTrustLevels that we support. If they are not valid then we will return an error.
- If for example a auth request contained {"cl", "cl.cm"} then cl(LOW_LEVEL) would be assigned to that request as long as all the above conditions have been met.
- If {"cl.cm"} then MEDIUM_LEVEL would be assigned. 

- Support any ordering of valid sets of vectors as per section 3.1 in RFC8485, https://datatracker.ietf.org/doc/html/rfc8485#section-3.1 we should process Vector components regardless of the order in which they arrive. For example a request with {"Cl.Cm"} should be processed exactly the same as {"Cm.Cl"}


**See RFC**
- VTR RFC https://datatracker.ietf.org/doc/html/rfc8485