### PR TITLE
GOVSI-1052: upgrade localstack to 0.12.20

### DIFF
--- a/ci/terraform/oidc/auth-code.tf
+++ b/ci/terraform/oidc/auth-code.tf
@@ -6,13 +6,14 @@ module "auth-code" {
   endpoint_method = "GET"
 
   handler_environment_variables = {
-    BASE_URL                = local.api_base_url
-    EVENTS_SNS_TOPIC_ARN    = aws_sns_topic.events.arn
-    AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name
-    LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
-    REDIS_KEY               = local.redis_key
-    ENVIRONMENT             = var.environment
-    DYNAMO_ENDPOINT         = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    BASE_URL                 = local.api_base_url
+    EVENTS_SNS_TOPIC_ARN     = aws_sns_topic.events.arn
+    AUDIT_SIGNING_KEY_ALIAS  = local.audit_signing_key_alias_name
+    LOCALSTACK_ENDPOINT      = var.use_localstack ? var.localstack_endpoint : null
+    REDIS_KEY                = local.redis_key
+    ENVIRONMENT              = var.environment
+    DYNAMO_ENDPOINT          = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    HEADERS_CASE_INSENSITIVE = var.use_localstack ? "true" : "false"
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.AuthCodeHandler::handleRequest"
 

--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -19,6 +19,7 @@ module "authorize" {
     ENVIRONMENT              = var.environment
     DYNAMO_ENDPOINT          = var.use_localstack ? var.lambda_dynamo_endpoint : null
     TERMS_CONDITIONS_VERSION = var.terms_and_conditions
+    HEADERS_CASE_INSENSITIVE = var.use_localstack ? "true" : "false"
   }
   handler_function_name                  = "uk.gov.di.authentication.oidc.lambda.AuthorisationHandler::handleRequest"
   rest_api_id                            = aws_api_gateway_rest_api.di_authentication_api.id

--- a/ci/terraform/oidc/client-info.tf
+++ b/ci/terraform/oidc/client-info.tf
@@ -7,13 +7,14 @@ module "client-info" {
   environment     = var.environment
 
   handler_environment_variables = {
-    BASE_URL                = local.frontend_api_base_url
-    EVENTS_SNS_TOPIC_ARN    = aws_sns_topic.events.arn
-    AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name
-    LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
-    REDIS_KEY               = local.redis_key
-    ENVIRONMENT             = var.environment
-    DYNAMO_ENDPOINT         = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    BASE_URL                 = local.frontend_api_base_url
+    EVENTS_SNS_TOPIC_ARN     = aws_sns_topic.events.arn
+    AUDIT_SIGNING_KEY_ALIAS  = local.audit_signing_key_alias_name
+    LOCALSTACK_ENDPOINT      = var.use_localstack ? var.localstack_endpoint : null
+    REDIS_KEY                = local.redis_key
+    ENVIRONMENT              = var.environment
+    DYNAMO_ENDPOINT          = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    HEADERS_CASE_INSENSITIVE = var.use_localstack ? "true" : "false"
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.ClientInfoHandler::handleRequest"
 

--- a/ci/terraform/oidc/jwks.tf
+++ b/ci/terraform/oidc/jwks.tf
@@ -7,11 +7,12 @@ module "jwks" {
   environment     = var.environment
 
   handler_environment_variables = {
-    BASE_URL                = local.api_base_url
-    EVENTS_SNS_TOPIC_ARN    = aws_sns_topic.events.arn
-    AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name
-    LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
-    TOKEN_SIGNING_KEY_ALIAS = local.id_token_signing_key_alias_name
+    BASE_URL                 = local.api_base_url
+    EVENTS_SNS_TOPIC_ARN     = aws_sns_topic.events.arn
+    AUDIT_SIGNING_KEY_ALIAS  = local.audit_signing_key_alias_name
+    LOCALSTACK_ENDPOINT      = var.use_localstack ? var.localstack_endpoint : null
+    TOKEN_SIGNING_KEY_ALIAS  = local.id_token_signing_key_alias_name
+    HEADERS_CASE_INSENSITIVE = var.use_localstack ? "true" : "false"
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.JwksHandler::handleRequest"
 

--- a/ci/terraform/oidc/login.tf
+++ b/ci/terraform/oidc/login.tf
@@ -15,6 +15,7 @@ module "login" {
     REDIS_KEY                = local.redis_key
     DYNAMO_ENDPOINT          = var.use_localstack ? var.lambda_dynamo_endpoint : null
     TERMS_CONDITIONS_VERSION = var.terms_and_conditions
+    HEADERS_CASE_INSENSITIVE = var.use_localstack ? "true" : "false"
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.LoginHandler::handleRequest"
 

--- a/ci/terraform/oidc/token.tf
+++ b/ci/terraform/oidc/token.tf
@@ -45,15 +45,17 @@ module "token" {
   environment     = var.environment
 
   handler_environment_variables = {
-    ENVIRONMENT             = var.environment
-    BASE_URL                = local.api_base_url
-    DYNAMO_ENDPOINT         = var.use_localstack ? var.lambda_dynamo_endpoint : null
-    EVENTS_SNS_TOPIC_ARN    = aws_sns_topic.events.arn
-    AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name
-    LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
-    REDIS_KEY               = local.redis_key
-    TOKEN_SIGNING_KEY_ALIAS = local.id_token_signing_key_alias_name
-    LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
+    ENVIRONMENT              = var.environment
+    BASE_URL                 = local.api_base_url
+    DYNAMO_ENDPOINT          = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    EVENTS_SNS_TOPIC_ARN     = aws_sns_topic.events.arn
+    AUDIT_SIGNING_KEY_ALIAS  = local.audit_signing_key_alias_name
+    LOCALSTACK_ENDPOINT      = var.use_localstack ? var.localstack_endpoint : null
+    REDIS_KEY                = local.redis_key
+    TOKEN_SIGNING_KEY_ALIAS  = local.id_token_signing_key_alias_name
+    LOCALSTACK_ENDPOINT      = var.use_localstack ? var.localstack_endpoint : null
+    HEADERS_CASE_INSENSITIVE = var.use_localstack ? "true" : "false"
+
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.TokenHandler::handleRequest"
 

--- a/ci/terraform/oidc/trustmarks.tf
+++ b/ci/terraform/oidc/trustmarks.tf
@@ -7,12 +7,13 @@ module "trustmarks" {
   environment     = var.environment
 
   handler_environment_variables = {
-    ENVIRONMENT             = var.environment
-    BASE_URL                = local.api_base_url
-    EVENTS_SNS_TOPIC_ARN    = aws_sns_topic.events.arn
-    AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name
-    LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
-    DYNAMO_ENDPOINT         = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    ENVIRONMENT              = var.environment
+    BASE_URL                 = local.api_base_url
+    EVENTS_SNS_TOPIC_ARN     = aws_sns_topic.events.arn
+    AUDIT_SIGNING_KEY_ALIAS  = local.audit_signing_key_alias_name
+    LOCALSTACK_ENDPOINT      = var.use_localstack ? var.localstack_endpoint : null
+    DYNAMO_ENDPOINT          = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    HEADERS_CASE_INSENSITIVE = var.use_localstack ? "true" : "false"
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.TrustMarkHandler::handleRequest"
 

--- a/ci/terraform/oidc/update_profile.tf
+++ b/ci/terraform/oidc/update_profile.tf
@@ -15,6 +15,7 @@ module "update_profile" {
     REDIS_KEY                = local.redis_key
     DYNAMO_ENDPOINT          = var.use_localstack ? var.lambda_dynamo_endpoint : null
     TERMS_CONDITIONS_VERSION = var.terms_and_conditions
+    HEADERS_CASE_INSENSITIVE = var.use_localstack ? "true" : "false"
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.UpdateProfileHandler::handleRequest"
 

--- a/ci/terraform/oidc/userexists.tf
+++ b/ci/terraform/oidc/userexists.tf
@@ -7,13 +7,15 @@ module "userexists" {
   environment     = var.environment
 
   handler_environment_variables = {
-    ENVIRONMENT             = var.environment
-    BASE_URL                = local.frontend_api_base_url
-    EVENTS_SNS_TOPIC_ARN    = aws_sns_topic.events.arn
-    AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name
-    LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
-    REDIS_KEY               = local.redis_key
-    DYNAMO_ENDPOINT         = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    ENVIRONMENT              = var.environment
+    BASE_URL                 = local.frontend_api_base_url
+    EVENTS_SNS_TOPIC_ARN     = aws_sns_topic.events.arn
+    AUDIT_SIGNING_KEY_ALIAS  = local.audit_signing_key_alias_name
+    LOCALSTACK_ENDPOINT      = var.use_localstack ? var.localstack_endpoint : null
+    REDIS_KEY                = local.redis_key
+    DYNAMO_ENDPOINT          = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    HEADERS_CASE_INSENSITIVE = var.use_localstack ? "true" : "false"
+
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.CheckUserExistsHandler::handleRequest"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       DEFAULT_REGION: eu-west-2
       TEST_AWS_ACCOUNT_ID: 123456789012
       DEBUG: "1"
+      KMS_PROVIDER: local-kms
     extra_hosts:
       - "notify.internal:host-gateway"
     networks:

--- a/docker/localstack.Dockerfile
+++ b/docker/localstack.Dockerfile
@@ -2,7 +2,7 @@
 #
 # Container used to run tasks requiring Localstack in the build pipeline.
 
-FROM localstack/localstack:0.12.15@sha256:9ad944dafff54830ac2c60e07f1f084963ceb3ff71b7dc4ff6d50864affa383d
+FROM localstack/localstack:0.12.20@sha256:ae2c8cbf90ec8dace5d34ff5690b049f030021a0c1a2f8e49bcb8cd6986fae52
 
 COPY localstack/*.sh /docker-entrypoint-initaws.d/
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/RequestHeaderHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/RequestHeaderHelper.java
@@ -36,7 +36,7 @@ public final class RequestHeaderHelper {
                     matchLowerCase);
             return true;
         } else {
-            LOGGER.error("Header {} is missing, matchLowerCase={}", headerName, matchLowerCase);
+            LOGGER.warn("Header {} is missing, matchLowerCase={}", headerName, matchLowerCase);
             return false;
         }
     }


### PR DESCRIPTION
## What?

Upgrade localstack to 0.12.20

Set HEADERS_CASE_INSENSITIVE in the relevant lambdas, only true on localstack.
Change localstack kms provider: 'KMS_PROVIDER: local-kms'.
Lower log level for when header missing.

## Why?

Move to the latest localstack version.

Localstack is now lower-casing headers in api gateway, so switch the flag to handle this when running on localstack.
Switch localstack kms provider to resolve integration test failures with kms.  'local-kms' supports more kms functionality than the localstack implementation.

## Related PRs

#1024 