### PR TITLE
GOVSI-1053: Add a GitHub action perform Sonar on merge

### DIFF
--- a/.github/workflows/sonar-analysis-on-merge.yml
+++ b/.github/workflows/sonar-analysis-on-merge.yml
@@ -1,0 +1,34 @@
+name: Sonar Analysis on Merge
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  run-code-analysis:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Run Unit Tests
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./gradlew --no-daemon test jacocoTestReport sonarqube -x integration-tests:test -x account-management-integration-tests:test -x spotlessApply spotlessCheck


### PR DESCRIPTION
## What?

- Add a new action that runs Sonar analysis on the main branch after each merge

## Why?

The current checks only analyse code in the current PR, we want to get an analysis of the repo as a whole to help us drive tech debt stories.

## Related PRs

#953 