### PR TITLE
BAU: Ensure the salt array is filled with randomness

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/Argon2EncoderHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/Argon2EncoderHelper.java
@@ -3,6 +3,7 @@ package uk.gov.di.authentication.shared.helpers;
 import org.bouncycastle.crypto.generators.Argon2BytesGenerator;
 import org.bouncycastle.crypto.params.Argon2Parameters;
 
+import java.security.SecureRandom;
 import java.util.Base64;
 
 public class Argon2EncoderHelper {
@@ -11,9 +12,11 @@ public class Argon2EncoderHelper {
     private static final int PARALLELISM = 1;
     private static final int ITERATIONS = 2;
     private static final Base64.Encoder BASE64_ENCODER = Base64.getEncoder().withoutPadding();
+    private static final SecureRandom RANDOM = new SecureRandom();
 
     public static String argon2Hash(String raw) {
         byte[] salt = new byte[32];
+        RANDOM.nextBytes(salt);
 
         var parameters =
                 new Argon2Parameters.Builder(Argon2Parameters.ARGON2_id)


### PR DESCRIPTION
## What?

- Use SecureRandom to populate the password salt with some random bytes

## Why?

We were always using an empty salt, we need to use some randomness
