### PR TITLE
GOVSI-824: Cloudwatch Log encryption and retention

### DIFF
--- a/ci/terraform/account-management/api-gateway.tf
+++ b/ci/terraform/account-management/api-gateway.tf
@@ -119,9 +119,10 @@ resource "aws_lambda_alias" "authorizer_alias" {
 }
 
 resource "aws_cloudwatch_log_group" "lambda_log_group" {
-  count = var.use_localstack ? 0 : 1
-  name  = "/aws/lambda/${aws_lambda_function.authorizer.function_name}"
-  tags  = local.default_tags
+  count      = var.use_localstack ? 0 : 1
+  name       = "/aws/lambda/${aws_lambda_function.authorizer.function_name}"
+  tags       = local.default_tags
+  kms_key_id = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
 
   depends_on = [
     aws_lambda_function.authorizer

--- a/ci/terraform/account-management/api-gateway.tf
+++ b/ci/terraform/account-management/api-gateway.tf
@@ -119,10 +119,11 @@ resource "aws_lambda_alias" "authorizer_alias" {
 }
 
 resource "aws_cloudwatch_log_group" "lambda_log_group" {
-  count      = var.use_localstack ? 0 : 1
-  name       = "/aws/lambda/${aws_lambda_function.authorizer.function_name}"
-  tags       = local.default_tags
-  kms_key_id = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  count             = var.use_localstack ? 0 : 1
+  name              = "/aws/lambda/${aws_lambda_function.authorizer.function_name}"
+  tags              = local.default_tags
+  kms_key_id        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  retention_in_days = var.cloudwatch_log_retention
 
   depends_on = [
     aws_lambda_function.authorizer

--- a/ci/terraform/account-management/authenticate.tf
+++ b/ci/terraform/account-management/authenticate.tf
@@ -24,6 +24,7 @@ module "authenticate" {
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
   cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  cloudwatch_log_retention  = var.cloudwatch_log_retention
   default_tags              = local.default_tags
 
   keep_lambda_warm             = var.keep_lambdas_warm

--- a/ci/terraform/account-management/authenticate.tf
+++ b/ci/terraform/account-management/authenticate.tf
@@ -23,6 +23,7 @@ module "authenticate" {
   lambda_role_arn           = aws_iam_role.lambda_iam_role.arn
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
+  cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   default_tags              = local.default_tags
 
   keep_lambda_warm             = var.keep_lambdas_warm

--- a/ci/terraform/account-management/authoriser-warmer.tf
+++ b/ci/terraform/account-management/authoriser-warmer.tf
@@ -100,8 +100,9 @@ resource "aws_lambda_function" "warmer_function" {
 resource "aws_cloudwatch_log_group" "warmer_lambda_log_group" {
   count = var.keep_lambdas_warm ? 1 : 0
 
-  name       = "/aws/lambda/${aws_lambda_function.warmer_function[0].function_name}"
-  kms_key_id = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  name              = "/aws/lambda/${aws_lambda_function.warmer_function[0].function_name}"
+  kms_key_id        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  retention_in_days = var.cloudwatch_log_retention
 
   tags = merge(local.default_tags, {
     lambda = "warmer"

--- a/ci/terraform/account-management/authoriser-warmer.tf
+++ b/ci/terraform/account-management/authoriser-warmer.tf
@@ -100,7 +100,9 @@ resource "aws_lambda_function" "warmer_function" {
 resource "aws_cloudwatch_log_group" "warmer_lambda_log_group" {
   count = var.keep_lambdas_warm ? 1 : 0
 
-  name = "/aws/lambda/${aws_lambda_function.warmer_function[0].function_name}"
+  name       = "/aws/lambda/${aws_lambda_function.warmer_function[0].function_name}"
+  kms_key_id = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+
   tags = merge(local.default_tags, {
     lambda = "warmer"
   })

--- a/ci/terraform/account-management/production-overrides.tfvars
+++ b/ci/terraform/account-management/production-overrides.tfvars
@@ -6,3 +6,5 @@ notify_template_map = {
   PHONE_NUMBER_UPDATED_TEMPLATE_ID = "beaf3eb2-135c-4517-800b-ca6b5ed85804"
   PASSWORD_UPDATED_TEMPLATE_ID     = "8d4c4948-000a-4de0-a8ba-76c259c1f983"
 }
+
+cloudwatch_log_retention = 5

--- a/ci/terraform/account-management/remove-account.tf
+++ b/ci/terraform/account-management/remove-account.tf
@@ -26,6 +26,7 @@ module "delete_account" {
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
   cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  cloudwatch_log_retention  = var.cloudwatch_log_retention
 
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"

--- a/ci/terraform/account-management/remove-account.tf
+++ b/ci/terraform/account-management/remove-account.tf
@@ -25,6 +25,7 @@ module "delete_account" {
   default_tags              = local.default_tags
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
+  cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
 
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"

--- a/ci/terraform/account-management/sandpit.tfvars
+++ b/ci/terraform/account-management/sandpit.tfvars
@@ -1,4 +1,5 @@
-environment       = "sandpit"
-use_localstack    = false
-notify_api_key    = 123456
-keep_lambdas_warm = false
+environment         = "sandpit"
+use_localstack      = false
+notify_api_key      = 123456
+keep_lambdas_warm   = false
+shared_state_bucket = "digital-identity-dev-tfstate"

--- a/ci/terraform/account-management/send_otp_notification.tf
+++ b/ci/terraform/account-management/send_otp_notification.tf
@@ -28,6 +28,7 @@ module "send_otp_notification" {
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
   cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  cloudwatch_log_retention  = var.cloudwatch_log_retention
   default_tags              = local.default_tags
   authorizer_id             = aws_api_gateway_authorizer.di_account_management_api.id
   use_localstack            = var.use_localstack

--- a/ci/terraform/account-management/send_otp_notification.tf
+++ b/ci/terraform/account-management/send_otp_notification.tf
@@ -27,6 +27,7 @@ module "send_otp_notification" {
   lambda_role_arn           = aws_iam_role.dynamo_sqs_lambda_iam_role.arn
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
+  cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   default_tags              = local.default_tags
   authorizer_id             = aws_api_gateway_authorizer.di_account_management_api.id
   use_localstack            = var.use_localstack

--- a/ci/terraform/account-management/shared.tf
+++ b/ci/terraform/account-management/shared.tf
@@ -1,0 +1,16 @@
+
+data "terraform_remote_state" "shared" {
+  backend = "s3"
+  config = {
+    bucket                      = var.shared_state_bucket
+    key                         = "${var.environment}-shared-terraform.tfstate"
+    role_arn                    = var.deployer_role_arn
+    region                      = var.aws_region
+    endpoint                    = var.use_localstack ? "http://localhost:45678" : null
+    iam_endpoint                = var.use_localstack ? "http://localhost:45678" : null
+    sts_endpoint                = var.use_localstack ? "http://localhost:45678" : null
+    skip_credentials_validation = var.use_localstack
+    skip_metadata_api_check     = var.use_localstack
+    force_path_style            = var.use_localstack
+  }
+}

--- a/ci/terraform/account-management/sqs.tf
+++ b/ci/terraform/account-management/sqs.tf
@@ -145,9 +145,10 @@ resource "aws_lambda_function" "email_sqs_lambda" {
 resource "aws_cloudwatch_log_group" "sqs_lambda_log_group" {
   count = var.use_localstack ? 0 : 1
 
-  name       = "/aws/lambda/${aws_lambda_function.email_sqs_lambda.function_name}"
-  tags       = local.default_tags
-  kms_key_id = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  name              = "/aws/lambda/${aws_lambda_function.email_sqs_lambda.function_name}"
+  tags              = local.default_tags
+  kms_key_id        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  retention_in_days = var.cloudwatch_log_retention
 
   depends_on = [
     aws_lambda_function.email_sqs_lambda

--- a/ci/terraform/account-management/sqs.tf
+++ b/ci/terraform/account-management/sqs.tf
@@ -145,8 +145,9 @@ resource "aws_lambda_function" "email_sqs_lambda" {
 resource "aws_cloudwatch_log_group" "sqs_lambda_log_group" {
   count = var.use_localstack ? 0 : 1
 
-  name = "/aws/lambda/${aws_lambda_function.email_sqs_lambda.function_name}"
-  tags = local.default_tags
+  name       = "/aws/lambda/${aws_lambda_function.email_sqs_lambda.function_name}"
+  tags       = local.default_tags
+  kms_key_id = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
 
   depends_on = [
     aws_lambda_function.email_sqs_lambda

--- a/ci/terraform/account-management/update-email.tf
+++ b/ci/terraform/account-management/update-email.tf
@@ -30,6 +30,7 @@ module "update_email" {
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
   cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  cloudwatch_log_retention  = var.cloudwatch_log_retention
 
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"

--- a/ci/terraform/account-management/update-email.tf
+++ b/ci/terraform/account-management/update-email.tf
@@ -29,6 +29,7 @@ module "update_email" {
   default_tags              = local.default_tags
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
+  cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
 
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"

--- a/ci/terraform/account-management/update-password.tf
+++ b/ci/terraform/account-management/update-password.tf
@@ -25,6 +25,7 @@ module "update_password" {
   default_tags              = local.default_tags
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
+  cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
 
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"

--- a/ci/terraform/account-management/update-password.tf
+++ b/ci/terraform/account-management/update-password.tf
@@ -26,6 +26,7 @@ module "update_password" {
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
   cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  cloudwatch_log_retention  = var.cloudwatch_log_retention
 
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"

--- a/ci/terraform/account-management/update-phone-number.tf
+++ b/ci/terraform/account-management/update-phone-number.tf
@@ -30,6 +30,7 @@ module "update_phone_number" {
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
   cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  cloudwatch_log_retention  = var.cloudwatch_log_retention
 
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"

--- a/ci/terraform/account-management/update-phone-number.tf
+++ b/ci/terraform/account-management/update-phone-number.tf
@@ -29,6 +29,7 @@ module "update_phone_number" {
   default_tags              = local.default_tags
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
+  cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
 
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"

--- a/ci/terraform/account-management/variables.tf
+++ b/ci/terraform/account-management/variables.tf
@@ -126,3 +126,9 @@ variable "lambda_warmer_zip_file" {
 variable "shared_state_bucket" {
   type = string
 }
+
+variable "cloudwatch_log_retention" {
+  default     = 1
+  type        = number
+  description = "The number of day to retain Cloudwatch logs for"
+}

--- a/ci/terraform/account-management/variables.tf
+++ b/ci/terraform/account-management/variables.tf
@@ -122,3 +122,7 @@ variable "lambda_warmer_zip_file" {
   description = "Location of the Lambda Warmer ZIP file"
   type        = string
 }
+
+variable "shared_state_bucket" {
+  type = string
+}

--- a/ci/terraform/modules/endpoint-module/lambda.tf
+++ b/ci/terraform/modules/endpoint-module/lambda.tf
@@ -30,8 +30,9 @@ resource "aws_lambda_function" "endpoint_lambda" {
 resource "aws_cloudwatch_log_group" "lambda_log_group" {
   count = var.use_localstack ? 0 : 1
 
-  name = "/aws/lambda/${aws_lambda_function.endpoint_lambda.function_name}"
-  tags = var.default_tags
+  name       = "/aws/lambda/${aws_lambda_function.endpoint_lambda.function_name}"
+  tags       = var.default_tags
+  kms_key_id = var.cloudwatch_key_arn
 
   depends_on = [
     aws_lambda_function.endpoint_lambda

--- a/ci/terraform/modules/endpoint-module/lambda.tf
+++ b/ci/terraform/modules/endpoint-module/lambda.tf
@@ -30,9 +30,10 @@ resource "aws_lambda_function" "endpoint_lambda" {
 resource "aws_cloudwatch_log_group" "lambda_log_group" {
   count = var.use_localstack ? 0 : 1
 
-  name       = "/aws/lambda/${aws_lambda_function.endpoint_lambda.function_name}"
-  tags       = var.default_tags
-  kms_key_id = var.cloudwatch_key_arn
+  name              = "/aws/lambda/${aws_lambda_function.endpoint_lambda.function_name}"
+  tags              = var.default_tags
+  kms_key_id        = var.cloudwatch_key_arn
+  retention_in_days = var.cloudwatch_log_retention
 
   depends_on = [
     aws_lambda_function.endpoint_lambda

--- a/ci/terraform/modules/endpoint-module/variables.tf
+++ b/ci/terraform/modules/endpoint-module/variables.tf
@@ -148,3 +148,8 @@ variable "cloudwatch_key_arn" {
   type        = string
   description = "The ARN of the KMS key to use log encryption"
 }
+
+variable "cloudwatch_log_retention" {
+  type        = number
+  description = "The number of day to retain Cloudwatch logs for"
+}

--- a/ci/terraform/modules/endpoint-module/variables.tf
+++ b/ci/terraform/modules/endpoint-module/variables.tf
@@ -143,3 +143,8 @@ variable "authorizer_id" {
   type    = string
   default = null
 }
+
+variable "cloudwatch_key_arn" {
+  type        = string
+  description = "The ARN of the KMS key to use log encryption"
+}

--- a/ci/terraform/modules/endpoint-module/warmer.tf
+++ b/ci/terraform/modules/endpoint-module/warmer.tf
@@ -117,8 +117,9 @@ resource "aws_lambda_function" "warmer_function" {
 resource "aws_cloudwatch_log_group" "warmer_lambda_log_group" {
   count = var.keep_lambda_warm && var.warmer_handler_function_name != null ? 1 : 0
 
-  name       = "/aws/lambda/${aws_lambda_function.warmer_function[0].function_name}"
-  kms_key_id = var.cloudwatch_key_arn
+  name              = "/aws/lambda/${aws_lambda_function.warmer_function[0].function_name}"
+  kms_key_id        = var.cloudwatch_key_arn
+  retention_in_days = var.cloudwatch_log_retention
 
   tags = merge(var.default_tags, {
     lambda = "warmer"

--- a/ci/terraform/modules/endpoint-module/warmer.tf
+++ b/ci/terraform/modules/endpoint-module/warmer.tf
@@ -117,7 +117,9 @@ resource "aws_lambda_function" "warmer_function" {
 resource "aws_cloudwatch_log_group" "warmer_lambda_log_group" {
   count = var.keep_lambda_warm && var.warmer_handler_function_name != null ? 1 : 0
 
-  name = "/aws/lambda/${aws_lambda_function.warmer_function[0].function_name}"
+  name       = "/aws/lambda/${aws_lambda_function.warmer_function[0].function_name}"
+  kms_key_id = var.cloudwatch_key_arn
+
   tags = merge(var.default_tags, {
     lambda = "warmer"
   })

--- a/ci/terraform/oidc/auth-code.tf
+++ b/ci/terraform/oidc/auth-code.tf
@@ -30,6 +30,7 @@ module "auth-code" {
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
   cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  cloudwatch_log_retention  = var.cloudwatch_log_retention
   default_tags              = local.default_tags
 
   keep_lambda_warm             = var.keep_lambdas_warm

--- a/ci/terraform/oidc/auth-code.tf
+++ b/ci/terraform/oidc/auth-code.tf
@@ -29,6 +29,7 @@ module "auth-code" {
   environment               = var.environment
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
+  cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   default_tags              = local.default_tags
 
   keep_lambda_warm             = var.keep_lambdas_warm

--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -31,6 +31,7 @@ module "authorize" {
   lambda_role_arn           = local.lambda_iam_role_arn
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
+  cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   default_tags              = local.default_tags
 
   keep_lambda_warm             = var.keep_lambdas_warm

--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -32,6 +32,7 @@ module "authorize" {
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
   cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  cloudwatch_log_retention  = var.cloudwatch_log_retention
   default_tags              = local.default_tags
 
   keep_lambda_warm             = var.keep_lambdas_warm

--- a/ci/terraform/oidc/client-info.tf
+++ b/ci/terraform/oidc/client-info.tf
@@ -30,6 +30,7 @@ module "client-info" {
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
   cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  cloudwatch_log_retention  = var.cloudwatch_log_retention
   default_tags              = local.default_tags
   api_key_required          = true
 

--- a/ci/terraform/oidc/client-info.tf
+++ b/ci/terraform/oidc/client-info.tf
@@ -29,6 +29,7 @@ module "client-info" {
   lambda_role_arn           = local.lambda_iam_role_arn
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
+  cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   default_tags              = local.default_tags
   api_key_required          = true
 

--- a/ci/terraform/oidc/jwks.tf
+++ b/ci/terraform/oidc/jwks.tf
@@ -25,6 +25,7 @@ module "jwks" {
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
   cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  cloudwatch_log_retention  = var.cloudwatch_log_retention
   default_tags              = local.default_tags
 
   keep_lambda_warm             = var.keep_lambdas_warm

--- a/ci/terraform/oidc/jwks.tf
+++ b/ci/terraform/oidc/jwks.tf
@@ -24,6 +24,7 @@ module "jwks" {
   lambda_role_arn           = local.lambda_iam_role_arn
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
+  cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   default_tags              = local.default_tags
 
   keep_lambda_warm             = var.keep_lambdas_warm

--- a/ci/terraform/oidc/login.tf
+++ b/ci/terraform/oidc/login.tf
@@ -31,6 +31,7 @@ module "login" {
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
   cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  cloudwatch_log_retention  = var.cloudwatch_log_retention
   default_tags              = local.default_tags
   api_key_required          = true
 

--- a/ci/terraform/oidc/login.tf
+++ b/ci/terraform/oidc/login.tf
@@ -30,6 +30,7 @@ module "login" {
   lambda_role_arn           = local.lambda_iam_role_arn
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
+  cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   default_tags              = local.default_tags
   api_key_required          = true
 

--- a/ci/terraform/oidc/logout.tf
+++ b/ci/terraform/oidc/logout.tf
@@ -32,6 +32,7 @@ module "logout" {
   lambda_role_arn           = local.lambda_iam_role_arn
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
+  cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   default_tags              = local.default_tags
 
   keep_lambda_warm             = var.keep_lambdas_warm

--- a/ci/terraform/oidc/logout.tf
+++ b/ci/terraform/oidc/logout.tf
@@ -33,6 +33,7 @@ module "logout" {
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
   cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  cloudwatch_log_retention  = var.cloudwatch_log_retention
   default_tags              = local.default_tags
 
   keep_lambda_warm             = var.keep_lambdas_warm

--- a/ci/terraform/oidc/mfa.tf
+++ b/ci/terraform/oidc/mfa.tf
@@ -29,6 +29,7 @@ module "mfa" {
   lambda_role_arn           = local.dynamo_sqs_lambda_iam_role_arn
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
+  cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   default_tags              = local.default_tags
   api_key_required          = true
 

--- a/ci/terraform/oidc/mfa.tf
+++ b/ci/terraform/oidc/mfa.tf
@@ -30,6 +30,7 @@ module "mfa" {
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
   cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  cloudwatch_log_retention  = var.cloudwatch_log_retention
   default_tags              = local.default_tags
   api_key_required          = true
 

--- a/ci/terraform/oidc/production-overrides.tfvars
+++ b/ci/terraform/oidc/production-overrides.tfvars
@@ -5,3 +5,5 @@ notify_template_map = {
   RESET_PASSWORD_TEMPLATE_ID              = "cc30aac4-4aae-4706-b147-9df40bd2feb8"
   PASSWORD_RESET_CONFIRMATION_TEMPLATE_ID = "99a548c9-b974-4933-9451-c85b3d6b6172"
 }
+
+cloudwatch_log_retention = 5

--- a/ci/terraform/oidc/register.tf
+++ b/ci/terraform/oidc/register.tf
@@ -26,6 +26,7 @@ module "register" {
   environment               = var.environment
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
+  cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   default_tags              = local.default_tags
 
   keep_lambda_warm             = var.keep_lambdas_warm

--- a/ci/terraform/oidc/register.tf
+++ b/ci/terraform/oidc/register.tf
@@ -27,6 +27,7 @@ module "register" {
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
   cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  cloudwatch_log_retention  = var.cloudwatch_log_retention
   default_tags              = local.default_tags
 
   keep_lambda_warm             = var.keep_lambdas_warm

--- a/ci/terraform/oidc/reset-password-request.tf
+++ b/ci/terraform/oidc/reset-password-request.tf
@@ -32,6 +32,7 @@ module "reset-password-request" {
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
   cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  cloudwatch_log_retention  = var.cloudwatch_log_retention
   default_tags              = local.default_tags
   api_key_required          = true
 

--- a/ci/terraform/oidc/reset-password-request.tf
+++ b/ci/terraform/oidc/reset-password-request.tf
@@ -31,6 +31,7 @@ module "reset-password-request" {
   lambda_role_arn           = local.dynamo_sqs_lambda_iam_role_arn
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
+  cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   default_tags              = local.default_tags
   api_key_required          = true
 

--- a/ci/terraform/oidc/reset_password.tf
+++ b/ci/terraform/oidc/reset_password.tf
@@ -32,6 +32,7 @@ module "reset_password" {
   lambda_role_arn           = local.dynamo_sqs_lambda_iam_role_arn
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
+  cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   default_tags              = local.default_tags
   api_key_required          = true
 

--- a/ci/terraform/oidc/reset_password.tf
+++ b/ci/terraform/oidc/reset_password.tf
@@ -33,6 +33,7 @@ module "reset_password" {
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
   cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  cloudwatch_log_retention  = var.cloudwatch_log_retention
   default_tags              = local.default_tags
   api_key_required          = true
 

--- a/ci/terraform/oidc/send_notification.tf
+++ b/ci/terraform/oidc/send_notification.tf
@@ -29,6 +29,7 @@ module "send_notification" {
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
   cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  cloudwatch_log_retention  = var.cloudwatch_log_retention
   default_tags              = local.default_tags
   api_key_required          = true
 

--- a/ci/terraform/oidc/send_notification.tf
+++ b/ci/terraform/oidc/send_notification.tf
@@ -28,6 +28,7 @@ module "send_notification" {
   lambda_role_arn           = local.dynamo_sqs_lambda_iam_role_arn
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
+  cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   default_tags              = local.default_tags
   api_key_required          = true
 

--- a/ci/terraform/oidc/signup.tf
+++ b/ci/terraform/oidc/signup.tf
@@ -31,6 +31,7 @@ module "signup" {
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
   cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  cloudwatch_log_retention  = var.cloudwatch_log_retention
   default_tags              = local.default_tags
   api_key_required          = true
 

--- a/ci/terraform/oidc/signup.tf
+++ b/ci/terraform/oidc/signup.tf
@@ -30,6 +30,7 @@ module "signup" {
   lambda_role_arn           = local.lambda_iam_role_arn
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
+  cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   default_tags              = local.default_tags
   api_key_required          = true
 

--- a/ci/terraform/oidc/sqs.tf
+++ b/ci/terraform/oidc/sqs.tf
@@ -112,7 +112,9 @@ resource "aws_lambda_function" "email_sqs_lambda" {
 resource "aws_cloudwatch_log_group" "sqs_lambda_log_group" {
   count = var.use_localstack ? 0 : 1
 
-  name = "/aws/lambda/${aws_lambda_function.email_sqs_lambda.function_name}"
+  name       = "/aws/lambda/${aws_lambda_function.email_sqs_lambda.function_name}"
+  kms_key_id = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+
   tags = local.default_tags
 
   depends_on = [

--- a/ci/terraform/oidc/sqs.tf
+++ b/ci/terraform/oidc/sqs.tf
@@ -112,8 +112,9 @@ resource "aws_lambda_function" "email_sqs_lambda" {
 resource "aws_cloudwatch_log_group" "sqs_lambda_log_group" {
   count = var.use_localstack ? 0 : 1
 
-  name       = "/aws/lambda/${aws_lambda_function.email_sqs_lambda.function_name}"
-  kms_key_id = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  name              = "/aws/lambda/${aws_lambda_function.email_sqs_lambda.function_name}"
+  kms_key_id        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  retention_in_days = var.cloudwatch_log_retention
 
   tags = local.default_tags
 

--- a/ci/terraform/oidc/token.tf
+++ b/ci/terraform/oidc/token.tf
@@ -31,6 +31,7 @@ module "token" {
   lambda_role_arn           = local.token_lambda_iam_role_arn
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
+  cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   default_tags              = local.default_tags
 
   keep_lambda_warm             = var.keep_lambdas_warm

--- a/ci/terraform/oidc/token.tf
+++ b/ci/terraform/oidc/token.tf
@@ -32,6 +32,7 @@ module "token" {
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
   cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  cloudwatch_log_retention  = var.cloudwatch_log_retention
   default_tags              = local.default_tags
 
   keep_lambda_warm             = var.keep_lambdas_warm

--- a/ci/terraform/oidc/trustmarks.tf
+++ b/ci/terraform/oidc/trustmarks.tf
@@ -29,6 +29,7 @@ module "trustmarks" {
   lambda_role_arn           = local.lambda_iam_role_arn
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
+  cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   default_tags              = local.default_tags
   api_key_required          = true
 

--- a/ci/terraform/oidc/trustmarks.tf
+++ b/ci/terraform/oidc/trustmarks.tf
@@ -30,6 +30,7 @@ module "trustmarks" {
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
   cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  cloudwatch_log_retention  = var.cloudwatch_log_retention
   default_tags              = local.default_tags
   api_key_required          = true
 

--- a/ci/terraform/oidc/update.tf
+++ b/ci/terraform/oidc/update.tf
@@ -27,6 +27,7 @@ module "update" {
   environment               = var.environment
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
+  cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   default_tags              = local.default_tags
 
   keep_lambda_warm             = var.keep_lambdas_warm

--- a/ci/terraform/oidc/update.tf
+++ b/ci/terraform/oidc/update.tf
@@ -28,6 +28,7 @@ module "update" {
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
   cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  cloudwatch_log_retention  = var.cloudwatch_log_retention
   default_tags              = local.default_tags
 
   keep_lambda_warm             = var.keep_lambdas_warm

--- a/ci/terraform/oidc/update_profile.tf
+++ b/ci/terraform/oidc/update_profile.tf
@@ -31,6 +31,7 @@ module "update_profile" {
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
   cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  cloudwatch_log_retention  = var.cloudwatch_log_retention
   default_tags              = local.default_tags
   api_key_required          = true
 

--- a/ci/terraform/oidc/update_profile.tf
+++ b/ci/terraform/oidc/update_profile.tf
@@ -30,6 +30,7 @@ module "update_profile" {
   lambda_role_arn           = local.lambda_iam_role_arn
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
+  cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   default_tags              = local.default_tags
   api_key_required          = true
 

--- a/ci/terraform/oidc/userexists.tf
+++ b/ci/terraform/oidc/userexists.tf
@@ -29,6 +29,7 @@ module "userexists" {
   lambda_role_arn           = local.lambda_iam_role_arn
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
+  cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   default_tags              = local.default_tags
   api_key_required          = true
 

--- a/ci/terraform/oidc/userexists.tf
+++ b/ci/terraform/oidc/userexists.tf
@@ -30,6 +30,7 @@ module "userexists" {
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
   cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  cloudwatch_log_retention  = var.cloudwatch_log_retention
   default_tags              = local.default_tags
   api_key_required          = true
 

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -31,6 +31,7 @@ module "userinfo" {
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
   cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  cloudwatch_log_retention  = var.cloudwatch_log_retention
   default_tags              = local.default_tags
 
   keep_lambda_warm             = var.keep_lambdas_warm

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -30,6 +30,7 @@ module "userinfo" {
   lambda_role_arn           = local.lambda_iam_role_arn
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
+  cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   default_tags              = local.default_tags
 
   keep_lambda_warm             = var.keep_lambdas_warm

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -181,3 +181,9 @@ variable "dns_state_role" {
 variable "shared_state_bucket" {
   type = string
 }
+
+variable "cloudwatch_log_retention" {
+  default     = 1
+  type        = number
+  description = "The number of day to retain Cloudwatch logs for"
+}

--- a/ci/terraform/oidc/verify_code.tf
+++ b/ci/terraform/oidc/verify_code.tf
@@ -30,6 +30,7 @@ module "verify_code" {
   lambda_role_arn           = local.lambda_iam_role_arn
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
+  cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   default_tags              = local.default_tags
   api_key_required          = true
 

--- a/ci/terraform/oidc/verify_code.tf
+++ b/ci/terraform/oidc/verify_code.tf
@@ -31,6 +31,7 @@ module "verify_code" {
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
   cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  cloudwatch_log_retention  = var.cloudwatch_log_retention
   default_tags              = local.default_tags
   api_key_required          = true
 

--- a/ci/terraform/oidc/wellknown.tf
+++ b/ci/terraform/oidc/wellknown.tf
@@ -25,6 +25,7 @@ module "openid_configuration_discovery" {
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
   cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  cloudwatch_log_retention  = var.cloudwatch_log_retention
   default_tags              = local.default_tags
 
   keep_lambda_warm             = var.keep_lambdas_warm

--- a/ci/terraform/oidc/wellknown.tf
+++ b/ci/terraform/oidc/wellknown.tf
@@ -24,6 +24,7 @@ module "openid_configuration_discovery" {
   lambda_role_arn           = local.lambda_iam_role_arn
   logging_endpoint_enabled  = var.logging_endpoint_enabled
   logging_endpoint_arn      = var.logging_endpoint_arn
+  cloudwatch_key_arn        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   default_tags              = local.default_tags
 
   keep_lambda_warm             = var.keep_lambdas_warm

--- a/ci/terraform/shared/kms.tf
+++ b/ci/terraform/shared/kms.tf
@@ -132,3 +132,65 @@ resource "aws_iam_role_policy_attachment" "attach_audit_signing_key_policy_dynam
   role       = aws_iam_role.dynamo_sqs_lambda_iam_role.name
   policy_arn = aws_iam_policy.audit_signing_key_lambda_kms_signing_policy[0].arn
 }
+
+# Cloudwatch Log Encryption
+data "aws_partition" "current" {}
+
+data "aws_region" "current" {}
+
+data "aws_iam_policy_document" "cloudwatch" {
+  policy_id = "key-policy-cloudwatch"
+  statement {
+    sid = "Enable IAM User Permissions for root user"
+    actions = [
+      "kms:*",
+    ]
+    effect = "Allow"
+    principals {
+      type = "AWS"
+      identifiers = [
+        format(
+          "arn:%s:iam::%s:root",
+          data.aws_partition.current.partition,
+          data.aws_caller_identity.current.account_id
+        )
+      ]
+    }
+    resources = ["*"]
+  }
+  statement {
+    sid = "AllowCloudWatchLogs"
+    actions = [
+      "kms:Encrypt*",
+      "kms:Decrypt*",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:Describe*"
+    ]
+    effect = "Allow"
+    principals {
+      type = "Service"
+      identifiers = [
+        format(
+          "logs.%s.amazonaws.com",
+          data.aws_region.current.name
+        )
+      ]
+    }
+    resources = ["*"]
+  }
+}
+
+resource "aws_kms_key" "cloudwatch_log_encryption" {
+  description             = "KMS key for Cloudwatch logs"
+  deletion_window_in_days = 30
+  enable_key_rotation     = true
+  policy                  = data.aws_iam_policy_document.cloudwatch.json
+
+  tags = local.default_tags
+}
+
+resource "aws_kms_alias" "cloudwatch_key_alias" {
+  name          = "alias/${var.environment}-cloudwatch-log-encryption-alias"
+  target_key_id = aws_kms_key.cloudwatch_log_encryption.key_id
+}

--- a/ci/terraform/shared/outputs.tf
+++ b/ci/terraform/shared/outputs.tf
@@ -65,3 +65,7 @@ output "stub_rp_client_credentials" {
   }]
   sensitive = true
 }
+
+output "cloudwatch_encryption_key_arn" {
+  value = aws_kms_key.cloudwatch_log_encryption.arn
+}


### PR DESCRIPTION
## What?

- Create a KMS Key for CloudWatch in the shared Terraform
- Use this key for all lambda log groups in OIDC and account management
- Add a 1 day log retention to all log groups
- Override the log retention in production to 5 days

## Why?

Implementing security best practices as advised by `checkov` ahead of ITHC
