### PR TITLE
BAU: Consistency check for audit fields

### DIFF
--- a/shared/src/test/java/uk/gov/di/authentication/audit/AuditPayloadConsistencyTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/audit/AuditPayloadConsistencyTest.java
@@ -10,8 +10,11 @@ import uk.gov.di.audit.AuditPayload.AuditEvent;
 import uk.gov.di.audit.AuditPayload.AuditEvent.User;
 import uk.gov.di.audit.AuditPayload.SignedAuditEvent;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -28,28 +31,13 @@ class AuditPayloadConsistencyTest {
 
     @Test
     void shouldHandleFullObjects() {
+        var eventBuilder = fillFieldsWithTestInput(AuditEvent.newBuilder());
+        var userBuilder = fillFieldsWithTestInput(User.newBuilder());
 
-        var emptyObject =
-                AuditEvent.newBuilder()
-                        .setEventId("test-setEventId")
-                        .setRequestId("test-setRequestId")
-                        .setSessionId("test-setSessionId")
-                        .setClientId("test-setClientId")
-                        .setTimestamp("test-setTimestamp")
-                        .setEventName("test-setEventName")
-                        .setUser(
-                                User.newBuilder()
-                                        .setId("test-setId")
-                                        .setEmail("test-setEmail")
-                                        .setIpAddress("test-setIpAddress")
-                                        .setPhoneNumber("test-setPhoneNumber")
-                                        .build())
-                        .putExtensions("test-putExtensions", "test-putExtensions")
-                        .putPlatform("test-putPlatform", "test-putPlatform")
-                        .build();
+        var realObject = eventBuilder.setUser(userBuilder.build()).build();
 
         assertThat(
-                eventWithSignature("signature", emptyObject),
+                eventWithSignature("signature", realObject),
                 hasHashValue("c988acfe4e7f90d39d5749f8842573d8d091cdd9e5e5a5d79ca65b59508e82a5"));
     }
 
@@ -93,5 +81,36 @@ class AuditPayloadConsistencyTest {
                         .appendText("]");
             }
         };
+    }
+
+    private <T> T fillFieldsWithTestInput(T builder) {
+        Arrays.stream(builder.getClass().getMethods())
+                .filter(this::isAWriterMethod)
+                .filter(this::hasStringParameter)
+                .forEach(
+                        method -> {
+                            try {
+                                if (method.getName().startsWith("set")) {
+                                    method.invoke(builder, "test-" + method.getName());
+                                } else {
+                                    method.invoke(
+                                            builder,
+                                            "test-" + method.getName(),
+                                            "test-" + method.getName());
+                                }
+                            } catch (IllegalAccessException | InvocationTargetException e) {
+                                throw new RuntimeException(e);
+                            }
+                        });
+
+        return builder;
+    }
+
+    private boolean hasStringParameter(Method method) {
+        return method.getParameterTypes()[0].equals(String.class);
+    }
+
+    private boolean isAWriterMethod(Method method) {
+        return method.getName().startsWith("set") || method.getName().startsWith("put");
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/audit/AuditPayloadConsistencyTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/audit/AuditPayloadConsistencyTest.java
@@ -1,0 +1,97 @@
+package uk.gov.di.authentication.audit;
+
+import com.google.protobuf.ByteString;
+import org.apache.commons.codec.binary.Hex;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.audit.AuditPayload.AuditEvent;
+import uk.gov.di.audit.AuditPayload.AuditEvent.User;
+import uk.gov.di.audit.AuditPayload.SignedAuditEvent;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class AuditPayloadConsistencyTest {
+
+    @Test
+    void shouldHandleEmptyObjects() {
+        var emptyObject = AuditEvent.newBuilder().build();
+
+        assertThat(
+                eventWithSignature("signature", emptyObject),
+                hasHashValue("6f4c1976b0660de7ada9cf0eb39d261e8cb293a9e0d208eeccbe29bf9247fe90"));
+    }
+
+    @Test
+    void shouldHandleFullObjects() {
+
+        var emptyObject =
+                AuditEvent.newBuilder()
+                        .setEventId("test-setEventId")
+                        .setRequestId("test-setRequestId")
+                        .setSessionId("test-setSessionId")
+                        .setClientId("test-setClientId")
+                        .setTimestamp("test-setTimestamp")
+                        .setEventName("test-setEventName")
+                        .setUser(
+                                User.newBuilder()
+                                        .setId("test-setId")
+                                        .setEmail("test-setEmail")
+                                        .setIpAddress("test-setIpAddress")
+                                        .setPhoneNumber("test-setPhoneNumber")
+                                        .build())
+                        .putExtensions("test-putExtensions", "test-putExtensions")
+                        .putPlatform("test-putPlatform", "test-putPlatform")
+                        .build();
+
+        assertThat(
+                eventWithSignature("signature", emptyObject),
+                hasHashValue("c988acfe4e7f90d39d5749f8842573d8d091cdd9e5e5a5d79ca65b59508e82a5"));
+    }
+
+    public SignedAuditEvent eventWithSignature(String signature, AuditEvent event) {
+        return SignedAuditEvent.newBuilder()
+                .setSignature(ByteString.copyFrom(signature.getBytes()))
+                .setPayload(event.toByteString())
+                .build();
+    }
+
+    private static Matcher<SignedAuditEvent> hasHashValue(String hash) {
+
+        return new TypeSafeDiagnosingMatcher<>() {
+            @Override
+            protected boolean matchesSafely(
+                    SignedAuditEvent item, Description mismatchDescription) {
+                try {
+                    var hashedPayload =
+                            Hex.encodeHexString(
+                                    MessageDigest.getInstance("SHA-256")
+                                            .digest(item.toByteArray()));
+                    var equals = hashedPayload.equals(hash);
+
+                    if (!equals) {
+                        mismatchDescription
+                                .appendText("a SignedAuditEvent with SHA256 hash [")
+                                .appendText(hashedPayload)
+                                .appendText("]");
+                    }
+                    return equals;
+                } catch (NoSuchAlgorithmException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description
+                        .appendText("a SignedAuditEvent with SHA256 hash [")
+                        .appendText(hash)
+                        .appendText("]");
+            }
+        };
+    }
+}


### PR DESCRIPTION
## What?

This PR adds a consistency test for the SignedAuditPayload

## Why?

We can't afford to accidentally break the payload format, so this PR programmatically fills out all fields with deterministic input and compares the hash of the output to a known hash.

This means that adding new fields or re-ordering fields will break this test and force the user to double-check their change.


