### PR TITLE
GOVSI-921: multi az redis for account management

### DIFF
--- a/ci/terraform/account-management/redis.tf
+++ b/ci/terraform/account-management/redis.tf
@@ -32,6 +32,7 @@ resource "aws_elasticache_replication_group" "account_management_sessions_store"
   engine_version                = "6.x"
   parameter_group_name          = "default.redis6.x"
   port                          = 6379
+  multi_az_enabled              = true
 
   at_rest_encryption_enabled = true
   transit_encryption_enabled = true


### PR DESCRIPTION
## What?

Make Account Management Redis multi AZ

## Why?

ITHC recommendation.
Increase the resilience of the Redis service.

## Related PRs

#821 