### PR TITLE
GOVSI-1105: Refactor Login and Logout integration tests

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -74,8 +74,8 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
         this.auditService = auditService;
     }
 
-    public LoginHandler() {
-        super(LoginRequest.class, ConfigurationService.getInstance());
+    public LoginHandler(ConfigurationService configurationService) {
+        super(LoginRequest.class, configurationService);
         this.codeStorageService =
                 new CodeStorageService(
                         new RedisConnectionService(ConfigurationService.getInstance()));
@@ -84,6 +84,10 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
                         new DynamoService(ConfigurationService.getInstance()),
                         ConfigurationService.getInstance());
         this.auditService = new AuditService();
+    }
+
+    public LoginHandler() {
+        this(ConfigurationService.getInstance());
     }
 
     @Override

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -42,6 +42,7 @@ test {
     environment "AWS_REGION", "eu-west-2"
     environment "AWS_SECRET_ACCESS_KEY", "mock-secret-key "
     environment "BASE_URL", "http://localhost"
+    environment "DEFAULT_LOGOUT_URI", "http://localhost:3000/signed-out"
     environment "DOMAIN_NAME", "localhost"
     environment "DYNAMO_ENDPOINT", "http://localhost:8000"
     environment "ENVIRONMENT", "local"

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
@@ -42,7 +42,11 @@ public class LogoutHandler
     private final TokenValidationService tokenValidationService;
 
     public LogoutHandler() {
-        this.configurationService = ConfigurationService.getInstance();
+        this(ConfigurationService.getInstance());
+    }
+
+    public LogoutHandler(ConfigurationService configurationService) {
+        this.configurationService = configurationService;
         this.sessionService = new SessionService(configurationService);
         this.dynamoClientService =
                 new DynamoClientService(

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/matchers/UriMatcher.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/matchers/UriMatcher.java
@@ -1,0 +1,94 @@
+package uk.gov.di.authentication.sharedtest.matchers;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLDecoder;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.Matchers.equalTo;
+
+public class UriMatcher<T> extends TypeSafeDiagnosingMatcher<URI> {
+
+    private final String name;
+    private final Function<URI, T> mapper;
+    private final Matcher<T> matcher;
+
+    private UriMatcher(String name, Function<URI, T> mapper, Matcher<T> matcher) {
+        this.name = name;
+        this.mapper = mapper;
+        this.matcher = matcher;
+    }
+
+    @Override
+    protected boolean matchesSafely(URI item, Description mismatchDescription) {
+        T actual = mapper.apply(item);
+
+        boolean matched = matcher.matches(actual);
+
+        if (!matched) {
+            mismatchDescription.appendText(description(actual));
+        }
+
+        return matched;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendDescriptionOf(matcher);
+    }
+
+    private String description(T value) {
+        return "a URI with " + name + ": " + value;
+    }
+
+    public static UriMatcher<URI> baseUri(URI expected) {
+        return new UriMatcher<>(
+                "base URI",
+                uri -> {
+                    try {
+                        return new URI(
+                                uri.getScheme(), uri.getAuthority(), uri.getPath(), null, null);
+                    } catch (URISyntaxException e) {
+                        throw new RuntimeException(e);
+                    }
+                },
+                equalTo(expected));
+    }
+
+    public static UriMatcher<Map<? extends String, ? extends String>> redirectQueryParameters(
+            Matcher<Map<? extends String, ? extends String>> expected) {
+        return new UriMatcher<>(
+                "uri query parameters",
+                uri -> {
+                    try {
+                        return parseQueryString(uri.getRawQuery());
+                    } catch (UnsupportedEncodingException e) {
+                        throw new RuntimeException(e);
+                    }
+                },
+                expected);
+    }
+
+    private static Map<String, String> parseQueryString(String queryString)
+            throws UnsupportedEncodingException {
+        if ((queryString == null) || (queryString.equals(""))) {
+            return Map.of();
+        }
+        String[] params = queryString.split("&");
+        return Arrays.stream(params)
+                .map(p -> p.split("=", 2))
+                .collect(
+                        Collectors.toMap(
+                                s -> URLDecoder.decode(s[0], UTF_8),
+                                s -> s.length == 1 ? null : URLDecoder.decode(s[1], UTF_8)));
+    }
+}


### PR DESCRIPTION
## What?

- Migrate the login endpoint integration test to use the new pattern
- Convert logout handler integration tests to use new pattern
- Uncomment failing assertions as these now work
- Add tests for missing scenarios
- Refactor APIGatewayProxyResponseEventMatcher to take other matchers as the `expected` argument
- Add a URI custom matcher to deal with matching redirect URI
- Refactor Logout tests to use custom matchers

## Why?

We are moving the integration tests over to a more efficient pattern

## Related PRs

#1026 
#1027 
#1031 + others