### PR TITLE
GOVSI-824: Add encryption at rest to SQS

### DIFF
--- a/ci/terraform/account-management/sqs.tf
+++ b/ci/terraform/account-management/sqs.tf
@@ -33,6 +33,9 @@ resource "aws_sqs_queue" "email_queue" {
   message_retention_seconds = 1209600
   receive_wait_time_seconds = 10
 
+  kms_master_key_id                 = var.use_localstack ? null : "alias/aws/sqs"
+  kms_data_key_reuse_period_seconds = var.use_localstack ? null : 300
+
   tags = local.default_tags
 }
 

--- a/ci/terraform/oidc/sqs.tf
+++ b/ci/terraform/oidc/sqs.tf
@@ -5,6 +5,9 @@ resource "aws_sqs_queue" "email_queue" {
   message_retention_seconds = 1209600
   receive_wait_time_seconds = 10
 
+  kms_master_key_id                 = var.use_localstack ? null : "alias/aws/sqs"
+  kms_data_key_reuse_period_seconds = var.use_localstack ? null : 300
+
   tags = local.default_tags
 }
 


### PR DESCRIPTION
## What?

- Add encryption at rest to SQS

## Why?

No data should be unencrypted at rest.