### PR TITLE
GOVSI-888: Use FQDN rather than URL for API Base Path mappings

### DIFF
--- a/ci/terraform/oidc/api-gateway-frontend.tf
+++ b/ci/terraform/oidc/api-gateway-frontend.tf
@@ -161,7 +161,7 @@ resource "aws_api_gateway_base_path_mapping" "frontend_api" {
 
   api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
   stage_name  = aws_api_gateway_stage.endpoint_frontend_stage.stage_name
-  domain_name = module.dns.frontend_api_url
+  domain_name = module.dns.frontend_api_fqdn
 }
 
 module "dashboard_frontend_api" {

--- a/ci/terraform/oidc/api-gateway.tf
+++ b/ci/terraform/oidc/api-gateway.tf
@@ -247,7 +247,7 @@ resource "aws_api_gateway_base_path_mapping" "api" {
 
   api_id      = aws_api_gateway_rest_api.di_authentication_api.id
   stage_name  = aws_api_gateway_stage.endpoint_stage.stage_name
-  domain_name = module.dns.oidc_api_url
+  domain_name = module.dns.oidc_api_fqdn
 }
 
 module "dashboard" {


### PR DESCRIPTION
## What?

- Use FQDN rather than URL for API Base Path mappings

## Why?

We had inadvertently used the URL rather than FQDN in the mapping causing deployment failurs.

## Related PRs

#808 