### PR TITLE
GOVSI-888: Correct calculation of base URL

### DIFF
--- a/ci/terraform/oidc/api-gateway-frontend.tf
+++ b/ci/terraform/oidc/api-gateway-frontend.tf
@@ -28,7 +28,7 @@ resource "aws_api_gateway_usage_plan_key" "di_auth_frontend_usage_plan_key" {
 }
 
 locals {
-  frontend_api_base_url = var.use_localstack ? "${var.aws_endpoint}/restapis/${aws_api_gateway_rest_api.di_authentication_frontend_api.id}/${var.environment}/_user_request_" : "https://${module.dns.frontend_api_url}"
+  frontend_api_base_url = var.use_localstack ? "${var.aws_endpoint}/restapis/${aws_api_gateway_rest_api.di_authentication_frontend_api.id}/${var.environment}/_user_request_" : module.dns.frontend_api_url
 }
 
 resource "aws_api_gateway_deployment" "frontend_deployment" {

--- a/ci/terraform/oidc/api-gateway.tf
+++ b/ci/terraform/oidc/api-gateway.tf
@@ -109,7 +109,7 @@ data "aws_region" "current" {
 }
 
 locals {
-  api_base_url = var.use_localstack ? "${var.aws_endpoint}/restapis/${aws_api_gateway_rest_api.di_authentication_api.id}/${var.environment}/_user_request_" : "https://${module.dns.oidc_api_url}"
+  api_base_url = var.use_localstack ? "${var.aws_endpoint}/restapis/${aws_api_gateway_rest_api.di_authentication_api.id}/${var.environment}/_user_request_" : module.dns.oidc_api_url
 }
 
 resource "aws_api_gateway_deployment" "deployment" {

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/WellknownHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/WellknownHandler.java
@@ -12,6 +12,7 @@ import com.nimbusds.oauth2.sdk.id.Issuer;
 import com.nimbusds.openid.connect.sdk.SubjectType;
 import com.nimbusds.openid.connect.sdk.claims.ClaimType;
 import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata;
+import org.apache.http.client.utils.URIBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.di.authentication.shared.entity.ValidScopes;
@@ -119,7 +120,7 @@ public class WellknownHandler
 
     private URI buildURI(String prefix, String baseUrl) {
         try {
-            return new URI(baseUrl + prefix);
+            return new URIBuilder(baseUrl).setPath(prefix).build();
         } catch (URISyntaxException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
## What?

- Correct the calculation of the non localstack API base URLs
- Use `URIBuilder` in wellknown to get rid of any additional `/` when composing URLs

## Why?

We have successfully deployed the new domain names to build, but still have some mis-configurations causing the acceptance tests to fail.
