### PR TITLE
GOVSI-867: Make constructor public so it can be initialised by AWS Lambda

### DIFF
--- a/audit-processors/src/main/java/uk/gov/di/authentication/audit/lambda/StorageSQSAuditHandler.java
+++ b/audit-processors/src/main/java/uk/gov/di/authentication/audit/lambda/StorageSQSAuditHandler.java
@@ -23,13 +23,13 @@ public class StorageSQSAuditHandler implements RequestHandler<SQSEvent, Object> 
     private final KmsConnectionService kmsConnectionService;
     private final ConfigurationService service;
 
-    StorageSQSAuditHandler(
+    public StorageSQSAuditHandler(
             KmsConnectionService kmsConnectionService, ConfigurationService service) {
         this.kmsConnectionService = kmsConnectionService;
         this.service = service;
     }
 
-    StorageSQSAuditHandler() {
+    public StorageSQSAuditHandler() {
         this.service = new ConfigurationService();
         this.kmsConnectionService = new KmsConnectionService(service);
     }


### PR DESCRIPTION
This PR addresses the following error:

```
Class uk.gov.di.authentication.audit.lambda.StorageSQSAuditHandler has no public zero-argument constructor: java.lang.Exception
```
