### PR TITLE
GOVSI-843: Add facility to share cookie consent across clients

### DIFF
--- a/ci/terraform/shared/localstack.tfvars
+++ b/ci/terraform/shared/localstack.tfvars
@@ -3,3 +3,13 @@ aws_endpoint          = "http://localhost:45678"
 aws_dynamodb_endpoint = "http://localhost:8000"
 use_localstack        = true
 keep_lambdas_warm     = false
+stub_rp_clients = [
+  {
+    client_name = "di-auth-stub-relying-party-local"
+    callback_urls = [
+      "http://localhost:8081/oidc/authorization-code/callback",
+      "https://di-auth-stub-relying-party-build.london.cloudapps.digital/oidc/authorization-code/callback",
+    ]
+    logout_urls = []
+  },
+]

--- a/ci/terraform/shared/stub-rp-clients.tf
+++ b/ci/terraform/shared/stub-rp-clients.tf
@@ -69,5 +69,8 @@ resource "aws_dynamodb_table_item" "stub_rp_client" {
     SubjectType = {
       S = "public"
     }
+    CookieConsentShared = {
+      N = "1"
+    }
   })
 }

--- a/echo-int-test-vars.sh
+++ b/echo-int-test-vars.sh
@@ -10,7 +10,7 @@ export API_KEY="$(terraform output -raw oidc_api_key)"
 export FRONTEND_API_GATEWAY_ID="$(terraform output -raw frontend_api_gateway_root_id)"
 export FRONTEND_API_KEY="$(terraform output -raw frontend_api_key)"
 export RESET_PASSWORD_URL="http://localhost:3000/reset-password?code="
+export STUB_RELYING_PARTY_REDIRECT_URI="https://di-auth-stub-relying-party-build.london.cloudapps.digital/"
 popd >/dev/null
 
-echo "API_GATEWAY_ID=$API_GATEWAY_ID;AWS_ACCESS_KEY_ID=BOB;AWS_SECRET_ACCESS_KEY=builder;LOGIN_URI=http://localhost:3000/;API_KEY=$API_KEY;FRONTEND_API_GATEWAY_ID=$FRONTEND_API_GATEWAY_ID;FRONTEND_API_KEY=$FRONTEND_API_KEY;"
-
+echo "API_GATEWAY_ID=$API_GATEWAY_ID;AWS_ACCESS_KEY_ID=BOB;AWS_SECRET_ACCESS_KEY=builder;LOGIN_URI=http://localhost:3000/;API_KEY=$API_KEY;FRONTEND_API_GATEWAY_ID=$FRONTEND_API_GATEWAY_ID;FRONTEND_API_KEY=$FRONTEND_API_KEY;STUB_RELYING_PARTY_REDIRECT_URI=$STUB_RELYING_PARTY_REDIRECT_URI;"

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.helpers.DynamoHelper;
 import uk.gov.di.authentication.helpers.KeyPairHelper;
 import uk.gov.di.authentication.helpers.RedisHelper;
+import uk.gov.di.authentication.oidc.entity.ResponseHeaders;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.shared.entity.SessionState;
 
@@ -26,13 +27,15 @@ import java.security.KeyPair;
 import java.util.Base64;
 
 import static java.util.Collections.singletonList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class AuthCodeIntegrationTest extends IntegrationTestEndpoints {
 
     private static final String AUTH_CODE_ENDPOINT = "/auth-code";
     private static final String EMAIL = "joe.bloggs@digital.cabinet-office.gov.uk";
-    private static final String TEST_PASSWORD = "test-pass-01";
     private static final URI REDIRECT_URI =
             URI.create(System.getenv("STUB_RELYING_PARTY_REDIRECT_URI"));
     private static final ClientID CLIENT_ID = new ClientID("test-client");
@@ -57,6 +60,9 @@ public class AuthCodeIntegrationTest extends IntegrationTestEndpoints {
                         .headers(headers)
                         .get();
         assertEquals(302, response.getStatus());
+        assertThat(
+                response.getHeaders().get(ResponseHeaders.LOCATION).toString(),
+                not(containsString("cookie_consent")));
     }
 
     private AuthenticationRequest generateAuthRequest() {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ClientRegistry.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ClientRegistry.java
@@ -19,6 +19,7 @@ public class ClientRegistry {
     private String serviceType;
     private String sectorIdentifierUri;
     private String subjectType;
+    private boolean cookieConsentShared = false;
     private boolean isInternalService = false;
 
     @DynamoDBHashKey(attributeName = "ClientID")
@@ -120,6 +121,16 @@ public class ClientRegistry {
 
     public ClientRegistry setSubjectType(String subjectType) {
         this.subjectType = subjectType;
+        return this;
+    }
+
+    @DynamoDBAttribute(attributeName = "CookieConsentShared")
+    public boolean isCookieConsentShared() {
+        return cookieConsentShared;
+    }
+
+    public ClientRegistry setCookieConsentShared(boolean cookieConsent) {
+        this.cookieConsentShared = cookieConsent;
         return this;
     }
 

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/CookieHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/CookieHelperTest.java
@@ -8,9 +8,12 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static uk.gov.di.authentication.shared.helpers.CookieHelper.REQUEST_COOKIE_HEADER;
 import static uk.gov.di.authentication.shared.helpers.CookieHelper.SessionCookieIds;
+import static uk.gov.di.authentication.shared.helpers.CookieHelper.getHttpCookieFromHeaders;
 import static uk.gov.di.authentication.shared.helpers.CookieHelper.parseSessionCookie;
 
 public class CookieHelperTest {
@@ -22,7 +25,8 @@ public class CookieHelperTest {
     @ParameterizedTest(name = "with header {0}")
     @MethodSource("inputs")
     void shouldReturnIdsFromValidCookieStringWithMultipleCookeies(String header) {
-        String cookieString = "Version=1; gs=session-id.456;name=ts";
+        String cookieString =
+                "Version=1; gs=session-id.456;cookies_preferences_set={\"analytics\":true};name=ts";
         Map<String, String> headers = Map.ofEntries(Map.entry(header, cookieString.toString()));
 
         SessionCookieIds ids = parseSessionCookie(headers).orElseThrow();
@@ -60,6 +64,27 @@ public class CookieHelperTest {
         assertEmpty(parseSessionCookie(Map.of(header, "gs=no-dot;")));
         assertEmpty(parseSessionCookie(Map.of(header, "gs=one-value.two-value.three-value;")));
         assertEmpty(parseSessionCookie(Map.of(header, "gsdsds=one-value.two-value")));
+    }
+
+    @ParameterizedTest(name = "with header {0}")
+    @MethodSource("inputs")
+    void shouldReturnCookiePrefsFromValidCookieStringWithMultipleCookies(String header) {
+        String cookieString =
+                "Version=1; gs=session-id.456;cookies_preferences_set={\"analytics\":false};name=ts";
+        Map<String, String> headers = Map.ofEntries(Map.entry(header, cookieString.toString()));
+
+        HttpCookie cookie =
+                getHttpCookieFromHeaders(headers, "cookies_preferences_set").orElseThrow();
+
+        assertThat(cookie.getValue(), containsString("\"analytics\":false"));
+    }
+
+    @ParameterizedTest(name = "with header {0}")
+    @MethodSource("inputs")
+    void shouldReturnEmptyCookiePrefsIfCookieNotPresent(String header) {
+        assertEmpty(getHttpCookieFromHeaders(null, "cookies_preferences_set"));
+        assertEmpty(getHttpCookieFromHeaders(Map.of(), "cookies_preferences_set"));
+        assertEmpty(getHttpCookieFromHeaders(Map.of("header", "value"), "cookies_preferences_set"));
     }
 
     private static void assertEmpty(Object input) {


### PR DESCRIPTION

## What?

Add facility to share cookie consent across clients

Uses a new internal-only database flag in the client-registry 'CookieConsent'.  This flag can only be set by the database schema migration scripts in the build pipeline, and cannot be set by external clients using the client registration api.  It is only available for our use to share existing consent across the internal clients.

When the flag is set any existing consent should be shared across the internal applications.  This is done by the 'auth-code' endpoint appending additional parameters to the redirect uri when redirecting:

- cookie_consent=accept - set consent to accept in the target client.
- cookie_consent=reject  - set consent to reject in the target client.
- cookie_consent=not-engaged - either use existing consent or show the cookie banner 

## Why?

The user's cookie consent should be shared across frontend and account management so they only have to provide it once, rather than see the cookie banner several times for what is supposed to look like a single application.

A PR to use the parameters in the frontend applications will follow.