### PR TITLE
GOVSI-867: Parse SNS payloads nested inside SQS messages

### DIFF
--- a/audit-processors/build.gradle
+++ b/audit-processors/build.gradle
@@ -13,7 +13,8 @@ dependencies {
     implementation configurations.lambda,
             configurations.sqs,
             project(":shared"),
-            "com.google.protobuf:protobuf-java:3.18.1"
+            "com.google.protobuf:protobuf-java:3.18.1",
+            "com.google.code.gson:gson:2.8.8"
 
     runtimeOnly configurations.logging_runtime
 

--- a/audit-processors/src/test/java/uk/gov/di/authentication/audit/lambda/StorageSQSAuditHandlerTest.java
+++ b/audit-processors/src/test/java/uk/gov/di/authentication/audit/lambda/StorageSQSAuditHandlerTest.java
@@ -2,6 +2,7 @@ package uk.gov.di.authentication.audit.lambda;
 
 import com.amazonaws.services.lambda.runtime.events.SQSEvent;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
+import com.google.gson.Gson;
 import com.google.protobuf.AbstractMessageLite;
 import com.google.protobuf.ByteString;
 import org.junit.jupiter.api.Test;
@@ -13,6 +14,7 @@ import uk.gov.di.authentication.shared.services.KmsConnectionService;
 import java.nio.ByteBuffer;
 import java.util.Base64;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -55,6 +57,7 @@ public class StorageSQSAuditHandlerTest {
         return Optional.of(payload)
                 .map(AbstractMessageLite::toByteArray)
                 .map(Base64.getEncoder()::encodeToString)
+                .map(encodedPayload -> new Gson().toJson(Map.of("Message", encodedPayload)))
                 .map(
                         body -> {
                             var message = new SQSMessage();


### PR DESCRIPTION
The SQS body will have a JSON object representing most of the original SNS message, which needs parsing out to get to the real payload inside.

