### PR TITLE
GOVSI-1105: Migrate auth-code integration test

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ApiGatewayHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ApiGatewayHandlerIntegrationTest.java
@@ -12,6 +12,8 @@ import uk.gov.di.authentication.helpers.RedisHelper;
 import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
+import java.net.HttpCookie;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -64,6 +66,16 @@ public abstract class ApiGatewayHandlerIntegrationTest {
                 });
 
         return handler.handleRequest(request, context);
+    }
+
+    protected Map<String, String> constructHeaders(Optional<HttpCookie> cookie) {
+        final Map<String, String> headers = new HashMap<>();
+        cookie.ifPresent(c -> headers.put("Cookie", c.toString()));
+        return headers;
+    }
+
+    protected HttpCookie buildSessionCookie(String sessionID, String clientSessionID) {
+        return new HttpCookie("gs", sessionID + "." + clientSessionID);
     }
 
     public static class IntegrationTestConfigurationService extends ConfigurationService {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
@@ -7,39 +7,39 @@ import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import com.nimbusds.openid.connect.sdk.Nonce;
 import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
-import jakarta.ws.rs.client.Client;
-import jakarta.ws.rs.client.ClientBuilder;
-import jakarta.ws.rs.core.MultivaluedHashMap;
-import jakarta.ws.rs.core.MultivaluedMap;
-import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.helpers.DynamoHelper;
 import uk.gov.di.authentication.helpers.KeyPairHelper;
 import uk.gov.di.authentication.helpers.RedisHelper;
 import uk.gov.di.authentication.oidc.entity.ResponseHeaders;
+import uk.gov.di.authentication.oidc.lambda.AuthCodeHandler;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.shared.entity.SessionState;
 
 import java.io.IOException;
-import java.net.HttpCookie;
 import java.net.URI;
 import java.security.KeyPair;
 import java.util.Base64;
+import java.util.Map;
+import java.util.Optional;
 
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class AuthCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
-
-    private static final String AUTH_CODE_ENDPOINT = "/auth-code";
     private static final String EMAIL = "joe.bloggs@digital.cabinet-office.gov.uk";
     private static final URI REDIRECT_URI =
             URI.create(System.getenv("STUB_RELYING_PARTY_REDIRECT_URI"));
     private static final ClientID CLIENT_ID = new ClientID("test-client");
-    private static final String COOKIE = "Cookie";
+
+    @BeforeEach
+    void setup() {
+        handler = new AuthCodeHandler(configurationService);
+    }
 
     @Test
     public void shouldReturn302WithSuccessfulAuthorisationResponse() throws IOException {
@@ -51,15 +51,15 @@ public class AuthCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         RedisHelper.addAuthRequestToSession(
                 clientSessionId, sessionId, generateAuthRequest().toParameters(), EMAIL);
         setUpDynamo(keyPair);
-        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
-        headers.add(COOKIE, buildCookieString(sessionId, clientSessionId));
-        Client client = ClientBuilder.newClient();
-        Response response =
-                client.target(ROOT_RESOURCE_URL + AUTH_CODE_ENDPOINT)
-                        .request()
-                        .headers(headers)
-                        .get();
-        assertEquals(302, response.getStatus());
+
+        var response =
+                makeRequest(
+                        Optional.empty(),
+                        constructHeaders(
+                                Optional.of(buildSessionCookie(sessionId, clientSessionId))),
+                        Map.of());
+
+        assertThat(response, hasStatus(302));
         assertThat(
                 response.getHeaders().get(ResponseHeaders.LOCATION).toString(),
                 not(containsString("cookie_consent")));
@@ -89,10 +89,5 @@ public class AuthCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 String.valueOf(ServiceType.MANDATORY),
                 "https://test.com",
                 "public");
-    }
-
-    private String buildCookieString(String sessionID, String clientSessionID) {
-        var cookie = new HttpCookie("gs", sessionID + "." + clientSessionID);
-        return cookie.toString();
     }
 }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -82,13 +82,17 @@ public class AuthCodeHandler
         this.auditService = auditService;
     }
 
-    public AuthCodeHandler() {
-        configurationService = ConfigurationService.getInstance();
+    public AuthCodeHandler(ConfigurationService configurationService) {
+        this.configurationService = configurationService;
         sessionService = new SessionService(configurationService);
         authorisationCodeService = new AuthorisationCodeService(configurationService);
         authorizationService = new AuthorizationService(configurationService);
         clientSessionService = new ClientSessionService(configurationService);
         auditService = new AuditService();
+    }
+
+    public AuthCodeHandler() {
+        this(ConfigurationService.getInstance());
     }
 
     @Override

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -77,13 +77,17 @@ public class AuthorisationHandler
         this.stateMachine = stateMachine;
     }
 
-    public AuthorisationHandler() {
-        configurationService = ConfigurationService.getInstance();
+    public AuthorisationHandler(ConfigurationService configurationService) {
+        this.configurationService = configurationService;
         this.sessionService = new SessionService(configurationService);
         this.clientSessionService = new ClientSessionService(configurationService);
         this.authorizationService = new AuthorizationService(configurationService);
         this.auditService = new AuditService();
         this.stateMachine = userJourneyStateMachine();
+    }
+
+    public AuthorisationHandler() {
+        this(ConfigurationService.getInstance());
     }
 
     @Override


### PR DESCRIPTION
## What?

- Alter `AuthCodeIntegration` test to follow new integration test pattern
- Move some helper methods into base class
- Add new constructor to handlers that allow passing in of a `ConfigurationService` instance, this simplifies test initialisation.

## Why?

We are moving all integration tests to a different pattern

## Related PRs

#1026 
#1027 
#1031 