### PR TITLE
BAU: Stop Terraform from being able to destroy tables

### DIFF
--- a/ci/terraform/shared/dynamodb.tf
+++ b/ci/terraform/shared/dynamodb.tf
@@ -33,7 +33,7 @@ resource "aws_dynamodb_table" "user_credentials_table" {
   }
 
   lifecycle {
-    prevent_destroy = false
+    prevent_destroy = true
   }
 
   tags = local.default_tags
@@ -87,7 +87,7 @@ resource "aws_dynamodb_table" "user_profile_table" {
   }
 
   lifecycle {
-    prevent_destroy = false
+    prevent_destroy = true
   }
 
   tags = local.default_tags


### PR DESCRIPTION
## What?

- Reinstate `prevent_destroy = true` to the user credentials and profile tables.

## Why?

We have purged and migrated live data, we now want to prevent accidental destruction
