### PR TITLE
GOVSI-921: additional cmk for lambda env var encryption

### DIFF
--- a/ci/terraform/account-management/sqs.tf
+++ b/ci/terraform/account-management/sqs.tf
@@ -193,6 +193,7 @@ resource "aws_lambda_function" "email_sqs_lambda" {
       NOTIFY_URL     = var.notify_url
     })
   }
+  kms_key_arn = data.terraform_remote_state.shared.outputs.lambda_env_vars_encryption_kms_key_arn
 
   tags = local.default_tags
 

--- a/ci/terraform/oidc/sqs.tf
+++ b/ci/terraform/oidc/sqs.tf
@@ -163,6 +163,7 @@ resource "aws_lambda_function" "email_sqs_lambda" {
       SMOKETEST_SMS_BUCKET_NAME = local.sms_bucket_name
     })
   }
+  kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn
 
   tags = local.default_tags
 }

--- a/ci/terraform/shared/data-transfer.tf
+++ b/ci/terraform/shared/data-transfer.tf
@@ -122,6 +122,7 @@ resource "aws_lambda_function" "data_transfer_lambda" {
       TERMS_CONDITIONS_VERSION = var.terms_and_conditions
     }
   }
+  kms_key_arn = aws_kms_key.lambda_env_vars_encryption_key.arn
 
   runtime = "java11"
 


### PR DESCRIPTION
## What?

Additional cmk for lambda env var encryption.

## Why?

Stragglers which don't use the shared modules for lambda functions.

## Related PRs

#823 