### PR TITLE
Remove unused inputs

### DIFF
--- a/ci/tasks/deploy-shared-api.yml
+++ b/ci/tasks/deploy-shared-api.yml
@@ -14,9 +14,6 @@ params:
   TEST_CLIENT_EMAIL_ALLOWLIST: ((test-client-email-allowlist))
 inputs:
   - name: api-src
-  - name: oidc-api-release
-  - name: frontend-api-release
-  - name: client-registry-api-release
   - name: account-migration-release
 outputs:
   - name: terraform-outputs


### PR DESCRIPTION
## What?

This task declares some inputs that it doesn't use.  I found this
confusing when I was trying to understand how the pipeline works.

## Why?

To make the pipeline simpler and easier to understand.

## Related PRs

alphagov/di-infrastructure#93