### PR TITLE
GOVSI-1143 - Create persistentIdHelper for extracting persistent ID from input headers

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/PersistentIdHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/PersistentIdHelper.java
@@ -1,0 +1,22 @@
+package uk.gov.di.authentication.shared.helpers;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Map;
+
+public class PersistentIdHelper {
+
+    private static final Logger LOG = LogManager.getLogger(PersistentIdHelper.class);
+    public static final String PERSISTENT_ID_HEADER_NAME = "di-persistent-session-id";
+    public static final String PERSISTENT_ID_UNKNOWN_VALUE = "unknown";
+
+    public static String extractPersistentIdFromHeaders(Map<String, String> headers) {
+        if (!headers.containsKey(PERSISTENT_ID_HEADER_NAME)
+                || headers.get(PERSISTENT_ID_HEADER_NAME) == null) {
+            return PERSISTENT_ID_UNKNOWN_VALUE;
+        }
+        LOG.info("PersistentID on request: {}", headers.get(PERSISTENT_ID_HEADER_NAME));
+        return headers.get(PERSISTENT_ID_HEADER_NAME);
+    }
+}

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/PersistentIdHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/PersistentIdHelperTest.java
@@ -1,0 +1,40 @@
+package uk.gov.di.authentication.shared.helpers;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class PersistentIdHelperTest {
+
+    @Test
+    void shouldReturnPersistentIdWhenExistsInHeader() {
+        String persistentIdInputHeader = "some-persistent-id-value";
+        Map<String, String> inputHeaders =
+                Map.of(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, persistentIdInputHeader);
+        String persistentId = PersistentIdHelper.extractPersistentIdFromHeaders(inputHeaders);
+
+        assertThat(persistentId, equalTo(persistentIdInputHeader));
+    }
+
+    @Test
+    void shouldReturnUnknownIfPersistentIdHeaderIsNotPresent() {
+        Map<String, String> inputHeaders = Collections.emptyMap();
+        String persistentId = PersistentIdHelper.extractPersistentIdFromHeaders(inputHeaders);
+
+        assertThat(persistentId, equalTo(PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE));
+    }
+
+    @Test
+    void shouldReturnUnknownIfPersistentIdIsNull() {
+        Map<String, String> inputHeaders = new HashMap<>();
+        inputHeaders.put(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, null);
+        String persistentId = PersistentIdHelper.extractPersistentIdFromHeaders(inputHeaders);
+
+        assertThat(persistentId, equalTo(PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE));
+    }
+}


### PR DESCRIPTION
## What?

- This helper will take in the input headers and pull out the persistent ID if it exists under the 'di-persistent-session-id' header name. If it does not exist then we will set the value to 'unknown'.
- This value will be used for updating the audit.
- The helper will be used by the frontend apis and account management apis.

## Why?

- To have a single place used for extracting the `di-persistent-session-id` from the input headers.