### PR TITLE
BAU: Refactor `RedisConnectionService`

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/shared/services/RedisConnectionServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/shared/services/RedisConnectionServiceIntegrationTest.java
@@ -1,0 +1,111 @@
+package uk.gov.di.authentication.shared.services;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class RedisConnectionServiceIntegrationTest {
+    private static final String REDIS_HOST =
+            System.getenv().getOrDefault("REDIS_HOST", "localhost");
+    private static final Optional<String> REDIS_PASSWORD =
+            Optional.ofNullable(System.getenv("REDIS_PASSWORD"));
+    private static final String TEST_VALUE = "my-test-value";
+    public static final int TEN_SECOND_EXPIRY = 60000;
+
+    private String testKey = "int-test-key-" + UUID.randomUUID();
+
+    @Test
+    void shouldSuccessfullySaveAndRetrieveIfRedisAvailable() {
+        try (RedisConnectionService redis =
+                new RedisConnectionService(REDIS_HOST, 6379, false, REDIS_PASSWORD, false)) {
+            redis.saveWithExpiry(testKey, TEST_VALUE, TEN_SECOND_EXPIRY);
+
+            assertThat(redis.getValue(testKey), equalTo(TEST_VALUE));
+        }
+    }
+
+    @Test
+    void shouldSuccessfullyCreateAValueThatExpires() {
+        try (RedisConnectionService redis =
+                new RedisConnectionService(REDIS_HOST, 6379, false, REDIS_PASSWORD, false)) {
+            redis.saveWithExpiry(testKey, TEST_VALUE, 1);
+            await().atMost(2, SECONDS)
+                    .untilAsserted(() -> assertThat(redis.getValue(testKey), is(nullValue())));
+        }
+    }
+
+    @Test
+    void keyExistsShouldCorrectlyReturnTrueWhenKeyExists() {
+        try (RedisConnectionService redis =
+                new RedisConnectionService(REDIS_HOST, 6379, false, REDIS_PASSWORD, false)) {
+            redis.saveWithExpiry(testKey, TEST_VALUE, TEN_SECOND_EXPIRY);
+
+            assertThat(redis.keyExists(testKey), is(true));
+        }
+    }
+
+    @Test
+    void keyExistsShouldCorrectlyReturnFalseWhenKeyExists() {
+        try (RedisConnectionService redis =
+                new RedisConnectionService(REDIS_HOST, 6379, false, REDIS_PASSWORD, false)) {
+            assertThat(redis.keyExists(testKey), is(false));
+        }
+    }
+
+    @Test
+    void popValueShouldReturnValueAndClearKeyWhenItExists() {
+        try (RedisConnectionService redis =
+                new RedisConnectionService(REDIS_HOST, 6379, false, REDIS_PASSWORD, false)) {
+            redis.saveWithExpiry(testKey, TEST_VALUE, TEN_SECOND_EXPIRY);
+
+            assertThat(redis.popValue(testKey), equalTo(TEST_VALUE));
+            assertThat(redis.keyExists(testKey), is(false));
+        }
+    }
+
+    @Test
+    void getValueReturnsNullIfKeyDoesNotExist() {
+        try (RedisConnectionService redis =
+                new RedisConnectionService(REDIS_HOST, 6379, false, REDIS_PASSWORD, false)) {
+            assertThat(redis.getValue(testKey), is(nullValue()));
+        }
+    }
+
+    @Test
+    void deleteValueRemovesValueFromRedisIfExists() {
+        try (RedisConnectionService redis =
+                new RedisConnectionService(REDIS_HOST, 6379, false, REDIS_PASSWORD, false)) {
+            redis.saveWithExpiry(testKey, TEST_VALUE, TEN_SECOND_EXPIRY);
+            redis.deleteValue(testKey);
+            assertThat(redis.keyExists(testKey), is(false));
+        }
+    }
+
+    @Test
+    void deleteValueDoesNotErrorIfKeyDoesNotExist() {
+        try (RedisConnectionService redis =
+                new RedisConnectionService(REDIS_HOST, 6379, false, REDIS_PASSWORD, false)) {
+            redis.deleteValue(testKey);
+            assertThat(redis.keyExists(testKey), is(false));
+        }
+    }
+
+    @Test
+    void shouldThrowRedisConnectionExceptionIfRedisUnavailable() {
+        try (RedisConnectionService redis =
+                new RedisConnectionService("bad-host-name", 6379, false, REDIS_PASSWORD, false)) {
+            assertThrows(
+                    RedisConnectionService.RedisConnectionException.class,
+                    () -> redis.saveWithExpiry(testKey, TEST_VALUE, TEN_SECOND_EXPIRY));
+        }
+    }
+}

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
@@ -227,7 +227,7 @@ public class RedisExtension
 
     @Override
     public void beforeAll(ExtensionContext context) throws Exception {
-        redis = new RedisConnectionService(REDIS_HOST, 6379, false, REDIS_PASSWORD);
+        redis = new RedisConnectionService(REDIS_HOST, 6379, false, REDIS_PASSWORD, false);
         RedisURI.Builder builder =
                 RedisURI.builder().withHost(REDIS_HOST).withPort(6379).withSsl(false);
         if (REDIS_PASSWORD.isPresent()) builder.withPassword(REDIS_PASSWORD.get().toCharArray());

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/RedisConnectionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/RedisConnectionService.java
@@ -17,6 +17,7 @@ import static io.lettuce.core.support.ConnectionPoolSupport.createGenericObjectP
 public class RedisConnectionService implements AutoCloseable {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RedisConnectionService.class);
+    public static final String REDIS_CONNECTION_ERROR = "Error getting Redis connection";
     private final RedisClient client;
 
     private final GenericObjectPool<StatefulRedisConnection<String, String>> pool;
@@ -43,8 +44,8 @@ public class RedisConnectionService implements AutoCloseable {
         try (StatefulRedisConnection<String, String> connection = pool.borrowObject()) {
             connection.sync().setex(key, expiry, value);
         } catch (Exception e) {
-            LOGGER.error("Error getting Redis connection");
-            throw new RuntimeException("Error getting Redis connection", e);
+            LOGGER.error(REDIS_CONNECTION_ERROR, e);
+            throw new RedisConnectionException(REDIS_CONNECTION_ERROR, e);
         }
     }
 
@@ -52,8 +53,8 @@ public class RedisConnectionService implements AutoCloseable {
         try (StatefulRedisConnection<String, String> connection = pool.borrowObject()) {
             return (connection.sync().exists(key) == 1);
         } catch (Exception e) {
-            LOGGER.error("Error getting Redis connection");
-            throw new RuntimeException("Error getting Redis connection", e);
+            LOGGER.error(REDIS_CONNECTION_ERROR, e);
+            throw new RedisConnectionException(REDIS_CONNECTION_ERROR, e);
         }
     }
 
@@ -61,8 +62,8 @@ public class RedisConnectionService implements AutoCloseable {
         try (StatefulRedisConnection<String, String> connection = pool.borrowObject()) {
             return connection.sync().get(key);
         } catch (Exception e) {
-            LOGGER.error("Error getting Redis connection");
-            throw new RuntimeException("Error getting Redis connection", e);
+            LOGGER.error(REDIS_CONNECTION_ERROR, e);
+            throw new RedisConnectionException(REDIS_CONNECTION_ERROR, e);
         }
     }
 
@@ -70,8 +71,8 @@ public class RedisConnectionService implements AutoCloseable {
         try (StatefulRedisConnection<String, String> connection = pool.borrowObject()) {
             return connection.sync().del(key);
         } catch (Exception e) {
-            LOGGER.error("Error getting Redis connection");
-            throw new RuntimeException("Error getting Redis connection", e);
+            LOGGER.error(REDIS_CONNECTION_ERROR, e);
+            throw new RedisConnectionException(REDIS_CONNECTION_ERROR, e);
         }
     }
 
@@ -84,8 +85,8 @@ public class RedisConnectionService implements AutoCloseable {
             TransactionResult result = commands.exec();
             return result.get(0);
         } catch (Exception e) {
-            LOGGER.error("Error getting Redis connection");
-            throw new RuntimeException("Error getting Redis connection", e);
+            LOGGER.error(REDIS_CONNECTION_ERROR, e);
+            throw new RedisConnectionException(REDIS_CONNECTION_ERROR, e);
         }
     }
 
@@ -93,8 +94,8 @@ public class RedisConnectionService implements AutoCloseable {
         try (StatefulRedisConnection<String, String> connection = pool.borrowObject()) {
             connection.sync().clientGetname();
         } catch (Exception e) {
-            LOGGER.error("Error getting Redis connection");
-            throw new RuntimeException("Error getting Redis connection", e);
+            LOGGER.error(REDIS_CONNECTION_ERROR, e);
+            throw new RedisConnectionException(REDIS_CONNECTION_ERROR, e);
         }
     }
 
@@ -102,5 +103,11 @@ public class RedisConnectionService implements AutoCloseable {
     public void close() {
         pool.close();
         client.shutdown();
+    }
+
+    public static class RedisConnectionException extends RuntimeException {
+        public RedisConnectionException(String message, Throwable cause) {
+            super(message, cause);
+        }
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/RedisConnectionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/RedisConnectionService.java
@@ -5,10 +5,9 @@ import io.lettuce.core.RedisURI;
 import io.lettuce.core.TransactionResult;
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.api.sync.RedisCommands;
+import io.lettuce.core.api.sync.RedisServerCommands;
 import org.apache.commons.pool2.impl.GenericObjectPool;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Optional;
 
@@ -16,20 +15,24 @@ import static io.lettuce.core.support.ConnectionPoolSupport.createGenericObjectP
 
 public class RedisConnectionService implements AutoCloseable {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(RedisConnectionService.class);
     public static final String REDIS_CONNECTION_ERROR = "Error getting Redis connection";
     private final RedisClient client;
 
     private final GenericObjectPool<StatefulRedisConnection<String, String>> pool;
 
     public RedisConnectionService(
-            String host, int port, boolean useSsl, Optional<String> password) {
+            String host, int port, boolean useSsl, Optional<String> password, boolean warmup) {
         RedisURI.Builder builder = RedisURI.builder().withHost(host).withPort(port).withSsl(useSsl);
         password.ifPresent(s -> builder.withPassword(s.toCharArray()));
         RedisURI redisURI = builder.build();
         this.client = RedisClient.create(redisURI);
         this.pool = createGenericObjectPool(client::connect, new GenericObjectPoolConfig<>());
-        warmUp();
+        if (warmup) warmUp();
+    }
+
+    public RedisConnectionService(
+            String host, int port, boolean useSsl, Optional<String> password) {
+        this(host, port, useSsl, password, true);
     }
 
     public RedisConnectionService(ConfigurationService configurationService) {
@@ -40,63 +43,48 @@ public class RedisConnectionService implements AutoCloseable {
                 configurationService.getRedisPassword());
     }
 
-    public void saveWithExpiry(String key, String value, long expiry) {
+    @FunctionalInterface
+    private interface RedisFunction<T> {
+        T getResult(RedisCommands<String, String> commands);
+    }
+
+    private <T> T executeCommand(RedisFunction<T> callable) {
         try (StatefulRedisConnection<String, String> connection = pool.borrowObject()) {
-            connection.sync().setex(key, expiry, value);
+            return callable.getResult(connection.sync());
         } catch (Exception e) {
-            LOGGER.error(REDIS_CONNECTION_ERROR, e);
             throw new RedisConnectionException(REDIS_CONNECTION_ERROR, e);
         }
     }
 
-    public boolean keyExists(String key) {
-        try (StatefulRedisConnection<String, String> connection = pool.borrowObject()) {
-            return (connection.sync().exists(key) == 1);
-        } catch (Exception e) {
-            LOGGER.error(REDIS_CONNECTION_ERROR, e);
-            throw new RedisConnectionException(REDIS_CONNECTION_ERROR, e);
-        }
+    public void saveWithExpiry(final String key, final String value, final long expiry) {
+        executeCommand(commands -> commands.setex(key, expiry, value));
     }
 
-    public String getValue(String key) {
-        try (StatefulRedisConnection<String, String> connection = pool.borrowObject()) {
-            return connection.sync().get(key);
-        } catch (Exception e) {
-            LOGGER.error(REDIS_CONNECTION_ERROR, e);
-            throw new RedisConnectionException(REDIS_CONNECTION_ERROR, e);
-        }
+    public boolean keyExists(final String key) {
+        return executeCommand(commands -> commands.exists(key) == 1);
     }
 
-    public long deleteValue(String key) {
-        try (StatefulRedisConnection<String, String> connection = pool.borrowObject()) {
-            return connection.sync().del(key);
-        } catch (Exception e) {
-            LOGGER.error(REDIS_CONNECTION_ERROR, e);
-            throw new RedisConnectionException(REDIS_CONNECTION_ERROR, e);
-        }
+    public String getValue(final String key) {
+        return executeCommand(commands -> commands.get(key));
     }
 
-    public String popValue(String key) {
-        try (StatefulRedisConnection<String, String> connection = pool.borrowObject()) {
-            RedisCommands<String, String> commands = connection.sync();
-            commands.multi();
-            commands.get(key);
-            commands.del(key);
-            TransactionResult result = commands.exec();
-            return result.get(0);
-        } catch (Exception e) {
-            LOGGER.error(REDIS_CONNECTION_ERROR, e);
-            throw new RedisConnectionException(REDIS_CONNECTION_ERROR, e);
-        }
+    public long deleteValue(final String key) {
+        return executeCommand(commands -> commands.del(key));
+    }
+
+    public String popValue(final String key) {
+        return executeCommand(
+                commands -> {
+                    commands.multi();
+                    commands.get(key);
+                    commands.del(key);
+                    TransactionResult result = commands.exec();
+                    return result.get(0);
+                });
     }
 
     private void warmUp() {
-        try (StatefulRedisConnection<String, String> connection = pool.borrowObject()) {
-            connection.sync().clientGetname();
-        } catch (Exception e) {
-            LOGGER.error(REDIS_CONNECTION_ERROR, e);
-            throw new RedisConnectionException(REDIS_CONNECTION_ERROR, e);
-        }
+        executeCommand(RedisServerCommands::clientGetname);
     }
 
     @Override

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/RedisConnectionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/RedisConnectionService.java
@@ -7,6 +7,8 @@ import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.api.sync.RedisCommands;
 import org.apache.commons.pool2.impl.GenericObjectPool;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Optional;
 
@@ -14,6 +16,7 @@ import static io.lettuce.core.support.ConnectionPoolSupport.createGenericObjectP
 
 public class RedisConnectionService implements AutoCloseable {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(RedisConnectionService.class);
     private final RedisClient client;
 
     private final GenericObjectPool<StatefulRedisConnection<String, String>> pool;
@@ -40,7 +43,8 @@ public class RedisConnectionService implements AutoCloseable {
         try (StatefulRedisConnection<String, String> connection = pool.borrowObject()) {
             connection.sync().setex(key, expiry, value);
         } catch (Exception e) {
-            e.printStackTrace();
+            LOGGER.error("Error getting Redis connection");
+            throw new RuntimeException("Error getting Redis connection", e);
         }
     }
 
@@ -48,7 +52,8 @@ public class RedisConnectionService implements AutoCloseable {
         try (StatefulRedisConnection<String, String> connection = pool.borrowObject()) {
             return (connection.sync().exists(key) == 1);
         } catch (Exception e) {
-            return false;
+            LOGGER.error("Error getting Redis connection");
+            throw new RuntimeException("Error getting Redis connection", e);
         }
     }
 
@@ -56,7 +61,8 @@ public class RedisConnectionService implements AutoCloseable {
         try (StatefulRedisConnection<String, String> connection = pool.borrowObject()) {
             return connection.sync().get(key);
         } catch (Exception e) {
-            return null;
+            LOGGER.error("Error getting Redis connection");
+            throw new RuntimeException("Error getting Redis connection", e);
         }
     }
 
@@ -64,7 +70,8 @@ public class RedisConnectionService implements AutoCloseable {
         try (StatefulRedisConnection<String, String> connection = pool.borrowObject()) {
             return connection.sync().del(key);
         } catch (Exception e) {
-            return 0;
+            LOGGER.error("Error getting Redis connection");
+            throw new RuntimeException("Error getting Redis connection", e);
         }
     }
 
@@ -77,7 +84,8 @@ public class RedisConnectionService implements AutoCloseable {
             TransactionResult result = commands.exec();
             return result.get(0);
         } catch (Exception e) {
-            return null;
+            LOGGER.error("Error getting Redis connection");
+            throw new RuntimeException("Error getting Redis connection", e);
         }
     }
 
@@ -85,7 +93,8 @@ public class RedisConnectionService implements AutoCloseable {
         try (StatefulRedisConnection<String, String> connection = pool.borrowObject()) {
             connection.sync().clientGetname();
         } catch (Exception e) {
-
+            LOGGER.error("Error getting Redis connection");
+            throw new RuntimeException("Error getting Redis connection", e);
         }
     }
 


### PR DESCRIPTION
## What?

- Remove uses of `e.printStackTrace()`
- Throw exception from Redis ops rather than returning a default value
- Add missing integration tests to improve coverage
- Refactor to use common pattern for each Redis operation

## Why?

Sonar analysis show the use `e.printStackTrace()` as a "hotspot" to be addressed.
Returning a default value may hide problems
Test coverage is good.
