### PR TITLE
GOVSI-921: add lambda warmers to vpc

### DIFF
--- a/ci/terraform/account-management/authoriser-warmer.tf
+++ b/ci/terraform/account-management/authoriser-warmer.tf
@@ -82,6 +82,11 @@ resource "aws_lambda_function" "warmer_function" {
 
   source_code_hash = filebase64sha256(var.lambda_warmer_zip_file)
 
+  vpc_config {
+    security_group_ids = [aws_vpc.account_management_vpc.default_security_group_id]
+    subnet_ids         = aws_subnet.account_management_subnets.*.id
+  }
+
   environment {
     variables = {
       LAMBDA_ARN             = aws_lambda_function.authorizer.arn

--- a/ci/terraform/modules/endpoint-module/warmer.tf
+++ b/ci/terraform/modules/endpoint-module/warmer.tf
@@ -100,6 +100,11 @@ resource "aws_lambda_function" "warmer_function" {
 
   source_code_hash = filebase64sha256(var.warmer_lambda_zip_file)
 
+  vpc_config {
+    security_group_ids = [var.security_group_id]
+    subnet_ids         = var.subnet_id
+  }
+
   environment {
     variables = merge(var.warmer_handler_environment_variables, {
       LAMBDA_ARN       = aws_lambda_function.endpoint_lambda.arn


### PR DESCRIPTION
## What?

Add lambda warmers to vpc

## Why?

ITHC recommendation.
The warmers were not in a vpc.
