### PR TITLE
GOVSI-1064 - Extend state logging

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -160,7 +160,6 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
             LOG.error("Error parsing UserInfo request", e);
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
         } catch (StateMachine.InvalidStateTransitionException e) {
-            LOG.error("Invalid transition in user journey", e);
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1017);
         }
     }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -242,10 +242,6 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
                     userContext.getSession().getSessionId());
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
         } catch (StateMachine.InvalidStateTransitionException e) {
-            LOGGER.error(
-                    "Invalid transition in user journey with session: {}. Unable to Login user",
-                    userContext.getSession().getSessionId(),
-                    e);
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1017);
         }
     }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
@@ -222,10 +222,6 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
                     userContext.getSession().getSessionId());
             return generateApiGatewayProxyErrorResponse(400, ERROR_1001);
         } catch (StateMachine.InvalidStateTransitionException e) {
-            LOGGER.error(
-                    "Invalid transition in user journey for session: {}",
-                    userContext.getSession().getSessionId(),
-                    e);
             return generateApiGatewayProxyErrorResponse(400, ERROR_1017);
         } catch (ClientNotFoundException e) {
             LOGGER.error(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
@@ -154,10 +154,6 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
                     e);
             return generateApiGatewayProxyErrorResponse(400, ERROR_1001);
         } catch (StateMachine.InvalidStateTransitionException e) {
-            LOGGER.error(
-                    "Invalid transition in user journey for session: {}",
-                    userContext.getSession().getSessionId(),
-                    e);
             return generateApiGatewayProxyErrorResponse(400, ERROR_1017);
         }
     }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
@@ -199,10 +199,6 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
                     e);
             return generateApiGatewayProxyErrorResponse(400, ERROR_1001);
         } catch (StateMachine.InvalidStateTransitionException e) {
-            LOGGER.error(
-                    "Invalid transition in user journey for session: {}",
-                    userContext.getSession().getSessionId(),
-                    e);
             return generateApiGatewayProxyErrorResponse(400, ERROR_1017);
         } catch (ClientNotFoundException e) {
             LOGGER.error(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
@@ -154,10 +154,6 @@ public class SignUpHandler extends BaseFrontendHandler<SignupRequest>
                     e);
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
         } catch (StateMachine.InvalidStateTransitionException e) {
-            LOG.error(
-                    "Invalid transition in user journey for session: {}",
-                    userContext.getSession().getSessionId(),
-                    e);
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1017);
         }
     }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
@@ -281,10 +281,6 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
             LOGGER.error("Error parsing request for session: {}", session.getSessionId(), e);
             return generateErrorResponse(ErrorResponse.ERROR_1001, context);
         } catch (InvalidStateTransitionException e) {
-            LOGGER.error(
-                    "Invalid transition in user journey for session: {}",
-                    session.getSessionId(),
-                    e);
             return generateErrorResponse(ErrorResponse.ERROR_1017, context);
         }
         LOGGER.error(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -173,10 +173,6 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                     e);
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
         } catch (StateMachine.InvalidStateTransitionException e) {
-            LOG.error(
-                    "Invalid transition in user journey for session: {}",
-                    userContext.getSession().getSessionId(),
-                    e);
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1017);
         } catch (ClientNotFoundException e) {
             LOG.error(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -126,9 +126,6 @@ public class AuthCodeHandler
                                                 session.getState(),
                                                 SYSTEM_HAS_ISSUED_AUTHORIZATION_CODE);
                             } catch (StateMachine.InvalidStateTransitionException e) {
-                                LOGGER.error(
-                                        "Invalid state transition for session: {}",
-                                        session.getSessionId());
                                 return generateApiGatewayProxyErrorResponse(
                                         400, ErrorResponse.ERROR_1017);
                             }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -220,7 +220,6 @@ public class AuthorisationHandler
         try {
             nextState = stateMachine.transition(session.getState(), sessionAction, userContext);
         } catch (StateMachine.InvalidStateTransitionException e) {
-            LOGGER.error("Invalid state transition in authorize", e);
             throw new RuntimeException(e);
         }
         URI redirectUri;

--- a/shared/src/main/java/uk/gov/di/authentication/shared/state/StateMachine.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/state/StateMachine.java
@@ -108,12 +108,12 @@ public class StateMachine<T, A, C> {
                         > 1) {
             throw handleNoTransitionContext(from, action);
         }
-        var sessionId =  context
-                .filter(c -> c instanceof UserContext)
-                .map(UserContext.class::cast)
-                .map(UserContext::getSession)
-                .map(Session::getSessionId)
-                .orElse(null);
+        var sessionId =
+                context.filter(c -> c instanceof UserContext)
+                        .map(UserContext.class::cast)
+                        .map(UserContext::getSession)
+                        .map(Session::getSessionId)
+                        .orElse(null);
         T to =
                 states.getOrDefault(from, emptyList()).stream()
                         .filter(


### PR DESCRIPTION
## What?

- Add sessionID to state transitions and invalid state transitions 
- Remove logging the InvalidStateTransition in the Lambda 

## Why?

- By adding the sessionID we can have a better ID of the users behaviour 
- We are currently logging the InvalidStateTransition twice and we should just rely on the StateMachine to log this error