### PR TITLE
GOVSI-834: forward cookie_consent from 'authorize'

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/RequestParameters.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/RequestParameters.java
@@ -1,0 +1,5 @@
+package uk.gov.di.authentication.oidc.entity;
+
+public interface RequestParameters {
+    String COOKIE_CONSENT = "cookie_consent";
+}


### PR DESCRIPTION
## What?

Forward cookie_consent from 'authorize'

## Why?

The cookie_consent flag first arrives when a client calls 'authorize', so it needs to be passed-on to the 'auth-code' endpoint for processing.

## Related PRs

#668 
