### PR TITLE
GOVSI-822: Create SQS cloudwatch groups and name VPCs

### DIFF
--- a/ci/terraform/account-management/sqs.tf
+++ b/ci/terraform/account-management/sqs.tf
@@ -147,3 +147,30 @@ resource "aws_lambda_function" "email_sqs_lambda" {
     aws_iam_role.lambda_iam_role,
   ]
 }
+
+resource "aws_cloudwatch_log_group" "sqs_lambda_log_group" {
+  count = var.use_localstack ? 0 : 1
+
+  name = "/aws/lambda/${aws_lambda_function.email_sqs_lambda.function_name}"
+  tags = local.default_tags
+
+  depends_on = [
+    aws_lambda_function.email_sqs_lambda
+  ]
+}
+
+resource "aws_cloudwatch_log_subscription_filter" "sqs_lambda_log_subscription" {
+  count = var.logging_endpoint_enabled ? 1 : 0
+
+  name            = "${aws_lambda_function.email_sqs_lambda.function_name}-log-subscription"
+  log_group_name  = aws_cloudwatch_log_group.sqs_lambda_log_group[0].name
+  filter_pattern  = ""
+  destination_arn = var.logging_endpoint_arn
+}
+
+resource "aws_lambda_alias" "sqs_lambda_active" {
+  name             = "${aws_lambda_function.email_sqs_lambda.function_name}-active"
+  description      = "Alias pointing at active version of Lambda"
+  function_name    = aws_lambda_function.email_sqs_lambda.arn
+  function_version = aws_lambda_function.email_sqs_lambda.version
+}

--- a/ci/terraform/account-management/vpc.tf
+++ b/ci/terraform/account-management/vpc.tf
@@ -3,7 +3,9 @@ resource "aws_vpc" "account_management_vpc" {
   enable_dns_hostnames = true
   enable_dns_support   = true
 
-  tags = local.default_tags
+  tags = merge(local.default_tags, {
+    Name = "${var.environment}-account-management-vpc"
+  })
 }
 
 data "aws_availability_zones" "available" {}

--- a/ci/terraform/shared/vpc.tf
+++ b/ci/terraform/shared/vpc.tf
@@ -3,7 +3,9 @@ resource "aws_vpc" "authentication" {
   enable_dns_hostnames = true
   enable_dns_support   = true
 
-  tags = local.default_tags
+  tags = merge(local.default_tags, {
+    Name = "${var.environment}-shared-vpc"
+  })
 }
 
 data "aws_availability_zones" "available" {}


### PR DESCRIPTION
## What?

- Ensure Cloudwatch group is created for the SQS lambda
- Add an active version alias to the SQS lambda
- Add log subscription to the cloudwatch lambda
- Add a `Name` tag to the VPCs

## Why?

The CloudWatch group needs to exist before the lambda can execute. The log subscription is also required for monitoring.

Naming the VPC makes it easier, in the console, to see which VPC is which.