### PR TITLE
GOVSI-1114: Add an extension to manage required SNS topics

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ subprojects {
         logging_runtime
         nimbus
         s3
+        sns
         sqs
         tests
         test_runtime
@@ -86,6 +87,7 @@ subprojects {
         nimbus "com.nimbusds:oauth2-oidc-sdk:${dependencyVersions.nimbusds_oauth_version}",
                 "com.nimbusds:nimbus-jose-jwt:${dependencyVersions.nimbusds_jwt_version}"
 
+        sns "com.amazonaws:aws-java-sdk-sns:${dependencyVersions.aws_sdk_version}"
 
         sqs "software.amazon.awssdk:sqs:2.17.73"
 

--- a/shared-test/build.gradle
+++ b/shared-test/build.gradle
@@ -17,6 +17,7 @@ dependencies {
             configurations.jackson,
             configurations.lettuce,
             configurations.dynamodb,
+            configurations.sns,
             "org.eclipse.jetty:jetty-server:11.0.7",
             "com.google.protobuf:protobuf-java:3.18.1",
             project(":shared")

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/ApiGatewayHandlerIntegrationTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/ApiGatewayHandlerIntegrationTest.java
@@ -12,6 +12,7 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.sharedtest.extensions.ClientStoreExtension;
 import uk.gov.di.authentication.sharedtest.extensions.KmsKeyExtension;
 import uk.gov.di.authentication.sharedtest.extensions.RedisExtension;
+import uk.gov.di.authentication.sharedtest.extensions.SnsTopicExtension;
 import uk.gov.di.authentication.sharedtest.extensions.UserStoreExtension;
 
 import java.net.HttpCookie;
@@ -62,6 +63,9 @@ public abstract class ApiGatewayHandlerIntegrationTest {
     @RegisterExtension
     protected static final KmsKeyExtension auditSigningKey =
             new KmsKeyExtension(TEST_CONFIGURATION_SERVICE.getAuditSigningKeyAlias());
+
+    @RegisterExtension
+    protected static final SnsTopicExtension auditTopic = new SnsTopicExtension("local-events");
 
     protected APIGatewayProxyResponseEvent makeRequest(
             Optional<Object> body, Map<String, String> headers, Map<String, String> queryString) {

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/SnsTopicExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/SnsTopicExtension.java
@@ -1,0 +1,38 @@
+package uk.gov.di.authentication.sharedtest.extensions;
+
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.sns.AmazonSNS;
+import com.amazonaws.services.sns.AmazonSNSClientBuilder;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class SnsTopicExtension implements BeforeAllCallback {
+
+    protected static final String REGION = System.getenv().getOrDefault("AWS_REGION", "eu-west-2");
+    protected static final String LOCALSTACK_ENDPOINT =
+            System.getenv().getOrDefault("LOCALSTACK_ENDPOINT", "http://localhost:45678");
+
+    private final String topicName;
+    private final AmazonSNS snsClient;
+
+    private String topicArn;
+
+    public SnsTopicExtension(String topicName) {
+        this.topicName = topicName;
+        this.snsClient =
+                AmazonSNSClientBuilder.standard()
+                        .withEndpointConfiguration(
+                                new AwsClientBuilder.EndpointConfiguration(
+                                        LOCALSTACK_ENDPOINT, REGION))
+                        .build();
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        topicArn = createTopic(topicName);
+    }
+
+    private String createTopic(String topicName) {
+        return snsClient.createTopic(topicName).getTopicArn();
+    }
+}

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -20,7 +20,7 @@ dependencies {
             configurations.dynamodb,
             configurations.lettuce,
             configurations.hamcrest,
-            "com.amazonaws:aws-java-sdk-sns:${dependencyVersions.aws_sdk_version}",
+            configurations.sns,
             "com.amazonaws:aws-java-sdk-ssm:${dependencyVersions.aws_sdk_version}",
             "com.googlecode.libphonenumber:libphonenumber:8.12.36",
             "com.google.protobuf:protobuf-java:3.18.1"


### PR DESCRIPTION
## What?

- Add a new extension to create a required SNS topic needed to execute integration tests (the call to `CreateTopic` actually reuses existing topic with same name if it already exists)
- Add an instance of this extension to the base integration test to represent the audit event topic

## Why?

We are adding the managing of required resources to the integration tests via extensions.