### PR TITLE
GOVSI-865: Create CounterFraudAuditLambda

### DIFF
--- a/account-management-api/src/main/resources/log4j2.xml
+++ b/account-management-api/src/main/resources/log4j2.xml
@@ -1,7 +1,7 @@
 <Configuration status="WARN">
     <Appenders>
         <Lambda name="Lambda">
-            <JsonLayout compact="true" eventEol="true" />
+            <JsonLayout compact="true" eventEol="true" objectMessageAsJsonObject="true" />
         </Lambda>
     </Appenders>
     <Loggers>

--- a/account-migrations/src/main/resources/log4j2.xml
+++ b/account-migrations/src/main/resources/log4j2.xml
@@ -1,7 +1,7 @@
 <Configuration status="WARN">
     <Appenders>
         <Lambda name="Lambda">
-            <JsonLayout compact="true" eventEol="true" />
+            <JsonLayout compact="true" eventEol="true" objectMessageAsJsonObject="true" />
         </Lambda>
     </Appenders>
     <Loggers>

--- a/audit-processors/src/main/java/uk/gov/di/authentication/audit/lambda/BaseAuditHandler.java
+++ b/audit-processors/src/main/java/uk/gov/di/authentication/audit/lambda/BaseAuditHandler.java
@@ -5,8 +5,8 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.SNSEvent;
 import com.amazonaws.services.lambda.runtime.events.SNSEvent.SNS;
 import com.amazonaws.services.lambda.runtime.events.SNSEvent.SNSRecord;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.audit.AuditPayload.AuditEvent;
 import uk.gov.di.audit.AuditPayload.SignedAuditEvent;
 import uk.gov.di.authentication.audit.helper.AuditEventHelper;
@@ -18,7 +18,7 @@ import java.util.Optional;
 
 public abstract class BaseAuditHandler implements RequestHandler<SNSEvent, Object> {
 
-    protected final Logger LOG = LoggerFactory.getLogger(getClass());
+    protected final Logger LOG = LogManager.getLogger(getClass());
     private final KmsConnectionService kmsConnectionService;
     private final ConfigurationService service;
 

--- a/audit-processors/src/main/java/uk/gov/di/authentication/audit/lambda/CounterFraudAuditLambda.java
+++ b/audit-processors/src/main/java/uk/gov/di/authentication/audit/lambda/CounterFraudAuditLambda.java
@@ -1,0 +1,38 @@
+package uk.gov.di.authentication.audit.lambda;
+
+import org.apache.logging.log4j.message.ObjectMessage;
+import uk.gov.di.audit.AuditPayload.AuditEvent;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.KmsConnectionService;
+
+import java.util.HashMap;
+
+public class CounterFraudAuditLambda extends BaseAuditHandler {
+
+    CounterFraudAuditLambda(
+            KmsConnectionService kmsConnectionService, ConfigurationService service) {
+        super(kmsConnectionService, service);
+    }
+
+    CounterFraudAuditLambda() {
+        super();
+    }
+
+    @Override
+    void handleAuditEvent(AuditEvent auditEvent) {
+        var eventData = new HashMap<String, String>();
+
+        eventData.put("event-id", auditEvent.getEventId());
+        eventData.put("request-id", auditEvent.getRequestId());
+        eventData.put("session-id", auditEvent.getSessionId());
+        eventData.put("client-id", auditEvent.getClientId());
+        eventData.put("timestamp", auditEvent.getTimestamp());
+        eventData.put("event-name", auditEvent.getEventName());
+
+        AuditEvent.User user = auditEvent.getUser();
+        // TODO - hash other field from the user object and include them too.
+        eventData.put("user.ip-address", user.getIpAddress());
+
+        LOG.info(new ObjectMessage(eventData));
+    }
+}

--- a/audit-processors/src/main/resources/log4j2.xml
+++ b/audit-processors/src/main/resources/log4j2.xml
@@ -1,7 +1,7 @@
 <Configuration status="WARN">
     <Appenders>
         <Lambda name="Lambda">
-            <JsonLayout compact="true" eventEol="true" />
+            <JsonLayout compact="true" eventEol="true" objectMessageAsJsonObject="true" />
         </Lambda>
     </Appenders>
     <Loggers>

--- a/audit-processors/src/test/java/uk/gov/di/authentication/audit/lambda/CounterFraudAuditLambdaTest.java
+++ b/audit-processors/src/test/java/uk/gov/di/authentication/audit/lambda/CounterFraudAuditLambdaTest.java
@@ -1,0 +1,98 @@
+package uk.gov.di.authentication.audit.lambda;
+
+import com.amazonaws.services.lambda.runtime.events.SNSEvent;
+import com.google.protobuf.AbstractMessageLite;
+import com.google.protobuf.ByteString;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
+import org.apache.logging.log4j.core.impl.MutableLogEvent;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.audit.AuditPayload.AuditEvent;
+import uk.gov.di.audit.AuditPayload.SignedAuditEvent;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.KmsConnectionService;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.shared.matchers.LogEventMatcher.hasMDCProperty;
+
+public class CounterFraudAuditLambdaTest {
+
+    private final KmsConnectionService kms = mock(KmsConnectionService.class);
+    private final ConfigurationService config = mock(ConfigurationService.class);
+
+    @Test
+    void handlesRequestsAppropriately() {
+        Logger logger = (Logger) LogManager.getLogger(CounterFraudAuditLambda.class);
+
+        var appender = new ListAppender();
+        appender.start();
+
+        logger.addAppender(appender);
+
+        when(config.getAuditSigningKeyAlias()).thenReturn("key_alias");
+        when(kms.validateSignature(any(ByteBuffer.class), any(ByteBuffer.class), anyString()))
+                .thenReturn(true);
+
+        var handler = new CounterFraudAuditLambda(kms, config);
+
+        var payload =
+                SignedAuditEvent.newBuilder()
+                        .setSignature(ByteString.copyFrom("signature".getBytes()))
+                        .setPayload(
+                                AuditEvent.newBuilder().setEventId("foo").build().toByteString())
+                        .build();
+
+        handler.handleRequest(inputEvent(payload), null);
+
+        LogEvent logEvent = appender.getEvents().get(1);
+
+        assertThat(logEvent, hasMDCProperty("event-id", "foo"));
+    }
+
+    private SNSEvent inputEvent(SignedAuditEvent payload) {
+        return Optional.of(payload)
+                .map(AbstractMessageLite::toByteArray)
+                .map(Base64.getEncoder()::encodeToString)
+                .map(new SNSEvent.SNS()::withMessage)
+                .map(new SNSEvent.SNSRecord()::withSns)
+                .map(List::of)
+                .map(new SNSEvent()::withRecords)
+                .get();
+    }
+
+    public static class ListAppender extends AbstractAppender {
+
+        final List<LogEvent> events = Collections.synchronizedList(new ArrayList<>());
+
+        public ListAppender() {
+            super("StubAppender", null, null, true, Property.EMPTY_ARRAY);
+        }
+
+        @Override
+        public void append(final LogEvent event) {
+            if (event instanceof MutableLogEvent) {
+                events.add(((MutableLogEvent) event).createMemento());
+            } else {
+                events.add(event);
+            }
+        }
+
+        public List<LogEvent> getEvents() {
+            return events;
+        }
+    }
+}

--- a/client-registry-api/src/main/resources/log4j2.xml
+++ b/client-registry-api/src/main/resources/log4j2.xml
@@ -1,7 +1,7 @@
 <Configuration status="WARN">
     <Appenders>
         <Lambda name="Lambda">
-            <JsonLayout compact="true" eventEol="true" />
+            <JsonLayout compact="true" eventEol="true" objectMessageAsJsonObject="true" />
         </Lambda>
     </Appenders>
     <Loggers>

--- a/frontend-api/src/main/resources/log4j2.xml
+++ b/frontend-api/src/main/resources/log4j2.xml
@@ -1,7 +1,7 @@
 <Configuration status="WARN">
     <Appenders>
         <Lambda name="Lambda">
-            <JsonLayout compact="true" eventEol="true" />
+            <JsonLayout compact="true" eventEol="true" objectMessageAsJsonObject="true" />
         </Lambda>
     </Appenders>
     <Loggers>

--- a/lambda-warmer/src/main/resources/log4j2.xml
+++ b/lambda-warmer/src/main/resources/log4j2.xml
@@ -1,7 +1,7 @@
 <Configuration status="WARN">
     <Appenders>
         <Lambda name="Lambda">
-            <JsonLayout compact="true" eventEol="true" />
+            <JsonLayout compact="true" eventEol="true" objectMessageAsJsonObject="true" />
         </Lambda>
     </Appenders>
     <Loggers>

--- a/lambda-warmer/src/test/resources/log4j2.xml
+++ b/lambda-warmer/src/test/resources/log4j2.xml
@@ -1,7 +1,7 @@
 <Configuration status="WARN">
     <Appenders>
         <Lambda name="Lambda">
-            <JsonLayout compact="true" eventEol="true" />
+            <JsonLayout compact="true" eventEol="true" objectMessageAsJsonObject="true" />
         </Lambda>
     </Appenders>
     <Loggers>

--- a/oidc-api/src/main/resources/log4j2.xml
+++ b/oidc-api/src/main/resources/log4j2.xml
@@ -1,7 +1,7 @@
 <Configuration status="WARN">
     <Appenders>
         <Lambda name="Lambda">
-            <JsonLayout compact="true" eventEol="true" />
+            <JsonLayout compact="true" eventEol="true" objectMessageAsJsonObject="true" />
         </Lambda>
     </Appenders>
     <Loggers>

--- a/shared/src/main/java/uk/gov/di/authentication/shared/matchers/LogEventMatcher.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/matchers/LogEventMatcher.java
@@ -1,0 +1,33 @@
+package uk.gov.di.authentication.shared.matchers;
+
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.message.ObjectMessage;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+import java.util.Map;
+
+public class LogEventMatcher {
+
+    public static Matcher<LogEvent> hasMDCProperty(String key, String value) {
+        return new TypeSafeMatcher<>() {
+
+            @Override
+            @SuppressWarnings("unchecked")
+            protected boolean matchesSafely(LogEvent item) {
+                var objectMessage = (ObjectMessage) item.getMessage();
+
+                var properties = (Map<String, String>) objectMessage.getParameter();
+
+                return properties.containsKey(key) && properties.get(key).equals(value);
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText(
+                        "a log event with MDC Property [" + key + ", " + value + "]");
+            }
+        };
+    }
+}


### PR DESCRIPTION
## What?

* Add CounterFraudAuditLambda and get it to handle any fields which don't need to be hashed.
* Some fields from User are not handled yet as they will require hashing.

## Why?

The Threat Intelligence and Counter-Fraud team need this data for audit purposes.