### PR TITLE
GOVSI-1143 - Pass persistent-session-id to the audit service

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandler.java
@@ -12,6 +12,7 @@ import uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent;
 import uk.gov.di.accountmanagement.entity.AuthenticateRequest;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
+import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -89,6 +90,8 @@ public class AuthenticateHandler
                                         AuditService.UNKNOWN,
                                         loginRequest.getEmail(),
                                         IpAddressHelper.extractIpAddress(input),
+                                        PersistentIdHelper.extractPersistentIdFromHeaders(
+                                                input.getHeaders()),
                                         AuditService.UNKNOWN);
 
                                 return generateEmptySuccessApiGatewayResponse();

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandler.java
@@ -17,6 +17,7 @@ import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
+import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.helpers.RequestBodyHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
@@ -101,6 +102,8 @@ public class RemoveAccountHandler
                                         userProfile.getSubjectID(),
                                         userProfile.getEmail(),
                                         IpAddressHelper.extractIpAddress(input),
+                                        PersistentIdHelper.extractPersistentIdFromHeaders(
+                                                input.getHeaders()),
                                         userProfile.getPhoneNumber());
 
                                 return generateEmptySuccessApiGatewayResponse();

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
@@ -16,6 +16,7 @@ import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
+import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.CodeGeneratorService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -174,6 +175,7 @@ public class SendOtpNotificationHandler
                 sendNotificationRequest.getEmail(),
                 IpAddressHelper.extractIpAddress(input),
                 sendNotificationRequest.getPhoneNumber(),
+                PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
                 pair("notification-type", sendNotificationRequest.getNotificationType()));
 
         LOGGER.info("Generating successful API response");

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
@@ -18,6 +18,7 @@ import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
+import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.helpers.RequestBodyHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -139,6 +140,8 @@ public class UpdateEmailHandler
                                         userProfile.getSubjectID(),
                                         userProfile.getEmail(),
                                         IpAddressHelper.extractIpAddress(input),
+                                        PersistentIdHelper.extractPersistentIdFromHeaders(
+                                                input.getHeaders()),
                                         userProfile.getPhoneNumber());
 
                                 LOGGER.info(

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandler.java
@@ -18,6 +18,7 @@ import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.Argon2MatcherHelper;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
+import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.helpers.RequestBodyHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -115,6 +116,8 @@ public class UpdatePasswordHandler
                                         userProfile.getSubjectID(),
                                         userProfile.getEmail(),
                                         IpAddressHelper.extractIpAddress(input),
+                                        PersistentIdHelper.extractPersistentIdFromHeaders(
+                                                input.getHeaders()),
                                         userProfile.getPhoneNumber());
 
                                 return generateEmptySuccessApiGatewayResponse();

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandler.java
@@ -18,6 +18,7 @@ import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
+import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.helpers.RequestBodyHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -128,6 +129,8 @@ public class UpdatePhoneNumberHandler
                                         userProfile.getSubjectID(),
                                         userProfile.getEmail(),
                                         IpAddressHelper.extractIpAddress(input),
+                                        PersistentIdHelper.extractPersistentIdFromHeaders(
+                                                input.getHeaders()),
                                         userProfile.getPhoneNumber());
 
                                 LOGGER.info(

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandlerTest.java
@@ -7,9 +7,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 
+import java.util.Map;
 import java.util.Optional;
 
 import static java.lang.String.format;
@@ -39,11 +41,13 @@ class AuthenticateHandlerTest {
 
     @Test
     public void shouldReturn204IfLoginIsSuccessful() {
+        String persistentIdValue = "some-persistent-session-id";
         when(authenticationService.userExists(EMAIL)).thenReturn(true);
         when(authenticationService.login(EMAIL, PASSWORD)).thenReturn(true);
         when(authenticationService.getPhoneNumber(EMAIL)).thenReturn(Optional.of(PHONE_NUMBER));
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setRequestContext(contextWithSourceIp("123.123.123.123"));
+        event.setHeaders(Map.of(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, persistentIdValue));
         event.setBody(format("{ \"password\": \"%s\", \"email\": \"%s\" }", PASSWORD, EMAIL));
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
@@ -58,6 +62,7 @@ class AuthenticateHandlerTest {
                         AuditService.UNKNOWN,
                         EMAIL,
                         "123.123.123.123",
+                        persistentIdValue,
                         AuditService.UNKNOWN);
     }
 

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandlerTest.java
@@ -12,6 +12,7 @@ import uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 
@@ -45,6 +46,7 @@ class RemoveAccountHandlerTest {
 
     @Test
     public void shouldReturn204IfAccountRemovalIsSuccessful() throws JsonProcessingException {
+        String persistentIdValue = "some-persistent-session-id";
         UserProfile userProfile = new UserProfile().setPublicSubjectID(SUBJECT.getValue());
         when(authenticationService.getUserProfileByEmail(EMAIL)).thenReturn(userProfile);
         APIGatewayProxyRequestEvent.ProxyRequestContext proxyRequestContext =
@@ -57,6 +59,7 @@ class RemoveAccountHandlerTest {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setRequestContext(proxyRequestContext);
         event.setBody(format("{ \"email\": \"%s\" }", EMAIL));
+        event.setHeaders(Map.of(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, persistentIdValue));
 
         when(authenticationService.userExists(EMAIL)).thenReturn(true);
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
@@ -73,6 +76,7 @@ class RemoveAccountHandlerTest {
                         userProfile.getSubjectID(),
                         userProfile.getEmail(),
                         "123.123.123.123",
+                        persistentIdValue,
                         userProfile.getPhoneNumber());
 
         assertThat(result, hasStatus(204));

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandlerTest.java
@@ -15,6 +15,7 @@ import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.CodeGeneratorService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -76,6 +77,7 @@ class SendOtpNotificationHandlerTest {
 
     @Test
     void shouldReturn204AndPutMessageOnQueueForAValidEmailRequest() throws JsonProcessingException {
+        String persistentIdValue = "some-persistent-session-id";
         when(validationService.validateEmailAddress(eq(TEST_EMAIL_ADDRESS)))
                 .thenReturn(Optional.empty());
         NotifyRequest notifyRequest =
@@ -84,7 +86,7 @@ class SendOtpNotificationHandlerTest {
         String serialisedRequest = objectMapper.writeValueAsString(notifyRequest);
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        event.setHeaders(Map.of());
+        event.setHeaders(Map.of(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, persistentIdValue));
         event.setRequestContext(contextWithSourceIp("123.123.123.123"));
         event.setBody(
                 format(
@@ -109,6 +111,7 @@ class SendOtpNotificationHandlerTest {
                         TEST_EMAIL_ADDRESS,
                         "123.123.123.123",
                         null,
+                        persistentIdValue,
                         pair("notification-type", VERIFY_EMAIL));
     }
 
@@ -148,6 +151,7 @@ class SendOtpNotificationHandlerTest {
                         TEST_EMAIL_ADDRESS,
                         "123.123.123.123",
                         TEST_PHONE_NUMBER,
+                        PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
                         pair("notification-type", VERIFY_PHONE_NUMBER));
     }
 

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandlerTest.java
@@ -15,6 +15,7 @@ import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.ValidationService;
@@ -65,6 +66,7 @@ class UpdateEmailHandlerTest {
 
     @Test
     public void shouldReturn204ForValidUpdateEmailRequest() throws JsonProcessingException {
+        String persistentIdValue = "some-persistent-session-id";
         UserProfile userProfile = new UserProfile().setPublicSubjectID(SUBJECT.getValue());
         when(dynamoService.getUserProfileByEmail(EXISTING_EMAIL_ADDRESS)).thenReturn(userProfile);
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
@@ -72,6 +74,7 @@ class UpdateEmailHandlerTest {
                 format(
                         "{\"existingEmailAddress\": \"%s\", \"replacementEmailAddress\": \"%s\", \"otp\": \"%s\"  }",
                         EXISTING_EMAIL_ADDRESS, NEW_EMAIL_ADDRESS, OTP));
+        event.setHeaders(Map.of(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, persistentIdValue));
         APIGatewayProxyRequestEvent.ProxyRequestContext proxyRequestContext =
                 new APIGatewayProxyRequestEvent.ProxyRequestContext();
         Map<String, Object> authorizerParams = new HashMap<>();
@@ -101,6 +104,7 @@ class UpdateEmailHandlerTest {
                         userProfile.getSubjectID(),
                         userProfile.getEmail(),
                         "123.123.123.123",
+                        persistentIdValue,
                         userProfile.getPhoneNumber());
     }
 

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandlerTest.java
@@ -16,6 +16,7 @@ import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.Argon2EncoderHelper;
+import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 
@@ -53,6 +54,7 @@ class UpdatePasswordHandlerTest {
 
     @Test
     public void shouldReturn204ForValidRequest() throws JsonProcessingException {
+        String persistentIdValue = "some-persistent-session-id";
         UserProfile userProfile = new UserProfile().setPublicSubjectID(SUBJECT.getValue());
         UserCredentials userCredentials = new UserCredentials().setPassword(CURRENT_PASSWORD);
         when(dynamoService.getUserProfileByEmail(EXISTING_EMAIL_ADDRESS)).thenReturn(userProfile);
@@ -63,6 +65,7 @@ class UpdatePasswordHandlerTest {
                 format(
                         "{ \"email\": \"%s\", \"newPassword\": \"%s\" }",
                         EXISTING_EMAIL_ADDRESS, NEW_PASSWORD));
+        event.setHeaders(Map.of(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, persistentIdValue));
         APIGatewayProxyRequestEvent.ProxyRequestContext proxyRequestContext =
                 new APIGatewayProxyRequestEvent.ProxyRequestContext();
         Map<String, Object> authorizerParams = new HashMap<>();
@@ -88,6 +91,7 @@ class UpdatePasswordHandlerTest {
                         userProfile.getSubjectID(),
                         userProfile.getEmail(),
                         "123.123.123.123",
+                        persistentIdValue,
                         userProfile.getPhoneNumber());
     }
 
@@ -150,6 +154,7 @@ class UpdatePasswordHandlerTest {
                         userProfile.getSubjectID(),
                         userProfile.getEmail(),
                         "123.123.123.123",
+                        PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
                         userProfile.getPhoneNumber());
     }
 }

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandlerTest.java
@@ -14,6 +14,7 @@ import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.ValidationService;
@@ -64,6 +65,7 @@ class UpdatePhoneNumberHandlerTest {
 
     @Test
     public void shouldReturn204ForValidUpdatePhoneNumberRequest() throws JsonProcessingException {
+        String persistentIdValue = "some-persistent-session-id";
         UserProfile userProfile = new UserProfile().setPublicSubjectID(SUBJECT.getValue());
         when(dynamoService.getUserProfileByEmail(EMAIL_ADDRESS)).thenReturn(userProfile);
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
@@ -71,6 +73,7 @@ class UpdatePhoneNumberHandlerTest {
                 format(
                         "{\"email\": \"%s\", \"phoneNumber\": \"%s\", \"otp\": \"%s\"  }",
                         EMAIL_ADDRESS, PHONE_NUMBER, OTP));
+        event.setHeaders(Map.of(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, persistentIdValue));
         APIGatewayProxyRequestEvent.ProxyRequestContext proxyRequestContext =
                 new APIGatewayProxyRequestEvent.ProxyRequestContext();
         Map<String, Object> authorizerParams = new HashMap<>();
@@ -98,6 +101,7 @@ class UpdatePhoneNumberHandlerTest {
                         userProfile.getSubjectID(),
                         userProfile.getEmail(),
                         "123.123.123.123",
+                        persistentIdValue,
                         userProfile.getPhoneNumber());
     }
 

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandler.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandler.java
@@ -74,6 +74,7 @@ public class ClientRegistrationHandler
                                     AuditService.UNKNOWN,
                                     AuditService.UNKNOWN,
                                     ipAddress,
+                                    AuditService.UNKNOWN,
                                     AuditService.UNKNOWN);
 
                             try {
@@ -97,6 +98,7 @@ public class ClientRegistrationHandler
                                             AuditService.UNKNOWN,
                                             AuditService.UNKNOWN,
                                             ipAddress,
+                                            AuditService.UNKNOWN,
                                             AuditService.UNKNOWN);
 
                                     return generateApiGatewayProxyResponse(
@@ -141,6 +143,7 @@ public class ClientRegistrationHandler
                                         AuditService.UNKNOWN,
                                         AuditService.UNKNOWN,
                                         ipAddress,
+                                        AuditService.UNKNOWN,
                                         AuditService.UNKNOWN);
 
                                 return generateApiGatewayProxyResponse(

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandler.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandler.java
@@ -74,6 +74,7 @@ public class UpdateClientConfigHandler
                                     AuditService.UNKNOWN,
                                     AuditService.UNKNOWN,
                                     ipAddress,
+                                    AuditService.UNKNOWN,
                                     AuditService.UNKNOWN);
                             try {
                                 String clientId = input.getPathParameters().get("clientId");
@@ -93,6 +94,7 @@ public class UpdateClientConfigHandler
                                             AuditService.UNKNOWN,
                                             AuditService.UNKNOWN,
                                             ipAddress,
+                                            AuditService.UNKNOWN,
                                             AuditService.UNKNOWN);
                                     LOGGER.error(
                                             "Invalid update Client config request. Invalid CliendId: {}",
@@ -119,6 +121,7 @@ public class UpdateClientConfigHandler
                                             AuditService.UNKNOWN,
                                             AuditService.UNKNOWN,
                                             ipAddress,
+                                            AuditService.UNKNOWN,
                                             AuditService.UNKNOWN);
                                     return generateApiGatewayProxyResponse(
                                             400, errorResponse.get().toJSONObject().toJSONString());
@@ -147,6 +150,7 @@ public class UpdateClientConfigHandler
                                         AuditService.UNKNOWN,
                                         AuditService.UNKNOWN,
                                         ipAddress,
+                                        AuditService.UNKNOWN,
                                         AuditService.UNKNOWN);
                                 LOGGER.error(
                                         "Invalid Client registration request. Missing parameters from request");

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandlerTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandlerTest.java
@@ -113,7 +113,7 @@ class ClientRegistrationHandlerTest {
 
         verify(auditService)
                 .submitAuditEvent(
-                        REGISTER_CLIENT_REQUEST_ERROR, "request-id", "", "", "", "", "", "");
+                        REGISTER_CLIENT_REQUEST_ERROR, "request-id", "", "", "", "", "", "", "");
     }
 
     @Test
@@ -131,7 +131,7 @@ class ClientRegistrationHandlerTest {
 
         verify(auditService)
                 .submitAuditEvent(
-                        REGISTER_CLIENT_REQUEST_ERROR, "request-id", "", "", "", "", "", "");
+                        REGISTER_CLIENT_REQUEST_ERROR, "request-id", "", "", "", "", "", "", "");
     }
 
     @Test
@@ -149,7 +149,7 @@ class ClientRegistrationHandlerTest {
 
         verify(auditService)
                 .submitAuditEvent(
-                        REGISTER_CLIENT_REQUEST_ERROR, "request-id", "", "", "", "", "", "");
+                        REGISTER_CLIENT_REQUEST_ERROR, "request-id", "", "", "", "", "", "", "");
     }
 
     private APIGatewayProxyResponseEvent makeHandlerRequest(APIGatewayProxyRequestEvent event) {
@@ -157,7 +157,7 @@ class ClientRegistrationHandlerTest {
 
         verify(auditService)
                 .submitAuditEvent(
-                        REGISTER_CLIENT_REQUEST_RECEIVED, "request-id", "", "", "", "", "", "");
+                        REGISTER_CLIENT_REQUEST_RECEIVED, "request-id", "", "", "", "", "", "", "");
 
         return response;
     }

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandlerTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandlerTest.java
@@ -98,7 +98,7 @@ class UpdateClientConfigHandlerTest {
 
         verify(auditService)
                 .submitAuditEvent(
-                        UPDATE_CLIENT_REQUEST_ERROR, "request-id", "", "", "", "", "", "");
+                        UPDATE_CLIENT_REQUEST_ERROR, "request-id", "", "", "", "", "", "", "");
     }
 
     @Test
@@ -112,7 +112,7 @@ class UpdateClientConfigHandlerTest {
 
         verify(auditService)
                 .submitAuditEvent(
-                        UPDATE_CLIENT_REQUEST_ERROR, "request-id", "", "", "", "", "", "");
+                        UPDATE_CLIENT_REQUEST_ERROR, "request-id", "", "", "", "", "", "", "");
     }
 
     @Test
@@ -128,7 +128,15 @@ class UpdateClientConfigHandlerTest {
 
         verify(auditService)
                 .submitAuditEvent(
-                        UPDATE_CLIENT_REQUEST_ERROR, "request-id", "", CLIENT_ID, "", "", "", "");
+                        UPDATE_CLIENT_REQUEST_ERROR,
+                        "request-id",
+                        "",
+                        CLIENT_ID,
+                        "",
+                        "",
+                        "",
+                        "",
+                        "");
     }
 
     @Test
@@ -151,7 +159,15 @@ class UpdateClientConfigHandlerTest {
 
         verify(auditService)
                 .submitAuditEvent(
-                        UPDATE_CLIENT_REQUEST_ERROR, "request-id", "", CLIENT_ID, "", "", "", "");
+                        UPDATE_CLIENT_REQUEST_ERROR,
+                        "request-id",
+                        "",
+                        CLIENT_ID,
+                        "",
+                        "",
+                        "",
+                        "",
+                        "");
     }
 
     @Test
@@ -171,7 +187,15 @@ class UpdateClientConfigHandlerTest {
 
         verify(auditService)
                 .submitAuditEvent(
-                        UPDATE_CLIENT_REQUEST_ERROR, "request-id", "", CLIENT_ID, "", "", "", "");
+                        UPDATE_CLIENT_REQUEST_ERROR,
+                        "request-id",
+                        "",
+                        CLIENT_ID,
+                        "",
+                        "",
+                        "",
+                        "",
+                        "");
     }
 
     private ClientRegistry createClientRegistry() {
@@ -192,7 +216,7 @@ class UpdateClientConfigHandlerTest {
 
         verify(auditService)
                 .submitAuditEvent(
-                        UPDATE_CLIENT_REQUEST_RECEIVED, "request-id", "", "", "", "", "", "");
+                        UPDATE_CLIENT_REQUEST_RECEIVED, "request-id", "", "", "", "", "", "", "");
 
         return response;
     }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -15,6 +15,7 @@ import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.SessionAction;
 import uk.gov.di.authentication.shared.entity.SessionState;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
+import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
@@ -94,6 +95,8 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
             String emailAddress = request.getEmail().toLowerCase();
             Optional<ErrorResponse> errorResponse =
                     validationService.validateEmailAddress(emailAddress);
+            String persistentSessionId =
+                    PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders());
             if (errorResponse.isPresent()) {
                 auditService.submitAuditEvent(
                         FrontendAuditableEvent.CHECK_USER_INVALID_EMAIL,
@@ -106,7 +109,8 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
                         AuditService.UNKNOWN,
                         emailAddress,
                         IpAddressHelper.extractIpAddress(input),
-                        AuditService.UNKNOWN);
+                        AuditService.UNKNOWN,
+                        persistentSessionId);
                 LOG.error(
                         "Encountered an error while processing request for session {}; errorResponse is {}",
                         userContext.getSession().getSessionId(),
@@ -134,7 +138,8 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
                         AuditService.UNKNOWN,
                         emailAddress,
                         IpAddressHelper.extractIpAddress(input),
-                        AuditService.UNKNOWN);
+                        AuditService.UNKNOWN,
+                        persistentSessionId);
             } else {
                 auditService.submitAuditEvent(
                         FrontendAuditableEvent.CHECK_USER_NO_ACCOUNT_WITH_EMAIL,
@@ -147,7 +152,8 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
                         AuditService.UNKNOWN,
                         emailAddress,
                         IpAddressHelper.extractIpAddress(input),
-                        AuditService.UNKNOWN);
+                        AuditService.UNKNOWN,
+                        persistentSessionId);
             }
             CheckUserExistsResponse checkUserExistsResponse =
                     new CheckUserExistsResponse(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ClientInfoHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ClientInfoHandler.java
@@ -16,6 +16,7 @@ import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
+import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
@@ -150,6 +151,8 @@ public class ClientInfoHandler
                                         AuditService.UNKNOWN,
                                         AuditService.UNKNOWN,
                                         IpAddressHelper.extractIpAddress(input),
+                                        PersistentIdHelper.extractPersistentIdFromHeaders(
+                                                input.getHeaders()),
                                         AuditService.UNKNOWN);
 
                                 return generateApiGatewayProxyResponse(200, clientInfoResponse);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -20,6 +20,7 @@ import uk.gov.di.authentication.shared.entity.SessionAction;
 import uk.gov.di.authentication.shared.entity.SessionState;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
+import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
@@ -100,9 +101,10 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
                 "Request received to the LoginHandler with session: {}",
                 userContext.getSession().getSessionId());
         try {
+            String persistentSessionId =
+                    PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders());
             UserProfile userProfile =
                     authenticationService.getUserProfileByEmail(request.getEmail());
-
             if (Objects.isNull(userProfile)) {
                 LOGGER.error(
                         "The user does not have an account for session: {}",
@@ -116,6 +118,7 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         IpAddressHelper.extractIpAddress(input),
+                        persistentSessionId,
                         AuditService.UNKNOWN);
 
                 return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1010);
@@ -143,6 +146,7 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
                         userProfile.getSubjectID(),
                         userProfile.getEmail(),
                         IpAddressHelper.extractIpAddress(input),
+                        persistentSessionId,
                         userProfile.getPhoneNumber());
 
                 sessionService.save(userContext.getSession().setState(nextState));
@@ -190,6 +194,7 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
                         AuditService.UNKNOWN,
                         request.getEmail(),
                         IpAddressHelper.extractIpAddress(input),
+                        persistentSessionId,
                         AuditService.UNKNOWN);
 
                 return generateApiGatewayProxyErrorResponse(401, ErrorResponse.ERROR_1008);
@@ -236,6 +241,7 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
                     userProfile.getSubjectID(),
                     userProfile.getEmail(),
                     IpAddressHelper.extractIpAddress(input),
+                    persistentSessionId,
                     userProfile.getPhoneNumber());
 
             return generateApiGatewayProxyResponse(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
@@ -20,6 +20,7 @@ import uk.gov.di.authentication.shared.entity.SessionAction;
 import uk.gov.di.authentication.shared.entity.SessionState;
 import uk.gov.di.authentication.shared.exceptions.ClientNotFoundException;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
+import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
@@ -107,7 +108,8 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
             LOGGER.info(
                     "MfaHandler received request for session: {}",
                     userContext.getSession().getSessionId());
-
+            String persistentSessionId =
+                    PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders());
             String email = request.getEmail().toLowerCase(Locale.ROOT);
             boolean codeRequestValid = validateCodeRequestAttempts(email, userContext);
             if (!codeRequestValid) {
@@ -122,7 +124,8 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
                         AuditService.UNKNOWN,
                         email,
                         IpAddressHelper.extractIpAddress(input),
-                        AuditService.UNKNOWN);
+                        AuditService.UNKNOWN,
+                        persistentSessionId);
 
                 return generateApiGatewayProxyResponse(
                         400, new BaseAPIResponse(userContext.getSession().getState()));
@@ -144,7 +147,8 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
                         AuditService.UNKNOWN,
                         email,
                         IpAddressHelper.extractIpAddress(input),
-                        AuditService.UNKNOWN);
+                        AuditService.UNKNOWN,
+                        persistentSessionId);
 
                 return generateApiGatewayProxyErrorResponse(400, ERROR_1000);
             }
@@ -166,7 +170,8 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
                         AuditService.UNKNOWN,
                         email,
                         IpAddressHelper.extractIpAddress(input),
-                        AuditService.UNKNOWN);
+                        AuditService.UNKNOWN,
+                        persistentSessionId);
 
                 return generateApiGatewayProxyErrorResponse(400, ERROR_1014);
             }
@@ -197,7 +202,8 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
                         AuditService.UNKNOWN,
                         email,
                         IpAddressHelper.extractIpAddress(input),
-                        phoneNumber);
+                        phoneNumber,
+                        persistentSessionId);
             } else {
                 auditService.submitAuditEvent(
                         FrontendAuditableEvent.MFA_CODE_SENT_FOR_TEST_CLIENT,
@@ -210,7 +216,8 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
                         AuditService.UNKNOWN,
                         email,
                         IpAddressHelper.extractIpAddress(input),
-                        phoneNumber);
+                        phoneNumber,
+                        persistentSessionId);
             }
             LOGGER.info(
                     "MfaHandler successfully processed request for session: {}",

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
@@ -19,6 +19,7 @@ import uk.gov.di.authentication.shared.entity.NotifyRequest;
 import uk.gov.di.authentication.shared.entity.SessionAction;
 import uk.gov.di.authentication.shared.entity.SessionState;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
+import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
@@ -135,7 +136,8 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
                     AuditService.UNKNOWN,
                     request.getEmail(),
                     IpAddressHelper.extractIpAddress(input),
-                    AuditService.UNKNOWN);
+                    AuditService.UNKNOWN,
+                    PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));
 
             Optional<ErrorResponse> errorResponse =
                     validatePasswordResetCount(request.getEmail(), userContext);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
@@ -17,6 +17,7 @@ import uk.gov.di.authentication.shared.entity.SessionAction;
 import uk.gov.di.authentication.shared.entity.SessionState;
 import uk.gov.di.authentication.shared.entity.TermsAndConditions;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
+import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
@@ -108,7 +109,8 @@ public class SignUpHandler extends BaseFrontendHandler<SignupRequest>
                             AuditService.UNKNOWN,
                             request.getEmail(),
                             IpAddressHelper.extractIpAddress(input),
-                            AuditService.UNKNOWN);
+                            AuditService.UNKNOWN,
+                            PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));
 
                     LOG.info(
                             "User already exists for session: {}",
@@ -134,7 +136,8 @@ public class SignUpHandler extends BaseFrontendHandler<SignupRequest>
                         AuditService.UNKNOWN,
                         request.getEmail(),
                         IpAddressHelper.extractIpAddress(input),
-                        AuditService.UNKNOWN);
+                        AuditService.UNKNOWN,
+                        PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));
 
                 sessionService.save(
                         userContext

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
@@ -21,6 +21,7 @@ import uk.gov.di.authentication.shared.entity.SessionState;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.ValidScopes;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
+import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
@@ -96,6 +97,7 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
                 AuditService.UNKNOWN,
                 AuditService.UNKNOWN,
                 AuditService.UNKNOWN,
+                AuditService.UNKNOWN,
                 AuditService.UNKNOWN);
     }
 
@@ -104,6 +106,7 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
         auditService.submitAuditEvent(
                 UPDATE_PROFILE_REQUEST_ERROR,
                 context.getAwsRequestId(),
+                AuditService.UNKNOWN,
                 AuditService.UNKNOWN,
                 AuditService.UNKNOWN,
                 AuditService.UNKNOWN,
@@ -124,6 +127,8 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
                 "UpdateProfileHandler processing request for session: {}", session.getSessionId());
 
         String ipAddress = IpAddressHelper.extractIpAddress(input);
+        String persistentSessionId =
+                PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders());
 
         try {
             if (!session.validateSession(request.getEmail())) {
@@ -155,7 +160,8 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
                                         .orElse(AuditService.UNKNOWN),
                                 email,
                                 ipAddress,
-                                request.getProfileInformation());
+                                request.getProfileInformation(),
+                                persistentSessionId);
                         sessionService.save(session.setState(nextState));
                         LOGGER.info(
                                 "Phone number updated and session state changed. Session: {}, Session state {}",
@@ -216,7 +222,8 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
                                 ipAddress,
                                 userProfile
                                         .map(UserProfile::getPhoneNumber)
-                                        .orElse(AuditService.UNKNOWN));
+                                        .orElse(AuditService.UNKNOWN),
+                                persistentSessionId);
 
                         LOGGER.info(
                                 "Consent updated for ClientID {} and session state changed. Session state {}, session {}",
@@ -244,7 +251,8 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
                                 ipAddress,
                                 userProfile
                                         .map(UserProfile::getPhoneNumber)
-                                        .orElse(AuditService.UNKNOWN));
+                                        .orElse(AuditService.UNKNOWN),
+                                persistentSessionId);
                         LOGGER.info(
                                 "Updated terms and conditions for session: {} for Version {}",
                                 session.getSessionId(),

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -23,6 +23,7 @@ import uk.gov.di.authentication.shared.entity.SessionState;
 import uk.gov.di.authentication.shared.entity.VectorOfTrust;
 import uk.gov.di.authentication.shared.exceptions.ClientNotFoundException;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
+import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
@@ -266,6 +267,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                     session.getEmailAddress(),
                     IpAddressHelper.extractIpAddress(input),
                     AuditService.UNKNOWN,
+                    PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
                     pair("notification-type", notificationType.name()));
 
             codeStorageService.deleteOtpCode(session.getEmailAddress(), notificationType);
@@ -294,6 +296,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                     session.getEmailAddress(),
                     IpAddressHelper.extractIpAddress(input),
                     AuditService.UNKNOWN,
+                    PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
                     pair("notification-type", notificationType.name()));
 
             codeStorageService.deleteOtpCode(session.getEmailAddress(), notificationType);
@@ -315,6 +318,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                     session.getEmailAddress(),
                     IpAddressHelper.extractIpAddress(input),
                     AuditService.UNKNOWN,
+                    PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
                     pair("notification-type", notificationType.name()));
 
             blockCodeForSessionAndResetCount(session);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ClientInfoHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ClientInfoHandlerTest.java
@@ -21,6 +21,7 @@ import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.VectorOfTrust;
+import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
@@ -28,6 +29,7 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SessionService;
 
 import java.net.URI;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -85,8 +87,12 @@ public class ClientInfoHandlerTest {
     public void shouldReturn200WithClientInfoResponseForKnownClientSessionId()
             throws JsonProcessingException {
         usingValidClientSession();
+        String persistentId = "some-persistent-id-value";
+        Map<String, String> headers = new HashMap<>();
+        headers.put(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, persistentId);
+        headers.put(CLIENT_SESSION_ID_HEADER, KNOWN_CLIENT_SESSION_ID);
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        event.setHeaders(Map.of(CLIENT_SESSION_ID_HEADER, KNOWN_CLIENT_SESSION_ID));
+        event.setHeaders(headers);
         event.setRequestContext(contextWithSourceIp("123.123.123.123"));
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
@@ -107,6 +113,7 @@ public class ClientInfoHandlerTest {
                         auditService.UNKNOWN,
                         auditService.UNKNOWN,
                         "123.123.123.123",
+                        persistentId,
                         AuditService.UNKNOWN);
     }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
@@ -23,6 +23,7 @@ import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.NotifyRequest;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.SessionState;
+import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
@@ -33,6 +34,7 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SessionService;
 
 import java.net.URI;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -114,12 +116,16 @@ public class MfaHandlerTest {
     @Test
     public void shouldReturn200ForSuccessfulMfaRequest() throws JsonProcessingException {
         usingValidSession();
+        String persistentId = "some-persistent-id-value";
+        Map<String, String> headers = new HashMap<>();
+        headers.put(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, persistentId);
+        headers.put("Session-Id", session.getSessionId());
         when(authenticationService.getPhoneNumber(TEST_EMAIL_ADDRESS))
                 .thenReturn(Optional.of(PHONE_NUMBER));
         when(codeGeneratorService.sixDigitCode()).thenReturn(CODE);
         NotifyRequest notifyRequest = new NotifyRequest(PHONE_NUMBER, MFA_SMS, CODE);
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        event.setHeaders(Map.of("Session-Id", session.getSessionId()));
+        event.setHeaders(headers);
         event.setBody(format("{ \"email\": \"%s\"}", TEST_EMAIL_ADDRESS));
         event.setRequestContext(contextWithSourceIp("123.123.123.123"));
 
@@ -138,7 +144,8 @@ public class MfaHandlerTest {
                         AuditService.UNKNOWN,
                         TEST_EMAIL_ADDRESS,
                         "123.123.123.123",
-                        PHONE_NUMBER);
+                        PHONE_NUMBER,
+                        persistentId);
     }
 
     @Test
@@ -170,7 +177,8 @@ public class MfaHandlerTest {
                         AuditService.UNKNOWN,
                         TEST_EMAIL_ADDRESS,
                         "123.123.123.123",
-                        PHONE_NUMBER);
+                        PHONE_NUMBER,
+                        PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE);
     }
 
     @Test
@@ -213,7 +221,8 @@ public class MfaHandlerTest {
                         AuditService.UNKNOWN,
                         "wrong.email@gov.uk",
                         "123.123.123.123",
-                        AuditService.UNKNOWN);
+                        AuditService.UNKNOWN,
+                        PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE);
     }
 
     @Test
@@ -239,7 +248,8 @@ public class MfaHandlerTest {
                         AuditService.UNKNOWN,
                         TEST_EMAIL_ADDRESS,
                         "123.123.123.123",
-                        AuditService.UNKNOWN);
+                        AuditService.UNKNOWN,
+                        PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE);
     }
 
     @Test
@@ -301,7 +311,8 @@ public class MfaHandlerTest {
                         AuditService.UNKNOWN,
                         TEST_EMAIL_ADDRESS,
                         "123.123.123.123",
-                        AuditService.UNKNOWN);
+                        AuditService.UNKNOWN,
+                        PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE);
     }
 
     @Test
@@ -334,7 +345,8 @@ public class MfaHandlerTest {
                         AuditService.UNKNOWN,
                         TEST_EMAIL_ADDRESS,
                         "123.123.123.123",
-                        AuditService.UNKNOWN);
+                        AuditService.UNKNOWN,
+                        PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE);
     }
 
     @Test
@@ -366,7 +378,8 @@ public class MfaHandlerTest {
                         AuditService.UNKNOWN,
                         TEST_EMAIL_ADDRESS,
                         "123.123.123.123",
-                        AuditService.UNKNOWN);
+                        AuditService.UNKNOWN,
+                        PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE);
     }
 
     @Test
@@ -399,7 +412,8 @@ public class MfaHandlerTest {
                         AuditService.UNKNOWN,
                         TEST_EMAIL_ADDRESS,
                         "123.123.123.123",
-                        PHONE_NUMBER);
+                        PHONE_NUMBER,
+                        PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE);
     }
 
     private void usingValidSession() {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandlerTest.java
@@ -30,6 +30,7 @@ import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.ValidScopes;
 import uk.gov.di.authentication.shared.entity.VectorOfTrust;
 import uk.gov.di.authentication.shared.exceptions.ClientNotFoundException;
+import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.AuthorizationService;
@@ -44,6 +45,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -129,8 +131,12 @@ class UpdateProfileHandlerTest {
     @Test
     public void shouldReturn200WhenUpdatingPhoneNumber() {
         usingValidSession();
+        String persistentId = "some-persistent-id-value";
+        Map<String, String> headers = new HashMap<>();
+        headers.put(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, persistentId);
+        headers.put("Session-Id", session.getSessionId());
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        event.setHeaders(Map.of("Session-Id", session.getSessionId()));
+        event.setHeaders(headers);
         event.setBody(
                 format(
                         "{ \"email\": \"%s\", \"updateProfileType\": \"%s\", \"profileInformation\": \"%s\" }",
@@ -150,7 +156,8 @@ class UpdateProfileHandlerTest {
                         "",
                         TEST_EMAIL_ADDRESS,
                         "",
-                        PHONE_NUMBER);
+                        PHONE_NUMBER,
+                        persistentId);
     }
 
     @Test
@@ -188,7 +195,8 @@ class UpdateProfileHandlerTest {
                         "",
                         TEST_EMAIL_ADDRESS,
                         "",
-                        "");
+                        "",
+                        PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE);
     }
 
     @Test
@@ -250,7 +258,8 @@ class UpdateProfileHandlerTest {
                         "",
                         TEST_EMAIL_ADDRESS,
                         "",
-                        "");
+                        "",
+                        PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE);
         BaseAPIResponse codeResponse =
                 new ObjectMapper().readValue(result.getBody(), BaseAPIResponse.class);
         assertThat(codeResponse.getSessionState(), equalTo(CONSENT_ADDED));
@@ -275,7 +284,7 @@ class UpdateProfileHandlerTest {
 
         verify(auditService)
                 .submitAuditEvent(
-                        UPDATE_PROFILE_REQUEST_ERROR, "request-id", "", "", "", "", "", "");
+                        UPDATE_PROFILE_REQUEST_ERROR, "request-id", "", "", "", "", "", "", "");
     }
 
     @Test
@@ -295,7 +304,7 @@ class UpdateProfileHandlerTest {
 
         verify(auditService)
                 .submitAuditEvent(
-                        UPDATE_PROFILE_REQUEST_ERROR, "request-id", "", "", "", "", "", "");
+                        UPDATE_PROFILE_REQUEST_ERROR, "request-id", "", "", "", "", "", "", "");
     }
 
     private void usingValidSession() {
@@ -324,7 +333,7 @@ class UpdateProfileHandlerTest {
 
         verify(auditService)
                 .submitAuditEvent(
-                        UPDATE_PROFILE_REQUEST_RECEIVED, "request-id", "", "", "", "", "", "");
+                        UPDATE_PROFILE_REQUEST_RECEIVED, "request-id", "", "", "", "", "", "", "");
 
         return response;
     }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeRequestHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeRequestHandlerTest.java
@@ -24,6 +24,7 @@ import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.SessionAction;
 import uk.gov.di.authentication.shared.entity.SessionState;
 import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
@@ -234,6 +235,7 @@ class VerifyCodeRequestHandlerTest {
                         TEST_EMAIL_ADDRESS,
                         "123.123.123.123",
                         AuditService.UNKNOWN,
+                        PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
                         pair("notification-type", VERIFY_EMAIL.name()));
     }
 
@@ -273,6 +275,7 @@ class VerifyCodeRequestHandlerTest {
                         TEST_EMAIL_ADDRESS,
                         "123.123.123.123",
                         AuditService.UNKNOWN,
+                        PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
                         pair("notification-type", VERIFY_PHONE_NUMBER.name()));
     }
 
@@ -395,6 +398,7 @@ class VerifyCodeRequestHandlerTest {
                         TEST_EMAIL_ADDRESS,
                         "123.123.123.123",
                         AuditService.UNKNOWN,
+                        PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
                         pair("notification-type", VERIFY_PHONE_NUMBER.name()));
     }
 
@@ -454,6 +458,7 @@ class VerifyCodeRequestHandlerTest {
                         TEST_EMAIL_ADDRESS,
                         "123.123.123.123",
                         AuditService.UNKNOWN,
+                        PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
                         pair("notification-type", VERIFY_EMAIL.name()));
     }
 
@@ -508,6 +513,7 @@ class VerifyCodeRequestHandlerTest {
                         TEST_EMAIL_ADDRESS,
                         "123.123.123.123",
                         AuditService.UNKNOWN,
+                        PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
                         pair("notification-type", MFA_SMS.name()));
     }
 
@@ -597,6 +603,7 @@ class VerifyCodeRequestHandlerTest {
                         TEST_EMAIL_ADDRESS,
                         "123.123.123.123",
                         AuditService.UNKNOWN,
+                        PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
                         pair("notification-type", MFA_SMS.name()));
     }
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -25,6 +25,7 @@ import uk.gov.di.authentication.shared.exceptions.ClientNotFoundException;
 import uk.gov.di.authentication.shared.helpers.CookieHelper;
 import uk.gov.di.authentication.shared.helpers.CookieHelper.SessionCookieIds;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
+import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthorisationCodeService;
 import uk.gov.di.authentication.shared.services.AuthorizationService;
@@ -227,7 +228,9 @@ public class AuthCodeHandler
                                         AuditService.UNKNOWN,
                                         session.getEmailAddress(),
                                         IpAddressHelper.extractIpAddress(input),
-                                        AuditService.UNKNOWN);
+                                        AuditService.UNKNOWN,
+                                        PersistentIdHelper.extractPersistentIdFromCookieHeader(
+                                                input.getHeaders()));
                                 return new APIGatewayProxyResponseEvent()
                                         .withStatusCode(302)
                                         .withHeaders(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -97,6 +97,9 @@ public class AuthorisationHandler
         return isWarming(input)
                 .orElseGet(
                         () -> {
+                            String persistentSessionId =
+                                    authorizationService.getExistingOrCreateNewPersistentSessionId(
+                                            input.getHeaders());
                             String ipAddress = IpAddressHelper.extractIpAddress(input);
                             auditService.submitAuditEvent(
                                     OidcAuditableEvent.AUTHORISATION_REQUEST_RECEIVED,
@@ -106,7 +109,8 @@ public class AuthorisationHandler
                                     AuditService.UNKNOWN,
                                     AuditService.UNKNOWN,
                                     ipAddress,
-                                    AuditService.UNKNOWN);
+                                    AuditService.UNKNOWN,
+                                    persistentSessionId);
                             LOGGER.info("Received authentication request");
 
                             Map<String, List<String>> queryStringParameters =
@@ -131,7 +135,8 @@ public class AuthorisationHandler
                                         e.getResponseMode(),
                                         e.getErrorObject(),
                                         context,
-                                        ipAddress);
+                                        ipAddress,
+                                        persistentSessionId);
                             }
                             Optional<ErrorObject> error =
                                     authorizationService.validateAuthRequest(authRequest);
@@ -139,7 +144,11 @@ public class AuthorisationHandler
                             return error.map(
                                             e ->
                                                     generateErrorResponse(
-                                                            authRequest, e, context, ipAddress))
+                                                            authRequest,
+                                                            e,
+                                                            context,
+                                                            ipAddress,
+                                                            persistentSessionId))
                                     .orElseGet(
                                             () ->
                                                     getOrCreateSessionAndRedirect(
@@ -150,9 +159,7 @@ public class AuthorisationHandler
                                                             authRequest,
                                                             context,
                                                             ipAddress,
-                                                            authorizationService
-                                                                    .getExistingOrCreateNewPersistentSessionId(
-                                                                            input.getHeaders())));
+                                                            persistentSessionId));
                         });
     }
 
@@ -171,12 +178,17 @@ public class AuthorisationHandler
                         authenticationRequest,
                         OIDCError.UNMET_AUTHENTICATION_REQUIREMENTS,
                         context,
-                        ipAddress);
+                        ipAddress,
+                        persistentSessionId);
             }
             if (authenticationRequest.getPrompt().contains(Prompt.Type.NONE)
                     && !isUserAuthenticated(existingSession)) {
                 return generateErrorResponse(
-                        authenticationRequest, OIDCError.LOGIN_REQUIRED, context, ipAddress);
+                        authenticationRequest,
+                        OIDCError.LOGIN_REQUIRED,
+                        context,
+                        ipAddress,
+                        persistentSessionId);
             }
             if (authenticationRequest.getPrompt().contains(Prompt.Type.LOGIN)
                     && isUserAuthenticated(existingSession)) {
@@ -201,6 +213,7 @@ public class AuthorisationHandler
                 AuditService.UNKNOWN,
                 ipAddress,
                 AuditService.UNKNOWN,
+                persistentSessionId,
                 pair("session-action", sessionAction));
 
         if (existingSession.isEmpty()) {
@@ -361,7 +374,8 @@ public class AuthorisationHandler
             AuthenticationRequest authRequest,
             ErrorObject errorObject,
             Context context,
-            String ipAddress) {
+            String ipAddress,
+            String persistentSessionId) {
 
         return generateErrorResponse(
                 authRequest.getRedirectionURI(),
@@ -369,7 +383,8 @@ public class AuthorisationHandler
                 authRequest.getResponseMode(),
                 errorObject,
                 context,
-                ipAddress);
+                ipAddress,
+                persistentSessionId);
     }
 
     private APIGatewayProxyResponseEvent generateErrorResponse(
@@ -378,7 +393,8 @@ public class AuthorisationHandler
             ResponseMode responseMode,
             ErrorObject errorObject,
             Context context,
-            String ipAddress) {
+            String ipAddress,
+            String persistentSessionId) {
 
         auditService.submitAuditEvent(
                 OidcAuditableEvent.AUTHORISATION_REQUEST_ERROR,
@@ -389,6 +405,7 @@ public class AuthorisationHandler
                 AuditService.UNKNOWN,
                 ipAddress,
                 AuditService.UNKNOWN,
+                persistentSessionId,
                 pair("description", errorObject.getDescription()));
 
         LOGGER.error(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -30,6 +30,7 @@ import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.SessionState;
 import uk.gov.di.authentication.shared.entity.VectorOfTrust;
 import uk.gov.di.authentication.shared.exceptions.ClientNotFoundException;
+import uk.gov.di.authentication.shared.helpers.CookieHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthorisationCodeService;
 import uk.gov.di.authentication.shared.services.AuthorizationService;
@@ -74,6 +75,7 @@ import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyRespon
 class AuthCodeHandlerTest {
     private static final String SESSION_ID = "a-session-id";
     private static final String CLIENT_SESSION_ID = "client-session-id";
+    private static final String PERSISTENT_SESSION_ID = "persistent-session-id";
     private static final String COOKIE = "Cookie";
     private static final String EMAIL = "joe.bloggs@digital.cabinet-office.gov.uk";
     private static final URI REDIRECT_URI = URI.create("http://localhost/redirect");
@@ -183,7 +185,8 @@ class AuthCodeHandlerTest {
                         AuditService.UNKNOWN,
                         EMAIL,
                         "123.123.123.123",
-                        AuditService.UNKNOWN);
+                        AuditService.UNKNOWN,
+                        PERSISTENT_SESSION_ID);
     }
 
     @ParameterizedTest
@@ -243,7 +246,8 @@ class AuthCodeHandlerTest {
                         AuditService.UNKNOWN,
                         EMAIL,
                         "123.123.123.123",
-                        AuditService.UNKNOWN);
+                        AuditService.UNKNOWN,
+                        PERSISTENT_SESSION_ID);
     }
 
     @Test
@@ -413,7 +417,13 @@ class AuthCodeHandlerTest {
 
     private static String buildCookieString() {
         return format(
-                "%s=%s.%s; Max-Age=%d; %s",
-                "gs", SESSION_ID, CLIENT_SESSION_ID, 3600, "Secure; HttpOnly;");
+                "%s=%s.%s; %s=%s; Max-Age=%d; %s",
+                "gs",
+                SESSION_ID,
+                CLIENT_SESSION_ID,
+                CookieHelper.PERSISTENT_COOKIE_NAME,
+                PERSISTENT_SESSION_ID,
+                3600,
+                "Secure; HttpOnly;");
     }
 }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -76,6 +76,7 @@ class AuthorisationHandlerTest {
     private static final String EXPECTED_PERSISTENT_COOKIE_STRING =
             "di-persistent-session-id=a-persistent-session-id; Max-Age=34190000; Domain=auth.ida.digital.cabinet-office.gov.uk; Secure; HttpOnly;";
     private static final URI LOGIN_URL = URI.create("https://example.com");
+    private static final String PERSISTENT_SESSION_ID = "a-persistent-session-id";
 
     private AuthorisationHandler handler;
 
@@ -90,7 +91,7 @@ class AuthorisationHandlerTest {
         when(authorizationService.validateAuthRequest(any(AuthenticationRequest.class)))
                 .thenReturn(Optional.empty());
         when(authorizationService.getExistingOrCreateNewPersistentSessionId(any()))
-                .thenReturn("a-persistent-session-id");
+                .thenReturn(PERSISTENT_SESSION_ID);
         when(sessionService.createSession()).thenReturn(new Session("new-session"));
         handler =
                 new AuthorisationHandler(
@@ -260,6 +261,7 @@ class AuthorisationHandlerTest {
                         "",
                         "123.123.123.123",
                         "",
+                        PERSISTENT_SESSION_ID,
                         pair("description", "Invalid request: Missing response_type parameter"));
     }
 
@@ -295,6 +297,7 @@ class AuthorisationHandlerTest {
                         "",
                         "123.123.123.123",
                         "",
+                        PERSISTENT_SESSION_ID,
                         pair("description", OAuth2Error.INVALID_SCOPE.getDescription()));
     }
 
@@ -329,6 +332,7 @@ class AuthorisationHandlerTest {
                         AuditService.UNKNOWN,
                         "123.123.123.123",
                         AuditService.UNKNOWN,
+                        PERSISTENT_SESSION_ID,
                         pair("session-action", USER_HAS_STARTED_A_NEW_JOURNEY));
     }
 
@@ -373,6 +377,7 @@ class AuthorisationHandlerTest {
                         AuditService.UNKNOWN,
                         "123.123.123.123",
                         AuditService.UNKNOWN,
+                        PERSISTENT_SESSION_ID,
                         pair("session-action", USER_HAS_STARTED_A_NEW_JOURNEY));
     }
 
@@ -395,6 +400,7 @@ class AuthorisationHandlerTest {
                         "",
                         "123.123.123.123",
                         "",
+                        PERSISTENT_SESSION_ID,
                         pair("description", OIDCError.LOGIN_REQUIRED.getDescription()));
     }
 
@@ -441,6 +447,7 @@ class AuthorisationHandlerTest {
                         AuditService.UNKNOWN,
                         "123.123.123.123",
                         AuditService.UNKNOWN,
+                        PERSISTENT_SESSION_ID,
                         pair("session-action", USER_HAS_STARTED_A_NEW_JOURNEY));
     }
 
@@ -482,6 +489,7 @@ class AuthorisationHandlerTest {
                         AuditService.UNKNOWN,
                         "123.123.123.123",
                         AuditService.UNKNOWN,
+                        PERSISTENT_SESSION_ID,
                         pair("session-action", USER_HAS_STARTED_A_NEW_JOURNEY));
     }
 
@@ -519,6 +527,7 @@ class AuthorisationHandlerTest {
                         AuditService.UNKNOWN,
                         "123.123.123.123",
                         AuditService.UNKNOWN,
+                        PERSISTENT_SESSION_ID,
                         pair("session-action", USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED));
     }
 
@@ -541,6 +550,7 @@ class AuthorisationHandlerTest {
                         "",
                         "123.123.123.123",
                         "",
+                        PERSISTENT_SESSION_ID,
                         pair(
                                 "description",
                                 "Invalid request: Invalid prompt parameter: Unknown prompt type: unrecognised"));
@@ -565,6 +575,7 @@ class AuthorisationHandlerTest {
                         "",
                         "123.123.123.123",
                         "",
+                        PERSISTENT_SESSION_ID,
                         pair(
                                 "description",
                                 "Invalid request: Invalid prompt parameter: Invalid prompt: none login"));
@@ -589,6 +600,7 @@ class AuthorisationHandlerTest {
                         "",
                         "123.123.123.123",
                         "",
+                        PERSISTENT_SESSION_ID,
                         pair(
                                 "description",
                                 OIDCError.UNMET_AUTHENTICATION_REQUIREMENTS.getDescription()));
@@ -613,6 +625,7 @@ class AuthorisationHandlerTest {
                         "",
                         "123.123.123.123",
                         "",
+                        PERSISTENT_SESSION_ID,
                         pair(
                                 "description",
                                 OIDCError.UNMET_AUTHENTICATION_REQUIREMENTS.getDescription()));
@@ -637,6 +650,7 @@ class AuthorisationHandlerTest {
                         "",
                         "123.123.123.123",
                         "",
+                        PERSISTENT_SESSION_ID,
                         pair(
                                 "description",
                                 OIDCError.UNMET_AUTHENTICATION_REQUIREMENTS.getDescription()));
@@ -677,6 +691,7 @@ class AuthorisationHandlerTest {
                         AuditService.UNKNOWN,
                         "123.123.123.123",
                         AuditService.UNKNOWN,
+                        PERSISTENT_SESSION_ID,
                         pair("session-action", USER_HAS_STARTED_A_NEW_JOURNEY));
     }
 
@@ -713,6 +728,7 @@ class AuthorisationHandlerTest {
                         AuditService.UNKNOWN,
                         "123.123.123.123",
                         AuditService.UNKNOWN,
+                        PERSISTENT_SESSION_ID,
                         pair("session-action", USER_HAS_STARTED_A_NEW_JOURNEY));
     }
 
@@ -728,7 +744,8 @@ class AuthorisationHandlerTest {
                         "",
                         "",
                         "123.123.123.123",
-                        "");
+                        "",
+                        PERSISTENT_SESSION_ID);
 
         return response;
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/PersistentIdHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/PersistentIdHelper.java
@@ -4,6 +4,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.Map;
+import java.util.Objects;
 
 public class PersistentIdHelper {
 
@@ -12,7 +13,8 @@ public class PersistentIdHelper {
     public static final String PERSISTENT_ID_UNKNOWN_VALUE = "unknown";
 
     public static String extractPersistentIdFromHeaders(Map<String, String> headers) {
-        if (!headers.containsKey(PERSISTENT_ID_HEADER_NAME)
+        if (Objects.isNull(headers)
+                || !headers.containsKey(PERSISTENT_ID_HEADER_NAME)
                 || headers.get(PERSISTENT_ID_HEADER_NAME) == null) {
             return PERSISTENT_ID_UNKNOWN_VALUE;
         }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/PersistentIdHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/PersistentIdHelper.java
@@ -19,4 +19,8 @@ public class PersistentIdHelper {
         LOG.info("PersistentID on request: {}", headers.get(PERSISTENT_ID_HEADER_NAME));
         return headers.get(PERSISTENT_ID_HEADER_NAME);
     }
+
+    public static String extractPersistentIdFromCookieHeader(Map<String, String> headers) {
+        return CookieHelper.parsePersistentCookie(headers).orElse(PERSISTENT_ID_UNKNOWN_VALUE);
+    }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
@@ -51,6 +51,7 @@ public class AuditService {
             String email,
             String ipAddress,
             String phoneNumber,
+            String persistentSessionId,
             MetadataPair... metadataPairs) {
         snsService.publishAuditMessage(
                 generateLogLine(
@@ -62,6 +63,7 @@ public class AuditService {
                         email,
                         ipAddress,
                         phoneNumber,
+                        persistentSessionId,
                         metadataPairs));
     }
 
@@ -74,6 +76,7 @@ public class AuditService {
             String email,
             String ipAddress,
             String phoneNumber,
+            String persistentSessionId,
             MetadataPair... metadataPairs) {
         var uniqueId = UUID.randomUUID();
         var timestamp = clock.instant().toString();

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/PersistentIdHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/PersistentIdHelperTest.java
@@ -37,4 +37,24 @@ class PersistentIdHelperTest {
 
         assertThat(persistentId, equalTo(PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE));
     }
+
+    @Test
+    void shouldReturnPersistentIdFromCookieHeaderWhenExists() {
+        String cookieString =
+                "Version=1; di-persistent-session-id=a-persistent-id;gs=session-id.456;cookies_preferences_set={\"analytics\":true};name=ts";
+        Map<String, String> inputHeaders = Map.of(CookieHelper.REQUEST_COOKIE_HEADER, cookieString);
+        String persistentId = PersistentIdHelper.extractPersistentIdFromCookieHeader(inputHeaders);
+
+        assertThat(persistentId, equalTo("a-persistent-id"));
+    }
+
+    @Test
+    void shouldReturnUnknownWhenPersistentCookieIsNotPresent() {
+        String cookieString =
+                "Version=1; gs=session-id.456;cookies_preferences_set={\"analytics\":true};name=ts";
+        Map<String, String> inputHeaders = Map.of(CookieHelper.REQUEST_COOKIE_HEADER, cookieString);
+        String persistentId = PersistentIdHelper.extractPersistentIdFromCookieHeader(inputHeaders);
+
+        assertThat(persistentId, equalTo(PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE));
+    }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
@@ -77,7 +77,8 @@ class AuditServiceTest {
                 "subject-id",
                 "email",
                 "ip-address",
-                "phone-number");
+                "phone-number",
+                "persistent-session-id");
 
         verify(snsService).publishAuditMessage(messageCaptor.capture());
         var serialisedAuditMessage = messageCaptor.getValue();
@@ -107,6 +108,7 @@ class AuditServiceTest {
                 "subject-id",
                 "email",
                 "ip-address",
+                "persistent-session-id",
                 "phone-number");
 
         verify(kmsConnectionService).sign(signingRequestCaptor.capture());
@@ -134,6 +136,7 @@ class AuditServiceTest {
                 "email",
                 "ip-address",
                 "phone-number",
+                "persistent-session-id",
                 pair("key", "value"),
                 pair("key2", "value2"));
 


### PR DESCRIPTION
## What?

- Create helper method to extract di-persistent-session-id from cookie
- When the persistent-session-id is sent as a header to an endpoint, extract it and pass it to the audit
- When the persistent-session-id is passed in the cookie (EG Auth Code) extract it from the cookie and pass it to audit

## Why?
When we receive a request via a 302 redirect, we want to extract the di-persistent-session-id from the cookie if it exists. If it doesn't exist then we will set it to 'unknown'. This is so that we have the capability to audit it
- The audit does not actually do anything with the persistent-session-id yet but this work is required before we are able to do that