### PR TITLE
BAU: Don't make authorise endpoint optional

### DIFF
--- a/ci/terraform/oidc/api-gateway.tf
+++ b/ci/terraform/oidc/api-gateway.tf
@@ -119,8 +119,8 @@ resource "aws_api_gateway_deployment" "deployment" {
     redeployment = sha1(jsonencode([
       module.auth-code.integration_trigger_value,
       module.auth-code.method_trigger_value,
-      var.use_localstack ? null : module.authorize[0].integration_trigger_value,
-      var.use_localstack ? null : module.authorize[0].method_trigger_value,
+      module.authorize.integration_trigger_value,
+      module.authorize.method_trigger_value,
       module.jwks.integration_trigger_value,
       module.jwks.method_trigger_value,
       module.logout.integration_trigger_value,

--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -1,8 +1,6 @@
 module "authorize" {
   source = "../modules/endpoint-module"
 
-  count = var.use_localstack ? 0 : 1
-
   endpoint_name   = "authorize"
   path_part       = "authorize"
   endpoint_method = "GET"


### PR DESCRIPTION
## What?

- Revert making authorise endpoint optional.

## Why?

In previous PR we made the authorise endpoint optional so we didn't need to deploy it localstack for integration tests, revert this as it is causing a destroy cycle in the pipeline.

We need to review how we do this with causing errors.
