### PR TITLE
GOVSI-619: ensure test client environment variables are set

### DIFF
--- a/ci/tasks/deploy-oidc-api.yml
+++ b/ci/tasks/deploy-oidc-api.yml
@@ -57,8 +57,8 @@ run:
         -var "dns_state_role=${DNS_DEPLOYER_ROLE_ARN}" \
         -var "shared_state_bucket=${STATE_BUCKET}" \
         -var "account_management_url=${AM_URL}" \
-        -var 'test_client_verify_email_otp=${TEST_CLIENT_VERIFY_EMAIL_OTP}' \
-        -var 'test_client_verify_phone_number_otp=${TEST_CLIENT_VERIFY_PHONE_NUMBER_OTP}' \
+        -var "test_client_verify_email_otp=${TEST_CLIENT_VERIFY_EMAIL_OTP}" \
+        -var "test_client_verify_phone_number_otp=${TEST_CLIENT_VERIFY_PHONE_NUMBER_OTP}" \
         -var "test_clients_enabled=${TEST_CLIENTS_ENABLED}" \
         -var-file "${DEPLOY_ENVIRONMENT}-overrides.tfvars" \
 

--- a/ci/terraform/oidc/send_notification.tf
+++ b/ci/terraform/oidc/send_notification.tf
@@ -16,6 +16,7 @@ module "send_notification" {
     REDIS_PORT              = local.external_redis_port
     REDIS_PASSWORD          = local.external_redis_password
     REDIS_TLS               = var.redis_use_tls
+    TEST_CLIENTS_ENABLED    = var.test_clients_enabled
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.SendNotificationHandler::handleRequest"
 

--- a/ci/terraform/oidc/verify_code.tf
+++ b/ci/terraform/oidc/verify_code.tf
@@ -20,6 +20,7 @@ module "verify_code" {
     TERMS_CONDITIONS_VERSION            = var.terms_and_conditions
     TEST_CLIENT_VERIFY_EMAIL_OTP        = var.test_client_verify_email_otp
     TEST_CLIENT_VERIFY_PHONE_NUMBER_OTP = var.test_client_verify_phone_number_otp
+    TEST_CLIENTS_ENABLED                = var.test_clients_enabled
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.VerifyCodeHandler::handleRequest"
 


### PR DESCRIPTION
## What?

Ensure test client environment variables are set.
Pass in the global flag to the lambdas as an environment variable.

## Why?

Test client environment variables not being set in the lambdas.