### PR TITLE
GOVSI-489: Create bucket for smoke test SMS codes

### DIFF
--- a/ci/terraform/shared/outputs.tf
+++ b/ci/terraform/shared/outputs.tf
@@ -73,3 +73,7 @@ output "stub_rp_client_credentials" {
 output "cloudwatch_encryption_key_arn" {
   value = aws_kms_key.cloudwatch_log_encryption.arn
 }
+
+output "sms_bucket_name_arn" {
+  value = aws_s3_bucket.smoketest_sms_bucket.arn
+}

--- a/ci/terraform/shared/s3.tf
+++ b/ci/terraform/shared/s3.tf
@@ -1,0 +1,15 @@
+resource "aws_s3_bucket" "smoketest_sms_bucket" {
+  bucket = "${var.environment}-smoke-test-sms-codes"
+
+  acl = "private"
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
+  tags = local.default_tags
+}


### PR DESCRIPTION
## What?

- Create code for SMS codes that will be used for smoketests

## Why?

We want a controlled way of passing OTP codes to the smoke tester