### PR TITLE
Fix CONSENT_REQUIRED state bug that allowed users to skip mfa during uplift

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/state/StateMachine.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/state/StateMachine.java
@@ -416,6 +416,9 @@ public class StateMachine<T, A, C> {
                         on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED).then(NEW))
                 .when(CONSENT_REQUIRED)
                 .allow(
+                        on(USER_HAS_STARTED_A_NEW_JOURNEY)
+                                .then(UPLIFT_REQUIRED_CM)
+                                .ifCondition(upliftRequired()),
                         on(USER_HAS_ACTIONED_CONSENT).then(CONSENT_ADDED),
                         on(USER_HAS_STARTED_A_NEW_JOURNEY)
                                 .then(UPDATED_TERMS_AND_CONDITIONS)

--- a/shared/src/test/java/uk/gov/di/authentication/shared/state/StateMachineJourneyTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/state/StateMachineJourneyTest.java
@@ -11,6 +11,7 @@ import uk.gov.di.authentication.shared.helpers.IdGenerator;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static uk.gov.di.authentication.shared.entity.SessionState.CONSENT_REQUIRED;
 import static uk.gov.di.authentication.shared.entity.SessionState.EMAIL_MAX_CODES_SENT;
 import static uk.gov.di.authentication.shared.entity.SessionState.MFA_CODE_MAX_RETRIES_REACHED;
 import static uk.gov.di.authentication.shared.entity.SessionState.MFA_CODE_NOT_VALID;
@@ -153,6 +154,25 @@ public class StateMachineJourneyTest {
         final SessionState nextState =
                 stateMachine.transition(
                         MFA_CODE_MAX_RETRIES_REACHED,
+                        SessionAction.USER_HAS_STARTED_A_NEW_JOURNEY,
+                        userContext);
+        assertThat(nextState, equalTo(UPLIFT_REQUIRED_CM));
+    }
+
+    @Test
+    public void
+            returns_UPLIFT_REQUIRED_CM_WhenUserStartsNewJourneyAfterReachingConsentPageWhilstUplifting() {
+        UserContext userContext =
+                UserContext.builder(
+                                session.setCurrentCredentialStrength(
+                                        CredentialTrustLevel.LOW_LEVEL))
+                        .withClientSession(
+                                new ClientSession(null, null, null)
+                                        .setEffectiveVectorOfTrust(VectorOfTrust.getDefaults()))
+                        .build();
+        final SessionState nextState =
+                stateMachine.transition(
+                        CONSENT_REQUIRED,
                         SessionAction.USER_HAS_STARTED_A_NEW_JOURNEY,
                         userContext);
         assertThat(nextState, equalTo(UPLIFT_REQUIRED_CM));


### PR DESCRIPTION
## What?

Fixed state machine to allow users to go through the uplift process if they start a new journey when currently in the CONSENT_REQUIRED state.

## Why?

There is a current issue that means users would be able to skip the mfa requirements and go straight to the consent page.
