### PR TITLE
Update email handler correct redis hash

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
@@ -79,7 +79,7 @@ public class UpdateEmailHandler
                                                 input.getBody(), UpdateEmailRequest.class);
                                 boolean isValidOtpCode =
                                         codeStorageService.isValidOtpCode(
-                                                updateInfoRequest.getExistingEmailAddress(),
+                                                updateInfoRequest.getReplacementEmailAddress(),
                                                 updateInfoRequest.getOtp(),
                                                 NotificationType.VERIFY_EMAIL);
                                 if (!isValidOtpCode) {

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandlerTest.java
@@ -68,7 +68,7 @@ class UpdateEmailHandlerTest {
         authorizerParams.put("principalId", SUBJECT.getValue());
         proxyRequestContext.setAuthorizer(authorizerParams);
         event.setRequestContext(proxyRequestContext);
-        when(codeStorageService.isValidOtpCode(EXISTING_EMAIL_ADDRESS, OTP, VERIFY_EMAIL))
+        when(codeStorageService.isValidOtpCode(NEW_EMAIL_ADDRESS, OTP, VERIFY_EMAIL))
                 .thenReturn(true);
         when(validationService.validateEmailAddressUpdate(
                         EXISTING_EMAIL_ADDRESS, NEW_EMAIL_ADDRESS))
@@ -96,7 +96,7 @@ class UpdateEmailHandlerTest {
         authorizerParams.put("principalId", SUBJECT.getValue());
         proxyRequestContext.setAuthorizer(authorizerParams);
         event.setRequestContext(proxyRequestContext);
-        when(codeStorageService.isValidOtpCode(EXISTING_EMAIL_ADDRESS, OTP, VERIFY_EMAIL))
+        when(codeStorageService.isValidOtpCode(NEW_EMAIL_ADDRESS, OTP, VERIFY_EMAIL))
                 .thenReturn(true);
         when(validationService.validateEmailAddressUpdate(
                         EXISTING_EMAIL_ADDRESS, NEW_EMAIL_ADDRESS))
@@ -142,7 +142,7 @@ class UpdateEmailHandlerTest {
         authorizerParams.put("principalId", SUBJECT.getValue());
         proxyRequestContext.setAuthorizer(authorizerParams);
         event.setRequestContext(proxyRequestContext);
-        when(codeStorageService.isValidOtpCode(EXISTING_EMAIL_ADDRESS, OTP, VERIFY_EMAIL))
+        when(codeStorageService.isValidOtpCode(INVALID_EMAIL_ADDRESS, OTP, VERIFY_EMAIL))
                 .thenReturn(false);
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
@@ -169,7 +169,7 @@ class UpdateEmailHandlerTest {
         authorizerParams.put("principalId", SUBJECT.getValue());
         proxyRequestContext.setAuthorizer(authorizerParams);
         event.setRequestContext(proxyRequestContext);
-        when(codeStorageService.isValidOtpCode(EXISTING_EMAIL_ADDRESS, OTP, VERIFY_EMAIL))
+        when(codeStorageService.isValidOtpCode(INVALID_EMAIL_ADDRESS, OTP, VERIFY_EMAIL))
                 .thenReturn(true);
         when(validationService.validateEmailAddressUpdate(
                         EXISTING_EMAIL_ADDRESS, INVALID_EMAIL_ADDRESS))


### PR DESCRIPTION
## What?

Update email handler changed to read correct value for email address.

## Why?

It fixes the bug where it can't validate an otp code.