### PR TITLE
GOVSI-1107: Exclude transition errors from alerting

### DIFF
--- a/ci/terraform/modules/endpoint-module/alerts.tf
+++ b/ci/terraform/modules/endpoint-module/alerts.tf
@@ -1,7 +1,7 @@
 resource "aws_cloudwatch_log_metric_filter" "lambda_error_metric_filter" {
   count          = var.use_localstack ? 0 : 1
   name           = replace("${var.environment}-${var.endpoint_name}-errors", ".", "")
-  pattern        = "ERROR"
+  pattern        = "{($.level = \"ERROR\") && ($.message != \"Session attempted invalid transition from*\")}"
   log_group_name = aws_cloudwatch_log_group.lambda_log_group[0].name
 
   metric_transformation {


### PR DESCRIPTION
## What?

- Exclude error that start with the phrase `Session attempted invalid transition from` from triggering alerts in the 2nd line channel.

## Why?

These errors are tied with a known, non-critical, issue and causing a lot of noise, when we have addresses the core problems then we will remove the exclusion.
