### PR TITLE
GOVSI-1100 - Compare the new password using the Argon2 verify method

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandler.java
@@ -16,6 +16,7 @@ import uk.gov.di.accountmanagement.entity.UpdatePasswordRequest;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.helpers.Argon2MatcherHelper;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.RequestBodyHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
@@ -85,9 +86,9 @@ public class UpdatePasswordHandler
                                                         updatePasswordRequest.getEmail())
                                                 .getPassword();
 
-                                if (updatePasswordRequest
-                                        .getNewPassword()
-                                        .equals(currentPassword)) {
+                                if (verifyPassword(
+                                        currentPassword, updatePasswordRequest.getNewPassword())) {
+                                    LOGGER.info("New password is the same as the old password");
                                     return generateApiGatewayProxyErrorResponse(
                                             400, ErrorResponse.ERROR_1024);
                                 }
@@ -125,5 +126,9 @@ public class UpdatePasswordHandler
                                         400, ErrorResponse.ERROR_1001);
                             }
                         });
+    }
+
+    private static boolean verifyPassword(String hashedPassword, String password) {
+        return Argon2MatcherHelper.matchRawStringWithEncoded(password, hashedPassword);
     }
 }

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandlerTest.java
@@ -15,6 +15,7 @@ import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.helpers.Argon2EncoderHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 
@@ -113,7 +114,8 @@ class UpdatePasswordHandlerTest {
     public void shouldReturn400WhenNewPasswordEqualsExistingPassword()
             throws JsonProcessingException {
         UserProfile userProfile = new UserProfile().setPublicSubjectID(SUBJECT.getValue());
-        UserCredentials userCredentials = new UserCredentials().setPassword(NEW_PASSWORD);
+        UserCredentials userCredentials =
+                new UserCredentials().setPassword(Argon2EncoderHelper.argon2Hash(NEW_PASSWORD));
         when(dynamoService.getUserProfileByEmail(EXISTING_EMAIL_ADDRESS)).thenReturn(userProfile);
         when(dynamoService.getUserCredentialsFromEmail(EXISTING_EMAIL_ADDRESS))
                 .thenReturn(userCredentials);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
@@ -15,6 +15,7 @@ import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.NotifyRequest;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
+import uk.gov.di.authentication.shared.helpers.Argon2MatcherHelper;
 import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
@@ -100,9 +101,10 @@ public class ResetPasswordHandler
                                 UserCredentials userCredentials =
                                         authenticationService.getUserCredentialsFromSubject(
                                                 subject.get());
-                                if (userCredentials
-                                        .getPassword()
-                                        .equals(resetPasswordWithCodeRequest.getPassword())) {
+                                if (verifyPassword(
+                                        userCredentials.getPassword(),
+                                        resetPasswordWithCodeRequest.getPassword())) {
+                                    LOGGER.info("New password is the same as the old password");
                                     return generateApiGatewayProxyErrorResponse(
                                             400, ErrorResponse.ERROR_1024);
                                 }
@@ -138,5 +140,9 @@ public class ResetPasswordHandler
 
     private String serialiseRequest(Object request) throws JsonProcessingException {
         return objectMapper.writeValueAsString(request);
+    }
+
+    private static boolean verifyPassword(String hashedPassword, String password) {
+        return Argon2MatcherHelper.matchRawStringWithEncoded(password, hashedPassword);
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandlerTest.java
@@ -12,6 +12,7 @@ import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.NotifyRequest;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
+import uk.gov.di.authentication.shared.helpers.Argon2EncoderHelper;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ValidationService;
@@ -96,7 +97,7 @@ class ResetPasswordHandlerTest {
         when(codeStorageService.getSubjectWithPasswordResetCode(CODE))
                 .thenReturn(Optional.of(SUBJECT));
         when(authenticationService.getUserCredentialsFromSubject(SUBJECT))
-                .thenReturn(generateUserCredentials(NEW_PASSWORD));
+                .thenReturn(generateUserCredentials(Argon2EncoderHelper.argon2Hash(NEW_PASSWORD)));
         NotifyRequest notifyRequest =
                 new NotifyRequest(EMAIL, NotificationType.PASSWORD_RESET_CONFIRMATION);
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();


### PR DESCRIPTION
## What?

 - Compare the new password using the Argon2 verify method
- Add logging

## Why?

- We were previously comparing the hashpassword against the plain text password which will not work. Use the Argon2 verify method to check if the new password is the same as the old one.