### PR TITLE
Fix the code blocked checkes for sendNotificationHandler and mfaHandler

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/state/StateMachine.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/state/StateMachine.java
@@ -205,6 +205,8 @@ public class StateMachine<T, A, C> {
                         on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED).then(NEW))
                 .when(EMAIL_CODE_MAX_RETRIES_REACHED)
                 .allow(
+                        on(USER_ENTERED_INVALID_EMAIL_VERIFICATION_CODE_TOO_MANY_TIMES)
+                                .then(EMAIL_CODE_MAX_RETRIES_REACHED),
                         on(USER_HAS_STARTED_A_NEW_JOURNEY).then(NEW),
                         on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED).then(NEW))
                 .when(EMAIL_CODE_VERIFIED)
@@ -276,6 +278,8 @@ public class StateMachine<T, A, C> {
                         on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED).then(NEW))
                 .when(PHONE_NUMBER_CODE_MAX_RETRIES_REACHED)
                 .allow(
+                        on(USER_ENTERED_INVALID_PHONE_VERIFICATION_CODE_TOO_MANY_TIMES)
+                                .then(PHONE_NUMBER_CODE_MAX_RETRIES_REACHED),
                         on(USER_HAS_STARTED_A_NEW_JOURNEY).then(NEW),
                         on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED).then(NEW))
                 .when(ACCOUNT_TEMPORARILY_LOCKED)
@@ -392,6 +396,8 @@ public class StateMachine<T, A, C> {
                         on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED).then(NEW))
                 .when(MFA_CODE_MAX_RETRIES_REACHED)
                 .allow(
+                        on(USER_ENTERED_INVALID_MFA_CODE_TOO_MANY_TIMES)
+                                .then(MFA_CODE_MAX_RETRIES_REACHED),
                         on(USER_HAS_STARTED_A_NEW_JOURNEY)
                                 .then(UPLIFT_REQUIRED_CM)
                                 .ifCondition(upliftRequired()),


### PR DESCRIPTION
## What?

Check for blocked code session in the sendNotificationHandler and mfaHandler in order to correctly reset the state in the event of a user already attempted the max OPT code tries and has started a new session.

## Why?

The session state gets reset if the user opens a new tab, so we need to check if the state should be blocked and reset it.
