### PR TITLE
GOVSI-830: Include client ID, if available, in the audit payloads

### DIFF
--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandler.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandler.java
@@ -61,6 +61,7 @@ public class ClientRegistrationHandler
                             auditService.submitAuditEvent(
                                     REGISTER_CLIENT_REQUEST_RECEIVED,
                                     context.getAwsRequestId(),
+                                    "",
                                     "");
 
                             try {
@@ -74,11 +75,13 @@ public class ClientRegistrationHandler
                                     auditService.submitAuditEvent(
                                             REGISTER_CLIENT_REQUEST_ERROR,
                                             context.getAwsRequestId(),
+                                            "",
                                             "");
 
                                     return generateApiGatewayProxyResponse(
                                             400, errorResponse.get().toJSONObject().toJSONString());
                                 }
+
                                 String clientID = clientService.generateClientID().toString();
                                 clientService.addClient(
                                         clientID,
@@ -111,6 +114,7 @@ public class ClientRegistrationHandler
                                 auditService.submitAuditEvent(
                                         REGISTER_CLIENT_REQUEST_ERROR,
                                         context.getAwsRequestId(),
+                                        "",
                                         "");
 
                                 return generateApiGatewayProxyResponse(

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandler.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandler.java
@@ -62,11 +62,14 @@ public class UpdateClientConfigHandler
                 .orElseGet(
                         () -> {
                             auditService.submitAuditEvent(
-                                    UPDATE_CLIENT_REQUEST_RECEIVED, context.getAwsRequestId(), "");
-
+                                    UPDATE_CLIENT_REQUEST_RECEIVED,
+                                    context.getAwsRequestId(),
+                                    "",
+                                    "");
                             try {
                                 String clientId = input.getPathParameters().get("clientId");
                                 LOGGER.info("Request received with ClientId {}", clientId);
+
                                 UpdateClientConfigRequest updateClientConfigRequest =
                                         objectMapper.readValue(
                                                 input.getBody(), UpdateClientConfigRequest.class);
@@ -74,7 +77,8 @@ public class UpdateClientConfigHandler
                                     auditService.submitAuditEvent(
                                             UPDATE_CLIENT_REQUEST_ERROR,
                                             context.getAwsRequestId(),
-                                            "");
+                                            "",
+                                            clientId);
                                     LOGGER.error("Client with ClientId {} is not valid", clientId);
                                     return generateApiGatewayProxyResponse(
                                             400,
@@ -89,7 +93,8 @@ public class UpdateClientConfigHandler
                                     auditService.submitAuditEvent(
                                             UPDATE_CLIENT_REQUEST_ERROR,
                                             context.getAwsRequestId(),
-                                            "");
+                                            "",
+                                            clientId);
                                     return generateApiGatewayProxyResponse(
                                             400, errorResponse.get().toJSONObject().toJSONString());
                                 }
@@ -110,7 +115,10 @@ public class UpdateClientConfigHandler
                                         200, clientRegistrationResponse);
                             } catch (JsonProcessingException | NullPointerException e) {
                                 auditService.submitAuditEvent(
-                                        UPDATE_CLIENT_REQUEST_ERROR, context.getAwsRequestId(), "");
+                                        UPDATE_CLIENT_REQUEST_ERROR,
+                                        context.getAwsRequestId(),
+                                        "",
+                                        "");
                                 LOGGER.error(
                                         "Request with path parameters {} is missing request parameters",
                                         input.getPathParameters());

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandlerTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandlerTest.java
@@ -114,7 +114,7 @@ class ClientRegistrationHandlerTest {
         assertThat(result, hasStatus(400));
         assertThat(result, hasBody(OAuth2Error.INVALID_REQUEST.toJSONObject().toJSONString()));
 
-        verify(auditService).submitAuditEvent(REGISTER_CLIENT_REQUEST_ERROR, "request-id", "");
+        verify(auditService).submitAuditEvent(REGISTER_CLIENT_REQUEST_ERROR, "request-id", "", "");
     }
 
     @Test
@@ -130,7 +130,7 @@ class ClientRegistrationHandlerTest {
         assertThat(result, hasStatus(400));
         assertThat(result, hasBody(INVALID_PUBLIC_KEY.toJSONObject().toJSONString()));
 
-        verify(auditService).submitAuditEvent(REGISTER_CLIENT_REQUEST_ERROR, "request-id", "");
+        verify(auditService).submitAuditEvent(REGISTER_CLIENT_REQUEST_ERROR, "request-id", "", "");
     }
 
     @Test
@@ -146,13 +146,14 @@ class ClientRegistrationHandlerTest {
         assertThat(result, hasStatus(400));
         assertThat(result, hasBody(INVALID_SCOPE.toJSONObject().toJSONString()));
 
-        verify(auditService).submitAuditEvent(REGISTER_CLIENT_REQUEST_ERROR, "request-id", "");
+        verify(auditService).submitAuditEvent(REGISTER_CLIENT_REQUEST_ERROR, "request-id", "", "");
     }
 
     private APIGatewayProxyResponseEvent makeHandlerRequest(APIGatewayProxyRequestEvent event) {
         var response = handler.handleRequest(event, context);
 
-        verify(auditService).submitAuditEvent(REGISTER_CLIENT_REQUEST_RECEIVED, "request-id", "");
+        verify(auditService)
+                .submitAuditEvent(REGISTER_CLIENT_REQUEST_RECEIVED, "request-id", "", "");
 
         return response;
     }

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandlerTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandlerTest.java
@@ -96,7 +96,7 @@ class UpdateClientConfigHandlerTest {
         assertThat(result, hasStatus(400));
         assertThat(result, hasBody(OAuth2Error.INVALID_REQUEST.toJSONObject().toJSONString()));
 
-        verify(auditService).submitAuditEvent(UPDATE_CLIENT_REQUEST_ERROR, "request-id", "");
+        verify(auditService).submitAuditEvent(UPDATE_CLIENT_REQUEST_ERROR, "request-id", "", "");
     }
 
     @Test
@@ -108,7 +108,7 @@ class UpdateClientConfigHandlerTest {
         assertThat(result, hasStatus(400));
         assertThat(result, hasBody(OAuth2Error.INVALID_REQUEST.toJSONObject().toJSONString()));
 
-        verify(auditService).submitAuditEvent(UPDATE_CLIENT_REQUEST_ERROR, "request-id", "");
+        verify(auditService).submitAuditEvent(UPDATE_CLIENT_REQUEST_ERROR, "request-id", "", "");
     }
 
     @Test
@@ -122,7 +122,8 @@ class UpdateClientConfigHandlerTest {
         assertThat(result, hasStatus(400));
         assertThat(result, hasBody(OAuth2Error.INVALID_CLIENT.toJSONObject().toJSONString()));
 
-        verify(auditService).submitAuditEvent(UPDATE_CLIENT_REQUEST_ERROR, "request-id", "");
+        verify(auditService)
+                .submitAuditEvent(UPDATE_CLIENT_REQUEST_ERROR, "request-id", "", CLIENT_ID);
     }
 
     @Test
@@ -143,7 +144,8 @@ class UpdateClientConfigHandlerTest {
         assertThat(result, hasStatus(400));
         assertThat(result, hasBody(INVALID_PUBLIC_KEY.toJSONObject().toJSONString()));
 
-        verify(auditService).submitAuditEvent(UPDATE_CLIENT_REQUEST_ERROR, "request-id", "");
+        verify(auditService)
+                .submitAuditEvent(UPDATE_CLIENT_REQUEST_ERROR, "request-id", "", CLIENT_ID);
     }
 
     @Test
@@ -161,7 +163,8 @@ class UpdateClientConfigHandlerTest {
         assertThat(result, hasStatus(400));
         assertThat(result, hasBody(INVALID_SCOPE.toJSONObject().toJSONString()));
 
-        verify(auditService).submitAuditEvent(UPDATE_CLIENT_REQUEST_ERROR, "request-id", "");
+        verify(auditService)
+                .submitAuditEvent(UPDATE_CLIENT_REQUEST_ERROR, "request-id", "", CLIENT_ID);
     }
 
     private ClientRegistry createClientRegistry() {
@@ -180,7 +183,7 @@ class UpdateClientConfigHandlerTest {
     private APIGatewayProxyResponseEvent makeHandlerRequest(APIGatewayProxyRequestEvent event) {
         var response = handler.handleRequest(event, context);
 
-        verify(auditService).submitAuditEvent(UPDATE_CLIENT_REQUEST_RECEIVED, "request-id", "");
+        verify(auditService).submitAuditEvent(UPDATE_CLIENT_REQUEST_RECEIVED, "request-id", "", "");
 
         return response;
     }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
@@ -98,13 +98,13 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
     @Override
     public void onRequestReceived(Context context) {
         auditService.submitAuditEvent(
-                ACCOUNT_MANAGEMENT_REQUEST_RECEIVED, context.getAwsRequestId(), "");
+                ACCOUNT_MANAGEMENT_REQUEST_RECEIVED, context.getAwsRequestId(), "", "");
     }
 
     @Override
     public void onRequestValidationError(Context context) {
         auditService.submitAuditEvent(
-                ACCOUNT_MANAGEMENT_REQUEST_ERROR, context.getAwsRequestId(), "");
+                ACCOUNT_MANAGEMENT_REQUEST_ERROR, context.getAwsRequestId(), "", "");
     }
 
     @Override
@@ -134,7 +134,8 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
                         auditService.submitAuditEvent(
                                 ACCOUNT_MANAGEMENT_PHONE_NUMBER_UPDATED,
                                 context.getAwsRequestId(),
-                                session.getSessionId());
+                                session.getSessionId(),
+                                "");
                         sessionService.save(session.setState(nextState));
                         LOGGER.info(
                                 "Phone number updated and session state changed. Session state {}",
@@ -182,7 +183,8 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
                         auditService.submitAuditEvent(
                                 ACCOUNT_MANAGEMENT_CONSENT_UPDATED,
                                 context.getAwsRequestId(),
-                                session.getSessionId());
+                                session.getSessionId(),
+                                clientId);
 
                         LOGGER.info(
                                 "Consent updated for ClientID {} and session state changed. Session state {}",
@@ -200,7 +202,8 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
                         auditService.submitAuditEvent(
                                 ACCOUNT_MANAGEMENT_TERMS_CONDS_ACCEPTANCE_UPDATED,
                                 context.getAwsRequestId(),
-                                session.getSessionId());
+                                session.getSessionId(),
+                                "");
                         LOGGER.info(
                                 "Updated terms and conditions. Email {} for Version {}",
                                 request.getEmail(),

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandlerTest.java
@@ -143,7 +143,8 @@ class UpdateProfileHandlerTest {
                 .submitAuditEvent(
                         ACCOUNT_MANAGEMENT_PHONE_NUMBER_UPDATED,
                         "request-id",
-                        session.getSessionId());
+                        session.getSessionId(),
+                        "");
     }
 
     @Test
@@ -176,7 +177,8 @@ class UpdateProfileHandlerTest {
                 .submitAuditEvent(
                         ACCOUNT_MANAGEMENT_TERMS_CONDS_ACCEPTANCE_UPDATED,
                         "request-id",
-                        session.getSessionId());
+                        session.getSessionId(),
+                        "");
     }
 
     @Test
@@ -221,7 +223,10 @@ class UpdateProfileHandlerTest {
 
         verify(auditService)
                 .submitAuditEvent(
-                        ACCOUNT_MANAGEMENT_CONSENT_UPDATED, "request-id", session.getSessionId());
+                        ACCOUNT_MANAGEMENT_CONSENT_UPDATED,
+                        "request-id",
+                        session.getSessionId(),
+                        clientID.getValue());
         BaseAPIResponse codeResponse =
                 new ObjectMapper().readValue(result.getBody(), BaseAPIResponse.class);
         assertThat(codeResponse.getSessionState(), equalTo(CONSENT_ADDED));
@@ -244,7 +249,8 @@ class UpdateProfileHandlerTest {
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1001));
 
-        verify(auditService).submitAuditEvent(ACCOUNT_MANAGEMENT_REQUEST_ERROR, "request-id", "");
+        verify(auditService)
+                .submitAuditEvent(ACCOUNT_MANAGEMENT_REQUEST_ERROR, "request-id", "", "");
     }
 
     @Test
@@ -262,7 +268,8 @@ class UpdateProfileHandlerTest {
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1017));
 
-        verify(auditService).submitAuditEvent(ACCOUNT_MANAGEMENT_REQUEST_ERROR, "request-id", "");
+        verify(auditService)
+                .submitAuditEvent(ACCOUNT_MANAGEMENT_REQUEST_ERROR, "request-id", "", "");
     }
 
     private void usingValidSession() {
@@ -290,7 +297,7 @@ class UpdateProfileHandlerTest {
         var response = handler.handleRequest(event, context);
 
         verify(auditService)
-                .submitAuditEvent(ACCOUNT_MANAGEMENT_REQUEST_RECEIVED, "request-id", "");
+                .submitAuditEvent(ACCOUNT_MANAGEMENT_REQUEST_RECEIVED, "request-id", "", "");
 
         return response;
     }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -92,6 +92,7 @@ public class AuthorisationHandler
                             auditService.submitAuditEvent(
                                     OidcAuditableEvent.AUTHORISATION_REQUEST_RECEIVED,
                                     context.getAwsRequestId(),
+                                    "",
                                     "");
                             LOGGER.info("Received authentication request");
 
@@ -301,6 +302,7 @@ public class AuthorisationHandler
         auditService.submitAuditEvent(
                 OidcAuditableEvent.AUTHORISATION_REQUEST_ERROR,
                 context.getAwsRequestId(),
+                "",
                 "",
                 pair("description", errorObject.getDescription()));
 

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -167,6 +167,7 @@ class AuthorisationHandlerTest {
                         AUTHORISATION_REQUEST_ERROR,
                         "request-id",
                         "",
+                        "",
                         pair("description", "Invalid request: Missing response_type parameter"));
     }
 
@@ -193,6 +194,7 @@ class AuthorisationHandlerTest {
                 .submitAuditEvent(
                         AUTHORISATION_REQUEST_ERROR,
                         "request-id",
+                        "",
                         "",
                         pair("description", OAuth2Error.INVALID_SCOPE.getDescription()));
     }
@@ -260,6 +262,7 @@ class AuthorisationHandlerTest {
                 .submitAuditEvent(
                         AUTHORISATION_REQUEST_ERROR,
                         "request-id",
+                        "",
                         "",
                         pair("description", OIDCError.LOGIN_REQUIRED.getDescription()));
     }
@@ -354,6 +357,7 @@ class AuthorisationHandlerTest {
                         AUTHORISATION_REQUEST_ERROR,
                         "request-id",
                         "",
+                        "",
                         pair(
                                 "description",
                                 "Invalid request: Invalid prompt parameter: Unknown prompt type: unrecognised"));
@@ -374,6 +378,7 @@ class AuthorisationHandlerTest {
                 .submitAuditEvent(
                         AUTHORISATION_REQUEST_ERROR,
                         "request-id",
+                        "",
                         "",
                         pair(
                                 "description",
@@ -396,6 +401,7 @@ class AuthorisationHandlerTest {
                         AUTHORISATION_REQUEST_ERROR,
                         "request-id",
                         "",
+                        "",
                         pair(
                                 "description",
                                 OIDCError.UNMET_AUTHENTICATION_REQUIREMENTS.getDescription()));
@@ -417,6 +423,7 @@ class AuthorisationHandlerTest {
                         AUTHORISATION_REQUEST_ERROR,
                         "request-id",
                         "",
+                        "",
                         pair(
                                 "description",
                                 OIDCError.UNMET_AUTHENTICATION_REQUIREMENTS.getDescription()));
@@ -437,6 +444,7 @@ class AuthorisationHandlerTest {
                 .submitAuditEvent(
                         AUTHORISATION_REQUEST_ERROR,
                         "request-id",
+                        "",
                         "",
                         pair(
                                 "description",
@@ -496,7 +504,7 @@ class AuthorisationHandlerTest {
 
         verify(auditService)
                 .submitAuditEvent(
-                        OidcAuditableEvent.AUTHORISATION_REQUEST_RECEIVED, "request-id", "");
+                        OidcAuditableEvent.AUTHORISATION_REQUEST_RECEIVED, "request-id", "", "");
 
         return response;
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/matchers/AuditMessageMatcher.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/matchers/AuditMessageMatcher.java
@@ -36,6 +36,10 @@ public class AuditMessageMatcher<T> extends TypeSafeDiagnosingMatcher<String> {
         return new AuditMessageMatcher<>("session ID", AuditEvent::getSessionId, sessionId);
     }
 
+    public static AuditMessageMatcher<String> hasClientId(String clientId) {
+        return new AuditMessageMatcher<>("client ID", AuditEvent::getClientId, clientId);
+    }
+
     @Override
     protected boolean matchesSafely(
             String serialisedAuditMessage, Description mismatchDescription) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
@@ -27,14 +27,17 @@ public class AuditService {
             AuditableEvent event,
             String requestId,
             String sessionId,
+            String clientId,
             MetadataPair... metadataPairs) {
-        snsService.publishAuditMessage(generateLogLine(event, requestId, sessionId, metadataPairs));
+        snsService.publishAuditMessage(
+                generateLogLine(event, requestId, sessionId, clientId, metadataPairs));
     }
 
     String generateLogLine(
             AuditableEvent eventEnum,
             String requestId,
             String sessionId,
+            String clientId,
             MetadataPair... metadataPairs) {
         var timestamp = clock.instant().toString();
 
@@ -43,7 +46,8 @@ public class AuditService {
                         .setEventName(eventEnum.toString())
                         .setTimestamp(timestamp)
                         .setRequestId(Optional.ofNullable(requestId).orElse(""))
-                        .setSessionId(Optional.ofNullable(sessionId).orElse(""));
+                        .setSessionId(Optional.ofNullable(sessionId).orElse(""))
+                        .setClientId(Optional.ofNullable(clientId).orElse(""));
         // TODO - Extract other values from the metadataPairs argument.
 
         var signedEventBuilder = SignedAuditEvent.newBuilder();

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
@@ -16,6 +16,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static uk.gov.di.authentication.shared.matchers.AuditMessageMatcher.hasClientId;
 import static uk.gov.di.authentication.shared.matchers.AuditMessageMatcher.hasEventName;
 import static uk.gov.di.authentication.shared.matchers.AuditMessageMatcher.hasRequestId;
 import static uk.gov.di.authentication.shared.matchers.AuditMessageMatcher.hasSessionId;
@@ -51,7 +52,7 @@ class AuditServiceTest {
     void shouldLogAuditEvent() {
         var auditService = new AuditService(FIXED_CLOCK, snsService);
 
-        auditService.submitAuditEvent(TEST_EVENT_ONE, "request-id", "session-id");
+        auditService.submitAuditEvent(TEST_EVENT_ONE, "request-id", "session-id", "client-id");
 
         verify(snsService).publishAuditMessage(messageCaptor.capture());
         var serialisedAuditMessage = messageCaptor.getValue();
@@ -60,6 +61,7 @@ class AuditServiceTest {
         assertThat(serialisedAuditMessage, hasEventName(TEST_EVENT_ONE.toString()));
         assertThat(serialisedAuditMessage, hasRequestId("request-id"));
         assertThat(serialisedAuditMessage, hasSessionId("session-id"));
+        assertThat(serialisedAuditMessage, hasClientId("client-id"));
     }
 
     @Test
@@ -70,6 +72,7 @@ class AuditServiceTest {
                 TEST_EVENT_ONE,
                 "request-id",
                 "session-id",
+                "client-id",
                 pair("key", "value"),
                 pair("key2", "value2"));
 


### PR DESCRIPTION
We will need to return to this - there are places in need of refactoring to expose client ID to the audit service
