### PR TITLE
GOVSI-865: Apply fixes to Counter Fraud lambda deployment

### DIFF
--- a/audit-processors/src/main/java/uk/gov/di/authentication/audit/lambda/CounterFraudAuditLambda.java
+++ b/audit-processors/src/main/java/uk/gov/di/authentication/audit/lambda/CounterFraudAuditLambda.java
@@ -9,12 +9,12 @@ import java.util.HashMap;
 
 public class CounterFraudAuditLambda extends BaseAuditHandler {
 
-    CounterFraudAuditLambda(
+    public CounterFraudAuditLambda(
             KmsConnectionService kmsConnectionService, ConfigurationService service) {
         super(kmsConnectionService, service);
     }
 
-    CounterFraudAuditLambda() {
+    public CounterFraudAuditLambda() {
         super();
     }
 

--- a/ci/terraform/audit-processors/counter_fraud.tf
+++ b/ci/terraform/audit-processors/counter_fraud.tf
@@ -12,7 +12,7 @@ module "fraud_realtime_logging_role" {
 }
 
 resource "aws_iam_policy" "fraud_realtime_logging_audit_payload_kms_verification" {
-  name        = "payload-kms-verification"
+  name_prefix = "payload-kms-verification-"
   path        = "/${var.environment}/fraud-realtime-logging/"
   description = "IAM policy for a lambda needing to verify payload signatures"
 
@@ -67,7 +67,7 @@ resource "aws_lambda_function" "fraud_realtime_logging_lambda" {
 resource "aws_sns_topic_subscription" "fraud_realtime_logging_lambda_subscription" {
   topic_arn = data.aws_sns_topic.event_stream.arn
   protocol  = "lambda"
-  endpoint  = aws_lambda_function.fraud_realtime_logging_lambda.function_name
+  endpoint  = aws_lambda_function.fraud_realtime_logging_lambda.arn
 }
 
 resource "aws_lambda_permission" "sns_can_execute_subscriber_fraud_realtime_logging_lambda" {


### PR DESCRIPTION
- Use name-prefix on the KMS access IAM policy for uniqueness
- Use lambda ARN as the SNS subscription endpoint rather than function name
- Make constructors public in `CounterFraudAuditLambda`
