### PR TITLE
Change MFA code storage to use the user email as the redis key instead of the session ID

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
@@ -168,14 +168,14 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
             LOGGER.info(
                     "User has requested too many OTP codes for session: {}",
                     session.getSessionId());
-            codeStorageService.saveCodeRequestBlockedForSession(
-                    email, session.getSessionId(), configurationService.getCodeExpiry());
+            codeStorageService.saveCodeRequestBlockedForEmail(
+                    email, configurationService.getCodeExpiry());
             SessionState nextState =
                     stateMachine.transition(session.getState(), SYSTEM_HAS_SENT_TOO_MANY_MFA_CODES);
             sessionService.save(session.setState(nextState).resetCodeRequestCount());
             return false;
         }
-        if (codeStorageService.isCodeRequestBlockedForSession(email, session.getSessionId())) {
+        if (codeStorageService.isCodeRequestBlockedForEmail(email)) {
             LOGGER.info(
                     "User is blocked from requesting any OTP codes for session: {}",
                     session.getSessionId());

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
@@ -209,8 +209,7 @@ public class MfaHandlerTest {
                 objectMapper.readValue(result.getBody(), BaseAPIResponse.class);
         assertEquals(SessionState.MFA_SMS_MAX_CODES_SENT, codeResponse.getSessionState());
         verify(codeStorageService)
-                .saveCodeRequestBlockedForSession(
-                        TEST_EMAIL_ADDRESS, session.getSessionId(), CODE_EXPIRY_TIME);
+                .saveCodeRequestBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_EXPIRY_TIME);
     }
 
     @Test
@@ -218,9 +217,7 @@ public class MfaHandlerTest {
             throws JsonProcessingException {
         usingValidSession();
         session.setState(MFA_SMS_MAX_CODES_SENT);
-        when(codeStorageService.isCodeRequestBlockedForSession(
-                        TEST_EMAIL_ADDRESS, session.getSessionId()))
-                .thenReturn(true);
+        when(codeStorageService.isCodeRequestBlockedForEmail(TEST_EMAIL_ADDRESS)).thenReturn(true);
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setHeaders(Map.of("Session-Id", session.getSessionId()));

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java
@@ -85,11 +85,27 @@ public class CodeStorageService {
         }
     }
 
+    public void saveCodeRequestBlockedForEmail(String email, long codeBlockedTime) {
+        String encodedHash = HashHelper.hashSha256String(email);
+        String key = CODE_REQUEST_BLOCKED_KEY_PREFIX + encodedHash;
+        try {
+            redisConnectionService.saveWithExpiry(key, CODE_BLOCKED_VALUE, codeBlockedTime);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     public boolean isCodeRequestBlockedForSession(String emailAddress, String sessionId) {
         return redisConnectionService.getValue(
                         CODE_REQUEST_BLOCKED_KEY_PREFIX
                                 + HashHelper.hashSha256String(emailAddress)
                                 + sessionId)
+                != null;
+    }
+
+    public boolean isCodeRequestBlockedForEmail(String emailAddress) {
+        return redisConnectionService.getValue(
+                        CODE_REQUEST_BLOCKED_KEY_PREFIX + HashHelper.hashSha256String(emailAddress))
                 != null;
     }
 


### PR DESCRIPTION
## What?

Change the MFA lambda to use the user's email address for the redis key value instead of the session ID in order to track when a user has requested too many codes.

## Why?

To solve the issue of users just starting a new session in order to get around the account locked timers
