### PR TITLE
BAU: Extract source IP from request input

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/IpAddressHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/IpAddressHelper.java
@@ -1,15 +1,19 @@
 package uk.gov.di.authentication.shared.helpers;
 
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent.ProxyRequestContext;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent.RequestIdentity;
 import uk.gov.di.authentication.shared.services.AuditService;
+
+import java.util.Optional;
 
 public class IpAddressHelper {
 
     public static String extractIpAddress(APIGatewayProxyRequestEvent input) {
-        if (input.getHeaders() == null) {
-            return AuditService.UNKNOWN;
-        } else {
-            return input.getHeaders().getOrDefault("x-forwarded-for", AuditService.UNKNOWN);
-        }
+        return Optional.ofNullable(input)
+                .map(APIGatewayProxyRequestEvent::getRequestContext)
+                .map(ProxyRequestContext::getIdentity)
+                .map(RequestIdentity::getSourceIp)
+                .orElse(AuditService.UNKNOWN);
     }
 }


### PR DESCRIPTION
This is the "proper" way to get the source IP of a request rather than pull it directly off the headers as we thought before
