### PR TITLE
GOVSI-951 - Set up Cloudwatch alarms for WAF Blocked requests

### DIFF
--- a/ci/terraform/account-management/alerts.tf
+++ b/ci/terraform/account-management/alerts.tf
@@ -16,6 +16,27 @@ resource "aws_cloudwatch_metric_alarm" "sqs_deadletter_cloudwatch_alarm" {
   alarm_actions     = [data.aws_sns_topic.slack_events.arn]
 }
 
+resource "aws_cloudwatch_metric_alarm" "waf_am_blocked_request_cloudwatch_alarm" {
+  count               = var.use_localstack ? 0 : 1
+  alarm_name          = replace("${var.environment}-account-management-waf-blocked-requests-alarm", ".", "")
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "BlockedRequests"
+  namespace           = "AWS/WAFV2"
+  period              = "3600"
+  statistic           = "Sum"
+  threshold           = var.waf_alarm_blocked_reqeuest_threshold
+
+  dimensions = {
+    Rule   = "ALL"
+    Region = var.aws_region
+    WebACL = aws_wafv2_web_acl.wafregional_web_acl_am_api[count.index].name
+  }
+
+  alarm_description = "${var.waf_alarm_blocked_reqeuest_threshold} or more blocked requests have been received by the ${aws_wafv2_web_acl.wafregional_web_acl_am_api[count.index].name} in the last hour"
+  alarm_actions     = [data.aws_sns_topic.slack_events.arn]
+}
+
 data "aws_sns_topic" "slack_events" {
   name = "${var.environment}-slack-events"
 }

--- a/ci/terraform/account-management/api-gateway.tf
+++ b/ci/terraform/account-management/api-gateway.tf
@@ -303,7 +303,7 @@ resource "aws_wafv2_web_acl" "wafregional_web_acl_am_api" {
     visibility_config {
       cloudwatch_metrics_enabled = true
       metric_name                = "${replace(var.environment, "-", "")}AMWafMaxRequestRate"
-      sampled_requests_enabled   = false
+      sampled_requests_enabled   = true
     }
   }
 
@@ -324,7 +324,7 @@ resource "aws_wafv2_web_acl" "wafregional_web_acl_am_api" {
     visibility_config {
       cloudwatch_metrics_enabled = true
       metric_name                = "${replace(var.environment, "-", "")}AMWafCommonRuleSet"
-      sampled_requests_enabled   = false
+      sampled_requests_enabled   = true
     }
   }
 
@@ -345,14 +345,14 @@ resource "aws_wafv2_web_acl" "wafregional_web_acl_am_api" {
     visibility_config {
       cloudwatch_metrics_enabled = true
       metric_name                = "${replace(var.environment, "-", "")}AmWafBaduleSet"
-      sampled_requests_enabled   = false
+      sampled_requests_enabled   = true
     }
   }
 
   visibility_config {
     cloudwatch_metrics_enabled = true
     metric_name                = "${replace(var.environment, "-", "")}AMWafRules"
-    sampled_requests_enabled   = false
+    sampled_requests_enabled   = true
   }
 }
 

--- a/ci/terraform/account-management/variables.tf
+++ b/ci/terraform/account-management/variables.tf
@@ -146,6 +146,12 @@ variable "dlq_alarm_threshold" {
   description = "The number of messages on a DLQ before a Cloudwatch alarm is generated"
 }
 
+variable "waf_alarm_blocked_reqeuest_threshold" {
+  default     = 20
+  type        = number
+  description = "The number of blocked requests caught by the WAF before a Cloudwatch alarm is generated"
+}
+
 variable "lambda_min_concurrency" {
   default     = 10
   type        = number

--- a/ci/terraform/oidc/alerts.tf
+++ b/ci/terraform/oidc/alerts.tf
@@ -16,6 +16,50 @@ resource "aws_cloudwatch_metric_alarm" "sqs_deadletter_cloudwatch_alarm" {
   alarm_actions     = [data.aws_sns_topic.slack_events.arn]
 }
 
+
+
+resource "aws_cloudwatch_metric_alarm" "waf_oidc_blocked_request_cloudwatch_alarm" {
+  count               = var.use_localstack ? 0 : 1
+  alarm_name          = replace("${var.environment}-oidc-waf-blocked-requests-alarm", ".", "")
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "BlockedRequests"
+  namespace           = "AWS/WAFV2"
+  period              = "3600"
+  statistic           = "Sum"
+  threshold           = var.waf_alarm_blocked_reqeuest_threshold
+
+  dimensions = {
+    Rule   = "ALL"
+    Region = var.aws_region
+    WebACL = aws_wafv2_web_acl.wafregional_web_acl_oidc_api[count.index].name
+  }
+
+  alarm_description = "${var.waf_alarm_blocked_reqeuest_threshold} or more blocked requests have been received by the ${aws_wafv2_web_acl.wafregional_web_acl_oidc_api[count.index].name} in the last hour"
+  alarm_actions     = [data.aws_sns_topic.slack_events.arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "waf_frontend_blocked_request_cloudwatch_alarm" {
+  count               = var.use_localstack ? 0 : 1
+  alarm_name          = replace("${var.environment}-frontend-waf-blocked-requests-alarm", ".", "")
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "BlockedRequests"
+  namespace           = "AWS/WAFV2"
+  period              = "3600"
+  statistic           = "Sum"
+  threshold           = var.waf_alarm_blocked_reqeuest_threshold
+
+  dimensions = {
+    Rule   = "ALL"
+    Region = var.aws_region
+    WebACL = aws_wafv2_web_acl.wafregional_web_acl_frontend_api[count.index].name
+  }
+
+  alarm_description = "${var.waf_alarm_blocked_reqeuest_threshold} or more blocked requests have been received by the ${aws_wafv2_web_acl.wafregional_web_acl_frontend_api[count.index].name} in the last hour"
+  alarm_actions     = [data.aws_sns_topic.slack_events.arn]
+}
+
 data "aws_sns_topic" "slack_events" {
   name = "${var.environment}-slack-events"
 }

--- a/ci/terraform/oidc/api-gateway.tf
+++ b/ci/terraform/oidc/api-gateway.tf
@@ -280,7 +280,7 @@ resource "aws_wafv2_web_acl" "wafregional_web_acl_oidc_api" {
     visibility_config {
       cloudwatch_metrics_enabled = true
       metric_name                = "${replace(var.environment, "-", "")}OidcWafMaxRequestRate"
-      sampled_requests_enabled   = false
+      sampled_requests_enabled   = true
     }
   }
 
@@ -308,7 +308,7 @@ resource "aws_wafv2_web_acl" "wafregional_web_acl_oidc_api" {
     visibility_config {
       cloudwatch_metrics_enabled = true
       metric_name                = "${replace(var.environment, "-", "")}OidcWafCommonRuleSet"
-      sampled_requests_enabled   = false
+      sampled_requests_enabled   = true
     }
   }
 
@@ -329,14 +329,14 @@ resource "aws_wafv2_web_acl" "wafregional_web_acl_oidc_api" {
     visibility_config {
       cloudwatch_metrics_enabled = true
       metric_name                = "${replace(var.environment, "-", "")}OidcWafBaduleSet"
-      sampled_requests_enabled   = false
+      sampled_requests_enabled   = true
     }
   }
 
   visibility_config {
     cloudwatch_metrics_enabled = true
     metric_name                = "${replace(var.environment, "-", "")}OidcWafRules"
-    sampled_requests_enabled   = false
+    sampled_requests_enabled   = true
   }
 }
 

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -177,6 +177,12 @@ variable "dlq_alarm_threshold" {
   description = "The number of messages on a DLQ before a Cloudwatch alarm is generated"
 }
 
+variable "waf_alarm_blocked_reqeuest_threshold" {
+  default     = 20
+  type        = number
+  description = "The number of blocked requests caught by the WAF before a Cloudwatch alarm is generated"
+}
+
 variable "test_client_verify_email_otp" {
   type = string
 }


### PR DESCRIPTION
## What?

- Set up a Cloudwatch alarm for each WAF which will alert when there's has been 20 or more blocked requests in a single hour. This is on a per WAF basis. When a CloudWatch alarm has been triggered, it will use the SNS topic that already exists. The messages on this SNS topic will be picked up by the alerting lambda which will post a message to slack. This uses the same method as we have in other places.
- Set sampled_requests_enabled to true. By setting this to true it will allow us to store a sampling of the web requests that match the rules. These can viewed by the AWS WAF Console. This is particularly useful to help analyse the cause of the blocked requests.

## Why?
- On each of the APIs (OIDC, Frontend and Account management) we have a WAF sitting in front to block requests which meet certain criteria. When we receive a certain amount of blocked requests we want to be alerts in case anything malicious is happening.
- By setting the sampled_requests_enabled to true it will allow us to store a sampling of the web requests that match the rules. These can viewed by the AWS WAF Console. This is particularly useful to help analyse the cause of the blocked requests.
