### PR TITLE
Add new state transition to allow password re-entry and add initial unit test for state machine journeys

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/state/StateMachine.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/state/StateMachine.java
@@ -310,6 +310,7 @@ public class StateMachine<T, A, C> {
                         on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED).then(NEW))
                 .when(MFA_SMS_CODE_SENT)
                 .allow(
+                        on(USER_ENTERED_VALID_CREDENTIALS).then(MFA_SMS_CODE_SENT),
                         on(SYSTEM_HAS_SENT_MFA_CODE).then(MFA_SMS_CODE_SENT),
                         on(SYSTEM_HAS_SENT_TOO_MANY_MFA_CODES).then(MFA_SMS_MAX_CODES_SENT),
                         on(USER_ENTERED_VALID_MFA_CODE)

--- a/shared/src/test/java/uk/gov/di/authentication/shared/state/StateMachineJourneyTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/state/StateMachineJourneyTest.java
@@ -1,0 +1,23 @@
+package uk.gov.di.authentication.shared.state;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.entity.SessionAction;
+import uk.gov.di.authentication.shared.entity.SessionState;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static uk.gov.di.authentication.shared.entity.SessionState.MFA_SMS_CODE_SENT;
+
+public class StateMachineJourneyTest {
+
+    private final StateMachine<SessionState, SessionAction, UserContext> stateMachine =
+            StateMachine.userJourneyStateMachine();
+
+    @Test
+    public void returns_MFA_SMS_CODE_SENT_WhenUserEntersPasswordAgain() {
+        final SessionState nextState =
+                stateMachine.transition(
+                        MFA_SMS_CODE_SENT, SessionAction.USER_ENTERED_VALID_CREDENTIALS);
+        assertThat(nextState, equalTo(MFA_SMS_CODE_SENT));
+    }
+}

--- a/shared/src/test/java/uk/gov/di/authentication/shared/state/StateMachineTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/state/StateMachineTest.java
@@ -1,8 +1,6 @@
 package uk.gov.di.authentication.shared.state;
 
 import org.junit.jupiter.api.Test;
-import uk.gov.di.authentication.shared.entity.SessionAction;
-import uk.gov.di.authentication.shared.entity.SessionState;
 
 import java.util.List;
 import java.util.Optional;
@@ -12,7 +10,6 @@ import static java.util.Map.ofEntries;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static uk.gov.di.authentication.shared.entity.SessionState.MFA_SMS_CODE_SENT;
 import static uk.gov.di.authentication.shared.state.StateMachineTest.Action.CONDITIONAL_MOVE;
 import static uk.gov.di.authentication.shared.state.StateMachineTest.Action.MOVE_TO_2;
 import static uk.gov.di.authentication.shared.state.StateMachineTest.Action.MOVE_TO_3;
@@ -46,7 +43,7 @@ public class StateMachineTest {
                 }
             };
 
-    private final StateMachine<State, Action, Boolean> testStateMachine =
+    private final StateMachine<State, Action, Boolean> stateMachine =
             new StateMachine<>(
                     ofEntries(
                             entry(STATE_1, List.of(new Transition<>(MOVE_TO_2, STATE_2))),
@@ -59,26 +56,22 @@ public class StateMachineTest {
                                             new Transition<>(
                                                     CONDITIONAL_MOVE, STATE_5, new Default<>())))));
 
-    private final StateMachine<SessionState, SessionAction, UserContext> stateMachine =
-            StateMachine.userJourneyStateMachine();
-
     @Test
     public void returnsCorrectNextStateForSimpleTransition() {
-        assertThat(testStateMachine.transition(STATE_1, MOVE_TO_2), equalTo(STATE_2));
-        assertThat(testStateMachine.transition(STATE_2, MOVE_TO_3), equalTo(STATE_3));
+        assertThat(stateMachine.transition(STATE_1, MOVE_TO_2), equalTo(STATE_2));
+        assertThat(stateMachine.transition(STATE_2, MOVE_TO_3), equalTo(STATE_3));
     }
 
     @Test
     public void returnsCorrectNextStateForConditionalTransition() {
         assertThat(
-                testStateMachine.transition(STATE_3, CONDITIONAL_MOVE, Boolean.TRUE),
-                equalTo(STATE_4));
+                stateMachine.transition(STATE_3, CONDITIONAL_MOVE, Boolean.TRUE), equalTo(STATE_4));
     }
 
     @Test
     public void returnsDefaultNextStateForConditionalTransitionWhenNoOtherConditionMatches() {
         assertThat(
-                testStateMachine.transition(STATE_3, CONDITIONAL_MOVE, Boolean.FALSE),
+                stateMachine.transition(STATE_3, CONDITIONAL_MOVE, Boolean.FALSE),
                 equalTo(STATE_5));
     }
 
@@ -86,14 +79,6 @@ public class StateMachineTest {
     public void throwsInvalidStateTransitionExceptionForMissingTransition() {
         assertThrows(
                 StateMachine.InvalidStateTransitionException.class,
-                () -> testStateMachine.transition(STATE_1, MOVE_TO_3));
-    }
-
-    @Test
-    public void returns_MFA_SMS_CODE_SENT_WhenUserEntersPasswordAgain() {
-        final SessionState nextState =
-                stateMachine.transition(
-                        MFA_SMS_CODE_SENT, SessionAction.USER_ENTERED_VALID_CREDENTIALS);
-        assertThat(nextState, equalTo(MFA_SMS_CODE_SENT));
+                () -> stateMachine.transition(STATE_1, MOVE_TO_3));
     }
 }


### PR DESCRIPTION

## What?

Added a new transition option in the state machine to allow password re-entry from login screen.

## Why?

If after entering password, the user uses the browser back button then allowing them to re-enter their password should be a valid transition.

