### PR TITLE
BAU: Extract `CaptureLoggingExtension`

### DIFF
--- a/audit-processors/build.gradle
+++ b/audit-processors/build.gradle
@@ -27,7 +27,8 @@ dependencies {
     runtimeOnly configurations.logging_runtime
 
     testImplementation configurations.tests,
-            configurations.lambda_tests
+            configurations.lambda_tests,
+            project(":shared-test")
 
     testRuntimeOnly configurations.test_runtime
 }

--- a/audit-processors/src/test/java/uk/gov/di/authentication/audit/lambda/CounterFraudAuditLambdaTest.java
+++ b/audit-processors/src/test/java/uk/gov/di/authentication/audit/lambda/CounterFraudAuditLambdaTest.java
@@ -24,8 +24,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.authentication.shared.matchers.LogEventMatcher.doesNotHaveObjectMessageProperty;
-import static uk.gov.di.authentication.shared.matchers.LogEventMatcher.hasObjectMessageProperty;
+import static uk.gov.di.authentication.sharedtest.logging.LogEventMatcher.doesNotHaveObjectMessageProperty;
+import static uk.gov.di.authentication.sharedtest.logging.LogEventMatcher.hasObjectMessageProperty;
 
 public class CounterFraudAuditLambdaTest {
 

--- a/audit-processors/src/test/java/uk/gov/di/authentication/audit/lambda/CounterFraudAuditLambdaTest.java
+++ b/audit-processors/src/test/java/uk/gov/di/authentication/audit/lambda/CounterFraudAuditLambdaTest.java
@@ -1,23 +1,16 @@
 package uk.gov.di.authentication.audit.lambda;
 
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LogEvent;
-import org.apache.logging.log4j.core.Logger;
-import org.apache.logging.log4j.core.appender.AbstractAppender;
-import org.apache.logging.log4j.core.config.Property;
-import org.apache.logging.log4j.core.impl.MutableLogEvent;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.audit.AuditPayload.AuditEvent;
 import uk.gov.di.audit.AuditPayload.AuditEvent.User;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.KmsConnectionService;
+import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -29,16 +22,15 @@ import static uk.gov.di.authentication.sharedtest.logging.LogEventMatcher.hasObj
 
 public class CounterFraudAuditLambdaTest {
 
+    @RegisterExtension
+    public final CaptureLoggingExtension logging =
+            new CaptureLoggingExtension(CounterFraudAuditLambda.class);
+
     private final KmsConnectionService kms = mock(KmsConnectionService.class);
     private final ConfigurationService config = mock(ConfigurationService.class);
-    private final ListAppender appender = new ListAppender();
 
     @BeforeEach
     public void setUp() {
-        Logger logger = (Logger) LogManager.getLogger(CounterFraudAuditLambda.class);
-
-        appender.start();
-        logger.addAppender(appender);
 
         when(config.getAuditSigningKeyAlias()).thenReturn("key_alias");
         when(config.getAuditHmacSecret()).thenReturn("i-am-a-fake-hash-key");
@@ -62,7 +54,7 @@ public class CounterFraudAuditLambdaTest {
 
         handler.handleAuditEvent(payload);
 
-        LogEvent logEvent = appender.getEvents().get(0);
+        LogEvent logEvent = logging.events().get(0);
 
         assertThat(logEvent, hasObjectMessageProperty("event-id", "test-event-id"));
         assertThat(logEvent, hasObjectMessageProperty("request-id", "test-request-id"));
@@ -89,7 +81,7 @@ public class CounterFraudAuditLambdaTest {
 
         handler.handleAuditEvent(payload);
 
-        LogEvent logEvent = appender.getEvents().get(0);
+        LogEvent logEvent = logging.events().get(0);
 
         assertThat(
                 logEvent,
@@ -122,7 +114,7 @@ public class CounterFraudAuditLambdaTest {
 
         handler.handleAuditEvent(payload);
 
-        LogEvent logEvent = appender.getEvents().get(0);
+        LogEvent logEvent = logging.events().get(0);
 
         assertThat(logEvent, hasObjectMessageProperty("extensions.key1", "value1"));
         assertThat(logEvent, hasObjectMessageProperty("extensions.key2", "value2"));
@@ -143,7 +135,7 @@ public class CounterFraudAuditLambdaTest {
 
         handler.handleAuditEvent(payload);
 
-        LogEvent logEvent = appender.getEvents().get(0);
+        LogEvent logEvent = logging.events().get(0);
 
         assertThat(logEvent, doesNotHaveObjectMessageProperty("user.id"));
     }
@@ -163,7 +155,7 @@ public class CounterFraudAuditLambdaTest {
 
         handler.handleAuditEvent(payload);
 
-        LogEvent logEvent = appender.getEvents().get(0);
+        LogEvent logEvent = logging.events().get(0);
 
         assertThat(logEvent, doesNotHaveObjectMessageProperty("user.email"));
     }
@@ -179,36 +171,8 @@ public class CounterFraudAuditLambdaTest {
 
         handler.handleAuditEvent(payload);
 
-        LogEvent logEvent = appender.getEvents().get(0);
+        LogEvent logEvent = logging.events().get(0);
 
         assertThat(logEvent, doesNotHaveObjectMessageProperty("user.phone"));
-    }
-
-    public static class ListAppender extends AbstractAppender {
-
-        final List<LogEvent> events = Collections.synchronizedList(new ArrayList<>());
-
-        public ListAppender() {
-            super("StubAppender", null, null, true, Property.EMPTY_ARRAY);
-        }
-
-        @Override
-        public void append(final LogEvent event) {
-            if (event instanceof MutableLogEvent) {
-                events.add(((MutableLogEvent) event).createMemento());
-            } else {
-                events.add(event);
-            }
-        }
-
-        public List<LogEvent> getEvents() {
-            return events;
-        }
-    }
-
-    @AfterEach
-    public void tearDown() {
-        Logger logger = (Logger) LogManager.getLogger(CounterFraudAuditLambda.class);
-        logger.removeAppender(appender);
     }
 }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/logging/CaptureLoggingExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/logging/CaptureLoggingExtension.java
@@ -1,0 +1,38 @@
+package uk.gov.di.authentication.sharedtest.logging;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.util.List;
+
+public class CaptureLoggingExtension implements BeforeEachCallback, AfterEachCallback {
+
+    private final StubAppender appender = new StubAppender();
+    private final Class<?> classUnderTest;
+
+    public CaptureLoggingExtension(Class<?> classUnderTest) {
+        this.classUnderTest = classUnderTest;
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) {
+        Logger logger = (Logger) LogManager.getLogger(classUnderTest);
+        logger.removeAppender(appender);
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext context) throws Exception {
+        Logger logger = (Logger) LogManager.getLogger(classUnderTest);
+
+        appender.start();
+        logger.addAppender(appender);
+    }
+
+    public List<LogEvent> events() {
+        return appender.getEvents();
+    }
+}

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/logging/LogEventMatcher.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/logging/LogEventMatcher.java
@@ -1,4 +1,4 @@
-package uk.gov.di.authentication.shared.matchers;
+package uk.gov.di.authentication.sharedtest.logging;
 
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.message.ObjectMessage;

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/logging/StubAppender.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/logging/StubAppender.java
@@ -1,0 +1,32 @@
+package uk.gov.di.authentication.sharedtest.logging;
+
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
+import org.apache.logging.log4j.core.impl.MutableLogEvent;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class StubAppender extends AbstractAppender {
+
+    final List<LogEvent> events = Collections.synchronizedList(new ArrayList<>());
+
+    public StubAppender() {
+        super("StubAppender", null, null, true, Property.EMPTY_ARRAY);
+    }
+
+    @Override
+    public void append(final LogEvent event) {
+        if (event instanceof MutableLogEvent) {
+            events.add(((MutableLogEvent) event).createMemento());
+        } else {
+            events.add(event);
+        }
+    }
+
+    public List<LogEvent> getEvents() {
+        return events;
+    }
+}


### PR DESCRIPTION
## What?

This extracts a component that attaches a stub appender to a class's logger and exposes log events to the test for analysis

## Why?

This resided in the audit-processors module rather than `shared-test` and we better modelled as an extension
