### PR TITLE
BAU: Make the key administerable by root users

### DIFF
--- a/ci/terraform/oidc/events-sns.tf
+++ b/ci/terraform/oidc/events-sns.tf
@@ -18,6 +18,17 @@ data "aws_iam_policy_document" "events_topic_encryption_key_access" {
     sid     = "GrantServiceAccess"
     actions = ["kms:GenerateDataKey*", "kms:Decrypt"]
   }
+
+  statement {
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+
+    effect  = "Allow"
+    sid     = "Enable IAM User Permissions"
+    actions = ["kms:*"]
+  }
 }
 
 


### PR DESCRIPTION
AWS won't let you create an un-administerable key
