### PR TITLE
BAU: Remove logging of request if missing parameters

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandler.java
@@ -90,9 +90,7 @@ public class AuthenticateHandler
 
                                 return generateEmptySuccessApiGatewayResponse();
                             } catch (JsonProcessingException e) {
-                                LOGGER.error(
-                                        "Request is missing parameters. The body present in request: {}",
-                                        input.getBody());
+                                LOGGER.error("Request is missing parameters.");
                                 return generateApiGatewayProxyErrorResponse(
                                         400, ErrorResponse.ERROR_1001);
                             }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/BaseFrontendHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/BaseFrontendHandler.java
@@ -104,9 +104,7 @@ public abstract class BaseFrontendHandler<T>
         try {
             request = objectMapper.readValue(input.getBody(), clazz);
         } catch (JsonProcessingException | ConstraintViolationException e) {
-            LOG.error(
-                    "Request is missing parameters. The body present in request: {}",
-                    input.getBody());
+            LOG.error("Request is missing parameters.");
             onRequestValidationError(context);
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
         }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -238,9 +238,8 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
                     200, new LoginResponse(concatPhoneNumber, userContext.getSession().getState()));
         } catch (JsonProcessingException e) {
             LOGGER.error(
-                    "Request is missing parameters with session: {}. The body present in request: {}",
-                    userContext.getSession().getSessionId(),
-                    input.getBody());
+                    "Could not serialize response for session: {}.",
+                    userContext.getSession().getSessionId());
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
         } catch (StateMachine.InvalidStateTransitionException e) {
             LOGGER.error(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
@@ -218,9 +218,8 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
                     200, new BaseAPIResponse(userContext.getSession().getState()));
         } catch (JsonProcessingException e) {
             LOGGER.error(
-                    "MFA request is missing parameters. session: {} Request Body: {}",
-                    userContext.getSession().getSessionId(),
-                    input.getBody());
+                    "MFA request is missing parameters. session: {}",
+                    userContext.getSession().getSessionId());
             return generateApiGatewayProxyErrorResponse(400, ERROR_1001);
         } catch (StateMachine.InvalidStateTransitionException e) {
             LOGGER.error(


### PR DESCRIPTION
## What?

- Don't log the request out if fails validation

## Why?

This could leak sensitive information into the logs