### PR TITLE
GOVSI-828: Create KMS signing key for audit payloads

### DIFF
--- a/ci/terraform/shared/kms.tf
+++ b/ci/terraform/shared/kms.tf
@@ -73,3 +73,44 @@ resource "aws_iam_role_policy_attachment" "lambda_kms_signing_policy" {
   role       = aws_iam_role.token_lambda_iam_role.name
   policy_arn = aws_iam_policy.lambda_kms_signing_policy[0].arn
 }
+
+# Audit signing key
+
+resource "aws_kms_key" "audit_payload_signing_key" {
+  description              = "KMS signing key for audit payloads"
+  deletion_window_in_days  = 30
+  key_usage                = "SIGN_VERIFY"
+  customer_master_key_spec = "ECC_NIST_P256"
+
+  tags = local.default_tags
+}
+
+resource "aws_kms_alias" "audit_payload_signing_key_alias" {
+  name          = "alias/${var.environment}-audit-payload-signing-key-alias"
+  target_key_id = aws_kms_key.audit_payload_signing_key.key_id
+}
+
+data "aws_iam_policy_document" "audit_payload_kms_signing_policy_document" {
+  count = var.use_localstack ? 0 : 1
+  statement {
+    sid    = "AllowAccessToKmsSigningKey"
+    effect = "Allow"
+
+    actions = [
+      "kms:Sign",
+      "kms:GetPublicKey",
+    ]
+    resources = [
+      aws_kms_key.audit_payload_signing_key.arn,
+    ]
+  }
+}
+
+resource "aws_iam_policy" "audit_signing_key_lambda_kms_signing_policy" {
+  count       = var.use_localstack ? 0 : 1
+  name        = "${var.environment}-standard-lambda-audit-payload-kms-signing-policy"
+  path        = "/"
+  description = "IAM policy for managing KMS connection for a lambda which allows signing of audit payloads"
+
+  policy = data.aws_iam_policy_document.audit_payload_kms_signing_policy_document[0].json
+}


### PR DESCRIPTION
This PR does not (a) grant any lambdas access to the signing key or (b) update the lambda app code to load the key
