### PR TITLE
BAU: Route counter-fraud logging correctly

### DIFF
--- a/ci/terraform/audit-processors/counter_fraud.tf
+++ b/ci/terraform/audit-processors/counter_fraud.tf
@@ -105,7 +105,7 @@ resource "aws_cloudwatch_log_group" "fraud_realtime_logging_lambda_log_group" {
 resource "aws_cloudwatch_log_subscription_filter" "fraud_realtime_logging_log_subscription" {
   count           = var.logging_endpoint_enabled ? 1 : 0
   name            = "${aws_lambda_function.fraud_realtime_logging_lambda.function_name}-log-subscription"
-  log_group_name  = aws_cloudwatch_log_group.lambda_log_group[0].name
+  log_group_name  = aws_cloudwatch_log_group.fraud_realtime_logging_lambda_log_group[0].name
   filter_pattern  = ""
   destination_arn = var.logging_endpoint_arn
 }


### PR DESCRIPTION
We were attaching two log groups to the same subscription filter.