### PR TITLE
GOVSI-1020: Add TICF auditing to MfaHandler

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/domain/FrontendAuditableEvent.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/domain/FrontendAuditableEvent.java
@@ -24,5 +24,6 @@ public enum FrontendAuditableEvent implements AuditableEvent {
     MFA_INVALID_CODE_REQUEST,
     MFA_MISMATCHED_EMAIL,
     MFA_MISSING_PHONE_NUMBER,
-    MFA_CODE_SENT
+    MFA_CODE_SENT,
+    MFA_CODE_SENT_FOR_TEST_CLIENT
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
@@ -204,6 +204,19 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
                         userWithEmailRequest.getEmail(),
                         IpAddressHelper.extractIpAddress(input),
                         phoneNumber);
+            } else {
+                auditService.submitAuditEvent(
+                        FrontendAuditableEvent.MFA_CODE_SENT_FOR_TEST_CLIENT,
+                        context.getAwsRequestId(),
+                        userContext.getSession().getSessionId(),
+                        userContext
+                                .getClient()
+                                .map(ClientRegistry::getClientID)
+                                .orElse(AuditService.UNKNOWN),
+                        AuditService.UNKNOWN,
+                        userWithEmailRequest.getEmail(),
+                        IpAddressHelper.extractIpAddress(input),
+                        phoneNumber);
             }
             LOGGER.info(
                     "MfaHandler successfully processed request for session: {}",


### PR DESCRIPTION
A few questions:

* Do we need to send an audit event for every request?
* Do we need to send an audit event if this is a test client? (especially relevant if the answer to the previous question is 'yes')
* Not sure client-id is being handled properly; I can't get it to show up in the tests.  Looks like this is also the case for some of the other lambdas I did yesterday.
* For the mismatched email case, should we submit the other email address in a MetadataPair?  If so, what should we name it?