### PR TITLE
GOVSI-1105: Add docker log test output

### DIFF
--- a/.github/workflows/pre-merge-checks-am.yml
+++ b/.github/workflows/pre-merge-checks-am.yml
@@ -85,11 +85,14 @@ jobs:
           name: account-management-integration-test-reports
           path: account-management-integration-tests/build/reports/tests/test/
           retention-days: 5
+      - name: Extract Cloudwatch logs
+        if: failure()
+        run: ./get-lambda-logs.sh
       - name: Upload Docker Container Logs
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: docker-container-logs
+          name: account-management-docker-container-logs
           path: logs/
           retention-days: 5
       - name: Stop Services

--- a/.github/workflows/pre-merge-checks-am.yml
+++ b/.github/workflows/pre-merge-checks-am.yml
@@ -85,6 +85,13 @@ jobs:
           name: account-management-integration-test-reports
           path: account-management-integration-tests/build/reports/tests/test/
           retention-days: 5
+      - name: Upload Docker Container Logs
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: docker-container-logs
+          path: logs/
+          retention-days: 5
       - name: Stop Services
         if: always()
         run: |

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -85,6 +85,13 @@ jobs:
           name: integration-test-reports
           path: integration-tests/build/reports/tests/test/
           retention-days: 5
+      - name: Upload Docker Container Logs
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: docker-container-logs
+          path: logs/
+          retention-days: 5
       - name: Stop Services
         if: always()
         run: |

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -85,6 +85,9 @@ jobs:
           name: integration-test-reports
           path: integration-tests/build/reports/tests/test/
           retention-days: 5
+      - name: Extract Cloudwatch logs
+        if: failure()
+        run: ./get-lambda-logs.sh
       - name: Upload Docker Container Logs
         uses: actions/upload-artifact@v2
         if: failure()

--- a/get-lambda-logs.sh
+++ b/get-lambda-logs.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -eu
+
+pushd logs
+
+LOG_GROUPS=$(docker-compose exec -T aws awslocal logs describe-log-groups)
+for LOG_GROUP in $(echo -n "${LOG_GROUPS}" | jq -rc '.logGroups[].logGroupName'); do
+  echo "Getting log group ${LOG_GROUP}..."
+  mkdir -p ".${LOG_GROUP}"
+    STREAMS=$(docker-compose exec -T aws awslocal logs describe-log-streams --log-group-name "${LOG_GROUP}")
+    for LOG_STREAM in $(echo -n "${STREAMS}" | jq -rc '.logStreams[].logStreamName'); do
+      echo "Downloading stream ${LOG_STREAM}..."
+      FILENAME=$(echo -n "${LOG_STREAM}" | tr /\[\] -)
+
+      docker-compose exec -T aws awslocal logs get-log-events --log-group-name "${LOG_GROUP}" --log-stream-name "${LOG_STREAM}" --output text > ".${LOG_GROUP}/${FILENAME}.log"
+    done
+done
+popd


### PR DESCRIPTION
## What?

- Upload the `logs` directory on integration failure (similar to how we upload to test reports), this is useful for debugging- 
- Use the AWS CLI to extract and download the cloudwatch log groups from localstack. The same information is available in the docker console log, but when downloaded into separate files.

## Why?

Very useful when debugging.
