### PR TITLE
GOVSI-620: Shorten trigger name to avoid 64 char limit

### DIFF
--- a/ci/terraform/account-management/authoriser-warmer.tf
+++ b/ci/terraform/account-management/authoriser-warmer.tf
@@ -138,7 +138,7 @@ resource "aws_lambda_permission" "allow_cloudwatch_to_call_warmer_lambda" {
 resource "aws_cloudwatch_event_rule" "warmer_deployment_trigger_rule" {
   count = var.keep_lambdas_warm ? 1 : 0
 
-  name          = "${aws_lambda_function.warmer_function[0].function_name}-deployment-trigger"
+  name          = "${aws_lambda_function.warmer_function[0].function_name}-on-deploy"
   event_pattern = local.warmer_deployment_event_pattern
   is_enabled    = true
 }

--- a/ci/terraform/modules/endpoint-module/warmer.tf
+++ b/ci/terraform/modules/endpoint-module/warmer.tf
@@ -154,7 +154,7 @@ resource "aws_lambda_permission" "allow_cloudwatch_to_call_warmer_lambda" {
 resource "aws_cloudwatch_event_rule" "warmer_deployment_trigger_rule" {
   count = var.keep_lambda_warm && var.warmer_handler_function_name != null ? 1 : 0
 
-  name          = "${aws_lambda_function.warmer_function[0].function_name}-deployment-trigger"
+  name          = "${aws_lambda_function.warmer_function[0].function_name}-on-deploy"
   event_pattern = var.warmer_deployment_event_pattern
   is_enabled    = true
 }


### PR DESCRIPTION
## What?

- Shorten trigger name to avoid 64 char limit

## Why?

 When deploying to `integration` and `production` the name blows the limit and the deployment failes

## Related PRs

#699 