### PR TITLE
BAU - Add condition to check whether a client is an internal client

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ClientRegistry.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ClientRegistry.java
@@ -19,6 +19,7 @@ public class ClientRegistry {
     private String serviceType;
     private String sectorIdentifierUri;
     private String subjectType;
+    private boolean isInternalService = false;
 
     @DynamoDBHashKey(attributeName = "ClientID")
     public String getClientID() {
@@ -119,6 +120,16 @@ public class ClientRegistry {
 
     public ClientRegistry setSubjectType(String subjectType) {
         this.subjectType = subjectType;
+        return this;
+    }
+
+    @DynamoDBAttribute(attributeName = "IsInternalService")
+    public boolean isInternalService() {
+        return isInternalService;
+    }
+
+    public ClientRegistry setInternalService(boolean internalService) {
+        isInternalService = internalService;
         return this;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
@@ -100,7 +100,7 @@ public class TokenService {
         SignedJWT idToken =
                 generateIDToken(
                         clientID, publicSubject, additionalTokenClaims, accessTokenHash, vot);
-        if (authRequestScopes.toStringList().contains(OIDCScopeValue.OFFLINE_ACCESS.getValue())) {
+        if (scopesForToken.contains(OIDCScopeValue.OFFLINE_ACCESS.getValue())) {
             RefreshToken refreshToken =
                     generateAndStoreRefreshToken(
                             clientID, internalSubject, scopesForToken, publicSubject);
@@ -194,7 +194,11 @@ public class TokenService {
                 clientConsent.getClaims().stream()
                         .filter(t -> claimsFromAuthnRequest.stream().anyMatch(t::equals))
                         .collect(Collectors.toSet());
-        return ValidScopes.getScopesForListOfClaims(claims);
+        List<String> scopesForIdToken = ValidScopes.getScopesForListOfClaims(claims);
+        if (authRequestScopes.contains(OIDCScopeValue.OFFLINE_ACCESS.getValue())) {
+            scopesForIdToken.add(OIDCScopeValue.OFFLINE_ACCESS.getValue());
+        }
+        return scopesForIdToken;
     }
 
     private Optional<ErrorObject> validateRefreshRequestParams(Map<String, String> requestBody) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/state/conditions/ClientIsAnInternalService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/state/conditions/ClientIsAnInternalService.java
@@ -1,0 +1,21 @@
+package uk.gov.di.authentication.shared.state.conditions;
+
+import uk.gov.di.authentication.shared.entity.ClientRegistry;
+import uk.gov.di.authentication.shared.state.Condition;
+import uk.gov.di.authentication.shared.state.UserContext;
+
+import java.util.Optional;
+
+public class ClientIsAnInternalService implements Condition<UserContext> {
+
+    @Override
+    public boolean isMet(Optional<UserContext> context) {
+        return context.flatMap(UserContext::getClient)
+                .map(ClientRegistry::isInternalService)
+                .orElse(false);
+    }
+
+    public static ClientIsAnInternalService clientIsAnInternalService() {
+        return new ClientIsAnInternalService();
+    }
+}

--- a/shared/src/test/java/uk/gov/di/authentication/shared/state/conditions/ClientIsAnInternalServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/state/conditions/ClientIsAnInternalServiceTest.java
@@ -1,0 +1,44 @@
+package uk.gov.di.authentication.shared.state.conditions;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.entity.ClientRegistry;
+import uk.gov.di.authentication.shared.state.UserContext;
+
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ClientIsAnInternalServiceTest {
+
+    private final ClientIsAnInternalService condition = new ClientIsAnInternalService();
+    private UserContext userContext = mock(UserContext.class);
+    private ClientRegistry client = mock(ClientRegistry.class);
+
+    @BeforeEach
+    public void setup() {
+        when(userContext.getClient()).thenReturn(Optional.of(client));
+    }
+
+    @Test
+    public void shouldReturnTrueIfClientIsAnInternalService() {
+        when(client.isInternalService()).thenReturn(true);
+
+        assertThat(condition.isMet(Optional.of(userContext)), equalTo(true));
+    }
+
+    @Test
+    public void shouldReturnFalseIfClientIsNotAnInternalService() {
+        when(client.isInternalService()).thenReturn(false);
+
+        assertThat(condition.isMet(Optional.of(userContext)), equalTo(false));
+    }
+
+    @Test
+    public void shouldReturnFalseIfClientHasNotSpecifiedWhetherTheyAreAnInternalService() {
+        assertThat(condition.isMet(Optional.of(userContext)), equalTo(false));
+    }
+}


### PR DESCRIPTION
## What?

- Add a isInternalService attribute to the client registry which defaults to false and cannot be set within the code. This means that we have complete control over when this is set by only setting it manually for the apps that we want to class as internal.
- Check if the client is internal before requesting consent
- Add offline access to scopes in token if it exists in auth request


## Why?

- We can use the isInternalService attribute to prevent showing certain pages to the user when using an internal service such as consent when a user uses account management
- So we don't lose the offline scope from the tokens if it is present in the auth request