### PR TITLE
BAU - - Check that current password is not null

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
@@ -101,12 +101,16 @@ public class ResetPasswordHandler
                                 UserCredentials userCredentials =
                                         authenticationService.getUserCredentialsFromSubject(
                                                 subject.get());
-                                if (verifyPassword(
-                                        userCredentials.getPassword(),
-                                        resetPasswordWithCodeRequest.getPassword())) {
-                                    LOGGER.info("New password is the same as the old password");
-                                    return generateApiGatewayProxyErrorResponse(
-                                            400, ErrorResponse.ERROR_1024);
+                                if (userCredentials.getPassword() != null) {
+                                    if (verifyPassword(
+                                            userCredentials.getPassword(),
+                                            resetPasswordWithCodeRequest.getPassword())) {
+                                        LOGGER.info("New password is the same as the old password");
+                                        return generateApiGatewayProxyErrorResponse(
+                                                400, ErrorResponse.ERROR_1024);
+                                    }
+                                } else {
+                                    LOGGER.info("Resetting password for migrated user");
                                 }
                                 codeStorageService.deleteSubjectWithPasswordResetCode(
                                         resetPasswordWithCodeRequest.getCode());


### PR DESCRIPTION
## What and Why?

- Before we check that the users new password is not the same as the old password, we should check that the old password is not null. If it is null, we know that it is a migrated user which is resetting their password.