### PR TITLE
BAU: Increase DLQ retention time for messages

### DIFF
--- a/ci/terraform/account-management/sqs.tf
+++ b/ci/terraform/account-management/sqs.tf
@@ -51,7 +51,7 @@ resource "aws_sqs_queue" "email_dead_letter_queue" {
   kms_master_key_id                 = var.use_localstack ? null : "alias/aws/sqs"
   kms_data_key_reuse_period_seconds = var.use_localstack ? null : 300
 
-  message_retention_seconds = 3600
+  message_retention_seconds = 3600 * 6
 
   tags = local.default_tags
 }

--- a/ci/terraform/oidc/sqs.tf
+++ b/ci/terraform/oidc/sqs.tf
@@ -21,7 +21,7 @@ resource "aws_sqs_queue" "email_dead_letter_queue" {
   kms_master_key_id                 = var.use_localstack ? null : "alias/aws/sqs"
   kms_data_key_reuse_period_seconds = var.use_localstack ? null : 300
 
-  message_retention_seconds = 3600
+  message_retention_seconds = 3600 * 6
 
   tags = local.default_tags
 }


### PR DESCRIPTION
## What?

- Increase the DLQ retention time to 6 hours

## Why?

We are getting e-mail address validation failures from Notify, we need to collect samples of the failing addresses, we can do this by looking at the DLQ, but 1 hour is not always enough time for us to respond to the alerts.

