### PR TITLE
GOVSI-1121 - Generate new persistent cookie in authorize

### DIFF
--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandlerTest.java
@@ -220,7 +220,15 @@ class UpdateProfileHandlerTest {
                         any(List.class)))
                 .thenReturn(authSuccessResponse);
 
-        event.setHeaders(Map.of(COOKIE, buildCookieString(CLIENT_SESSION_ID)));
+        event.setHeaders(
+                Map.of(
+                        COOKIE,
+                        buildCookieString(
+                                "gs",
+                                SESSION_ID + "." + CLIENT_SESSION_ID,
+                                3600,
+                                "Secure; HttpOnly;",
+                                "domain")));
         event.setBody(
                 format(
                         "{ \"email\": \"%s\", \"updateProfileType\": \"%s\", \"profileInformation\": \"%s\" }",

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -47,7 +47,7 @@ import static uk.gov.di.authentication.shared.entity.SessionState.AUTHENTICATED;
 import static uk.gov.di.authentication.shared.entity.SessionState.AUTHENTICATION_REQUIRED;
 import static uk.gov.di.authentication.shared.entity.SessionState.CONSENT_REQUIRED;
 import static uk.gov.di.authentication.shared.entity.SessionState.UPLIFT_REQUIRED_CM;
-import static uk.gov.di.authentication.shared.helpers.CookieHelper.getHttpCookieFromResponseHeaders;
+import static uk.gov.di.authentication.shared.helpers.CookieHelper.getHttpCookieFromMultiValueResponseHeaders;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -100,8 +100,41 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 getHeaderValueByParamName(response, ResponseHeaders.LOCATION),
                 startsWith(configurationService.getLoginURI().toString()));
         assertThat(
-                getHttpCookieFromResponseHeaders(response.getHeaders(), "gs").isPresent(),
+                getHttpCookieFromMultiValueResponseHeaders(response.getMultiValueHeaders(), "gs")
+                        .isPresent(),
                 equalTo(true));
+    }
+
+    @Test
+    void shouldRedirectToLoginWithSamePersistentCookieValueInRequest() {
+        var response =
+                makeRequest(
+                        Optional.empty(),
+                        constructHeaders(
+                                Optional.of(
+                                        new HttpCookie(
+                                                "di-persistent-session-id",
+                                                "persistent-id-value"))),
+                        constructQueryStringParameters(
+                                Optional.of(CLIENT_ID),
+                                Optional.empty(),
+                                "openid",
+                                Optional.of("Cl.Cm")));
+        assertThat(response, hasStatus(302));
+        assertThat(
+                getHeaderValueByParamName(response, ResponseHeaders.LOCATION),
+                startsWith(configurationService.getLoginURI().toString()));
+        assertThat(
+                response.getMultiValueHeaders().get(ResponseHeaders.SET_COOKIE).size(), equalTo(2));
+        assertThat(
+                getHttpCookieFromMultiValueResponseHeaders(response.getMultiValueHeaders(), "gs")
+                        .isPresent(),
+                equalTo(true));
+        var persistentCookie =
+                getHttpCookieFromMultiValueResponseHeaders(
+                        response.getMultiValueHeaders(), "di-persistent-session-id");
+        assertThat(persistentCookie.isPresent(), equalTo(true));
+        assertThat(persistentCookie.get().getValue(), equalTo("persistent-id-value"));
     }
 
     @Test
@@ -122,7 +155,13 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 getHeaderValueByParamName(response, ResponseHeaders.LOCATION),
                 startsWith(configurationService.getLoginURI().toString()));
         assertThat(
-                getHttpCookieFromResponseHeaders(response.getHeaders(), "gs").isPresent(),
+                getHttpCookieFromMultiValueResponseHeaders(response.getMultiValueHeaders(), "gs")
+                        .isPresent(),
+                equalTo(true));
+        assertThat(
+                getHttpCookieFromMultiValueResponseHeaders(
+                                response.getMultiValueHeaders(), "di-persistent-session-id")
+                        .isPresent(),
                 equalTo(true));
     }
 
@@ -160,7 +199,13 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 getHeaderValueByParamName(response, ResponseHeaders.LOCATION),
                 startsWith(configurationService.getLoginURI().toString()));
         assertThat(
-                getHttpCookieFromResponseHeaders(response.getHeaders(), "gs").isPresent(),
+                getHttpCookieFromMultiValueResponseHeaders(response.getMultiValueHeaders(), "gs")
+                        .isPresent(),
+                equalTo(true));
+        assertThat(
+                getHttpCookieFromMultiValueResponseHeaders(
+                                response.getMultiValueHeaders(), "di-persistent-session-id")
+                        .isPresent(),
                 equalTo(true));
     }
 
@@ -181,7 +226,13 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 getHeaderValueByParamName(response, ResponseHeaders.LOCATION),
                 startsWith(configurationService.getLoginURI().toString()));
         assertThat(
-                getHttpCookieFromResponseHeaders(response.getHeaders(), "gs").isPresent(),
+                getHttpCookieFromMultiValueResponseHeaders(response.getMultiValueHeaders(), "gs")
+                        .isPresent(),
+                equalTo(true));
+        assertThat(
+                getHttpCookieFromMultiValueResponseHeaders(
+                                response.getMultiValueHeaders(), "di-persistent-session-id")
+                        .isPresent(),
                 equalTo(true));
     }
 
@@ -206,8 +257,13 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(
                 getHeaderValueByParamName(response, ResponseHeaders.LOCATION),
                 startsWith(configurationService.getLoginURI().toString()));
-
-        var cookie = getHttpCookieFromResponseHeaders(response.getHeaders(), "gs");
+        var cookie =
+                getHttpCookieFromMultiValueResponseHeaders(response.getMultiValueHeaders(), "gs");
+        assertThat(
+                getHttpCookieFromMultiValueResponseHeaders(
+                                response.getMultiValueHeaders(), "di-persistent-session-id")
+                        .isPresent(),
+                equalTo(true));
         assertThat(cookie.isPresent(), equalTo(true));
         assertThat(cookie.get().getValue(), not(startsWith(sessionId)));
     }
@@ -232,7 +288,13 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(response, hasStatus(302));
 
         // TODO: Update assertions to reflect code issuance, once we've written that code
-        var cookie = getHttpCookieFromResponseHeaders(response.getHeaders(), "gs");
+        var cookie =
+                getHttpCookieFromMultiValueResponseHeaders(response.getMultiValueHeaders(), "gs");
+        assertThat(
+                getHttpCookieFromMultiValueResponseHeaders(
+                                response.getMultiValueHeaders(), "di-persistent-session-id")
+                        .isPresent(),
+                equalTo(true));
         assertThat(cookie.isPresent(), equalTo(true));
         assertThat(cookie.get().getValue(), not(startsWith(sessionId)));
     }
@@ -273,7 +335,13 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                                 Optional.empty()));
 
         assertThat(response, hasStatus(302));
-        var cookie = getHttpCookieFromResponseHeaders(response.getHeaders(), "gs");
+        var cookie =
+                getHttpCookieFromMultiValueResponseHeaders(response.getMultiValueHeaders(), "gs");
+        assertThat(
+                getHttpCookieFromMultiValueResponseHeaders(
+                                response.getMultiValueHeaders(), "di-persistent-session-id")
+                        .isPresent(),
+                equalTo(true));
         assertThat(cookie.isPresent(), equalTo(true));
         assertThat(cookie.get().getValue(), not(startsWith(sessionId)));
         assertThat(
@@ -300,7 +368,13 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                                 Optional.empty()));
 
         assertThat(response, hasStatus(302));
-        var cookie = getHttpCookieFromResponseHeaders(response.getHeaders(), "gs");
+        var cookie =
+                getHttpCookieFromMultiValueResponseHeaders(response.getMultiValueHeaders(), "gs");
+        assertThat(
+                getHttpCookieFromMultiValueResponseHeaders(
+                                response.getMultiValueHeaders(), "di-persistent-session-id")
+                        .isPresent(),
+                equalTo(true));
         assertThat(cookie.isPresent(), equalTo(true));
         assertThat(cookie.get().getValue(), not(startsWith(sessionId)));
         assertThat(
@@ -331,7 +405,13 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         assertThat(response, hasStatus(302));
 
-        var cookie = getHttpCookieFromResponseHeaders(response.getHeaders(), "gs");
+        var cookie =
+                getHttpCookieFromMultiValueResponseHeaders(response.getMultiValueHeaders(), "gs");
+        assertThat(
+                getHttpCookieFromMultiValueResponseHeaders(
+                                response.getMultiValueHeaders(), "di-persistent-session-id")
+                        .isPresent(),
+                equalTo(true));
         assertThat(cookie.isPresent(), equalTo(true));
         assertThat(cookie.get().getValue(), not(startsWith(sessionId)));
 
@@ -363,7 +443,13 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         assertThat(response, hasStatus(302));
 
-        var cookie = getHttpCookieFromResponseHeaders(response.getHeaders(), "gs");
+        var cookie =
+                getHttpCookieFromMultiValueResponseHeaders(response.getMultiValueHeaders(), "gs");
+        assertThat(
+                getHttpCookieFromMultiValueResponseHeaders(
+                                response.getMultiValueHeaders(), "di-persistent-session-id")
+                        .isPresent(),
+                equalTo(true));
         assertThat(cookie.isPresent(), equalTo(true));
         assertThat(cookie.get().getValue(), not(startsWith(sessionId)));
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -23,6 +23,7 @@ import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.SessionAction;
 import uk.gov.di.authentication.shared.entity.SessionState;
 import uk.gov.di.authentication.shared.exceptions.ClientNotFoundException;
+import uk.gov.di.authentication.shared.helpers.CookieHelper;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthorizationService;
@@ -40,7 +41,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static java.lang.String.format;
 import static uk.gov.di.authentication.oidc.entity.RequestParameters.COOKIE_CONSENT;
 import static uk.gov.di.authentication.oidc.entity.RequestParameters.GA;
 import static uk.gov.di.authentication.shared.entity.SessionAction.USER_HAS_STARTED_A_NEW_JOURNEY;
@@ -148,7 +148,10 @@ public class AuthorisationHandler
                                                                             input.getHeaders()),
                                                             authRequest,
                                                             context,
-                                                            ipAddress));
+                                                            ipAddress,
+                                                            authorizationService
+                                                                    .getExistingOrCreateNewPersistentSessionId(
+                                                                            input.getHeaders())));
                         });
     }
 
@@ -157,7 +160,8 @@ public class AuthorisationHandler
             Optional<Session> existingSession,
             AuthenticationRequest authenticationRequest,
             Context context,
-            String ipAddress) {
+            String ipAddress,
+            String persistentSessionId) {
         final SessionAction sessionAction;
         if (authenticationRequest.getPrompt() != null) {
             if (authenticationRequest.getPrompt().contains(Prompt.Type.CONSENT)
@@ -197,10 +201,15 @@ public class AuthorisationHandler
                 pair("session-action", sessionAction));
 
         if (existingSession.isEmpty()) {
-            return createSessionAndRedirect(session, authRequestParameters, authenticationRequest);
+            return createSessionAndRedirect(
+                    session, authRequestParameters, authenticationRequest, persistentSessionId);
         } else {
             return updateSessionAndRedirect(
-                    authRequestParameters, authenticationRequest, session, sessionAction);
+                    authRequestParameters,
+                    authenticationRequest,
+                    session,
+                    sessionAction,
+                    persistentSessionId);
         }
     }
 
@@ -208,7 +217,8 @@ public class AuthorisationHandler
             Map<String, List<String>> authRequestParameters,
             AuthenticationRequest authenticationRequest,
             Session session,
-            SessionAction sessionAction) {
+            SessionAction sessionAction,
+            String persistentSessionId) {
         ClientSession clientSession =
                 new ClientSession(
                         authRequestParameters,
@@ -230,7 +240,7 @@ public class AuthorisationHandler
         String redirectUri =
                 buildRedirectURI(authRequestParameters, authenticationRequest, nextState);
 
-        return redirect(session, clientSessionID, redirectUri);
+        return redirect(session, clientSessionID, redirectUri, persistentSessionId);
     }
 
     private boolean isUserAuthenticated(Optional<Session> existingSession) {
@@ -259,7 +269,8 @@ public class AuthorisationHandler
     private APIGatewayProxyResponseEvent createSessionAndRedirect(
             Session session,
             Map<String, List<String>> authRequest,
-            AuthenticationRequest authenticationRequest) {
+            AuthenticationRequest authenticationRequest,
+            String persistentSessionId) {
         String clientSessionID =
                 clientSessionService.generateClientSession(
                         new ClientSession(
@@ -277,7 +288,7 @@ public class AuthorisationHandler
         LOGGER.info("Session saved successfully {}", session.getSessionId());
 
         var redirectURI = buildRedirectURI(authRequest, authenticationRequest, null);
-        return redirect(session, clientSessionID, redirectURI);
+        return redirect(session, clientSessionID, redirectURI, persistentSessionId);
     }
 
     private String buildRedirectURI(
@@ -315,24 +326,32 @@ public class AuthorisationHandler
     }
 
     private APIGatewayProxyResponseEvent redirect(
-            Session session, String clientSessionID, String redirectURI) {
+            Session session,
+            String clientSessionID,
+            String redirectURI,
+            String persistentSessionId) {
         LOGGER.info(
                 "Redirecting for SessionId: {} and ClientSessionId: {}",
                 session.getSessionId(),
                 clientSessionID);
+        List<String> cookies =
+                List.of(
+                        CookieHelper.buildCookieString(
+                                CookieHelper.SESSION_COOKIE_NAME,
+                                session.getSessionId() + "." + clientSessionID,
+                                configurationService.getSessionCookieMaxAge(),
+                                configurationService.getSessionCookieAttributes(),
+                                configurationService.getDomainName()),
+                        CookieHelper.buildCookieString(
+                                CookieHelper.PERSISTENT_COOKIE_NAME,
+                                persistentSessionId,
+                                configurationService.getPersistentCookieMaxAge(),
+                                configurationService.getSessionCookieAttributes(),
+                                configurationService.getDomainName()));
         return new APIGatewayProxyResponseEvent()
                 .withStatusCode(302)
-                .withHeaders(
-                        Map.of(
-                                ResponseHeaders.LOCATION,
-                                redirectURI,
-                                ResponseHeaders.SET_COOKIE,
-                                buildCookieString(
-                                        session,
-                                        configurationService.getSessionCookieMaxAge(),
-                                        configurationService.getSessionCookieAttributes(),
-                                        clientSessionID,
-                                        configurationService.getDomainName())));
+                .withHeaders(Map.of(ResponseHeaders.LOCATION, redirectURI))
+                .withMultiValueHeaders(Map.of(ResponseHeaders.SET_COOKIE, cookies));
     }
 
     private APIGatewayProxyResponseEvent generateErrorResponse(
@@ -384,17 +403,6 @@ public class AuthorisationHandler
             APIGatewayProxyRequestEvent input) {
         return input.getQueryStringParameters().entrySet().stream()
                 .collect(Collectors.toMap(Map.Entry::getKey, entry -> List.of(entry.getValue())));
-    }
-
-    private String buildCookieString(
-            Session session,
-            Integer maxAge,
-            String attributes,
-            String clientSessionID,
-            String domain) {
-        return format(
-                "%s=%s.%s; Max-Age=%d; Domain=%s; %s",
-                "gs", session.getSessionId(), clientSessionID, maxAge, domain, attributes);
     }
 
     private String getCookieConsentValue(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/LogoutHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/LogoutHandlerTest.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static java.lang.String.format;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -44,7 +45,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.authentication.shared.helpers.CookieHelper.buildCookieString;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 class LogoutHandlerTest {
@@ -360,5 +360,11 @@ class LogoutHandlerTest {
                 .setPostLogoutRedirectUrls(singletonList(CLIENT_LOGOUT_URI.toString()))
                 .setScopes(singletonList("openid"))
                 .setRedirectUrls(singletonList("http://localhost/redirect"));
+    }
+
+    private static String buildCookieString(String clientSessionId) {
+        return format(
+                "%s=%s.%s; Max-Age=%d; %s",
+                "gs", "a-session-id", clientSessionId, 3600, "Secure; HttpOnly;");
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/CookieHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/CookieHelper.java
@@ -5,6 +5,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.net.HttpCookie;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -17,9 +18,10 @@ public class CookieHelper {
 
     public static final String REQUEST_COOKIE_HEADER = "Cookie";
     public static final String RESPONSE_COOKIE_HEADER = "Set-Cookie";
-    private static final String SESSION_ID = "a-session-id";
+    public static final String PERSISTENT_COOKIE_NAME = "di-persistent-session-id";
+    public static final String SESSION_COOKIE_NAME = "gs";
 
-    public static Optional<HttpCookie> getHttpCookieFromHeaders(
+    public static Optional<HttpCookie> getHttpCookieFromRequestHeaders(
             Map<String, String> headers, String cookieName) {
         return getHttpCookieFromHeaders(headers, cookieName, REQUEST_COOKIE_HEADER);
     }
@@ -27,6 +29,29 @@ public class CookieHelper {
     public static Optional<HttpCookie> getHttpCookieFromResponseHeaders(
             Map<String, String> headers, String cookieName) {
         return getHttpCookieFromHeaders(headers, cookieName, RESPONSE_COOKIE_HEADER);
+    }
+
+    public static Optional<HttpCookie> getHttpCookieFromMultiValueResponseHeaders(
+            Map<String, List<String>> headers, String cookieName) {
+        String cookie =
+                Stream.of(RESPONSE_COOKIE_HEADER, RESPONSE_COOKIE_HEADER.toLowerCase())
+                        .filter(headers.keySet()::contains)
+                        .findFirst()
+                        .orElse(null);
+        if (cookie == null) {
+            return Optional.empty();
+        }
+        return headers.get(cookie).stream()
+                .filter(
+                        t ->
+                                getHttpCookieFromHeaders(
+                                                Map.of(RESPONSE_COOKIE_HEADER, t),
+                                                cookieName,
+                                                RESPONSE_COOKIE_HEADER)
+                                        .isPresent())
+                .map(CookieHelper::parseStringToHttpCookie)
+                .findFirst()
+                .orElse(Optional.empty());
     }
 
     public static Optional<HttpCookie> getHttpCookieFromHeaders(
@@ -51,21 +76,13 @@ public class CookieHelper {
             return Optional.empty();
         }
 
-        HttpCookie httpCookie;
-        try {
-            httpCookie = HttpCookie.parse(cookie).stream().findFirst().orElse(null);
-        } catch (IllegalArgumentException e) {
-            return Optional.empty();
-        }
-        if (httpCookie == null) {
-            return Optional.empty();
-        }
-        return Optional.of(httpCookie);
+        return parseStringToHttpCookie(cookie);
     }
 
     public static Optional<SessionCookieIds> parseSessionCookie(Map<String, String> headers) {
-        Optional<HttpCookie> httpCookie = getHttpCookieFromHeaders(headers, "gs");
-        if (!httpCookie.isPresent()) {
+        Optional<HttpCookie> httpCookie =
+                getHttpCookieFromRequestHeaders(headers, SESSION_COOKIE_NAME);
+        if (httpCookie.isEmpty()) {
             return Optional.empty();
         }
 
@@ -88,6 +105,35 @@ public class CookieHelper {
                 });
     }
 
+    public static Optional<String> parsePersistentCookie(Map<String, String> headers) {
+        Optional<HttpCookie> httpCookie =
+                getHttpCookieFromRequestHeaders(headers, PERSISTENT_COOKIE_NAME);
+        if (httpCookie.isEmpty()) {
+            return Optional.empty();
+        }
+
+        String[] cookieValues = httpCookie.get().getValue().split("\\.");
+        if (cookieValues.length != 1) {
+            return Optional.empty();
+        }
+        final String persistentId = cookieValues[0];
+
+        return Optional.of(persistentId);
+    }
+
+    private static Optional<HttpCookie> parseStringToHttpCookie(String cookie) {
+        HttpCookie httpCookie;
+        try {
+            httpCookie = HttpCookie.parse(cookie).stream().findFirst().orElse(null);
+        } catch (IllegalArgumentException e) {
+            return Optional.empty();
+        }
+        if (httpCookie == null) {
+            return Optional.empty();
+        }
+        return Optional.of(httpCookie);
+    }
+
     private static Optional<String> cookieHeader(Map<String, String> headers, String headerName) {
         if (headers == null) {
             return Optional.empty();
@@ -104,9 +150,14 @@ public class CookieHelper {
         String getClientSessionId();
     }
 
-    public static String buildCookieString(String clientSessionId) {
+    public static String buildCookieString(
+            String cookieName,
+            String cookieValue,
+            Integer maxAge,
+            String attributes,
+            String domain) {
         return format(
-                "%s=%s.%s; Max-Age=%d; %s",
-                "gs", SESSION_ID, clientSessionId, 3600, "Secure; HttpOnly;");
+                "%s=%s; Max-Age=%d; Domain=%s; %s",
+                cookieName, cookieValue, maxAge, domain, attributes);
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthorizationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthorizationService.java
@@ -20,11 +20,14 @@ import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.ValidScopes;
 import uk.gov.di.authentication.shared.entity.VectorOfTrust;
 import uk.gov.di.authentication.shared.exceptions.ClientNotFoundException;
+import uk.gov.di.authentication.shared.helpers.CookieHelper;
+import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 
@@ -189,5 +192,9 @@ public class AuthorizationService {
             }
         }
         return true;
+    }
+
+    public String getExistingOrCreateNewPersistentSessionId(Map<String, String> headers) {
+        return CookieHelper.parsePersistentCookie(headers).orElse(IdGenerator.generate());
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -164,6 +164,11 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return Integer.parseInt(System.getenv().getOrDefault("SESSION_COOKIE_MAX_AGE", "3600"));
     }
 
+    public int getPersistentCookieMaxAge() {
+        return Integer.parseInt(
+                System.getenv().getOrDefault("PERSISTENT_COOKIE_MAX_AGE", "34190000"));
+    }
+
     public long getSessionExpiry() {
         return Long.parseLong(System.getenv().getOrDefault("SESSION_EXPIRY", "3600"));
     }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/CookieHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/CookieHelperTest.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.net.HttpCookie;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -11,11 +13,12 @@ import java.util.stream.Stream;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static uk.gov.di.authentication.shared.helpers.CookieHelper.PERSISTENT_COOKIE_NAME;
 import static uk.gov.di.authentication.shared.helpers.CookieHelper.REQUEST_COOKIE_HEADER;
 import static uk.gov.di.authentication.shared.helpers.CookieHelper.RESPONSE_COOKIE_HEADER;
-import static uk.gov.di.authentication.shared.helpers.CookieHelper.SessionCookieIds;
-import static uk.gov.di.authentication.shared.helpers.CookieHelper.getHttpCookieFromHeaders;
+import static uk.gov.di.authentication.shared.helpers.CookieHelper.getHttpCookieFromMultiValueResponseHeaders;
 import static uk.gov.di.authentication.shared.helpers.CookieHelper.getHttpCookieFromResponseHeaders;
+import static uk.gov.di.authentication.shared.helpers.CookieHelper.parsePersistentCookie;
 import static uk.gov.di.authentication.shared.helpers.CookieHelper.parseSessionCookie;
 
 public class CookieHelperTest {
@@ -30,12 +33,12 @@ public class CookieHelperTest {
 
     @ParameterizedTest(name = "with header {0}")
     @MethodSource("inputs")
-    void shouldReturnIdsFromValidCookieStringWithMultipleCookeies(String header) {
+    void shouldReturnIdsFromValidSessionCookieStringWithMultipleCookies(String header) {
         String cookieString =
                 "Version=1; gs=session-id.456;cookies_preferences_set={\"analytics\":true};name=ts";
-        Map<String, String> headers = Map.ofEntries(Map.entry(header, cookieString.toString()));
+        Map<String, String> headers = Map.ofEntries(Map.entry(header, cookieString));
 
-        SessionCookieIds ids = parseSessionCookie(headers).orElseThrow();
+        CookieHelper.SessionCookieIds ids = parseSessionCookie(headers).orElseThrow();
 
         assertEquals("session-id", ids.getSessionId());
         assertEquals("456", ids.getClientSessionId());
@@ -43,11 +46,23 @@ public class CookieHelperTest {
 
     @ParameterizedTest(name = "with header {0}")
     @MethodSource("inputs")
-    void shouldReturnIdsFromValidCookie(String header) {
+    void shouldReturnIdsFromValidPersistentCookieStringWithMultipleCookies(String header) {
+        String cookieString =
+                "Version=1; di-persistent-session-id=a-persistent-id;gs=session-id.456;cookies_preferences_set={\"analytics\":true};name=ts";
+        Map<String, String> headers = Map.ofEntries(Map.entry(header, cookieString));
+
+        String id = parsePersistentCookie(headers).orElseThrow();
+
+        assertEquals("a-persistent-id", id);
+    }
+
+    @ParameterizedTest(name = "with header {0}")
+    @MethodSource("inputs")
+    void shouldReturnIdsFromValidSessionCookie(String header) {
         HttpCookie cookie = new HttpCookie("gs", "session-id.456");
         Map<String, String> headers = Map.ofEntries(Map.entry(header, cookie.toString()));
 
-        SessionCookieIds ids = parseSessionCookie(headers).orElseThrow();
+        CookieHelper.SessionCookieIds ids = parseSessionCookie(headers).orElseThrow();
 
         assertEquals("session-id", ids.getSessionId());
         assertEquals("456", ids.getClientSessionId());
@@ -55,10 +70,21 @@ public class CookieHelperTest {
 
     @ParameterizedTest(name = "with header {0}")
     @MethodSource("inputs")
-    void shouldReturnEmptyIfCookieNotPresent(String header) {
+    void shouldReturnIdsFromValidPersistentCookie(String header) {
+        HttpCookie cookie = new HttpCookie("di-persistent-session-id", "a-persistent-id");
+        Map<String, String> headers = Map.ofEntries(Map.entry(header, cookie.toString()));
+
+        String id = parsePersistentCookie(headers).orElseThrow();
+
+        assertEquals("a-persistent-id", id);
+    }
+
+    @ParameterizedTest(name = "with header {0}")
+    @MethodSource("inputs")
+    void shouldReturnEmptyIfSessionCookieNotPresent(String header) {
         assertEmpty(parseSessionCookie(null));
         assertEmpty(parseSessionCookie(Map.of()));
-        assertEmpty(parseSessionCookie(Map.of("header", "value")));
+        assertEmpty(parseSessionCookie(Map.of(header, "value")));
     }
 
     @ParameterizedTest(name = "with header {0}")
@@ -67,20 +93,38 @@ public class CookieHelperTest {
         assertEmpty(parseSessionCookie(Map.of(header, "")));
         assertEmpty(parseSessionCookie(Map.of(header, "someinvalidvalue")));
         assertEmpty(parseSessionCookie(Map.of(header, "gs=this is bad")));
-        assertEmpty(parseSessionCookie(Map.of(header, "gs=no-dot;")));
+        assertEmpty(parseSessionCookie(Map.of(header, "gs=no-dot")));
         assertEmpty(parseSessionCookie(Map.of(header, "gs=one-value.two-value.three-value;")));
         assertEmpty(parseSessionCookie(Map.of(header, "gsdsds=one-value.two-value")));
     }
 
     @ParameterizedTest(name = "with header {0}")
     @MethodSource("inputs")
-    void shouldReturnCookiePrefsFromValidCookieStringWithMultipleCookies(String header) {
+    void shouldReturnEmptyIPersistentCookieMalformatted(String header) {
+        assertEmpty(parsePersistentCookie(Map.of(header, "")));
+        assertEmpty(parsePersistentCookie(Map.of(header, "someinvalidvalue")));
+        assertEmpty(
+                parsePersistentCookie(Map.of(header, "di-persistent-session-id=dot.fsfdfsfd;")));
+        assertEmpty(
+                parsePersistentCookie(
+                        Map.of(
+                                header,
+                                "di-persistent-session-id=one-value.two-value.three-value;")));
+        assertEmpty(
+                parsePersistentCookie(
+                        Map.of(header, "di-persistent-session-idfds=one-value.two-value\"")));
+    }
+
+    @ParameterizedTest(name = "with header {0}")
+    @MethodSource("inputs")
+    void shouldReturnCookiePrefsFromValidSessionCookieStringWithMultipleCookies(String header) {
         String cookieString =
                 "Version=1; gs=session-id.456;cookies_preferences_set={\"analytics\":false};name=ts";
-        Map<String, String> headers = Map.ofEntries(Map.entry(header, cookieString.toString()));
+        Map<String, String> headers = Map.ofEntries(Map.entry(header, cookieString));
 
         HttpCookie cookie =
-                getHttpCookieFromHeaders(headers, "cookies_preferences_set").orElseThrow();
+                CookieHelper.getHttpCookieFromRequestHeaders(headers, "cookies_preferences_set")
+                        .orElseThrow();
 
         assertThat(cookie.getValue(), containsString("\"analytics\":false"));
     }
@@ -88,9 +132,27 @@ public class CookieHelperTest {
     @ParameterizedTest(name = "with header {0}")
     @MethodSource("inputs")
     void shouldReturnEmptyCookiePrefsIfCookieNotPresent(String header) {
-        assertEmpty(getHttpCookieFromHeaders(null, "cookies_preferences_set"));
-        assertEmpty(getHttpCookieFromHeaders(Map.of(), "cookies_preferences_set"));
-        assertEmpty(getHttpCookieFromHeaders(Map.of("header", "value"), "cookies_preferences_set"));
+        assertEmpty(getHttpCookieFromResponseHeaders(null, "cookies_preferences_set"));
+        assertEmpty(
+                CookieHelper.getHttpCookieFromRequestHeaders(Map.of(), "cookies_preferences_set"));
+        assertEmpty(
+                CookieHelper.getHttpCookieFromRequestHeaders(
+                        Map.of(header, "value"), "cookies_preferences_set"));
+    }
+
+    @ParameterizedTest(name = "with header {0}")
+    @MethodSource("responseInputs")
+    void shouldReturnIdsFromPersistentCookieStringWithMultipleValuesMap(String header) {
+        Map<String, List<String>> cookieMap = new HashMap<>();
+        String persistentCookie = "di-persistent-session-id=a-persistent-id";
+        String sessionCookie = "gs=session-id.456";
+        cookieMap.put(header, List.of(persistentCookie, sessionCookie));
+
+        HttpCookie httpCookie =
+                getHttpCookieFromMultiValueResponseHeaders(cookieMap, PERSISTENT_COOKIE_NAME)
+                        .orElseThrow();
+
+        assertEquals("a-persistent-id", httpCookie.getValue());
     }
 
     @ParameterizedTest(name = "with header {0}")
@@ -98,7 +160,7 @@ public class CookieHelperTest {
     void shouldReturnCookiePrefsFromValidResponseCookieStringWithMultipleCookies(String header) {
         String cookieString =
                 "Version=1; gs=session-id.456;cookies_preferences_set={\"analytics\":false};name=ts";
-        Map<String, String> headers = Map.ofEntries(Map.entry(header, cookieString.toString()));
+        Map<String, String> headers = Map.ofEntries(Map.entry(header, cookieString));
 
         HttpCookie cookie =
                 getHttpCookieFromResponseHeaders(headers, "cookies_preferences_set").orElseThrow();

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuthorizationServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuthorizationServiceTest.java
@@ -23,12 +23,14 @@ import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.VectorOfTrust;
 import uk.gov.di.authentication.shared.exceptions.ClientNotFoundException;
+import uk.gov.di.authentication.shared.helpers.CookieHelper;
 import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static java.lang.String.format;
@@ -365,6 +367,19 @@ class AuthorizationServiceTest {
 
         assertEquals(userContext.getSession(), session);
         assertEquals(userContext.getClientSession(), clientSession);
+    }
+
+    @Test
+    void shouldGetPersistentCookieIdFromExistingCookie() {
+        Map<String, String> requestCookieHeader =
+                Map.of(
+                        CookieHelper.REQUEST_COOKIE_HEADER,
+                        "di-persistent-session-id=some-persistent-id;gs=session-id.456");
+
+        String persistentSessionId =
+                authorizationService.getExistingOrCreateNewPersistentSessionId(requestCookieHeader);
+
+        assertEquals(persistentSessionId, "some-persistent-id");
     }
 
     private ClientRegistry generateClientRegistry(String redirectURI, String clientID) {


### PR DESCRIPTION
## What?

- Create persistent cookie on authorize if one doesn't exist. If it does exist, then use the value from the existing cookie and put it in a new cookie.
- Set the expiry of the cookie to 13 months.
- Use the multivalue map to have multiple cookies under the Set-Cookie header as explained here https://aws.amazon.com/blogs/compute/support-for-multi-value-parameters-in-amazon-api-gateway/
- Add new methods in the CookieHelper to parse a multivalues map to help with testing
- Remove test data from the CookieHelper class

## Why?

- To have a new cookie which is used across the GOV.UK Sign In and account management applications