### PR TITLE
Update blocked sessions to be tracked in redis with the user email address as the redis key

### DIFF
--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/helpers/RedisHelper.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/helpers/RedisHelper.java
@@ -26,6 +26,7 @@ import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_EMA
 import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_PHONE_NUMBER;
 import static uk.gov.di.authentication.shared.services.AuthorisationCodeService.AUTH_CODE_PREFIX;
 import static uk.gov.di.authentication.shared.services.ClientSessionService.CLIENT_SESSION_PREFIX;
+import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_BLOCKED_KEY_PREFIX;
 
 public class RedisHelper {
 
@@ -140,11 +141,11 @@ public class RedisHelper {
         }
     }
 
-    public static void blockPhoneCode(String email, String sessionId) {
+    public static void blockPhoneCode(String email) {
         try (RedisConnectionService redis =
                 new RedisConnectionService(REDIS_HOST, 6379, false, REDIS_PASSWORD)) {
 
-            new CodeStorageService(redis).saveCodeBlockedForSession(email, sessionId, 10);
+            new CodeStorageService(redis).saveBlockedForEmail(email, CODE_BLOCKED_KEY_PREFIX, 10);
         }
     }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -49,6 +49,7 @@ import static uk.gov.di.authentication.shared.entity.SessionState.PHONE_NUMBER_C
 import static uk.gov.di.authentication.shared.entity.SessionState.UPDATED_TERMS_AND_CONDITIONS;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
+import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_BLOCKED_KEY_PREFIX;
 import static uk.gov.di.authentication.shared.state.StateMachine.userJourneyStateMachine;
 
 public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
@@ -198,8 +199,8 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
     }
 
     private boolean isCodeBlockedForSession(Session session) {
-        return codeStorageService.isCodeBlockedForSession(
-                session.getEmailAddress(), session.getSessionId());
+        return codeStorageService.isBlockedForEmail(
+                session.getEmailAddress(), CODE_BLOCKED_KEY_PREFIX);
     }
 
     private APIGatewayProxyResponseEvent generateSuccessResponse(Session session)
@@ -221,9 +222,9 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
     }
 
     private void blockCodeForSessionAndResetCount(Session session) {
-        codeStorageService.saveCodeBlockedForSession(
+        codeStorageService.saveBlockedForEmail(
                 session.getEmailAddress(),
-                session.getSessionId(),
+                CODE_BLOCKED_KEY_PREFIX,
                 configurationService.getCodeExpiry());
         sessionService.save(session.resetRetryCount());
     }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
@@ -50,6 +50,7 @@ import static uk.gov.di.authentication.shared.entity.SessionState.MFA_SMS_MAX_CO
 import static uk.gov.di.authentication.shared.entity.SessionState.UPLIFT_REQUIRED_CM;
 import static uk.gov.di.authentication.shared.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 import static uk.gov.di.authentication.shared.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
+import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_REQUEST_BLOCKED_KEY_PREFIX;
 
 public class MfaHandlerTest {
 
@@ -209,7 +210,8 @@ public class MfaHandlerTest {
                 objectMapper.readValue(result.getBody(), BaseAPIResponse.class);
         assertEquals(SessionState.MFA_SMS_MAX_CODES_SENT, codeResponse.getSessionState());
         verify(codeStorageService)
-                .saveCodeRequestBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_EXPIRY_TIME);
+                .saveBlockedForEmail(
+                        TEST_EMAIL_ADDRESS, CODE_REQUEST_BLOCKED_KEY_PREFIX, CODE_EXPIRY_TIME);
     }
 
     @Test
@@ -217,7 +219,9 @@ public class MfaHandlerTest {
             throws JsonProcessingException {
         usingValidSession();
         session.setState(MFA_SMS_MAX_CODES_SENT);
-        when(codeStorageService.isCodeRequestBlockedForEmail(TEST_EMAIL_ADDRESS)).thenReturn(true);
+        when(codeStorageService.isBlockedForEmail(
+                        TEST_EMAIL_ADDRESS, CODE_REQUEST_BLOCKED_KEY_PREFIX))
+                .thenReturn(true);
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setHeaders(Map.of("Session-Id", session.getSessionId()));

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
@@ -51,6 +51,7 @@ import static uk.gov.di.authentication.shared.entity.SessionState.RESET_PASSWORD
 import static uk.gov.di.authentication.shared.entity.SessionState.RESET_PASSWORD_LINK_SENT;
 import static uk.gov.di.authentication.shared.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 import static uk.gov.di.authentication.shared.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
+import static uk.gov.di.authentication.shared.services.CodeStorageService.PASSWORD_RESET_BLOCKED_KEY_PREFIX;
 
 class ResetPasswordRequestHandlerTest {
 
@@ -231,7 +232,7 @@ class ResetPasswordRequestHandlerTest {
 
         assertEquals(400, result.getStatusCode());
         verify(codeStorageService)
-                .savePasswordResetBlockedForSession(TEST_EMAIL_ADDRESS, sessionId, 900);
+                .saveBlockedForEmail(TEST_EMAIL_ADDRESS, PASSWORD_RESET_BLOCKED_KEY_PREFIX, 900);
         verify(session).resetPasswordResetCount();
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1022));
     }
@@ -249,7 +250,8 @@ class ResetPasswordRequestHandlerTest {
         when(session.getSessionId()).thenReturn(sessionId);
         when(session.validateSession(TEST_EMAIL_ADDRESS)).thenReturn(true);
         when(session.getPasswordResetCount()).thenReturn(0);
-        when(codeStorageService.isPasswordResetBlockedForSession(TEST_EMAIL_ADDRESS, sessionId))
+        when(codeStorageService.isBlockedForEmail(
+                        TEST_EMAIL_ADDRESS, PASSWORD_RESET_BLOCKED_KEY_PREFIX))
                 .thenReturn(true);
         when(sessionService.getSessionFromRequestHeaders(anyMap()))
                 .thenReturn(Optional.of(session));

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
@@ -64,6 +64,7 @@ import static uk.gov.di.authentication.shared.entity.SessionState.VERIFY_EMAIL_C
 import static uk.gov.di.authentication.shared.entity.SessionState.VERIFY_PHONE_NUMBER_CODE_SENT;
 import static uk.gov.di.authentication.shared.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 import static uk.gov.di.authentication.shared.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
+import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_REQUEST_BLOCKED_KEY_PREFIX;
 
 class SendNotificationHandlerTest {
 
@@ -402,8 +403,8 @@ class SendNotificationHandlerTest {
                 objectMapper.readValue(result.getBody(), BaseAPIResponse.class);
         assertEquals(SessionState.EMAIL_MAX_CODES_SENT, codeResponse.getSessionState());
         verify(codeStorageService)
-                .saveCodeRequestBlockedForSession(
-                        TEST_EMAIL_ADDRESS, session.getSessionId(), CODE_EXPIRY_TIME);
+                .saveBlockedForEmail(
+                        TEST_EMAIL_ADDRESS, CODE_REQUEST_BLOCKED_KEY_PREFIX, CODE_EXPIRY_TIME);
         verify(codeStorageService, never())
                 .saveOtpCode(
                         TEST_EMAIL_ADDRESS, TEST_SIX_DIGIT_CODE, CODE_EXPIRY_TIME, VERIFY_EMAIL);
@@ -432,8 +433,8 @@ class SendNotificationHandlerTest {
                 objectMapper.readValue(result.getBody(), BaseAPIResponse.class);
         assertEquals(SessionState.PHONE_NUMBER_MAX_CODES_SENT, codeResponse.getSessionState());
         verify(codeStorageService)
-                .saveCodeRequestBlockedForSession(
-                        TEST_EMAIL_ADDRESS, session.getSessionId(), CODE_EXPIRY_TIME);
+                .saveBlockedForEmail(
+                        TEST_EMAIL_ADDRESS, CODE_REQUEST_BLOCKED_KEY_PREFIX, CODE_EXPIRY_TIME);
         verify(codeStorageService, never())
                 .saveOtpCode(
                         TEST_EMAIL_ADDRESS,
@@ -447,8 +448,8 @@ class SendNotificationHandlerTest {
             throws JsonProcessingException {
         when(validationService.validateEmailAddress(eq(TEST_EMAIL_ADDRESS)))
                 .thenReturn(Optional.empty());
-        when(codeStorageService.isCodeRequestBlockedForSession(
-                        TEST_EMAIL_ADDRESS, session.getSessionId()))
+        when(codeStorageService.isBlockedForEmail(
+                        TEST_EMAIL_ADDRESS, CODE_REQUEST_BLOCKED_KEY_PREFIX))
                 .thenReturn(true);
         session.setState(SessionState.EMAIL_MAX_CODES_SENT);
         usingValidSession();

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
@@ -202,7 +202,7 @@ public class VerifyCodeIntegrationTest extends IntegrationTestEndpoints {
         String sessionId = RedisHelper.createSession();
         RedisHelper.addEmailToSession(sessionId, EMAIL_ADDRESS);
         RedisHelper.setSessionState(sessionId, SessionState.PHONE_NUMBER_CODE_NOT_VALID);
-        RedisHelper.blockPhoneCode(EMAIL_ADDRESS, sessionId);
+        RedisHelper.blockPhoneCode(EMAIL_ADDRESS);
         MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
         headers.add("Session-Id", sessionId);
         headers.add("X-API-Key", FRONTEND_API_KEY);
@@ -227,7 +227,7 @@ public class VerifyCodeIntegrationTest extends IntegrationTestEndpoints {
         String sessionId = RedisHelper.createSession();
         RedisHelper.setSessionState(sessionId, SessionState.EMAIL_CODE_NOT_VALID);
         RedisHelper.addEmailToSession(sessionId, EMAIL_ADDRESS);
-        RedisHelper.blockPhoneCode(EMAIL_ADDRESS, sessionId);
+        RedisHelper.blockPhoneCode(EMAIL_ADDRESS);
         MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
         headers.add("Session-Id", sessionId);
         headers.add("X-API-Key", FRONTEND_API_KEY);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/helpers/RedisHelper.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/helpers/RedisHelper.java
@@ -29,6 +29,7 @@ import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_EMA
 import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_PHONE_NUMBER;
 import static uk.gov.di.authentication.shared.services.AuthorisationCodeService.AUTH_CODE_PREFIX;
 import static uk.gov.di.authentication.shared.services.ClientSessionService.CLIENT_SESSION_PREFIX;
+import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_BLOCKED_KEY_PREFIX;
 
 public class RedisHelper {
 
@@ -179,11 +180,11 @@ public class RedisHelper {
         }
     }
 
-    public static void blockPhoneCode(String email, String sessionId) {
+    public static void blockPhoneCode(String email) {
         try (RedisConnectionService redis =
                 new RedisConnectionService(REDIS_HOST, 6379, false, REDIS_PASSWORD)) {
 
-            new CodeStorageService(redis).saveCodeBlockedForSession(email, sessionId, 10);
+            new CodeStorageService(redis).saveBlockedForEmail(email, CODE_BLOCKED_KEY_PREFIX, 10);
         }
     }
 


### PR DESCRIPTION
## What?

Updated the CodeStorageService to use the user's email address as the redis key rather than the sessionID.

## Why?

This will prevent users from being able to bypass any locks against their accounts by simply starting a new session.
