### PR TITLE
GOVSI-620: Warm Lambdas on deployment

### DIFF
--- a/ci/terraform/account-management/authenticate.tf
+++ b/ci/terraform/account-management/authenticate.tf
@@ -32,6 +32,7 @@ module "authenticate" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
+  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 
   use_localstack = var.use_localstack
 }

--- a/ci/terraform/account-management/remove-account.tf
+++ b/ci/terraform/account-management/remove-account.tf
@@ -33,5 +33,5 @@ module "delete_account" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
-
+  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 }

--- a/ci/terraform/account-management/send_otp_notification.tf
+++ b/ci/terraform/account-management/send_otp_notification.tf
@@ -38,6 +38,7 @@ module "send_otp_notification" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
+  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 
   depends_on = [
     aws_api_gateway_rest_api.di_account_management_api,

--- a/ci/terraform/account-management/site.tf
+++ b/ci/terraform/account-management/site.tf
@@ -70,4 +70,22 @@ locals {
     authorizerRequestId          = "$context.authorizer.requestId"
     authorizerStatus             = "$context.authorizer.status"
   })
+
+  warmer_deployment_event_pattern = jsonencode({
+    "source" : [
+      "uk.gov.di.deployer"
+    ],
+    "resources" : [
+      "account-management-api"
+    ],
+    "detail-type" : [
+      "deployment-complete"
+    ],
+    "detail" : {
+      "environment" : [
+        var.environment
+      ]
+    }
+  })
+
 }

--- a/ci/terraform/account-management/update-email.tf
+++ b/ci/terraform/account-management/update-email.tf
@@ -37,4 +37,5 @@ module "update_email" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
+  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 }

--- a/ci/terraform/account-management/update-password.tf
+++ b/ci/terraform/account-management/update-password.tf
@@ -33,4 +33,5 @@ module "update_password" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
+  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 }

--- a/ci/terraform/account-management/update-phone-number.tf
+++ b/ci/terraform/account-management/update-phone-number.tf
@@ -37,4 +37,5 @@ module "update_phone_number" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
+  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 }

--- a/ci/terraform/modules/endpoint-module/variables.tf
+++ b/ci/terraform/modules/endpoint-module/variables.tf
@@ -134,6 +134,10 @@ variable "warmer_delay_millis" {
   default = 200
 }
 
+variable "warmer_deployment_event_pattern" {
+  description = "The Cloudwatch event pattern that will manually trigger the warmer"
+}
+
 variable "authorizer_id" {
   type    = string
   default = null

--- a/ci/terraform/modules/endpoint-module/warmer.tf
+++ b/ci/terraform/modules/endpoint-module/warmer.tf
@@ -144,9 +144,34 @@ resource "aws_cloudwatch_event_target" "warmer_schedule_target" {
 resource "aws_lambda_permission" "allow_cloudwatch_to_call_warmer_lambda" {
   count = var.keep_lambda_warm && var.warmer_handler_function_name != null ? 1 : 0
 
-  statement_id  = "AllowExecutionFromCloudWatch"
+  statement_id  = "AllowExecutionFromCloudWatchScheduleRule"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.warmer_function[0].function_name
   principal     = "events.amazonaws.com"
   source_arn    = aws_cloudwatch_event_rule.warmer_schedule_rule[0].arn
+}
+
+resource "aws_cloudwatch_event_rule" "warmer_deployment_trigger_rule" {
+  count = var.keep_lambda_warm && var.warmer_handler_function_name != null ? 1 : 0
+
+  name          = "${aws_lambda_function.warmer_function[0].function_name}-deployment-trigger"
+  event_pattern = var.warmer_deployment_event_pattern
+  is_enabled    = true
+}
+
+resource "aws_cloudwatch_event_target" "warmer_deployment_target" {
+  count = var.keep_lambda_warm && var.warmer_handler_function_name != null ? 1 : 0
+
+  arn  = aws_lambda_function.warmer_function[0].arn
+  rule = aws_cloudwatch_event_rule.warmer_deployment_trigger_rule[0].name
+}
+
+resource "aws_lambda_permission" "allow_cloudwatch_deployment_rule_to_call_warmer_lambda" {
+  count = var.keep_lambda_warm && var.warmer_handler_function_name != null ? 1 : 0
+
+  statement_id  = "AllowExecutionFromCloudWatchDeploymentRule"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.warmer_function[0].function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.warmer_deployment_trigger_rule[0].arn
 }

--- a/ci/terraform/oidc/auth-code.tf
+++ b/ci/terraform/oidc/auth-code.tf
@@ -39,6 +39,7 @@ module "auth-code" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
+  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 
   use_localstack = var.use_localstack
   depends_on = [

--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -41,6 +41,7 @@ module "authorize" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
+  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 
   use_localstack = var.use_localstack
   depends_on = [

--- a/ci/terraform/oidc/client-info.tf
+++ b/ci/terraform/oidc/client-info.tf
@@ -40,6 +40,7 @@ module "client-info" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
+  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/jwks.tf
+++ b/ci/terraform/oidc/jwks.tf
@@ -34,6 +34,7 @@ module "jwks" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
+  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/login.tf
+++ b/ci/terraform/oidc/login.tf
@@ -41,6 +41,7 @@ module "login" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
+  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 
   use_localstack = var.use_localstack
 }

--- a/ci/terraform/oidc/logout.tf
+++ b/ci/terraform/oidc/logout.tf
@@ -42,6 +42,7 @@ module "logout" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
+  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/mfa.tf
+++ b/ci/terraform/oidc/mfa.tf
@@ -40,6 +40,7 @@ module "mfa" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
+  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/register.tf
+++ b/ci/terraform/oidc/register.tf
@@ -36,6 +36,7 @@ module "register" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
+  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/reset-password-request.tf
+++ b/ci/terraform/oidc/reset-password-request.tf
@@ -42,6 +42,7 @@ module "reset-password-request" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
+  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/reset_password.tf
+++ b/ci/terraform/oidc/reset_password.tf
@@ -43,6 +43,7 @@ module "reset_password" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
+  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/send_notification.tf
+++ b/ci/terraform/oidc/send_notification.tf
@@ -39,6 +39,7 @@ module "send_notification" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
+  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/signup.tf
+++ b/ci/terraform/oidc/signup.tf
@@ -41,6 +41,7 @@ module "signup" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
+  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/site.tf
+++ b/ci/terraform/oidc/site.tf
@@ -73,6 +73,23 @@ locals {
     integrationLatency   = "$context.integration.latency"
     integrationRequestId = "$context.integration.requestId"
   })
+
+  warmer_deployment_event_pattern = jsonencode({
+    "source" : [
+      "uk.gov.di.deployer"
+    ],
+    "resources" : [
+      "oidc"
+    ],
+    "detail-type" : [
+      "deployment-complete"
+    ],
+    "detail" : {
+      "environment" : [
+        var.environment
+      ]
+    }
+  })
 }
 
 data "aws_caller_identity" "current" {}

--- a/ci/terraform/oidc/token.tf
+++ b/ci/terraform/oidc/token.tf
@@ -41,6 +41,7 @@ module "token" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
+  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/trustmarks.tf
+++ b/ci/terraform/oidc/trustmarks.tf
@@ -40,6 +40,7 @@ module "trustmarks" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
+  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/update.tf
+++ b/ci/terraform/oidc/update.tf
@@ -37,6 +37,7 @@ module "update" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
+  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/update_profile.tf
+++ b/ci/terraform/oidc/update_profile.tf
@@ -41,6 +41,7 @@ module "update_profile" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
+  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/userexists.tf
+++ b/ci/terraform/oidc/userexists.tf
@@ -40,6 +40,7 @@ module "userexists" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
+  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -40,6 +40,7 @@ module "userinfo" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
+  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/verify_code.tf
+++ b/ci/terraform/oidc/verify_code.tf
@@ -41,6 +41,7 @@ module "verify_code" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
+  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/wellknown.tf
+++ b/ci/terraform/oidc/wellknown.tf
@@ -34,6 +34,7 @@ module "openid_configuration_discovery" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
+  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 
   use_localstack = var.use_localstack
 


### PR DESCRIPTION
## What?

- Add a new lambda warmer trigger for custom event
- Custom event will be triggered from Concourse pipeline using `aws put-events` (we may be able to achieve this using CloudTrail events too, but lets start simple).

## Why?

The warmer runs on schedule every 10 mins, if a new version is deployed it may be up to 10 mins before they are warmed by the warmer.
