### PR TITLE
BAU - Improve cloudwatch alarm description

### DIFF
--- a/ci/terraform/account-management/alerts.tf
+++ b/ci/terraform/account-management/alerts.tf
@@ -7,12 +7,12 @@ resource "aws_cloudwatch_metric_alarm" "sqs_deadletter_cloudwatch_alarm" {
   namespace           = "AWS/SQS"
   period              = "300"
   statistic           = "Sum"
-  threshold           = "1"
+  threshold           = var.dlq_alarm_threshold
 
   dimensions = {
     QueueName = aws_sqs_queue.email_dead_letter_queue.name
   }
-  alarm_description = "This metric monitors number of deadletters on the queue"
+  alarm_description = "${var.dlq_alarm_threshold} or more messages have appeared on the ${aws_sqs_queue.email_dead_letter_queue.name}"
   alarm_actions     = [data.aws_sns_topic.slack_events.arn]
 }
 

--- a/ci/terraform/account-management/variables.tf
+++ b/ci/terraform/account-management/variables.tf
@@ -140,6 +140,12 @@ variable "cloudwatch_log_retention" {
   description = "The number of day to retain Cloudwatch logs for"
 }
 
+variable "dlq_alarm_threshold" {
+  default     = 1
+  type        = number
+  description = "The number of messages on a DLQ before a Cloudwatch alarm is generated"
+}
+
 variable "lambda_min_concurrency" {
   default     = 10
   type        = number

--- a/ci/terraform/modules/endpoint-module/alerts.tf
+++ b/ci/terraform/modules/endpoint-module/alerts.tf
@@ -20,8 +20,8 @@ resource "aws_cloudwatch_metric_alarm" "lambda_error_cloudwatch_alarm" {
   namespace           = aws_cloudwatch_log_metric_filter.lambda_error_metric_filter[0].metric_transformation[0].namespace
   period              = "3600"
   statistic           = "Sum"
-  threshold           = "5"
-  alarm_description   = "This metric monitors errors within a Lambda"
+  threshold           = var.lambda_log_alarm_threshold
+  alarm_description   = "${var.lambda_log_alarm_threshold} or more errors have occurred in the ${var.environment} ${var.endpoint_name} lambda"
   alarm_actions       = [data.aws_sns_topic.slack_events.arn]
 }
 

--- a/ci/terraform/modules/endpoint-module/variables.tf
+++ b/ci/terraform/modules/endpoint-module/variables.tf
@@ -153,6 +153,12 @@ variable "cloudwatch_log_retention" {
   description = "The number of day to retain Cloudwatch logs for"
 }
 
+variable "lambda_log_alarm_threshold" {
+  type        = number
+  description = "The number of errors in a lambda logs before generating a Cloudwatch alarm"
+  default     = 5
+}
+
 variable "lambda_env_vars_encryption_kms_key_arn" {
   type = string
 }

--- a/ci/terraform/oidc/alerts.tf
+++ b/ci/terraform/oidc/alerts.tf
@@ -7,12 +7,12 @@ resource "aws_cloudwatch_metric_alarm" "sqs_deadletter_cloudwatch_alarm" {
   namespace           = "AWS/SQS"
   period              = "300"
   statistic           = "Sum"
-  threshold           = "1"
+  threshold           = var.dlq_alarm_threshold
 
   dimensions = {
     QueueName = aws_sqs_queue.email_dead_letter_queue.name
   }
-  alarm_description = "This metric monitors number of deadletters on the queue"
+  alarm_description = "${var.dlq_alarm_threshold} or more messages have appeared on the ${aws_sqs_queue.email_dead_letter_queue.name}"
   alarm_actions     = [data.aws_sns_topic.slack_events.arn]
 }
 

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -171,6 +171,12 @@ variable "lambda_min_concurrency" {
   description = "The number of lambda instance to keep 'warm'"
 }
 
+variable "dlq_alarm_threshold" {
+  default     = 1
+  type        = number
+  description = "The number of messages on a DLQ before a Cloudwatch alarm is generated"
+}
+
 variable "test_client_verify_email_otp" {
   type = string
 }


### PR DESCRIPTION
## What?

- Personalise the alarm description by adding the threshold value and the environment and name of the AWS service that caused the alarm

## Why?

- To make it easier to identify what caused the cloudwatch alarm when it is raised in Slack
