### PR TITLE
BAU: Allow Terraform to recreate user tables

### DIFF
--- a/ci/terraform/shared/dynamodb.tf
+++ b/ci/terraform/shared/dynamodb.tf
@@ -33,7 +33,7 @@ resource "aws_dynamodb_table" "user_credentials_table" {
   }
 
   lifecycle {
-    prevent_destroy = true
+    prevent_destroy = false
   }
 
   tags = local.default_tags
@@ -87,7 +87,7 @@ resource "aws_dynamodb_table" "user_profile_table" {
   }
 
   lifecycle {
-    prevent_destroy = true
+    prevent_destroy = false
   }
 
   tags = local.default_tags


### PR DESCRIPTION
## What?

- Remove the `prevent_destroy` safe guard on the user profile and credentials tables

## Why?

This is temporary to allow us to delete and re-create the tables in preparation for go live. This change will be reverted prior to the service going live.
