### PR TITLE
GOVSI-1114: Refactor KMS helper into extension

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
@@ -15,9 +15,11 @@ import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import com.nimbusds.openid.connect.sdk.claims.IDTokenClaimsSet;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.authentication.oidc.lambda.LogoutHandler;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.gov.di.authentication.sharedtest.extensions.TokenSigningExtension;
 
 import java.io.IOException;
 import java.net.URI;
@@ -45,6 +47,9 @@ public class LogoutIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             "https://di-auth-stub-relying-party-build.london.cloudapps.digital/";
     public static final String SESSION_ID = "session-id";
     public static final String CLIENT_SESSION_ID = "client-session-id";
+
+    @RegisterExtension
+    protected static final TokenSigningExtension tokenSigner = new TokenSigningExtension();
 
     @BeforeEach
     void setup() {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
@@ -18,7 +18,6 @@ import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.oidc.lambda.LogoutHandler;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
-import uk.gov.di.authentication.sharedtest.helper.KmsHelper;
 
 import java.io.IOException;
 import java.net.URI;
@@ -138,7 +137,7 @@ public class LogoutIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         expiryDate,
                         new Date());
         idTokenClaims.setNonce(nonce);
-        SignedJWT signedJWT = KmsHelper.signIdToken(idTokenClaims.toJWTClaimsSet());
+        SignedJWT signedJWT = tokenSigner.signIdToken(idTokenClaims.toJWTClaimsSet());
         redis.createSession(sessionId);
         redis.addAuthRequestToSession(
                 clientSessionId,

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
@@ -142,7 +142,7 @@ public class LogoutIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         expiryDate,
                         new Date());
         idTokenClaims.setNonce(nonce);
-        SignedJWT signedJWT = tokenSigner.signIdToken(idTokenClaims.toJWTClaimsSet());
+        SignedJWT signedJWT = tokenSigner.signJwt(idTokenClaims.toJWTClaimsSet());
         redis.createSession(sessionId);
         redis.addAuthRequestToSession(
                 clientSessionId,

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
@@ -35,7 +35,6 @@ import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.shared.entity.ValidScopes;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.helper.KeyPairHelper;
-import uk.gov.di.authentication.sharedtest.helper.KmsHelper;
 
 import java.net.URI;
 import java.security.KeyPair;
@@ -184,7 +183,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         .subject(publicSubject.getValue())
                         .jwtID(UUID.randomUUID().toString())
                         .build();
-        return KmsHelper.signAccessToken(claimsSet);
+        return tokenSigner.signAccessToken(claimsSet);
     }
 
     private void setUpDynamo(KeyPair keyPair, Scope scope, Subject internalSubject) {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
@@ -28,12 +28,14 @@ import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import net.minidev.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.authentication.oidc.lambda.TokenHandler;
 import uk.gov.di.authentication.shared.entity.ClientConsent;
 import uk.gov.di.authentication.shared.entity.RefreshTokenStore;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.shared.entity.ValidScopes;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.gov.di.authentication.sharedtest.extensions.TokenSigningExtension;
 import uk.gov.di.authentication.sharedtest.helper.KeyPairHelper;
 
 import java.net.URI;
@@ -65,6 +67,9 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     private static final String CLIENT_ID = "test-id";
     private static final String REFRESH_TOKEN_PREFIX = "REFRESH_TOKEN:";
     private static final String REDIRECT_URI = "http://localhost/redirect";
+
+    @RegisterExtension
+    protected static final TokenSigningExtension tokenSigner = new TokenSigningExtension();
 
     @BeforeEach
     void setup() {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
@@ -188,7 +188,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         .subject(publicSubject.getValue())
                         .jwtID(UUID.randomUUID().toString())
                         .build();
-        return tokenSigner.signAccessToken(claimsSet);
+        return tokenSigner.signJwt(claimsSet);
     }
 
     private void setUpDynamo(KeyPair keyPair, Scope scope, Subject internalSubject) {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
@@ -16,7 +16,6 @@ import uk.gov.di.authentication.shared.entity.AccessTokenStore;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.helper.KeyPairHelper;
-import uk.gov.di.authentication.sharedtest.helper.KmsHelper;
 
 import java.security.KeyPair;
 import java.time.LocalDateTime;
@@ -71,7 +70,7 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         .subject(publicSubject.getValue())
                         .jwtID(UUID.randomUUID().toString())
                         .build();
-        SignedJWT signedJWT = KmsHelper.signAccessToken(claimsSet);
+        SignedJWT signedJWT = tokenSigner.signAccessToken(claimsSet);
         AccessToken accessToken = new BearerAccessToken(signedJWT.serialize());
         AccessTokenStore accessTokenStore =
                 new AccessTokenStore(accessToken.getValue(), internalSubject.getValue());

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
@@ -11,10 +11,12 @@ import com.nimbusds.openid.connect.sdk.UserInfoErrorResponse;
 import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.authentication.oidc.lambda.UserInfoHandler;
 import uk.gov.di.authentication.shared.entity.AccessTokenStore;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.gov.di.authentication.sharedtest.extensions.TokenSigningExtension;
 import uk.gov.di.authentication.sharedtest.helper.KeyPairHelper;
 
 import java.security.KeyPair;
@@ -43,6 +45,9 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     private static final String TEST_PASSWORD = "password-1";
     private static final String CLIENT_ID = "client-id-one";
     private static final String ACCESS_TOKEN_PREFIX = "ACCESS_TOKEN:";
+
+    @RegisterExtension
+    protected static final TokenSigningExtension tokenSigner = new TokenSigningExtension();
 
     @BeforeEach
     void setup() {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
@@ -75,7 +75,7 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         .subject(publicSubject.getValue())
                         .jwtID(UUID.randomUUID().toString())
                         .build();
-        SignedJWT signedJWT = tokenSigner.signAccessToken(claimsSet);
+        SignedJWT signedJWT = tokenSigner.signJwt(claimsSet);
         AccessToken accessToken = new BearerAccessToken(signedJWT.serialize());
         AccessTokenStore accessTokenStore =
                 new AccessTokenStore(accessToken.getValue(), internalSubject.getValue());

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/ApiGatewayHandlerIntegrationTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/ApiGatewayHandlerIntegrationTest.java
@@ -10,8 +10,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.sharedtest.extensions.ClientStoreExtension;
-import uk.gov.di.authentication.sharedtest.extensions.KmsKeyExtension;
 import uk.gov.di.authentication.sharedtest.extensions.RedisExtension;
+import uk.gov.di.authentication.sharedtest.extensions.TokenSigningExtension;
 import uk.gov.di.authentication.sharedtest.extensions.UserStoreExtension;
 
 import java.net.HttpCookie;
@@ -59,7 +59,8 @@ public abstract class ApiGatewayHandlerIntegrationTest {
     @RegisterExtension
     protected static final ClientStoreExtension clientStore = new ClientStoreExtension();
 
-    @RegisterExtension protected static final KmsKeyExtension tokenSigner = new KmsKeyExtension();
+    @RegisterExtension
+    protected static final TokenSigningExtension tokenSigner = new TokenSigningExtension();
 
     protected APIGatewayProxyResponseEvent makeRequest(
             Optional<Object> body, Map<String, String> headers, Map<String, String> queryString) {

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/ApiGatewayHandlerIntegrationTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/ApiGatewayHandlerIntegrationTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.sharedtest.extensions.ClientStoreExtension;
+import uk.gov.di.authentication.sharedtest.extensions.KmsKeyExtension;
 import uk.gov.di.authentication.sharedtest.extensions.RedisExtension;
 import uk.gov.di.authentication.sharedtest.extensions.UserStoreExtension;
 
@@ -57,6 +58,8 @@ public abstract class ApiGatewayHandlerIntegrationTest {
 
     @RegisterExtension
     protected static final ClientStoreExtension clientStore = new ClientStoreExtension();
+
+    @RegisterExtension protected static final KmsKeyExtension tokenSigner = new KmsKeyExtension();
 
     protected APIGatewayProxyResponseEvent makeRequest(
             Optional<Object> body, Map<String, String> headers, Map<String, String> queryString) {

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/ApiGatewayHandlerIntegrationTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/ApiGatewayHandlerIntegrationTest.java
@@ -11,7 +11,6 @@ import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.sharedtest.extensions.ClientStoreExtension;
 import uk.gov.di.authentication.sharedtest.extensions.RedisExtension;
-import uk.gov.di.authentication.sharedtest.extensions.TokenSigningExtension;
 import uk.gov.di.authentication.sharedtest.extensions.UserStoreExtension;
 
 import java.net.HttpCookie;
@@ -58,9 +57,6 @@ public abstract class ApiGatewayHandlerIntegrationTest {
 
     @RegisterExtension
     protected static final ClientStoreExtension clientStore = new ClientStoreExtension();
-
-    @RegisterExtension
-    protected static final TokenSigningExtension tokenSigner = new TokenSigningExtension();
 
     protected APIGatewayProxyResponseEvent makeRequest(
             Optional<Object> body, Map<String, String> headers, Map<String, String> queryString) {

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/KmsKeyExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/KmsKeyExtension.java
@@ -6,95 +6,27 @@ import com.amazonaws.services.kms.AWSKMSClientBuilder;
 import com.amazonaws.services.kms.model.CreateAliasRequest;
 import com.amazonaws.services.kms.model.CreateKeyRequest;
 import com.amazonaws.services.kms.model.DescribeKeyRequest;
-import com.amazonaws.services.kms.model.KeySpec;
 import com.amazonaws.services.kms.model.NotFoundException;
-import com.amazonaws.services.kms.model.SignRequest;
-import com.amazonaws.services.kms.model.SignResult;
-import com.amazonaws.services.kms.model.SigningAlgorithmSpec;
-import com.nimbusds.jose.JOSEException;
-import com.nimbusds.jose.JWSAlgorithm;
-import com.nimbusds.jose.JWSHeader;
-import com.nimbusds.jose.crypto.impl.ECDSA;
-import com.nimbusds.jose.util.Base64URL;
-import com.nimbusds.jwt.JWTClaimsSet;
-import com.nimbusds.jwt.SignedJWT;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import uk.gov.di.authentication.shared.services.KmsConnectionService;
 
-import java.nio.ByteBuffer;
-import java.util.Optional;
+import static com.amazonaws.services.kms.model.KeySpec.ECC_NIST_P256;
 
 public class KmsKeyExtension implements BeforeAllCallback {
 
-    private static final String REGION = System.getenv().getOrDefault("AWS_REGION", "eu-west-2");
-    private static final String LOCALSTACK_ENDPOINT =
+    protected static final String REGION = System.getenv().getOrDefault("AWS_REGION", "eu-west-2");
+    protected static final String LOCALSTACK_ENDPOINT =
             System.getenv().getOrDefault("LOCALSTACK_ENDPOINT", "http://localhost:45678");
-    private static final String TOKEN_SIGNING_KEY_ALIAS =
-            System.getenv().get("TOKEN_SIGNING_KEY_ALIAS");
 
-    private final KmsConnectionService kmsConnectionService =
-            new KmsConnectionService(
-                    Optional.of(LOCALSTACK_ENDPOINT), REGION, TOKEN_SIGNING_KEY_ALIAS);
+    protected AWSKMS kms;
+    protected final String keyAlias;
 
-    private AWSKMS kms;
-
-    public SignedJWT signIdToken(JWTClaimsSet claimsSet) {
-        try {
-            JWSHeader jwsHeader =
-                    new JWSHeader.Builder(JWSAlgorithm.ES256)
-                            .keyID(TOKEN_SIGNING_KEY_ALIAS)
-                            .build();
-            Base64URL encodedHeader = jwsHeader.toBase64URL();
-            Base64URL encodedClaims = Base64URL.encode(claimsSet.toString());
-            String message = encodedHeader + "." + encodedClaims;
-            ByteBuffer messageToSign = ByteBuffer.wrap(message.getBytes());
-            SignRequest signRequest = new SignRequest();
-            signRequest.setMessage(messageToSign);
-            signRequest.setKeyId(TOKEN_SIGNING_KEY_ALIAS);
-            signRequest.setSigningAlgorithm(SigningAlgorithmSpec.ECDSA_SHA_256.toString());
-            SignResult signResult = kmsConnectionService.sign(signRequest);
-            String signature =
-                    Base64URL.encode(
-                                    ECDSA.transcodeSignatureToConcat(
-                                            signResult.getSignature().array(),
-                                            ECDSA.getSignatureByteArrayLength(JWSAlgorithm.ES256)))
-                            .toString();
-            return SignedJWT.parse(message + "." + signature);
-        } catch (java.text.ParseException | JOSEException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public SignedJWT signAccessToken(JWTClaimsSet claimsSet) {
-        try {
-            JWSHeader jwsHeader =
-                    new JWSHeader.Builder(JWSAlgorithm.ES256)
-                            .keyID(TOKEN_SIGNING_KEY_ALIAS)
-                            .build();
-            Base64URL encodedHeader = jwsHeader.toBase64URL();
-            Base64URL encodedClaims = Base64URL.encode(claimsSet.toString());
-            String message = encodedHeader + "." + encodedClaims;
-            ByteBuffer messageToSign = ByteBuffer.wrap(message.getBytes());
-            SignRequest signRequest = new SignRequest();
-            signRequest.setMessage(messageToSign);
-            signRequest.setKeyId(TOKEN_SIGNING_KEY_ALIAS);
-            signRequest.setSigningAlgorithm(SigningAlgorithmSpec.ECDSA_SHA_256.toString());
-            SignResult signResult = kmsConnectionService.sign(signRequest);
-            String signature =
-                    Base64URL.encode(
-                                    ECDSA.transcodeSignatureToConcat(
-                                            signResult.getSignature().array(),
-                                            ECDSA.getSignatureByteArrayLength(JWSAlgorithm.ES256)))
-                            .toString();
-            return SignedJWT.parse(message + "." + signature);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+    public KmsKeyExtension(String keyAlias) {
+        this.keyAlias = keyAlias;
     }
 
     @Override
-    public void beforeAll(ExtensionContext context) throws Exception {
+    public void beforeAll(ExtensionContext context) {
         kms =
                 AWSKMSClientBuilder.standard()
                         .withEndpointConfiguration(
@@ -102,16 +34,14 @@ public class KmsKeyExtension implements BeforeAllCallback {
                                         LOCALSTACK_ENDPOINT, REGION))
                         .build();
 
-        if (!keyExists(TOKEN_SIGNING_KEY_ALIAS)) {
-            createTokenSigningKey(TOKEN_SIGNING_KEY_ALIAS);
+        if (!keyExists(keyAlias)) {
+            createTokenSigningKey(keyAlias);
         }
     }
 
-    private void createTokenSigningKey(String keyAlias) {
+    protected void createTokenSigningKey(String keyAlias) {
         CreateKeyRequest keyRequest =
-                new CreateKeyRequest()
-                        .withKeySpec(KeySpec.ECC_NIST_P256)
-                        .withKeyUsage("SIGN_VERIFY");
+                new CreateKeyRequest().withKeySpec(ECC_NIST_P256).withKeyUsage("SIGN_VERIFY");
 
         var keyResponse = kms.createKey(keyRequest);
 
@@ -123,7 +53,7 @@ public class KmsKeyExtension implements BeforeAllCallback {
         kms.createAlias(aliasRequest);
     }
 
-    private boolean keyExists(String keyAlias) {
+    protected boolean keyExists(String keyAlias) {
         try {
             var request = new DescribeKeyRequest().withKeyId(keyAlias);
             kms.describeKey(request);

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/TokenSigningExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/TokenSigningExtension.java
@@ -1,0 +1,84 @@
+package uk.gov.di.authentication.sharedtest.extensions;
+
+import com.amazonaws.services.kms.model.SignRequest;
+import com.amazonaws.services.kms.model.SignResult;
+import com.amazonaws.services.kms.model.SigningAlgorithmSpec;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.impl.ECDSA;
+import com.nimbusds.jose.util.Base64URL;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import uk.gov.di.authentication.shared.services.KmsConnectionService;
+
+import java.nio.ByteBuffer;
+import java.util.Optional;
+
+public class TokenSigningExtension extends KmsKeyExtension {
+
+    private static final String TOKEN_SIGNING_KEY_ALIAS =
+            System.getenv().get("TOKEN_SIGNING_KEY_ALIAS");
+
+    private final KmsConnectionService kmsConnectionService =
+            new KmsConnectionService(
+                    Optional.of(LOCALSTACK_ENDPOINT), REGION, TOKEN_SIGNING_KEY_ALIAS);
+
+    public TokenSigningExtension() {
+        super(TOKEN_SIGNING_KEY_ALIAS);
+    }
+
+    public SignedJWT signIdToken(JWTClaimsSet claimsSet) {
+        try {
+            JWSHeader jwsHeader =
+                    new JWSHeader.Builder(JWSAlgorithm.ES256)
+                            .keyID(TOKEN_SIGNING_KEY_ALIAS)
+                            .build();
+            Base64URL encodedHeader = jwsHeader.toBase64URL();
+            Base64URL encodedClaims = Base64URL.encode(claimsSet.toString());
+            String message = encodedHeader + "." + encodedClaims;
+            ByteBuffer messageToSign = ByteBuffer.wrap(message.getBytes());
+            SignRequest signRequest = new SignRequest();
+            signRequest.setMessage(messageToSign);
+            signRequest.setKeyId(TOKEN_SIGNING_KEY_ALIAS);
+            signRequest.setSigningAlgorithm(SigningAlgorithmSpec.ECDSA_SHA_256.toString());
+            SignResult signResult = kmsConnectionService.sign(signRequest);
+            String signature =
+                    Base64URL.encode(
+                                    ECDSA.transcodeSignatureToConcat(
+                                            signResult.getSignature().array(),
+                                            ECDSA.getSignatureByteArrayLength(JWSAlgorithm.ES256)))
+                            .toString();
+            return SignedJWT.parse(message + "." + signature);
+        } catch (java.text.ParseException | JOSEException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public SignedJWT signAccessToken(JWTClaimsSet claimsSet) {
+        try {
+            JWSHeader jwsHeader =
+                    new JWSHeader.Builder(JWSAlgorithm.ES256)
+                            .keyID(TOKEN_SIGNING_KEY_ALIAS)
+                            .build();
+            Base64URL encodedHeader = jwsHeader.toBase64URL();
+            Base64URL encodedClaims = Base64URL.encode(claimsSet.toString());
+            String message = encodedHeader + "." + encodedClaims;
+            ByteBuffer messageToSign = ByteBuffer.wrap(message.getBytes());
+            SignRequest signRequest = new SignRequest();
+            signRequest.setMessage(messageToSign);
+            signRequest.setKeyId(TOKEN_SIGNING_KEY_ALIAS);
+            signRequest.setSigningAlgorithm(SigningAlgorithmSpec.ECDSA_SHA_256.toString());
+            SignResult signResult = kmsConnectionService.sign(signRequest);
+            String signature =
+                    Base64URL.encode(
+                                    ECDSA.transcodeSignatureToConcat(
+                                            signResult.getSignature().array(),
+                                            ECDSA.getSignatureByteArrayLength(JWSAlgorithm.ES256)))
+                            .toString();
+            return SignedJWT.parse(message + "." + signature);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/TokenSigningExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/TokenSigningExtension.java
@@ -28,7 +28,7 @@ public class TokenSigningExtension extends KmsKeyExtension {
         super(TOKEN_SIGNING_KEY_ALIAS);
     }
 
-    public SignedJWT signIdToken(JWTClaimsSet claimsSet) {
+    public SignedJWT signJwt(JWTClaimsSet claimsSet) {
         try {
             JWSHeader jwsHeader =
                     new JWSHeader.Builder(JWSAlgorithm.ES256)
@@ -51,33 +51,6 @@ public class TokenSigningExtension extends KmsKeyExtension {
                             .toString();
             return SignedJWT.parse(message + "." + signature);
         } catch (java.text.ParseException | JOSEException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    public SignedJWT signAccessToken(JWTClaimsSet claimsSet) {
-        try {
-            JWSHeader jwsHeader =
-                    new JWSHeader.Builder(JWSAlgorithm.ES256)
-                            .keyID(TOKEN_SIGNING_KEY_ALIAS)
-                            .build();
-            Base64URL encodedHeader = jwsHeader.toBase64URL();
-            Base64URL encodedClaims = Base64URL.encode(claimsSet.toString());
-            String message = encodedHeader + "." + encodedClaims;
-            ByteBuffer messageToSign = ByteBuffer.wrap(message.getBytes());
-            SignRequest signRequest = new SignRequest();
-            signRequest.setMessage(messageToSign);
-            signRequest.setKeyId(TOKEN_SIGNING_KEY_ALIAS);
-            signRequest.setSigningAlgorithm(SigningAlgorithmSpec.ECDSA_SHA_256.toString());
-            SignResult signResult = kmsConnectionService.sign(signRequest);
-            String signature =
-                    Base64URL.encode(
-                                    ECDSA.transcodeSignatureToConcat(
-                                            signResult.getSignature().array(),
-                                            ECDSA.getSignatureByteArrayLength(JWSAlgorithm.ES256)))
-                            .toString();
-            return SignedJWT.parse(message + "." + signature);
-        } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }


### PR DESCRIPTION
## What?

- Refactor the `KmsHelper` class into an extension
- Add the extension to the base integration helper class
- Add code to create key (and alias) if it doesn't exist
- Create a new extension `TokenSigningExtension` that extends `KmsKeyExtension`
- Move specific token signing and verification code to the new extension
- Leave the base `KmsKeyExtension` generic as this will also be used to provide audit signing keys

## Why?

We are refactoring how provide the AWS/Localstack resources to integration tests. This extension will, later, later be used to create the KMS keys in localstack rather than us pre-creating them using Terraform.
