### PR TITLE
GOVSI-865: Ensure unique policy names

### DIFF
--- a/ci/terraform/audit-processors/storage.tf
+++ b/ci/terraform/audit-processors/storage.tf
@@ -12,7 +12,7 @@ module "audit_storage_lambda_role" {
 }
 
 resource "aws_iam_policy" "audit_payload_kms_verification" {
-  name        = "payload-kms-verification"
+  name_prefix = "payload-kms-verification"
   path        = "/${var.environment}/audit-storage/"
   description = "IAM policy for a lambda needing to verify payload signatures"
 


### PR DESCRIPTION
## What?

- Use `name_prefix` rather than name on the IAM policies. 

## Why?

We are getting name conflicts (even though they are in different paths)