### PR TITLE
GOVSI-620: Use CloudTrail pattern instead of custom event

### DIFF
--- a/ci/terraform/account-management/authenticate.tf
+++ b/ci/terraform/account-management/authenticate.tf
@@ -32,7 +32,6 @@ module "authenticate" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
-  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 
   use_localstack = var.use_localstack
 }

--- a/ci/terraform/account-management/remove-account.tf
+++ b/ci/terraform/account-management/remove-account.tf
@@ -33,5 +33,4 @@ module "delete_account" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
-  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 }

--- a/ci/terraform/account-management/send_otp_notification.tf
+++ b/ci/terraform/account-management/send_otp_notification.tf
@@ -38,7 +38,6 @@ module "send_otp_notification" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
-  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 
   depends_on = [
     aws_api_gateway_rest_api.di_account_management_api,

--- a/ci/terraform/account-management/site.tf
+++ b/ci/terraform/account-management/site.tf
@@ -70,22 +70,4 @@ locals {
     authorizerRequestId          = "$context.authorizer.requestId"
     authorizerStatus             = "$context.authorizer.status"
   })
-
-  warmer_deployment_event_pattern = jsonencode({
-    "source" : [
-      "uk.gov.di.deployer"
-    ],
-    "resources" : [
-      "account-management-api"
-    ],
-    "detail-type" : [
-      "deployment-complete"
-    ],
-    "detail" : {
-      "environment" : [
-        var.environment
-      ]
-    }
-  })
-
 }

--- a/ci/terraform/account-management/update-email.tf
+++ b/ci/terraform/account-management/update-email.tf
@@ -37,5 +37,4 @@ module "update_email" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
-  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 }

--- a/ci/terraform/account-management/update-password.tf
+++ b/ci/terraform/account-management/update-password.tf
@@ -33,5 +33,4 @@ module "update_password" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
-  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 }

--- a/ci/terraform/account-management/update-phone-number.tf
+++ b/ci/terraform/account-management/update-phone-number.tf
@@ -37,5 +37,4 @@ module "update_phone_number" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
-  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 }

--- a/ci/terraform/modules/endpoint-module/variables.tf
+++ b/ci/terraform/modules/endpoint-module/variables.tf
@@ -134,10 +134,6 @@ variable "warmer_delay_millis" {
   default = 200
 }
 
-variable "warmer_deployment_event_pattern" {
-  description = "The Cloudwatch event pattern that will manually trigger the warmer"
-}
-
 variable "authorizer_id" {
   type    = string
   default = null

--- a/ci/terraform/modules/endpoint-module/warmer.tf
+++ b/ci/terraform/modules/endpoint-module/warmer.tf
@@ -144,7 +144,8 @@ resource "aws_cloudwatch_event_target" "warmer_schedule_target" {
 resource "aws_lambda_permission" "allow_cloudwatch_to_call_warmer_lambda" {
   count = var.keep_lambda_warm && var.warmer_handler_function_name != null ? 1 : 0
 
-  statement_id  = "AllowExecutionFromCloudWatchScheduleRule"
+  statement_id_prefix = "AllowExecutionFromCloudWatchScheduleRule"
+
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.warmer_function[0].function_name
   principal     = "events.amazonaws.com"
@@ -154,9 +155,30 @@ resource "aws_lambda_permission" "allow_cloudwatch_to_call_warmer_lambda" {
 resource "aws_cloudwatch_event_rule" "warmer_deployment_trigger_rule" {
   count = var.keep_lambda_warm && var.warmer_handler_function_name != null ? 1 : 0
 
-  name          = "${aws_lambda_function.warmer_function[0].function_name}-on-deploy"
-  event_pattern = var.warmer_deployment_event_pattern
-  is_enabled    = true
+  name = "${aws_lambda_function.warmer_function[0].function_name}-on-deploy"
+  event_pattern = jsonencode({
+    "source" : [
+      "aws.lambda"
+    ],
+    "detail-type" : [
+      "AWS API Call via CloudTrail"
+    ],
+    "detail" : {
+      "eventSource" : [
+        "lambda.amazonaws.com"
+      ],
+      "eventName" : [
+        "UpdateAlias20150331"
+      ],
+      "requestParameters" : {
+        "functionName" : [
+          aws_lambda_function.endpoint_lambda.arn
+        ]
+      }
+    }
+  })
+
+  is_enabled = true
 }
 
 resource "aws_cloudwatch_event_target" "warmer_deployment_target" {
@@ -169,7 +191,8 @@ resource "aws_cloudwatch_event_target" "warmer_deployment_target" {
 resource "aws_lambda_permission" "allow_cloudwatch_deployment_rule_to_call_warmer_lambda" {
   count = var.keep_lambda_warm && var.warmer_handler_function_name != null ? 1 : 0
 
-  statement_id  = "AllowExecutionFromCloudWatchDeploymentRule"
+  statement_id_prefix = "AllowExecutionFromCloudWatchDeploymentRule"
+
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.warmer_function[0].function_name
   principal     = "events.amazonaws.com"

--- a/ci/terraform/oidc/auth-code.tf
+++ b/ci/terraform/oidc/auth-code.tf
@@ -39,7 +39,6 @@ module "auth-code" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
-  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 
   use_localstack = var.use_localstack
   depends_on = [

--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -41,7 +41,6 @@ module "authorize" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
-  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 
   use_localstack = var.use_localstack
   depends_on = [

--- a/ci/terraform/oidc/client-info.tf
+++ b/ci/terraform/oidc/client-info.tf
@@ -40,7 +40,6 @@ module "client-info" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
-  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/jwks.tf
+++ b/ci/terraform/oidc/jwks.tf
@@ -34,7 +34,6 @@ module "jwks" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
-  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/login.tf
+++ b/ci/terraform/oidc/login.tf
@@ -41,7 +41,6 @@ module "login" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
-  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 
   use_localstack = var.use_localstack
 }

--- a/ci/terraform/oidc/logout.tf
+++ b/ci/terraform/oidc/logout.tf
@@ -42,7 +42,6 @@ module "logout" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
-  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/mfa.tf
+++ b/ci/terraform/oidc/mfa.tf
@@ -40,7 +40,6 @@ module "mfa" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
-  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/register.tf
+++ b/ci/terraform/oidc/register.tf
@@ -36,7 +36,6 @@ module "register" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
-  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/reset-password-request.tf
+++ b/ci/terraform/oidc/reset-password-request.tf
@@ -42,7 +42,6 @@ module "reset-password-request" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
-  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/reset_password.tf
+++ b/ci/terraform/oidc/reset_password.tf
@@ -43,7 +43,6 @@ module "reset_password" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
-  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/send_notification.tf
+++ b/ci/terraform/oidc/send_notification.tf
@@ -39,7 +39,6 @@ module "send_notification" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
-  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/signup.tf
+++ b/ci/terraform/oidc/signup.tf
@@ -41,7 +41,6 @@ module "signup" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
-  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/site.tf
+++ b/ci/terraform/oidc/site.tf
@@ -73,23 +73,6 @@ locals {
     integrationLatency   = "$context.integration.latency"
     integrationRequestId = "$context.integration.requestId"
   })
-
-  warmer_deployment_event_pattern = jsonencode({
-    "source" : [
-      "uk.gov.di.deployer"
-    ],
-    "resources" : [
-      "oidc"
-    ],
-    "detail-type" : [
-      "deployment-complete"
-    ],
-    "detail" : {
-      "environment" : [
-        var.environment
-      ]
-    }
-  })
 }
 
 data "aws_caller_identity" "current" {}

--- a/ci/terraform/oidc/token.tf
+++ b/ci/terraform/oidc/token.tf
@@ -41,7 +41,6 @@ module "token" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
-  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/trustmarks.tf
+++ b/ci/terraform/oidc/trustmarks.tf
@@ -40,7 +40,6 @@ module "trustmarks" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
-  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/update.tf
+++ b/ci/terraform/oidc/update.tf
@@ -37,7 +37,6 @@ module "update" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
-  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/update_profile.tf
+++ b/ci/terraform/oidc/update_profile.tf
@@ -41,7 +41,6 @@ module "update_profile" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
-  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/userexists.tf
+++ b/ci/terraform/oidc/userexists.tf
@@ -40,7 +40,6 @@ module "userexists" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
-  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -40,7 +40,6 @@ module "userinfo" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
-  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/verify_code.tf
+++ b/ci/terraform/oidc/verify_code.tf
@@ -41,7 +41,6 @@ module "verify_code" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
-  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 
   use_localstack = var.use_localstack
 

--- a/ci/terraform/oidc/wellknown.tf
+++ b/ci/terraform/oidc/wellknown.tf
@@ -34,7 +34,6 @@ module "openid_configuration_discovery" {
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }
-  warmer_deployment_event_pattern = local.warmer_deployment_event_pattern
 
   use_localstack = var.use_localstack
 


### PR DESCRIPTION
## What?

- Rather than using a custom event and pattern use a CloudTrail pattern instead
- Match the event of a successful `UpdateAlias` call to trigger the lambda, this should mean the lambda warmer is called as soon as the new version has been attached to the alias
- Use `statement_id_prefix` on the Lambda permission instead of a fixed `statement_id` as Terraform doesn't destroy before creation and bombs out with a "duplicate name" error when updating permissions.

## Why?

This seems a neater way of doing it than using a custom event which we must remember to trigger in the pipeline

## Related PRs

#699 