### PR TITLE
GOVSI-619: add test client environment variable switch to mfa lambda

### DIFF
--- a/ci/terraform/oidc/mfa.tf
+++ b/ci/terraform/oidc/mfa.tf
@@ -17,6 +17,7 @@ module "mfa" {
     REDIS_PASSWORD          = local.external_redis_password
     REDIS_TLS               = var.redis_use_tls
     DYNAMO_ENDPOINT         = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    TEST_CLIENTS_ENABLED    = var.test_clients_enabled
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.MfaHandler::handleRequest"
 


### PR DESCRIPTION
## What?

Add test client environment variable switch to mfa lambda

## Why?

Needs the switch to enable test client behaviour.

## Related PRs

#764 