### PR TITLE
Add default security headers to all api gateway responses

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ApiGatewayResponseHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ApiGatewayResponseHelper.java
@@ -3,6 +3,7 @@ package uk.gov.di.authentication.shared.helpers;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.http.HttpHeaders;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
@@ -11,6 +12,21 @@ import java.util.List;
 import java.util.Map;
 
 public class ApiGatewayResponseHelper {
+
+    private static final String XSS_PROTECTION_HEADER_NAME = "X-XSS-Protection";
+    private static final String CONTENT_TYPE_OPTIONS_HEADER_NAME = "X-Content-Type-Options";
+    private static final String CONTENT_SECURITY_POLICY_HEADER_NAME = "Content-Security-Policy";
+    private static final String STRICT_TRANSPORT_SECURITY_HEADER_NAME = "Strict-Transport-Security";
+    private static final String X_FRAME_OPTIONS_HEADER_NAME = "X-Frame-Options";
+
+    private static final String CACHE_CONTROL_HEADER_VALUE = "no-cache, no-store";
+    private static final String PRAGMA_HEADER_VALUE = "no-cache";
+    private static final String XSS_PROTECTION_HEADER_VALUE = "1; mode=block";
+    private static final String CONTENT_TYPE_OPTIONS_HEADER_VALUE = "nosniff";
+    private static final String CONTENT_SECURITY_POLICY_HEADER_VALUE = "frame-ancestors 'none'";
+    private static final String STRICT_TRANSPORT_SECURITY_HEADER_VALUE =
+            "max-age=31536000; includeSubDomains";
+    private static final String X_FRAME_OPTIONS_HEADER_VALUE = "DENY";
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ApiGatewayResponseHelper.class);
 
@@ -46,9 +62,28 @@ public class ApiGatewayResponseHelper {
                 new APIGatewayProxyResponseEvent();
         apiGatewayProxyResponseEvent.setStatusCode(statusCode);
         apiGatewayProxyResponseEvent.setBody(body);
+
         if (multiValueHeaders != null) {
             apiGatewayProxyResponseEvent.setMultiValueHeaders(multiValueHeaders);
         }
+
+        Map<String, String> securityHeaders =
+                Map.ofEntries(
+                        Map.entry(HttpHeaders.CACHE_CONTROL, CACHE_CONTROL_HEADER_VALUE),
+                        Map.entry(HttpHeaders.PRAGMA, PRAGMA_HEADER_VALUE),
+                        Map.entry(XSS_PROTECTION_HEADER_NAME, XSS_PROTECTION_HEADER_VALUE),
+                        Map.entry(
+                                CONTENT_TYPE_OPTIONS_HEADER_NAME,
+                                CONTENT_TYPE_OPTIONS_HEADER_VALUE),
+                        Map.entry(
+                                CONTENT_SECURITY_POLICY_HEADER_NAME,
+                                CONTENT_SECURITY_POLICY_HEADER_VALUE),
+                        Map.entry(
+                                STRICT_TRANSPORT_SECURITY_HEADER_NAME,
+                                STRICT_TRANSPORT_SECURITY_HEADER_VALUE),
+                        Map.entry(X_FRAME_OPTIONS_HEADER_NAME, X_FRAME_OPTIONS_HEADER_VALUE));
+        apiGatewayProxyResponseEvent.setHeaders(securityHeaders);
+
         return apiGatewayProxyResponseEvent;
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ApiGatewayResponseHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ApiGatewayResponseHelperTest.java
@@ -1,0 +1,64 @@
+package uk.gov.di.authentication.shared.helpers;
+
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import org.apache.http.HttpHeaders;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.entity.ErrorResponse;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsMapContaining.hasEntry;
+
+public class ApiGatewayResponseHelperTest {
+
+    @Test
+    void ShouldAddDefaultSecurityHeadersForErrorResponses() {
+        APIGatewayProxyResponseEvent result =
+                ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse(
+                        404, ErrorResponse.ERROR_1000);
+
+        assertThat(result.getHeaders(), hasEntry(HttpHeaders.CACHE_CONTROL, "no-cache, no-store"));
+        assertThat(result.getHeaders(), hasEntry(HttpHeaders.PRAGMA, "no-cache"));
+        assertThat(result.getHeaders(), hasEntry("X-XSS-Protection", "1; mode=block"));
+        assertThat(result.getHeaders(), hasEntry("X-Content-Type-Options", "nosniff"));
+        assertThat(
+                result.getHeaders(), hasEntry("Content-Security-Policy", "frame-ancestors 'none'"));
+        assertThat(
+                result.getHeaders(),
+                hasEntry("Strict-Transport-Security", "max-age=31536000; includeSubDomains"));
+        assertThat(result.getHeaders(), hasEntry("X-Frame-Options", "DENY"));
+    }
+
+    @Test
+    void ShouldAddDefaultSecurityHeadersForSuccessResponses() {
+        APIGatewayProxyResponseEvent result =
+                ApiGatewayResponseHelper.generateEmptySuccessApiGatewayResponse();
+
+        assertThat(result.getHeaders(), hasEntry(HttpHeaders.CACHE_CONTROL, "no-cache, no-store"));
+        assertThat(result.getHeaders(), hasEntry(HttpHeaders.PRAGMA, "no-cache"));
+        assertThat(result.getHeaders(), hasEntry("X-XSS-Protection", "1; mode=block"));
+        assertThat(result.getHeaders(), hasEntry("X-Content-Type-Options", "nosniff"));
+        assertThat(
+                result.getHeaders(), hasEntry("Content-Security-Policy", "frame-ancestors 'none'"));
+        assertThat(
+                result.getHeaders(),
+                hasEntry("Strict-Transport-Security", "max-age=31536000; includeSubDomains"));
+        assertThat(result.getHeaders(), hasEntry("X-Frame-Options", "DENY"));
+    }
+
+    @Test
+    void shouldAddDefaultSecurityHeadersForAllResponses() {
+        APIGatewayProxyResponseEvent result =
+                ApiGatewayResponseHelper.generateApiGatewayProxyResponse(200, "test-body", null);
+
+        assertThat(result.getHeaders(), hasEntry(HttpHeaders.CACHE_CONTROL, "no-cache, no-store"));
+        assertThat(result.getHeaders(), hasEntry(HttpHeaders.PRAGMA, "no-cache"));
+        assertThat(result.getHeaders(), hasEntry("X-XSS-Protection", "1; mode=block"));
+        assertThat(result.getHeaders(), hasEntry("X-Content-Type-Options", "nosniff"));
+        assertThat(
+                result.getHeaders(), hasEntry("Content-Security-Policy", "frame-ancestors 'none'"));
+        assertThat(
+                result.getHeaders(),
+                hasEntry("Strict-Transport-Security", "max-age=31536000; includeSubDomains"));
+        assertThat(result.getHeaders(), hasEntry("X-Frame-Options", "DENY"));
+    }
+}


### PR DESCRIPTION
## What?

Add some default security headers to all api gateway responses in the helper class.

## Why?

The missing headers was identified as a security risk from the ITHC.
