### PR TITLE
GOVSI-921: add lambda warmers to vpc

### DIFF
--- a/ci/terraform/account-management/authenticate.tf
+++ b/ci/terraform/account-management/authenticate.tf
@@ -16,6 +16,7 @@ module "authenticate" {
   root_resource_id         = aws_api_gateway_rest_api.di_account_management_api.root_resource_id
   execution_arn            = aws_api_gateway_rest_api.di_account_management_api.execution_arn
   lambda_zip_file          = var.lambda_zip_file
+  authentication_vpc_arn   = aws_vpc.account_management_vpc.arn
   security_group_id        = aws_vpc.account_management_vpc.default_security_group_id
   subnet_id                = aws_subnet.account_management_subnets.*.id
   environment              = var.environment

--- a/ci/terraform/account-management/authoriser-warmer.tf
+++ b/ci/terraform/account-management/authoriser-warmer.tf
@@ -82,6 +82,11 @@ resource "aws_lambda_function" "warmer_function" {
 
   source_code_hash = filebase64sha256(var.lambda_warmer_zip_file)
 
+  vpc_config {
+    security_group_ids = [aws_vpc.account_management_vpc.default_security_group_id]
+    subnet_ids         = aws_subnet.account_management_subnets.*.id
+  }
+
   environment {
     variables = {
       LAMBDA_ARN             = aws_lambda_function.authorizer.arn

--- a/ci/terraform/account-management/remove-account.tf
+++ b/ci/terraform/account-management/remove-account.tf
@@ -16,6 +16,7 @@ module "delete_account" {
   root_resource_id         = aws_api_gateway_rest_api.di_account_management_api.root_resource_id
   execution_arn            = aws_api_gateway_rest_api.di_account_management_api.execution_arn
   lambda_zip_file          = var.lambda_zip_file
+  authentication_vpc_arn   = aws_vpc.account_management_vpc.arn
   security_group_id        = aws_vpc.account_management_vpc.default_security_group_id
   subnet_id                = aws_subnet.account_management_subnets.*.id
   environment              = var.environment

--- a/ci/terraform/account-management/send_otp_notification.tf
+++ b/ci/terraform/account-management/send_otp_notification.tf
@@ -21,6 +21,7 @@ module "send_otp_notification" {
   root_resource_id         = aws_api_gateway_rest_api.di_account_management_api.root_resource_id
   execution_arn            = aws_api_gateway_rest_api.di_account_management_api.execution_arn
   lambda_zip_file          = var.lambda_zip_file
+  authentication_vpc_arn   = aws_vpc.account_management_vpc.arn
   security_group_id        = aws_vpc.account_management_vpc.default_security_group_id
   subnet_id                = aws_subnet.account_management_subnets.*.id
   lambda_role_arn          = aws_iam_role.dynamo_sqs_lambda_iam_role.arn

--- a/ci/terraform/account-management/update-email.tf
+++ b/ci/terraform/account-management/update-email.tf
@@ -20,6 +20,7 @@ module "update_email" {
   root_resource_id         = aws_api_gateway_rest_api.di_account_management_api.root_resource_id
   execution_arn            = aws_api_gateway_rest_api.di_account_management_api.execution_arn
   lambda_zip_file          = var.lambda_zip_file
+  authentication_vpc_arn   = aws_vpc.account_management_vpc.arn
   security_group_id        = aws_vpc.account_management_vpc.default_security_group_id
   subnet_id                = aws_subnet.account_management_subnets.*.id
   environment              = var.environment

--- a/ci/terraform/account-management/update-password.tf
+++ b/ci/terraform/account-management/update-password.tf
@@ -16,6 +16,7 @@ module "update_password" {
   root_resource_id         = aws_api_gateway_rest_api.di_account_management_api.root_resource_id
   execution_arn            = aws_api_gateway_rest_api.di_account_management_api.execution_arn
   lambda_zip_file          = var.lambda_zip_file
+  authentication_vpc_arn   = aws_vpc.account_management_vpc.arn
   security_group_id        = aws_vpc.account_management_vpc.default_security_group_id
   subnet_id                = aws_subnet.account_management_subnets.*.id
   environment              = var.environment

--- a/ci/terraform/account-management/update-phone-number.tf
+++ b/ci/terraform/account-management/update-phone-number.tf
@@ -20,6 +20,7 @@ module "update_phone_number" {
   root_resource_id         = aws_api_gateway_rest_api.di_account_management_api.root_resource_id
   execution_arn            = aws_api_gateway_rest_api.di_account_management_api.execution_arn
   lambda_zip_file          = var.lambda_zip_file
+  authentication_vpc_arn   = aws_vpc.account_management_vpc.arn
   security_group_id        = aws_vpc.account_management_vpc.default_security_group_id
   subnet_id                = aws_subnet.account_management_subnets.*.id
   environment              = var.environment

--- a/ci/terraform/modules/endpoint-module/variables.tf
+++ b/ci/terraform/modules/endpoint-module/variables.tf
@@ -63,6 +63,10 @@ variable "environment" {
   type = string
 }
 
+variable "authentication_vpc_arn" {
+  type = string
+}
+
 variable "security_group_id" {
   type        = string
   description = "The id of the security for the lambda"

--- a/ci/terraform/modules/endpoint-module/warmer.tf
+++ b/ci/terraform/modules/endpoint-module/warmer.tf
@@ -51,6 +51,40 @@ resource "aws_iam_role_policy_attachment" "lambda_warmer_execution" {
   policy_arn = aws_iam_policy.lambda_warmer_policy[0].arn
 }
 
+resource "aws_iam_role_policy_attachment" "lambda_warmer_networking" {
+  count = var.keep_lambda_warm && var.warmer_handler_function_name != null ? 1 : 0
+
+  role       = aws_iam_role.lambda_warmer_role[0].name
+  policy_arn = aws_iam_policy.warmer_endpoint_networking_policy.arn
+}
+
+resource "aws_iam_policy" "warmer_endpoint_networking_policy" {
+  name        = replace("${var.environment}-${var.endpoint_name}-standard-warmer-lambda-networking", ".", "")
+  path        = "/"
+  description = "IAM policy for managing VPC connection for a lambda"
+
+  policy = data.aws_iam_policy_document.warmer_endpoint_networking_policy.json
+}
+
+data "aws_iam_policy_document" "warmer_endpoint_networking_policy" {
+  version = "2012-10-17"
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "ec2:DescribeNetworkInterfaces",
+      "ec2:CreateNetworkInterface",
+      "ec2:DeleteNetworkInterface",
+    ]
+    resources = ["*"]
+    condition {
+      test     = "ArnLikeIfExists"
+      variable = "ec2:Vpc"
+      values   = [var.authentication_vpc_arn]
+    }
+  }
+}
+
 data "aws_iam_policy_document" "lambda_logging_policy" {
   version = "2012-10-17"
 
@@ -99,6 +133,11 @@ resource "aws_lambda_function" "warmer_function" {
   }
 
   source_code_hash = filebase64sha256(var.warmer_lambda_zip_file)
+
+  vpc_config {
+    security_group_ids = [var.security_group_id]
+    subnet_ids         = var.subnet_id
+  }
 
   environment {
     variables = merge(var.warmer_handler_environment_variables, {

--- a/ci/terraform/oidc/auth-code.tf
+++ b/ci/terraform/oidc/auth-code.tf
@@ -23,6 +23,7 @@ module "auth-code" {
   root_resource_id         = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
   execution_arn            = aws_api_gateway_rest_api.di_authentication_api.execution_arn
   lambda_zip_file          = var.oidc_api_lambda_zip_file
+  authentication_vpc_arn   = local.authentication_vpc_arn
   security_group_id        = local.authentication_security_group_id
   subnet_id                = local.authentication_subnet_ids
   lambda_role_arn          = local.lambda_iam_role_arn

--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -26,6 +26,7 @@ module "authorize" {
   root_resource_id         = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
   execution_arn            = aws_api_gateway_rest_api.di_authentication_api.execution_arn
   lambda_zip_file          = var.oidc_api_lambda_zip_file
+  authentication_vpc_arn   = local.authentication_vpc_arn
   security_group_id        = local.authentication_security_group_id
   subnet_id                = local.authentication_subnet_ids
   lambda_role_arn          = local.lambda_iam_role_arn

--- a/ci/terraform/oidc/client-info.tf
+++ b/ci/terraform/oidc/client-info.tf
@@ -24,6 +24,7 @@ module "client-info" {
   root_resource_id         = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
   execution_arn            = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
   lambda_zip_file          = var.frontend_api_lambda_zip_file
+  authentication_vpc_arn   = local.authentication_vpc_arn
   security_group_id        = local.authentication_security_group_id
   subnet_id                = local.authentication_subnet_ids
   lambda_role_arn          = local.lambda_iam_role_arn

--- a/ci/terraform/oidc/jwks.tf
+++ b/ci/terraform/oidc/jwks.tf
@@ -19,6 +19,7 @@ module "jwks" {
   root_resource_id         = aws_api_gateway_resource.wellknown_resource.id
   execution_arn            = aws_api_gateway_rest_api.di_authentication_api.execution_arn
   lambda_zip_file          = var.oidc_api_lambda_zip_file
+  authentication_vpc_arn   = local.authentication_vpc_arn
   security_group_id        = local.authentication_security_group_id
   subnet_id                = local.authentication_subnet_ids
   lambda_role_arn          = local.lambda_iam_role_arn

--- a/ci/terraform/oidc/login.tf
+++ b/ci/terraform/oidc/login.tf
@@ -26,6 +26,7 @@ module "login" {
   root_resource_id         = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
   execution_arn            = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
   lambda_zip_file          = var.frontend_api_lambda_zip_file
+  authentication_vpc_arn   = local.authentication_vpc_arn
   security_group_id        = local.authentication_security_group_id
   subnet_id                = local.authentication_subnet_ids
   lambda_role_arn          = local.lambda_iam_role_arn

--- a/ci/terraform/oidc/logout.tf
+++ b/ci/terraform/oidc/logout.tf
@@ -27,6 +27,7 @@ module "logout" {
   root_resource_id         = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
   execution_arn            = aws_api_gateway_rest_api.di_authentication_api.execution_arn
   lambda_zip_file          = var.oidc_api_lambda_zip_file
+  authentication_vpc_arn   = local.authentication_vpc_arn
   security_group_id        = local.authentication_security_group_id
   subnet_id                = local.authentication_subnet_ids
   lambda_role_arn          = local.lambda_iam_role_arn

--- a/ci/terraform/oidc/mfa.tf
+++ b/ci/terraform/oidc/mfa.tf
@@ -25,6 +25,7 @@ module "mfa" {
   root_resource_id         = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
   execution_arn            = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
   lambda_zip_file          = var.frontend_api_lambda_zip_file
+  authentication_vpc_arn   = local.authentication_vpc_arn
   security_group_id        = local.authentication_security_group_id
   subnet_id                = local.authentication_subnet_ids
   lambda_role_arn          = local.dynamo_sqs_lambda_iam_role_arn

--- a/ci/terraform/oidc/register.tf
+++ b/ci/terraform/oidc/register.tf
@@ -19,6 +19,7 @@ module "register" {
   rest_api_id              = aws_api_gateway_rest_api.di_authentication_api.id
   root_resource_id         = aws_api_gateway_resource.register_resource.id
   execution_arn            = aws_api_gateway_rest_api.di_authentication_api.execution_arn
+  authentication_vpc_arn   = local.authentication_vpc_arn
   lambda_zip_file          = var.client_registry_api_lambda_zip_file
   security_group_id        = local.authentication_security_group_id
   subnet_id                = local.authentication_subnet_ids

--- a/ci/terraform/oidc/reset-password-request.tf
+++ b/ci/terraform/oidc/reset-password-request.tf
@@ -26,6 +26,7 @@ module "reset-password-request" {
   root_resource_id         = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
   execution_arn            = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
   lambda_zip_file          = var.frontend_api_lambda_zip_file
+  authentication_vpc_arn   = local.authentication_vpc_arn
   security_group_id        = local.authentication_security_group_id
   subnet_id                = local.authentication_subnet_ids
   lambda_role_arn          = local.dynamo_sqs_lambda_iam_role_arn

--- a/ci/terraform/oidc/reset_password.tf
+++ b/ci/terraform/oidc/reset_password.tf
@@ -27,6 +27,7 @@ module "reset_password" {
   root_resource_id         = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
   execution_arn            = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
   lambda_zip_file          = var.frontend_api_lambda_zip_file
+  authentication_vpc_arn   = local.authentication_vpc_arn
   security_group_id        = local.authentication_security_group_id
   subnet_id                = local.authentication_subnet_ids
   lambda_role_arn          = local.dynamo_sqs_lambda_iam_role_arn

--- a/ci/terraform/oidc/send_notification.tf
+++ b/ci/terraform/oidc/send_notification.tf
@@ -24,6 +24,7 @@ module "send_notification" {
   root_resource_id         = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
   execution_arn            = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
   lambda_zip_file          = var.frontend_api_lambda_zip_file
+  authentication_vpc_arn   = local.authentication_vpc_arn
   security_group_id        = local.authentication_security_group_id
   subnet_id                = local.authentication_subnet_ids
   lambda_role_arn          = local.dynamo_sqs_lambda_iam_role_arn

--- a/ci/terraform/oidc/shared.tf
+++ b/ci/terraform/oidc/shared.tf
@@ -19,6 +19,7 @@ locals {
   external_redis_host              = var.use_localstack ? var.external_redis_host : data.terraform_remote_state.shared.outputs.redis_host
   external_redis_port              = var.use_localstack ? var.external_redis_port : data.terraform_remote_state.shared.outputs.redis_port
   external_redis_password          = var.use_localstack ? var.external_redis_password : data.terraform_remote_state.shared.outputs.redis_password
+  authentication_vpc_arn           = data.terraform_remote_state.shared.outputs.authentication_vpc_arn
   authentication_security_group_id = data.terraform_remote_state.shared.outputs.authentication_security_group_id
   authentication_subnet_ids        = data.terraform_remote_state.shared.outputs.authentication_subnet_ids
   lambda_iam_role_arn              = data.terraform_remote_state.shared.outputs.lambda_iam_role_arn

--- a/ci/terraform/oidc/signup.tf
+++ b/ci/terraform/oidc/signup.tf
@@ -25,6 +25,7 @@ module "signup" {
   root_resource_id         = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
   execution_arn            = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
   lambda_zip_file          = var.frontend_api_lambda_zip_file
+  authentication_vpc_arn   = local.authentication_vpc_arn
   security_group_id        = local.authentication_security_group_id
   subnet_id                = local.authentication_subnet_ids
   lambda_role_arn          = local.lambda_iam_role_arn

--- a/ci/terraform/oidc/token.tf
+++ b/ci/terraform/oidc/token.tf
@@ -26,6 +26,7 @@ module "token" {
   root_resource_id         = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
   execution_arn            = aws_api_gateway_rest_api.di_authentication_api.execution_arn
   lambda_zip_file          = var.oidc_api_lambda_zip_file
+  authentication_vpc_arn   = local.authentication_vpc_arn
   security_group_id        = local.authentication_security_group_id
   subnet_id                = local.authentication_subnet_ids
   lambda_role_arn          = local.token_lambda_iam_role_arn

--- a/ci/terraform/oidc/trustmarks.tf
+++ b/ci/terraform/oidc/trustmarks.tf
@@ -24,6 +24,7 @@ module "trustmarks" {
   root_resource_id         = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
   execution_arn            = aws_api_gateway_rest_api.di_authentication_api.execution_arn
   lambda_zip_file          = var.oidc_api_lambda_zip_file
+  authentication_vpc_arn   = local.authentication_vpc_arn
   security_group_id        = local.authentication_security_group_id
   subnet_id                = local.authentication_subnet_ids
   lambda_role_arn          = local.lambda_iam_role_arn

--- a/ci/terraform/oidc/update.tf
+++ b/ci/terraform/oidc/update.tf
@@ -21,6 +21,7 @@ module "update" {
   root_resource_id         = aws_api_gateway_resource.register_resource.id
   execution_arn            = aws_api_gateway_rest_api.di_authentication_api.execution_arn
   lambda_zip_file          = var.client_registry_api_lambda_zip_file
+  authentication_vpc_arn   = local.authentication_vpc_arn
   security_group_id        = local.authentication_security_group_id
   subnet_id                = local.authentication_subnet_ids
   lambda_role_arn          = local.lambda_iam_role_arn

--- a/ci/terraform/oidc/update_profile.tf
+++ b/ci/terraform/oidc/update_profile.tf
@@ -25,6 +25,7 @@ module "update_profile" {
   root_resource_id         = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
   execution_arn            = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
   lambda_zip_file          = var.frontend_api_lambda_zip_file
+  authentication_vpc_arn   = local.authentication_vpc_arn
   security_group_id        = local.authentication_security_group_id
   subnet_id                = local.authentication_subnet_ids
   lambda_role_arn          = local.lambda_iam_role_arn

--- a/ci/terraform/oidc/userexists.tf
+++ b/ci/terraform/oidc/userexists.tf
@@ -24,6 +24,7 @@ module "userexists" {
   root_resource_id         = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
   execution_arn            = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
   lambda_zip_file          = var.frontend_api_lambda_zip_file
+  authentication_vpc_arn   = local.authentication_vpc_arn
   security_group_id        = local.authentication_security_group_id
   subnet_id                = local.authentication_subnet_ids
   lambda_role_arn          = local.lambda_iam_role_arn

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -25,6 +25,7 @@ module "userinfo" {
   root_resource_id         = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
   execution_arn            = aws_api_gateway_rest_api.di_authentication_api.execution_arn
   lambda_zip_file          = var.oidc_api_lambda_zip_file
+  authentication_vpc_arn   = local.authentication_vpc_arn
   security_group_id        = local.authentication_security_group_id
   subnet_id                = local.authentication_subnet_ids
   lambda_role_arn          = local.lambda_iam_role_arn

--- a/ci/terraform/oidc/verify_code.tf
+++ b/ci/terraform/oidc/verify_code.tf
@@ -28,6 +28,7 @@ module "verify_code" {
   root_resource_id         = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
   execution_arn            = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
   lambda_zip_file          = var.frontend_api_lambda_zip_file
+  authentication_vpc_arn   = local.authentication_vpc_arn
   security_group_id        = local.authentication_security_group_id
   subnet_id                = local.authentication_subnet_ids
   lambda_role_arn          = local.lambda_iam_role_arn

--- a/ci/terraform/oidc/wellknown.tf
+++ b/ci/terraform/oidc/wellknown.tf
@@ -19,6 +19,7 @@ module "openid_configuration_discovery" {
   root_resource_id         = aws_api_gateway_resource.wellknown_resource.id
   execution_arn            = aws_api_gateway_rest_api.di_authentication_api.execution_arn
   lambda_zip_file          = var.oidc_api_lambda_zip_file
+  authentication_vpc_arn   = local.authentication_vpc_arn
   security_group_id        = local.authentication_security_group_id
   subnet_id                = local.authentication_subnet_ids
   lambda_role_arn          = local.lambda_iam_role_arn


### PR DESCRIPTION
## What?

Add lambda warmers to vpc.
Includes additional rights for the lambda warmers to join the vpc.

## Why?

ITHC recommendation.
The warmers were not in a vpc.

## Related PRs

#823 