### PR TITLE
GOVSI-1061/1062: Fix errors when auditing phone number updates

### DIFF
--- a/audit-processors/src/main/java/uk/gov/di/authentication/audit/lambda/CounterFraudAuditLambda.java
+++ b/audit-processors/src/main/java/uk/gov/di/authentication/audit/lambda/CounterFraudAuditLambda.java
@@ -43,11 +43,11 @@ public class CounterFraudAuditLambda extends BaseAuditHandler {
             eventData.put("user.id", encodeHexString(hmacSha256(user.getId(), hmacKey)));
         }
 
-        if (isPresent(user.getId())) {
+        if (isPresent(user.getEmail())) {
             eventData.put("user.email", encodeHexString(hmacSha256(user.getEmail(), hmacKey)));
         }
 
-        if (isPresent(user.getId())) {
+        if (isPresent(user.getPhoneNumber())) {
             eventData.put(
                     "user.phone", encodeHexString(hmacSha256(user.getPhoneNumber(), hmacKey)));
         }

--- a/audit-processors/src/test/java/uk/gov/di/authentication/audit/lambda/CounterFraudAuditLambdaTest.java
+++ b/audit-processors/src/test/java/uk/gov/di/authentication/audit/lambda/CounterFraudAuditLambdaTest.java
@@ -129,17 +129,58 @@ public class CounterFraudAuditLambdaTest {
     }
 
     @Test
-    void shouldHashNotHashMissingSensitiveFields() {
+    void shouldNotHashMissingSensitiveFields_Id() {
         var handler = new CounterFraudAuditLambda(kms, config);
 
-        var payload = AuditEvent.newBuilder().setUser(User.newBuilder().build()).build();
+        var payload =
+                AuditEvent.newBuilder()
+                        .setUser(
+                                User.newBuilder()
+                                        .setEmail("test-email")
+                                        .setPhoneNumber("test-phone")
+                                        .build())
+                        .build();
+
+        handler.handleAuditEvent(payload);
+
+        LogEvent logEvent = appender.getEvents().get(0);
+
+        assertThat(logEvent, doesNotHaveObjectMessageProperty("user.id"));
+    }
+
+    @Test
+    void shouldNotHashMissingSensitiveFields_Email() {
+        var handler = new CounterFraudAuditLambda(kms, config);
+
+        var payload =
+                AuditEvent.newBuilder()
+                        .setUser(
+                                User.newBuilder()
+                                        .setId("test-id")
+                                        .setPhoneNumber("test-phone")
+                                        .build())
+                        .build();
 
         handler.handleAuditEvent(payload);
 
         LogEvent logEvent = appender.getEvents().get(0);
 
         assertThat(logEvent, doesNotHaveObjectMessageProperty("user.email"));
-        assertThat(logEvent, doesNotHaveObjectMessageProperty("user.id"));
+    }
+
+    @Test
+    void shouldNotHashMissingSensitiveFields_Phone() {
+        var handler = new CounterFraudAuditLambda(kms, config);
+
+        var payload =
+                AuditEvent.newBuilder()
+                        .setUser(User.newBuilder().setId("test-id").setEmail("test-email").build())
+                        .build();
+
+        handler.handleAuditEvent(payload);
+
+        LogEvent logEvent = appender.getEvents().get(0);
+
         assertThat(logEvent, doesNotHaveObjectMessageProperty("user.phone"));
     }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
@@ -166,9 +166,7 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
                                         .orElse(AuditService.UNKNOWN),
                                 email,
                                 ipAddress,
-                                userProfile
-                                        .map(UserProfile::getPhoneNumber)
-                                        .orElse(AuditService.UNKNOWN));
+                                request.getProfileInformation());
                         sessionService.save(session.setState(nextState));
                         LOGGER.info(
                                 "Phone number updated and session state changed. Session: {}, Session state {}",

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandlerTest.java
@@ -148,7 +148,7 @@ class UpdateProfileHandlerTest {
                         "",
                         TEST_EMAIL_ADDRESS,
                         "",
-                        "");
+                        PHONE_NUMBER);
     }
 
     @Test


### PR DESCRIPTION
## What?

This PR fixes two bugs:

- Hashing each user data field individually based on their presence, rather than using user.id as a proxy for their presence.
- Pass phone number from the request to update profile rather than use the loaded userprofile, as it has stale data at that point.
