### PR TITLE
GOVSI-824: Add shared_state_bucket var to account management deployer

### DIFF
--- a/ci/tasks/deploy-acct-mgmt-api.yml
+++ b/ci/tasks/deploy-acct-mgmt-api.yml
@@ -38,6 +38,7 @@ run:
         -var 'logging_endpoint_arn=arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod' \
         -var 'lambda_zip_file=../../../../api-release/account-management-api.zip' \
         -var 'lambda_warmer_zip_file=../../../../lambda-warmer-release/lambda-warmer.zip' \
+        -var "shared_state_bucket=${STATE_BUCKET}" \
         -var-file "${DEPLOY_ENVIRONMENT}-overrides.tfvars" \
 
       terraform output --json > ../../../../terraform-outputs/${DEPLOY_ENVIRONMENT}-account-managment-api-terraform-outputs.json


### PR DESCRIPTION
## What?

- Inject `shared_state_bucket` variable at deploy time of account management

## Why?

In #667 we added the use of the shared terraform state but omitted to inject the state bucket at deploy time.


## Related PRs

#667 