### PR TITLE
Fix missing state machine transitions

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/state/StateMachine.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/state/StateMachine.java
@@ -149,6 +149,8 @@ public class StateMachine<T, A, C> {
                         on(SYSTEM_HAS_SENT_EMAIL_VERIFICATION_CODE).then(VERIFY_EMAIL_CODE_SENT),
                         on(SYSTEM_HAS_SENT_TOO_MANY_EMAIL_VERIFICATION_CODES)
                                 .then(EMAIL_MAX_CODES_SENT),
+                        on(USER_ENTERED_INVALID_EMAIL_VERIFICATION_CODE_TOO_MANY_TIMES)
+                                .then(EMAIL_CODE_MAX_RETRIES_REACHED),
                         on(USER_HAS_STARTED_A_NEW_JOURNEY).then(NEW),
                         on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED).then(NEW))
                 .when(RESET_PASSWORD_LINK_SENT)
@@ -272,6 +274,7 @@ public class StateMachine<T, A, C> {
                 .allow(
                         on(SYSTEM_HAS_SENT_PHONE_VERIFICATION_CODE)
                                 .then(VERIFY_PHONE_NUMBER_CODE_SENT),
+                        on(USER_ENTERED_A_NEW_PHONE_NUMBER).then(ADDED_UNVERIFIED_PHONE_NUMBER),
                         on(USER_HAS_STARTED_A_NEW_JOURNEY).then(NEW),
                         on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED).then(NEW))
                 .when(PHONE_NUMBER_CODE_VERIFIED)
@@ -388,6 +391,7 @@ public class StateMachine<T, A, C> {
                                 .then(MFA_CODE_REQUESTS_BLOCKED),
                         on(SYSTEM_HAS_SENT_MFA_CODE).then(MFA_SMS_CODE_SENT),
                         on(USER_ENTERED_INVALID_MFA_CODE).then(MFA_CODE_NOT_VALID),
+                        on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND),
                         on(USER_HAS_STARTED_A_NEW_JOURNEY)
                                 .then(UPLIFT_REQUIRED_CM)
                                 .ifCondition(upliftRequired()),


### PR DESCRIPTION
## What?

Fixed missing state machine transitions for phone and email verification and additional transition for blocked during a new user journey caused by using the browser back button.

## Why?

Fixed missing state machine transitions that are required for when blocked during the phone or email verification stage.
