### PR TITLE
GOVSI-1011: Fix incorrect policy role attachment

### DIFF
--- a/ci/terraform/account-management/ssm.tf
+++ b/ci/terraform/account-management/ssm.tf
@@ -119,12 +119,7 @@ resource "aws_iam_role_policy_attachment" "lambda_iam_role_parameters" {
   role       = aws_iam_role.lambda_iam_role.name
 }
 
-resource "aws_iam_role_policy_attachment" "token_lambda_iam_role_parameters" {
-  policy_arn = aws_iam_policy.parameter_policy.arn
-  role       = aws_iam_role.lambda_iam_role.name
-}
-
 resource "aws_iam_role_policy_attachment" "dynamo_sqs_lambda_iam_role_parameters" {
   policy_arn = aws_iam_policy.parameter_policy.arn
-  role       = aws_iam_role.lambda_iam_role.name
+  role       = aws_iam_role.dynamo_sqs_lambda_iam_role.name
 }

--- a/ci/terraform/shared/ssm.tf
+++ b/ci/terraform/shared/ssm.tf
@@ -121,10 +121,10 @@ resource "aws_iam_role_policy_attachment" "lambda_iam_role_parameters" {
 
 resource "aws_iam_role_policy_attachment" "token_lambda_iam_role_parameters" {
   policy_arn = aws_iam_policy.parameter_policy.arn
-  role       = aws_iam_role.lambda_iam_role.name
+  role       = aws_iam_role.token_lambda_iam_role.name
 }
 
 resource "aws_iam_role_policy_attachment" "dynamo_sqs_lambda_iam_role_parameters" {
   policy_arn = aws_iam_policy.parameter_policy.arn
-  role       = aws_iam_role.lambda_iam_role.name
+  role       = aws_iam_role.dynamo_sqs_lambda_iam_role.name
 }


### PR DESCRIPTION
## What?

- The SSM policy was not correctly being assigned to the token or dynamo SQS lambda roles

## Why?

The lambdas are failing to read SSM

## Related PRs

#872 