### PR TITLE
BAU: run account management checks when gradle config changes.

### DIFF
--- a/.github/workflows/pre-merge-checks-am.yml
+++ b/.github/workflows/pre-merge-checks-am.yml
@@ -1,7 +1,7 @@
 name: Pre-merge checks for Account Management
 on:
   pull_request:
-    paths: ['account-management-api/**', 'account-management-integration-tests/**', 'ci/terraform/account-management/**']
+    paths: ['account-management-api/**', 'account-management-integration-tests/**', 'ci/terraform/account-management/**', '**/*.gradle*', '**/gradle-wrapper.properties']
     types:
       - opened
       - reopened

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ build
 **/terraform.log
 ci/terraform/**/*.plan
 logs/
+.vscode/


### PR DESCRIPTION
## What?

Run account management checks when gradle config changes.
Ignore .vscode directory.

## Why?

Account management checks were not being run for dependabot or gradle version changes.