### PR TITLE
GOVSI-1114: Add SQS extension to manage queue dependency

### DIFF
--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdateEmailIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdateEmailIntegrationTest.java
@@ -1,25 +1,22 @@
 package uk.gov.di.accountmanagement.api;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.nimbusds.oauth2.sdk.id.Subject;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.accountmanagement.entity.UpdateEmailRequest;
 import uk.gov.di.accountmanagement.lambda.UpdateEmailHandler;
-import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
-import uk.gov.di.authentication.sharedtest.extensions.NotifyStubExtension;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static uk.gov.di.accountmanagement.entity.NotificationType.EMAIL_UPDATED;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
-import static uk.gov.di.authentication.sharedtest.matchers.JsonMatcher.hasField;
-import static uk.gov.di.authentication.sharedtest.matchers.JsonMatcher.hasFieldWithValue;
 
 public class UpdateEmailIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
@@ -27,24 +24,13 @@ public class UpdateEmailIntegrationTest extends ApiGatewayHandlerIntegrationTest
     private static final String NEW_EMAIL_ADDRESS = "joe.b@digital.cabinet-office.gov.uk";
     private static final Subject SUBJECT = new Subject();
 
-    @RegisterExtension
-    private static final NotifyStubExtension notify =
-            new NotifyStubExtension(8888, ObjectMapperFactory.getInstance());
-
     @BeforeEach
     void setup() {
         handler = new UpdateEmailHandler(TEST_CONFIGURATION_SERVICE);
-        notify.init();
-    }
-
-    @AfterEach
-    void resetStub() {
-        notify.reset();
     }
 
     @Test
-    public void shouldCallUpdateEmailEndpointAndReturn204WhenLoginIsSuccessful()
-            throws JsonProcessingException {
+    public void shouldCallUpdateEmailEndpointAndReturn204WhenLoginIsSuccessful() {
         String publicSubjectID = userStore.signUp(EXISTING_EMAIL_ADDRESS, "password-1", SUBJECT);
         String otp = redis.generateAndSaveEmailCode(NEW_EMAIL_ADDRESS, 300);
         var response =
@@ -59,10 +45,10 @@ public class UpdateEmailIntegrationTest extends ApiGatewayHandlerIntegrationTest
 
         assertThat(response, hasStatus(204));
 
-        var notifyRequest = notify.waitForRequest(60);
+        List<NotifyRequest> requests = notificationsQueue.getMessages(NotifyRequest.class);
 
-        assertThat(notifyRequest, hasField("personalisation"));
-        var personalisation = notifyRequest.get("personalisation");
-        assertThat(personalisation, hasFieldWithValue("email-address", equalTo(NEW_EMAIL_ADDRESS)));
+        assertThat(requests, hasSize(1));
+        assertThat(requests.get(0).getDestination(), equalTo(NEW_EMAIL_ADDRESS));
+        assertThat(requests.get(0).getNotificationType(), equalTo(EMAIL_UPDATED));
     }
 }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/ApiGatewayHandlerIntegrationTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/ApiGatewayHandlerIntegrationTest.java
@@ -13,6 +13,7 @@ import uk.gov.di.authentication.sharedtest.extensions.ClientStoreExtension;
 import uk.gov.di.authentication.sharedtest.extensions.KmsKeyExtension;
 import uk.gov.di.authentication.sharedtest.extensions.RedisExtension;
 import uk.gov.di.authentication.sharedtest.extensions.SnsTopicExtension;
+import uk.gov.di.authentication.sharedtest.extensions.SqsQueueExtension;
 import uk.gov.di.authentication.sharedtest.extensions.UserStoreExtension;
 
 import java.net.HttpCookie;
@@ -66,6 +67,10 @@ public abstract class ApiGatewayHandlerIntegrationTest {
 
     @RegisterExtension
     protected static final SnsTopicExtension auditTopic = new SnsTopicExtension("local-events");
+
+    @RegisterExtension
+    protected static final SqsQueueExtension notificationsQueue =
+            new SqsQueueExtension("local-email-notification-queue");
 
     protected APIGatewayProxyResponseEvent makeRequest(
             Optional<Object> body, Map<String, String> headers, Map<String, String> queryString) {

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/SqsQueueExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/SqsQueueExtension.java
@@ -1,0 +1,51 @@
+package uk.gov.di.authentication.sharedtest.extensions;
+
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.AmazonSQSClient;
+import com.amazonaws.services.sqs.model.PurgeQueueRequest;
+import com.amazonaws.services.sqs.model.QueueDoesNotExistException;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.util.Optional;
+
+public class SqsQueueExtension implements BeforeAllCallback {
+
+    protected static final String REGION = System.getenv().getOrDefault("AWS_REGION", "eu-west-2");
+    protected static final String LOCALSTACK_ENDPOINT =
+            System.getenv().getOrDefault("LOCALSTACK_ENDPOINT", "http://localhost:45678");
+
+    private final String queueName;
+    private final AmazonSQS sqsClient;
+
+    private String queueUrl;
+
+    public SqsQueueExtension(String queueName) {
+        this.queueName = queueName;
+        this.sqsClient =
+                AmazonSQSClient.builder()
+                        .withEndpointConfiguration(
+                                new AwsClientBuilder.EndpointConfiguration(
+                                        LOCALSTACK_ENDPOINT, REGION))
+                        .build();
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        queueUrl = getQueueUrlFor(queueName).orElseGet(() -> createQueue(queueName));
+        sqsClient.purgeQueue(new PurgeQueueRequest().withQueueUrl(queueUrl));
+    }
+
+    private Optional<String> getQueueUrlFor(String queueName) {
+        try {
+            return Optional.of(sqsClient.getQueueUrl(queueName).getQueueUrl());
+        } catch (QueueDoesNotExistException ignored) {
+            return Optional.empty();
+        }
+    }
+
+    private String createQueue(String queueName) {
+        return sqsClient.createQueue(queueName).getQueueUrl();
+    }
+}

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/SqsQueueExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/SqsQueueExtension.java
@@ -3,26 +3,37 @@ package uk.gov.di.authentication.sharedtest.extensions;
 import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.AmazonSQSClient;
+import com.amazonaws.services.sqs.model.Message;
 import com.amazonaws.services.sqs.model.PurgeQueueRequest;
 import com.amazonaws.services.sqs.model.QueueDoesNotExistException;
+import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static java.text.MessageFormat.format;
 
 public class SqsQueueExtension implements BeforeAllCallback {
 
     protected static final String REGION = System.getenv().getOrDefault("AWS_REGION", "eu-west-2");
     protected static final String LOCALSTACK_ENDPOINT =
             System.getenv().getOrDefault("LOCALSTACK_ENDPOINT", "http://localhost:45678");
+    public static final int DEFAULT_NUMBER_OF_MESSAGES = 10;
 
-    private final String queueName;
+    private final String queueNameSuffix;
     private final AmazonSQS sqsClient;
+    private final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
 
     private String queueUrl;
 
-    public SqsQueueExtension(String queueName) {
-        this.queueName = queueName;
+    public SqsQueueExtension(String queueNameSuffix) {
+        this.queueNameSuffix = queueNameSuffix;
         this.sqsClient =
                 AmazonSQSClient.builder()
                         .withEndpointConfiguration(
@@ -31,8 +42,34 @@ public class SqsQueueExtension implements BeforeAllCallback {
                         .build();
     }
 
+    public String getQueueUrl() {
+        return queueUrl;
+    }
+
+    public <T> List<T> getMessages(Class<T> messageClass) {
+        return getMessages(messageClass, DEFAULT_NUMBER_OF_MESSAGES);
+    }
+
+    public <T> List<T> getMessages(Class<T> messageClass, int numberOfMessages) {
+        return getMessages(numberOfMessages).stream()
+                .map(
+                        m -> {
+                            try {
+                                return objectMapper.readValue(m.getBody(), messageClass);
+                            } catch (JsonProcessingException e) {
+                                throw new RuntimeException(e);
+                            }
+                        })
+                .collect(Collectors.toList());
+    }
+
     @Override
     public void beforeAll(ExtensionContext context) {
+        var queueName =
+                format(
+                        "{0}-{1}",
+                        context.getTestClass().map(Class::getSimpleName).orElse("unknown"),
+                        queueNameSuffix);
         queueUrl = getQueueUrlFor(queueName).orElseGet(() -> createQueue(queueName));
         sqsClient.purgeQueue(new PurgeQueueRequest().withQueueUrl(queueUrl));
     }
@@ -47,5 +84,13 @@ public class SqsQueueExtension implements BeforeAllCallback {
 
     private String createQueue(String queueName) {
         return sqsClient.createQueue(queueName).getQueueUrl();
+    }
+
+    private List<Message> getMessages(int numberOfMessages) {
+        var request =
+                new ReceiveMessageRequest()
+                        .withQueueUrl(queueUrl)
+                        .withMaxNumberOfMessages(numberOfMessages);
+        return sqsClient.receiveMessage(request).getMessages();
     }
 }


### PR DESCRIPTION
## What?

- Add a new SqsQueueExtension to create queue dependency before running tests
- Ensure each test class gets its own queue
- Clear queue before each test
- Refactor integration tests for handlers that send to notifications queue to assert on queue contents rather than use the NotifyStub to wait for notify requests.

## Why?

Please include reason for the change and any other relevant context.

## Related PRs

Please include links to PRs in other repositories relevant to this PR.
Delete this section if not needed.