### PR TITLE
GOVSI-1052: support lower-casing of headers by api gateway or localstack

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -10,6 +10,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.VerifyCodeRequest;
+import uk.gov.di.authentication.shared.domain.RequestHeaders;
 import uk.gov.di.authentication.shared.entity.BaseAPIResponse;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
@@ -53,6 +54,7 @@ import static uk.gov.di.authentication.shared.entity.SessionState.PHONE_NUMBER_C
 import static uk.gov.di.authentication.shared.entity.SessionState.UPDATED_TERMS_AND_CONDITIONS;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
+import static uk.gov.di.authentication.shared.helpers.RequestHeaderHelper.getHeaderValueFromHeaders;
 import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
 import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_BLOCKED_KEY_PREFIX;
 import static uk.gov.di.authentication.shared.state.StateMachine.userJourneyStateMachine;
@@ -67,7 +69,6 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
     private final ValidationService validationService;
     private final StateMachine<SessionState, SessionAction, UserContext> stateMachine;
     private final AuditService auditService;
-    private static final String CLIENT_SESSION_ID_HEADER = "Client-Session-Id";
 
     protected VerifyCodeHandler(
             ConfigurationService configurationService,
@@ -157,7 +158,10 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                     session,
                     codeRequest.getNotificationType(),
                     userContext.getClientSession(),
-                    input.getHeaders().get(CLIENT_SESSION_ID_HEADER),
+                    getHeaderValueFromHeaders(
+                            input.getHeaders(),
+                            RequestHeaders.CLIENT_SESSION_ID_HEADER,
+                            configurationService.getHeadersCaseInsensitive()),
                     input,
                     context,
                     userContext);

--- a/shared/src/main/java/uk/gov/di/authentication/shared/domain/RequestHeaders.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/domain/RequestHeaders.java
@@ -1,0 +1,10 @@
+package uk.gov.di.authentication.shared.domain;
+
+public final class RequestHeaders {
+
+    public static final String SESSION_ID_HEADER = "Session-Id";
+    public static final String CLIENT_SESSION_ID_HEADER = "Client-Session-Id";
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+
+    private RequestHeaders() {}
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/RequestHeaderHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/RequestHeaderHelper.java
@@ -1,0 +1,56 @@
+package uk.gov.di.authentication.shared.helpers;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Map;
+
+public final class RequestHeaderHelper {
+
+    private static final Logger LOGGER = LogManager.getLogger(RequestHeaderHelper.class);
+
+    private RequestHeaderHelper() {}
+
+    public static boolean headersContainValidHeader(
+            Map<String, String> headers, String headerName, boolean matchLowerCase) {
+        if (headers == null || headers.isEmpty()) {
+            LOGGER.error("All headers are missing or empty when looking for header {}", headerName);
+            return false;
+        } else if (!matchLowerCase && headers.containsKey(headerName)) {
+            LOGGER.info("Found header {}, matchLowerCase={}", headerName, matchLowerCase);
+            return true;
+        } else if (matchLowerCase
+                && (headers.containsKey(headerName)
+                        && headers.containsKey(headerName.toLowerCase()))) {
+            LOGGER.error(
+                    "Found both headers {} and lowercase version, matchLowerCase={}",
+                    headerName,
+                    matchLowerCase);
+            return false;
+        } else if (matchLowerCase
+                && (headers.containsKey(headerName)
+                        || headers.containsKey(headerName.toLowerCase()))) {
+            LOGGER.info(
+                    "Found header {} lowercase version, matchLowerCase={}",
+                    headerName,
+                    matchLowerCase);
+            return true;
+        } else {
+            LOGGER.error("Header {} is missing, matchLowerCase={}", headerName, matchLowerCase);
+            return false;
+        }
+    }
+
+    public static String getHeaderValueFromHeaders(
+            Map<String, String> headers, String headerName, boolean matchLowerCase) {
+        if (headers == null || headers.isEmpty()) {
+            return null;
+        } else if (headers.containsKey(headerName)) {
+            return headers.get(headerName);
+        } else if (matchLowerCase && headers.containsKey(headerName.toLowerCase())) {
+            return headers.get(headerName.toLowerCase());
+        } else {
+            return null;
+        }
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -88,6 +88,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return System.getenv().getOrDefault("FRONTEND_BASE_URL", "");
     }
 
+    public boolean getHeadersCaseInsensitive() {
+        return System.getenv().getOrDefault("HEADERS_CASE_INSENSITIVE", "false").equals("true");
+    }
+
     public long getIDTokenExpiry() {
         return Long.parseLong(System.getenv().getOrDefault("ID_TOKEN_EXPIRY", "120"));
     }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/RequestHeaderHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/RequestHeaderHelperTest.java
@@ -1,0 +1,89 @@
+package uk.gov.di.authentication.shared.helpers;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static uk.gov.di.authentication.shared.helpers.RequestHeaderHelper.getHeaderValueFromHeaders;
+import static uk.gov.di.authentication.shared.helpers.RequestHeaderHelper.headersContainValidHeader;
+
+class RequestHeaderHelperTest {
+
+    private static final Map<String, String> MAP_ONE_ENTRY_UPPER_CASE =
+            Map.of("Session-Id", "session-id-123");
+    private static final Map<String, String> MAP_TWO_ENTRIES_UPPER_CASE =
+            Map.of("Session-Id", "session-id-123", "Client-Session-Id", "client-session-id-123");
+    private static final Map<String, String> MAP_ONE_ENTRY_LOWER_CASE =
+            Map.of("session-id", "session-id-123");
+    private static final Map<String, String> MAP_TWO_ENTRIES_LOWER_CASE =
+            Map.of("session-id", "session-id-123", "client-session-id", "client-session-id-123");
+
+    private static Stream<Arguments> headersTestParameters() {
+        return Stream.of(
+                arguments(null, null, false, false, null),
+                arguments(null, null, true, false, null),
+                arguments(Collections.emptyMap(), null, false, false, null),
+                arguments(Collections.emptyMap(), null, true, false, null),
+                arguments(Collections.emptyMap(), "", false, false, null),
+                arguments(Collections.emptyMap(), "", true, false, null),
+                arguments(MAP_ONE_ENTRY_UPPER_CASE, "Missing-Header", false, false, null),
+                arguments(MAP_ONE_ENTRY_UPPER_CASE, "Missing-Header", true, false, null),
+                arguments(MAP_TWO_ENTRIES_UPPER_CASE, "Missing-Header", false, false, null),
+                arguments(MAP_TWO_ENTRIES_UPPER_CASE, "Missing-Header", true, false, null),
+                arguments(MAP_ONE_ENTRY_UPPER_CASE, "Session-Id", false, true, "session-id-123"),
+                arguments(MAP_ONE_ENTRY_UPPER_CASE, "Session-Id", true, true, "session-id-123"),
+                arguments(
+                        MAP_TWO_ENTRIES_UPPER_CASE,
+                        "Client-Session-Id",
+                        false,
+                        true,
+                        "client-session-id-123"),
+                arguments(
+                        MAP_TWO_ENTRIES_UPPER_CASE,
+                        "Client-Session-Id",
+                        true,
+                        true,
+                        "client-session-id-123"),
+                arguments(MAP_ONE_ENTRY_UPPER_CASE, "session-id", false, false, null),
+                arguments(MAP_ONE_ENTRY_UPPER_CASE, "session-id", true, false, null),
+                arguments(MAP_TWO_ENTRIES_UPPER_CASE, "client-session-id", false, false, null),
+                arguments(MAP_TWO_ENTRIES_UPPER_CASE, "client-session-id", true, false, null),
+                arguments(MAP_ONE_ENTRY_LOWER_CASE, "Session-Id", false, false, null),
+                arguments(MAP_ONE_ENTRY_LOWER_CASE, "Session-Id", true, true, "session-id-123"),
+                arguments(MAP_TWO_ENTRIES_LOWER_CASE, "Client-Session-Id", false, false, null),
+                arguments(
+                        MAP_TWO_ENTRIES_LOWER_CASE,
+                        "Client-Session-Id",
+                        true,
+                        true,
+                        "client-session-id-123"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("headersTestParameters")
+    void testHeadersContainValidHeader(
+            Map<String, String> headers,
+            String headerName,
+            boolean matchLowerCase,
+            boolean expectedValidity) {
+        assertEquals(
+                expectedValidity, headersContainValidHeader(headers, headerName, matchLowerCase));
+    }
+
+    @ParameterizedTest
+    @MethodSource("headersTestParameters")
+    void doIt(
+            Map<String, String> headers,
+            String headerName,
+            boolean matchLowerCase,
+            boolean expectedValidity,
+            String expectedValue) {
+        assertEquals(expectedValue, getHeaderValueFromHeaders(headers, headerName, matchLowerCase));
+    }
+}

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/ClientSessionServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/ClientSessionServiceTest.java
@@ -1,0 +1,117 @@
+package uk.gov.di.authentication.shared.services;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.entity.ClientSession;
+import uk.gov.di.authentication.shared.entity.VectorOfTrust;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ClientSessionServiceTest {
+
+    private final RedisConnectionService redis = mock(RedisConnectionService.class);
+    private final ConfigurationService configuration = mock(ConfigurationService.class);
+    private final ObjectMapper objectMapper =
+            JsonMapper.builder().addModule(new JavaTimeModule()).build();
+
+    private final ClientSessionService clientSessionService =
+            new ClientSessionService(configuration, redis);
+
+    @Test
+    void shouldRetrieveClientSessionUsingRequestHeaders() throws JsonProcessingException {
+        when(redis.getValue("client-session-cs1")).thenReturn(generateSerialisedClientSession());
+
+        Optional<ClientSession> clientSessionInRedis =
+                clientSessionService.getClientSessionFromRequestHeaders(
+                        Map.of("Session-Id", "session-id", "Client-Session-Id", "cs1"));
+
+        clientSessionInRedis.ifPresentOrElse(
+                clientSession ->
+                        assertThat(
+                                clientSession.getAuthRequestParams().containsKey("authparam"),
+                                is(true)),
+                () -> fail("Could not retrieve client session"));
+    }
+
+    @Test
+    void shouldNotRetrieveClientSessionUsingNullRequestHeaders() throws JsonProcessingException {
+        when(redis.getValue("client-session-cs1")).thenReturn(generateSerialisedClientSession());
+
+        Optional<ClientSession> clientSessionInRedis =
+                clientSessionService.getClientSessionFromRequestHeaders(null);
+
+        assertTrue(clientSessionInRedis.isEmpty());
+    }
+
+    @Test
+    void shouldNotRetrieveClientSessionForLowerCaseHeaderName() throws JsonProcessingException {
+        when(redis.getValue("client-session-cs1")).thenReturn(generateSerialisedClientSession());
+
+        Optional<ClientSession> clientSessionInRedis =
+                clientSessionService.getClientSessionFromRequestHeaders(
+                        Map.of("Session-Id", "session-id", "client-Session-id", "cs1"));
+
+        assertTrue(clientSessionInRedis.isEmpty());
+    }
+
+    @Test
+    void shouldNotRetrieveClientSessionWithNoHeaders() throws JsonProcessingException {
+        when(redis.getValue("client-session-cs1")).thenReturn(generateSerialisedClientSession());
+
+        Optional<ClientSession> clientSessionInRedis =
+                clientSessionService.getClientSessionFromRequestHeaders(Collections.emptyMap());
+
+        assertTrue(clientSessionInRedis.isEmpty());
+    }
+
+    @Test
+    void shouldNotRetrieveClientSessionWithMissingHeader() throws JsonProcessingException {
+        when(redis.getValue("client-session-cs1")).thenReturn(generateSerialisedClientSession());
+
+        Optional<ClientSession> clientSessionInRedis =
+                clientSessionService.getClientSessionFromRequestHeaders(
+                        Map.of("Something", "Else"));
+
+        assertTrue(clientSessionInRedis.isEmpty());
+    }
+
+    @Test
+    void shouldNotRetrieveClientSessionAndThrowExceptionIfNotPresentInRedis() {
+        final Map headers = Map.of("Session-Id", "session-id", "Client-Session-Id", "cs1");
+
+        RuntimeException exception =
+                assertThrows(
+                        RuntimeException.class,
+                        () -> clientSessionService.getClientSessionFromRequestHeaders(headers),
+                        "Expected to throw exception");
+
+        assertTrue(
+                exception
+                        .getMessage()
+                        .contains(
+                                "java.lang.IllegalArgumentException: argument \"content\" is null"));
+    }
+
+    private String generateSerialisedClientSession() throws JsonProcessingException {
+        return objectMapper.writeValueAsString(
+                new ClientSession(
+                        Map.of("authparam", List.of("v1", "v2")),
+                        LocalDateTime.now(),
+                        VectorOfTrust.getDefaults()));
+    }
+}

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/SessionServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/SessionServiceTest.java
@@ -36,7 +36,7 @@ class SessionServiceTest {
     private final SessionService sessionService = new SessionService(configuration, redis);
 
     @Test
-    public void shouldPersistSessionToRedisWithExpiry() throws JsonProcessingException {
+    void shouldPersistSessionToRedisWithExpiry() throws JsonProcessingException {
         when(configuration.getSessionExpiry()).thenReturn(1234L);
 
         var session = new Session("session-id").addClientSession("client-session-id");
@@ -48,7 +48,7 @@ class SessionServiceTest {
     }
 
     @Test
-    public void shouldRetrieveSessionUsingRequestHeaders() throws JsonProcessingException {
+    void shouldRetrieveSessionUsingRequestHeaders() throws JsonProcessingException {
         when(redis.keyExists("session-id")).thenReturn(true);
         when(redis.getValue("session-id")).thenReturn(generateSearlizedSession());
 
@@ -61,25 +61,35 @@ class SessionServiceTest {
     }
 
     @Test
-    public void shouldNotRetrieveSessionWithNoHeaders() {
+    void shouldNotRetrieveSessionForLowerCaseHeaderName() throws JsonProcessingException {
+        when(redis.keyExists("session-id")).thenReturn(true);
+        when(redis.getValue("session-id")).thenReturn(generateSearlizedSession());
+
+        var sessionInRedis =
+                sessionService.getSessionFromRequestHeaders(Map.of("session-id", "session-id"));
+        assertTrue(sessionInRedis.isEmpty());
+    }
+
+    @Test
+    void shouldNotRetrieveSessionWithNoHeaders() {
         var session = sessionService.getSessionFromRequestHeaders(Collections.emptyMap());
         assertTrue(session.isEmpty());
     }
 
     @Test
-    public void shouldNotRetrieveSessionWithNullHeaders() {
+    void shouldNotRetrieveSessionWithNullHeaders() {
         var session = sessionService.getSessionFromRequestHeaders(null);
         assertTrue(session.isEmpty());
     }
 
     @Test
-    public void shouldNotRetrieveSessionWithMissingHeader() {
+    void shouldNotRetrieveSessionWithMissingHeader() {
         var session = sessionService.getSessionFromRequestHeaders(Map.of("Something", "Else"));
         assertTrue(session.isEmpty());
     }
 
     @Test
-    public void shouldNotRetrieveSessionIfNotPresentInRedis() {
+    void shouldNotRetrieveSessionIfNotPresentInRedis() {
         when(redis.keyExists("session-id")).thenReturn(false);
 
         var session =


### PR DESCRIPTION
## What?

Support lower-casing of headers by api gateway or localstack.

Groundwork to support upgrading to the latest localstack version, the upgrade will follow in another PR.

## Why?

We send http headers to API Gateway capitalised and retrieve them capitalised in the lambdas.  In theory http headers are case-insensitive so this capitalisation should not matter, but at the moment we get out what we put in.

Rightly or wrongly localstack has started to lower-case header names in their implementation which has broken our tests.  This is fine in theory if headers are genuinely case insensitive but it does cause an issue.  There is some suggestion that a later version or different flavour of the actual AWS api gateway will behave like this.

This PR provides a way to work around the issue by partially supporting case-insensitive header names if this is required.

This is configurable with a switch, so our current behaviour will stay exactly the same and will only change when testing in localstack.