### PR TITLE
Add missing state machine transitions for Forgotten password page issues

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/state/StateMachine.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/state/StateMachine.java
@@ -330,6 +330,7 @@ public class StateMachine<T, A, C> {
                         on(USER_ENTERED_INVALID_PASSWORD_TOO_MANY_TIMES)
                                 .then(ACCOUNT_TEMPORARILY_LOCKED),
                         on(ACCOUNT_LOCK_EXPIRED).then(AUTHENTICATION_REQUIRED),
+                        on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND),
                         on(USER_HAS_STARTED_A_NEW_JOURNEY).then(NEW),
                         on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED).then(NEW))
                 .when(AUTHENTICATION_REQUIRED)


### PR DESCRIPTION
## What?

GOVSI-1031: Add missing state transitions to the "RESET_PASSWORD_LINK_SENT" state to allow a user to reach the forgotten password page, and the use the browser back button to go pack and enter their password.

GOVSI-1032: Add missing state transitions to allow the user to directly return to the sign-in-or-create page after reaching the forgotten password lock screen.

## Why?

Fix multiple bugs that cause an invalid state machine transition around the forgotten password page.
