### PR TITLE
BAU: Increase minimum concurrency to 25 in production

### DIFF
--- a/ci/terraform/account-management/authenticate.tf
+++ b/ci/terraform/account-management/authenticate.tf
@@ -30,6 +30,9 @@ module "authenticate" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_handler_environment_variables = {
+    LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
+  }
 
   use_localstack = var.use_localstack
 }

--- a/ci/terraform/account-management/authoriser-warmer.tf
+++ b/ci/terraform/account-management/authoriser-warmer.tf
@@ -84,9 +84,10 @@ resource "aws_lambda_function" "warmer_function" {
 
   environment {
     variables = {
-      LAMBDA_ARN       = aws_lambda_function.authorizer.arn
-      LAMBDA_QUALIFIER = aws_lambda_alias.authorizer_alias.name
-      LAMBDA_TYPE      = "AUTHORIZER"
+      LAMBDA_ARN             = aws_lambda_function.authorizer.arn
+      LAMBDA_QUALIFIER       = aws_lambda_alias.authorizer_alias.name
+      LAMBDA_TYPE            = "AUTHORIZER"
+      LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
     }
   }
 

--- a/ci/terraform/account-management/localstack.tfvars
+++ b/ci/terraform/account-management/localstack.tfvars
@@ -4,3 +4,4 @@ aws_dynamodb_endpoint     = "http://localhost:8000"
 use_localstack            = true
 api_deployment_stage_name = "local"
 keep_lambdas_warm         = false
+shared_state_bucket       = "terraform-state"

--- a/ci/terraform/account-management/production-overrides.tfvars
+++ b/ci/terraform/account-management/production-overrides.tfvars
@@ -8,3 +8,4 @@ notify_template_map = {
 }
 
 cloudwatch_log_retention = 5
+lambda_min_concurrency   = 25

--- a/ci/terraform/account-management/remove-account.tf
+++ b/ci/terraform/account-management/remove-account.tf
@@ -31,5 +31,8 @@ module "delete_account" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_handler_environment_variables = {
+    LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
+  }
 
 }

--- a/ci/terraform/account-management/send_otp_notification.tf
+++ b/ci/terraform/account-management/send_otp_notification.tf
@@ -36,6 +36,9 @@ module "send_otp_notification" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_handler_environment_variables = {
+    LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
+  }
 
   depends_on = [
     aws_api_gateway_rest_api.di_account_management_api,

--- a/ci/terraform/account-management/update-email.tf
+++ b/ci/terraform/account-management/update-email.tf
@@ -35,4 +35,7 @@ module "update_email" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_handler_environment_variables = {
+    LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
+  }
 }

--- a/ci/terraform/account-management/update-password.tf
+++ b/ci/terraform/account-management/update-password.tf
@@ -31,4 +31,7 @@ module "update_password" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_handler_environment_variables = {
+    LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
+  }
 }

--- a/ci/terraform/account-management/update-phone-number.tf
+++ b/ci/terraform/account-management/update-phone-number.tf
@@ -35,4 +35,7 @@ module "update_phone_number" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_handler_environment_variables = {
+    LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
+  }
 }

--- a/ci/terraform/account-management/variables.tf
+++ b/ci/terraform/account-management/variables.tf
@@ -132,3 +132,9 @@ variable "cloudwatch_log_retention" {
   type        = number
   description = "The number of day to retain Cloudwatch logs for"
 }
+
+variable "lambda_min_concurrency" {
+  default     = 10
+  type        = number
+  description = "The number of lambda instance to keep 'warm'"
+}

--- a/ci/terraform/oidc/auth-code.tf
+++ b/ci/terraform/oidc/auth-code.tf
@@ -37,6 +37,9 @@ module "auth-code" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_handler_environment_variables = {
+    LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
+  }
 
   use_localstack = var.use_localstack
   depends_on = [

--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -39,6 +39,9 @@ module "authorize" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_handler_environment_variables = {
+    LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
+  }
 
   use_localstack = var.use_localstack
   depends_on = [

--- a/ci/terraform/oidc/client-info.tf
+++ b/ci/terraform/oidc/client-info.tf
@@ -38,6 +38,9 @@ module "client-info" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_handler_environment_variables = {
+    LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
+  }
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/jwks.tf
+++ b/ci/terraform/oidc/jwks.tf
@@ -32,6 +32,9 @@ module "jwks" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_handler_environment_variables = {
+    LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
+  }
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/login.tf
+++ b/ci/terraform/oidc/login.tf
@@ -39,6 +39,9 @@ module "login" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_handler_environment_variables = {
+    LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
+  }
 
   use_localstack = var.use_localstack
 }

--- a/ci/terraform/oidc/logout.tf
+++ b/ci/terraform/oidc/logout.tf
@@ -40,6 +40,9 @@ module "logout" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_handler_environment_variables = {
+    LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
+  }
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/mfa.tf
+++ b/ci/terraform/oidc/mfa.tf
@@ -38,6 +38,9 @@ module "mfa" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_handler_environment_variables = {
+    LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
+  }
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/production-overrides.tfvars
+++ b/ci/terraform/oidc/production-overrides.tfvars
@@ -7,3 +7,4 @@ notify_template_map = {
 }
 
 cloudwatch_log_retention = 5
+lambda_min_concurrency   = 25

--- a/ci/terraform/oidc/register.tf
+++ b/ci/terraform/oidc/register.tf
@@ -34,6 +34,9 @@ module "register" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_handler_environment_variables = {
+    LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
+  }
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/reset-password-request.tf
+++ b/ci/terraform/oidc/reset-password-request.tf
@@ -40,6 +40,9 @@ module "reset-password-request" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_handler_environment_variables = {
+    LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
+  }
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/reset_password.tf
+++ b/ci/terraform/oidc/reset_password.tf
@@ -41,6 +41,9 @@ module "reset_password" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_handler_environment_variables = {
+    LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
+  }
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/send_notification.tf
+++ b/ci/terraform/oidc/send_notification.tf
@@ -37,6 +37,9 @@ module "send_notification" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_handler_environment_variables = {
+    LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
+  }
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/signup.tf
+++ b/ci/terraform/oidc/signup.tf
@@ -39,6 +39,9 @@ module "signup" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_handler_environment_variables = {
+    LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
+  }
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/token.tf
+++ b/ci/terraform/oidc/token.tf
@@ -39,6 +39,9 @@ module "token" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_handler_environment_variables = {
+    LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
+  }
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/trustmarks.tf
+++ b/ci/terraform/oidc/trustmarks.tf
@@ -38,6 +38,9 @@ module "trustmarks" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_handler_environment_variables = {
+    LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
+  }
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/update.tf
+++ b/ci/terraform/oidc/update.tf
@@ -35,6 +35,9 @@ module "update" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_handler_environment_variables = {
+    LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
+  }
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/update_profile.tf
+++ b/ci/terraform/oidc/update_profile.tf
@@ -39,6 +39,9 @@ module "update_profile" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_handler_environment_variables = {
+    LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
+  }
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/userexists.tf
+++ b/ci/terraform/oidc/userexists.tf
@@ -38,6 +38,9 @@ module "userexists" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_handler_environment_variables = {
+    LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
+  }
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -38,6 +38,9 @@ module "userinfo" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_handler_environment_variables = {
+    LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
+  }
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -187,3 +187,9 @@ variable "cloudwatch_log_retention" {
   type        = number
   description = "The number of day to retain Cloudwatch logs for"
 }
+
+variable "lambda_min_concurrency" {
+  default     = 10
+  type        = number
+  description = "The number of lambda instance to keep 'warm'"
+}

--- a/ci/terraform/oidc/verify_code.tf
+++ b/ci/terraform/oidc/verify_code.tf
@@ -39,6 +39,9 @@ module "verify_code" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_handler_environment_variables = {
+    LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
+  }
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/wellknown.tf
+++ b/ci/terraform/oidc/wellknown.tf
@@ -32,6 +32,9 @@ module "openid_configuration_discovery" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_handler_environment_variables = {
+    LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
+  }
 
   use_localstack = var.use_localstack
 


### PR DESCRIPTION
## What?

- Inject `LAMBDA_MIN_CONCURRENCY` env variable to warmer, this should default to 10
- Override in production to be 25

## Why?

We need to production to be responsive with a greater number of users