### PR TITLE
GOVSI-777: update support link in password reset confirmation email

### DIFF
--- a/ci/terraform/oidc/sqs.tf
+++ b/ci/terraform/oidc/sqs.tf
@@ -154,13 +154,14 @@ resource "aws_lambda_function" "email_sqs_lambda" {
   }
   environment {
     variables = merge(var.notify_template_map, {
-      FRONTEND_BASE_URL         = module.dns.frontend_url
-      ACCOUNT_MANAGEMENT_URI    = module.dns.account_management_url
-      RESET_PASSWORD_ROUTE      = var.reset_password_route
-      NOTIFY_API_KEY            = var.notify_api_key
-      NOTIFY_URL                = var.notify_url
-      NOTIFY_TEST_PHONE_NUMBER  = var.notify_test_phone_number
-      SMOKETEST_SMS_BUCKET_NAME = local.sms_bucket_name
+      FRONTEND_BASE_URL           = module.dns.frontend_url
+      ACCOUNT_MANAGEMENT_URI      = module.dns.account_management_url
+      RESET_PASSWORD_ROUTE        = var.reset_password_route
+      CUSTOMER_SUPPORT_LINK_ROUTE = var.customer_support_link_route
+      NOTIFY_API_KEY              = var.notify_api_key
+      NOTIFY_URL                  = var.notify_url
+      NOTIFY_TEST_PHONE_NUMBER    = var.notify_test_phone_number
+      SMOKETEST_SMS_BUCKET_NAME   = local.sms_bucket_name
     })
   }
   kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -144,6 +144,11 @@ variable "reset_password_route" {
   default = "reset-password?code="
 }
 
+variable "customer_support_link_route" {
+  type    = string
+  default = "support"
+}
+
 variable "dns_state_bucket" {
   type = string
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandler.java
@@ -115,6 +115,14 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                                     notificationService.getNotificationTemplateId(RESET_PASSWORD));
                             break;
                         case PASSWORD_RESET_CONFIRMATION:
+                            Map<String, Object> passwordResetConfirmationPersonalisation =
+                                    new HashMap<>();
+                            passwordResetConfirmationPersonalisation.put(
+                                    "customer-support-link",
+                                    buildURI(
+                                                    configService.getFrontendBaseUrl(),
+                                                    configService.getCustomerSupportLinkRoute())
+                                            .toString());
                             notificationService.sendEmail(
                                     notifyRequest.getDestination(),
                                     Collections.emptyMap(),

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandlerTest.java
@@ -38,6 +38,10 @@ public class NotificationHandlerTest {
     private static final String NOTIFY_PHONE_NUMBER = "01234567899";
     private static final String TEMPLATE_ID = "fdsfdssd";
     private static final String BUCKET_NAME = "test-s3-bucket";
+    private static final String FRONTEND_BASE_URL = "https://localhost:8080/frontend";
+    private static final String CUSTOMER_SUPPORT_LINK_URL =
+            "https://localhost:8080/frontend/support";
+    private static final String CUSTOMER_SUPPORT_LINK_ROUTE = "support";
     private final Context context = mock(Context.class);
     private final NotificationService notificationService = mock(NotificationService.class);
     private final ConfigurationService configService = mock(ConfigurationService.class);
@@ -75,6 +79,8 @@ public class NotificationHandlerTest {
             throws JsonProcessingException, NotificationClientException {
         when(notificationService.getNotificationTemplateId(PASSWORD_RESET_CONFIRMATION))
                 .thenReturn(TEMPLATE_ID);
+        when(configService.getFrontendBaseUrl()).thenReturn(FRONTEND_BASE_URL);
+        when(configService.getCustomerSupportLinkRoute()).thenReturn(CUSTOMER_SUPPORT_LINK_ROUTE);
 
         NotifyRequest notifyRequest =
                 new NotifyRequest(TEST_EMAIL_ADDRESS, PASSWORD_RESET_CONFIRMATION);
@@ -82,6 +88,9 @@ public class NotificationHandlerTest {
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
 
         handler.handleRequest(sqsEvent, context);
+
+        Map<String, Object> personalisation = new HashMap<>();
+        personalisation.put("customer-support-link", CUSTOMER_SUPPORT_LINK_URL);
 
         verify(notificationService)
                 .sendEmail(TEST_EMAIL_ADDRESS, Collections.emptyMap(), TEMPLATE_ID);


### PR DESCRIPTION
## What?

Pass customer support link url as a personalisation to password reset confirmation email template. 

## Why?

The customer support links is different for each environment so the templates must be parameterized.

## Related PRs

#886 