### PR TITLE
GOVSI-1114: Add KmsKeyExtension for audit signing key

### DIFF
--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/AuthenticateIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/AuthenticateIntegrationTest.java
@@ -16,7 +16,7 @@ public class AuthenticateIntegrationTest extends ApiGatewayHandlerIntegrationTes
 
     @BeforeEach
     void setup() {
-        handler = new AuthenticateHandler(configurationService);
+        handler = new AuthenticateHandler(TEST_CONFIGURATION_SERVICE);
     }
 
     @Test

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdateEmailIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdateEmailIntegrationTest.java
@@ -33,7 +33,7 @@ public class UpdateEmailIntegrationTest extends ApiGatewayHandlerIntegrationTest
 
     @BeforeEach
     void setup() {
-        handler = new UpdateEmailHandler(configurationService);
+        handler = new UpdateEmailHandler(TEST_CONFIGURATION_SERVICE);
         notify.init();
     }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
@@ -37,7 +37,7 @@ public class AuthCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @BeforeEach
     void setup() {
-        handler = new AuthCodeHandler(configurationService);
+        handler = new AuthCodeHandler(TEST_CONFIGURATION_SERVICE);
     }
 
     @Test

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -62,7 +62,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     @BeforeEach
     void setup() {
         registerClient(CLIENT_ID, "test-client", singletonList("openid"));
-        handler = new AuthorisationHandler(configurationService);
+        handler = new AuthorisationHandler(TEST_CONFIGURATION_SERVICE);
     }
 
     @Test
@@ -97,7 +97,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(response, hasStatus(302));
         assertThat(
                 getHeaderValueByParamName(response, ResponseHeaders.LOCATION),
-                startsWith(configurationService.getLoginURI().toString()));
+                startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
         assertThat(
                 getHttpCookieFromMultiValueResponseHeaders(response.getMultiValueHeaders(), "gs")
                         .isPresent(),
@@ -122,7 +122,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(response, hasStatus(302));
         assertThat(
                 getHeaderValueByParamName(response, ResponseHeaders.LOCATION),
-                startsWith(configurationService.getLoginURI().toString()));
+                startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
         assertThat(
                 response.getMultiValueHeaders().get(ResponseHeaders.SET_COOKIE).size(), equalTo(2));
         assertThat(
@@ -152,7 +152,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(response, hasStatus(302));
         assertThat(
                 getHeaderValueByParamName(response, ResponseHeaders.LOCATION),
-                startsWith(configurationService.getLoginURI().toString()));
+                startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
         assertThat(
                 getHttpCookieFromMultiValueResponseHeaders(response.getMultiValueHeaders(), "gs")
                         .isPresent(),
@@ -196,7 +196,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(response, hasStatus(302));
         assertThat(
                 getHeaderValueByParamName(response, ResponseHeaders.LOCATION),
-                startsWith(configurationService.getLoginURI().toString()));
+                startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
         assertThat(
                 getHttpCookieFromMultiValueResponseHeaders(response.getMultiValueHeaders(), "gs")
                         .isPresent(),
@@ -223,7 +223,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(response, hasStatus(302));
         assertThat(
                 getHeaderValueByParamName(response, ResponseHeaders.LOCATION),
-                startsWith(configurationService.getLoginURI().toString()));
+                startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
         assertThat(
                 getHttpCookieFromMultiValueResponseHeaders(response.getMultiValueHeaders(), "gs")
                         .isPresent(),
@@ -255,7 +255,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(response, hasStatus(302));
         assertThat(
                 getHeaderValueByParamName(response, ResponseHeaders.LOCATION),
-                startsWith(configurationService.getLoginURI().toString()));
+                startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
         var cookie =
                 getHttpCookieFromMultiValueResponseHeaders(response.getMultiValueHeaders(), "gs");
         assertThat(
@@ -345,7 +345,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(cookie.get().getValue(), not(startsWith(sessionId)));
         assertThat(
                 getHeaderValueByParamName(response, ResponseHeaders.LOCATION),
-                startsWith(configurationService.getLoginURI().toString()));
+                startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
     }
 
     @Test
@@ -378,7 +378,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(cookie.get().getValue(), not(startsWith(sessionId)));
         assertThat(
                 getHeaderValueByParamName(response, ResponseHeaders.LOCATION),
-                startsWith(configurationService.getLoginURI().toString()));
+                startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
         String newSessionId = cookie.get().getValue().split("\\.")[0];
         assertThat(redis.getSession(newSessionId).getState(), equalTo(AUTHENTICATION_REQUIRED));
     }
@@ -414,7 +414,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(cookie.get().getValue(), not(startsWith(sessionId)));
 
         String redirectUri = getHeaderValueByParamName(response, ResponseHeaders.LOCATION);
-        assertThat(redirectUri, startsWith(configurationService.getLoginURI().toString()));
+        assertThat(redirectUri, startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
         assertThat(URI.create(redirectUri).getQuery(), equalTo("interrupt=UPLIFT_REQUIRED_CM"));
 
         String newSessionId = cookie.get().getValue().split("\\.")[0];
@@ -452,7 +452,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(cookie.get().getValue(), not(startsWith(sessionId)));
 
         String redirectUri = getHeaderValueByParamName(response, ResponseHeaders.LOCATION);
-        assertThat(redirectUri, startsWith(configurationService.getLoginURI().toString()));
+        assertThat(redirectUri, startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
         assertThat(URI.create(redirectUri).getQuery(), equalTo("interrupt=CONSENT_REQUIRED"));
 
         String newSessionId = cookie.get().getValue().split("\\.")[0];

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientInfoIntegrationTest.java
@@ -44,7 +44,7 @@ public class ClientInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest 
 
     @BeforeEach
     void setup() {
-        handler = new ClientInfoHandler(configurationService);
+        handler = new ClientInfoHandler(TEST_CONFIGURATION_SERVICE);
     }
 
     @Test

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientRegistrationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientRegistrationIntegrationTest.java
@@ -26,7 +26,7 @@ public class ClientRegistrationIntegrationTest extends ApiGatewayHandlerIntegrat
 
     @BeforeEach
     void setup() {
-        handler = new ClientRegistrationHandler(configurationService);
+        handler = new ClientRegistrationHandler(TEST_CONFIGURATION_SERVICE);
     }
 
     @Test

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/JwksIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/JwksIntegrationTest.java
@@ -18,7 +18,7 @@ public class JwksIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @BeforeEach
     void setup() {
-        handler = new JwksHandler(configurationService);
+        handler = new JwksHandler(TEST_CONFIGURATION_SERVICE);
     }
 
     @Test

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
@@ -50,7 +50,7 @@ public class LoginIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @BeforeEach
     void setup() {
-        handler = new LoginHandler(configurationService);
+        handler = new LoginHandler(TEST_CONFIGURATION_SERVICE);
     }
 
     @ParameterizedTest

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
@@ -53,7 +53,7 @@ public class LogoutIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @BeforeEach
     void setup() {
-        handler = new LogoutHandler(configurationService);
+        handler = new LogoutHandler(TEST_CONFIGURATION_SERVICE);
     }
 
     @Test
@@ -97,7 +97,7 @@ public class LogoutIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 response,
                 isRedirectTo(
                         allOf(
-                                baseUri(configurationService.getDefaultLogoutURI()),
+                                baseUri(TEST_CONFIGURATION_SERVICE.getDefaultLogoutURI()),
                                 redirectQueryParameters(hasEntry("state", STATE)))));
     }
 
@@ -123,7 +123,7 @@ public class LogoutIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 response,
                 isRedirectTo(
                         allOf(
-                                baseUri(configurationService.getDefaultLogoutURI()),
+                                baseUri(TEST_CONFIGURATION_SERVICE.getDefaultLogoutURI()),
                                 redirectQueryParameters(hasEntry("state", STATE)),
                                 redirectQueryParameters(
                                         hasEntry("error_code", "invalid_request")))));

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordIntegrationTest.java
@@ -32,7 +32,7 @@ public class ResetPasswordIntegrationTest extends ApiGatewayHandlerIntegrationTe
 
     @BeforeEach
     public void setUp() {
-        handler = new ResetPasswordHandler(configurationService);
+        handler = new ResetPasswordHandler(TEST_CONFIGURATION_SERVICE);
         notifyStub.init();
     }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordRequestIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordRequestIntegrationTest.java
@@ -30,7 +30,7 @@ public class ResetPasswordRequestIntegrationTest extends ApiGatewayHandlerIntegr
 
     @BeforeEach
     public void setUp() {
-        handler = new ResetPasswordRequestHandler(configurationService);
+        handler = new ResetPasswordRequestHandler(TEST_CONFIGURATION_SERVICE);
         notifyStub.init();
     }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/SignupIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/SignupIntegrationTest.java
@@ -23,7 +23,7 @@ public class SignupIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @BeforeEach
     void setup() {
-        handler = new SignUpHandler(configurationService);
+        handler = new SignUpHandler(TEST_CONFIGURATION_SERVICE);
     }
 
     @Test

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
@@ -73,7 +73,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @BeforeEach
     void setup() {
-        handler = new TokenHandler(configurationService);
+        handler = new TokenHandler(TEST_CONFIGURATION_SERVICE);
     }
 
     @Test

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateClientConfigIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateClientConfigIntegrationTest.java
@@ -26,7 +26,7 @@ public class UpdateClientConfigIntegrationTest extends ApiGatewayHandlerIntegrat
 
     @BeforeEach
     void setup() {
-        handler = new UpdateClientConfigHandler(configurationService);
+        handler = new UpdateClientConfigHandler(TEST_CONFIGURATION_SERVICE);
     }
 
     @Test

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateProfileIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateProfileIntegrationTest.java
@@ -47,7 +47,7 @@ public class UpdateProfileIntegrationTest extends ApiGatewayHandlerIntegrationTe
 
     @BeforeEach
     void setup() {
-        handler = new UpdateProfileHandler(configurationService);
+        handler = new UpdateProfileHandler(TEST_CONFIGURATION_SERVICE);
     }
 
     @Test

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserExistsIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserExistsIntegrationTest.java
@@ -25,7 +25,7 @@ public class UserExistsIntegrationTest extends ApiGatewayHandlerIntegrationTest 
 
     @BeforeEach
     void setup() {
-        handler = new CheckUserExistsHandler(configurationService);
+        handler = new CheckUserExistsHandler(TEST_CONFIGURATION_SERVICE);
     }
 
     @Test

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
@@ -51,7 +51,7 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @BeforeEach
     void setup() {
-        handler = new UserInfoHandler(configurationService);
+        handler = new UserInfoHandler(TEST_CONFIGURATION_SERVICE);
     }
 
     @Test

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
@@ -47,7 +47,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
 
     @BeforeEach
     void setup() {
-        handler = new VerifyCodeHandler(configurationService);
+        handler = new VerifyCodeHandler(TEST_CONFIGURATION_SERVICE);
     }
 
     @Test

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/ApiGatewayHandlerIntegrationTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/ApiGatewayHandlerIntegrationTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.sharedtest.extensions.ClientStoreExtension;
+import uk.gov.di.authentication.sharedtest.extensions.KmsKeyExtension;
 import uk.gov.di.authentication.sharedtest.extensions.RedisExtension;
 import uk.gov.di.authentication.sharedtest.extensions.UserStoreExtension;
 
@@ -41,12 +42,12 @@ public abstract class ApiGatewayHandlerIntegrationTest {
                                     Optional.ofNullable(
                                                     System.getenv().get("FRONTEND_API_GATEWAY_ID"))
                                             .orElse("")));
+    protected static final ConfigurationService TEST_CONFIGURATION_SERVICE =
+            new IntegrationTestConfigurationService();
 
     protected RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> handler;
     protected final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
     protected final Context context = mock(Context.class);
-    protected final ConfigurationService configurationService =
-            new IntegrationTestConfigurationService();
 
     @RegisterExtension
     protected static final RedisExtension redis =
@@ -57,6 +58,10 @@ public abstract class ApiGatewayHandlerIntegrationTest {
 
     @RegisterExtension
     protected static final ClientStoreExtension clientStore = new ClientStoreExtension();
+
+    @RegisterExtension
+    protected static final KmsKeyExtension auditSigningKey =
+            new KmsKeyExtension(TEST_CONFIGURATION_SERVICE.getAuditSigningKeyAlias());
 
     protected APIGatewayProxyResponseEvent makeRequest(
             Optional<Object> body, Map<String, String> headers, Map<String, String> queryString) {

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/KmsKeyExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/KmsKeyExtension.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import static com.amazonaws.services.kms.model.KeySpec.ECC_NIST_P256;
+import static com.amazonaws.services.kms.model.KeyUsageType.SIGN_VERIFY;
 
 public class KmsKeyExtension implements BeforeAllCallback {
 
@@ -41,7 +42,7 @@ public class KmsKeyExtension implements BeforeAllCallback {
 
     protected void createTokenSigningKey(String keyAlias) {
         CreateKeyRequest keyRequest =
-                new CreateKeyRequest().withKeySpec(ECC_NIST_P256).withKeyUsage("SIGN_VERIFY");
+                new CreateKeyRequest().withKeySpec(ECC_NIST_P256).withKeyUsage(SIGN_VERIFY);
 
         var keyResponse = kms.createKey(keyRequest);
 


### PR DESCRIPTION
## What?

- Initialise a new KmsKeyExtension in the base test for the Audit Signing key
- Refactor the TestConfiguration to be static so we can use configuration values to initialise extensions
- Use KeyUsageType enum rather than string

## Why?

All integration tests require a an audit signing key for the handlers to work correctly.

## Related PRs

#1083 
