### PR TITLE
Fix state machine for blocked states and restarting new sessions

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/state/StateMachine.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/state/StateMachine.java
@@ -192,11 +192,13 @@ public class StateMachine<T, A, C> {
                         on(SYSTEM_HAS_SENT_EMAIL_VERIFICATION_CODE).then(VERIFY_EMAIL_CODE_SENT),
                         on(SYSTEM_IS_BLOCKED_FROM_SENDING_ANY_EMAIL_VERIFICATION_CODES)
                                 .then(EMAIL_CODE_REQUESTS_BLOCKED),
+                        on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND),
                         on(USER_HAS_STARTED_A_NEW_JOURNEY).then(NEW),
                         on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED).then(NEW))
                 .when(EMAIL_CODE_REQUESTS_BLOCKED)
                 .allow(
                         on(SYSTEM_HAS_SENT_EMAIL_VERIFICATION_CODE).then(VERIFY_EMAIL_CODE_SENT),
+                        on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND),
                         on(USER_HAS_STARTED_A_NEW_JOURNEY).then(NEW),
                         on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED).then(NEW))
                 .when(EMAIL_CODE_NOT_VALID)
@@ -211,6 +213,7 @@ public class StateMachine<T, A, C> {
                 .allow(
                         on(USER_ENTERED_INVALID_EMAIL_VERIFICATION_CODE_TOO_MANY_TIMES)
                                 .then(EMAIL_CODE_MAX_RETRIES_REACHED),
+                        on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND),
                         on(USER_HAS_STARTED_A_NEW_JOURNEY).then(NEW),
                         on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED).then(NEW))
                 .when(EMAIL_CODE_VERIFIED)
@@ -261,6 +264,8 @@ public class StateMachine<T, A, C> {
                                 .then(VERIFY_PHONE_NUMBER_CODE_SENT),
                         on(SYSTEM_IS_BLOCKED_FROM_SENDING_ANY_PHONE_VERIFICATION_CODES)
                                 .then(PHONE_NUMBER_CODE_REQUESTS_BLOCKED),
+                        on(USER_ENTERED_A_NEW_PHONE_NUMBER).then(ADDED_UNVERIFIED_PHONE_NUMBER),
+                        on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND),
                         on(USER_HAS_STARTED_A_NEW_JOURNEY).then(NEW),
                         on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED).then(NEW))
                 .when(PHONE_NUMBER_CODE_REQUESTS_BLOCKED)
@@ -288,6 +293,8 @@ public class StateMachine<T, A, C> {
                 .allow(
                         on(USER_ENTERED_INVALID_PHONE_VERIFICATION_CODE_TOO_MANY_TIMES)
                                 .then(PHONE_NUMBER_CODE_MAX_RETRIES_REACHED),
+                        on(USER_ENTERED_A_NEW_PHONE_NUMBER).then(ADDED_UNVERIFIED_PHONE_NUMBER),
+                        on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND),
                         on(USER_HAS_STARTED_A_NEW_JOURNEY).then(NEW),
                         on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED).then(NEW))
                 .when(ACCOUNT_TEMPORARILY_LOCKED)
@@ -295,6 +302,7 @@ public class StateMachine<T, A, C> {
                         on(SYSTEM_HAS_SENT_RESET_PASSWORD_LINK).then(RESET_PASSWORD_LINK_SENT),
                         on(USER_ENTERED_INVALID_PASSWORD_TOO_MANY_TIMES)
                                 .then(ACCOUNT_TEMPORARILY_LOCKED),
+                        on(ACCOUNT_LOCK_EXPIRED).then(AUTHENTICATION_REQUIRED),
                         on(USER_HAS_STARTED_A_NEW_JOURNEY).then(NEW),
                         on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED).then(NEW))
                 .when(AUTHENTICATION_REQUIRED)
@@ -368,6 +376,7 @@ public class StateMachine<T, A, C> {
                         on(SYSTEM_HAS_SENT_MFA_CODE).then(MFA_SMS_CODE_SENT),
                         on(SYSTEM_IS_BLOCKED_FROM_SENDING_ANY_MFA_VERIFICATION_CODES)
                                 .then(MFA_CODE_REQUESTS_BLOCKED),
+                        on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND),
                         on(USER_HAS_STARTED_A_NEW_JOURNEY)
                                 .then(UPLIFT_REQUIRED_CM)
                                 .ifCondition(upliftRequired()),
@@ -375,7 +384,10 @@ public class StateMachine<T, A, C> {
                         on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED).then(NEW))
                 .when(MFA_CODE_REQUESTS_BLOCKED)
                 .allow(
+                        on(SYSTEM_IS_BLOCKED_FROM_SENDING_ANY_MFA_VERIFICATION_CODES)
+                                .then(MFA_CODE_REQUESTS_BLOCKED),
                         on(SYSTEM_HAS_SENT_MFA_CODE).then(MFA_SMS_CODE_SENT),
+                        on(USER_ENTERED_INVALID_MFA_CODE).then(MFA_CODE_NOT_VALID),
                         on(USER_HAS_STARTED_A_NEW_JOURNEY)
                                 .then(UPLIFT_REQUIRED_CM)
                                 .ifCondition(upliftRequired()),
@@ -408,6 +420,8 @@ public class StateMachine<T, A, C> {
                 .allow(
                         on(USER_ENTERED_INVALID_MFA_CODE_TOO_MANY_TIMES)
                                 .then(MFA_CODE_MAX_RETRIES_REACHED),
+                        on(SYSTEM_HAS_SENT_MFA_CODE).then(MFA_SMS_CODE_SENT),
+                        on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND),
                         on(USER_HAS_STARTED_A_NEW_JOURNEY)
                                 .then(UPLIFT_REQUIRED_CM)
                                 .ifCondition(upliftRequired()),

--- a/shared/src/test/java/uk/gov/di/authentication/shared/state/journeys/EmailVerificationJourneyTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/state/journeys/EmailVerificationJourneyTest.java
@@ -1,0 +1,312 @@
+package uk.gov.di.authentication.shared.state.journeys;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.entity.ClientRegistry;
+import uk.gov.di.authentication.shared.entity.ClientSession;
+import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
+import uk.gov.di.authentication.shared.entity.Session;
+import uk.gov.di.authentication.shared.entity.SessionAction;
+import uk.gov.di.authentication.shared.entity.SessionState;
+import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.helpers.IdGenerator;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.state.StateMachine;
+import uk.gov.di.authentication.shared.state.UserContext;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.shared.entity.SessionAction.SYSTEM_HAS_SENT_EMAIL_VERIFICATION_CODE;
+import static uk.gov.di.authentication.shared.entity.SessionAction.SYSTEM_HAS_SENT_TOO_MANY_EMAIL_VERIFICATION_CODES;
+import static uk.gov.di.authentication.shared.entity.SessionAction.USER_ENTERED_INVALID_EMAIL_VERIFICATION_CODE;
+import static uk.gov.di.authentication.shared.entity.SessionAction.USER_ENTERED_INVALID_EMAIL_VERIFICATION_CODE_TOO_MANY_TIMES;
+import static uk.gov.di.authentication.shared.entity.SessionAction.USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS;
+import static uk.gov.di.authentication.shared.entity.SessionAction.USER_ENTERED_VALID_EMAIL_VERIFICATION_CODE;
+import static uk.gov.di.authentication.shared.entity.SessionState.EMAIL_CODE_MAX_RETRIES_REACHED;
+import static uk.gov.di.authentication.shared.entity.SessionState.EMAIL_CODE_NOT_VALID;
+import static uk.gov.di.authentication.shared.entity.SessionState.EMAIL_CODE_VERIFIED;
+import static uk.gov.di.authentication.shared.entity.SessionState.EMAIL_MAX_CODES_SENT;
+import static uk.gov.di.authentication.shared.entity.SessionState.NEW;
+import static uk.gov.di.authentication.shared.entity.SessionState.USER_NOT_FOUND;
+import static uk.gov.di.authentication.shared.entity.SessionState.VERIFY_EMAIL_CODE_SENT;
+import static uk.gov.di.authentication.shared.state.StateMachineJourneyTest.CLIENT_ID;
+import static uk.gov.di.authentication.shared.state.StateMachineJourneyTest.generateAuthRequest;
+import static uk.gov.di.authentication.shared.state.StateMachineJourneyTest.generateLowLevelVectorOfTrust;
+import static uk.gov.di.authentication.shared.state.StateMachineJourneyTest.generateUserProfile;
+
+public class EmailVerificationJourneyTest {
+    private final ConfigurationService mockConfigurationService = mock(ConfigurationService.class);
+
+    private final Session session = new Session(IdGenerator.generate());
+
+    private StateMachine<SessionState, SessionAction, UserContext> stateMachine;
+
+    @BeforeEach
+    void setup() {
+        when(mockConfigurationService.getTermsAndConditionsVersion()).thenReturn("1.0");
+
+        stateMachine = StateMachine.userJourneyStateMachine(mockConfigurationService);
+    }
+
+    @Test
+    public void testCanVerifyEmail() {
+        UserProfile userProfile =
+                generateUserProfile(true, "1.0", new HashSet<String>(Collections.emptyList()));
+
+        UserContext userContext =
+                UserContext.builder(
+                                session.setCurrentCredentialStrength(
+                                        CredentialTrustLevel.LOW_LEVEL))
+                        .withClientSession(
+                                new ClientSession(
+                                                generateAuthRequest("Cl").toParameters(),
+                                                null,
+                                                null)
+                                        .setEffectiveVectorOfTrust(generateLowLevelVectorOfTrust()))
+                        .withUserProfile(userProfile)
+                        .withClient(new ClientRegistry().setClientID(CLIENT_ID.toString()))
+                        .build();
+
+        List<JourneyTransition> transitions =
+                Arrays.asList(
+                        new JourneyTransition(
+                                userContext,
+                                USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS,
+                                USER_NOT_FOUND),
+                        new JourneyTransition(
+                                userContext,
+                                SYSTEM_HAS_SENT_EMAIL_VERIFICATION_CODE,
+                                VERIFY_EMAIL_CODE_SENT),
+                        new JourneyTransition(
+                                userContext,
+                                USER_ENTERED_VALID_EMAIL_VERIFICATION_CODE,
+                                EMAIL_CODE_VERIFIED));
+
+        SessionState currentState = NEW;
+
+        for (JourneyTransition transition : transitions) {
+            currentState =
+                    stateMachine.transition(
+                            currentState,
+                            transition.getSessionAction(),
+                            transition.getUserContext());
+            assertThat(currentState, equalTo(transition.getExpectedSessionState()));
+        }
+    }
+
+    @Test
+    public void testCanReachBlockedStatusIfTooManyCodesAreRequested() {
+        UserProfile userProfile =
+                generateUserProfile(true, "1.0", new HashSet<String>(Collections.emptyList()));
+
+        UserContext userContext =
+                UserContext.builder(
+                                session.setCurrentCredentialStrength(
+                                        CredentialTrustLevel.LOW_LEVEL))
+                        .withClientSession(
+                                new ClientSession(
+                                                generateAuthRequest("Cl").toParameters(),
+                                                null,
+                                                null)
+                                        .setEffectiveVectorOfTrust(generateLowLevelVectorOfTrust()))
+                        .withUserProfile(userProfile)
+                        .withClient(new ClientRegistry().setClientID(CLIENT_ID.toString()))
+                        .build();
+
+        List<JourneyTransition> transitions =
+                Arrays.asList(
+                        new JourneyTransition(
+                                userContext,
+                                USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS,
+                                USER_NOT_FOUND),
+                        new JourneyTransition(
+                                userContext,
+                                SYSTEM_HAS_SENT_EMAIL_VERIFICATION_CODE,
+                                VERIFY_EMAIL_CODE_SENT),
+                        new JourneyTransition(
+                                userContext,
+                                SYSTEM_HAS_SENT_TOO_MANY_EMAIL_VERIFICATION_CODES,
+                                EMAIL_MAX_CODES_SENT));
+
+        SessionState currentState = NEW;
+
+        for (JourneyTransition transition : transitions) {
+            currentState =
+                    stateMachine.transition(
+                            currentState,
+                            transition.getSessionAction(),
+                            transition.getUserContext());
+            assertThat(currentState, equalTo(transition.getExpectedSessionState()));
+        }
+    }
+
+    @Test
+    public void testCanReachBlockedByRequestingTooManyCodesButEnterANewEmailAddressToStartAgain() {
+        UserProfile userProfile =
+                generateUserProfile(true, "1.0", new HashSet<String>(Collections.emptyList()));
+
+        UserContext userContext =
+                UserContext.builder(
+                                session.setCurrentCredentialStrength(
+                                        CredentialTrustLevel.LOW_LEVEL))
+                        .withClientSession(
+                                new ClientSession(
+                                                generateAuthRequest("Cl").toParameters(),
+                                                null,
+                                                null)
+                                        .setEffectiveVectorOfTrust(generateLowLevelVectorOfTrust()))
+                        .withUserProfile(userProfile)
+                        .withClient(new ClientRegistry().setClientID(CLIENT_ID.toString()))
+                        .build();
+
+        List<JourneyTransition> transitions =
+                Arrays.asList(
+                        new JourneyTransition(
+                                userContext,
+                                USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS,
+                                USER_NOT_FOUND),
+                        new JourneyTransition(
+                                userContext,
+                                SYSTEM_HAS_SENT_EMAIL_VERIFICATION_CODE,
+                                VERIFY_EMAIL_CODE_SENT),
+                        new JourneyTransition(
+                                userContext,
+                                SYSTEM_HAS_SENT_TOO_MANY_EMAIL_VERIFICATION_CODES,
+                                EMAIL_MAX_CODES_SENT),
+                        new JourneyTransition(
+                                userContext,
+                                USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS,
+                                USER_NOT_FOUND),
+                        new JourneyTransition(
+                                userContext,
+                                SYSTEM_HAS_SENT_EMAIL_VERIFICATION_CODE,
+                                VERIFY_EMAIL_CODE_SENT));
+
+        SessionState currentState = NEW;
+
+        for (JourneyTransition transition : transitions) {
+            currentState =
+                    stateMachine.transition(
+                            currentState,
+                            transition.getSessionAction(),
+                            transition.getUserContext());
+            assertThat(currentState, equalTo(transition.getExpectedSessionState()));
+        }
+    }
+
+    @Test
+    public void testCanReachBlockedStatusIfIncorrectCodeIsEnteredTooManyTimes() {
+        UserProfile userProfile =
+                generateUserProfile(true, "1.0", new HashSet<String>(Collections.emptyList()));
+
+        UserContext userContext =
+                UserContext.builder(
+                                session.setCurrentCredentialStrength(
+                                        CredentialTrustLevel.LOW_LEVEL))
+                        .withClientSession(
+                                new ClientSession(
+                                                generateAuthRequest("Cl").toParameters(),
+                                                null,
+                                                null)
+                                        .setEffectiveVectorOfTrust(generateLowLevelVectorOfTrust()))
+                        .withUserProfile(userProfile)
+                        .withClient(new ClientRegistry().setClientID(CLIENT_ID.toString()))
+                        .build();
+
+        List<JourneyTransition> transitions =
+                Arrays.asList(
+                        new JourneyTransition(
+                                userContext,
+                                USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS,
+                                USER_NOT_FOUND),
+                        new JourneyTransition(
+                                userContext,
+                                SYSTEM_HAS_SENT_EMAIL_VERIFICATION_CODE,
+                                VERIFY_EMAIL_CODE_SENT),
+                        new JourneyTransition(
+                                userContext,
+                                USER_ENTERED_INVALID_EMAIL_VERIFICATION_CODE,
+                                EMAIL_CODE_NOT_VALID),
+                        new JourneyTransition(
+                                userContext,
+                                USER_ENTERED_INVALID_EMAIL_VERIFICATION_CODE_TOO_MANY_TIMES,
+                                EMAIL_CODE_MAX_RETRIES_REACHED));
+
+        SessionState currentState = NEW;
+
+        for (JourneyTransition transition : transitions) {
+            currentState =
+                    stateMachine.transition(
+                            currentState,
+                            transition.getSessionAction(),
+                            transition.getUserContext());
+            assertThat(currentState, equalTo(transition.getExpectedSessionState()));
+        }
+    }
+
+    @Test
+    public void
+            testCanReachBlockedByIncorrectCodeTooManyTimesButEnterANewEmailAddressToStartAgain() {
+        UserProfile userProfile =
+                generateUserProfile(true, "1.0", new HashSet<String>(Collections.emptyList()));
+
+        UserContext userContext =
+                UserContext.builder(
+                                session.setCurrentCredentialStrength(
+                                        CredentialTrustLevel.LOW_LEVEL))
+                        .withClientSession(
+                                new ClientSession(
+                                                generateAuthRequest("Cl").toParameters(),
+                                                null,
+                                                null)
+                                        .setEffectiveVectorOfTrust(generateLowLevelVectorOfTrust()))
+                        .withUserProfile(userProfile)
+                        .withClient(new ClientRegistry().setClientID(CLIENT_ID.toString()))
+                        .build();
+
+        List<JourneyTransition> transitions =
+                Arrays.asList(
+                        new JourneyTransition(
+                                userContext,
+                                USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS,
+                                USER_NOT_FOUND),
+                        new JourneyTransition(
+                                userContext,
+                                SYSTEM_HAS_SENT_EMAIL_VERIFICATION_CODE,
+                                VERIFY_EMAIL_CODE_SENT),
+                        new JourneyTransition(
+                                userContext,
+                                USER_ENTERED_INVALID_EMAIL_VERIFICATION_CODE,
+                                EMAIL_CODE_NOT_VALID),
+                        new JourneyTransition(
+                                userContext,
+                                USER_ENTERED_INVALID_EMAIL_VERIFICATION_CODE_TOO_MANY_TIMES,
+                                EMAIL_CODE_MAX_RETRIES_REACHED),
+                        new JourneyTransition(
+                                userContext,
+                                USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS,
+                                USER_NOT_FOUND),
+                        new JourneyTransition(
+                                userContext,
+                                SYSTEM_HAS_SENT_EMAIL_VERIFICATION_CODE,
+                                VERIFY_EMAIL_CODE_SENT));
+
+        SessionState currentState = NEW;
+
+        for (JourneyTransition transition : transitions) {
+            currentState =
+                    stateMachine.transition(
+                            currentState,
+                            transition.getSessionAction(),
+                            transition.getUserContext());
+            assertThat(currentState, equalTo(transition.getExpectedSessionState()));
+        }
+    }
+}

--- a/shared/src/test/java/uk/gov/di/authentication/shared/state/journeys/MfaJourneyTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/state/journeys/MfaJourneyTest.java
@@ -1,0 +1,367 @@
+package uk.gov.di.authentication.shared.state.journeys;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.entity.ClientRegistry;
+import uk.gov.di.authentication.shared.entity.ClientSession;
+import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
+import uk.gov.di.authentication.shared.entity.Session;
+import uk.gov.di.authentication.shared.entity.SessionAction;
+import uk.gov.di.authentication.shared.entity.SessionState;
+import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.entity.VectorOfTrust;
+import uk.gov.di.authentication.shared.helpers.IdGenerator;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.state.StateMachine;
+import uk.gov.di.authentication.shared.state.UserContext;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.shared.entity.SessionAction.SYSTEM_HAS_ISSUED_AUTHORIZATION_CODE;
+import static uk.gov.di.authentication.shared.entity.SessionAction.SYSTEM_HAS_SENT_MFA_CODE;
+import static uk.gov.di.authentication.shared.entity.SessionAction.SYSTEM_HAS_SENT_TOO_MANY_MFA_CODES;
+import static uk.gov.di.authentication.shared.entity.SessionAction.SYSTEM_IS_BLOCKED_FROM_SENDING_ANY_MFA_VERIFICATION_CODES;
+import static uk.gov.di.authentication.shared.entity.SessionAction.USER_ENTERED_INVALID_MFA_CODE;
+import static uk.gov.di.authentication.shared.entity.SessionAction.USER_ENTERED_INVALID_MFA_CODE_TOO_MANY_TIMES;
+import static uk.gov.di.authentication.shared.entity.SessionAction.USER_ENTERED_REGISTERED_EMAIL_ADDRESS;
+import static uk.gov.di.authentication.shared.entity.SessionAction.USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS;
+import static uk.gov.di.authentication.shared.entity.SessionAction.USER_ENTERED_VALID_CREDENTIALS;
+import static uk.gov.di.authentication.shared.entity.SessionAction.USER_ENTERED_VALID_MFA_CODE;
+import static uk.gov.di.authentication.shared.entity.SessionState.AUTHENTICATED;
+import static uk.gov.di.authentication.shared.entity.SessionState.AUTHENTICATION_REQUIRED;
+import static uk.gov.di.authentication.shared.entity.SessionState.LOGGED_IN;
+import static uk.gov.di.authentication.shared.entity.SessionState.MFA_CODE_MAX_RETRIES_REACHED;
+import static uk.gov.di.authentication.shared.entity.SessionState.MFA_CODE_NOT_VALID;
+import static uk.gov.di.authentication.shared.entity.SessionState.MFA_CODE_REQUESTS_BLOCKED;
+import static uk.gov.di.authentication.shared.entity.SessionState.MFA_CODE_VERIFIED;
+import static uk.gov.di.authentication.shared.entity.SessionState.MFA_SMS_CODE_SENT;
+import static uk.gov.di.authentication.shared.entity.SessionState.MFA_SMS_MAX_CODES_SENT;
+import static uk.gov.di.authentication.shared.entity.SessionState.NEW;
+import static uk.gov.di.authentication.shared.entity.SessionState.USER_NOT_FOUND;
+import static uk.gov.di.authentication.shared.state.StateMachineJourneyTest.CLIENT_ID;
+import static uk.gov.di.authentication.shared.state.StateMachineJourneyTest.generateAuthRequest;
+import static uk.gov.di.authentication.shared.state.StateMachineJourneyTest.generateUserProfile;
+
+public class MfaJourneyTest {
+    private final ConfigurationService mockConfigurationService = mock(ConfigurationService.class);
+
+    private final Session session = new Session(IdGenerator.generate());
+
+    private StateMachine<SessionState, SessionAction, UserContext> stateMachine;
+
+    @BeforeEach
+    void setup() {
+        when(mockConfigurationService.getTermsAndConditionsVersion()).thenReturn("1.0");
+
+        stateMachine = StateMachine.userJourneyStateMachine(mockConfigurationService);
+    }
+
+    @Test
+    public void testCanSignInWithMfa() {
+        UserProfile userProfile =
+                generateUserProfile(
+                        true,
+                        "1.0",
+                        new HashSet<String>(
+                                Arrays.asList(
+                                        "phone_number",
+                                        "phone_number_verified",
+                                        "email",
+                                        "email_verified",
+                                        "sub")));
+
+        UserContext userContext =
+                UserContext.builder(
+                                session.setCurrentCredentialStrength(
+                                        CredentialTrustLevel.LOW_LEVEL))
+                        .withClientSession(
+                                new ClientSession(
+                                                generateAuthRequest("Cl.Cm").toParameters(),
+                                                null,
+                                                null)
+                                        .setEffectiveVectorOfTrust(VectorOfTrust.getDefaults()))
+                        .withUserProfile(userProfile)
+                        .withClient(new ClientRegistry().setClientID(CLIENT_ID.toString()))
+                        .build();
+
+        List<JourneyTransition> transitions =
+                Arrays.asList(
+                        new JourneyTransition(
+                                userContext,
+                                USER_ENTERED_REGISTERED_EMAIL_ADDRESS,
+                                AUTHENTICATION_REQUIRED),
+                        new JourneyTransition(
+                                userContext, USER_ENTERED_VALID_CREDENTIALS, LOGGED_IN),
+                        new JourneyTransition(
+                                userContext, SYSTEM_HAS_SENT_MFA_CODE, MFA_SMS_CODE_SENT),
+                        new JourneyTransition(
+                                userContext, USER_ENTERED_VALID_MFA_CODE, MFA_CODE_VERIFIED),
+                        new JourneyTransition(
+                                userContext, SYSTEM_HAS_ISSUED_AUTHORIZATION_CODE, AUTHENTICATED));
+
+        SessionState currentState = NEW;
+
+        for (JourneyTransition transition : transitions) {
+            currentState =
+                    stateMachine.transition(
+                            currentState,
+                            transition.getSessionAction(),
+                            transition.getUserContext());
+            assertThat(currentState, equalTo(transition.getExpectedSessionState()));
+        }
+    }
+
+    @Test
+    public void testCanReachMfaBlockedStatusIfTooManyCodesAreRequested() {
+        UserProfile userProfile =
+                generateUserProfile(
+                        true,
+                        "1.0",
+                        new HashSet<String>(
+                                Arrays.asList(
+                                        "phone_number",
+                                        "phone_number_verified",
+                                        "email",
+                                        "email_verified",
+                                        "sub")));
+
+        UserContext userContext =
+                UserContext.builder(
+                                session.setCurrentCredentialStrength(
+                                        CredentialTrustLevel.LOW_LEVEL))
+                        .withClientSession(
+                                new ClientSession(
+                                                generateAuthRequest("Cl.Cm").toParameters(),
+                                                null,
+                                                null)
+                                        .setEffectiveVectorOfTrust(VectorOfTrust.getDefaults()))
+                        .withUserProfile(userProfile)
+                        .withClient(new ClientRegistry().setClientID(CLIENT_ID.toString()))
+                        .build();
+
+        List<JourneyTransition> transitions =
+                Arrays.asList(
+                        new JourneyTransition(
+                                userContext,
+                                USER_ENTERED_REGISTERED_EMAIL_ADDRESS,
+                                AUTHENTICATION_REQUIRED),
+                        new JourneyTransition(
+                                userContext, USER_ENTERED_VALID_CREDENTIALS, LOGGED_IN),
+                        new JourneyTransition(
+                                userContext, SYSTEM_HAS_SENT_MFA_CODE, MFA_SMS_CODE_SENT),
+                        new JourneyTransition(
+                                userContext,
+                                SYSTEM_HAS_SENT_TOO_MANY_MFA_CODES,
+                                MFA_SMS_MAX_CODES_SENT),
+                        new JourneyTransition(
+                                userContext,
+                                SYSTEM_IS_BLOCKED_FROM_SENDING_ANY_MFA_VERIFICATION_CODES,
+                                MFA_CODE_REQUESTS_BLOCKED));
+
+        SessionState currentState = NEW;
+
+        for (JourneyTransition transition : transitions) {
+            currentState =
+                    stateMachine.transition(
+                            currentState,
+                            transition.getSessionAction(),
+                            transition.getUserContext());
+            assertThat(currentState, equalTo(transition.getExpectedSessionState()));
+        }
+    }
+
+    @Test
+    public void testCanReachMfaBlockedByRequestingTooManyCodesButEnterANewEmailAndStartAgain() {
+        UserProfile userProfile =
+                generateUserProfile(
+                        true,
+                        "1.0",
+                        new HashSet<String>(
+                                Arrays.asList(
+                                        "phone_number",
+                                        "phone_number_verified",
+                                        "email",
+                                        "email_verified",
+                                        "sub")));
+
+        UserContext userContext =
+                UserContext.builder(
+                                session.setCurrentCredentialStrength(
+                                        CredentialTrustLevel.LOW_LEVEL))
+                        .withClientSession(
+                                new ClientSession(
+                                                generateAuthRequest("Cl.Cm").toParameters(),
+                                                null,
+                                                null)
+                                        .setEffectiveVectorOfTrust(VectorOfTrust.getDefaults()))
+                        .withUserProfile(userProfile)
+                        .withClient(new ClientRegistry().setClientID(CLIENT_ID.toString()))
+                        .build();
+
+        List<JourneyTransition> transitions =
+                Arrays.asList(
+                        new JourneyTransition(
+                                userContext,
+                                USER_ENTERED_REGISTERED_EMAIL_ADDRESS,
+                                AUTHENTICATION_REQUIRED),
+                        new JourneyTransition(
+                                userContext, USER_ENTERED_VALID_CREDENTIALS, LOGGED_IN),
+                        new JourneyTransition(
+                                userContext, SYSTEM_HAS_SENT_MFA_CODE, MFA_SMS_CODE_SENT),
+                        new JourneyTransition(
+                                userContext,
+                                SYSTEM_HAS_SENT_TOO_MANY_MFA_CODES,
+                                MFA_SMS_MAX_CODES_SENT),
+                        new JourneyTransition(
+                                userContext,
+                                USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS,
+                                USER_NOT_FOUND),
+                        new JourneyTransition(
+                                userContext,
+                                USER_ENTERED_REGISTERED_EMAIL_ADDRESS,
+                                AUTHENTICATION_REQUIRED),
+                        new JourneyTransition(
+                                userContext, USER_ENTERED_VALID_CREDENTIALS, LOGGED_IN));
+
+        SessionState currentState = NEW;
+
+        for (JourneyTransition transition : transitions) {
+            currentState =
+                    stateMachine.transition(
+                            currentState,
+                            transition.getSessionAction(),
+                            transition.getUserContext());
+            assertThat(currentState, equalTo(transition.getExpectedSessionState()));
+        }
+    }
+
+    @Test
+    public void testCanReachMfaBlockedStatusIfTooManyIncorrectAttemptsAreMade() {
+        UserProfile userProfile =
+                generateUserProfile(
+                        true,
+                        "1.0",
+                        new HashSet<String>(
+                                Arrays.asList(
+                                        "phone_number",
+                                        "phone_number_verified",
+                                        "email",
+                                        "email_verified",
+                                        "sub")));
+
+        UserContext userContext =
+                UserContext.builder(
+                                session.setCurrentCredentialStrength(
+                                        CredentialTrustLevel.LOW_LEVEL))
+                        .withClientSession(
+                                new ClientSession(
+                                                generateAuthRequest("Cl.Cm").toParameters(),
+                                                null,
+                                                null)
+                                        .setEffectiveVectorOfTrust(VectorOfTrust.getDefaults()))
+                        .withUserProfile(userProfile)
+                        .withClient(new ClientRegistry().setClientID(CLIENT_ID.toString()))
+                        .build();
+
+        List<JourneyTransition> transitions =
+                Arrays.asList(
+                        new JourneyTransition(
+                                userContext,
+                                USER_ENTERED_REGISTERED_EMAIL_ADDRESS,
+                                AUTHENTICATION_REQUIRED),
+                        new JourneyTransition(
+                                userContext, USER_ENTERED_VALID_CREDENTIALS, LOGGED_IN),
+                        new JourneyTransition(
+                                userContext, SYSTEM_HAS_SENT_MFA_CODE, MFA_SMS_CODE_SENT),
+                        new JourneyTransition(
+                                userContext, USER_ENTERED_INVALID_MFA_CODE, MFA_CODE_NOT_VALID),
+                        new JourneyTransition(
+                                userContext,
+                                USER_ENTERED_INVALID_MFA_CODE_TOO_MANY_TIMES,
+                                MFA_CODE_MAX_RETRIES_REACHED));
+
+        SessionState currentState = NEW;
+
+        for (JourneyTransition transition : transitions) {
+            currentState =
+                    stateMachine.transition(
+                            currentState,
+                            transition.getSessionAction(),
+                            transition.getUserContext());
+            assertThat(currentState, equalTo(transition.getExpectedSessionState()));
+        }
+    }
+
+    @Test
+    public void testCanReachMfaBlockedByIncorrectCodeTooManyTimesAndEnterANewEmailAndStartAgain() {
+        UserProfile userProfile =
+                generateUserProfile(
+                        true,
+                        "1.0",
+                        new HashSet<String>(
+                                Arrays.asList(
+                                        "phone_number",
+                                        "phone_number_verified",
+                                        "email",
+                                        "email_verified",
+                                        "sub")));
+
+        UserContext userContext =
+                UserContext.builder(
+                                session.setCurrentCredentialStrength(
+                                        CredentialTrustLevel.LOW_LEVEL))
+                        .withClientSession(
+                                new ClientSession(
+                                                generateAuthRequest("Cl.Cm").toParameters(),
+                                                null,
+                                                null)
+                                        .setEffectiveVectorOfTrust(VectorOfTrust.getDefaults()))
+                        .withUserProfile(userProfile)
+                        .withClient(new ClientRegistry().setClientID(CLIENT_ID.toString()))
+                        .build();
+
+        List<JourneyTransition> transitions =
+                Arrays.asList(
+                        new JourneyTransition(
+                                userContext,
+                                USER_ENTERED_REGISTERED_EMAIL_ADDRESS,
+                                AUTHENTICATION_REQUIRED),
+                        new JourneyTransition(
+                                userContext, USER_ENTERED_VALID_CREDENTIALS, LOGGED_IN),
+                        new JourneyTransition(
+                                userContext, SYSTEM_HAS_SENT_MFA_CODE, MFA_SMS_CODE_SENT),
+                        new JourneyTransition(
+                                userContext, USER_ENTERED_INVALID_MFA_CODE, MFA_CODE_NOT_VALID),
+                        new JourneyTransition(
+                                userContext,
+                                USER_ENTERED_INVALID_MFA_CODE_TOO_MANY_TIMES,
+                                MFA_CODE_MAX_RETRIES_REACHED),
+                        new JourneyTransition(
+                                userContext,
+                                USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS,
+                                USER_NOT_FOUND),
+                        new JourneyTransition(
+                                userContext,
+                                USER_ENTERED_REGISTERED_EMAIL_ADDRESS,
+                                AUTHENTICATION_REQUIRED),
+                        new JourneyTransition(
+                                userContext, USER_ENTERED_VALID_CREDENTIALS, LOGGED_IN));
+
+        SessionState currentState = NEW;
+
+        for (JourneyTransition transition : transitions) {
+            currentState =
+                    stateMachine.transition(
+                            currentState,
+                            transition.getSessionAction(),
+                            transition.getUserContext());
+            assertThat(currentState, equalTo(transition.getExpectedSessionState()));
+        }
+    }
+}

--- a/shared/src/test/java/uk/gov/di/authentication/shared/state/journeys/PhoneVerificationJourneyTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/state/journeys/PhoneVerificationJourneyTest.java
@@ -1,0 +1,437 @@
+package uk.gov.di.authentication.shared.state.journeys;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.entity.ClientRegistry;
+import uk.gov.di.authentication.shared.entity.ClientSession;
+import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
+import uk.gov.di.authentication.shared.entity.Session;
+import uk.gov.di.authentication.shared.entity.SessionAction;
+import uk.gov.di.authentication.shared.entity.SessionState;
+import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.helpers.IdGenerator;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.state.StateMachine;
+import uk.gov.di.authentication.shared.state.UserContext;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.shared.entity.SessionAction.SYSTEM_HAS_SENT_EMAIL_VERIFICATION_CODE;
+import static uk.gov.di.authentication.shared.entity.SessionAction.SYSTEM_HAS_SENT_PHONE_VERIFICATION_CODE;
+import static uk.gov.di.authentication.shared.entity.SessionAction.SYSTEM_HAS_SENT_TOO_MANY_PHONE_VERIFICATION_CODES;
+import static uk.gov.di.authentication.shared.entity.SessionAction.SYSTEM_IS_BLOCKED_FROM_SENDING_ANY_PHONE_VERIFICATION_CODES;
+import static uk.gov.di.authentication.shared.entity.SessionAction.USER_ENTERED_A_NEW_PHONE_NUMBER;
+import static uk.gov.di.authentication.shared.entity.SessionAction.USER_ENTERED_INVALID_PHONE_VERIFICATION_CODE;
+import static uk.gov.di.authentication.shared.entity.SessionAction.USER_ENTERED_INVALID_PHONE_VERIFICATION_CODE_TOO_MANY_TIMES;
+import static uk.gov.di.authentication.shared.entity.SessionAction.USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS;
+import static uk.gov.di.authentication.shared.entity.SessionAction.USER_ENTERED_VALID_EMAIL_VERIFICATION_CODE;
+import static uk.gov.di.authentication.shared.entity.SessionAction.USER_ENTERED_VALID_PHONE_VERIFICATION_CODE;
+import static uk.gov.di.authentication.shared.entity.SessionAction.USER_HAS_CREATED_A_PASSWORD;
+import static uk.gov.di.authentication.shared.entity.SessionState.ADDED_UNVERIFIED_PHONE_NUMBER;
+import static uk.gov.di.authentication.shared.entity.SessionState.EMAIL_CODE_VERIFIED;
+import static uk.gov.di.authentication.shared.entity.SessionState.NEW;
+import static uk.gov.di.authentication.shared.entity.SessionState.PHONE_NUMBER_CODE_MAX_RETRIES_REACHED;
+import static uk.gov.di.authentication.shared.entity.SessionState.PHONE_NUMBER_CODE_NOT_VALID;
+import static uk.gov.di.authentication.shared.entity.SessionState.PHONE_NUMBER_CODE_REQUESTS_BLOCKED;
+import static uk.gov.di.authentication.shared.entity.SessionState.PHONE_NUMBER_CODE_VERIFIED;
+import static uk.gov.di.authentication.shared.entity.SessionState.PHONE_NUMBER_MAX_CODES_SENT;
+import static uk.gov.di.authentication.shared.entity.SessionState.TWO_FACTOR_REQUIRED;
+import static uk.gov.di.authentication.shared.entity.SessionState.USER_NOT_FOUND;
+import static uk.gov.di.authentication.shared.entity.SessionState.VERIFY_EMAIL_CODE_SENT;
+import static uk.gov.di.authentication.shared.entity.SessionState.VERIFY_PHONE_NUMBER_CODE_SENT;
+import static uk.gov.di.authentication.shared.state.StateMachineJourneyTest.CLIENT_ID;
+import static uk.gov.di.authentication.shared.state.StateMachineJourneyTest.generateAuthRequest;
+import static uk.gov.di.authentication.shared.state.StateMachineJourneyTest.generateLowLevelVectorOfTrust;
+import static uk.gov.di.authentication.shared.state.StateMachineJourneyTest.generateUserProfile;
+
+public class PhoneVerificationJourneyTest {
+    private final ConfigurationService mockConfigurationService = mock(ConfigurationService.class);
+
+    private final Session session = new Session(IdGenerator.generate());
+
+    private StateMachine<SessionState, SessionAction, UserContext> stateMachine;
+
+    @BeforeEach
+    void setup() {
+        when(mockConfigurationService.getTermsAndConditionsVersion()).thenReturn("1.0");
+
+        stateMachine = StateMachine.userJourneyStateMachine(mockConfigurationService);
+    }
+
+    @Test
+    public void testCanVerifyPhone() {
+        UserProfile userProfile =
+                generateUserProfile(
+                        true,
+                        "1.0",
+                        new HashSet<String>(
+                                Arrays.asList(
+                                        "phone_number",
+                                        "phone_number_verified",
+                                        "email",
+                                        "email_verified",
+                                        "sub")));
+
+        UserContext userContext =
+                UserContext.builder(
+                                session.setCurrentCredentialStrength(
+                                        CredentialTrustLevel.LOW_LEVEL))
+                        .withClientSession(
+                                new ClientSession(
+                                                generateAuthRequest("Cl").toParameters(),
+                                                null,
+                                                null)
+                                        .setEffectiveVectorOfTrust(generateLowLevelVectorOfTrust()))
+                        .withUserProfile(userProfile)
+                        .withClient(new ClientRegistry().setClientID(CLIENT_ID.toString()))
+                        .build();
+
+        List<JourneyTransition> transitions =
+                Arrays.asList(
+                        new JourneyTransition(
+                                userContext,
+                                USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS,
+                                USER_NOT_FOUND),
+                        new JourneyTransition(
+                                userContext,
+                                SYSTEM_HAS_SENT_EMAIL_VERIFICATION_CODE,
+                                VERIFY_EMAIL_CODE_SENT),
+                        new JourneyTransition(
+                                userContext,
+                                USER_ENTERED_VALID_EMAIL_VERIFICATION_CODE,
+                                EMAIL_CODE_VERIFIED),
+                        new JourneyTransition(
+                                userContext, USER_HAS_CREATED_A_PASSWORD, TWO_FACTOR_REQUIRED),
+                        new JourneyTransition(
+                                userContext,
+                                USER_ENTERED_A_NEW_PHONE_NUMBER,
+                                ADDED_UNVERIFIED_PHONE_NUMBER),
+                        new JourneyTransition(
+                                userContext,
+                                SYSTEM_HAS_SENT_PHONE_VERIFICATION_CODE,
+                                VERIFY_PHONE_NUMBER_CODE_SENT),
+                        new JourneyTransition(
+                                userContext,
+                                USER_ENTERED_VALID_PHONE_VERIFICATION_CODE,
+                                PHONE_NUMBER_CODE_VERIFIED));
+
+        SessionState currentState = NEW;
+
+        for (JourneyTransition transition : transitions) {
+            currentState =
+                    stateMachine.transition(
+                            currentState,
+                            transition.getSessionAction(),
+                            transition.getUserContext());
+            assertThat(currentState, equalTo(transition.getExpectedSessionState()));
+        }
+    }
+
+    @Test
+    public void testCanReachBlockedStatusIfTooManyCodesAreRequested() {
+        UserProfile userProfile =
+                generateUserProfile(
+                        true,
+                        "1.0",
+                        new HashSet<String>(
+                                Arrays.asList(
+                                        "phone_number",
+                                        "phone_number_verified",
+                                        "email",
+                                        "email_verified",
+                                        "sub")));
+
+        UserContext userContext =
+                UserContext.builder(
+                                session.setCurrentCredentialStrength(
+                                        CredentialTrustLevel.LOW_LEVEL))
+                        .withClientSession(
+                                new ClientSession(
+                                                generateAuthRequest("Cl").toParameters(),
+                                                null,
+                                                null)
+                                        .setEffectiveVectorOfTrust(generateLowLevelVectorOfTrust()))
+                        .withUserProfile(userProfile)
+                        .withClient(new ClientRegistry().setClientID(CLIENT_ID.toString()))
+                        .build();
+
+        List<JourneyTransition> transitions =
+                Arrays.asList(
+                        new JourneyTransition(
+                                userContext,
+                                USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS,
+                                USER_NOT_FOUND),
+                        new JourneyTransition(
+                                userContext,
+                                SYSTEM_HAS_SENT_EMAIL_VERIFICATION_CODE,
+                                VERIFY_EMAIL_CODE_SENT),
+                        new JourneyTransition(
+                                userContext,
+                                USER_ENTERED_VALID_EMAIL_VERIFICATION_CODE,
+                                EMAIL_CODE_VERIFIED),
+                        new JourneyTransition(
+                                userContext, USER_HAS_CREATED_A_PASSWORD, TWO_FACTOR_REQUIRED),
+                        new JourneyTransition(
+                                userContext,
+                                USER_ENTERED_A_NEW_PHONE_NUMBER,
+                                ADDED_UNVERIFIED_PHONE_NUMBER),
+                        new JourneyTransition(
+                                userContext,
+                                SYSTEM_HAS_SENT_PHONE_VERIFICATION_CODE,
+                                VERIFY_PHONE_NUMBER_CODE_SENT),
+                        new JourneyTransition(
+                                userContext,
+                                SYSTEM_HAS_SENT_TOO_MANY_PHONE_VERIFICATION_CODES,
+                                PHONE_NUMBER_MAX_CODES_SENT));
+
+        SessionState currentState = NEW;
+
+        for (JourneyTransition transition : transitions) {
+            currentState =
+                    stateMachine.transition(
+                            currentState,
+                            transition.getSessionAction(),
+                            transition.getUserContext());
+            assertThat(currentState, equalTo(transition.getExpectedSessionState()));
+        }
+    }
+
+    @Test
+    public void
+            testCanReachBlockedByRequestingTooManyCodesButEnterANewPhoneNumberAndStillBeBlocked() {
+        UserProfile userProfile =
+                generateUserProfile(
+                        true,
+                        "1.0",
+                        new HashSet<String>(
+                                Arrays.asList(
+                                        "phone_number",
+                                        "phone_number_verified",
+                                        "email",
+                                        "email_verified",
+                                        "sub")));
+
+        UserContext userContext =
+                UserContext.builder(
+                                session.setCurrentCredentialStrength(
+                                        CredentialTrustLevel.LOW_LEVEL))
+                        .withClientSession(
+                                new ClientSession(
+                                                generateAuthRequest("Cl").toParameters(),
+                                                null,
+                                                null)
+                                        .setEffectiveVectorOfTrust(generateLowLevelVectorOfTrust()))
+                        .withUserProfile(userProfile)
+                        .withClient(new ClientRegistry().setClientID(CLIENT_ID.toString()))
+                        .build();
+
+        List<JourneyTransition> transitions =
+                Arrays.asList(
+                        new JourneyTransition(
+                                userContext,
+                                USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS,
+                                USER_NOT_FOUND),
+                        new JourneyTransition(
+                                userContext,
+                                SYSTEM_HAS_SENT_EMAIL_VERIFICATION_CODE,
+                                VERIFY_EMAIL_CODE_SENT),
+                        new JourneyTransition(
+                                userContext,
+                                USER_ENTERED_VALID_EMAIL_VERIFICATION_CODE,
+                                EMAIL_CODE_VERIFIED),
+                        new JourneyTransition(
+                                userContext, USER_HAS_CREATED_A_PASSWORD, TWO_FACTOR_REQUIRED),
+                        new JourneyTransition(
+                                userContext,
+                                USER_ENTERED_A_NEW_PHONE_NUMBER,
+                                ADDED_UNVERIFIED_PHONE_NUMBER),
+                        new JourneyTransition(
+                                userContext,
+                                SYSTEM_HAS_SENT_PHONE_VERIFICATION_CODE,
+                                VERIFY_PHONE_NUMBER_CODE_SENT),
+                        new JourneyTransition(
+                                userContext,
+                                SYSTEM_HAS_SENT_TOO_MANY_PHONE_VERIFICATION_CODES,
+                                PHONE_NUMBER_MAX_CODES_SENT),
+                        new JourneyTransition(
+                                userContext,
+                                USER_ENTERED_A_NEW_PHONE_NUMBER,
+                                ADDED_UNVERIFIED_PHONE_NUMBER),
+                        new JourneyTransition(
+                                userContext,
+                                SYSTEM_IS_BLOCKED_FROM_SENDING_ANY_PHONE_VERIFICATION_CODES,
+                                PHONE_NUMBER_CODE_REQUESTS_BLOCKED));
+
+        SessionState currentState = NEW;
+
+        for (JourneyTransition transition : transitions) {
+            currentState =
+                    stateMachine.transition(
+                            currentState,
+                            transition.getSessionAction(),
+                            transition.getUserContext());
+            assertThat(currentState, equalTo(transition.getExpectedSessionState()));
+        }
+    }
+
+    @Test
+    public void testCanReachBlockedStatusIfIncorrectCodeIsEnteredTooManyTimes() {
+        UserProfile userProfile =
+                generateUserProfile(
+                        true,
+                        "1.0",
+                        new HashSet<String>(
+                                Arrays.asList(
+                                        "phone_number",
+                                        "phone_number_verified",
+                                        "email",
+                                        "email_verified",
+                                        "sub")));
+
+        UserContext userContext =
+                UserContext.builder(
+                                session.setCurrentCredentialStrength(
+                                        CredentialTrustLevel.LOW_LEVEL))
+                        .withClientSession(
+                                new ClientSession(
+                                                generateAuthRequest("Cl").toParameters(),
+                                                null,
+                                                null)
+                                        .setEffectiveVectorOfTrust(generateLowLevelVectorOfTrust()))
+                        .withUserProfile(userProfile)
+                        .withClient(new ClientRegistry().setClientID(CLIENT_ID.toString()))
+                        .build();
+
+        List<JourneyTransition> transitions =
+                Arrays.asList(
+                        new JourneyTransition(
+                                userContext,
+                                USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS,
+                                USER_NOT_FOUND),
+                        new JourneyTransition(
+                                userContext,
+                                SYSTEM_HAS_SENT_EMAIL_VERIFICATION_CODE,
+                                VERIFY_EMAIL_CODE_SENT),
+                        new JourneyTransition(
+                                userContext,
+                                USER_ENTERED_VALID_EMAIL_VERIFICATION_CODE,
+                                EMAIL_CODE_VERIFIED),
+                        new JourneyTransition(
+                                userContext, USER_HAS_CREATED_A_PASSWORD, TWO_FACTOR_REQUIRED),
+                        new JourneyTransition(
+                                userContext,
+                                USER_ENTERED_A_NEW_PHONE_NUMBER,
+                                ADDED_UNVERIFIED_PHONE_NUMBER),
+                        new JourneyTransition(
+                                userContext,
+                                SYSTEM_HAS_SENT_PHONE_VERIFICATION_CODE,
+                                VERIFY_PHONE_NUMBER_CODE_SENT),
+                        new JourneyTransition(
+                                userContext,
+                                USER_ENTERED_INVALID_PHONE_VERIFICATION_CODE,
+                                PHONE_NUMBER_CODE_NOT_VALID),
+                        new JourneyTransition(
+                                userContext,
+                                USER_ENTERED_INVALID_PHONE_VERIFICATION_CODE_TOO_MANY_TIMES,
+                                PHONE_NUMBER_CODE_MAX_RETRIES_REACHED));
+
+        SessionState currentState = NEW;
+
+        for (JourneyTransition transition : transitions) {
+            currentState =
+                    stateMachine.transition(
+                            currentState,
+                            transition.getSessionAction(),
+                            transition.getUserContext());
+            assertThat(currentState, equalTo(transition.getExpectedSessionState()));
+        }
+    }
+
+    @Test
+    public void
+            testCanReachBlockedByIncorrectCodeTooManyTimesButEnterANewPhoneNumberAndStillBeBlocked() {
+        UserProfile userProfile =
+                generateUserProfile(
+                        true,
+                        "1.0",
+                        new HashSet<String>(
+                                Arrays.asList(
+                                        "phone_number",
+                                        "phone_number_verified",
+                                        "email",
+                                        "email_verified",
+                                        "sub")));
+
+        UserContext userContext =
+                UserContext.builder(
+                                session.setCurrentCredentialStrength(
+                                        CredentialTrustLevel.LOW_LEVEL))
+                        .withClientSession(
+                                new ClientSession(
+                                                generateAuthRequest("Cl").toParameters(),
+                                                null,
+                                                null)
+                                        .setEffectiveVectorOfTrust(generateLowLevelVectorOfTrust()))
+                        .withUserProfile(userProfile)
+                        .withClient(new ClientRegistry().setClientID(CLIENT_ID.toString()))
+                        .build();
+
+        List<JourneyTransition> transitions =
+                Arrays.asList(
+                        new JourneyTransition(
+                                userContext,
+                                USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS,
+                                USER_NOT_FOUND),
+                        new JourneyTransition(
+                                userContext,
+                                SYSTEM_HAS_SENT_EMAIL_VERIFICATION_CODE,
+                                VERIFY_EMAIL_CODE_SENT),
+                        new JourneyTransition(
+                                userContext,
+                                USER_ENTERED_VALID_EMAIL_VERIFICATION_CODE,
+                                EMAIL_CODE_VERIFIED),
+                        new JourneyTransition(
+                                userContext, USER_HAS_CREATED_A_PASSWORD, TWO_FACTOR_REQUIRED),
+                        new JourneyTransition(
+                                userContext,
+                                USER_ENTERED_A_NEW_PHONE_NUMBER,
+                                ADDED_UNVERIFIED_PHONE_NUMBER),
+                        new JourneyTransition(
+                                userContext,
+                                SYSTEM_HAS_SENT_PHONE_VERIFICATION_CODE,
+                                VERIFY_PHONE_NUMBER_CODE_SENT),
+                        new JourneyTransition(
+                                userContext,
+                                USER_ENTERED_INVALID_PHONE_VERIFICATION_CODE,
+                                PHONE_NUMBER_CODE_NOT_VALID),
+                        new JourneyTransition(
+                                userContext,
+                                USER_ENTERED_INVALID_PHONE_VERIFICATION_CODE_TOO_MANY_TIMES,
+                                PHONE_NUMBER_CODE_MAX_RETRIES_REACHED),
+                        new JourneyTransition(
+                                userContext,
+                                USER_ENTERED_A_NEW_PHONE_NUMBER,
+                                ADDED_UNVERIFIED_PHONE_NUMBER),
+                        new JourneyTransition(
+                                userContext,
+                                USER_ENTERED_INVALID_PHONE_VERIFICATION_CODE_TOO_MANY_TIMES,
+                                PHONE_NUMBER_CODE_MAX_RETRIES_REACHED));
+
+        SessionState currentState = NEW;
+
+        for (JourneyTransition transition : transitions) {
+            currentState =
+                    stateMachine.transition(
+                            currentState,
+                            transition.getSessionAction(),
+                            transition.getUserContext());
+            assertThat(currentState, equalTo(transition.getExpectedSessionState()));
+        }
+    }
+}


### PR DESCRIPTION
## What?

Added some missing state machine transitions for when a user gets into a blocked state and directly moves back to the sign-in-or-create page and attempts to sign in.

## Why?

Fix current state machine errors that occur due to recently added functionality around user blocked states.
