### PR TITLE
GOVSI-911: Use updated sign-in url in account confirmation email

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandler.java
@@ -74,8 +74,7 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                         case ACCOUNT_CREATED_CONFIRMATION:
                             notifyPersonalisation.put(
                                     "sign-in-page-url",
-                                    buildURI(configService.getAccountManagementURI(), "/sign-in")
-                                            .toString());
+                                    buildURI(configService.getAccountManagementURI()).toString());
                             notificationService.sendEmail(
                                     notifyRequest.getDestination(),
                                     notifyPersonalisation,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandlerTest.java
@@ -90,8 +90,8 @@ public class NotificationHandlerTest {
     @Test
     public void shouldSuccessfullyProcessAccountCreatedConfirmationFromSQSQueue()
             throws JsonProcessingException, NotificationClientException {
-        String accountManagementUrl = "http://account-management/sign-in";
-        String baseUrl = "http://account-management/";
+        String accountManagementUrl = "http://account-management/";
+        String baseUrl = "http://account-management";
         when(notificationService.getNotificationTemplateId(ACCOUNT_CREATED_CONFIRMATION))
                 .thenReturn(TEMPLATE_ID);
         when(configService.getAccountManagementURI()).thenReturn(baseUrl);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/SendNotificationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/SendNotificationIntegrationTest.java
@@ -120,7 +120,6 @@ public class SendNotificationIntegrationTest {
         JsonNode request = notifyStub.waitForRequest(60);
         JsonNode personalisation = request.get("personalisation");
         assertEquals(TEST_EMAIL_ADDRESS, request.get("email_address").asText());
-        assertEquals(
-                "http://localhost:3000/sign-in", personalisation.get("sign-in-page-url").asText());
+        assertEquals("http://localhost:3000/", personalisation.get("sign-in-page-url").asText());
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ConstructUriHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ConstructUriHelper.java
@@ -18,4 +18,8 @@ public class ConstructUriHelper {
                 ? URI.create(baseUrl)
                 : URI.create(baseUrl + path.replaceAll("^/+", ""));
     }
+
+    public static URI buildURI(String baseUrl) {
+        return buildURI(baseUrl, null);
+    }
 }


### PR DESCRIPTION
## What?

Use updated sign in url in account confirmation email

## Why?

Sign in url was changed when the real domain names came into use.
