### PR TITLE
GOVSI-1105: Integration test refactor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -227,6 +227,7 @@ task oidcTerraform (type: Terraform) {
             environment "FRONTEND_API_GATEWAY_ID", json.frontend_api_gateway_root_id.value
             environment "FRONTEND_API_KEY", json.frontend_api_key.value
             environment "EVENTS_SNS_TOPIC_ARN", json.events_sns_topic_arn.value
+            environment "EMAIL_QUEUE_URL", json.email_queue.value
         }
     }
     dependsOn ":client-registry-api:buildZip"

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandler.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandler.java
@@ -46,7 +46,10 @@ public class UpdateClientConfigHandler
     }
 
     public UpdateClientConfigHandler() {
-        ConfigurationService configurationService = ConfigurationService.getInstance();
+        this(ConfigurationService.getInstance());
+    }
+
+    public UpdateClientConfigHandler(ConfigurationService configurationService) {
         this.clientService =
                 new DynamoClientService(
                         configurationService.getAwsRegion(),

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
@@ -52,7 +52,10 @@ public class ResetPasswordHandler
     }
 
     public ResetPasswordHandler() {
-        ConfigurationService configurationService = ConfigurationService.getInstance();
+        this(ConfigurationService.getInstance());
+    }
+
+    public ResetPasswordHandler(ConfigurationService configurationService) {
         this.authenticationService = new DynamoService(configurationService);
         this.sqsClient =
                 new AwsSqsClient(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
@@ -82,7 +82,11 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
     }
 
     public ResetPasswordRequestHandler() {
-        super(ResetPasswordRequest.class, ConfigurationService.getInstance());
+        this(ConfigurationService.getInstance());
+    }
+
+    public ResetPasswordRequestHandler(ConfigurationService configurationService) {
+        super(ResetPasswordRequest.class, configurationService);
         this.sqsClient =
                 new AwsSqsClient(
                         configurationService.getAwsRegion(),

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
@@ -66,7 +66,11 @@ public class SignUpHandler extends BaseFrontendHandler<SignupRequest>
     }
 
     public SignUpHandler() {
-        super(SignupRequest.class, ConfigurationService.getInstance());
+        this(ConfigurationService.getInstance());
+    }
+
+    public SignUpHandler(ConfigurationService configurationService) {
+        super(SignupRequest.class, configurationService);
         this.validationService = new ValidationService();
         this.auditService = new AuditService();
     }

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -50,6 +50,7 @@ test {
     environment "LOGIN_URI", "http://localhost:3000"
     environment "REDIS_KEY", "session"
     environment "RESET_PASSWORD_URL", "http://localhost:3000/reset-password?code="
+    environment "SQS_ENDPOINT", "http://localhost:45678"
     environment "STUB_RELYING_PARTY_REDIRECT_URI", "https://di-auth-stub-relying-party-build.london.cloudapps.digital/"
     environment "TERMS_CONDITIONS_VERSION", "1.0"
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ApiGatewayHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ApiGatewayHandlerIntegrationTest.java
@@ -54,8 +54,18 @@ public abstract class ApiGatewayHandlerIntegrationTest {
 
     protected APIGatewayProxyResponseEvent makeRequest(
             Optional<Object> body, Map<String, String> headers, Map<String, String> queryString) {
+        return makeRequest(body, headers, queryString, Map.of());
+    }
+
+    protected APIGatewayProxyResponseEvent makeRequest(
+            Optional<Object> body,
+            Map<String, String> headers,
+            Map<String, String> queryString,
+            Map<String, String> pathParams) {
         APIGatewayProxyRequestEvent request = new APIGatewayProxyRequestEvent();
-        request.withHeaders(headers).withQueryStringParameters(queryString);
+        request.withHeaders(headers)
+                .withQueryStringParameters(queryString)
+                .withPathParameters(pathParams);
         body.ifPresent(
                 o -> {
                     if (o instanceof String) {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordIntegrationTest.java
@@ -1,7 +1,6 @@
 package uk.gov.di.authentication.api;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -11,6 +10,7 @@ import uk.gov.di.authentication.frontendapi.entity.ResetPasswordWithCodeRequest;
 import uk.gov.di.authentication.frontendapi.lambda.ResetPasswordHandler;
 import uk.gov.di.authentication.helpers.DynamoHelper;
 import uk.gov.di.authentication.helpers.RedisHelper;
+import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.sharedtest.extensions.NotifyStubExtension;
 
 import java.util.HashMap;
@@ -27,11 +27,9 @@ public class ResetPasswordIntegrationTest extends ApiGatewayHandlerIntegrationTe
     private static final String PASSWORD = "Pa55word";
     private static final String CODE = "0123456789";
 
-    private static final ObjectMapper objectMapper = new ObjectMapper();
-
     @RegisterExtension
     public static final NotifyStubExtension notifyStub =
-            new NotifyStubExtension(8888, objectMapper);
+            new NotifyStubExtension(8888, ObjectMapperFactory.getInstance());
 
     @BeforeEach
     public void setUp() {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordRequestIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordRequestIntegrationTest.java
@@ -1,39 +1,38 @@
 package uk.gov.di.authentication.api;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.ws.rs.core.MultivaluedHashMap;
-import jakarta.ws.rs.core.MultivaluedMap;
-import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.authentication.frontendapi.entity.ResetPasswordRequest;
+import uk.gov.di.authentication.frontendapi.lambda.ResetPasswordRequestHandler;
 import uk.gov.di.authentication.helpers.DynamoHelper;
 import uk.gov.di.authentication.helpers.RedisHelper;
-import uk.gov.di.authentication.helpers.RequestHelper;
 import uk.gov.di.authentication.shared.entity.BaseAPIResponse;
+import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.sharedtest.extensions.NotifyStubExtension;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static uk.gov.di.authentication.shared.entity.SessionState.AUTHENTICATION_REQUIRED;
 import static uk.gov.di.authentication.shared.entity.SessionState.NEW;
 import static uk.gov.di.authentication.shared.entity.SessionState.RESET_PASSWORD_LINK_SENT;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class ResetPasswordRequestIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
-    private static final String RESET_PASSWORD_ENDPOINT = "/reset-password-request";
-
-    private static final ObjectMapper objectMapper = new ObjectMapper();
-
     @RegisterExtension
     public static final NotifyStubExtension notifyStub =
-            new NotifyStubExtension(8888, objectMapper);
+            new NotifyStubExtension(8888, ObjectMapperFactory.getInstance());
 
     @BeforeEach
     public void setUp() {
+        handler = new ResetPasswordRequestHandler(configurationService);
         notifyStub.init();
     }
 
@@ -52,24 +51,18 @@ public class ResetPasswordRequestIntegrationTest extends ApiGatewayHandlerIntegr
         String sessionId = RedisHelper.createSession();
         RedisHelper.addEmailToSession(sessionId, email);
         RedisHelper.setSessionState(sessionId, AUTHENTICATION_REQUIRED);
-        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
-        headers.add("Session-Id", sessionId);
-        headers.add("X-API-Key", FRONTEND_API_KEY);
-        Response response =
-                RequestHelper.request(
-                        FRONTEND_ROOT_RESOURCE_URL,
-                        RESET_PASSWORD_ENDPOINT,
-                        new ResetPasswordRequest(email),
-                        headers);
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Session-Id", sessionId);
+        headers.put("X-API-Key", FRONTEND_API_KEY);
 
+        var response = makeRequest(Optional.of(new ResetPasswordRequest(email)), headers, Map.of());
         notifyStub.waitForRequest(60);
 
-        assertEquals(200, response.getStatus());
+        assertThat(response, hasStatus(200));
 
-        String responseString = response.readEntity(String.class);
         BaseAPIResponse resetPasswordResponse =
-                objectMapper.readValue(responseString, BaseAPIResponse.class);
-        assertEquals(RESET_PASSWORD_LINK_SENT, resetPasswordResponse.getSessionState());
+                objectMapper.readValue(response.getBody(), BaseAPIResponse.class);
+        assertThat(resetPasswordResponse.getSessionState(), equalTo(RESET_PASSWORD_LINK_SENT));
     }
 
     @Test
@@ -82,17 +75,12 @@ public class ResetPasswordRequestIntegrationTest extends ApiGatewayHandlerIntegr
         String sessionId = RedisHelper.createSession();
         RedisHelper.addEmailToSession(sessionId, email);
         RedisHelper.setSessionState(sessionId, NEW);
-        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
-        headers.add("Session-Id", sessionId);
-        headers.add("X-API-Key", FRONTEND_API_KEY);
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Session-Id", sessionId);
+        headers.put("X-API-Key", FRONTEND_API_KEY);
 
-        Response response =
-                RequestHelper.request(
-                        FRONTEND_ROOT_RESOURCE_URL,
-                        RESET_PASSWORD_ENDPOINT,
-                        new ResetPasswordRequest(email),
-                        headers);
+        var response = makeRequest(Optional.of(new ResetPasswordRequest(email)), headers, Map.of());
 
-        assertEquals(400, response.getStatus());
+        assertThat(response, hasStatus(400));
     }
 }


### PR DESCRIPTION
## What?

- Use new test pattern for Reset Password handler integration test
- Add assertion to ensure Notify request contains correct content
- Use new test pattern for Reset Password Request handler integration test
- Remove static instance of object mapper as non-static instance inherited from base class
- Use new test pattern for Sign Up handler integration tests
- Use new test pattern for Update Client handler integration tests

## Why?

We are migrating all integration tests to more efficient pattern

## Related PRs

#1026 
#1027 
#1031 
#1037 + more