### PR TITLE
GOVSI-1105: Integration test refactor

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ClientInfoHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ClientInfoHandler.java
@@ -54,16 +54,20 @@ public class ClientInfoHandler
         this.auditService = auditService;
     }
 
-    public ClientInfoHandler() {
-        configurationService = ConfigurationService.getInstance();
-        clientSessionService = new ClientSessionService(configurationService);
-        clientService =
+    public ClientInfoHandler(ConfigurationService configurationService) {
+        this.configurationService = configurationService;
+        this.clientSessionService = new ClientSessionService(configurationService);
+        this.clientService =
                 new DynamoClientService(
                         configurationService.getAwsRegion(),
                         configurationService.getEnvironment(),
                         configurationService.getDynamoEndpointUri());
         this.sessionService = new SessionService(configurationService);
         this.auditService = new AuditService();
+    }
+
+    public ClientInfoHandler() {
+        this(ConfigurationService.getInstance());
     }
 
     @Override

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/JwksIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/JwksIntegrationTest.java
@@ -1,27 +1,31 @@
 package uk.gov.di.authentication.api;
 
 import com.nimbusds.jose.jwk.JWKSet;
-import jakarta.ws.rs.client.Client;
-import jakarta.ws.rs.client.ClientBuilder;
-import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.oidc.lambda.JwksHandler;
 
 import java.text.ParseException;
+import java.util.Map;
+import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class JwksIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
-    private static final String JWKS_ENDPOINT = "/.well-known/jwks.json";
+    @BeforeEach
+    void setup() {
+        handler = new JwksHandler(configurationService);
+    }
 
     @Test
     public void shouldReturn200AndClientInfoResponseForValidClient() throws ParseException {
-        Client client = ClientBuilder.newClient();
-        Response response = client.target(ROOT_RESOURCE_URL + JWKS_ENDPOINT).request().get();
 
-        assertEquals(200, response.getStatus());
-        String responseString = response.readEntity(String.class);
-        assertTrue(JWKSet.parse(responseString).getKeys().size() == 1);
+        var response = makeRequest(Optional.empty(), Map.of(), Map.of());
+
+        assertThat(response, hasStatus(200));
+        assertThat(JWKSet.parse(response.getBody()).getKeys(), hasSize(1));
     }
 }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/JwksHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/JwksHandler.java
@@ -28,11 +28,15 @@ public class JwksHandler
         this.configurationService = configurationService;
     }
 
-    public JwksHandler() {
-        this.configurationService = ConfigurationService.getInstance();
+    public JwksHandler(ConfigurationService configurationService) {
+        this.configurationService = configurationService;
         this.tokenValidationService =
                 new TokenValidationService(
                         configurationService, new KmsConnectionService(configurationService));
+    }
+
+    public JwksHandler() {
+        this(ConfigurationService.getInstance());
     }
 
     @Override


### PR DESCRIPTION
## What?

- Migrate the ClientInfo endpoint integration test to use the new pattern
- Migrate the JWKS endpoint integration test to use the new pattern

## Why?

We are converting all integration tests to use a more efficient testing pattern

## Related PRs

#1026 
#1027 