### PR TITLE
GOVSI-1144: Clear `ThreadContext` map on pre-warm check

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/WarmerHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/WarmerHelper.java
@@ -4,6 +4,7 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.ThreadContext;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.util.Optional;
@@ -19,6 +20,8 @@ public class WarmerHelper {
 
     public static Optional<APIGatewayProxyResponseEvent> isWarming(
             APIGatewayProxyRequestEvent input) {
+        ThreadContext.clearMap();
+
         if (input.getHeaders() != null && input.getHeaders().containsKey(WARMUP_HEADER)) {
             try {
                 LOGGER.info("Warmup Request Received {}", input.getHeaders().get(WARMUP_HEADER));


### PR DESCRIPTION
Lambdas do not start fresh containers per request.
