### PR TITLE
BAU - Adjust logging in the AuthorisationHandler

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -391,7 +391,7 @@ public class AuthorisationHandler
                 AuditService.UNKNOWN,
                 pair("description", errorObject.getDescription()));
 
-        LOGGER.error(
+        LOGGER.warn(
                 "Returning error response: {} {}",
                 errorObject.getCode(),
                 errorObject.getDescription());

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthorizationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthorizationService.java
@@ -112,19 +112,26 @@ public class AuthorizationService {
                             authRequest.getRedirectionURI().toString()));
         }
         if (!authRequest.getResponseType().toString().equals("code")) {
+            LOGGER.warn(
+                    "Unsupported responseType included in request. Expected responseType of code");
             return Optional.of(OAuth2Error.UNSUPPORTED_RESPONSE_TYPE);
         }
         if (!areScopesValid(authRequest.getScope().toStringList())
                 || !client.get().getScopes().containsAll(authRequest.getScope().toStringList())) {
+            LOGGER.warn(
+                    "Invalid scopes in authRequest. Scopes in request: {}",
+                    authRequest.getScope().toStringList());
             return Optional.of(OAuth2Error.INVALID_SCOPE);
         }
         if (authRequest.getNonce() == null) {
+            LOGGER.warn("Nonce is missing from authRequest");
             return Optional.of(
                     new ErrorObject(
                             OAuth2Error.INVALID_REQUEST_CODE,
                             "Request is missing nonce parameter"));
         }
         if (authRequest.getState() == null) {
+            LOGGER.warn("State is missing from authRequest");
             return Optional.of(
                     new ErrorObject(
                             OAuth2Error.INVALID_REQUEST_CODE,
@@ -135,6 +142,7 @@ public class AuthorizationService {
             VectorOfTrust vectorOfTrust =
                     VectorOfTrust.parseFromAuthRequestAttribute(authRequestVtr);
         } catch (IllegalArgumentException e) {
+            LOGGER.warn("vtr in AuthRequest is not valid. vtr in request: {}", authRequestVtr);
             return Optional.of(
                     new ErrorObject(OAuth2Error.INVALID_REQUEST_CODE, "Request vtr not valid"));
         }


### PR DESCRIPTION
## What and Why?
- Add additional logging in the AuthorizationService where we validate the authn request.
- Downgrade the log line from ERROR to WARN where we log out the error response. As this endpoint is public we have little control over what can be sent to us and should only be alerted in the case of an actual error.
