### PR TITLE
GOVSI-619: suppress account created emails for test users on test clients

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
@@ -113,10 +113,12 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
                         userContext.getSession().getSessionId());
                 NotifyRequest notifyRequest =
                         new NotifyRequest(request.getEmail(), ACCOUNT_CREATED_CONFIRMATION);
-                sqsClient.send(objectMapper.writeValueAsString((notifyRequest)));
-                LOGGER.info(
-                        "AccountCreatedConfirmation email placed on queue for session: {}",
-                        userContext.getSession().getSessionId());
+                if (!isTestClientAndAllowedEmail(userContext, ACCOUNT_CREATED_CONFIRMATION)) {
+                    sqsClient.send(objectMapper.writeValueAsString((notifyRequest)));
+                    LOGGER.info(
+                            "AccountCreatedConfirmation email placed on queue for session: {}",
+                            userContext.getSession().getSessionId());
+                }
                 return generateEmptySuccessApiGatewayResponse();
             }
             boolean codeRequestValid =

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
@@ -486,6 +486,27 @@ class SendNotificationHandlerTest {
         assertEquals(204, result.getStatusCode());
     }
 
+    @Test
+    public void shouldReturn204AndNotSendAccountCreationEmailForTestClientAndTestUser()
+            throws JsonProcessingException {
+        usingValidSession();
+        usingValidClientSession(TEST_CLIENT_ID);
+        when(configurationService.isTestClientsEnabled()).thenReturn(true);
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        event.setHeaders(Map.of("Session-Id", session.getSessionId()));
+        event.setBody(
+                format(
+                        "{ \"email\": \"%s\", \"notificationType\": \"%s\" }",
+                        TEST_EMAIL_ADDRESS, ACCOUNT_CREATED_CONFIRMATION));
+        APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
+
+        NotifyRequest notifyRequest =
+                new NotifyRequest(TEST_EMAIL_ADDRESS, ACCOUNT_CREATED_CONFIRMATION);
+        verify(awsSqsClient, never()).send(objectMapper.writeValueAsString(notifyRequest));
+
+        assertEquals(204, result.getStatusCode());
+    }
+
     private void maxOutCodeRequestCount() {
         session.incrementCodeRequestCount();
         session.incrementCodeRequestCount();


### PR DESCRIPTION
## What?

Suppress account created emails for test users on test clients

## Why?

Notifications for test users on test clients are suppressed in local and build environments.
The account created email was built in parallel with the test client work so suppression currently missing.
