### PR TITLE
GOVSI-1011: Add the GetParameters permission to account management

### DIFF
--- a/ci/terraform/account-management/ssm.tf
+++ b/ci/terraform/account-management/ssm.tf
@@ -83,6 +83,7 @@ data "aws_iam_policy_document" "redis_parameter_policy" {
 
     actions = [
       "ssm:GetParameter",
+      "ssm:GetParameters",
     ]
 
     resources = [


### PR DESCRIPTION
## What?

- Add the GetParameters permission to account management Redis parameter policy

## Why?

We added this permission to the shared session store parameters, but omitted to also add to account management

## Related PRs

#911 