### PR TITLE
BAU: Decompose `ConfigurationService`

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/configuration/AuditPublisherConfiguration.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/configuration/AuditPublisherConfiguration.java
@@ -1,6 +1,6 @@
 package uk.gov.di.authentication.shared.configuration;
 
-public interface AuditPublisherConfiguration {
+public interface AuditPublisherConfiguration extends BaseLambdaConfiguration {
 
     default String getAuditSigningKeyAlias() {
         return System.getenv("AUDIT_SIGNING_KEY_ALIAS");

--- a/shared/src/main/java/uk/gov/di/authentication/shared/configuration/AuditPublisherConfiguration.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/configuration/AuditPublisherConfiguration.java
@@ -1,0 +1,12 @@
+package uk.gov.di.authentication.shared.configuration;
+
+public interface AuditPublisherConfiguration {
+
+    default String getAuditSigningKeyAlias() {
+        return System.getenv("AUDIT_SIGNING_KEY_ALIAS");
+    }
+
+    default String getEventsSnsTopicArn() {
+        return System.getenv("EVENTS_SNS_TOPIC_ARN");
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/configuration/BaseLambdaConfiguration.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/configuration/BaseLambdaConfiguration.java
@@ -1,0 +1,18 @@
+package uk.gov.di.authentication.shared.configuration;
+
+import java.util.Optional;
+
+public interface BaseLambdaConfiguration {
+
+    default String getAwsRegion() {
+        return System.getenv("AWS_REGION");
+    }
+
+    default String getEnvironment() {
+        return System.getenv("ENVIRONMENT");
+    }
+
+    default Optional<String> getLocalstackEndpointUri() {
+        return Optional.ofNullable(System.getenv("LOCALSTACK_ENDPOINT"));
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -8,6 +8,7 @@ import com.amazonaws.services.simplesystemsmanagement.model.GetParametersRequest
 import com.amazonaws.services.simplesystemsmanagement.model.ParameterNotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.di.authentication.shared.configuration.AuditPublisherConfiguration;
 
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
@@ -17,7 +18,7 @@ import java.util.stream.Collectors;
 
 import static java.text.MessageFormat.format;
 
-public class ConfigurationService {
+public class ConfigurationService implements AuditPublisherConfiguration {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ConfigurationService.class);
     private static ConfigurationService configurationService;
@@ -88,10 +89,6 @@ public class ConfigurationService {
 
     public String getEnvironment() {
         return System.getenv("ENVIRONMENT");
-    }
-
-    public String getEventsSnsTopicArn() {
-        return System.getenv("EVENTS_SNS_TOPIC_ARN");
     }
 
     public String getFrontendBaseUrl() {
@@ -208,10 +205,6 @@ public class ConfigurationService {
 
     public String getTokenSigningKeyAlias() {
         return System.getenv("TOKEN_SIGNING_KEY_ALIAS");
-    }
-
-    public String getAuditSigningKeyAlias() {
-        return System.getenv("AUDIT_SIGNING_KEY_ALIAS");
     }
 
     public String getAuditStorageS3Bucket() {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -9,6 +9,7 @@ import com.amazonaws.services.simplesystemsmanagement.model.ParameterNotFoundExc
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.di.authentication.shared.configuration.AuditPublisherConfiguration;
+import uk.gov.di.authentication.shared.configuration.BaseLambdaConfiguration;
 
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
@@ -18,7 +19,7 @@ import java.util.stream.Collectors;
 
 import static java.text.MessageFormat.format;
 
-public class ConfigurationService implements AuditPublisherConfiguration {
+public class ConfigurationService implements BaseLambdaConfiguration, AuditPublisherConfiguration {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ConfigurationService.class);
     private static ConfigurationService configurationService;
@@ -45,10 +46,6 @@ public class ConfigurationService implements AuditPublisherConfiguration {
 
     public long getAuthCodeExpiry() {
         return Long.parseLong(System.getenv().getOrDefault("AUTH_CODE_EXPIRY", "300"));
-    }
-
-    public String getAwsRegion() {
-        return System.getenv("AWS_REGION");
     }
 
     public Optional<String> getBaseURL() {
@@ -87,20 +84,12 @@ public class ConfigurationService implements AuditPublisherConfiguration {
         return System.getenv("EMAIL_QUEUE_URL");
     }
 
-    public String getEnvironment() {
-        return System.getenv("ENVIRONMENT");
-    }
-
     public String getFrontendBaseUrl() {
         return System.getenv().getOrDefault("FRONTEND_BASE_URL", "");
     }
 
     public long getIDTokenExpiry() {
         return Long.parseLong(System.getenv().getOrDefault("ID_TOKEN_EXPIRY", "120"));
-    }
-
-    public Optional<String> getLocalstackEndpointUri() {
-        return Optional.ofNullable(System.getenv("LOCALSTACK_ENDPOINT"));
     }
 
     public URI getLoginURI() {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/SnsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/SnsService.java
@@ -5,6 +5,7 @@ import com.amazonaws.services.sns.AmazonSNS;
 import com.amazonaws.services.sns.AmazonSNSClientBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.gov.di.authentication.shared.configuration.AuditPublisherConfiguration;
 
 public class SnsService {
 
@@ -12,7 +13,7 @@ public class SnsService {
     private final AmazonSNS snsClient;
     private static final Logger LOGGER = LoggerFactory.getLogger(SnsService.class);
 
-    public SnsService(ConfigurationService configService) {
+    public SnsService(AuditPublisherConfiguration configService) {
         this.topicArn = configService.getEventsSnsTopicArn();
         var localstackEndpointUri = configService.getLocalstackEndpointUri();
         var awsRegion = configService.getAwsRegion();


### PR DESCRIPTION
## What?

This PR is an example of how we can decompose `ConfigurationService` into capabilities using mixins, implemented using interfaces and default methods.

## Why?

There is a single object for configuration all lambdas, which means all services have access to configuration objects that they don't need.

Configuration should be done at the API level or lower, with mixins used for shared capabilities such as "AWS Region" or "Environment"

The aim of the game is to have a separate `ConfigurationService` per sub module, with shared capabilities in `uk.gov.di.authentication.shared.configuration`
