### PR TITLE
GOVSI-619: use double quotes to interpolate test client email allowlist

### DIFF
--- a/ci/tasks/deploy-shared-api.yml
+++ b/ci/tasks/deploy-shared-api.yml
@@ -37,7 +37,7 @@ run:
         -var "environment=${DEPLOY_ENVIRONMENT}" \
         -var 'logging_endpoint_enabled=true' \
         -var 'logging_endpoint_arn=arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod' \
-        -var 'test_client_email_allowlist=${TEST_CLIENT_EMAIL_ALLOWLIST}' \
+        -var "test_client_email_allowlist=${TEST_CLIENT_EMAIL_ALLOWLIST}" \
         -var-file ${DEPLOY_ENVIRONMENT}-stub-clients.tfvars \
         -var-file ${DEPLOY_ENVIRONMENT}-sizing.tfvars \
 


### PR DESCRIPTION
## What?

Use double quotes to interpolate test client email allowlist

## Why?

${TEST_CLIENT_EMAIL_ALLOWLIST} has been added to the client-registry list rather than the actual email addresses.

## Related PRs

#716 