### PR TITLE
GOVSI-1028: Delete incorrect password count from redis after a password reset request

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
@@ -100,6 +100,15 @@ public class ResetPasswordHandler
                                 authenticationService.updatePassword(
                                         userCredentials.getEmail(),
                                         resetPasswordWithCodeRequest.getPassword());
+
+                                int incorrectPasswordCount =
+                                        codeStorageService.getIncorrectPasswordCount(
+                                                userCredentials.getEmail());
+                                if (incorrectPasswordCount != 0) {
+                                    codeStorageService.deleteIncorrectPasswordCount(
+                                            userCredentials.getEmail());
+                                }
+
                                 NotifyRequest notifyRequest =
                                         new NotifyRequest(
                                                 userCredentials.getEmail(),


### PR DESCRIPTION
## What?

Delete a users incorrect password count from redis after a password reset request.

## Why?

After a user resets their password this should unlock their account if it was previously blocked due to too many incorrect password attempts.
