### PR TITLE
GOVSI-921: make Redis multi AZ

### DIFF
--- a/ci/terraform/shared/redis.tf
+++ b/ci/terraform/shared/redis.tf
@@ -32,6 +32,7 @@ resource "aws_elasticache_replication_group" "sessions_store" {
   engine_version                = "6.x"
   parameter_group_name          = "default.redis6.x"
   port                          = 6379
+  multi_az_enabled              = true
 
   at_rest_encryption_enabled = true
   transit_encryption_enabled = true


### PR DESCRIPTION
## What?

Make Redis multi AZ

## Why?

ITHC recommendation.
Increase the resilience of the Redis service.