### PR TITLE
GOVSI-1105: Convert User Exists integration tests to new pattern

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -63,7 +63,11 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
     }
 
     public CheckUserExistsHandler() {
-        super(CheckUserExistsRequest.class, ConfigurationService.getInstance());
+        this(ConfigurationService.getInstance());
+    }
+
+    public CheckUserExistsHandler(ConfigurationService configurationService) {
+        super(CheckUserExistsRequest.class, configurationService);
         this.validationService = new ValidationService();
         this.auditService = new AuditService();
     }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ApiGatewayHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ApiGatewayHandlerIntegrationTest.java
@@ -88,6 +88,24 @@ public abstract class ApiGatewayHandlerIntegrationTest {
         return headers;
     }
 
+    protected Map<String, String> constructFrontendHeaders(String sessionId) {
+        return constructFrontendHeaders(sessionId, Optional.empty());
+    }
+
+    protected Map<String, String> constructFrontendHeaders(
+            String sessionId, String clientSessionId) {
+        return constructFrontendHeaders(sessionId, Optional.of(clientSessionId));
+    }
+
+    protected Map<String, String> constructFrontendHeaders(
+            String sessionId, Optional<String> clientSessionId) {
+        var headers = new HashMap<String, String>();
+        headers.put("Session-Id", sessionId);
+        headers.put("X-API-Key", FRONTEND_API_KEY);
+        clientSessionId.ifPresent(id -> headers.put("Client-Session-Id", id));
+        return headers;
+    }
+
     protected HttpCookie buildSessionCookie(String sessionID, String clientSessionID) {
         return new HttpCookie("gs", sessionID + "." + clientSessionID);
     }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserExistsIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserExistsIntegrationTest.java
@@ -1,30 +1,33 @@
 package uk.gov.di.authentication.api;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.ws.rs.core.MultivaluedHashMap;
-import jakarta.ws.rs.core.MultivaluedMap;
-import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.frontendapi.entity.BaseFrontendRequest;
 import uk.gov.di.authentication.frontendapi.entity.CheckUserExistsRequest;
 import uk.gov.di.authentication.frontendapi.entity.CheckUserExistsResponse;
+import uk.gov.di.authentication.frontendapi.lambda.CheckUserExistsHandler;
 import uk.gov.di.authentication.helpers.DynamoHelper;
 import uk.gov.di.authentication.helpers.RedisHelper;
-import uk.gov.di.authentication.helpers.RequestHelper;
 import uk.gov.di.authentication.shared.entity.SessionState;
 
 import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.authentication.shared.entity.SessionState.AUTHENTICATION_REQUIRED;
 import static uk.gov.di.authentication.shared.entity.SessionState.USER_NOT_FOUND;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class UserExistsIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
-    private static final String USEREXISTS_ENDPOINT = "/user-exists";
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    @BeforeEach
+    void setup() {
+        handler = new CheckUserExistsHandler(configurationService);
+    }
 
     @Test
     public void shouldCallUserExistsEndpointAndReturnAuthenticationRequestStateWhenUserExists()
@@ -34,21 +37,16 @@ public class UserExistsIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         DynamoHelper.signUp(emailAddress, "password-1");
         RedisHelper.setSessionState(sessionId, SessionState.NEW);
 
-        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
-        headers.add("Session-Id", sessionId);
-        headers.add("X-API-Key", FRONTEND_API_KEY);
-        BaseFrontendRequest request = new CheckUserExistsRequest(emailAddress);
+        CheckUserExistsRequest request = new CheckUserExistsRequest(emailAddress);
 
-        Response response =
-                RequestHelper.request(
-                        FRONTEND_ROOT_RESOURCE_URL, USEREXISTS_ENDPOINT, request, headers);
+        var response =
+                makeRequest(Optional.of(request), constructFrontendHeaders(sessionId), Map.of());
 
-        assertEquals(200, response.getStatus());
-        String responseString = response.readEntity(String.class);
+        assertThat(response, hasStatus(200));
         CheckUserExistsResponse checkUserExistsResponse =
-                objectMapper.readValue(responseString, CheckUserExistsResponse.class);
-        assertEquals(request.getEmail(), checkUserExistsResponse.getEmail());
-        assertEquals(AUTHENTICATION_REQUIRED, checkUserExistsResponse.getSessionState());
+                objectMapper.readValue(response.getBody(), CheckUserExistsResponse.class);
+        assertThat(checkUserExistsResponse.getEmail(), equalTo(emailAddress));
+        assertThat(checkUserExistsResponse.getSessionState(), equalTo(AUTHENTICATION_REQUIRED));
         assertTrue(checkUserExistsResponse.doesUserExist());
     }
 
@@ -57,21 +55,18 @@ public class UserExistsIntegrationTest extends ApiGatewayHandlerIntegrationTest 
             throws IOException {
         String emailAddress = "joe.bloggs+2@digital.cabinet-office.gov.uk";
         String sessionId = RedisHelper.createSession();
-        MultivaluedMap<String, Object> headers = new MultivaluedHashMap<>();
-        headers.add("Session-Id", sessionId);
-        headers.add("X-API-Key", FRONTEND_API_KEY);
         RedisHelper.setSessionState(sessionId, SessionState.NEW);
         BaseFrontendRequest request = new CheckUserExistsRequest(emailAddress);
-        Response response =
-                RequestHelper.request(
-                        FRONTEND_ROOT_RESOURCE_URL, USEREXISTS_ENDPOINT, request, headers);
 
-        assertEquals(200, response.getStatus());
-        String responseString = response.readEntity(String.class);
+        var response =
+                makeRequest(Optional.of(request), constructFrontendHeaders(sessionId), Map.of());
+
+        assertThat(response, hasStatus(200));
+
         CheckUserExistsResponse checkUserExistsResponse =
-                objectMapper.readValue(responseString, CheckUserExistsResponse.class);
-        assertEquals(request.getEmail(), checkUserExistsResponse.getEmail());
-        assertEquals(USER_NOT_FOUND, checkUserExistsResponse.getSessionState());
+                objectMapper.readValue(response.getBody(), CheckUserExistsResponse.class);
+        assertThat(checkUserExistsResponse.getEmail(), equalTo(emailAddress));
+        assertThat(checkUserExistsResponse.getSessionState(), equalTo(USER_NOT_FOUND));
         assertFalse(checkUserExistsResponse.doesUserExist());
     }
 }


### PR DESCRIPTION
## What?

- Use new test pattern for Check User Exists handler integration tests
- Add variants of `constructFrontendHeaders` base method to cater for tests with a clientSessionId

## Why?

We're converting all integration tests to a new pattern
