### PR TITLE
GOVSI-834: output cookie domain from terraform

### DIFF
--- a/ci/terraform/oidc/outputs.tf
+++ b/ci/terraform/oidc/outputs.tf
@@ -31,3 +31,7 @@ output "frontend_api_key" {
 output "email_queue" {
   value = aws_sqs_queue.email_queue.id
 }
+
+output "analytics_cookie_domain" {
+  value = var.environment == "production" ? "${var.service_domain_name}" : "${var.environment}.${var.service_domain_name}"
+}


### PR DESCRIPTION

## What?

Output cookie domain from terraform

## Why?

To feed into a frontend environment variable so that cookies are always set on the right domain regardless of environment.

## Related PRs

#682 
