### PR TITLE
BAU - Check if userprofile is not null before building usercontext

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthorizationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthorizationService.java
@@ -150,7 +150,9 @@ public class AuthorizationService {
             if (session.getEmailAddress() != null) {
                 UserProfile userProfile =
                         dynamoService.getUserProfileByEmail(session.getEmailAddress());
-                builder.withUserProfile(userProfile);
+                if (userProfile != null) {
+                    builder.withUserProfile(userProfile);
+                }
             }
             userContext = builder.withClient(clientRegistry).build();
         } catch (NoSuchElementException e) {


### PR DESCRIPTION
## What?

- Check if userprofile is not null before building usercontext

## Why?

- The email will exist in the session but not the userprofile if they haven't got the password screen on the signup journey. Therefore we should first check if userprofile is not null before building it in the usercontext