### PR TITLE
GOVSI-1065: Transition includes

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/state/StateMachine.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/state/StateMachine.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static java.util.Collections.emptyList;
 import static uk.gov.di.authentication.shared.entity.SessionAction.ACCOUNT_LOCK_EXPIRED;
@@ -563,15 +564,21 @@ public class StateMachine<T, A, C> {
     public static class StateRuleBuilder<T, A, C> {
         private final Builder<T, A, C> stateMachineBuilder;
         private final T state;
+        private final List<Transition<T, A, C>> includes = new ArrayList<>();
 
         @SafeVarargs
         public final Builder<T, A, C> allow(final Transition.Builder<T, A, C>... transitions) {
             stateMachineBuilder.addStateRule(
                     state,
-                    Arrays.asList(transitions).stream()
-                            .map(b -> b.build())
+                    Stream.concat(Arrays.stream(transitions)
+                            .map(Transition.Builder::build), includes.stream())
                             .collect(Collectors.toList()));
             return stateMachineBuilder;
+        }
+
+        public final StateRuleBuilder<T, A, C> include(final List<Transition<T, A, C>>... includes) {
+            Arrays.stream(includes).forEach(this.includes::addAll);
+            return this;
         }
 
         protected StateRuleBuilder(Builder<T, A, C> stateMachineBuilder, T state) {

--- a/shared/src/test/java/uk/gov/di/authentication/shared/state/StateMachineTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/state/StateMachineTest.java
@@ -115,52 +115,51 @@ public class StateMachineTest {
 
     @Test
     void builderReturnsCorrectlyConfiguredMachine() {
-        final List<Transition<State, Action, Boolean>> A_TRANSITION_INCLUDE = List.of(
-                on(ACTION_COMMON_TO_SOME_STATES)
-                        .then(STATE_7)
-                        .build()
-        );
+        final List<Transition<State, Action, Boolean>> A_TRANSITION_INCLUDE =
+                List.of(on(ACTION_COMMON_TO_SOME_STATES).then(STATE_7).build());
 
-        var builtMachine = StateMachine.<State, Action, Boolean>builder()
-                .when(STATE_1)
-                .include(A_TRANSITION_INCLUDE)
-                .allow(
-                        on(MOVE_TO_2)
-                               .then(STATE_2)
-                )
-                .when(STATE_2)
-                .include(A_TRANSITION_INCLUDE)
-                .allow(
-                        on(CONDITIONAL_MOVE)
-                                .ifCondition(testCondition)
-                                .then(STATE_4),
-                        on(CONDITIONAL_MOVE)
-                                .ifCondition(testCondition)
-                                .then(STATE_5).byDefault(),
-                        on(MOVE_TO_3)
-                                .then(STATE_3)
-                )
-                .atAnyState()
-                .allow(
-                        on(ACTION_THAT_CAN_OCCUR_AT_ANY_STATE)
-                                .then(STATE_6)
-                )
-                .build();
-
+        var builtMachine =
+                StateMachine.<State, Action, Boolean>builder()
+                        .when(STATE_1)
+                        .include(A_TRANSITION_INCLUDE)
+                        .allow(on(MOVE_TO_2).then(STATE_2))
+                        .when(STATE_2)
+                        .include(A_TRANSITION_INCLUDE)
+                        .allow(
+                                on(CONDITIONAL_MOVE).ifCondition(testCondition).then(STATE_4),
+                                on(CONDITIONAL_MOVE)
+                                        .ifCondition(testCondition)
+                                        .then(STATE_5)
+                                        .byDefault(),
+                                on(MOVE_TO_3).then(STATE_3))
+                        .atAnyState()
+                        .allow(on(ACTION_THAT_CAN_OCCUR_AT_ANY_STATE).then(STATE_6))
+                        .build();
 
         assertThat(builtMachine.transition(STATE_1, MOVE_TO_2, true), equalTo(STATE_2));
-        assertThat(builtMachine.transition(STATE_1, ACTION_COMMON_TO_SOME_STATES, true), equalTo(STATE_7));
-        assertThat(builtMachine.transition(STATE_2, ACTION_COMMON_TO_SOME_STATES, true), equalTo(STATE_7));
+        assertThat(
+                builtMachine.transition(STATE_1, ACTION_COMMON_TO_SOME_STATES, true),
+                equalTo(STATE_7));
+        assertThat(
+                builtMachine.transition(STATE_2, ACTION_COMMON_TO_SOME_STATES, true),
+                equalTo(STATE_7));
         assertThat(builtMachine.transition(STATE_2, CONDITIONAL_MOVE, false), equalTo(STATE_5));
         assertThat(builtMachine.transition(STATE_2, MOVE_TO_3, false), equalTo(STATE_3));
-        assertThat(builtMachine.transition(STATE_1, ACTION_THAT_CAN_OCCUR_AT_ANY_STATE, true), equalTo(STATE_6));
-        assertThat(builtMachine.transition(STATE_2, ACTION_THAT_CAN_OCCUR_AT_ANY_STATE, true), equalTo(STATE_6));
-        assertThat(builtMachine.transition(STATE_3, ACTION_THAT_CAN_OCCUR_AT_ANY_STATE, true), equalTo(STATE_6));
-        assertThrows(StateMachine.InvalidStateTransitionException.class, () -> builtMachine.transition(STATE_3, ACTION_COMMON_TO_SOME_STATES, true));
+        assertThat(
+                builtMachine.transition(STATE_1, ACTION_THAT_CAN_OCCUR_AT_ANY_STATE, true),
+                equalTo(STATE_6));
+        assertThat(
+                builtMachine.transition(STATE_2, ACTION_THAT_CAN_OCCUR_AT_ANY_STATE, true),
+                equalTo(STATE_6));
+        assertThat(
+                builtMachine.transition(STATE_3, ACTION_THAT_CAN_OCCUR_AT_ANY_STATE, true),
+                equalTo(STATE_6));
+        assertThrows(
+                StateMachine.InvalidStateTransitionException.class,
+                () -> builtMachine.transition(STATE_3, ACTION_COMMON_TO_SOME_STATES, true));
     }
 
-    private static Transition.Builder<State, Action, Boolean> on(
-            Action action) {
+    private static Transition.Builder<State, Action, Boolean> on(Action action) {
         return Transition.<State, Action, Boolean>builder().on(action);
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/state/StateMachineTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/state/StateMachineTest.java
@@ -10,8 +10,18 @@ import static java.util.Map.ofEntries;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static uk.gov.di.authentication.shared.state.StateMachineTest.Action.*;
-import static uk.gov.di.authentication.shared.state.StateMachineTest.State.*;
+import static uk.gov.di.authentication.shared.state.StateMachineTest.Action.ACTION_COMMON_TO_SOME_STATES;
+import static uk.gov.di.authentication.shared.state.StateMachineTest.Action.ACTION_THAT_CAN_OCCUR_AT_ANY_STATE;
+import static uk.gov.di.authentication.shared.state.StateMachineTest.Action.CONDITIONAL_MOVE;
+import static uk.gov.di.authentication.shared.state.StateMachineTest.Action.MOVE_TO_2;
+import static uk.gov.di.authentication.shared.state.StateMachineTest.Action.MOVE_TO_3;
+import static uk.gov.di.authentication.shared.state.StateMachineTest.State.STATE_1;
+import static uk.gov.di.authentication.shared.state.StateMachineTest.State.STATE_2;
+import static uk.gov.di.authentication.shared.state.StateMachineTest.State.STATE_3;
+import static uk.gov.di.authentication.shared.state.StateMachineTest.State.STATE_4;
+import static uk.gov.di.authentication.shared.state.StateMachineTest.State.STATE_5;
+import static uk.gov.di.authentication.shared.state.StateMachineTest.State.STATE_6;
+import static uk.gov.di.authentication.shared.state.StateMachineTest.State.STATE_7;
 
 public class StateMachineTest {
 
@@ -21,14 +31,16 @@ public class StateMachineTest {
         STATE_3,
         STATE_4,
         STATE_5,
-        STATE_6
+        STATE_6,
+        STATE_7
     }
 
     enum Action {
         MOVE_TO_2,
         MOVE_TO_3,
         CONDITIONAL_MOVE,
-        ACTION_THAT_CAN_OCCUR_AT_ANY_STATE
+        ACTION_THAT_CAN_OCCUR_AT_ANY_STATE,
+        ACTION_COMMON_TO_SOME_STATES
     }
 
     private final Condition<Boolean> testCondition =
@@ -99,5 +111,56 @@ public class StateMachineTest {
         assertThat(
                 stateMachine.transition(STATE_6, ACTION_THAT_CAN_OCCUR_AT_ANY_STATE),
                 equalTo(STATE_6));
+    }
+
+    @Test
+    void builderReturnsCorrectlyConfiguredMachine() {
+        final List<Transition<State, Action, Boolean>> A_TRANSITION_INCLUDE = List.of(
+                on(ACTION_COMMON_TO_SOME_STATES)
+                        .then(STATE_7)
+                        .build()
+        );
+
+        var builtMachine = StateMachine.<State, Action, Boolean>builder()
+                .when(STATE_1)
+                .include(A_TRANSITION_INCLUDE)
+                .allow(
+                        on(MOVE_TO_2)
+                               .then(STATE_2)
+                )
+                .when(STATE_2)
+                .include(A_TRANSITION_INCLUDE)
+                .allow(
+                        on(CONDITIONAL_MOVE)
+                                .ifCondition(testCondition)
+                                .then(STATE_4),
+                        on(CONDITIONAL_MOVE)
+                                .ifCondition(testCondition)
+                                .then(STATE_5).byDefault(),
+                        on(MOVE_TO_3)
+                                .then(STATE_3)
+                )
+                .atAnyState()
+                .allow(
+                        on(ACTION_THAT_CAN_OCCUR_AT_ANY_STATE)
+                                .then(STATE_6)
+                )
+                .build();
+
+
+        assertThat(builtMachine.transition(STATE_1, MOVE_TO_2, true), equalTo(STATE_2));
+        assertThat(builtMachine.transition(STATE_1, ACTION_COMMON_TO_SOME_STATES, true), equalTo(STATE_7));
+        assertThat(builtMachine.transition(STATE_2, ACTION_COMMON_TO_SOME_STATES, true), equalTo(STATE_7));
+        assertThat(builtMachine.transition(STATE_2, CONDITIONAL_MOVE, false), equalTo(STATE_5));
+        assertThat(builtMachine.transition(STATE_2, MOVE_TO_3, false), equalTo(STATE_3));
+        assertThat(builtMachine.transition(STATE_1, ACTION_THAT_CAN_OCCUR_AT_ANY_STATE, true), equalTo(STATE_6));
+        assertThat(builtMachine.transition(STATE_2, ACTION_THAT_CAN_OCCUR_AT_ANY_STATE, true), equalTo(STATE_6));
+        assertThat(builtMachine.transition(STATE_3, ACTION_THAT_CAN_OCCUR_AT_ANY_STATE, true), equalTo(STATE_6));
+        assertThrows(StateMachine.InvalidStateTransitionException.class, () -> builtMachine.transition(STATE_3, ACTION_COMMON_TO_SOME_STATES, true));
+    }
+
+    private static Transition.Builder<State, Action, Boolean> on(
+            Action action) {
+        return Transition.<State, Action, Boolean>builder().on(action);
     }
 }


### PR DESCRIPTION
## What?

- Add an `include()` method to the statemachine builder which allows common transitions to be applied to multiple states
- Move the common `USER_ENTERED_VALID_MFA_CODE` transitions to an include

## Why?

We are finding scenarios where the same group of transitions need to exist at different states, this PR lays ground work for being to extract these common transactions into "includes" and use them where required.

## Related PRs

#1007 