### PR TITLE
GOVSI-1067: Audit issuing of auth tokens

### DIFF
--- a/oidc-api/build.gradle
+++ b/oidc-api/build.gradle
@@ -22,7 +22,8 @@ dependencies {
             project(":client-registry-api")
 
     testImplementation configurations.tests,
-            configurations.lambda_tests
+            configurations.lambda_tests,
+            project(":shared-test")
     testRuntimeOnly configurations.test_runtime
 }
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/domain/OidcAuditableEvent.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/domain/OidcAuditableEvent.java
@@ -5,5 +5,6 @@ import uk.gov.di.authentication.shared.domain.AuditableEvent;
 public enum OidcAuditableEvent implements AuditableEvent {
     AUTHORISATION_REQUEST_ERROR,
     AUTHORISATION_INITIATED,
-    AUTHORISATION_REQUEST_RECEIVED
+    AUTHORISATION_REQUEST_RECEIVED,
+    AUTH_CODE_ISSUED
 }


### PR DESCRIPTION
## What?

Audit issuing of auth tokens

## Why?

An audit event is needed to tie together the end of both the sign-in and sign-up journeys; both end with issuing an auth token.

## Note

GOVSI-1067 specified that this should be done in TokenHandler, but in practice we have no way to get hold of the sessionId from within the TokenHandler.  It was agreed via Slack that AuthCodeHandler would also be a suitable place to fire the audit event as it is the "last stop" in the audit flow.