### PR TITLE
GOVSI-921: use cmk to encrypt lambda env vars in audit-processors

### DIFF
--- a/ci/terraform/audit-processors/counter_fraud.tf
+++ b/ci/terraform/audit-processors/counter_fraud.tf
@@ -69,6 +69,7 @@ resource "aws_lambda_function" "fraud_realtime_logging_lambda" {
       AUDIT_HMAC_SECRET       = random_password.hmac_key.result
     }
   }
+  kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn
 
   runtime = "java11"
 

--- a/ci/terraform/audit-processors/shared.tf
+++ b/ci/terraform/audit-processors/shared.tf
@@ -15,17 +15,18 @@ data "terraform_remote_state" "shared" {
 }
 
 locals {
-  authentication_security_group_id = data.terraform_remote_state.shared.outputs.authentication_security_group_id
-  authentication_subnet_ids        = data.terraform_remote_state.shared.outputs.authentication_subnet_ids
-  lambda_iam_role_arn              = data.terraform_remote_state.shared.outputs.lambda_iam_role_arn
-  lambda_iam_role_name             = data.terraform_remote_state.shared.outputs.lambda_iam_role_name
-  audit_signing_key_alias_name     = data.terraform_remote_state.shared.outputs.audit_signing_key_alias_name
-  audit_signing_key_arn            = data.terraform_remote_state.shared.outputs.audit_signing_key_arn
-  logging_endpoint_enabled         = var.logging_endpoint_enabled
-  logging_endpoint_arn             = var.logging_endpoint_arn
-  cloudwatch_key_arn               = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
-  cloudwatch_log_retention         = 5
-  authentication_vpc_arn           = data.terraform_remote_state.shared.outputs.authentication_vpc_arn
+  authentication_security_group_id       = data.terraform_remote_state.shared.outputs.authentication_security_group_id
+  authentication_subnet_ids              = data.terraform_remote_state.shared.outputs.authentication_subnet_ids
+  lambda_iam_role_arn                    = data.terraform_remote_state.shared.outputs.lambda_iam_role_arn
+  lambda_iam_role_name                   = data.terraform_remote_state.shared.outputs.lambda_iam_role_name
+  audit_signing_key_alias_name           = data.terraform_remote_state.shared.outputs.audit_signing_key_alias_name
+  audit_signing_key_arn                  = data.terraform_remote_state.shared.outputs.audit_signing_key_arn
+  logging_endpoint_enabled               = var.logging_endpoint_enabled
+  logging_endpoint_arn                   = var.logging_endpoint_arn
+  cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  cloudwatch_log_retention               = 5
+  authentication_vpc_arn                 = data.terraform_remote_state.shared.outputs.authentication_vpc_arn
+  lambda_env_vars_encryption_kms_key_arn = data.terraform_remote_state.shared.outputs.lambda_env_vars_encryption_kms_key_arn
 }
 
 data "aws_sns_topic" "event_stream" {

--- a/ci/terraform/audit-processors/storage.tf
+++ b/ci/terraform/audit-processors/storage.tf
@@ -60,6 +60,7 @@ resource "aws_lambda_function" "audit_processor_lambda" {
       AUDIT_STORAGE_S3_BUCKET = var.use_localstack ? null : aws_s3_bucket.audit_storage_bucket[0].bucket
     }
   }
+  kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn
 
   runtime = "java11"
 


### PR DESCRIPTION
## What?

Use cmk to encrypt lambda env vars in audit-processors

## Why?

Stragglers which don't use the shared modules for lambda functions.

## Related PRs

#879 
#823 
