### PR TITLE
GOVSI-1105: Convert Update Profile integration tests to new pattern

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
@@ -26,7 +26,6 @@ import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
-import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.state.StateMachine;
 import uk.gov.di.authentication.shared.state.StateMachine.InvalidStateTransitionException;
@@ -55,9 +54,6 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
 
     private static final Logger LOGGER = LoggerFactory.getLogger(UpdateProfileHandler.class);
 
-    private final AuthenticationService authenticationService;
-    private final SessionService sessionService;
-    private final ConfigurationService configurationService;
     private final AuditService auditService;
     private final StateMachine<SessionState, SessionAction, UserContext> stateMachine;
 
@@ -76,22 +72,16 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
                 clientSessionService,
                 clientService,
                 authenticationService);
-        this.authenticationService = authenticationService;
-        this.sessionService = sessionService;
-        this.configurationService = configurationService;
         this.auditService = auditService;
         this.stateMachine = stateMachine;
     }
 
     public UpdateProfileHandler() {
-        super(UpdateProfileRequest.class, ConfigurationService.getInstance());
-        configurationService = ConfigurationService.getInstance();
-        this.authenticationService =
-                new DynamoService(
-                        configurationService.getAwsRegion(),
-                        configurationService.getEnvironment(),
-                        configurationService.getDynamoEndpointUri());
-        sessionService = new SessionService(configurationService);
+        this(ConfigurationService.getInstance());
+    }
+
+    public UpdateProfileHandler(ConfigurationService configurationService) {
+        super(UpdateProfileRequest.class, configurationService);
         auditService = new AuditService();
         this.stateMachine = userJourneyStateMachine();
     }

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -53,6 +53,7 @@ test {
     environment "SQS_ENDPOINT", "http://localhost:45678"
     environment "STUB_RELYING_PARTY_REDIRECT_URI", "https://di-auth-stub-relying-party-build.london.cloudapps.digital/"
     environment "TERMS_CONDITIONS_VERSION", "1.0"
+    environment "HEADERS_CASE_INSENSITIVE", "true"
 
     dependsOn ":auditTerraform"
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ApiGatewayHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ApiGatewayHandlerIntegrationTest.java
@@ -82,10 +82,18 @@ public abstract class ApiGatewayHandlerIntegrationTest {
         return handler.handleRequest(request, context);
     }
 
-    protected Map<String, String> constructHeaders(Optional<HttpCookie> cookie) {
+    protected Map<String, String> constructOidcHeaders(Optional<HttpCookie> cookie) {
         final Map<String, String> headers = new HashMap<>();
         cookie.ifPresent(c -> headers.put("Cookie", c.toString()));
         return headers;
+    }
+
+    protected Map<String, String> constructFrontendHeaders(
+            String sessionId, String clientSessionId) {
+        return Map.of(
+                "Session-Id", sessionId,
+                "Client-Session-Id", clientSessionId,
+                "X-API-Key", FRONTEND_API_KEY);
     }
 
     protected HttpCookie buildSessionCookie(String sessionID, String clientSessionID) {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
@@ -55,7 +55,7 @@ public class AuthCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var response =
                 makeRequest(
                         Optional.empty(),
-                        constructHeaders(
+                        constructOidcHeaders(
                                 Optional.of(buildSessionCookie(sessionId, clientSessionId))),
                         Map.of());
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -71,7 +71,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var response =
                 makeRequest(
                         Optional.empty(),
-                        constructHeaders(Optional.empty()),
+                        constructOidcHeaders(Optional.empty()),
                         constructQueryStringParameters(
                                 Optional.of(INVALID_CLIENT_ID),
                                 Optional.empty(),
@@ -89,7 +89,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var response =
                 makeRequest(
                         Optional.empty(),
-                        constructHeaders(Optional.empty()),
+                        constructOidcHeaders(Optional.empty()),
                         constructQueryStringParameters(
                                 Optional.of(CLIENT_ID),
                                 Optional.empty(),
@@ -110,7 +110,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var response =
                 makeRequest(
                         Optional.empty(),
-                        constructHeaders(Optional.empty()),
+                        constructOidcHeaders(Optional.empty()),
                         constructQueryStringParameters(
                                 Optional.of(AM_CLIENT_ID),
                                 Optional.empty(),
@@ -131,7 +131,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var response =
                 makeRequest(
                         Optional.empty(),
-                        constructHeaders(Optional.empty()),
+                        constructOidcHeaders(Optional.empty()),
                         constructQueryStringParameters(
                                 Optional.of(CLIENT_ID),
                                 Optional.empty(),
@@ -149,7 +149,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var response =
                 makeRequest(
                         Optional.empty(),
-                        constructHeaders(Optional.of(new HttpCookie("gs", "this is bad"))),
+                        constructOidcHeaders(Optional.of(new HttpCookie("gs", "this is bad"))),
                         constructQueryStringParameters(
                                 Optional.of(CLIENT_ID),
                                 Optional.empty(),
@@ -169,7 +169,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var response =
                 makeRequest(
                         Optional.empty(),
-                        constructHeaders(
+                        constructOidcHeaders(
                                 Optional.of(buildSessionCookie("123", DUMMY_CLIENT_SESSION_ID))),
                         constructQueryStringParameters(
                                 Optional.of(CLIENT_ID),
@@ -194,7 +194,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var response =
                 makeRequest(
                         Optional.empty(),
-                        constructHeaders(
+                        constructOidcHeaders(
                                 Optional.of(
                                         buildSessionCookie(sessionId, DUMMY_CLIENT_SESSION_ID))),
                         constructQueryStringParameters(
@@ -221,7 +221,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var response =
                 makeRequest(
                         Optional.empty(),
-                        constructHeaders(
+                        constructOidcHeaders(
                                 Optional.of(
                                         buildSessionCookie(sessionId, DUMMY_CLIENT_SESSION_ID))),
                         constructQueryStringParameters(
@@ -242,7 +242,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var response =
                 makeRequest(
                         Optional.empty(),
-                        constructHeaders(Optional.empty()),
+                        constructOidcHeaders(Optional.empty()),
                         constructQueryStringParameters(
                                 Optional.of(CLIENT_ID),
                                 Optional.of(NONE.toString()),
@@ -263,7 +263,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var response =
                 makeRequest(
                         Optional.empty(),
-                        constructHeaders(
+                        constructOidcHeaders(
                                 Optional.of(
                                         buildSessionCookie(sessionId, DUMMY_CLIENT_SESSION_ID))),
                         constructQueryStringParameters(
@@ -290,7 +290,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var response =
                 makeRequest(
                         Optional.empty(),
-                        constructHeaders(
+                        constructOidcHeaders(
                                 Optional.of(
                                         buildSessionCookie(sessionId, DUMMY_CLIENT_SESSION_ID))),
                         constructQueryStringParameters(
@@ -320,7 +320,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var response =
                 makeRequest(
                         Optional.empty(),
-                        constructHeaders(
+                        constructOidcHeaders(
                                 Optional.of(
                                         buildSessionCookie(sessionId, DUMMY_CLIENT_SESSION_ID))),
                         constructQueryStringParameters(
@@ -352,7 +352,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var response =
                 makeRequest(
                         Optional.empty(),
-                        constructHeaders(
+                        constructOidcHeaders(
                                 Optional.of(
                                         buildSessionCookie(sessionId, DUMMY_CLIENT_SESSION_ID))),
                         constructQueryStringParameters(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
@@ -59,7 +59,7 @@ public class LogoutIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var response =
                 makeRequest(
                         Optional.empty(),
-                        constructHeaders(
+                        constructOidcHeaders(
                                 Optional.of(buildSessionCookie(SESSION_ID, CLIENT_SESSION_ID))),
                         Map.of(
                                 "id_token_hint",
@@ -85,7 +85,7 @@ public class LogoutIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var response =
                 makeRequest(
                         Optional.empty(),
-                        constructHeaders(
+                        constructOidcHeaders(
                                 Optional.of(buildSessionCookie(SESSION_ID, CLIENT_SESSION_ID))),
                         Map.of("id_token_hint", signedJWT.serialize(), "state", STATE));
 
@@ -105,7 +105,7 @@ public class LogoutIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var response =
                 makeRequest(
                         Optional.empty(),
-                        constructHeaders(
+                        constructOidcHeaders(
                                 Optional.of(buildSessionCookie(SESSION_ID, CLIENT_SESSION_ID))),
                         Map.of(
                                 "id_token_hint",


### PR DESCRIPTION
## What?

- Use new test pattern for Update Profile handler integration tests
- Add new base `constructFrontendHeaders` method to build common headers (need to retrofit this to other tests)
- Rename original `constructHeaders` method to `constructOidcHeaders` reflecting its use with OIDC API

## Why?

We're converting the pattern for all integration tests

## Related PRs

#1026 
#1027 
#1031 
#1037 and more