### PR TITLE
GOVSI-1064 - Pass UserContext to StateMachine when it is available

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
@@ -261,7 +261,8 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
             SessionState nextState =
                     stateMachine.transition(
                             session.getState(),
-                            getSessionActionForMaxCodeRequests(notificationType));
+                            getSessionActionForMaxCodeRequests(notificationType),
+                            userContext);
             sessionService.save(session.setState(nextState));
             return false;
         }
@@ -272,7 +273,8 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
             SessionState nextState =
                     stateMachine.transition(
                             session.getState(),
-                            getSessionActionForMaxCodeAttempts(notificationType));
+                            getSessionActionForMaxCodeAttempts(notificationType),
+                            userContext);
             sessionService.save(session.setState(nextState));
             return false;
         }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
@@ -83,7 +83,9 @@ public class SignUpHandler extends BaseFrontendHandler<SignupRequest>
                     userContext.getSession().getSessionId());
             var nextState =
                     stateMachine.transition(
-                            userContext.getSession().getState(), USER_HAS_CREATED_A_PASSWORD);
+                            userContext.getSession().getState(),
+                            USER_HAS_CREATED_A_PASSWORD,
+                            userContext);
 
             Optional<ErrorResponse> passwordValidationErrors =
                     validationService.validatePassword(request.getPassword());

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
@@ -153,7 +153,9 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
                     {
                         var nextState =
                                 stateMachine.transition(
-                                        session.getState(), USER_ENTERED_A_NEW_PHONE_NUMBER);
+                                        session.getState(),
+                                        USER_ENTERED_A_NEW_PHONE_NUMBER,
+                                        userContext);
                         authenticationService.updatePhoneNumber(
                                 request.getEmail(), request.getProfileInformation());
                         auditService.submitAuditEvent(
@@ -211,7 +213,7 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
 
                         var nextState =
                                 stateMachine.transition(
-                                        session.getState(), USER_HAS_ACTIONED_CONSENT);
+                                        session.getState(), USER_HAS_ACTIONED_CONSENT, userContext);
 
                         sessionService.save(session.setState(nextState));
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -124,7 +124,8 @@ public class AuthCodeHandler
                                 nextState =
                                         stateMachine.transition(
                                                 session.getState(),
-                                                SYSTEM_HAS_ISSUED_AUTHORIZATION_CODE);
+                                                SYSTEM_HAS_ISSUED_AUTHORIZATION_CODE,
+                                                UserContext.builder(session).build());
                             } catch (StateMachine.InvalidStateTransitionException e) {
                                 return generateApiGatewayProxyErrorResponse(
                                         400, ErrorResponse.ERROR_1017);


### PR DESCRIPTION
## What?

- Build the UserContext in AuthCode so we have the SessionID when logging State transitions

## Why?

- This allows us to achieve more accurate logging by logging out the session ID with each state transition and state transition error 