### PR TITLE
Fix state machine bug to allow transition from reset password state back to entering email

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/state/StateMachine.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/state/StateMachine.java
@@ -157,7 +157,8 @@ public class StateMachine<T, A, C> {
                                 .then(RESET_PASSWORD_LINK_MAX_RETRIES_REACHED),
                         on(SYSTEM_HAS_SENT_RESET_PASSWORD_LINK).then(RESET_PASSWORD_LINK_SENT),
                         on(USER_HAS_STARTED_A_NEW_JOURNEY).then(NEW),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED).then(NEW))
+                        on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED).then(NEW),
+                        on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(AUTHENTICATION_REQUIRED))
                 .when(RESET_PASSWORD_LINK_MAX_RETRIES_REACHED)
                 .allow(
                         on(SYSTEM_HAS_SENT_RESET_PASSWORD_LINK).then(RESET_PASSWORD_LINK_SENT),

--- a/shared/src/test/java/uk/gov/di/authentication/shared/state/StateMachineJourneyTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/state/StateMachineJourneyTest.java
@@ -10,6 +10,7 @@ import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import net.minidev.json.JSONArray;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.entity.ClientConsent;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.Session;
@@ -24,6 +25,7 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 import java.net.URI;
 import java.util.Collections;
 import java.util.Date;
+import java.util.Set;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -43,8 +45,9 @@ import static uk.gov.di.authentication.shared.entity.SessionState.VERIFY_EMAIL_C
 
 public class StateMachineJourneyTest {
 
+    public static final ClientID CLIENT_ID = new ClientID("test-client");
+
     private static final URI REDIRECT_URI = URI.create("test-uri");
-    private static final ClientID CLIENT_ID = new ClientID("test-client");
 
     private final ConfigurationService mockConfigurationService = mock(ConfigurationService.class);
 
@@ -208,11 +211,15 @@ public class StateMachineJourneyTest {
     }
 
     public static UserProfile generateUserProfile(
-            boolean phoneNumberVerified, String acceptedTermsAndConditionsVersion) {
+            boolean phoneNumberVerified,
+            String acceptedTermsAndConditionsVersion,
+            Set<String> consentClaims) {
         UserProfile userProfile = new UserProfile();
         userProfile.setPhoneNumberVerified(phoneNumberVerified);
         userProfile.setTermsAndConditions(
                 new TermsAndConditions(acceptedTermsAndConditionsVersion, new Date().toString()));
+        userProfile.setClientConsent(
+                new ClientConsent(CLIENT_ID.toString(), consentClaims, new Date().toString()));
         return userProfile;
     }
 
@@ -229,6 +236,8 @@ public class StateMachineJourneyTest {
         Scope scope = new Scope();
         Nonce nonce = new Nonce();
         scope.add(OIDCScopeValue.OPENID);
+        scope.add("phone");
+        scope.add("email");
         JSONArray jsonArray = new JSONArray();
         jsonArray.add(vtr);
         return new AuthenticationRequest.Builder(responseType, scope, CLIENT_ID, REDIRECT_URI)

--- a/shared/src/test/java/uk/gov/di/authentication/shared/state/journeys/SignInJourneyTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/state/journeys/SignInJourneyTest.java
@@ -23,23 +23,27 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.shared.entity.SessionAction.SYSTEM_HAS_ISSUED_AUTHORIZATION_CODE;
 import static uk.gov.di.authentication.shared.entity.SessionAction.SYSTEM_HAS_SENT_MFA_CODE;
+import static uk.gov.di.authentication.shared.entity.SessionAction.SYSTEM_HAS_SENT_RESET_PASSWORD_LINK;
 import static uk.gov.di.authentication.shared.entity.SessionAction.USER_ENTERED_REGISTERED_EMAIL_ADDRESS;
+import static uk.gov.di.authentication.shared.entity.SessionAction.USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS;
 import static uk.gov.di.authentication.shared.entity.SessionAction.USER_ENTERED_VALID_CREDENTIALS;
 import static uk.gov.di.authentication.shared.entity.SessionAction.USER_ENTERED_VALID_MFA_CODE;
 import static uk.gov.di.authentication.shared.entity.SessionAction.USER_HAS_STARTED_A_NEW_JOURNEY;
+import static uk.gov.di.authentication.shared.entity.SessionState.AUTHENTICATED;
 import static uk.gov.di.authentication.shared.entity.SessionState.AUTHENTICATION_REQUIRED;
 import static uk.gov.di.authentication.shared.entity.SessionState.LOGGED_IN;
+import static uk.gov.di.authentication.shared.entity.SessionState.MFA_CODE_VERIFIED;
 import static uk.gov.di.authentication.shared.entity.SessionState.MFA_SMS_CODE_SENT;
 import static uk.gov.di.authentication.shared.entity.SessionState.NEW;
-import static uk.gov.di.authentication.shared.entity.SessionState.UPDATED_TERMS_AND_CONDITIONS;
-import static uk.gov.di.authentication.shared.entity.SessionState.UPLIFT_REQUIRED_CM;
+import static uk.gov.di.authentication.shared.entity.SessionState.RESET_PASSWORD_LINK_SENT;
 import static uk.gov.di.authentication.shared.state.StateMachineJourneyTest.CLIENT_ID;
 import static uk.gov.di.authentication.shared.state.StateMachineJourneyTest.generateAuthRequest;
 import static uk.gov.di.authentication.shared.state.StateMachineJourneyTest.generateLowLevelVectorOfTrust;
 import static uk.gov.di.authentication.shared.state.StateMachineJourneyTest.generateUserProfile;
 
-public class TermsAndConditionsJourneyTest {
+public class SignInJourneyTest {
     private final ConfigurationService mockConfigurationService = mock(ConfigurationService.class);
 
     private final Session session = new Session(IdGenerator.generate());
@@ -54,10 +58,18 @@ public class TermsAndConditionsJourneyTest {
     }
 
     @Test
-    public void testCanReachTermsAndConditionsWithout2FA() {
+    public void testCanSignInWithout2FA() {
         UserProfile userProfile =
                 generateUserProfile(
-                        true, "0.1", new HashSet<String>(Arrays.asList("phone", "email")));
+                        true,
+                        "1.0",
+                        new HashSet<String>(
+                                Arrays.asList(
+                                        "phone_number",
+                                        "phone_number_verified",
+                                        "email",
+                                        "email_verified",
+                                        "sub")));
 
         UserContext userContext =
                 UserContext.builder(
@@ -80,9 +92,7 @@ public class TermsAndConditionsJourneyTest {
                                 USER_ENTERED_REGISTERED_EMAIL_ADDRESS,
                                 AUTHENTICATION_REQUIRED),
                         new JourneyTransition(
-                                userContext,
-                                USER_ENTERED_VALID_CREDENTIALS,
-                                UPDATED_TERMS_AND_CONDITIONS));
+                                userContext, USER_ENTERED_VALID_CREDENTIALS, AUTHENTICATED));
 
         SessionState currentState = NEW;
 
@@ -97,21 +107,29 @@ public class TermsAndConditionsJourneyTest {
     }
 
     @Test
-    public void testCanReachTermsAndConditionsWith2FA() {
+    public void testCanSignInWith2FA() {
         UserProfile userProfile =
                 generateUserProfile(
-                        true, "0.1", new HashSet<String>(Arrays.asList("phone", "email")));
+                        true,
+                        "1.0",
+                        new HashSet<String>(
+                                Arrays.asList(
+                                        "phone_number",
+                                        "phone_number_verified",
+                                        "email",
+                                        "email_verified",
+                                        "sub")));
 
         UserContext userContext =
                 UserContext.builder(
                                 session.setCurrentCredentialStrength(
-                                        CredentialTrustLevel.MEDIUM_LEVEL))
+                                        CredentialTrustLevel.LOW_LEVEL))
                         .withClientSession(
                                 new ClientSession(
                                                 generateAuthRequest("Cl.Cm").toParameters(),
                                                 null,
                                                 null)
-                                        .setEffectiveVectorOfTrust(generateLowLevelVectorOfTrust()))
+                                        .setEffectiveVectorOfTrust(VectorOfTrust.getDefaults()))
                         .withUserProfile(userProfile)
                         .withClient(new ClientRegistry().setClientID(CLIENT_ID.toString()))
                         .build();
@@ -127,9 +145,9 @@ public class TermsAndConditionsJourneyTest {
                         new JourneyTransition(
                                 userContext, SYSTEM_HAS_SENT_MFA_CODE, MFA_SMS_CODE_SENT),
                         new JourneyTransition(
-                                userContext,
-                                USER_ENTERED_VALID_MFA_CODE,
-                                UPDATED_TERMS_AND_CONDITIONS));
+                                userContext, USER_ENTERED_VALID_MFA_CODE, MFA_CODE_VERIFIED),
+                        new JourneyTransition(
+                                userContext, SYSTEM_HAS_ISSUED_AUTHORIZATION_CODE, AUTHENTICATED));
 
         SessionState currentState = NEW;
 
@@ -145,10 +163,18 @@ public class TermsAndConditionsJourneyTest {
 
     @Test
     public void
-            testAfterReachingTermsAndConditionsNewSessionShouldGoBackToTermsAndConditionsIfUpliftIsNotRequired() {
+            testCanReSignInUsingOriginalLoginDetailsAfterRequestingAPasswordResetAndStartingANewJourney() {
         UserProfile userProfile =
                 generateUserProfile(
-                        true, "0.1", new HashSet<String>(Arrays.asList("phone", "email")));
+                        true,
+                        "1.0",
+                        new HashSet<String>(
+                                Arrays.asList(
+                                        "phone_number",
+                                        "phone_number_verified",
+                                        "email",
+                                        "email_verified",
+                                        "sub")));
 
         UserContext userContext =
                 UserContext.builder(
@@ -172,12 +198,15 @@ public class TermsAndConditionsJourneyTest {
                                 AUTHENTICATION_REQUIRED),
                         new JourneyTransition(
                                 userContext,
-                                USER_ENTERED_VALID_CREDENTIALS,
-                                UPDATED_TERMS_AND_CONDITIONS),
+                                SYSTEM_HAS_SENT_RESET_PASSWORD_LINK,
+                                RESET_PASSWORD_LINK_SENT),
+                        new JourneyTransition(userContext, USER_HAS_STARTED_A_NEW_JOURNEY, NEW),
                         new JourneyTransition(
                                 userContext,
-                                USER_HAS_STARTED_A_NEW_JOURNEY,
-                                UPDATED_TERMS_AND_CONDITIONS));
+                                USER_ENTERED_REGISTERED_EMAIL_ADDRESS,
+                                AUTHENTICATION_REQUIRED),
+                        new JourneyTransition(
+                                userContext, USER_ENTERED_VALID_CREDENTIALS, AUTHENTICATED));
 
         SessionState currentState = NEW;
 
@@ -193,10 +222,18 @@ public class TermsAndConditionsJourneyTest {
 
     @Test
     public void
-            testNewSessionAfterReachingTermsAndConditionsShouldGoTo_MFA_SMS_CODE_SENT_WhenUpliftIsRequired() {
+            testCanReSignInUsingOriginalLoginDetailsAfterRequestingAPasswordResetAndNotStartingANewJourney() {
         UserProfile userProfile =
                 generateUserProfile(
-                        true, "0.1", new HashSet<String>(Arrays.asList("phone", "email")));
+                        true,
+                        "1.0",
+                        new HashSet<String>(
+                                Arrays.asList(
+                                        "phone_number",
+                                        "phone_number_verified",
+                                        "email",
+                                        "email_verified",
+                                        "sub")));
 
         UserContext userContext =
                 UserContext.builder(
@@ -212,19 +249,6 @@ public class TermsAndConditionsJourneyTest {
                         .withClient(new ClientRegistry().setClientID(CLIENT_ID.toString()))
                         .build();
 
-        UserContext upliftedUserContext =
-                UserContext.builder(
-                                session.setCurrentCredentialStrength(
-                                        CredentialTrustLevel.LOW_LEVEL))
-                        .withClientSession(
-                                new ClientSession(
-                                                generateAuthRequest("Cl").toParameters(),
-                                                null,
-                                                null)
-                                        .setEffectiveVectorOfTrust(VectorOfTrust.getDefaults()))
-                        .withUserProfile(userProfile)
-                        .build();
-
         List<JourneyTransition> transitions =
                 Arrays.asList(
                         new JourneyTransition(
@@ -233,14 +257,12 @@ public class TermsAndConditionsJourneyTest {
                                 AUTHENTICATION_REQUIRED),
                         new JourneyTransition(
                                 userContext,
-                                USER_ENTERED_VALID_CREDENTIALS,
-                                UPDATED_TERMS_AND_CONDITIONS),
+                                SYSTEM_HAS_SENT_RESET_PASSWORD_LINK,
+                                RESET_PASSWORD_LINK_SENT),
                         new JourneyTransition(
-                                upliftedUserContext,
-                                USER_HAS_STARTED_A_NEW_JOURNEY,
-                                UPLIFT_REQUIRED_CM),
-                        new JourneyTransition(
-                                upliftedUserContext, SYSTEM_HAS_SENT_MFA_CODE, MFA_SMS_CODE_SENT));
+                                userContext,
+                                USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS,
+                                AUTHENTICATION_REQUIRED));
 
         SessionState currentState = NEW;
 


### PR DESCRIPTION
## What?

Fix state machine to add missing transition from RESET_PASSWORD_LINK_SENT back to USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS in case they have multiple tabs open.

## Why?

Fix a current bug that results in an invalid state transition when the user has multiple tabs and trys to reset password but then use another tab to re-sign in.
