### PR TITLE
GOVSI-1105: Refactor of AuthorisationIntegrationTests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -226,6 +226,7 @@ task oidcTerraform (type: Terraform) {
             environment "API_KEY", json.frontend_api_key.value
             environment "FRONTEND_API_GATEWAY_ID", json.frontend_api_gateway_root_id.value
             environment "FRONTEND_API_KEY", json.frontend_api_key.value
+            environment "EVENTS_SNS_TOPIC_ARN", json.events_sns_topic_arn.value
         }
     }
     dependsOn ":client-registry-api:buildZip"

--- a/ci/terraform/oidc/api-gateway.tf
+++ b/ci/terraform/oidc/api-gateway.tf
@@ -119,8 +119,8 @@ resource "aws_api_gateway_deployment" "deployment" {
     redeployment = sha1(jsonencode([
       module.auth-code.integration_trigger_value,
       module.auth-code.method_trigger_value,
-      module.authorize.integration_trigger_value,
-      module.authorize.method_trigger_value,
+      var.use_localstack ? null : module.authorize[0].integration_trigger_value,
+      var.use_localstack ? null : module.authorize[0].method_trigger_value,
       module.jwks.integration_trigger_value,
       module.jwks.method_trigger_value,
       module.logout.integration_trigger_value,

--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -1,6 +1,8 @@
 module "authorize" {
   source = "../modules/endpoint-module"
 
+  count = var.use_localstack ? 0 : 1
+
   endpoint_name   = "authorize"
   path_part       = "authorize"
   endpoint_method = "GET"

--- a/ci/terraform/oidc/outputs.tf
+++ b/ci/terraform/oidc/outputs.tf
@@ -35,3 +35,7 @@ output "email_queue" {
 output "analytics_cookie_domain" {
   value = module.dns.service_domain_name
 }
+
+output "events_sns_topic_arn" {
+  value = aws_sns_topic.events.arn
+}

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -17,6 +17,7 @@ dependencies {
             configurations.sqs,
             configurations.dynamodb,
             configurations.lettuce,
+            configurations.lambda,
             "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.0",
             project(":client-registry-api"),
             project(":frontend-api"),
@@ -36,11 +37,20 @@ test {
         showStandardStreams = false
     }
 
+    environment "AUDIT_SIGNING_KEY_ALIAS", "alias/local-audit-payload-signing-key-alias"
     environment "AWS_ACCESS_KEY_ID", "mock-access-key"
+    environment "AWS_REGION", "eu-west-2"
     environment "AWS_SECRET_ACCESS_KEY", "mock-secret-key "
-    environment "STUB_RELYING_PARTY_REDIRECT_URI", "https://di-auth-stub-relying-party-build.london.cloudapps.digital/"
-    environment "LOGIN_URI", "http://localhost:3000/"
+    environment "BASE_URL", "http://localhost"
+    environment "DOMAIN_NAME", "localhost"
+    environment "DYNAMO_ENDPOINT", "http://localhost:8000"
+    environment "ENVIRONMENT", "local"
+    environment "LOCALSTACK_ENDPOINT", "http://localhost:45678"
+    environment "LOGIN_URI", "http://localhost:3000"
+    environment "REDIS_KEY", "session"
     environment "RESET_PASSWORD_URL", "http://localhost:3000/reset-password?code="
+    environment "STUB_RELYING_PARTY_REDIRECT_URI", "https://di-auth-stub-relying-party-build.london.cloudapps.digital/"
+    environment "TERMS_CONDITIONS_VERSION", "1.0"
 
     dependsOn ":auditTerraform"
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ApiGatewayHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ApiGatewayHandlerIntegrationTest.java
@@ -41,7 +41,8 @@ public abstract class ApiGatewayHandlerIntegrationTest {
     protected RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> handler;
     protected final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
     protected final Context context = mock(Context.class);
-    protected final ConfigurationService configurationService = ConfigurationService.getInstance();
+    protected final ConfigurationService configurationService =
+            new IntegrationTestConfigurationService();
 
     @BeforeEach
     void flushData() {
@@ -49,20 +50,26 @@ public abstract class ApiGatewayHandlerIntegrationTest {
         DynamoHelper.flushData();
     }
 
-    protected APIGatewayProxyResponseEvent makeRequest(Optional<Object> body, Map<String, String> headers,  Map<String, String> queryString) {
+    protected APIGatewayProxyResponseEvent makeRequest(
+            Optional<Object> body, Map<String, String> headers, Map<String, String> queryString) {
         APIGatewayProxyRequestEvent request = new APIGatewayProxyRequestEvent();
-        request
-                .withHeaders(headers)
-                .withQueryStringParameters(queryString);
-        body.ifPresent(o -> {
-            try {
-                request
-                        .withBody(objectMapper.writeValueAsString(o));
-            } catch (JsonProcessingException e) {
-                throw new RuntimeException("Could not serialise test body", e);
-            }
-        });
+        request.withHeaders(headers).withQueryStringParameters(queryString);
+        body.ifPresent(
+                o -> {
+                    try {
+                        request.withBody(objectMapper.writeValueAsString(o));
+                    } catch (JsonProcessingException e) {
+                        throw new RuntimeException("Could not serialise test body", e);
+                    }
+                });
 
         return handler.handleRequest(request, context);
+    }
+
+    public static class IntegrationTestConfigurationService extends ConfigurationService {
+        @Override
+        public String getRedisHost() {
+            return "localhost";
+        }
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
@@ -32,7 +32,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class AuthCodeIntegrationTest extends IntegrationTestEndpoints {
+public class AuthCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     private static final String AUTH_CODE_ENDPOINT = "/auth-code";
     private static final String EMAIL = "joe.bloggs@digital.cabinet-office.gov.uk";

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -64,7 +64,7 @@ import static uk.gov.di.authentication.shared.entity.SessionState.UPLIFT_REQUIRE
 import static uk.gov.di.authentication.shared.helpers.CookieHelper.getHttpCookieFromResponseHeaders;
 import static uk.gov.di.authentication.shared.state.StateMachine.userJourneyStateMachine;
 
-public class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
+class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     private static final String AUTHORIZE_ENDPOINT = "/authorize";
 
@@ -76,7 +76,7 @@ public class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTe
     private static final KeyPair KEY_PAIR = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         registerClient(CLIENT_ID, "test-client", singletonList("openid"));
         handler =
                 new AuthorisationHandler(
@@ -95,7 +95,7 @@ public class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTe
     }
 
     @Test
-    public void shouldReturnUnmetAuthenticationRequirementsErrorWhenUsingInvalidClient() {
+    void shouldReturnUnmetAuthenticationRequirementsErrorWhenUsingInvalidClient() {
         var response =
                 makeRequest(
                         Optional.empty(),
@@ -112,7 +112,7 @@ public class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTe
     }
 
     @Test
-    public void shouldRedirectToLoginWhenNoCookie() {
+    void shouldRedirectToLoginWhenNoCookie() {
         var response =
                 makeRequest(
                         Optional.empty(),
@@ -132,7 +132,7 @@ public class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTe
     }
 
     @Test
-    public void shouldRedirectToLoginForAccountManagementClient() {
+    void shouldRedirectToLoginForAccountManagementClient() {
         registerClient(AM_CLIENT_ID, "am-client-name", List.of("openid", "am"));
         var response =
                 makeRequest(
@@ -154,7 +154,7 @@ public class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTe
     }
 
     @Test
-    public void shouldReturnInvalidScopeErrorWhenNotAccountManagementClient() {
+    void shouldReturnInvalidScopeErrorWhenNotAccountManagementClient() {
         var response =
                 makeRequest(
                         Optional.empty(),
@@ -172,7 +172,7 @@ public class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTe
     }
 
     @Test
-    public void shouldRedirectToLoginWhenBadCookie() {
+    void shouldRedirectToLoginWhenBadCookie() {
         var response =
                 makeRequest(
                         Optional.empty(),
@@ -192,7 +192,7 @@ public class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTe
     }
 
     @Test
-    public void shouldRedirectToLoginWhenCookieHasUnknownSessionId() {
+    void shouldRedirectToLoginWhenCookieHasUnknownSessionId() {
         var response =
                 makeRequest(
                         Optional.empty(),
@@ -212,7 +212,7 @@ public class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTe
     }
 
     @Test
-    public void shouldRedirectToLoginWhenSessionFromCookieIsNotAuthenticated() throws Exception {
+    void shouldRedirectToLoginWhenSessionFromCookieIsNotAuthenticated() throws Exception {
         String sessionId = givenAnExistingSession(AUTHENTICATION_REQUIRED);
         RedisHelper.addEmailToSession(sessionId, TEST_EMAIL_ADDRESS);
         registerUserWithConsentedScope(Optional.empty());
@@ -238,8 +238,7 @@ public class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTe
     }
 
     @Test
-    public void shouldIssueAuthorisationCodeWhenSessionFromCookieIsAuthenticated()
-            throws Exception {
+    void shouldIssueAuthorisationCodeWhenSessionFromCookieIsAuthenticated() throws Exception {
         String sessionId = givenAnExistingSession(AUTHENTICATED);
         RedisHelper.addEmailToSession(sessionId, TEST_EMAIL_ADDRESS);
         registerUserWithConsentedScope(Optional.of(new Scope(OPENID)));
@@ -263,7 +262,7 @@ public class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTe
     }
 
     @Test
-    public void shouldReturnLoginRequiredErrorWhenPromptNoneAndUserUnauthenticated() {
+    void shouldReturnLoginRequiredErrorWhenPromptNoneAndUserUnauthenticated() {
         var response =
                 makeRequest(
                         Optional.empty(),
@@ -280,7 +279,7 @@ public class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTe
     }
 
     @Test
-    public void shouldNotPromptForLoginWhenPromptNoneAndUserAuthenticated() throws Exception {
+    void shouldNotPromptForLoginWhenPromptNoneAndUserAuthenticated() throws Exception {
         String sessionId = givenAnExistingSession(AUTHENTICATED);
         RedisHelper.addEmailToSession(sessionId, TEST_EMAIL_ADDRESS);
         registerUserWithConsentedScope(Optional.of(new Scope(OPENID)));
@@ -306,7 +305,7 @@ public class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTe
     }
 
     @Test
-    public void shouldPromptForLoginWhenPromptLoginAndUserAuthenticated() throws Exception {
+    void shouldPromptForLoginWhenPromptLoginAndUserAuthenticated() throws Exception {
         String sessionId = givenAnExistingSession(AUTHENTICATED);
         RedisHelper.addEmailToSession(sessionId, TEST_EMAIL_ADDRESS);
         registerUserWithConsentedScope(Optional.empty());
@@ -335,7 +334,7 @@ public class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTe
     }
 
     @Test
-    public void shouldRequireUpliftWhenHighCredentialLevelOfTrustRequested() throws Exception {
+    void shouldRequireUpliftWhenHighCredentialLevelOfTrustRequested() throws Exception {
         String sessionId = givenAnExistingSession(AUTHENTICATED, LOW_LEVEL);
         RedisHelper.addEmailToSession(sessionId, TEST_EMAIL_ADDRESS);
         registerUserWithConsentedScope(Optional.empty());
@@ -366,7 +365,7 @@ public class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTe
     }
 
     @Test
-    public void shouldRequireConsentWhenUserAuthenticatedAndConsentIsNotGiven() throws Exception {
+    void shouldRequireConsentWhenUserAuthenticatedAndConsentIsNotGiven() throws Exception {
         String sessionId = givenAnExistingSession(AUTHENTICATED);
         RedisHelper.addEmailToSession(sessionId, TEST_EMAIL_ADDRESS);
         registerUserWithConsentedScope(Optional.empty());

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -5,7 +5,6 @@ import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.openid.connect.sdk.Nonce;
 import com.nimbusds.openid.connect.sdk.OIDCError;
-import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.client.Invocation;
@@ -45,6 +44,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import static com.nimbusds.openid.connect.sdk.OIDCScopeValue.OPENID;
 import static com.nimbusds.openid.connect.sdk.Prompt.Type.LOGIN;
 import static com.nimbusds.openid.connect.sdk.Prompt.Type.NONE;
 import static java.lang.String.format;
@@ -55,13 +55,13 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.LOW_LEVEL;
 import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.MEDIUM_LEVEL;
 import static uk.gov.di.authentication.shared.entity.SessionState.AUTHENTICATED;
 import static uk.gov.di.authentication.shared.entity.SessionState.AUTHENTICATION_REQUIRED;
 import static uk.gov.di.authentication.shared.entity.SessionState.CONSENT_REQUIRED;
 import static uk.gov.di.authentication.shared.entity.SessionState.UPLIFT_REQUIRED_CM;
+import static uk.gov.di.authentication.shared.helpers.CookieHelper.getHttpCookieFromResponseHeaders;
 import static uk.gov.di.authentication.shared.state.StateMachine.userJourneyStateMachine;
 
 public class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -78,30 +78,33 @@ public class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTe
     @BeforeEach
     public void setup() {
         registerClient(CLIENT_ID, "test-client", singletonList("openid"));
-        handler = new AuthorisationHandler(
-                configurationService,
-                new SessionService(configurationService),
-                new ClientSessionService(configurationService),
-                new AuthorizationService(configurationService),
-                new AuditService(
-                        Clock.systemUTC(),
-                        new SnsService(configurationService),
-                        new KmsConnectionService(configurationService.getLocalstackEndpointUri(),
-                                configurationService.getAwsRegion(),
-                                configurationService.getAuditSigningKeyAlias())),
-                userJourneyStateMachine());
+        handler =
+                new AuthorisationHandler(
+                        configurationService,
+                        new SessionService(configurationService),
+                        new ClientSessionService(configurationService),
+                        new AuthorizationService(configurationService),
+                        new AuditService(
+                                Clock.systemUTC(),
+                                new SnsService(configurationService),
+                                new KmsConnectionService(
+                                        configurationService.getLocalstackEndpointUri(),
+                                        configurationService.getAwsRegion(),
+                                        configurationService.getAuditSigningKeyAlias())),
+                        userJourneyStateMachine());
     }
 
     @Test
     public void shouldReturnUnmetAuthenticationRequirementsErrorWhenUsingInvalidClient() {
-        var response = makeRequest(
-                Optional.empty(),
-                constructHeaders(Optional.empty()),
-                constructQueryStringParameters(
-                        Optional.of(INVALID_CLIENT_ID),
+        var response =
+                makeRequest(
                         Optional.empty(),
-                        "openid",
-                        Optional.empty()));
+                        constructHeaders(Optional.empty()),
+                        constructQueryStringParameters(
+                                Optional.of(INVALID_CLIENT_ID),
+                                Optional.empty(),
+                                "openid",
+                                Optional.empty()));
         assertEquals(302, response.getStatusCode());
         assertThat(
                 getHeaderValueByParamName(response, ResponseHeaders.LOCATION),
@@ -110,41 +113,58 @@ public class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTe
 
     @Test
     public void shouldRedirectToLoginWhenNoCookie() {
-        Response response =
-                doAuthorisationRequest(
-                        Optional.of(CLIENT_ID),
+        var response =
+                makeRequest(
                         Optional.empty(),
-                        Optional.empty(),
-                        "openid",
-                        Optional.of("Cl.Cm"));
-
-        assertEquals(302, response.getStatus());
+                        constructHeaders(Optional.empty()),
+                        constructQueryStringParameters(
+                                Optional.of(CLIENT_ID),
+                                Optional.empty(),
+                                "openid",
+                                Optional.of("Cl.Cm")));
+        assertEquals(302, response.getStatusCode());
         assertThat(
                 getHeaderValueByParamName(response, ResponseHeaders.LOCATION),
                 startsWith(configurationService.getLoginURI().toString()));
-        assertNotNull(response.getCookies().get("gs"));
+        assertThat(
+                getHttpCookieFromResponseHeaders(response.getHeaders(), "gs").isPresent(),
+                equalTo(true));
     }
 
     @Test
     public void shouldRedirectToLoginForAccountManagementClient() {
         registerClient(AM_CLIENT_ID, "am-client-name", List.of("openid", "am"));
-        Response response =
-                doAuthorisationRequest(
-                        Optional.of(AM_CLIENT_ID), Optional.empty(), Optional.empty(), "openid am");
+        var response =
+                makeRequest(
+                        Optional.empty(),
+                        constructHeaders(Optional.empty()),
+                        constructQueryStringParameters(
+                                Optional.of(AM_CLIENT_ID),
+                                Optional.empty(),
+                                "openid am",
+                                Optional.empty()));
 
-        assertEquals(302, response.getStatus());
+        assertEquals(302, response.getStatusCode());
         assertThat(
                 getHeaderValueByParamName(response, ResponseHeaders.LOCATION),
                 startsWith(configurationService.getLoginURI().toString()));
-        assertNotNull(response.getCookies().get("gs"));
+        assertThat(
+                getHttpCookieFromResponseHeaders(response.getHeaders(), "gs").isPresent(),
+                equalTo(true));
     }
 
     @Test
     public void shouldReturnInvalidScopeErrorWhenNotAccountManagementClient() {
-        Response response =
-                doAuthorisationRequest(
-                        Optional.of(CLIENT_ID), Optional.empty(), Optional.empty(), "openid am");
-        assertEquals(302, response.getStatus());
+        var response =
+                makeRequest(
+                        Optional.empty(),
+                        constructHeaders(Optional.empty()),
+                        constructQueryStringParameters(
+                                Optional.of(CLIENT_ID),
+                                Optional.empty(),
+                                "openid am",
+                                Optional.empty()));
+        assertEquals(302, response.getStatusCode());
         assertThat(
                 getHeaderValueByParamName(response, ResponseHeaders.LOCATION),
                 containsString(
@@ -153,34 +173,42 @@ public class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTe
 
     @Test
     public void shouldRedirectToLoginWhenBadCookie() {
-        Response response =
-                doAuthorisationRequest(
-                        Optional.of(CLIENT_ID),
-                        Optional.of(new Cookie("gs", "this is bad")),
+        var response =
+                makeRequest(
                         Optional.empty(),
-                        "openid");
-
-        assertEquals(302, response.getStatus());
+                        constructHeaders(Optional.of(new Cookie("gs", "this is bad"))),
+                        constructQueryStringParameters(
+                                Optional.of(CLIENT_ID),
+                                Optional.empty(),
+                                "openid",
+                                Optional.empty()));
+        assertEquals(302, response.getStatusCode());
         assertThat(
                 getHeaderValueByParamName(response, ResponseHeaders.LOCATION),
                 startsWith(configurationService.getLoginURI().toString()));
-        assertNotNull(response.getCookies().get("gs"));
+        assertThat(
+                getHttpCookieFromResponseHeaders(response.getHeaders(), "gs").isPresent(),
+                equalTo(true));
     }
 
     @Test
     public void shouldRedirectToLoginWhenCookieHasUnknownSessionId() {
-        Response response =
-                doAuthorisationRequest(
-                        Optional.of(CLIENT_ID),
-                        Optional.of(new Cookie("gs", "123.456")),
+        var response =
+                makeRequest(
                         Optional.empty(),
-                        "openid");
-
-        assertEquals(302, response.getStatus());
+                        constructHeaders(Optional.of(new Cookie("gs", "123.456"))),
+                        constructQueryStringParameters(
+                                Optional.of(CLIENT_ID),
+                                Optional.empty(),
+                                "openid",
+                                Optional.empty()));
+        assertEquals(302, response.getStatusCode());
         assertThat(
                 getHeaderValueByParamName(response, ResponseHeaders.LOCATION),
                 startsWith(configurationService.getLoginURI().toString()));
-        assertNotNull(response.getCookies().get("gs"));
+        assertThat(
+                getHttpCookieFromResponseHeaders(response.getHeaders(), "gs").isPresent(),
+                equalTo(true));
     }
 
     @Test
@@ -189,19 +217,24 @@ public class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTe
         RedisHelper.addEmailToSession(sessionId, TEST_EMAIL_ADDRESS);
         registerUserWithConsentedScope(Optional.empty());
 
-        Response response =
-                doAuthorisationRequest(
-                        Optional.of(CLIENT_ID),
-                        Optional.of(new Cookie("gs", format("%s.456", sessionId))),
+        var response =
+                makeRequest(
                         Optional.empty(),
-                        "openid");
-
-        assertEquals(302, response.getStatus());
+                        constructHeaders(
+                                Optional.of(new Cookie("gs", format("%s.456", sessionId)))),
+                        constructQueryStringParameters(
+                                Optional.of(CLIENT_ID),
+                                Optional.empty(),
+                                "openid",
+                                Optional.empty()));
+        assertEquals(302, response.getStatusCode());
         assertThat(
                 getHeaderValueByParamName(response, ResponseHeaders.LOCATION),
                 startsWith(configurationService.getLoginURI().toString()));
-        assertNotNull(response.getCookies().get("gs"));
-        assertThat(response.getCookies().get("gs").getValue(), not(startsWith(sessionId)));
+
+        var cookie = getHttpCookieFromResponseHeaders(response.getHeaders(), "gs");
+        assertThat(cookie.isPresent(), equalTo(true));
+        assertThat(cookie.get().getValue(), not(startsWith(sessionId)));
     }
 
     @Test
@@ -209,30 +242,38 @@ public class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTe
             throws Exception {
         String sessionId = givenAnExistingSession(AUTHENTICATED);
         RedisHelper.addEmailToSession(sessionId, TEST_EMAIL_ADDRESS);
-        registerUserWithConsentedScope(Optional.of(new Scope(OIDCScopeValue.OPENID)));
+        registerUserWithConsentedScope(Optional.of(new Scope(OPENID)));
 
-        Response response =
-                doAuthorisationRequest(
-                        Optional.of(CLIENT_ID),
-                        Optional.of(new Cookie("gs", format("%s.456", sessionId))),
+        var response =
+                makeRequest(
                         Optional.empty(),
-                        "openid");
+                        constructHeaders(
+                                Optional.of(new Cookie("gs", format("%s.456", sessionId)))),
+                        constructQueryStringParameters(
+                                Optional.of(CLIENT_ID),
+                                Optional.empty(),
+                                "openid",
+                                Optional.empty()));
+        assertEquals(302, response.getStatusCode());
 
-        assertEquals(302, response.getStatus());
         // TODO: Update assertions to reflect code issuance, once we've written that code
-        assertNotNull(response.getCookies().get("gs"));
-        assertThat(response.getCookies().get("gs").getValue(), not(startsWith(sessionId)));
+        var cookie = getHttpCookieFromResponseHeaders(response.getHeaders(), "gs");
+        assertThat(cookie.isPresent(), equalTo(true));
+        assertThat(cookie.get().getValue(), not(startsWith(sessionId)));
     }
 
     @Test
     public void shouldReturnLoginRequiredErrorWhenPromptNoneAndUserUnauthenticated() {
-        Response response =
-                doAuthorisationRequest(
-                        Optional.of(CLIENT_ID),
+        var response =
+                makeRequest(
                         Optional.empty(),
-                        Optional.of(NONE.toString()),
-                        "openid");
-        assertEquals(302, response.getStatus());
+                        constructHeaders(Optional.empty()),
+                        constructQueryStringParameters(
+                                Optional.of(CLIENT_ID),
+                                Optional.of(NONE.toString()),
+                                "openid",
+                                Optional.empty()));
+        assertEquals(302, response.getStatusCode());
         assertThat(
                 getHeaderValueByParamName(response, ResponseHeaders.LOCATION),
                 containsString(OIDCError.LOGIN_REQUIRED_CODE));
@@ -242,18 +283,23 @@ public class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTe
     public void shouldNotPromptForLoginWhenPromptNoneAndUserAuthenticated() throws Exception {
         String sessionId = givenAnExistingSession(AUTHENTICATED);
         RedisHelper.addEmailToSession(sessionId, TEST_EMAIL_ADDRESS);
-        registerUserWithConsentedScope(Optional.of(new Scope(OIDCScopeValue.OPENID)));
+        registerUserWithConsentedScope(Optional.of(new Scope(OPENID)));
 
-        Response response =
-                doAuthorisationRequest(
-                        Optional.of(CLIENT_ID),
-                        Optional.of(new Cookie("gs", format("%s.456", sessionId))),
-                        Optional.of(NONE.toString()),
-                        OIDCScopeValue.OPENID.getValue());
+        var response =
+                makeRequest(
+                        Optional.empty(),
+                        constructHeaders(
+                                Optional.of(new Cookie("gs", format("%s.456", sessionId)))),
+                        constructQueryStringParameters(
+                                Optional.of(CLIENT_ID),
+                                Optional.of(NONE.toString()),
+                                OPENID.getValue(),
+                                Optional.empty()));
 
-        assertEquals(302, response.getStatus());
-        assertNotNull(response.getCookies().get("gs"));
-        assertThat(response.getCookies().get("gs").getValue(), not(startsWith(sessionId)));
+        assertEquals(302, response.getStatusCode());
+        var cookie = getHttpCookieFromResponseHeaders(response.getHeaders(), "gs");
+        assertThat(cookie.isPresent(), equalTo(true));
+        assertThat(cookie.get().getValue(), not(startsWith(sessionId)));
         assertThat(
                 getHeaderValueByParamName(response, ResponseHeaders.LOCATION),
                 startsWith(configurationService.getLoginURI().toString()));
@@ -265,20 +311,25 @@ public class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTe
         RedisHelper.addEmailToSession(sessionId, TEST_EMAIL_ADDRESS);
         registerUserWithConsentedScope(Optional.empty());
 
-        Response response =
-                doAuthorisationRequest(
-                        Optional.of(CLIENT_ID),
-                        Optional.of(new Cookie("gs", format("%s.456", sessionId))),
-                        Optional.of(LOGIN.toString()),
-                        "openid");
+        var response =
+                makeRequest(
+                        Optional.empty(),
+                        constructHeaders(
+                                Optional.of(new Cookie("gs", format("%s.456", sessionId)))),
+                        constructQueryStringParameters(
+                                Optional.of(CLIENT_ID),
+                                Optional.of(LOGIN.toString()),
+                                OPENID.getValue(),
+                                Optional.empty()));
 
-        assertEquals(302, response.getStatus());
-        assertNotNull(response.getCookies().get("gs"));
-        assertThat(response.getCookies().get("gs").getValue(), not(startsWith(sessionId)));
+        assertEquals(302, response.getStatusCode());
+        var cookie = getHttpCookieFromResponseHeaders(response.getHeaders(), "gs");
+        assertThat(cookie.isPresent(), equalTo(true));
+        assertThat(cookie.get().getValue(), not(startsWith(sessionId)));
         assertThat(
                 getHeaderValueByParamName(response, ResponseHeaders.LOCATION),
                 startsWith(configurationService.getLoginURI().toString()));
-        String newSessionId = response.getCookies().get("gs").getValue().split("\\.")[0];
+        String newSessionId = cookie.get().getValue().split("\\.")[0];
         assertThat(
                 RedisHelper.getSession(newSessionId).getState(), equalTo(AUTHENTICATION_REQUIRED));
     }
@@ -289,20 +340,28 @@ public class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTe
         RedisHelper.addEmailToSession(sessionId, TEST_EMAIL_ADDRESS);
         registerUserWithConsentedScope(Optional.empty());
 
-        Response response =
-                doAuthorisationRequest(
-                        Optional.of(CLIENT_ID),
-                        Optional.of(new Cookie("gs", format("%s.456", sessionId))),
+        var response =
+                makeRequest(
                         Optional.empty(),
-                        "openid");
+                        constructHeaders(
+                                Optional.of(new Cookie("gs", format("%s.456", sessionId)))),
+                        constructQueryStringParameters(
+                                Optional.of(CLIENT_ID),
+                                Optional.empty(),
+                                OPENID.getValue(),
+                                Optional.of(MEDIUM_LEVEL.getValue())));
 
-        assertEquals(302, response.getStatus());
-        assertNotNull(response.getCookies().get("gs"));
-        assertThat(response.getCookies().get("gs").getValue(), not(startsWith(sessionId)));
+        assertEquals(302, response.getStatusCode());
+
+        var cookie = getHttpCookieFromResponseHeaders(response.getHeaders(), "gs");
+        assertThat(cookie.isPresent(), equalTo(true));
+        assertThat(cookie.get().getValue(), not(startsWith(sessionId)));
+
         String redirectUri = getHeaderValueByParamName(response, ResponseHeaders.LOCATION);
         assertThat(redirectUri, startsWith(configurationService.getLoginURI().toString()));
         assertThat(URI.create(redirectUri).getQuery(), equalTo("interrupt=UPLIFT_REQUIRED_CM"));
-        String newSessionId = response.getCookies().get("gs").getValue().split("\\.")[0];
+
+        String newSessionId = cookie.get().getValue().split("\\.")[0];
         assertThat(RedisHelper.getSession(newSessionId).getState(), equalTo(UPLIFT_REQUIRED_CM));
     }
 
@@ -312,20 +371,26 @@ public class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTe
         RedisHelper.addEmailToSession(sessionId, TEST_EMAIL_ADDRESS);
         registerUserWithConsentedScope(Optional.empty());
 
-        Response response =
-                doAuthorisationRequest(
-                        Optional.of(CLIENT_ID),
-                        Optional.of(new Cookie("gs", format("%s.456", sessionId))),
-                        Optional.of(NONE.toString()),
-                        OIDCScopeValue.OPENID.getValue());
+        var response =
+                makeRequest(
+                        Optional.empty(),
+                        constructHeaders(
+                                Optional.of(new Cookie("gs", format("%s.456", sessionId)))),
+                        constructQueryStringParameters(
+                                Optional.of(CLIENT_ID),
+                                Optional.of(NONE.toString()),
+                                OPENID.getValue(),
+                                Optional.empty()));
 
-        assertEquals(302, response.getStatus());
-        assertNotNull(response.getCookies().get("gs"));
-        assertThat(response.getCookies().get("gs").getValue(), not(startsWith(sessionId)));
+        var cookie = getHttpCookieFromResponseHeaders(response.getHeaders(), "gs");
+        assertThat(cookie.isPresent(), equalTo(true));
+        assertThat(cookie.get().getValue(), not(startsWith(sessionId)));
+
         String redirectUri = getHeaderValueByParamName(response, ResponseHeaders.LOCATION);
         assertThat(redirectUri, startsWith(configurationService.getLoginURI().toString()));
         assertThat(URI.create(redirectUri).getQuery(), equalTo("interrupt=CONSENT_REQUIRED"));
-        String newSessionId = response.getCookies().get("gs").getValue().split("\\.")[0];
+
+        String newSessionId = cookie.get().getValue().split("\\.")[0];
         assertThat(RedisHelper.getSession(newSessionId).getState(), equalTo(CONSENT_REQUIRED));
     }
 
@@ -387,26 +452,33 @@ public class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTe
         Nonce nonce = new Nonce();
         queryStringParameters.putAll(
                 Map.of(
-                        "response_type", "code",
-                        "redirect_uri", "localhost",
-                        "state", "8VAVNSxHO1HwiNDhwchQKdd7eOUK3ltKfQzwPDxu9LU",
-                        "nonce", nonce.getValue(),
-                        "client_id", clientId.orElse("test-client"),
-                        "scope", scopes));
+                        "response_type",
+                        "code",
+                        "redirect_uri",
+                        "localhost",
+                        "state",
+                        "8VAVNSxHO1HwiNDhwchQKdd7eOUK3ltKfQzwPDxu9LU",
+                        "nonce",
+                        nonce.getValue(),
+                        "client_id",
+                        clientId.orElse("test-client"),
+                        "scope",
+                        scopes));
 
         prompt.ifPresent(s -> queryStringParameters.put("prompt", s));
 
-        vtr.ifPresent(s -> {
-            JSONArray jsonArray = new JSONArray();
-            jsonArray.add(vtr.get());
-            queryStringParameters.put("vtr", jsonArray.toJSONString());
-        });
+        vtr.ifPresent(
+                s -> {
+                    JSONArray jsonArray = new JSONArray();
+                    jsonArray.add(vtr.get());
+                    queryStringParameters.put("vtr", jsonArray.toJSONString());
+                });
         return queryStringParameters;
     }
 
     private Map<String, String> constructHeaders(Optional<Cookie> cookie) {
         final Map<String, String> headers = new HashMap<>();
-        cookie.ifPresent(c  -> headers.put("Cookie", format("{0}={1}", c.getName(), c.getValue())));
+        cookie.ifPresent(c -> headers.put("Cookie", format("%s=%s", c.getName(), c.getValue())));
         return headers;
     }
 
@@ -414,10 +486,10 @@ public class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTe
         return response.getHeaders().get(paramName).get(0).toString();
     }
 
-    private String getHeaderValueByParamName(APIGatewayProxyResponseEvent response, String paramName) {
+    private String getHeaderValueByParamName(
+            APIGatewayProxyResponseEvent response, String paramName) {
         return response.getHeaders().get(paramName);
     }
-
 
     private void registerUserWithConsentedScope(Optional<Scope> consentedScope) {
         DynamoHelper.signUp(TEST_EMAIL_ADDRESS, TEST_PASSWORD);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -53,7 +53,7 @@ import static uk.gov.di.authentication.shared.entity.SessionState.AUTHENTICATION
 import static uk.gov.di.authentication.shared.entity.SessionState.CONSENT_REQUIRED;
 import static uk.gov.di.authentication.shared.entity.SessionState.UPLIFT_REQUIRED_CM;
 
-public class AuthorisationIntegrationTest extends IntegrationTestEndpoints {
+public class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     private static final String AUTHORIZE_ENDPOINT = "/authorize";
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientInfoIntegrationTest.java
@@ -32,7 +32,7 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class ClientInfoIntegrationTest extends IntegrationTestEndpoints {
+public class ClientInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     private static final String CLIENTINFO_ENDPOINT = "/client-info";
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientRegistrationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientRegistrationIntegrationTest.java
@@ -17,7 +17,7 @@ import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class ClientRegistrationIntegrationTest extends IntegrationTestEndpoints {
+public class ClientRegistrationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     private static final String REGISTER_ENDPOINT = "/connect/register";
     private final ObjectMapper objectMapper = new ObjectMapper();

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/JwksIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/JwksIntegrationTest.java
@@ -11,7 +11,7 @@ import java.text.ParseException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class JwksIntegrationTest extends IntegrationTestEndpoints {
+public class JwksIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     private static final String JWKS_ENDPOINT = "/.well-known/jwks.json";
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
@@ -39,7 +39,7 @@ import static uk.gov.di.authentication.shared.entity.SessionState.CONSENT_REQUIR
 import static uk.gov.di.authentication.shared.entity.SessionState.LOGGED_IN;
 import static uk.gov.di.authentication.shared.entity.SessionState.UPDATED_TERMS_AND_CONDITIONS;
 
-public class LoginIntegrationTest extends IntegrationTestEndpoints {
+public class LoginIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     private static final String LOGIN_ENDPOINT = "/login";
     private static final String CLIENT_ID = "test-client-id";

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
@@ -35,7 +35,7 @@ import java.util.List;
 
 import static java.util.Collections.singletonList;
 
-public class LogoutIntegrationTest extends IntegrationTestEndpoints {
+public class LogoutIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     private static final String LOGOUT_ENDPOINT = "/logout";
     private static final String COOKIE = "Cookie";

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordIntegrationTest.java
@@ -19,8 +19,8 @@ import uk.gov.di.authentication.helpers.RedisHelper;
 import uk.gov.di.authentication.sharedtest.extensions.NotifyStubExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static uk.gov.di.authentication.api.IntegrationTestEndpoints.API_KEY;
-import static uk.gov.di.authentication.api.IntegrationTestEndpoints.FRONTEND_ROOT_RESOURCE_URL;
+import static uk.gov.di.authentication.api.ApiGatewayHandlerIntegrationTest.API_KEY;
+import static uk.gov.di.authentication.api.ApiGatewayHandlerIntegrationTest.FRONTEND_ROOT_RESOURCE_URL;
 
 public class ResetPasswordIntegrationTest {
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordRequestIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordRequestIntegrationTest.java
@@ -22,7 +22,7 @@ import static uk.gov.di.authentication.shared.entity.SessionState.AUTHENTICATION
 import static uk.gov.di.authentication.shared.entity.SessionState.NEW;
 import static uk.gov.di.authentication.shared.entity.SessionState.RESET_PASSWORD_LINK_SENT;
 
-public class ResetPasswordRequestIntegrationTest extends IntegrationTestEndpoints {
+public class ResetPasswordRequestIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     private static final String RESET_PASSWORD_ENDPOINT = "/reset-password-request";
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/SignupIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/SignupIntegrationTest.java
@@ -18,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.authentication.shared.entity.SessionState.EMAIL_CODE_VERIFIED;
 import static uk.gov.di.authentication.shared.entity.SessionState.TWO_FACTOR_REQUIRED;
 
-public class SignupIntegrationTest extends IntegrationTestEndpoints {
+public class SignupIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     private static final String SIGNUP_ENDPOINT = "/signup";
     private final ObjectMapper objectMapper = new ObjectMapper();

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
@@ -62,7 +62,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-public class TokenIntegrationTest extends IntegrationTestEndpoints {
+public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     private static final String TOKEN_ENDPOINT = "/token";
     private static final String TEST_EMAIL = "joe.bloggs@digital.cabinet-office.gov.uk";

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateClientConfigIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateClientConfigIntegrationTest.java
@@ -17,7 +17,7 @@ import uk.gov.di.authentication.shared.entity.UpdateClientConfigRequest;
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class UpdateClientConfigIntegrationTest extends IntegrationTestEndpoints {
+public class UpdateClientConfigIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
     private static final String CLIENT_ID = "client-id-1";

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateProfileIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateProfileIntegrationTest.java
@@ -43,7 +43,7 @@ import static uk.gov.di.authentication.shared.entity.SessionState.ADDED_UNVERIFI
 import static uk.gov.di.authentication.shared.entity.SessionState.CONSENT_ADDED;
 import static uk.gov.di.authentication.shared.entity.SessionState.UPDATED_TERMS_AND_CONDITIONS_ACCEPTED;
 
-public class UpdateProfileIntegrationTest extends IntegrationTestEndpoints {
+public class UpdateProfileIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     private static final String UPDATE_PROFILE_ENDPOINT = "/update-profile";
     private static final String EMAIL_ADDRESS = "test@test.com";

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserExistsIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserExistsIntegrationTest.java
@@ -21,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.authentication.shared.entity.SessionState.AUTHENTICATION_REQUIRED;
 import static uk.gov.di.authentication.shared.entity.SessionState.USER_NOT_FOUND;
 
-public class UserExistsIntegrationTest extends IntegrationTestEndpoints {
+public class UserExistsIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     private static final String USEREXISTS_ENDPOINT = "/user-exists";
     private final ObjectMapper objectMapper = new ObjectMapper();

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
@@ -34,7 +34,7 @@ import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class UserInfoIntegrationTest extends IntegrationTestEndpoints {
+public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     private static final String USERINFO_ENDPOINT = "/userinfo";
     private static final String TEST_EMAIL_ADDRESS = "joe.bloggs@digital.cabinet-office.gov.uk";

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
@@ -37,7 +37,7 @@ import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_EMAIL;
 
-public class VerifyCodeIntegrationTest extends IntegrationTestEndpoints {
+public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     private static final String VERIFY_CODE_ENDPOINT = "/verify-code";
     private static final String EMAIL_ADDRESS = "test@test.com";

--- a/integration-tests/src/test/java/uk/gov/di/authentication/helpers/RequestHelper.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/helpers/RequestHelper.java
@@ -6,7 +6,7 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 
-import static uk.gov.di.authentication.api.IntegrationTestEndpoints.ROOT_RESOURCE_URL;
+import static uk.gov.di.authentication.api.ApiGatewayHandlerIntegrationTest.ROOT_RESOURCE_URL;
 
 public class RequestHelper {
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/CookieHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/CookieHelper.java
@@ -16,11 +16,22 @@ public class CookieHelper {
     private static final Logger LOGGER = LoggerFactory.getLogger(CookieHelper.class);
 
     public static final String REQUEST_COOKIE_HEADER = "Cookie";
+    public static final String RESPONSE_COOKIE_HEADER = "Set-Cookie";
     private static final String SESSION_ID = "a-session-id";
 
     public static Optional<HttpCookie> getHttpCookieFromHeaders(
             Map<String, String> headers, String cookieName) {
-        var cookieHeader = cookieHeader(headers);
+        return getHttpCookieFromHeaders(headers, cookieName, REQUEST_COOKIE_HEADER);
+    }
+
+    public static Optional<HttpCookie> getHttpCookieFromResponseHeaders(
+            Map<String, String> headers, String cookieName) {
+        return getHttpCookieFromHeaders(headers, cookieName, RESPONSE_COOKIE_HEADER);
+    }
+
+    public static Optional<HttpCookie> getHttpCookieFromHeaders(
+            Map<String, String> headers, String cookieName, String headerName) {
+        var cookieHeader = cookieHeader(headers, headerName);
 
         if (cookieHeader.isEmpty()) {
             return Optional.empty();
@@ -77,12 +88,12 @@ public class CookieHelper {
                 });
     }
 
-    private static Optional<String> cookieHeader(Map<String, String> headers) {
+    private static Optional<String> cookieHeader(Map<String, String> headers, String headerName) {
         if (headers == null) {
             return Optional.empty();
         }
 
-        return Stream.of(REQUEST_COOKIE_HEADER, REQUEST_COOKIE_HEADER.toLowerCase())
+        return Stream.of(headerName, headerName.toLowerCase())
                 .filter(headers.keySet()::contains)
                 .findFirst();
     }


### PR DESCRIPTION
## What?

- Rename class to better reflect its purpose
- Make base class `abstract`
- Add a RequestHandler variable that will be populated by the sub-classes
- Add a mock `Context` object and an ObjectMapper to serialise requests
- Add a base `makeRequest()` method that will construct a request, from a given body and headers, and send it to the handler
- Change the first integration test in `AuthorisationIntegrationTest` to use the new mechanism
- Add new environment variable to `build.gradle` for the test task
- Add output to Terraform to feed SNS topic ARN into integration tests
- Refactor all, remaining, tests in `AuthorisationIntegrationTest` to call handler directly rather than make HTTP request
- Create a `TestConfigurationService` class to override the value for the Redis host
- Add new method to `CookieHelper` to extract cookies from a response (rather than a request)
- JUnit 5 does need tests to be `public`, remove the modifiers (this was picked up by Sonar static analysis)

## Why?

We are refactoring the Integration test to make them run faster. This PR refactors the AuthorisationHandler integration tests and demonstrates the pattern for the remaining tests. Other PRs to follow to refactor remaining tests, one handler at a time.

Once these are all done, we will review how provision the localstack dependencies.

