### PR TITLE
GOVSI-619: use double quotes to interpolate test client global switch

### DIFF
--- a/ci/tasks/deploy-oidc-api.yml
+++ b/ci/tasks/deploy-oidc-api.yml
@@ -59,7 +59,7 @@ run:
         -var "account_management_url=${AM_URL}" \
         -var 'test_client_verify_email_otp=${TEST_CLIENT_VERIFY_EMAIL_OTP}' \
         -var 'test_client_verify_phone_number_otp=${TEST_CLIENT_VERIFY_PHONE_NUMBER_OTP}' \
-        -var 'test_clients_enabled=${TEST_CLIENTS_ENABLED}' \
+        -var "test_clients_enabled=${TEST_CLIENTS_ENABLED}" \
         -var-file "${DEPLOY_ENVIRONMENT}-overrides.tfvars" \
 
       terraform output --json > ../../../../terraform-outputs/${DEPLOY_ENVIRONMENT}-terraform-outputs.json


### PR DESCRIPTION
## What?

Use double quotes to interpolate test client global switch.

## Why?

${TEST_CLIENTS_ENABLED} is the value set without the correct interpolation.

## Related PRs

#730 