### PR TITLE
BAU: Remove SLF4j

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandler.java
@@ -6,8 +6,8 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent;
 import uk.gov.di.accountmanagement.entity.AuthenticateRequest;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
@@ -24,7 +24,7 @@ import static uk.gov.di.authentication.shared.helpers.WarmerHelper.isWarming;
 public class AuthenticateHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(AuthenticateHandler.class);
+    private static final Logger LOGGER = LogManager.getLogger(AuthenticateHandler.class);
 
     private final AuthenticationService authenticationService;
     private final ObjectMapper objectMapper = new ObjectMapper();

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthoriseAccessTokenHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthoriseAccessTokenHandler.java
@@ -8,8 +8,8 @@ import com.nimbusds.jwt.util.DateUtils;
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.oauth2.sdk.token.AccessTokenType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.accountmanagement.entity.AuthPolicy;
 import uk.gov.di.accountmanagement.entity.TokenAuthorizerContext;
 import uk.gov.di.authentication.shared.entity.CustomScopeValue;
@@ -30,7 +30,7 @@ import static uk.gov.di.authentication.shared.helpers.WarmerHelper.WARMUP_HEADER
 public class AuthoriseAccessTokenHandler
         implements RequestHandler<TokenAuthorizerContext, AuthPolicy> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(AuthoriseAccessTokenHandler.class);
+    private static final Logger LOGGER = LogManager.getLogger(AuthoriseAccessTokenHandler.class);
 
     private final TokenValidationService tokenValidationService;
     private final ConfigurationService configurationService;

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/NotificationHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/NotificationHandler.java
@@ -6,8 +6,8 @@ import com.amazonaws.services.lambda.runtime.events.SQSEvent;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.accountmanagement.entity.NotificationType;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.accountmanagement.services.NotificationService;
@@ -22,7 +22,7 @@ import static uk.gov.di.authentication.shared.helpers.ConstructUriHelper.buildUR
 
 public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(NotificationHandler.class);
+    private static final Logger LOGGER = LogManager.getLogger(NotificationHandler.class);
     private final NotificationService notificationService;
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final ConfigurationService configService;

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandler.java
@@ -7,8 +7,8 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.id.Subject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent;
 import uk.gov.di.accountmanagement.entity.NotificationType;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
@@ -32,7 +32,7 @@ import static uk.gov.di.authentication.shared.helpers.WarmerHelper.isWarming;
 public class RemoveAccountHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(RemoveAccountHandler.class);
+    private static final Logger LOGGER = LogManager.getLogger(RemoveAccountHandler.class);
 
     private final AuthenticationService authenticationService;
     private final AwsSqsClient sqsClient;

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
@@ -6,8 +6,8 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
@@ -36,7 +36,7 @@ import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair
 public class SendOtpNotificationHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(SendOtpNotificationHandler.class);
+    private static final Logger LOGGER = LogManager.getLogger(SendOtpNotificationHandler.class);
 
     private final ConfigurationService configurationService;
     private final ValidationService validationService;

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
@@ -7,8 +7,8 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.id.Subject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent;
 import uk.gov.di.accountmanagement.entity.NotificationType;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
@@ -40,7 +40,7 @@ public class UpdateEmailHandler
     private final AwsSqsClient sqsClient;
     private final ValidationService validationService;
     private final CodeStorageService codeStorageService;
-    private static final Logger LOGGER = LoggerFactory.getLogger(UpdateEmailHandler.class);
+    private static final Logger LOGGER = LogManager.getLogger(UpdateEmailHandler.class);
     private final AuditService auditService;
 
     public UpdateEmailHandler() {

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandler.java
@@ -7,8 +7,8 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.id.Subject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent;
 import uk.gov.di.accountmanagement.entity.NotificationType;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
@@ -37,7 +37,7 @@ public class UpdatePasswordHandler
     private final AwsSqsClient sqsClient;
     private final AuditService auditService;
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(UpdatePasswordHandler.class);
+    private static final Logger LOGGER = LogManager.getLogger(UpdatePasswordHandler.class);
 
     public UpdatePasswordHandler() {
         ConfigurationService configurationService = ConfigurationService.getInstance();

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandler.java
@@ -7,8 +7,8 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.id.Subject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent;
 import uk.gov.di.accountmanagement.entity.NotificationType;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
@@ -40,7 +40,7 @@ public class UpdatePhoneNumberHandler
     private final AwsSqsClient sqsClient;
     private final ValidationService validationService;
     private final CodeStorageService codeStorageService;
-    private static final Logger LOGGER = LoggerFactory.getLogger(UpdatePhoneNumberHandler.class);
+    private static final Logger LOGGER = LogManager.getLogger(UpdatePhoneNumberHandler.class);
     private final AuditService auditService;
 
     public UpdatePhoneNumberHandler() {

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/CodeStorageService.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/services/CodeStorageService.java
@@ -1,7 +1,7 @@
 package uk.gov.di.accountmanagement.services;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.accountmanagement.entity.NotificationType;
 import uk.gov.di.authentication.shared.helpers.HashHelper;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
@@ -10,7 +10,7 @@ import static java.lang.String.format;
 
 public class CodeStorageService {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(CodeStorageService.class);
+    private static final Logger LOGGER = LogManager.getLogger(CodeStorageService.class);
     private final RedisConnectionService redisConnectionService;
     private static final String EMAIL_KEY_PREFIX = "email-code:";
     private static final String PHONE_NUMBER_KEY_PREFIX = "phone-number-code:";

--- a/account-migrations/src/main/java/uk/gov/di/authentication/accountmigration/DataMigrationHandler.java
+++ b/account-migrations/src/main/java/uk/gov/di/authentication/accountmigration/DataMigrationHandler.java
@@ -11,8 +11,8 @@ import com.nimbusds.oauth2.sdk.id.Subject;
 import com.opencsv.bean.CsvToBean;
 import com.opencsv.bean.CsvToBeanBuilder;
 import org.apache.commons.lang3.tuple.Pair;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.entity.TermsAndConditions;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
@@ -27,7 +27,7 @@ import java.util.stream.Collectors;
 
 public class DataMigrationHandler implements RequestHandler<S3Event, String> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(DataMigrationHandler.class);
+    private static final Logger LOG = LogManager.getLogger(DataMigrationHandler.class);
     private static final int BATCH_SIZE = 1000;
 
     private final AuthenticationService authenticationService;

--- a/audit-processors/src/main/java/uk/gov/di/authentication/audit/helper/AuditEventHelper.java
+++ b/audit-processors/src/main/java/uk/gov/di/authentication/audit/helper/AuditEventHelper.java
@@ -1,8 +1,8 @@
 package uk.gov.di.authentication.audit.helper;
 
 import com.google.protobuf.InvalidProtocolBufferException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.audit.AuditPayload.AuditEvent;
 import uk.gov.di.audit.AuditPayload.SignedAuditEvent;
 
@@ -10,7 +10,7 @@ import java.util.Optional;
 
 public class AuditEventHelper {
 
-    private static final Logger LOG = LoggerFactory.getLogger(AuditEventHelper.class);
+    private static final Logger LOG = LogManager.getLogger(AuditEventHelper.class);
 
     public static Optional<AuditEvent> extractPayload(Optional<SignedAuditEvent> signedAuditEvent) {
         return signedAuditEvent

--- a/audit-processors/src/main/java/uk/gov/di/authentication/audit/lambda/StorageSQSAuditHandler.java
+++ b/audit-processors/src/main/java/uk/gov/di/authentication/audit/lambda/StorageSQSAuditHandler.java
@@ -7,8 +7,8 @@ import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
 import com.google.gson.JsonParser;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.audit.AuditPayload.AuditEvent;
 import uk.gov.di.audit.AuditPayload.SignedAuditEvent;
 import uk.gov.di.authentication.audit.helper.AuditEventHelper;
@@ -24,7 +24,7 @@ import java.util.stream.Collectors;
 
 public class StorageSQSAuditHandler implements RequestHandler<SQSEvent, Object> {
 
-    protected final Logger LOG = LoggerFactory.getLogger(getClass());
+    protected final Logger LOG = LogManager.getLogger(getClass());
     private final KmsConnectionService kmsConnectionService;
     private final ConfigurationService service;
     private final S3Service s3service;

--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,6 @@ subprojects {
 
         lambda "com.amazonaws:aws-lambda-java-core:${dependencyVersions.aws_lambda_core_version}",
                 "com.amazonaws:aws-lambda-java-events:${dependencyVersions.aws_lambda_events_version}",
-                "org.apache.logging.log4j:log4j-slf4j18-impl:2.13.0",
                 "com.amazonaws:aws-lambda-java-log4j2:1.2.0"
 
         lambda_tests "com.amazonaws:aws-lambda-java-tests:1.1.0"
@@ -75,8 +74,7 @@ subprojects {
         lettuce "org.apache.commons:commons-pool2:2.11.1",
                 "io.lettuce:lettuce-core:6.1.5.RELEASE"
 
-        logging_runtime "org.apache.logging.log4j:log4j-slf4j18-impl:2.13.0",
-                "com.amazonaws:aws-lambda-java-log4j2:1.2.0"
+        logging_runtime "com.amazonaws:aws-lambda-java-log4j2:1.2.0"
 
         jackson "com.fasterxml.jackson.core:jackson-core:${dependencyVersions.jackson_version}",
                 "com.fasterxml.jackson.core:jackson-databind:${dependencyVersions.jackson_version}",

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandler.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandler.java
@@ -9,8 +9,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
 import org.apache.commons.validator.routines.UrlValidator;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.clientregistry.entity.ClientRegistrationRequest;
 import uk.gov.di.authentication.clientregistry.entity.ClientRegistrationResponse;
 import uk.gov.di.authentication.clientregistry.services.ClientConfigValidationService;
@@ -34,7 +34,7 @@ public class ClientRegistrationHandler
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final ClientConfigValidationService validationService;
     private final AuditService auditService;
-    private static final Logger LOGGER = LoggerFactory.getLogger(ClientRegistrationHandler.class);
+    private static final Logger LOGGER = LogManager.getLogger(ClientRegistrationHandler.class);
 
     public ClientRegistrationHandler(
             ClientService clientService,

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandler.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandler.java
@@ -8,8 +8,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.clientregistry.entity.ClientRegistrationResponse;
 import uk.gov.di.authentication.clientregistry.services.ClientConfigValidationService;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
@@ -34,7 +34,7 @@ public class UpdateClientConfigHandler
     private final ClientConfigValidationService validationService;
     private final AuditService auditService;
     private final ObjectMapper objectMapper = new ObjectMapper();
-    private static final Logger LOGGER = LoggerFactory.getLogger(UpdateClientConfigHandler.class);
+    private static final Logger LOGGER = LogManager.getLogger(UpdateClientConfigHandler.class);
 
     public UpdateClientConfigHandler(
             ClientService clientService,

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/BaseFrontendHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/BaseFrontendHandler.java
@@ -7,8 +7,8 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.validation.ConstraintViolationException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.frontendapi.entity.BaseFrontendRequest;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
@@ -32,7 +32,7 @@ import static uk.gov.di.authentication.shared.helpers.WarmerHelper.isWarming;
 public abstract class BaseFrontendHandler<T>
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(BaseFrontendHandler.class);
+    private static final Logger LOG = LogManager.getLogger(BaseFrontendHandler.class);
     private static final String CLIENT_ID = "client_id";
     private final Class<T> clazz;
     protected final ConfigurationService configurationService;

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -5,8 +5,8 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.CheckUserExistsRequest;
 import uk.gov.di.authentication.frontendapi.entity.CheckUserExistsResponse;
@@ -36,7 +36,7 @@ import static uk.gov.di.authentication.shared.state.StateMachine.userJourneyStat
 public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsRequest>
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(CheckUserExistsHandler.class);
+    private static final Logger LOG = LogManager.getLogger(CheckUserExistsHandler.class);
 
     private final ValidationService validationService;
     private final AuditService auditService;

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ClientInfoHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ClientInfoHandler.java
@@ -7,8 +7,8 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.ClientInfoResponse;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
@@ -34,7 +34,7 @@ import static uk.gov.di.authentication.shared.helpers.WarmerHelper.isWarming;
 public class ClientInfoHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ClientInfoHandler.class);
+    private static final Logger LOGGER = LogManager.getLogger(ClientInfoHandler.class);
     private final ConfigurationService configurationService;
     private final ClientSessionService clientSessionService;
     private final ClientService clientService;

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -5,8 +5,8 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.LoginRequest;
 import uk.gov.di.authentication.frontendapi.entity.LoginResponse;
@@ -46,7 +46,7 @@ import static uk.gov.di.authentication.shared.state.StateMachine.userJourneyStat
 public class LoginHandler extends BaseFrontendHandler<LoginRequest>
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(LoginHandler.class);
+    private static final Logger LOGGER = LogManager.getLogger(LoginHandler.class);
     private final CodeStorageService codeStorageService;
     private final UserMigrationService userMigrationService;
     private final AuditService auditService;

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
@@ -5,8 +5,8 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.MfaRequest;
 import uk.gov.di.authentication.frontendapi.services.AwsSqsClient;
@@ -52,7 +52,7 @@ import static uk.gov.di.authentication.shared.state.StateMachine.userJourneyStat
 public class MfaHandler extends BaseFrontendHandler<MfaRequest>
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(MfaHandler.class);
+    private static final Logger LOGGER = LogManager.getLogger(MfaHandler.class);
 
     private final CodeGeneratorService codeGeneratorService;
     private final CodeStorageService codeStorageService;

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandler.java
@@ -8,8 +8,8 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.entity.NotifyRequest;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.NotificationService;
@@ -32,7 +32,7 @@ import static uk.gov.di.authentication.shared.helpers.ConstructUriHelper.buildUR
 
 public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(NotificationHandler.class);
+    private static final Logger LOG = LogManager.getLogger(NotificationHandler.class);
 
     private final NotificationService notificationService;
     private final ObjectMapper objectMapper = new ObjectMapper();

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
@@ -7,8 +7,8 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.validation.ConstraintViolationException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.frontendapi.entity.ResetPasswordWithCodeRequest;
 import uk.gov.di.authentication.frontendapi.services.AwsSqsClient;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
@@ -39,7 +39,7 @@ public class ResetPasswordHandler
     private final ValidationService validationService;
     private final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ResetPasswordHandler.class);
+    private static final Logger LOGGER = LogManager.getLogger(ResetPasswordHandler.class);
 
     public ResetPasswordHandler(
             AuthenticationService authenticationService,

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
@@ -5,8 +5,8 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.ResetPasswordRequest;
@@ -46,7 +46,7 @@ import static uk.gov.di.authentication.shared.state.StateMachine.userJourneyStat
 public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswordRequest>
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ResetPasswordRequestHandler.class);
+    private static final Logger LOGGER = LogManager.getLogger(ResetPasswordRequestHandler.class);
 
     private final ValidationService validationService;
     private final AwsSqsClient sqsClient;

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
@@ -5,8 +5,8 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import uk.gov.di.authentication.frontendapi.entity.SendNotificationRequest;
 import uk.gov.di.authentication.frontendapi.services.AwsSqsClient;
@@ -55,7 +55,7 @@ import static uk.gov.di.authentication.shared.state.StateMachine.userJourneyStat
 public class SendNotificationHandler extends BaseFrontendHandler<SendNotificationRequest>
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(SendNotificationHandler.class);
+    private static final Logger LOGGER = LogManager.getLogger(SendNotificationHandler.class);
 
     private final ValidationService validationService;
     private final AwsSqsClient sqsClient;

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
@@ -6,8 +6,8 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.nimbusds.oauth2.sdk.id.Subject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.SignupRequest;
 import uk.gov.di.authentication.shared.entity.BaseAPIResponse;
@@ -39,7 +39,7 @@ import static uk.gov.di.authentication.shared.state.StateMachine.userJourneyStat
 public class SignUpHandler extends BaseFrontendHandler<SignupRequest>
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(SignUpHandler.class);
+    private static final Logger LOG = LogManager.getLogger(SignUpHandler.class);
 
     private final ValidationService validationService;
     private final AuditService auditService;

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
@@ -8,8 +8,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.frontendapi.entity.UpdateProfileRequest;
 import uk.gov.di.authentication.shared.entity.BaseAPIResponse;
 import uk.gov.di.authentication.shared.entity.ClientConsent;
@@ -52,7 +52,7 @@ import static uk.gov.di.authentication.shared.state.StateMachine.userJourneyStat
 public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileRequest>
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(UpdateProfileHandler.class);
+    private static final Logger LOGGER = LogManager.getLogger(UpdateProfileHandler.class);
 
     private final AuditService auditService;
     private final StateMachine<SessionState, SessionAction, UserContext> stateMachine;

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -6,8 +6,8 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.VerifyCodeRequest;
 import uk.gov.di.authentication.shared.domain.RequestHeaders;
@@ -62,7 +62,7 @@ import static uk.gov.di.authentication.shared.state.StateMachine.userJourneyStat
 public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(VerifyCodeHandler.class);
+    private static final Logger LOG = LogManager.getLogger(VerifyCodeHandler.class);
 
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final CodeStorageService codeStorageService;

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/UserMigrationService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/UserMigrationService.java
@@ -1,9 +1,9 @@
 package uk.gov.di.authentication.frontendapi.services;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.bouncycastle.crypto.generators.BCrypt;
 import org.bouncycastle.crypto.generators.OpenBSDBCrypt;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -13,7 +13,7 @@ import java.util.Optional;
 
 public class UserMigrationService {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(UserMigrationService.class);
+    private static final Logger LOGGER = LogManager.getLogger(UserMigrationService.class);
 
     private final AuthenticationService authenticationService;
     private final ConfigurationService configurationService;

--- a/lambda-warmer/src/main/java/uk/gov/di/lambdawarmer/lambda/LambdaWarmerHandler.java
+++ b/lambda-warmer/src/main/java/uk/gov/di/lambdawarmer/lambda/LambdaWarmerHandler.java
@@ -9,8 +9,8 @@ import com.amazonaws.services.lambda.model.ServiceException;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.ScheduledEvent;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -24,7 +24,7 @@ import static java.text.MessageFormat.format;
 
 public class LambdaWarmerHandler implements RequestHandler<ScheduledEvent, String> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(LambdaWarmerHandler.class);
+    private static final Logger LOGGER = LogManager.getLogger(LambdaWarmerHandler.class);
     private final ConfigurationService configurationService;
     private final AWSLambda awsLambda;
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -12,8 +12,8 @@ import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import com.nimbusds.openid.connect.sdk.AuthenticationSuccessResponse;
 import org.apache.http.NameValuePair;
 import org.apache.http.message.BasicNameValuePair;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.oidc.domain.OidcAuditableEvent;
 import uk.gov.di.authentication.oidc.entity.ResponseHeaders;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
@@ -52,7 +52,7 @@ import static uk.gov.di.authentication.shared.state.StateMachine.userJourneyStat
 public class AuthCodeHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(AuthCodeHandler.class);
+    private static final Logger LOGGER = LogManager.getLogger(AuthCodeHandler.class);
 
     public static final String COOKIE_CONSENT_ACCEPT = "accept";
     public static final String COOKIE_CONSENT_REJECT = "reject";

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -14,8 +14,8 @@ import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import com.nimbusds.openid.connect.sdk.OIDCError;
 import com.nimbusds.openid.connect.sdk.Prompt;
 import org.apache.http.client.utils.URIBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.oidc.domain.OidcAuditableEvent;
 import uk.gov.di.authentication.oidc.entity.ResponseHeaders;
 import uk.gov.di.authentication.shared.entity.ClientSession;
@@ -53,7 +53,7 @@ import static uk.gov.di.authentication.shared.state.StateMachine.userJourneyStat
 public class AuthorisationHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(AuthorisationHandler.class);
+    private static final Logger LOGGER = LogManager.getLogger(AuthorisationHandler.class);
 
     private final SessionService sessionService;
     private final ConfigurationService configurationService;

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/JwksHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/JwksHandler.java
@@ -5,8 +5,8 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.nimbusds.jose.jwk.JWKSet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.KmsConnectionService;
 import uk.gov.di.authentication.shared.services.TokenValidationService;
@@ -19,7 +19,7 @@ public class JwksHandler
 
     private final TokenValidationService tokenValidationService;
     private final ConfigurationService configurationService;
-    private static final Logger LOG = LoggerFactory.getLogger(JwksHandler.class);
+    private static final Logger LOG = LogManager.getLogger(JwksHandler.class);
 
     public JwksHandler(
             TokenValidationService tokenValidationService,

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
@@ -8,8 +8,8 @@ import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
 import org.apache.http.client.utils.URIBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.oidc.entity.ResponseHeaders;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.Session;
@@ -33,7 +33,7 @@ import static uk.gov.di.authentication.shared.helpers.WarmerHelper.isWarming;
 public class LogoutHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(LogoutHandler.class);
+    private static final Logger LOG = LogManager.getLogger(LogoutHandler.class);
 
     private final ConfigurationService configurationService;
     private final SessionService sessionService;

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
@@ -15,8 +15,8 @@ import com.nimbusds.oauth2.sdk.id.Subject;
 import com.nimbusds.oauth2.sdk.token.RefreshToken;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import com.nimbusds.openid.connect.sdk.OIDCTokenResponse;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.entity.AuthCodeExchangeData;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
@@ -51,7 +51,7 @@ import static uk.gov.di.authentication.shared.helpers.WarmerHelper.isWarming;
 public class TokenHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(TokenHandler.class);
+    private static final Logger LOG = LogManager.getLogger(TokenHandler.class);
 
     private final ClientService clientService;
     private final TokenService tokenService;

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TrustMarkHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TrustMarkHandler.java
@@ -6,8 +6,8 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.oidc.entity.TrustMarkResponse;
 import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -22,7 +22,7 @@ public class TrustMarkHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     private final ConfigurationService configurationService;
-    private static final Logger LOG = LoggerFactory.getLogger(TrustMarkHandler.class);
+    private static final Logger LOG = LogManager.getLogger(TrustMarkHandler.class);
 
     public TrustMarkHandler(ConfigurationService configurationService) {
         this.configurationService = configurationService;

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandler.java
@@ -6,8 +6,8 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.nimbusds.openid.connect.sdk.UserInfoErrorResponse;
 import com.nimbusds.openid.connect.sdk.claims.UserInfo;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.oidc.services.UserInfoService;
 import uk.gov.di.authentication.shared.exceptions.UserInfoValidationException;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -27,7 +27,7 @@ import static uk.gov.di.authentication.shared.helpers.WarmerHelper.isWarming;
 public class UserInfoHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(UserInfoHandler.class);
+    private static final Logger LOGGER = LogManager.getLogger(UserInfoHandler.class);
     private final ConfigurationService configurationService;
     private final UserInfoService userInfoService;
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/WellknownHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/WellknownHandler.java
@@ -13,8 +13,8 @@ import com.nimbusds.oauth2.sdk.id.Issuer;
 import com.nimbusds.openid.connect.sdk.SubjectType;
 import com.nimbusds.openid.connect.sdk.claims.ClaimType;
 import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.entity.ValidScopes;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
@@ -30,7 +30,7 @@ import static uk.gov.di.authentication.shared.helpers.WarmerHelper.isWarming;
 public class WellknownHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(WellknownHandler.class);
+    private static final Logger LOG = LogManager.getLogger(WellknownHandler.class);
 
     private final ConfigurationService configService;
     private final String baseUrl;

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/UserInfoService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/UserInfoService.java
@@ -10,8 +10,8 @@ import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.oauth2.sdk.token.AccessTokenType;
 import com.nimbusds.oauth2.sdk.token.BearerTokenError;
 import com.nimbusds.openid.connect.sdk.claims.UserInfo;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.entity.AccessTokenStore;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.UserProfile;
@@ -37,7 +37,7 @@ public class UserInfoService {
     private final DynamoClientService clientService;
     private static final String ACCESS_TOKEN_PREFIX = "ACCESS_TOKEN:";
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(UserInfoService.class);
+    private static final Logger LOGGER = LogManager.getLogger(UserInfoService.class);
 
     public UserInfoService(
             RedisConnectionService redisConnectionService,

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/VectorOfTrust.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/VectorOfTrust.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import net.minidev.json.JSONArray;
 import net.minidev.json.parser.JSONParser;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -16,7 +16,7 @@ import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.retrie
 
 public class VectorOfTrust {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(VectorOfTrust.class);
+    private static final Logger LOGGER = LogManager.getLogger(VectorOfTrust.class);
 
     @JsonProperty("credential_trust_level")
     private final CredentialTrustLevel credentialTrustLevel;

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ApiGatewayResponseHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ApiGatewayResponseHelper.java
@@ -4,8 +4,8 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.HttpHeaders;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 
 import java.util.List;
@@ -28,7 +28,7 @@ public class ApiGatewayResponseHelper {
             "max-age=31536000; includeSubDomains";
     private static final String X_FRAME_OPTIONS_HEADER_VALUE = "DENY";
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ApiGatewayResponseHelper.class);
+    private static final Logger LOGGER = LogManager.getLogger(ApiGatewayResponseHelper.class);
 
     public static <T> APIGatewayProxyResponseEvent generateApiGatewayProxyResponse(
             int statusCode, T body) throws JsonProcessingException {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ClientSubjectHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ClientSubjectHelper.java
@@ -1,7 +1,7 @@
 package uk.gov.di.authentication.shared.helpers;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.nio.charset.StandardCharsets;
@@ -10,7 +10,7 @@ import java.security.NoSuchAlgorithmException;
 
 public class ClientSubjectHelper {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ClientSubjectHelper.class);
+    private static final Logger LOGGER = LogManager.getLogger(ClientSubjectHelper.class);
 
     private static final ConfigurationService configurationService =
             ConfigurationService.getInstance();

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/CookieHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/CookieHelper.java
@@ -1,7 +1,7 @@
 package uk.gov.di.authentication.shared.helpers;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.net.HttpCookie;
 import java.util.Arrays;
@@ -13,7 +13,7 @@ import static java.lang.String.format;
 
 public class CookieHelper {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(CookieHelper.class);
+    private static final Logger LOGGER = LogManager.getLogger(CookieHelper.class);
 
     public static final String REQUEST_COOKIE_HEADER = "Cookie";
     public static final String RESPONSE_COOKIE_HEADER = "Set-Cookie";

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/IpAddressHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/IpAddressHelper.java
@@ -3,8 +3,8 @@ package uk.gov.di.authentication.shared.helpers;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent.ProxyRequestContext;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent.RequestIdentity;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.services.AuditService;
 
 import java.util.Optional;
@@ -13,7 +13,7 @@ import static java.util.Collections.emptyMap;
 
 public class IpAddressHelper {
 
-    private static final Logger LOG = LoggerFactory.getLogger(IpAddressHelper.class);
+    private static final Logger LOG = LogManager.getLogger(IpAddressHelper.class);
 
     public static String extractIpAddress(APIGatewayProxyRequestEvent input) {
         var headers =

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ObjectMapperFactory.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ObjectMapperFactory.java
@@ -16,8 +16,8 @@ import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -54,8 +54,7 @@ public class ObjectMapperFactory {
     }
 
     public static class ValidatingBeanDeserializer extends BeanDeserializer {
-        private static final Logger LOGGER =
-                LoggerFactory.getLogger(ValidatingBeanDeserializer.class);
+        private static final Logger LOGGER = LogManager.getLogger(ValidatingBeanDeserializer.class);
         private final Validator validator;
 
         public ValidatingBeanDeserializer(BeanDeserializerBase src) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/PhoneNumberHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/PhoneNumberHelper.java
@@ -2,12 +2,12 @@ package uk.gov.di.authentication.shared.helpers;
 
 import com.google.i18n.phonenumbers.NumberParseException;
 import com.google.i18n.phonenumbers.PhoneNumberUtil;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class PhoneNumberHelper {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(PhoneNumberHelper.class);
+    private static final Logger LOGGER = LogManager.getLogger(PhoneNumberHelper.class);
 
     public static String formatPhoneNumber(String phoneNumber) {
         PhoneNumberUtil phoneUtil = PhoneNumberUtil.getInstance();

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/RequestBodyHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/RequestBodyHelper.java
@@ -3,8 +3,8 @@ package uk.gov.di.authentication.shared.helpers;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.nio.charset.Charset;
 import java.util.HashMap;
@@ -12,7 +12,7 @@ import java.util.Map;
 
 public class RequestBodyHelper {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(RequestBodyHelper.class);
+    private static final Logger LOGGER = LogManager.getLogger(RequestBodyHelper.class);
 
     public static Map<String, String> parseRequestBody(String body) {
         Map<String, String> query_pairs = new HashMap<>();

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/WarmerHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/WarmerHelper.java
@@ -2,8 +2,8 @@ package uk.gov.di.authentication.shared.helpers;
 
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.util.Optional;
@@ -13,7 +13,7 @@ import static java.lang.Thread.sleep;
 public class WarmerHelper {
     private static final ConfigurationService configurationService =
             ConfigurationService.getInstance();
-    private static final Logger LOGGER = LoggerFactory.getLogger(WarmerHelper.class);
+    private static final Logger LOGGER = LogManager.getLogger(WarmerHelper.class);
 
     public static final String WARMUP_HEADER = "__WARMUP_REQUEST__";
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthorisationCodeService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthorisationCodeService.java
@@ -3,8 +3,8 @@ package uk.gov.di.authentication.shared.services;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.entity.AuthCodeExchangeData;
 import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 
@@ -12,7 +12,7 @@ import java.util.Optional;
 
 public class AuthorisationCodeService {
 
-    private static final Logger LOG = LoggerFactory.getLogger(AuthorisationCodeService.class);
+    private static final Logger LOG = LogManager.getLogger(AuthorisationCodeService.class);
     public static final String AUTH_CODE_PREFIX = "auth-code-";
 
     private final RedisConnectionService redisConnectionService;

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthorizationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthorizationService.java
@@ -11,8 +11,8 @@ import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import com.nimbusds.openid.connect.sdk.AuthenticationSuccessResponse;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URIBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.Session;
@@ -36,7 +36,7 @@ public class AuthorizationService {
     private static final String CLIENT_ID = "client_id";
     private final DynamoClientService dynamoClientService;
     private final DynamoService dynamoService;
-    private static final Logger LOGGER = LoggerFactory.getLogger(AuthorizationService.class);
+    private static final Logger LOGGER = LogManager.getLogger(AuthorizationService.class);
 
     public AuthorizationService(
             DynamoClientService dynamoClientService, DynamoService dynamoService) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ClientSessionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ClientSessionService.java
@@ -2,8 +2,8 @@ package uk.gov.di.authentication.shared.services;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
@@ -17,7 +17,7 @@ import static uk.gov.di.authentication.shared.helpers.RequestHeaderHelper.header
 
 public class ClientSessionService {
 
-    private static final Logger LOG = LoggerFactory.getLogger(ClientSessionService.class);
+    private static final Logger LOG = LogManager.getLogger(ClientSessionService.class);
     public static final String CLIENT_SESSION_PREFIX = "client-session-";
 
     private final RedisConnectionService redisConnectionService;

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java
@@ -1,7 +1,7 @@
 package uk.gov.di.authentication.shared.services;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.helpers.HashHelper;
 
@@ -15,7 +15,7 @@ public class CodeStorageService {
     public static final String CODE_BLOCKED_KEY_PREFIX = "code-blocked:";
     public static final String PASSWORD_RESET_BLOCKED_KEY_PREFIX = "password-reset-blocked:";
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(CodeStorageService.class);
+    private static final Logger LOGGER = LogManager.getLogger(CodeStorageService.class);
     private final RedisConnectionService redisConnectionService;
     private static final String EMAIL_KEY_PREFIX = "email-code:";
     private static final String PHONE_NUMBER_KEY_PREFIX = "phone-number-code:";

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -6,8 +6,8 @@ import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement
 import com.amazonaws.services.simplesystemsmanagement.model.GetParameterRequest;
 import com.amazonaws.services.simplesystemsmanagement.model.GetParametersRequest;
 import com.amazonaws.services.simplesystemsmanagement.model.ParameterNotFoundException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.configuration.AuditPublisherConfiguration;
 import uk.gov.di.authentication.shared.configuration.BaseLambdaConfiguration;
 
@@ -21,7 +21,7 @@ import static java.text.MessageFormat.format;
 
 public class ConfigurationService implements BaseLambdaConfiguration, AuditPublisherConfiguration {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ConfigurationService.class);
+    private static final Logger LOGGER = LogManager.getLogger(ConfigurationService.class);
     private static ConfigurationService configurationService;
 
     public static ConfigurationService getInstance() {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/KmsConnectionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/KmsConnectionService.java
@@ -9,8 +9,8 @@ import com.amazonaws.services.kms.model.SignRequest;
 import com.amazonaws.services.kms.model.SignResult;
 import com.amazonaws.services.kms.model.SigningAlgorithmSpec;
 import com.amazonaws.services.kms.model.VerifyRequest;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.nio.ByteBuffer;
 import java.util.Optional;
@@ -18,7 +18,7 @@ import java.util.Optional;
 public class KmsConnectionService {
 
     private final AWSKMS kmsClient;
-    private static final Logger LOGGER = LoggerFactory.getLogger(KmsConnectionService.class);
+    private static final Logger LOGGER = LogManager.getLogger(KmsConnectionService.class);
 
     public KmsConnectionService(ConfigurationService configurationService) {
         this(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/SessionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/SessionService.java
@@ -1,8 +1,8 @@
 package uk.gov.di.authentication.shared.services;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.helpers.CookieHelper;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
@@ -17,7 +17,7 @@ import static uk.gov.di.authentication.shared.helpers.RequestHeaderHelper.header
 
 public class SessionService {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(SessionService.class);
+    private static final Logger LOGGER = LogManager.getLogger(SessionService.class);
 
     private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.getInstance();
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/SnsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/SnsService.java
@@ -3,15 +3,15 @@ package uk.gov.di.authentication.shared.services;
 import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.sns.AmazonSNS;
 import com.amazonaws.services.sns.AmazonSNSClientBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.configuration.AuditPublisherConfiguration;
 
 public class SnsService {
 
     private final String topicArn;
     private final AmazonSNS snsClient;
-    private static final Logger LOGGER = LoggerFactory.getLogger(SnsService.class);
+    private static final Logger LOGGER = LogManager.getLogger(SnsService.class);
 
     public SnsService(AuditPublisherConfiguration configService) {
         this.topicArn = configService.getEventsSnsTopicArn();

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
@@ -36,8 +36,8 @@ import com.nimbusds.openid.connect.sdk.OIDCTokenResponse;
 import com.nimbusds.openid.connect.sdk.claims.AccessTokenHash;
 import com.nimbusds.openid.connect.sdk.claims.IDTokenClaimsSet;
 import com.nimbusds.openid.connect.sdk.token.OIDCTokens;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.entity.AccessTokenStore;
 import uk.gov.di.authentication.shared.entity.ClientConsent;
 import uk.gov.di.authentication.shared.entity.RefreshTokenStore;
@@ -72,7 +72,7 @@ public class TokenService {
     private final RedisConnectionService redisConnectionService;
     private final KmsConnectionService kmsConnectionService;
     private static final JWSAlgorithm TOKEN_ALGORITHM = JWSAlgorithm.ES256;
-    private static final Logger LOGGER = LoggerFactory.getLogger(TokenService.class);
+    private static final Logger LOGGER = LogManager.getLogger(TokenService.class);
     private static final String REFRESH_TOKEN_PREFIX = "REFRESH_TOKEN:";
     private static final String ACCESS_TOKEN_PREFIX = "ACCESS_TOKEN:";
     private static final List<String> ALLOWED_GRANTS =

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenValidationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenValidationService.java
@@ -17,12 +17,12 @@ import com.nimbusds.jwt.util.DateUtils;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.oauth2.sdk.token.RefreshToken;
 import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.openssl.PEMException;
 import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.security.Provider;
 import java.security.PublicKey;
@@ -36,7 +36,7 @@ public class TokenValidationService {
 
     private final ConfigurationService configService;
     private final KmsConnectionService kmsConnectionService;
-    private static final Logger LOGGER = LoggerFactory.getLogger(TokenValidationService.class);
+    private static final Logger LOGGER = LogManager.getLogger(TokenValidationService.class);
 
     public TokenValidationService(
             ConfigurationService configService, KmsConnectionService kmsConnectionService) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/state/StateMachine.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/state/StateMachine.java
@@ -1,7 +1,7 @@
 package uk.gov.di.authentication.shared.state;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.SessionAction;
 import uk.gov.di.authentication.shared.entity.SessionState;
@@ -97,7 +97,7 @@ public class StateMachine<T, A, C> {
     private final Map<T, List<Transition<T, A, C>>> states;
     private final List<Transition<T, A, C>> anyStateTransitions;
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(StateMachine.class);
+    private static final Logger LOGGER = LogManager.getLogger(StateMachine.class);
 
     public StateMachine(Map<T, List<Transition<T, A, C>>> states) {
         this(states, List.of());

--- a/shared/src/main/java/uk/gov/di/authentication/shared/state/conditions/ClientDoesNotRequireMfa.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/state/conditions/ClientDoesNotRequireMfa.java
@@ -2,8 +2,8 @@ package uk.gov.di.authentication.shared.state.conditions;
 
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.VectorOfTrust;
 import uk.gov.di.authentication.shared.state.Condition;
@@ -16,7 +16,7 @@ import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.LOW_LE
 
 public class ClientDoesNotRequireMfa implements Condition<UserContext> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(ClientDoesNotRequireMfa.class);
+    private static final Logger LOG = LogManager.getLogger(ClientDoesNotRequireMfa.class);
 
     @Override
     public boolean isMet(Optional<UserContext> context) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/state/conditions/ConsentNotGiven.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/state/conditions/ConsentNotGiven.java
@@ -2,8 +2,8 @@ package uk.gov.di.authentication.shared.state.conditions;
 
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.entity.ClientConsent;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
@@ -17,7 +17,7 @@ import java.util.Optional;
 
 public class ConsentNotGiven implements Condition<UserContext> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(ConsentNotGiven.class);
+    private static final Logger LOG = LogManager.getLogger(ConsentNotGiven.class);
 
     @Override
     public boolean isMet(Optional<UserContext> context) {


### PR DESCRIPTION
## What?

This PR removes slf4j in favour of using log4j2 directly.

## Why?

We don't gain any tangible benefit from slf4j when we can use the lambda-provided logging directly.
