### PR TITLE
GOVSI-865: Use unique state file name for build deploy

### DIFF
--- a/ci/tasks/deploy-audit-processors.yml
+++ b/ci/tasks/deploy-audit-processors.yml
@@ -24,7 +24,7 @@ run:
       terraform init -input=false \
         -backend-config "role_arn=${DEPLOYER_ROLE_ARN}" \
         -backend-config "bucket=${STATE_BUCKET}" \
-        -backend-config "key=${DEPLOY_ENVIRONMENT}-terraform.tfstate" \
+        -backend-config "key=${DEPLOY_ENVIRONMENT}-audit-terraform.tfstate" \
         -backend-config "encrypt=true" \
         -backend-config "region=eu-west-2"
 


### PR DESCRIPTION
## What?

- We were using the same state file name as for the OIDC deploy, use a unique name

## Why?

The conflict caused inadvertent destruction of resources