### PR TITLE
BAU: Fix failing integration tests

### DIFF
--- a/ci/terraform/account-management/authenticate.tf
+++ b/ci/terraform/account-management/authenticate.tf
@@ -8,6 +8,7 @@ module "authenticate" {
     ENVIRONMENT             = var.environment
     BASE_URL                = local.oidc_api_base_url
     DYNAMO_ENDPOINT         = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
     EVENTS_SNS_TOPIC_ARN    = data.aws_sns_topic.events.arn
     AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name
   }

--- a/ci/terraform/account-management/remove-account.tf
+++ b/ci/terraform/account-management/remove-account.tf
@@ -7,6 +7,7 @@ module "delete_account" {
   handler_environment_variables = {
     ENVIRONMENT             = var.environment
     DYNAMO_ENDPOINT         = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
     EMAIL_QUEUE_URL         = aws_sqs_queue.email_queue.id
     EVENTS_SNS_TOPIC_ARN    = data.aws_sns_topic.events.arn
     AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name

--- a/ci/terraform/account-management/update-password.tf
+++ b/ci/terraform/account-management/update-password.tf
@@ -7,6 +7,7 @@ module "update_password" {
   handler_environment_variables = {
     ENVIRONMENT             = var.environment
     DYNAMO_ENDPOINT         = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
     EMAIL_QUEUE_URL         = aws_sqs_queue.email_queue.id
     EVENTS_SNS_TOPIC_ARN    = data.aws_sns_topic.events.arn
     AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name


### PR DESCRIPTION
## What?

- Add missing `LOCALSTACK_ENDPOINT` environment variable to account management APIs. 

## Why?

Tests are failing as real KMS is being called.
