### PR TITLE
GOVSI-1065: Default state transitions

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/state/StateMachine.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/state/StateMachine.java
@@ -177,9 +177,7 @@ public class StateMachine<T, A, C> {
                         on(SYSTEM_HAS_SENT_TOO_MANY_EMAIL_VERIFICATION_CODES)
                                 .then(EMAIL_MAX_CODES_SENT),
                         on(USER_ENTERED_INVALID_EMAIL_VERIFICATION_CODE_TOO_MANY_TIMES)
-                                .then(EMAIL_CODE_MAX_RETRIES_REACHED),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY).then(NEW),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED).then(NEW))
+                                .then(EMAIL_CODE_MAX_RETRIES_REACHED))
                 .when(RESET_PASSWORD_LINK_SENT)
                 .allow(
                         on(SYSTEM_HAS_SENT_RESET_PASSWORD_LINK_TOO_MANY_TIMES)
@@ -208,15 +206,11 @@ public class StateMachine<T, A, C> {
                                 .ifCondition(clientDoesNotRequireMfa())
                                 .then(AUTHENTICATED),
                         on(USER_ENTERED_VALID_CREDENTIALS).then(LOGGED_IN),
-                        on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY).then(NEW),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED).then(NEW))
+                        on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND))
                 .when(RESET_PASSWORD_LINK_MAX_RETRIES_REACHED)
                 .allow(
                         on(SYSTEM_HAS_SENT_RESET_PASSWORD_LINK).then(RESET_PASSWORD_LINK_SENT),
-                        on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY).then(NEW),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED).then(NEW))
+                        on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND))
                 .when(USER_NOT_FOUND)
                 .allow(
                         on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND),
@@ -227,9 +221,7 @@ public class StateMachine<T, A, C> {
                         on(SYSTEM_HAS_SENT_TOO_MANY_EMAIL_VERIFICATION_CODES)
                                 .then(EMAIL_MAX_CODES_SENT),
                         on(SYSTEM_IS_BLOCKED_FROM_SENDING_ANY_EMAIL_VERIFICATION_CODES)
-                                .then(EMAIL_CODE_REQUESTS_BLOCKED),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY).then(NEW),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED).then(NEW))
+                                .then(EMAIL_CODE_REQUESTS_BLOCKED))
                 .when(VERIFY_EMAIL_CODE_SENT)
                 .allow(
                         on(USER_ENTERED_REGISTERED_EMAIL_ADDRESS).then(AUTHENTICATION_REQUIRED),
@@ -238,51 +230,37 @@ public class StateMachine<T, A, C> {
                         on(SYSTEM_HAS_SENT_EMAIL_VERIFICATION_CODE).then(VERIFY_EMAIL_CODE_SENT),
                         on(SYSTEM_HAS_SENT_TOO_MANY_EMAIL_VERIFICATION_CODES)
                                 .then(EMAIL_MAX_CODES_SENT),
-                        on(USER_ENTERED_INVALID_EMAIL_VERIFICATION_CODE).then(EMAIL_CODE_NOT_VALID),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY).then(NEW),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED).then(NEW))
+                        on(USER_ENTERED_INVALID_EMAIL_VERIFICATION_CODE).then(EMAIL_CODE_NOT_VALID))
                 .when(EMAIL_MAX_CODES_SENT)
                 .allow(
                         on(SYSTEM_HAS_SENT_EMAIL_VERIFICATION_CODE).then(VERIFY_EMAIL_CODE_SENT),
                         on(SYSTEM_IS_BLOCKED_FROM_SENDING_ANY_EMAIL_VERIFICATION_CODES)
                                 .then(EMAIL_CODE_REQUESTS_BLOCKED),
-                        on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY).then(NEW),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED).then(NEW))
+                        on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND))
                 .when(EMAIL_CODE_REQUESTS_BLOCKED)
                 .allow(
                         on(SYSTEM_HAS_SENT_EMAIL_VERIFICATION_CODE).then(VERIFY_EMAIL_CODE_SENT),
-                        on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY).then(NEW),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED).then(NEW))
+                        on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND))
                 .when(EMAIL_CODE_NOT_VALID)
                 .allow(
                         on(USER_ENTERED_VALID_EMAIL_VERIFICATION_CODE).then(EMAIL_CODE_VERIFIED),
                         on(USER_ENTERED_INVALID_EMAIL_VERIFICATION_CODE).then(EMAIL_CODE_NOT_VALID),
                         on(USER_ENTERED_INVALID_EMAIL_VERIFICATION_CODE_TOO_MANY_TIMES)
                                 .then(EMAIL_CODE_MAX_RETRIES_REACHED),
-                        on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY).then(NEW),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED).then(NEW))
+                        on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND))
                 .when(EMAIL_CODE_MAX_RETRIES_REACHED)
                 .allow(
                         on(USER_ENTERED_INVALID_EMAIL_VERIFICATION_CODE_TOO_MANY_TIMES)
                                 .then(EMAIL_CODE_MAX_RETRIES_REACHED),
-                        on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY).then(NEW),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED).then(NEW))
+                        on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND))
                 .when(EMAIL_CODE_VERIFIED)
                 .allow(
                         on(USER_ENTERED_INVALID_EMAIL_VERIFICATION_CODE).then(EMAIL_CODE_NOT_VALID),
                         on(USER_HAS_CREATED_A_PASSWORD).then(TWO_FACTOR_REQUIRED),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY).then(NEW),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED).then(NEW),
                         on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND))
                 .when(TWO_FACTOR_REQUIRED)
                 .allow(
                         on(USER_ENTERED_A_NEW_PHONE_NUMBER).then(ADDED_UNVERIFIED_PHONE_NUMBER),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY).then(NEW),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED).then(NEW),
                         on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND))
                 .when(ADDED_UNVERIFIED_PHONE_NUMBER)
                 .allow(
@@ -292,9 +270,7 @@ public class StateMachine<T, A, C> {
                                 .then(PHONE_NUMBER_CODE_REQUESTS_BLOCKED),
                         on(SYSTEM_HAS_SENT_PHONE_VERIFICATION_CODE)
                                 .then(VERIFY_PHONE_NUMBER_CODE_SENT),
-                        on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY).then(NEW),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED).then(NEW))
+                        on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND))
                 .when(VERIFY_PHONE_NUMBER_CODE_SENT)
                 .allow(
                         on(USER_ENTERED_VALID_PHONE_VERIFICATION_CODE)
@@ -312,9 +288,7 @@ public class StateMachine<T, A, C> {
                                 .then(PHONE_NUMBER_MAX_CODES_SENT),
                         on(USER_ENTERED_INVALID_PHONE_VERIFICATION_CODE)
                                 .then(PHONE_NUMBER_CODE_NOT_VALID),
-                        on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY).then(NEW),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED).then(NEW))
+                        on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND))
                 .when(PHONE_NUMBER_MAX_CODES_SENT)
                 .allow(
                         on(SYSTEM_HAS_SENT_PHONE_VERIFICATION_CODE)
@@ -322,23 +296,17 @@ public class StateMachine<T, A, C> {
                         on(SYSTEM_IS_BLOCKED_FROM_SENDING_ANY_PHONE_VERIFICATION_CODES)
                                 .then(PHONE_NUMBER_CODE_REQUESTS_BLOCKED),
                         on(USER_ENTERED_A_NEW_PHONE_NUMBER).then(ADDED_UNVERIFIED_PHONE_NUMBER),
-                        on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY).then(NEW),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED).then(NEW))
+                        on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND))
                 .when(PHONE_NUMBER_CODE_REQUESTS_BLOCKED)
                 .allow(
                         on(SYSTEM_HAS_SENT_PHONE_VERIFICATION_CODE)
                                 .then(VERIFY_PHONE_NUMBER_CODE_SENT),
                         on(USER_ENTERED_A_NEW_PHONE_NUMBER).then(ADDED_UNVERIFIED_PHONE_NUMBER),
-                        on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY).then(NEW),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED).then(NEW))
+                        on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND))
                 .when(PHONE_NUMBER_CODE_VERIFIED)
                 .allow(
                         on(SYSTEM_HAS_ISSUED_AUTHORIZATION_CODE).then(AUTHENTICATED),
-                        on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY).then(NEW),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED).then(NEW))
+                        on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND))
                 .when(PHONE_NUMBER_CODE_NOT_VALID)
                 .allow(
                         on(USER_ENTERED_VALID_PHONE_VERIFICATION_CODE)
@@ -347,26 +315,20 @@ public class StateMachine<T, A, C> {
                                 .then(PHONE_NUMBER_CODE_NOT_VALID),
                         on(USER_ENTERED_INVALID_PHONE_VERIFICATION_CODE_TOO_MANY_TIMES)
                                 .then(PHONE_NUMBER_CODE_MAX_RETRIES_REACHED),
-                        on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY).then(NEW),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED).then(NEW))
+                        on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND))
                 .when(PHONE_NUMBER_CODE_MAX_RETRIES_REACHED)
                 .allow(
                         on(USER_ENTERED_INVALID_PHONE_VERIFICATION_CODE_TOO_MANY_TIMES)
                                 .then(PHONE_NUMBER_CODE_MAX_RETRIES_REACHED),
                         on(USER_ENTERED_A_NEW_PHONE_NUMBER).then(ADDED_UNVERIFIED_PHONE_NUMBER),
-                        on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY).then(NEW),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED).then(NEW))
+                        on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND))
                 .when(ACCOUNT_TEMPORARILY_LOCKED)
                 .allow(
                         on(SYSTEM_HAS_SENT_RESET_PASSWORD_LINK).then(RESET_PASSWORD_LINK_SENT),
                         on(USER_ENTERED_INVALID_PASSWORD_TOO_MANY_TIMES)
                                 .then(ACCOUNT_TEMPORARILY_LOCKED),
                         on(ACCOUNT_LOCK_EXPIRED).then(AUTHENTICATION_REQUIRED),
-                        on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY).then(NEW),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED).then(NEW))
+                        on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND))
                 .when(AUTHENTICATION_REQUIRED)
                 .allow(
                         on(USER_ENTERED_VALID_CREDENTIALS)
@@ -396,9 +358,7 @@ public class StateMachine<T, A, C> {
                         on(SYSTEM_HAS_SENT_RESET_PASSWORD_LINK).then(RESET_PASSWORD_LINK_SENT),
                         on(USER_ENTERED_INVALID_PASSWORD_TOO_MANY_TIMES)
                                 .then(ACCOUNT_TEMPORARILY_LOCKED),
-                        on(ACCOUNT_LOCK_EXPIRED).then(AUTHENTICATION_REQUIRED),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY).then(NEW),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED).then(NEW))
+                        on(ACCOUNT_LOCK_EXPIRED).then(AUTHENTICATION_REQUIRED))
                 .when(LOGGED_IN)
                 .allow(
                         on(SYSTEM_HAS_SENT_MFA_CODE).then(MFA_SMS_CODE_SENT),
@@ -406,9 +366,7 @@ public class StateMachine<T, A, C> {
                                 .then(MFA_CODE_REQUESTS_BLOCKED),
                         on(USER_ENTERED_INVALID_MFA_CODE_TOO_MANY_TIMES)
                                 .then(MFA_CODE_MAX_RETRIES_REACHED),
-                        on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY).then(NEW),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED).then(NEW))
+                        on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND))
                 .when(MFA_SMS_CODE_SENT)
                 .allow(
                         on(USER_ENTERED_VALID_CREDENTIALS).then(MFA_SMS_CODE_SENT),
@@ -431,9 +389,7 @@ public class StateMachine<T, A, C> {
                         on(USER_HAS_STARTED_A_NEW_JOURNEY)
                                 .then(UPLIFT_REQUIRED_CM)
                                 .ifCondition(upliftRequired()),
-                        on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY).then(NEW),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED).then(NEW))
+                        on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND))
                 .when(MFA_SMS_MAX_CODES_SENT)
                 .allow(
                         on(SYSTEM_HAS_SENT_MFA_CODE).then(MFA_SMS_CODE_SENT),
@@ -442,9 +398,7 @@ public class StateMachine<T, A, C> {
                         on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND),
                         on(USER_HAS_STARTED_A_NEW_JOURNEY)
                                 .then(UPLIFT_REQUIRED_CM)
-                                .ifCondition(upliftRequired()),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY).then(NEW),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED).then(NEW))
+                                .ifCondition(upliftRequired()))
                 .when(MFA_CODE_REQUESTS_BLOCKED)
                 .allow(
                         on(SYSTEM_IS_BLOCKED_FROM_SENDING_ANY_MFA_VERIFICATION_CODES)
@@ -454,9 +408,7 @@ public class StateMachine<T, A, C> {
                         on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND),
                         on(USER_HAS_STARTED_A_NEW_JOURNEY)
                                 .then(UPLIFT_REQUIRED_CM)
-                                .ifCondition(upliftRequired()),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY).then(NEW),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED).then(NEW))
+                                .ifCondition(upliftRequired()))
                 .when(MFA_CODE_NOT_VALID)
                 .allow(
                         on(USER_ENTERED_VALID_MFA_CODE)
@@ -478,9 +430,7 @@ public class StateMachine<T, A, C> {
                         on(USER_HAS_STARTED_A_NEW_JOURNEY)
                                 .then(UPLIFT_REQUIRED_CM)
                                 .ifCondition(upliftRequired()),
-                        on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY).then(NEW),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED).then(NEW))
+                        on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND))
                 .when(MFA_CODE_MAX_RETRIES_REACHED)
                 .allow(
                         on(USER_ENTERED_INVALID_MFA_CODE_TOO_MANY_TIMES)
@@ -489,9 +439,7 @@ public class StateMachine<T, A, C> {
                         on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND),
                         on(USER_HAS_STARTED_A_NEW_JOURNEY)
                                 .then(UPLIFT_REQUIRED_CM)
-                                .ifCondition(upliftRequired()),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY).then(NEW),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED).then(NEW))
+                                .ifCondition(upliftRequired()))
                 .when(MFA_CODE_VERIFIED)
                 .allow(on(SYSTEM_HAS_ISSUED_AUTHORIZATION_CODE).then(AUTHENTICATED))
                 .when(UPDATED_TERMS_AND_CONDITIONS)
@@ -513,15 +461,11 @@ public class StateMachine<T, A, C> {
                                         userHasNotAcceptedTermsAndConditionsVersion(
                                                 configurationService
                                                         .getTermsAndConditionsVersion())),
-                        on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY).then(NEW),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED).then(NEW))
+                        on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND))
                 .when(UPDATED_TERMS_AND_CONDITIONS_ACCEPTED)
                 .allow(
                         on(SYSTEM_HAS_ISSUED_AUTHORIZATION_CODE).then(AUTHENTICATED),
-                        on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY).then(NEW),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED).then(NEW))
+                        on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND))
                 .when(CONSENT_REQUIRED)
                 .allow(
                         on(USER_HAS_STARTED_A_NEW_JOURNEY)
@@ -538,14 +482,11 @@ public class StateMachine<T, A, C> {
                                 .then(CONSENT_REQUIRED)
                                 .ifCondition(userHasNotGivenConsent()),
                         on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY).then(AUTHENTICATED),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED).then(NEW))
+                        on(USER_HAS_STARTED_A_NEW_JOURNEY).then(AUTHENTICATED))
                 .when(CONSENT_ADDED)
                 .allow(
                         on(SYSTEM_HAS_ISSUED_AUTHORIZATION_CODE).then(AUTHENTICATED),
-                        on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY).then(NEW),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED).then(NEW))
+                        on(USER_ENTERED_UNREGISTERED_EMAIL_ADDRESS).then(USER_NOT_FOUND))
                 .when(AUTHENTICATED)
                 .allow(
                         on(SYSTEM_HAS_ISSUED_AUTHORIZATION_CODE).then(AUTHENTICATED),
@@ -569,11 +510,11 @@ public class StateMachine<T, A, C> {
                         on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED)
                                 .then(AUTHENTICATION_REQUIRED))
                 .when(UPLIFT_REQUIRED_CM)
-                .allow(
-                        on(SYSTEM_HAS_SENT_MFA_CODE).then(MFA_SMS_CODE_SENT),
-                        on(USER_HAS_STARTED_A_NEW_JOURNEY).then(NEW))
+                .allow(on(SYSTEM_HAS_SENT_MFA_CODE).then(MFA_SMS_CODE_SENT))
                 .atAnyState()
-                .allow()
+                .allow(
+                        on(USER_HAS_STARTED_A_NEW_JOURNEY).then(NEW),
+                        on(USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED).then(NEW))
                 .build();
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/state/StateMachine.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/state/StateMachine.java
@@ -124,7 +124,19 @@ public class StateMachine<T, A, C> {
                                         t.getAction().equals(action)
                                                 && t.getCondition().isMet(context))
                         .findFirst()
-                        .orElseThrow(() -> handleBadStateTransition(from, action, sessionId))
+                        .orElseGet(
+                                () ->
+                                        anyStateTransitions.stream()
+                                                .filter(
+                                                        t ->
+                                                                t.getAction().equals(action)
+                                                                        && t.getCondition()
+                                                                                .isMet(context))
+                                                .findFirst()
+                                                .orElseThrow(
+                                                        () ->
+                                                                handleBadStateTransition(
+                                                                        from, action, sessionId)))
                         .getNextState();
 
         LOGGER.info(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/state/StateMachine.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/state/StateMachine.java
@@ -7,7 +7,13 @@ import uk.gov.di.authentication.shared.entity.SessionAction;
 import uk.gov.di.authentication.shared.entity.SessionState;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;

--- a/shared/src/test/java/uk/gov/di/authentication/shared/state/StateMachineTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/state/StateMachineTest.java
@@ -10,14 +10,8 @@ import static java.util.Map.ofEntries;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static uk.gov.di.authentication.shared.state.StateMachineTest.Action.CONDITIONAL_MOVE;
-import static uk.gov.di.authentication.shared.state.StateMachineTest.Action.MOVE_TO_2;
-import static uk.gov.di.authentication.shared.state.StateMachineTest.Action.MOVE_TO_3;
-import static uk.gov.di.authentication.shared.state.StateMachineTest.State.STATE_1;
-import static uk.gov.di.authentication.shared.state.StateMachineTest.State.STATE_2;
-import static uk.gov.di.authentication.shared.state.StateMachineTest.State.STATE_3;
-import static uk.gov.di.authentication.shared.state.StateMachineTest.State.STATE_4;
-import static uk.gov.di.authentication.shared.state.StateMachineTest.State.STATE_5;
+import static uk.gov.di.authentication.shared.state.StateMachineTest.Action.*;
+import static uk.gov.di.authentication.shared.state.StateMachineTest.State.*;
 
 public class StateMachineTest {
 
@@ -26,13 +20,15 @@ public class StateMachineTest {
         STATE_2,
         STATE_3,
         STATE_4,
-        STATE_5
+        STATE_5,
+        STATE_6
     }
 
     enum Action {
         MOVE_TO_2,
         MOVE_TO_3,
-        CONDITIONAL_MOVE
+        CONDITIONAL_MOVE,
+        ACTION_THAT_CAN_OCCUR_AT_ANY_STATE
     }
 
     private final Condition<Boolean> testCondition =
@@ -54,7 +50,8 @@ public class StateMachineTest {
                                             new Transition<>(
                                                     CONDITIONAL_MOVE, STATE_4, testCondition),
                                             new Transition<>(
-                                                    CONDITIONAL_MOVE, STATE_5, new Default<>())))));
+                                                    CONDITIONAL_MOVE, STATE_5, new Default<>())))),
+                    List.of(new Transition<>(Action.ACTION_THAT_CAN_OCCUR_AT_ANY_STATE, STATE_6)));
 
     @Test
     public void returnsCorrectNextStateForSimpleTransition() {
@@ -80,5 +77,27 @@ public class StateMachineTest {
         assertThrows(
                 StateMachine.InvalidStateTransitionException.class,
                 () -> stateMachine.transition(STATE_1, MOVE_TO_3));
+    }
+
+    @Test
+    void returnsCorrectNextStateWhenUsingAnAnyStateTransition() {
+        assertThat(
+                stateMachine.transition(STATE_1, ACTION_THAT_CAN_OCCUR_AT_ANY_STATE),
+                equalTo(STATE_6));
+        assertThat(
+                stateMachine.transition(STATE_2, ACTION_THAT_CAN_OCCUR_AT_ANY_STATE),
+                equalTo(STATE_6));
+        assertThat(
+                stateMachine.transition(STATE_3, ACTION_THAT_CAN_OCCUR_AT_ANY_STATE),
+                equalTo(STATE_6));
+        assertThat(
+                stateMachine.transition(STATE_4, ACTION_THAT_CAN_OCCUR_AT_ANY_STATE),
+                equalTo(STATE_6));
+        assertThat(
+                stateMachine.transition(STATE_5, ACTION_THAT_CAN_OCCUR_AT_ANY_STATE),
+                equalTo(STATE_6));
+        assertThat(
+                stateMachine.transition(STATE_6, ACTION_THAT_CAN_OCCUR_AT_ANY_STATE),
+                equalTo(STATE_6));
     }
 }


### PR DESCRIPTION
## What?

- Store a list of transitions that can occur at any state (normally backward steps), not yet populated
- Add builder for default transitions
- Alter the `transition()` method to look at the the `anyStateTransition` list for a matching action/condition before throwing the normal exception.

## Why?

We have a number of transitions in the state machine that can occur at any state, by allowing a default transition we can keep the code more succinct!
