### PR TITLE
BAU: Re-enable client registry API in non-prod

### DIFF
--- a/ci/terraform/oidc/production-overrides.tfvars
+++ b/ci/terraform/oidc/production-overrides.tfvars
@@ -7,5 +7,6 @@ notify_template_map = {
   ACCOUNT_CREATED_CONFIRMATION_TEMPLATE_ID = "360b4786-0b34-45e2-b909-88de67490a0e"
 }
 
-cloudwatch_log_retention = 5
-lambda_min_concurrency   = 25
+cloudwatch_log_retention    = 5
+lambda_min_concurrency      = 25
+client_registry_api_enabled = false

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -201,5 +201,5 @@ variable "test_clients_enabled" {
 }
 
 variable "client_registry_api_enabled" {
-  default = false
+  default = true
 }


### PR DESCRIPTION
## What?

- Make the default value of `client_registry_api_enabled` to be `true`
- Override this in production to be `false`

## Why?

The previous PR disabled the client registry, this re-enables it in all environments except production

## Related PRs

#864 