### PR TITLE
GOVSI-1053: Add SonarQube checks

### DIFF
--- a/.github/workflows/pre-merge-checks-am.yml
+++ b/.github/workflows/pre-merge-checks-am.yml
@@ -54,7 +54,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew --no-daemon test sonarqube -x integration-tests:test -x account-management-integration-tests:test -x spotlessApply spotlessCheck
+        run: ./gradlew --no-daemon test jacocoTestReport sonarqube -x integration-tests:test -x account-management-integration-tests:test -x spotlessApply spotlessCheck
 
   integration-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/pre-merge-checks-am.yml
+++ b/.github/workflows/pre-merge-checks-am.yml
@@ -51,7 +51,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Run Unit Tests
-        run: ./gradlew --no-daemon test -x integration-tests:test -x account-management-integration-tests:test -x spotlessApply spotlessCheck
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./gradlew --no-daemon test sonarqube -x integration-tests:test -x account-management-integration-tests:test -x spotlessApply spotlessCheck
 
   integration-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -54,7 +54,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew --no-daemon test sonarqube -x integration-tests:test -x account-management-integration-tests:test -x spotlessApply spotlessCheck
+        run: ./gradlew --no-daemon test jacocoTestReport sonarqube -x integration-tests:test -x account-management-integration-tests:test -x spotlessApply spotlessCheck
 
   integration-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -51,7 +51,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Run Unit Tests
-        run: ./gradlew --no-daemon test -x integration-tests:test -x account-management-integration-tests:test -x spotlessApply spotlessCheck
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./gradlew --no-daemon test sonarqube -x integration-tests:test -x account-management-integration-tests:test -x spotlessApply spotlessCheck
 
   integration-tests:
     runs-on: ubuntu-latest

--- a/account-management-api/build.gradle
+++ b/account-management-api/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id "java"
+    id "jacoco"
 }
 
 group "uk.gov.di.authentication.accountmanagement"
@@ -42,4 +43,11 @@ task buildZip(type: Zip) {
 java {
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled true
+    }
+    dependsOn "test"
 }

--- a/account-migrations/build.gradle
+++ b/account-migrations/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java'
+    id "jacoco"
 }
 
 group "uk.gov.di.authentication.accountmigration"
@@ -36,4 +37,11 @@ task buildZip(type: Zip) {
     into("lib") {
         from configurations.runtimeClasspath
     }
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled true
+    }
+    dependsOn "test"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import java.util.stream.Collectors
+
 plugins {
     id "com.diffplug.spotless" version "5.15.1"
     id "com.avast.gradle.docker-compose" version "0.14.9"

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id "com.diffplug.spotless" version "5.15.1"
-    id 'com.avast.gradle.docker-compose' version "0.14.9"
+    id "com.avast.gradle.docker-compose" version "0.14.9"
+    id "org.sonarqube" version "3.3"
 }
 
 apply plugin: "java"
@@ -250,4 +251,12 @@ task acctMgmtTerraform (type: Terraform) {
     }
     dependsOn ":account-management-api:buildZip"
     dependsOn "auditTerraform"
+}
+
+sonarqube {
+    properties {
+        property "sonar.projectKey", "alphagov_di-authentication-api"
+        property "sonar.organization", "alphagov"
+        property "sonar.host.url", "https://sonarcloud.io"
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id "com.diffplug.spotless" version "5.15.1"
     id "com.avast.gradle.docker-compose" version "0.14.9"
     id "org.sonarqube" version "3.3"
+    id "jacoco"
 }
 
 apply plugin: "java"
@@ -259,4 +260,11 @@ sonarqube {
         property "sonar.organization", "alphagov"
         property "sonar.host.url", "https://sonarcloud.io"
     }
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled true
+    }
+    dependsOn "test"
 }

--- a/client-registry-api/build.gradle
+++ b/client-registry-api/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id "java"
+    id "jacoco"
 }
 
 group "uk.gov.di.clientregistry"
@@ -39,4 +40,11 @@ task buildZip(type: Zip) {
 java {
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled true
+    }
+    dependsOn "test"
 }

--- a/frontend-api/build.gradle
+++ b/frontend-api/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id "java"
+    id "jacoco"
 }
 
 group "uk.gov.di.authentication.frontendapi"
@@ -42,4 +43,11 @@ task buildZip(type: Zip) {
 java {
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled true
+    }
+    dependsOn "test"
 }

--- a/oidc-api/build.gradle
+++ b/oidc-api/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id "java"
+    id "jacoco"
 }
 
 group "uk.gov.di.authentication.oidc"
@@ -41,4 +42,11 @@ task buildZip(type: Zip) {
 java {
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled true
+    }
+    dependsOn "test"
 }

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id "java-library"
+    id "jacoco"
 }
 
 group "uk.gov.di"
@@ -36,4 +37,11 @@ test {
 java {
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled true
+    }
+    dependsOn "test"
 }


### PR DESCRIPTION
## What?

- Add Sonar plugin to Gradle
- Add Jacoco plugin to Gradle
- Run coverage reports in Github Actions on PR
- Configure unit tests to report coverage to SonarCloud

## Why?

To allow us to get an overview of how well tested our code is, as well as linting and static code analysis
