### PR TITLE
GOVSI-828: Sign audit payloads

### DIFF
--- a/ci/terraform/oidc/auth-code.tf
+++ b/ci/terraform/oidc/auth-code.tf
@@ -6,15 +6,16 @@ module "auth-code" {
   endpoint_method = "GET"
 
   handler_environment_variables = {
-    BASE_URL             = local.api_base_url
-    EVENTS_SNS_TOPIC_ARN = aws_sns_topic.events.arn
-    LOCALSTACK_ENDPOINT  = var.use_localstack ? var.localstack_endpoint : null
-    REDIS_HOST           = local.external_redis_host
-    REDIS_PORT           = local.external_redis_port
-    REDIS_PASSWORD       = local.external_redis_password
-    REDIS_TLS            = var.redis_use_tls
-    ENVIRONMENT          = var.environment
-    DYNAMO_ENDPOINT      = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    BASE_URL                = local.api_base_url
+    EVENTS_SNS_TOPIC_ARN    = aws_sns_topic.events.arn
+    AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name
+    LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
+    REDIS_HOST              = local.external_redis_host
+    REDIS_PORT              = local.external_redis_port
+    REDIS_PASSWORD          = local.external_redis_password
+    REDIS_TLS               = var.redis_use_tls
+    ENVIRONMENT             = var.environment
+    DYNAMO_ENDPOINT         = var.use_localstack ? var.lambda_dynamo_endpoint : null
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.AuthCodeHandler::handleRequest"
 

--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -10,6 +10,7 @@ module "authorize" {
     BASE_URL                 = local.api_base_url
     DOMAIN_NAME              = "${var.environment}.${var.service_domain_name}"
     EVENTS_SNS_TOPIC_ARN     = aws_sns_topic.events.arn
+    AUDIT_SIGNING_KEY_ALIAS  = local.audit_signing_key_alias_name
     LOGIN_URI                = var.use_localstack ? "http://localhost:3000/" : "https://front.${var.environment}.${var.service_domain_name}/"
     LOCALSTACK_ENDPOINT      = var.use_localstack ? var.localstack_endpoint : null
     REDIS_HOST               = local.external_redis_host

--- a/ci/terraform/oidc/client-info.tf
+++ b/ci/terraform/oidc/client-info.tf
@@ -7,15 +7,16 @@ module "client-info" {
   environment     = var.environment
 
   handler_environment_variables = {
-    BASE_URL             = local.frontend_api_base_url
-    EVENTS_SNS_TOPIC_ARN = aws_sns_topic.events.arn
-    LOCALSTACK_ENDPOINT  = var.use_localstack ? var.localstack_endpoint : null
-    REDIS_HOST           = local.external_redis_host
-    REDIS_PORT           = local.external_redis_port
-    REDIS_PASSWORD       = local.external_redis_password
-    REDIS_TLS            = var.redis_use_tls
-    ENVIRONMENT          = var.environment
-    DYNAMO_ENDPOINT      = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    BASE_URL                = local.frontend_api_base_url
+    EVENTS_SNS_TOPIC_ARN    = aws_sns_topic.events.arn
+    AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name
+    LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
+    REDIS_HOST              = local.external_redis_host
+    REDIS_PORT              = local.external_redis_port
+    REDIS_PASSWORD          = local.external_redis_password
+    REDIS_TLS               = var.redis_use_tls
+    ENVIRONMENT             = var.environment
+    DYNAMO_ENDPOINT         = var.use_localstack ? var.lambda_dynamo_endpoint : null
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.ClientInfoHandler::handleRequest"
 

--- a/ci/terraform/oidc/jwks.tf
+++ b/ci/terraform/oidc/jwks.tf
@@ -9,6 +9,7 @@ module "jwks" {
   handler_environment_variables = {
     BASE_URL                = local.api_base_url
     EVENTS_SNS_TOPIC_ARN    = aws_sns_topic.events.arn
+    AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
     TOKEN_SIGNING_KEY_ALIAS = local.id_token_signing_key_alias_name
   }

--- a/ci/terraform/oidc/login.tf
+++ b/ci/terraform/oidc/login.tf
@@ -10,6 +10,7 @@ module "login" {
     ENVIRONMENT              = var.environment
     BASE_URL                 = local.frontend_api_base_url
     EVENTS_SNS_TOPIC_ARN     = aws_sns_topic.events.arn
+    AUDIT_SIGNING_KEY_ALIAS  = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT      = var.use_localstack ? var.localstack_endpoint : null
     REDIS_HOST               = local.external_redis_host
     REDIS_PORT               = local.external_redis_port

--- a/ci/terraform/oidc/logout.tf
+++ b/ci/terraform/oidc/logout.tf
@@ -10,6 +10,7 @@ module "logout" {
     DEFAULT_LOGOUT_URI      = "https://di-authentication-frontend.london.cloudapps.digital/signed-out"
     BASE_URL                = local.api_base_url
     EVENTS_SNS_TOPIC_ARN    = aws_sns_topic.events.arn
+    AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
     REDIS_HOST              = local.external_redis_host
     REDIS_PORT              = local.external_redis_port

--- a/ci/terraform/oidc/mfa.tf
+++ b/ci/terraform/oidc/mfa.tf
@@ -7,15 +7,16 @@ module "mfa" {
   environment     = var.environment
 
   handler_environment_variables = {
-    ENVIRONMENT          = var.environment
-    EMAIL_QUEUE_URL      = aws_sqs_queue.email_queue.id
-    EVENTS_SNS_TOPIC_ARN = aws_sns_topic.events.arn
-    LOCALSTACK_ENDPOINT  = var.use_localstack ? var.localstack_endpoint : null
-    REDIS_HOST           = local.external_redis_host
-    REDIS_PORT           = local.external_redis_port
-    REDIS_PASSWORD       = local.external_redis_password
-    REDIS_TLS            = var.redis_use_tls
-    DYNAMO_ENDPOINT      = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    ENVIRONMENT             = var.environment
+    EMAIL_QUEUE_URL         = aws_sqs_queue.email_queue.id
+    EVENTS_SNS_TOPIC_ARN    = aws_sns_topic.events.arn
+    AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name
+    LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
+    REDIS_HOST              = local.external_redis_host
+    REDIS_PORT              = local.external_redis_port
+    REDIS_PASSWORD          = local.external_redis_password
+    REDIS_TLS               = var.redis_use_tls
+    DYNAMO_ENDPOINT         = var.use_localstack ? var.lambda_dynamo_endpoint : null
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.MfaHandler::handleRequest"
 

--- a/ci/terraform/oidc/register.tf
+++ b/ci/terraform/oidc/register.tf
@@ -6,11 +6,12 @@ module "register" {
   endpoint_method = "POST"
 
   handler_environment_variables = {
-    ENVIRONMENT          = var.environment
-    BASE_URL             = local.api_base_url
-    DYNAMO_ENDPOINT      = var.use_localstack ? var.lambda_dynamo_endpoint : null
-    EVENTS_SNS_TOPIC_ARN = aws_sns_topic.events.arn
-    LOCALSTACK_ENDPOINT  = var.use_localstack ? var.localstack_endpoint : null
+    ENVIRONMENT             = var.environment
+    BASE_URL                = local.api_base_url
+    DYNAMO_ENDPOINT         = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    EVENTS_SNS_TOPIC_ARN    = aws_sns_topic.events.arn
+    AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name
+    LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
   }
   handler_function_name = "uk.gov.di.authentication.clientregistry.lambda.ClientRegistrationHandler::handleRequest"
 

--- a/ci/terraform/oidc/reset-password-request.tf
+++ b/ci/terraform/oidc/reset-password-request.tf
@@ -7,17 +7,18 @@ module "reset-password-request" {
   environment     = var.environment
 
   handler_environment_variables = {
-    ENVIRONMENT          = var.environment
-    BASE_URL             = local.frontend_api_base_url
-    SQS_ENDPOINT         = var.use_localstack ? "http://localhost:45678/" : null
-    EMAIL_QUEUE_URL      = aws_sqs_queue.email_queue.id
-    EVENTS_SNS_TOPIC_ARN = aws_sns_topic.events.arn
-    LOCALSTACK_ENDPOINT  = var.use_localstack ? var.localstack_endpoint : null
-    REDIS_HOST           = local.external_redis_host
-    REDIS_PORT           = local.external_redis_port
-    REDIS_PASSWORD       = local.external_redis_password
-    REDIS_TLS            = var.redis_use_tls
-    DYNAMO_ENDPOINT      = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    ENVIRONMENT             = var.environment
+    BASE_URL                = local.frontend_api_base_url
+    SQS_ENDPOINT            = var.use_localstack ? "http://localhost:45678/" : null
+    EMAIL_QUEUE_URL         = aws_sqs_queue.email_queue.id
+    EVENTS_SNS_TOPIC_ARN    = aws_sns_topic.events.arn
+    AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name
+    LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
+    REDIS_HOST              = local.external_redis_host
+    REDIS_PORT              = local.external_redis_port
+    REDIS_PASSWORD          = local.external_redis_password
+    REDIS_TLS               = var.redis_use_tls
+    DYNAMO_ENDPOINT         = var.use_localstack ? var.lambda_dynamo_endpoint : null
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.ResetPasswordRequestHandler::handleRequest"
 

--- a/ci/terraform/oidc/reset_password.tf
+++ b/ci/terraform/oidc/reset_password.tf
@@ -13,6 +13,7 @@ module "reset_password" {
     EMAIL_QUEUE_URL          = aws_sqs_queue.email_queue.id
     ENVIRONMENT              = var.environment
     EVENTS_SNS_TOPIC_ARN     = aws_sns_topic.events.arn
+    AUDIT_SIGNING_KEY_ALIAS  = local.audit_signing_key_alias_name
     REDIS_HOST               = local.external_redis_host
     REDIS_PORT               = local.external_redis_port
     REDIS_PASSWORD           = local.external_redis_password

--- a/ci/terraform/oidc/send_notification.tf
+++ b/ci/terraform/oidc/send_notification.tf
@@ -7,14 +7,15 @@ module "send_notification" {
   environment     = var.environment
 
   handler_environment_variables = {
-    ENVIRONMENT          = var.environment
-    EMAIL_QUEUE_URL      = aws_sqs_queue.email_queue.id
-    EVENTS_SNS_TOPIC_ARN = aws_sns_topic.events.arn
-    LOCALSTACK_ENDPOINT  = var.use_localstack ? var.localstack_endpoint : null
-    REDIS_HOST           = local.external_redis_host
-    REDIS_PORT           = local.external_redis_port
-    REDIS_PASSWORD       = local.external_redis_password
-    REDIS_TLS            = var.redis_use_tls
+    ENVIRONMENT             = var.environment
+    EMAIL_QUEUE_URL         = aws_sqs_queue.email_queue.id
+    EVENTS_SNS_TOPIC_ARN    = aws_sns_topic.events.arn
+    AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name
+    LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
+    REDIS_HOST              = local.external_redis_host
+    REDIS_PORT              = local.external_redis_port
+    REDIS_PASSWORD          = local.external_redis_password
+    REDIS_TLS               = var.redis_use_tls
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.SendNotificationHandler::handleRequest"
 

--- a/ci/terraform/oidc/shared.tf
+++ b/ci/terraform/oidc/shared.tf
@@ -30,4 +30,5 @@ locals {
   email_lambda_iam_role_arn        = data.terraform_remote_state.shared.outputs.email_lambda_iam_role_arn
   token_lambda_iam_role_arn        = data.terraform_remote_state.shared.outputs.token_lambda_iam_role_arn
   id_token_signing_key_alias_name  = data.terraform_remote_state.shared.outputs.id_token_signing_key_alias_name
+  audit_signing_key_alias_name     = data.terraform_remote_state.shared.outputs.audit_signing_key_alias_name
 }

--- a/ci/terraform/oidc/signup.tf
+++ b/ci/terraform/oidc/signup.tf
@@ -10,6 +10,7 @@ module "signup" {
     ENVIRONMENT              = var.environment
     BASE_URL                 = local.frontend_api_base_url
     EVENTS_SNS_TOPIC_ARN     = aws_sns_topic.events.arn
+    AUDIT_SIGNING_KEY_ALIAS  = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT      = var.use_localstack ? var.localstack_endpoint : null
     REDIS_HOST               = local.external_redis_host
     REDIS_PORT               = local.external_redis_port

--- a/ci/terraform/oidc/token.tf
+++ b/ci/terraform/oidc/token.tf
@@ -11,6 +11,7 @@ module "token" {
     BASE_URL                = local.api_base_url
     DYNAMO_ENDPOINT         = var.use_localstack ? var.lambda_dynamo_endpoint : null
     EVENTS_SNS_TOPIC_ARN    = aws_sns_topic.events.arn
+    AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
     REDIS_HOST              = local.external_redis_host
     REDIS_PORT              = local.external_redis_port

--- a/ci/terraform/oidc/trustmarks.tf
+++ b/ci/terraform/oidc/trustmarks.tf
@@ -7,15 +7,16 @@ module "trustmarks" {
   environment     = var.environment
 
   handler_environment_variables = {
-    ENVIRONMENT          = var.environment
-    BASE_URL             = local.api_base_url
-    EVENTS_SNS_TOPIC_ARN = aws_sns_topic.events.arn
-    LOCALSTACK_ENDPOINT  = var.use_localstack ? var.localstack_endpoint : null
-    REDIS_HOST           = local.external_redis_host
-    REDIS_PORT           = local.external_redis_port
-    REDIS_PASSWORD       = local.external_redis_password
-    REDIS_TLS            = var.redis_use_tls
-    DYNAMO_ENDPOINT      = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    ENVIRONMENT             = var.environment
+    BASE_URL                = local.api_base_url
+    EVENTS_SNS_TOPIC_ARN    = aws_sns_topic.events.arn
+    AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name
+    LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
+    REDIS_HOST              = local.external_redis_host
+    REDIS_PORT              = local.external_redis_port
+    REDIS_PASSWORD          = local.external_redis_password
+    REDIS_TLS               = var.redis_use_tls
+    DYNAMO_ENDPOINT         = var.use_localstack ? var.lambda_dynamo_endpoint : null
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.TrustMarkHandler::handleRequest"
 

--- a/ci/terraform/oidc/update.tf
+++ b/ci/terraform/oidc/update.tf
@@ -8,11 +8,12 @@ module "update" {
   integration_request_parameters = { "integration.request.path.clientId" = "method.request.path.clientId" }
 
   handler_environment_variables = {
-    ENVIRONMENT          = var.environment
-    BASE_URL             = local.api_base_url
-    DYNAMO_ENDPOINT      = var.use_localstack ? var.lambda_dynamo_endpoint : null
-    EVENTS_SNS_TOPIC_ARN = aws_sns_topic.events.arn
-    LOCALSTACK_ENDPOINT  = var.use_localstack ? var.localstack_endpoint : null
+    ENVIRONMENT             = var.environment
+    BASE_URL                = local.api_base_url
+    DYNAMO_ENDPOINT         = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    EVENTS_SNS_TOPIC_ARN    = aws_sns_topic.events.arn
+    AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name
+    LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
   }
   handler_function_name = "uk.gov.di.authentication.clientregistry.lambda.UpdateClientConfigHandler::handleRequest"
 

--- a/ci/terraform/oidc/update_profile.tf
+++ b/ci/terraform/oidc/update_profile.tf
@@ -10,6 +10,7 @@ module "update_profile" {
     ENVIRONMENT              = var.environment
     BASE_URL                 = local.frontend_api_base_url
     EVENTS_SNS_TOPIC_ARN     = aws_sns_topic.events.arn
+    AUDIT_SIGNING_KEY_ALIAS  = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT      = var.use_localstack ? var.localstack_endpoint : null
     REDIS_HOST               = local.external_redis_host
     REDIS_PORT               = local.external_redis_port

--- a/ci/terraform/oidc/userexists.tf
+++ b/ci/terraform/oidc/userexists.tf
@@ -7,15 +7,16 @@ module "userexists" {
   environment     = var.environment
 
   handler_environment_variables = {
-    ENVIRONMENT          = var.environment
-    BASE_URL             = local.frontend_api_base_url
-    EVENTS_SNS_TOPIC_ARN = aws_sns_topic.events.arn
-    LOCALSTACK_ENDPOINT  = var.use_localstack ? var.localstack_endpoint : null
-    REDIS_HOST           = local.external_redis_host
-    REDIS_PORT           = local.external_redis_port
-    REDIS_PASSWORD       = local.external_redis_password
-    REDIS_TLS            = var.redis_use_tls
-    DYNAMO_ENDPOINT      = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    ENVIRONMENT             = var.environment
+    BASE_URL                = local.frontend_api_base_url
+    EVENTS_SNS_TOPIC_ARN    = aws_sns_topic.events.arn
+    AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name
+    LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
+    REDIS_HOST              = local.external_redis_host
+    REDIS_PORT              = local.external_redis_port
+    REDIS_PASSWORD          = local.external_redis_password
+    REDIS_TLS               = var.redis_use_tls
+    DYNAMO_ENDPOINT         = var.use_localstack ? var.lambda_dynamo_endpoint : null
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.CheckUserExistsHandler::handleRequest"
 

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -10,6 +10,7 @@ module "userinfo" {
     ENVIRONMENT             = var.environment
     BASE_URL                = local.api_base_url
     EVENTS_SNS_TOPIC_ARN    = aws_sns_topic.events.arn
+    AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
     REDIS_HOST              = local.external_redis_host
     REDIS_PORT              = local.external_redis_port

--- a/ci/terraform/oidc/verify_code.tf
+++ b/ci/terraform/oidc/verify_code.tf
@@ -10,6 +10,7 @@ module "verify_code" {
     ENVIRONMENT              = var.environment
     BASE_URL                 = local.frontend_api_base_url
     EVENTS_SNS_TOPIC_ARN     = aws_sns_topic.events.arn
+    AUDIT_SIGNING_KEY_ALIAS  = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT      = var.use_localstack ? var.localstack_endpoint : null
     REDIS_HOST               = local.external_redis_host
     REDIS_PORT               = local.external_redis_port

--- a/ci/terraform/oidc/wellknown.tf
+++ b/ci/terraform/oidc/wellknown.tf
@@ -7,10 +7,11 @@ module "openid_configuration_discovery" {
   environment     = var.environment
 
   handler_environment_variables = {
-    ENVIRONMENT          = var.environment
-    BASE_URL             = local.api_base_url
-    EVENTS_SNS_TOPIC_ARN = aws_sns_topic.events.arn
-    LOCALSTACK_ENDPOINT  = var.use_localstack ? var.localstack_endpoint : null
+    ENVIRONMENT             = var.environment
+    BASE_URL                = local.api_base_url
+    EVENTS_SNS_TOPIC_ARN    = aws_sns_topic.events.arn
+    AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name
+    LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.WellknownHandler::handleRequest"
 

--- a/ci/terraform/shared/outputs.tf
+++ b/ci/terraform/shared/outputs.tf
@@ -56,6 +56,10 @@ output "id_token_signing_key_alias_name" {
   value = aws_kms_alias.id_token_signing_key_alias.name
 }
 
+output "audit_signing_key_alias_name" {
+  value = aws_kms_alias.audit_payload_signing_key_alias.name
+}
+
 output "stub_rp_client_credentials" {
   value = [for i, rp in var.stub_rp_clients : {
     client_name = rp.client_name

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -142,6 +142,10 @@ public class ConfigurationService {
         return System.getenv("TOKEN_SIGNING_KEY_ALIAS");
     }
 
+    public String getAuditSigningKeyAlias() {
+        return System.getenv("AUDIT_SIGNING_KEY_ALIAS");
+    }
+
     public int getWarmupDelayMillis() {
         return Integer.parseInt(System.getenv().getOrDefault("WARMER_DELAY", "75"));
     }


### PR DESCRIPTION
## What?

Sign the audit payloads with a key from KMS

## Why?

Assert provenance of audit messages.
