### PR TITLE
GOVSI-1144: Attach session id to all loglines

### DIFF
--- a/account-management-api/src/main/resources/log4j2.xml
+++ b/account-management-api/src/main/resources/log4j2.xml
@@ -1,7 +1,9 @@
 <Configuration status="WARN">
     <Appenders>
         <Lambda name="Lambda">
-            <JsonLayout compact="true" eventEol="true" objectMessageAsJsonObject="true" />
+            <JsonLayout compact="true" eventEol="true" objectMessageAsJsonObject="true" >
+                <KeyValuePair key="session-id" value="$${ctx:sessionId:-unknown}"/>
+            </JsonLayout>
         </Lambda>
     </Appenders>
     <Loggers>

--- a/account-migrations/src/main/resources/log4j2.xml
+++ b/account-migrations/src/main/resources/log4j2.xml
@@ -1,7 +1,9 @@
 <Configuration status="WARN">
     <Appenders>
         <Lambda name="Lambda">
-            <JsonLayout compact="true" eventEol="true" objectMessageAsJsonObject="true" />
+            <JsonLayout compact="true" eventEol="true" objectMessageAsJsonObject="true" >
+                <KeyValuePair key="session-id" value="$${ctx:sessionId:-unknown}"/>
+            </JsonLayout>
         </Lambda>
     </Appenders>
     <Loggers>

--- a/audit-processors/src/main/resources/log4j2.xml
+++ b/audit-processors/src/main/resources/log4j2.xml
@@ -1,7 +1,9 @@
 <Configuration status="WARN">
     <Appenders>
         <Lambda name="Lambda">
-            <JsonLayout compact="true" eventEol="true" objectMessageAsJsonObject="true" />
+            <JsonLayout compact="true" eventEol="true" objectMessageAsJsonObject="true" >
+                <KeyValuePair key="session-id" value="$${ctx:sessionId:-unknown}"/>
+            </JsonLayout>
         </Lambda>
     </Appenders>
     <Loggers>

--- a/client-registry-api/src/main/resources/log4j2.xml
+++ b/client-registry-api/src/main/resources/log4j2.xml
@@ -1,7 +1,9 @@
 <Configuration status="WARN">
     <Appenders>
         <Lambda name="Lambda">
-            <JsonLayout compact="true" eventEol="true" objectMessageAsJsonObject="true" />
+            <JsonLayout compact="true" eventEol="true" objectMessageAsJsonObject="true" >
+                <KeyValuePair key="session-id" value="$${ctx:sessionId:-unknown}"/>
+            </JsonLayout>
         </Lambda>
     </Appenders>
     <Loggers>

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/BaseFrontendHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/BaseFrontendHandler.java
@@ -27,6 +27,7 @@ import java.util.Locale;
 import java.util.Optional;
 
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachSessionIdToLogs;
 import static uk.gov.di.authentication.shared.helpers.WarmerHelper.isWarming;
 
 public abstract class BaseFrontendHandler<T>
@@ -99,6 +100,8 @@ public abstract class BaseFrontendHandler<T>
         if (session.isEmpty()) {
             LOG.error("Session cannot be found");
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1000);
+        } else {
+            attachSessionIdToLogs(session.get());
         }
         final T request;
         try {

--- a/frontend-api/src/main/resources/log4j2.xml
+++ b/frontend-api/src/main/resources/log4j2.xml
@@ -1,7 +1,9 @@
 <Configuration status="WARN">
     <Appenders>
         <Lambda name="Lambda">
-            <JsonLayout compact="true" eventEol="true" objectMessageAsJsonObject="true" />
+            <JsonLayout compact="true" eventEol="true" objectMessageAsJsonObject="true" >
+                <KeyValuePair key="session-id" value="$${ctx:sessionId:-unknown}"/>
+            </JsonLayout>
         </Lambda>
     </Appenders>
     <Loggers>

--- a/lambda-warmer/src/main/resources/log4j2.xml
+++ b/lambda-warmer/src/main/resources/log4j2.xml
@@ -1,7 +1,9 @@
 <Configuration status="WARN">
     <Appenders>
         <Lambda name="Lambda">
-            <JsonLayout compact="true" eventEol="true" objectMessageAsJsonObject="true" />
+            <JsonLayout compact="true" eventEol="true" objectMessageAsJsonObject="true" >
+                <KeyValuePair key="session-id" value="$${ctx:sessionId:-unknown}"/>
+            </JsonLayout>
         </Lambda>
     </Appenders>
     <Loggers>

--- a/lambda-warmer/src/test/resources/log4j2.xml
+++ b/lambda-warmer/src/test/resources/log4j2.xml
@@ -1,7 +1,9 @@
 <Configuration status="WARN">
     <Appenders>
         <Lambda name="Lambda">
-            <JsonLayout compact="true" eventEol="true" objectMessageAsJsonObject="true" />
+            <JsonLayout compact="true" eventEol="true" objectMessageAsJsonObject="true" >
+                <KeyValuePair key="session-id" value="$${ctx:sessionId:-unknown}"/>
+            </JsonLayout>
         </Lambda>
     </Appenders>
     <Loggers>

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -46,6 +46,7 @@ import static uk.gov.di.authentication.oidc.entity.RequestParameters.COOKIE_CONS
 import static uk.gov.di.authentication.oidc.entity.RequestParameters.GA;
 import static uk.gov.di.authentication.shared.entity.SessionAction.SYSTEM_HAS_ISSUED_AUTHORIZATION_CODE;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachSessionIdToLogs;
 import static uk.gov.di.authentication.shared.helpers.WarmerHelper.isWarming;
 import static uk.gov.di.authentication.shared.state.StateMachine.userJourneyStateMachine;
 
@@ -117,6 +118,8 @@ public class AuthCodeHandler
                                 return generateApiGatewayProxyErrorResponse(
                                         400, ErrorResponse.ERROR_1000);
                             }
+
+                            attachSessionIdToLogs(session);
 
                             LOGGER.info(
                                     "AuthCodeHandler processing request for session: {}",

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -46,6 +46,7 @@ import static uk.gov.di.authentication.oidc.entity.RequestParameters.GA;
 import static uk.gov.di.authentication.shared.entity.SessionAction.USER_HAS_STARTED_A_NEW_JOURNEY;
 import static uk.gov.di.authentication.shared.entity.SessionAction.USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED;
 import static uk.gov.di.authentication.shared.entity.SessionState.INTERRUPT_STATES;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachSessionIdToLogs;
 import static uk.gov.di.authentication.shared.helpers.WarmerHelper.isWarming;
 import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
 import static uk.gov.di.authentication.shared.state.StateMachine.userJourneyStateMachine;
@@ -184,6 +185,8 @@ public class AuthorisationHandler
         }
 
         var session = existingSession.orElseGet(sessionService::createSession);
+
+        attachSessionIdToLogs(session);
 
         auditService.submitAuditEvent(
                 OidcAuditableEvent.AUTHORISATION_INITIATED,

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachSessionIdToLogs;
 import static uk.gov.di.authentication.shared.helpers.WarmerHelper.isWarming;
 
 public class LogoutHandler
@@ -99,6 +100,8 @@ public class LogoutHandler
 
     private APIGatewayProxyResponseEvent processLogoutRequest(
             Session session, APIGatewayProxyRequestEvent input, Optional<String> state) {
+
+        attachSessionIdToLogs(session);
 
         CookieHelper.SessionCookieIds sessionCookieIds =
                 CookieHelper.parseSessionCookie(input.getHeaders()).get();

--- a/oidc-api/src/main/resources/log4j2.xml
+++ b/oidc-api/src/main/resources/log4j2.xml
@@ -1,7 +1,9 @@
 <Configuration status="WARN">
     <Appenders>
         <Lambda name="Lambda">
-            <JsonLayout compact="true" eventEol="true" objectMessageAsJsonObject="true" />
+            <JsonLayout compact="true" eventEol="true" objectMessageAsJsonObject="true" >
+                <KeyValuePair key="session-id" value="$${ctx:sessionId:-unknown}"/>
+            </JsonLayout>
         </Lambda>
     </Appenders>
     <Loggers>

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/LogLineHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/LogLineHelper.java
@@ -1,0 +1,11 @@
+package uk.gov.di.authentication.shared.helpers;
+
+import org.apache.logging.log4j.ThreadContext;
+import uk.gov.di.authentication.shared.entity.Session;
+
+public class LogLineHelper {
+
+    public static void attachSessionIdToLogs(Session session) {
+        ThreadContext.put("sessionId", session.getSessionId());
+    }
+}


### PR DESCRIPTION
## What?

This PR uses Log4j2's `ThreadContext` and `JsonLayout` to attach a `session-id` key in all JSON log lines

## Why?

This will make it easier to query by session id when doing log exploration and reduces the noise in the log message itself (as they no longer need to attach session id in the templated line).

Before:

```
{
  ...
  "message": "Action happened for session id foo-bar-baz"
  ...
}
```

After:

```
{
  ...
  "message": "Action happened for session id foo-bar-baz",
  "session-id": "foo-bar-baz"
  ...
}
```

If the session id is not available, the field value is `unknown`.

There will be a future PR to remove session ids from the `message` field.
