### PR TITLE
GOVSI-380: submit metadata pairs in audit payload

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/matchers/AuditMessageMatcher.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/matchers/AuditMessageMatcher.java
@@ -4,6 +4,7 @@ import org.hamcrest.Description;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 import uk.gov.di.audit.AuditPayload.AuditEvent;
 import uk.gov.di.audit.AuditPayload.SignedAuditEvent;
+import uk.gov.di.authentication.shared.services.AuditService.MetadataPair;
 
 import java.util.Base64;
 import java.util.function.Function;
@@ -60,6 +61,15 @@ public class AuditMessageMatcher<T> extends TypeSafeDiagnosingMatcher<String> {
         Function<AuditEvent, String> getPhoneNumber =
                 (auditEvent) -> auditEvent.getUser().getPhoneNumber();
         return new AuditMessageMatcher<>("phone number", getPhoneNumber, phoneNumber);
+    }
+
+    public static AuditMessageMatcher<String> hasMetadataPair(MetadataPair metadataPair) {
+        Function<AuditEvent, String> getValue =
+                (auditEvent) -> auditEvent.getExtensionsOrThrow(metadataPair.getKey());
+        return new AuditMessageMatcher<>(
+                String.format("metadata value for key '%s'", metadataPair.getKey()),
+                getValue,
+                metadataPair.getValue().toString());
     }
 
     @Override

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
@@ -9,6 +9,7 @@ import uk.gov.di.authentication.shared.domain.AuditableEvent;
 
 import java.nio.ByteBuffer;
 import java.time.Clock;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.Objects;
 import java.util.Optional;
@@ -77,7 +78,7 @@ public class AuditService {
         var uniqueId = UUID.randomUUID();
         var timestamp = clock.instant().toString();
 
-        var auditEvent =
+        var auditEventBuilder =
                 AuditEvent.newBuilder()
                         .setEventName(eventEnum.toString())
                         .setEventId(uniqueId.toString())
@@ -93,8 +94,15 @@ public class AuditService {
                                                 Optional.ofNullable(ipAddress).orElse(UNKNOWN))
                                         .setPhoneNumber(
                                                 Optional.ofNullable(phoneNumber).orElse(UNKNOWN))
-                                        .build())
-                        .build();
+                                        .build());
+
+        Arrays.stream(metadataPairs)
+                .forEach(
+                        pair ->
+                                auditEventBuilder.putExtensions(
+                                        pair.getKey(), pair.getValue().toString()));
+
+        var auditEvent = auditEventBuilder.build();
 
         var signedEventBuilder =
                 SignedAuditEvent.newBuilder()
@@ -124,6 +132,14 @@ public class AuditService {
 
         public static MetadataPair pair(String key, Object value) {
             return new MetadataPair(key, value);
+        }
+
+        public String getKey() {
+            return key;
+        }
+
+        public Object getValue() {
+            return value;
         }
 
         @Override

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
@@ -29,6 +29,7 @@ import static uk.gov.di.authentication.shared.matchers.AuditMessageMatcher.hasCl
 import static uk.gov.di.authentication.shared.matchers.AuditMessageMatcher.hasEmail;
 import static uk.gov.di.authentication.shared.matchers.AuditMessageMatcher.hasEventName;
 import static uk.gov.di.authentication.shared.matchers.AuditMessageMatcher.hasIpAddress;
+import static uk.gov.di.authentication.shared.matchers.AuditMessageMatcher.hasMetadataPair;
 import static uk.gov.di.authentication.shared.matchers.AuditMessageMatcher.hasPhoneNumber;
 import static uk.gov.di.authentication.shared.matchers.AuditMessageMatcher.hasRequestId;
 import static uk.gov.di.authentication.shared.matchers.AuditMessageMatcher.hasSessionId;
@@ -141,5 +142,7 @@ class AuditServiceTest {
 
         assertThat(serialisedAuditMessage, hasTimestamp(FIXED_TIMESTAMP));
         assertThat(serialisedAuditMessage, hasEventName(TEST_EVENT_ONE.toString()));
+        assertThat(serialisedAuditMessage, hasMetadataPair(pair("key", "value")));
+        assertThat(serialisedAuditMessage, hasMetadataPair(pair("key2", "value2")));
     }
 }


### PR DESCRIPTION
## What?

Submit metadata pairs in audit payload.

## Why?

These provide a mechanism to submit arbitrary key-value pairs.  We are using this for things such as error messages.
