### PR TITLE
GOVSI-1055: Use new roles in API lambdas

### DIFF
--- a/ci/terraform/oidc/auth-code.tf
+++ b/ci/terraform/oidc/auth-code.tf
@@ -24,7 +24,7 @@ module "auth-code" {
   authentication_vpc_arn                 = local.authentication_vpc_arn
   security_group_id                      = local.authentication_security_group_id
   subnet_id                              = local.authentication_subnet_ids
-  lambda_role_arn                        = local.lambda_iam_role_arn
+  lambda_role_arn                        = module.oidc_default_role.arn
   environment                            = var.environment
   logging_endpoint_enabled               = var.logging_endpoint_enabled
   logging_endpoint_arn                   = var.logging_endpoint_arn

--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -27,7 +27,7 @@ module "authorize" {
   authentication_vpc_arn                 = local.authentication_vpc_arn
   security_group_id                      = local.authentication_security_group_id
   subnet_id                              = local.authentication_subnet_ids
-  lambda_role_arn                        = local.lambda_iam_role_arn
+  lambda_role_arn                        = module.oidc_default_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled
   logging_endpoint_arn                   = var.logging_endpoint_arn
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/client-info.tf
+++ b/ci/terraform/oidc/client-info.tf
@@ -25,7 +25,7 @@ module "client-info" {
   authentication_vpc_arn                 = local.authentication_vpc_arn
   security_group_id                      = local.authentication_security_group_id
   subnet_id                              = local.authentication_subnet_ids
-  lambda_role_arn                        = local.lambda_iam_role_arn
+  lambda_role_arn                        = module.oidc_default_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled
   logging_endpoint_arn                   = var.logging_endpoint_arn
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/events-sns.tf
+++ b/ci/terraform/oidc/events-sns.tf
@@ -45,23 +45,3 @@ resource "aws_iam_policy" "lambda_sns_policy" {
 
   policy = data.aws_iam_policy_document.events_policy_document.json
 }
-
-resource "aws_iam_role_policy_attachment" "lambda_sns" {
-  role       = local.lambda_iam_role_name
-  policy_arn = aws_iam_policy.lambda_sns_policy.arn
-}
-
-resource "aws_iam_role_policy_attachment" "lambda_sns_token" {
-  role       = local.lambda_iam_role_name
-  policy_arn = aws_iam_policy.lambda_sns_policy.arn
-}
-
-resource "aws_iam_role_policy_attachment" "lambda_sns_sqs" {
-  role       = local.sqs_lambda_iam_role_name
-  policy_arn = aws_iam_policy.lambda_sns_policy.arn
-}
-
-resource "aws_iam_role_policy_attachment" "lambda_sns_dynamo" {
-  role       = local.dynamo_sqs_lambda_iam_role_name
-  policy_arn = aws_iam_policy.lambda_sns_policy.arn
-}

--- a/ci/terraform/oidc/jwks.tf
+++ b/ci/terraform/oidc/jwks.tf
@@ -23,7 +23,7 @@ module "jwks" {
   authentication_vpc_arn                 = local.authentication_vpc_arn
   security_group_id                      = local.authentication_security_group_id
   subnet_id                              = local.authentication_subnet_ids
-  lambda_role_arn                        = local.lambda_iam_role_arn
+  lambda_role_arn                        = module.oidc_default_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled
   logging_endpoint_arn                   = var.logging_endpoint_arn
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/lambda-roles.tf
+++ b/ci/terraform/oidc/lambda-roles.tf
@@ -4,11 +4,17 @@ module "oidc_default_role" {
   role_name   = "oidc-default-role"
   vpc_arn     = local.authentication_vpc_arn
 
-  policies_to_attach = var.use_localstack ? [aws_iam_policy.lambda_sns_policy.arn] : [
+  policies_to_attach = var.use_localstack ? [
+    aws_iam_policy.lambda_sns_policy.arn,
+    aws_iam_policy.redis_parameter_policy.arn,
+    aws_iam_policy.pepper_parameter_policy.arn
+    ] : [
     aws_iam_policy.oidc_default_id_token_public_key_kms_policy[0].arn,
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy[0].arn,
     aws_iam_policy.dynamo_access_policy[0].arn,
-    aws_iam_policy.lambda_sns_policy.arn
+    aws_iam_policy.lambda_sns_policy.arn,
+    aws_iam_policy.redis_parameter_policy.arn,
+    aws_iam_policy.pepper_parameter_policy.arn
   ]
 }
 
@@ -29,10 +35,14 @@ module "oidc_dynamo_sqs_role" {
   role_name   = "oidc-dynamo-sqs"
   vpc_arn     = local.authentication_vpc_arn
 
-  policies_to_attach = var.use_localstack ? [aws_iam_policy.lambda_sns_policy.arn] : [
+  policies_to_attach = var.use_localstack ? [
+    aws_iam_policy.lambda_sns_policy.arn,
+    aws_iam_policy.redis_parameter_policy.arn
+    ] : [
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy[0].arn,
     aws_iam_policy.dynamo_access_policy[0].arn,
-    aws_iam_policy.lambda_sns_policy.arn
+    aws_iam_policy.lambda_sns_policy.arn,
+    aws_iam_policy.redis_parameter_policy.arn
   ]
 
 }

--- a/ci/terraform/oidc/login.tf
+++ b/ci/terraform/oidc/login.tf
@@ -26,7 +26,7 @@ module "login" {
   authentication_vpc_arn                 = local.authentication_vpc_arn
   security_group_id                      = local.authentication_security_group_id
   subnet_id                              = local.authentication_subnet_ids
-  lambda_role_arn                        = local.lambda_iam_role_arn
+  lambda_role_arn                        = module.oidc_default_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled
   logging_endpoint_arn                   = var.logging_endpoint_arn
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/logout.tf
+++ b/ci/terraform/oidc/logout.tf
@@ -27,7 +27,7 @@ module "logout" {
   authentication_vpc_arn                 = local.authentication_vpc_arn
   security_group_id                      = local.authentication_security_group_id
   subnet_id                              = local.authentication_subnet_ids
-  lambda_role_arn                        = local.lambda_iam_role_arn
+  lambda_role_arn                        = module.oidc_default_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled
   logging_endpoint_arn                   = var.logging_endpoint_arn
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/mfa.tf
+++ b/ci/terraform/oidc/mfa.tf
@@ -25,7 +25,7 @@ module "mfa" {
   authentication_vpc_arn                 = local.authentication_vpc_arn
   security_group_id                      = local.authentication_security_group_id
   subnet_id                              = local.authentication_subnet_ids
-  lambda_role_arn                        = local.dynamo_sqs_lambda_iam_role_arn
+  lambda_role_arn                        = module.oidc_dynamo_sqs_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled
   logging_endpoint_arn                   = var.logging_endpoint_arn
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/register.tf
+++ b/ci/terraform/oidc/register.tf
@@ -24,7 +24,7 @@ module "register" {
   lambda_zip_file                        = var.client_registry_api_lambda_zip_file
   security_group_id                      = local.authentication_security_group_id
   subnet_id                              = local.authentication_subnet_ids
-  lambda_role_arn                        = local.lambda_iam_role_arn
+  lambda_role_arn                        = module.oidc_default_role.arn
   environment                            = var.environment
   logging_endpoint_enabled               = var.logging_endpoint_enabled
   logging_endpoint_arn                   = var.logging_endpoint_arn

--- a/ci/terraform/oidc/reset-password-request.tf
+++ b/ci/terraform/oidc/reset-password-request.tf
@@ -26,7 +26,7 @@ module "reset-password-request" {
   authentication_vpc_arn                 = local.authentication_vpc_arn
   security_group_id                      = local.authentication_security_group_id
   subnet_id                              = local.authentication_subnet_ids
-  lambda_role_arn                        = local.dynamo_sqs_lambda_iam_role_arn
+  lambda_role_arn                        = module.oidc_dynamo_sqs_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled
   logging_endpoint_arn                   = var.logging_endpoint_arn
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/reset_password.tf
+++ b/ci/terraform/oidc/reset_password.tf
@@ -27,7 +27,7 @@ module "reset_password" {
   authentication_vpc_arn                 = local.authentication_vpc_arn
   security_group_id                      = local.authentication_security_group_id
   subnet_id                              = local.authentication_subnet_ids
-  lambda_role_arn                        = local.dynamo_sqs_lambda_iam_role_arn
+  lambda_role_arn                        = module.oidc_dynamo_sqs_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled
   logging_endpoint_arn                   = var.logging_endpoint_arn
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/send_notification.tf
+++ b/ci/terraform/oidc/send_notification.tf
@@ -24,7 +24,7 @@ module "send_notification" {
   authentication_vpc_arn                 = local.authentication_vpc_arn
   security_group_id                      = local.authentication_security_group_id
   subnet_id                              = local.authentication_subnet_ids
-  lambda_role_arn                        = local.dynamo_sqs_lambda_iam_role_arn
+  lambda_role_arn                        = module.oidc_dynamo_sqs_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled
   logging_endpoint_arn                   = var.logging_endpoint_arn
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/shared.tf
+++ b/ci/terraform/oidc/shared.tf
@@ -20,14 +20,6 @@ locals {
   authentication_vpc_arn                 = data.terraform_remote_state.shared.outputs.authentication_vpc_arn
   authentication_security_group_id       = data.terraform_remote_state.shared.outputs.authentication_security_group_id
   authentication_subnet_ids              = data.terraform_remote_state.shared.outputs.authentication_subnet_ids
-  lambda_iam_role_arn                    = data.terraform_remote_state.shared.outputs.lambda_iam_role_arn
-  lambda_iam_role_name                   = data.terraform_remote_state.shared.outputs.lambda_iam_role_name
-  dynamo_sqs_lambda_iam_role_arn         = data.terraform_remote_state.shared.outputs.dynamo_sqs_lambda_iam_role_arn
-  dynamo_sqs_lambda_iam_role_name        = data.terraform_remote_state.shared.outputs.dynamo_sqs_lambda_iam_role_name
-  sqs_lambda_iam_role_arn                = data.terraform_remote_state.shared.outputs.sqs_lambda_iam_role_arn
-  sqs_lambda_iam_role_name               = data.terraform_remote_state.shared.outputs.sqs_lambda_iam_role_name
-  email_lambda_iam_role_arn              = data.terraform_remote_state.shared.outputs.email_lambda_iam_role_arn
-  token_lambda_iam_role_arn              = data.terraform_remote_state.shared.outputs.token_lambda_iam_role_arn
   id_token_signing_key_alias_name        = data.terraform_remote_state.shared.outputs.id_token_signing_key_alias_name
   id_token_signing_key_alias_arn         = data.terraform_remote_state.shared.outputs.id_token_signing_key_alias_arn
   audit_signing_key_alias_name           = data.terraform_remote_state.shared.outputs.audit_signing_key_alias_name

--- a/ci/terraform/oidc/shared.tf
+++ b/ci/terraform/oidc/shared.tf
@@ -29,4 +29,6 @@ locals {
   events_topic_encryption_key_arn        = data.terraform_remote_state.shared.outputs.events_topic_encryption_key_arn
   lambda_parameter_encryption_key_id     = data.terraform_remote_state.shared.outputs.lambda_parameter_encryption_key_id
   lambda_parameter_encryption_alias_id   = data.terraform_remote_state.shared.outputs.lambda_parameter_encryption_alias_id
+  redis_ssm_parameter_policy             = data.terraform_remote_state.shared.outputs.redis_ssm_parameter_policy
+  pepper_ssm_parameter_policy            = data.terraform_remote_state.shared.outputs.pepper_ssm_parameter_policy
 }

--- a/ci/terraform/oidc/signup.tf
+++ b/ci/terraform/oidc/signup.tf
@@ -25,7 +25,7 @@ module "signup" {
   authentication_vpc_arn                 = local.authentication_vpc_arn
   security_group_id                      = local.authentication_security_group_id
   subnet_id                              = local.authentication_subnet_ids
-  lambda_role_arn                        = local.lambda_iam_role_arn
+  lambda_role_arn                        = module.oidc_default_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled
   logging_endpoint_arn                   = var.logging_endpoint_arn
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/sqs.tf
+++ b/ci/terraform/oidc/sqs.tf
@@ -47,7 +47,7 @@ data "aws_iam_policy_document" "email_queue_policy_document" {
 
     principals {
       type        = "AWS"
-      identifiers = [local.sqs_lambda_iam_role_arn, local.dynamo_sqs_lambda_iam_role_arn]
+      identifiers = [module.oidc_sqs_role.arn, module.oidc_dynamo_sqs_role.arn]
     }
 
     actions = [
@@ -67,7 +67,7 @@ data "aws_iam_policy_document" "email_queue_policy_document" {
 
     principals {
       type        = "AWS"
-      identifiers = [local.email_lambda_iam_role_arn]
+      identifiers = [module.oidc_email_role.arn]
     }
 
     actions = [
@@ -147,7 +147,7 @@ resource "aws_lambda_event_source_mapping" "lambda_sqs_mapping" {
 resource "aws_lambda_function" "email_sqs_lambda" {
   filename      = var.frontend_api_lambda_zip_file
   function_name = "${var.environment}-email-notification-sqs-lambda"
-  role          = local.email_lambda_iam_role_arn
+  role          = module.oidc_email_role.arn
   handler       = "uk.gov.di.authentication.frontendapi.lambda.NotificationHandler::handleRequest"
   timeout       = 30
   memory_size   = 512

--- a/ci/terraform/oidc/ssm.tf
+++ b/ci/terraform/oidc/ssm.tf
@@ -93,7 +93,7 @@ data "aws_iam_policy_document" "pepper_parameter_policy" {
 }
 
 resource "aws_iam_policy" "pepper_parameter_policy" {
-  policy      = data.aws_iam_policy_document.pepper_parameter_policy[0].json
+  policy      = data.aws_iam_policy_document.pepper_parameter_policy.json
   path        = "/${var.environment}/lambda-parameters/"
   name_prefix = "pepper-parameter-store-policy"
 }

--- a/ci/terraform/oidc/ssm.tf
+++ b/ci/terraform/oidc/ssm.tf
@@ -1,0 +1,99 @@
+data "aws_ssm_parameter" "redis_master_host" {
+  name = "${var.environment}-${local.redis_key}-redis-master-host"
+}
+
+data "aws_ssm_parameter" "redis_replica_host" {
+  name = "${var.environment}-${local.redis_key}-redis-replica-host"
+}
+
+data "aws_ssm_parameter" "redis_tls" {
+  name = "${var.environment}-${local.redis_key}-redis-tls"
+}
+
+data "aws_ssm_parameter" "redis_password" {
+  name = "${var.environment}-${local.redis_key}-redis-password"
+}
+
+data "aws_ssm_parameter" "redis_port" {
+  name = "${var.environment}-${local.redis_key}-redis-port"
+}
+
+data "aws_iam_policy_document" "redis_parameter_policy" {
+  statement {
+    sid    = "AllowGetParameters"
+    effect = "Allow"
+
+    actions = [
+      "ssm:GetParameter",
+      "ssm:GetParameters",
+    ]
+
+    resources = [
+      data.aws_ssm_parameter.redis_master_host.arn,
+      data.aws_ssm_parameter.redis_replica_host.arn,
+      data.aws_ssm_parameter.redis_tls.arn,
+      data.aws_ssm_parameter.redis_password.arn,
+      data.aws_ssm_parameter.redis_port.arn,
+    ]
+  }
+  statement {
+    sid    = "AllowDecryptOfParameters"
+    effect = "Allow"
+
+    actions = [
+      "kms:Decrypt",
+    ]
+
+    resources = [
+      local.lambda_parameter_encryption_alias_id,
+      local.lambda_parameter_encryption_key_id
+    ]
+  }
+}
+
+resource "aws_iam_policy" "redis_parameter_policy" {
+  policy      = data.aws_iam_policy_document.redis_parameter_policy.json
+  path        = "/${var.environment}/redis/${local.redis_key}/"
+  name_prefix = "parameter-store-policy"
+}
+
+## Password pepper policy
+
+data "aws_ssm_parameter" "password_pepper" {
+  name = "${var.environment}-password-pepper"
+}
+
+data "aws_iam_policy_document" "pepper_parameter_policy" {
+  statement {
+    sid    = "AllowGetParameters"
+    effect = "Allow"
+
+    actions = [
+      "ssm:GetParameter",
+      "ssm:GetParameters",
+    ]
+
+    resources = [
+      data.aws_ssm_parameter.password_pepper.arn
+    ]
+  }
+  statement {
+    sid    = "AllowDecryptOfParameters"
+    effect = "Allow"
+
+    actions = [
+      "kms:Decrypt",
+    ]
+
+    resources = [
+      local.lambda_parameter_encryption_alias_id,
+      local.lambda_parameter_encryption_key_id
+    ]
+  }
+}
+
+resource "aws_iam_policy" "pepper_parameter_policy" {
+  policy      = data.aws_iam_policy_document.pepper_parameter_policy[0].json
+  path        = "/${var.environment}/lambda-parameters/"
+  name_prefix = "pepper-parameter-store-policy"
+}

--- a/ci/terraform/oidc/ssm.tf
+++ b/ci/terraform/oidc/ssm.tf
@@ -1,99 +1,21 @@
-data "aws_ssm_parameter" "redis_master_host" {
-  name = "${var.environment}-${local.redis_key}-redis-master-host"
-}
-
-data "aws_ssm_parameter" "redis_replica_host" {
-  name = "${var.environment}-${local.redis_key}-redis-replica-host"
-}
-
-data "aws_ssm_parameter" "redis_tls" {
-  name = "${var.environment}-${local.redis_key}-redis-tls"
-}
-
-data "aws_ssm_parameter" "redis_password" {
-  name = "${var.environment}-${local.redis_key}-redis-password"
-}
-
-data "aws_ssm_parameter" "redis_port" {
-  name = "${var.environment}-${local.redis_key}-redis-port"
-}
-
-data "aws_iam_policy_document" "redis_parameter_policy" {
-  statement {
-    sid    = "AllowGetParameters"
-    effect = "Allow"
-
-    actions = [
-      "ssm:GetParameter",
-      "ssm:GetParameters",
-    ]
-
-    resources = [
-      data.aws_ssm_parameter.redis_master_host.arn,
-      data.aws_ssm_parameter.redis_replica_host.arn,
-      data.aws_ssm_parameter.redis_tls.arn,
-      data.aws_ssm_parameter.redis_password.arn,
-      data.aws_ssm_parameter.redis_port.arn,
-    ]
-  }
-  statement {
-    sid    = "AllowDecryptOfParameters"
-    effect = "Allow"
-
-    actions = [
-      "kms:Decrypt",
-    ]
-
-    resources = [
-      local.lambda_parameter_encryption_alias_id,
-      local.lambda_parameter_encryption_key_id
-    ]
-  }
+data "aws_iam_policy" "redis_parameter_policy" {
+  arn = local.redis_ssm_parameter_policy
 }
 
 resource "aws_iam_policy" "redis_parameter_policy" {
-  policy      = data.aws_iam_policy_document.redis_parameter_policy.json
+  policy      = data.aws_iam_policy.redis_parameter_policy.policy
   path        = "/${var.environment}/redis/${local.redis_key}/"
   name_prefix = "parameter-store-policy"
 }
 
 ## Password pepper policy
 
-data "aws_ssm_parameter" "password_pepper" {
-  name = "${var.environment}-password-pepper"
-}
-
-data "aws_iam_policy_document" "pepper_parameter_policy" {
-  statement {
-    sid    = "AllowGetParameters"
-    effect = "Allow"
-
-    actions = [
-      "ssm:GetParameter",
-      "ssm:GetParameters",
-    ]
-
-    resources = [
-      data.aws_ssm_parameter.password_pepper.arn
-    ]
-  }
-  statement {
-    sid    = "AllowDecryptOfParameters"
-    effect = "Allow"
-
-    actions = [
-      "kms:Decrypt",
-    ]
-
-    resources = [
-      local.lambda_parameter_encryption_alias_id,
-      local.lambda_parameter_encryption_key_id
-    ]
-  }
+data "aws_iam_policy" "pepper_parameter_policy" {
+  arn = local.pepper_ssm_parameter_policy
 }
 
 resource "aws_iam_policy" "pepper_parameter_policy" {
-  policy      = data.aws_iam_policy_document.pepper_parameter_policy.json
+  policy      = data.aws_iam_policy.pepper_parameter_policy.policy
   path        = "/${var.environment}/lambda-parameters/"
   name_prefix = "pepper-parameter-store-policy"
 }

--- a/ci/terraform/oidc/token.tf
+++ b/ci/terraform/oidc/token.tf
@@ -66,7 +66,7 @@ module "token" {
   authentication_vpc_arn                 = local.authentication_vpc_arn
   security_group_id                      = local.authentication_security_group_id
   subnet_id                              = local.authentication_subnet_ids
-  lambda_role_arn                        = local.token_lambda_iam_role_arn
+  lambda_role_arn                        = module.oidc_token_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled
   logging_endpoint_arn                   = var.logging_endpoint_arn
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/token.tf
+++ b/ci/terraform/oidc/token.tf
@@ -4,10 +4,11 @@ module "oidc_token_role" {
   role_name   = "oidc-token"
   vpc_arn     = local.authentication_vpc_arn
 
-  policies_to_attach = var.use_localstack ? [] : [
+  policies_to_attach = var.use_localstack ? [aws_iam_policy.redis_parameter_policy.arn] : [
     aws_iam_policy.oidc_token_kms_signing_policy[0].arn,
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy[0].arn,
-    aws_iam_policy.dynamo_access_policy[0].arn
+    aws_iam_policy.dynamo_access_policy[0].arn,
+    aws_iam_policy.redis_parameter_policy.arn
   ]
 }
 

--- a/ci/terraform/oidc/trustmarks.tf
+++ b/ci/terraform/oidc/trustmarks.tf
@@ -24,7 +24,7 @@ module "trustmarks" {
   authentication_vpc_arn                 = local.authentication_vpc_arn
   security_group_id                      = local.authentication_security_group_id
   subnet_id                              = local.authentication_subnet_ids
-  lambda_role_arn                        = local.lambda_iam_role_arn
+  lambda_role_arn                        = module.oidc_default_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled
   logging_endpoint_arn                   = var.logging_endpoint_arn
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/update.tf
+++ b/ci/terraform/oidc/update.tf
@@ -25,7 +25,7 @@ module "update" {
   authentication_vpc_arn                 = local.authentication_vpc_arn
   security_group_id                      = local.authentication_security_group_id
   subnet_id                              = local.authentication_subnet_ids
-  lambda_role_arn                        = local.lambda_iam_role_arn
+  lambda_role_arn                        = module.oidc_default_role.arn
   environment                            = var.environment
   logging_endpoint_enabled               = var.logging_endpoint_enabled
   logging_endpoint_arn                   = var.logging_endpoint_arn

--- a/ci/terraform/oidc/update_profile.tf
+++ b/ci/terraform/oidc/update_profile.tf
@@ -26,7 +26,7 @@ module "update_profile" {
   authentication_vpc_arn                 = local.authentication_vpc_arn
   security_group_id                      = local.authentication_security_group_id
   subnet_id                              = local.authentication_subnet_ids
-  lambda_role_arn                        = local.lambda_iam_role_arn
+  lambda_role_arn                        = module.oidc_default_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled
   logging_endpoint_arn                   = var.logging_endpoint_arn
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/userexists.tf
+++ b/ci/terraform/oidc/userexists.tf
@@ -26,7 +26,7 @@ module "userexists" {
   authentication_vpc_arn                 = local.authentication_vpc_arn
   security_group_id                      = local.authentication_security_group_id
   subnet_id                              = local.authentication_subnet_ids
-  lambda_role_arn                        = local.lambda_iam_role_arn
+  lambda_role_arn                        = module.oidc_default_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled
   logging_endpoint_arn                   = var.logging_endpoint_arn
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -25,7 +25,7 @@ module "userinfo" {
   authentication_vpc_arn                 = local.authentication_vpc_arn
   security_group_id                      = local.authentication_security_group_id
   subnet_id                              = local.authentication_subnet_ids
-  lambda_role_arn                        = local.lambda_iam_role_arn
+  lambda_role_arn                        = module.oidc_default_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled
   logging_endpoint_arn                   = var.logging_endpoint_arn
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/verify_code.tf
+++ b/ci/terraform/oidc/verify_code.tf
@@ -28,7 +28,7 @@ module "verify_code" {
   authentication_vpc_arn                 = local.authentication_vpc_arn
   security_group_id                      = local.authentication_security_group_id
   subnet_id                              = local.authentication_subnet_ids
-  lambda_role_arn                        = local.lambda_iam_role_arn
+  lambda_role_arn                        = module.oidc_default_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled
   logging_endpoint_arn                   = var.logging_endpoint_arn
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/shared/localstack.tfvars
+++ b/ci/terraform/shared/localstack.tfvars
@@ -25,3 +25,4 @@ stub_rp_clients = [
 ]
 test_client_email_allowlist = "testclient.user1@digital.cabinet-office.gov.uk,testclient.user2@digital.cabinet-office.gov.uk"
 terms_and_conditions        = "1.0"
+password_pepper             = "fake-pepper"

--- a/ci/terraform/shared/outputs.tf
+++ b/ci/terraform/shared/outputs.tf
@@ -109,3 +109,11 @@ output "lambda_parameter_encryption_key_id" {
 output "lambda_parameter_encryption_alias_id" {
   value = aws_kms_alias.parameter_store_key_alias.id
 }
+
+output "redis_ssm_parameter_policy" {
+  value = aws_iam_policy.parameter_policy.arn
+}
+
+output "pepper_ssm_parameter_policy" {
+  value = aws_iam_policy.pepper_parameter_policy.arn
+}

--- a/ci/terraform/shared/sandpit.tfvars
+++ b/ci/terraform/shared/sandpit.tfvars
@@ -2,5 +2,6 @@ environment                 = "sandpit"
 keep_lambdas_warm           = false
 redis_node_size             = "cache.t2.micro"
 test_client_email_allowlist = "testclient.user1@digital.cabinet-office.gov.uk,testclient.user2@digital.cabinet-office.gov.uk"
+password_pepper             = "fake-pepper"
 
 enable_api_gateway_execution_request_tracing = true

--- a/ci/terraform/shared/ssm.tf
+++ b/ci/terraform/shared/ssm.tf
@@ -77,13 +77,11 @@ resource "aws_ssm_parameter" "redis_port" {
 }
 
 resource "aws_ssm_parameter" "password_pepper" {
-  count  = var.password_pepper == null ? 0 : 1
   name   = "${var.environment}-password-pepper"
   type   = "SecureString"
   key_id = aws_kms_alias.parameter_store_key_alias.id
   value  = var.password_pepper
 }
-
 
 data "aws_iam_policy_document" "redis_parameter_policy" {
   statement {
@@ -140,7 +138,6 @@ resource "aws_iam_role_policy_attachment" "dynamo_sqs_lambda_iam_role_parameters
 }
 
 data "aws_iam_policy_document" "pepper_parameter_policy" {
-  count = var.password_pepper == null ? 0 : 1
   statement {
     sid    = "AllowGetParameters"
     effect = "Allow"
@@ -151,7 +148,7 @@ data "aws_iam_policy_document" "pepper_parameter_policy" {
     ]
 
     resources = [
-      aws_ssm_parameter.password_pepper[0].arn
+      aws_ssm_parameter.password_pepper.arn
     ]
   }
   statement {
@@ -170,14 +167,12 @@ data "aws_iam_policy_document" "pepper_parameter_policy" {
 }
 
 resource "aws_iam_policy" "pepper_parameter_policy" {
-  count       = var.password_pepper == null ? 0 : 1
-  policy      = data.aws_iam_policy_document.pepper_parameter_policy[0].json
+  policy      = data.aws_iam_policy_document.pepper_parameter_policy.json
   path        = "/${var.environment}/lambda-parameters/"
   name_prefix = "pepper-parameter-store-policy"
 }
 
 resource "aws_iam_role_policy_attachment" "lambda_iam_role_pepper_parameters" {
-  count      = var.password_pepper == null ? 0 : 1
-  policy_arn = aws_iam_policy.pepper_parameter_policy[0].arn
+  policy_arn = aws_iam_policy.pepper_parameter_policy.arn
   role       = aws_iam_role.lambda_iam_role.name
 }


### PR DESCRIPTION
This PR uses the roles created in a previous PR as the execution role in API lambdas
