### PR TITLE
GOVSI-1100 - Validate new password against existing password

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandler.java
@@ -79,6 +79,19 @@ public class UpdatePasswordHandler
                                         new Subject(userProfile.getPublicSubjectID()),
                                         authorizerParams);
 
+                                String currentPassword =
+                                        dynamoService
+                                                .getUserCredentialsFromEmail(
+                                                        updatePasswordRequest.getEmail())
+                                                .getPassword();
+
+                                if (updatePasswordRequest
+                                        .getNewPassword()
+                                        .equals(currentPassword)) {
+                                    return generateApiGatewayProxyErrorResponse(
+                                            400, ErrorResponse.ERROR_1024);
+                                }
+
                                 dynamoService.updatePassword(
                                         updatePasswordRequest.getEmail(),
                                         updatePasswordRequest.getNewPassword());

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
@@ -97,11 +97,17 @@ public class ResetPasswordHandler
                                     return generateApiGatewayProxyErrorResponse(
                                             400, ErrorResponse.ERROR_1021);
                                 }
-                                codeStorageService.deleteSubjectWithPasswordResetCode(
-                                        resetPasswordWithCodeRequest.getCode());
                                 UserCredentials userCredentials =
                                         authenticationService.getUserCredentialsFromSubject(
                                                 subject.get());
+                                if (userCredentials
+                                        .getPassword()
+                                        .equals(resetPasswordWithCodeRequest.getPassword())) {
+                                    return generateApiGatewayProxyErrorResponse(
+                                            400, ErrorResponse.ERROR_1024);
+                                }
+                                codeStorageService.deleteSubjectWithPasswordResetCode(
+                                        resetPasswordWithCodeRequest.getCode());
                                 authenticationService.updatePassword(
                                         userCredentials.getEmail(),
                                         resetPasswordWithCodeRequest.getPassword());

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
@@ -28,7 +28,8 @@ public enum ErrorResponse {
     ERROR_1020(1020, "Invalid OTP code"),
     ERROR_1021(1021, "Invalid Password reset code"),
     ERROR_1022(1022, "User has requested too many password resets"),
-    ERROR_1023(1023, "User cannot request another password reset");
+    ERROR_1023(1023, "User cannot request another password reset"),
+    ERROR_1024(1024, "New password cannot be the same as current password");
 
     @JsonProperty("code")
     private int code;


### PR DESCRIPTION
## What?

- When a user tries to either reset or change their password using their existing password then we should not allow that and return an error to the frontend. The frontend will look for this error and display an appropriate error message to the user.

## Why?

- Because a user shouldn't be able to change their password to their existing password.