### PR TITLE
GOVSI-1143 - Start saving the persistent-session-id to Audit

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandler.java
@@ -90,9 +90,9 @@ public class AuthenticateHandler
                                         AuditService.UNKNOWN,
                                         loginRequest.getEmail(),
                                         IpAddressHelper.extractIpAddress(input),
+                                        AuditService.UNKNOWN,
                                         PersistentIdHelper.extractPersistentIdFromHeaders(
-                                                input.getHeaders()),
-                                        AuditService.UNKNOWN);
+                                                input.getHeaders()));
 
                                 return generateEmptySuccessApiGatewayResponse();
                             } catch (JsonProcessingException e) {

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandler.java
@@ -102,9 +102,9 @@ public class RemoveAccountHandler
                                         userProfile.getSubjectID(),
                                         userProfile.getEmail(),
                                         IpAddressHelper.extractIpAddress(input),
+                                        userProfile.getPhoneNumber(),
                                         PersistentIdHelper.extractPersistentIdFromHeaders(
-                                                input.getHeaders()),
-                                        userProfile.getPhoneNumber());
+                                                input.getHeaders()));
 
                                 return generateEmptySuccessApiGatewayResponse();
                             } catch (JsonProcessingException e) {

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
@@ -140,9 +140,9 @@ public class UpdateEmailHandler
                                         userProfile.getSubjectID(),
                                         userProfile.getEmail(),
                                         IpAddressHelper.extractIpAddress(input),
+                                        userProfile.getPhoneNumber(),
                                         PersistentIdHelper.extractPersistentIdFromHeaders(
-                                                input.getHeaders()),
-                                        userProfile.getPhoneNumber());
+                                                input.getHeaders()));
 
                                 LOGGER.info(
                                         "Message successfully added to queue. Generating successful gateway response");

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandler.java
@@ -116,9 +116,9 @@ public class UpdatePasswordHandler
                                         userProfile.getSubjectID(),
                                         userProfile.getEmail(),
                                         IpAddressHelper.extractIpAddress(input),
+                                        userProfile.getPhoneNumber(),
                                         PersistentIdHelper.extractPersistentIdFromHeaders(
-                                                input.getHeaders()),
-                                        userProfile.getPhoneNumber());
+                                                input.getHeaders()));
 
                                 return generateEmptySuccessApiGatewayResponse();
 

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandler.java
@@ -129,9 +129,9 @@ public class UpdatePhoneNumberHandler
                                         userProfile.getSubjectID(),
                                         userProfile.getEmail(),
                                         IpAddressHelper.extractIpAddress(input),
+                                        userProfile.getPhoneNumber(),
                                         PersistentIdHelper.extractPersistentIdFromHeaders(
-                                                input.getHeaders()),
-                                        userProfile.getPhoneNumber());
+                                                input.getHeaders()));
 
                                 LOGGER.info(
                                         "Message successfully added to queue. Generating successful gateway response");

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandlerTest.java
@@ -62,8 +62,8 @@ class AuthenticateHandlerTest {
                         AuditService.UNKNOWN,
                         EMAIL,
                         "123.123.123.123",
-                        persistentIdValue,
-                        AuditService.UNKNOWN);
+                        AuditService.UNKNOWN,
+                        persistentIdValue);
     }
 
     @Test

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandlerTest.java
@@ -76,8 +76,8 @@ class RemoveAccountHandlerTest {
                         userProfile.getSubjectID(),
                         userProfile.getEmail(),
                         "123.123.123.123",
-                        persistentIdValue,
-                        userProfile.getPhoneNumber());
+                        userProfile.getPhoneNumber(),
+                        persistentIdValue);
 
         assertThat(result, hasStatus(204));
     }

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandlerTest.java
@@ -104,8 +104,8 @@ class UpdateEmailHandlerTest {
                         userProfile.getSubjectID(),
                         userProfile.getEmail(),
                         "123.123.123.123",
-                        persistentIdValue,
-                        userProfile.getPhoneNumber());
+                        userProfile.getPhoneNumber(),
+                        persistentIdValue);
     }
 
     @Test

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandlerTest.java
@@ -91,8 +91,8 @@ class UpdatePasswordHandlerTest {
                         userProfile.getSubjectID(),
                         userProfile.getEmail(),
                         "123.123.123.123",
-                        persistentIdValue,
-                        userProfile.getPhoneNumber());
+                        userProfile.getPhoneNumber(),
+                        persistentIdValue);
     }
 
     @Test
@@ -154,7 +154,7 @@ class UpdatePasswordHandlerTest {
                         userProfile.getSubjectID(),
                         userProfile.getEmail(),
                         "123.123.123.123",
-                        PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
-                        userProfile.getPhoneNumber());
+                        userProfile.getPhoneNumber(),
+                        PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE);
     }
 }

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandlerTest.java
@@ -101,8 +101,8 @@ class UpdatePhoneNumberHandlerTest {
                         userProfile.getSubjectID(),
                         userProfile.getEmail(),
                         "123.123.123.123",
-                        persistentIdValue,
-                        userProfile.getPhoneNumber());
+                        userProfile.getPhoneNumber(),
+                        persistentIdValue);
     }
 
     @Test

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -118,8 +118,8 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         IpAddressHelper.extractIpAddress(input),
-                        persistentSessionId,
-                        AuditService.UNKNOWN);
+                        AuditService.UNKNOWN,
+                        persistentSessionId);
 
                 return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1010);
             }
@@ -146,8 +146,8 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
                         userProfile.getSubjectID(),
                         userProfile.getEmail(),
                         IpAddressHelper.extractIpAddress(input),
-                        persistentSessionId,
-                        userProfile.getPhoneNumber());
+                        userProfile.getPhoneNumber(),
+                        persistentSessionId);
 
                 sessionService.save(userContext.getSession().setState(nextState));
                 return generateApiGatewayProxyResponse(
@@ -194,8 +194,8 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
                         AuditService.UNKNOWN,
                         request.getEmail(),
                         IpAddressHelper.extractIpAddress(input),
-                        persistentSessionId,
-                        AuditService.UNKNOWN);
+                        AuditService.UNKNOWN,
+                        persistentSessionId);
 
                 return generateApiGatewayProxyErrorResponse(401, ErrorResponse.ERROR_1008);
             }
@@ -241,8 +241,8 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
                     userProfile.getSubjectID(),
                     userProfile.getEmail(),
                     IpAddressHelper.extractIpAddress(input),
-                    persistentSessionId,
-                    userProfile.getPhoneNumber());
+                    userProfile.getPhoneNumber(),
+                    persistentSessionId);
 
             return generateApiGatewayProxyResponse(
                     200, new LoginResponse(concatPhoneNumber, userContext.getSession().getState()));

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
@@ -151,8 +151,8 @@ class LoginHandlerTest {
                         userProfile.getSubjectID(),
                         userProfile.getEmail(),
                         "123.123.123.123",
-                        persistentId,
-                        userProfile.getPhoneNumber());
+                        userProfile.getPhoneNumber(),
+                        persistentId);
     }
 
     @Test
@@ -268,8 +268,8 @@ class LoginHandlerTest {
                         userProfile.getSubjectID(),
                         userProfile.getEmail(),
                         "123.123.123.123",
-                        PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
-                        userProfile.getPhoneNumber());
+                        userProfile.getPhoneNumber(),
+                        PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE);
     }
 
     @Test
@@ -327,8 +327,8 @@ class LoginHandlerTest {
                         "",
                         EMAIL,
                         "123.123.123.123",
-                        PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
-                        "");
+                        "",
+                        PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE);
 
         assertThat(result, hasStatus(401));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1008));
@@ -404,8 +404,8 @@ class LoginHandlerTest {
                         "",
                         "",
                         "123.123.123.123",
-                        PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
-                        "");
+                        "",
+                        PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE);
 
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1010));

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/matchers/AuditMessageMatcher.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/matchers/AuditMessageMatcher.java
@@ -37,6 +37,11 @@ public class AuditMessageMatcher<T> extends TypeSafeDiagnosingMatcher<String> {
         return new AuditMessageMatcher<>("session ID", AuditEvent::getSessionId, sessionId);
     }
 
+    public static AuditMessageMatcher<String> hasPersistentSessionId(String persistentSessionId) {
+        return new AuditMessageMatcher<>(
+                "persistent session ID", AuditEvent::getPersistentSessionId, persistentSessionId);
+    }
+
     public static AuditMessageMatcher<String> hasClientId(String clientId) {
         return new AuditMessageMatcher<>("client ID", AuditEvent::getClientId, clientId);
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
@@ -88,6 +88,7 @@ public class AuditService {
                         .setRequestId(Optional.ofNullable(requestId).orElse(UNKNOWN))
                         .setSessionId(Optional.ofNullable(sessionId).orElse(UNKNOWN))
                         .setClientId(Optional.ofNullable(clientId).orElse(UNKNOWN))
+                        .setPersistentSessionId(persistentSessionId)
                         .setUser(
                                 AuditEvent.User.newBuilder()
                                         .setId(Optional.ofNullable(subjectId).orElse(UNKNOWN))

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
@@ -32,6 +32,7 @@ import static uk.gov.di.authentication.sharedtest.matchers.AuditMessageMatcher.h
 import static uk.gov.di.authentication.sharedtest.matchers.AuditMessageMatcher.hasEventName;
 import static uk.gov.di.authentication.sharedtest.matchers.AuditMessageMatcher.hasIpAddress;
 import static uk.gov.di.authentication.sharedtest.matchers.AuditMessageMatcher.hasMetadataPair;
+import static uk.gov.di.authentication.sharedtest.matchers.AuditMessageMatcher.hasPersistentSessionId;
 import static uk.gov.di.authentication.sharedtest.matchers.AuditMessageMatcher.hasPhoneNumber;
 import static uk.gov.di.authentication.sharedtest.matchers.AuditMessageMatcher.hasRequestId;
 import static uk.gov.di.authentication.sharedtest.matchers.AuditMessageMatcher.hasSessionId;
@@ -87,6 +88,7 @@ class AuditServiceTest {
         assertThat(serialisedAuditMessage, hasEventName(TEST_EVENT_ONE.toString()));
         assertThat(serialisedAuditMessage, hasRequestId("request-id"));
         assertThat(serialisedAuditMessage, hasSessionId("session-id"));
+        assertThat(serialisedAuditMessage, hasPersistentSessionId("persistent-session-id"));
         assertThat(serialisedAuditMessage, hasClientId("client-id"));
         assertThat(serialisedAuditMessage, hasSubjectId("subject-id"));
         assertThat(serialisedAuditMessage, hasEmail("email"));


### PR DESCRIPTION
## What?

- Start saving the persistent-session-id to Audit
- Put persistent-session-id and phone number in correct order

## Why?
- So we can see the persistent-session-id in the Audit 
- - There were some situations where persistent-session-id and phone number were audited in the wrong order