### PR TITLE
GOVSI-1114: Remove Terraforming of Localstack resources

### DIFF
--- a/account-management-integration-tests/build.gradle
+++ b/account-management-integration-tests/build.gradle
@@ -48,5 +48,5 @@ test {
     testLogging {
         showStandardStreams = false
     }
-    dependsOn ":acctMgmtTerraform"
+    dependsOn ":composeUp"
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -78,12 +78,10 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
     public LoginHandler(ConfigurationService configurationService) {
         super(LoginRequest.class, configurationService);
         this.codeStorageService =
-                new CodeStorageService(
-                        new RedisConnectionService(ConfigurationService.getInstance()));
+                new CodeStorageService(new RedisConnectionService(configurationService));
         this.userMigrationService =
                 new UserMigrationService(
-                        new DynamoService(ConfigurationService.getInstance()),
-                        ConfigurationService.getInstance());
+                        new DynamoService(configurationService), configurationService);
         this.auditService = new AuditService(configurationService);
     }
 

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -48,6 +48,7 @@ test {
     environment "ENVIRONMENT", "local"
     environment "LOCALSTACK_ENDPOINT", "http://localhost:45678"
     environment "LOGIN_URI", "http://localhost:3000"
+    environment "ROOT_RESOURCE_URL", "http://localhost"
     environment "REDIS_KEY", "session"
     environment "RESET_PASSWORD_URL", "http://localhost:3000/reset-password?code="
     environment "SQS_ENDPOINT", "http://localhost:45678"
@@ -55,5 +56,5 @@ test {
     environment "TERMS_CONDITIONS_VERSION", "1.0"
     environment "HEADERS_CASE_INSENSITIVE", "true"
 
-    dependsOn ":auditTerraform"
+    dependsOn ":composeUp"
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
@@ -15,11 +15,9 @@ import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import com.nimbusds.openid.connect.sdk.claims.IDTokenClaimsSet;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.authentication.oidc.lambda.LogoutHandler;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
-import uk.gov.di.authentication.sharedtest.extensions.TokenSigningExtension;
 
 import java.io.IOException;
 import java.net.URI;
@@ -47,9 +45,6 @@ public class LogoutIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             "https://di-auth-stub-relying-party-build.london.cloudapps.digital/";
     public static final String SESSION_ID = "session-id";
     public static final String CLIENT_SESSION_ID = "client-session-id";
-
-    @RegisterExtension
-    protected static final TokenSigningExtension tokenSigner = new TokenSigningExtension();
 
     @BeforeEach
     void setup() {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
@@ -28,14 +28,12 @@ import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import net.minidev.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.authentication.oidc.lambda.TokenHandler;
 import uk.gov.di.authentication.shared.entity.ClientConsent;
 import uk.gov.di.authentication.shared.entity.RefreshTokenStore;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.shared.entity.ValidScopes;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
-import uk.gov.di.authentication.sharedtest.extensions.TokenSigningExtension;
 import uk.gov.di.authentication.sharedtest.helper.KeyPairHelper;
 
 import java.net.URI;
@@ -67,9 +65,6 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     private static final String CLIENT_ID = "test-id";
     private static final String REFRESH_TOKEN_PREFIX = "REFRESH_TOKEN:";
     private static final String REDIRECT_URI = "http://localhost/redirect";
-
-    @RegisterExtension
-    protected static final TokenSigningExtension tokenSigner = new TokenSigningExtension();
 
     @BeforeEach
     void setup() {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
@@ -11,12 +11,10 @@ import com.nimbusds.openid.connect.sdk.UserInfoErrorResponse;
 import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.authentication.oidc.lambda.UserInfoHandler;
 import uk.gov.di.authentication.shared.entity.AccessTokenStore;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
-import uk.gov.di.authentication.sharedtest.extensions.TokenSigningExtension;
 import uk.gov.di.authentication.sharedtest.helper.KeyPairHelper;
 
 import java.security.KeyPair;
@@ -45,9 +43,6 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     private static final String TEST_PASSWORD = "password-1";
     private static final String CLIENT_ID = "client-id-one";
     private static final String ACCESS_TOKEN_PREFIX = "ACCESS_TOKEN:";
-
-    @RegisterExtension
-    protected static final TokenSigningExtension tokenSigner = new TokenSigningExtension();
 
     @BeforeEach
     void setup() {

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/ClientStoreExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/ClientStoreExtension.java
@@ -1,6 +1,7 @@
 package uk.gov.di.authentication.sharedtest.extensions;
 
 import com.amazonaws.services.dynamodbv2.model.AttributeDefinition;
+import com.amazonaws.services.dynamodbv2.model.BillingMode;
 import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
 import com.amazonaws.services.dynamodbv2.model.GlobalSecondaryIndex;
 import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
@@ -23,8 +24,7 @@ public class ClientStoreExtension extends DynamoExtension implements AfterEachCa
     public static final String CLIENT_NAME_FIELD = "ClientName";
     public static final String CLIENT_NAME_INDEX = "ClientNameIndex";
 
-    private final DynamoClientService dynamoClientService =
-            new DynamoClientService(REGION, ENVIRONMENT, Optional.of(DYNAMO_ENDPOINT));
+    private DynamoClientService dynamoClientService;
 
     public void registerClient(
             String clientID,
@@ -55,6 +55,13 @@ public class ClientStoreExtension extends DynamoExtension implements AfterEachCa
     }
 
     @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+        super.beforeAll(context);
+        dynamoClientService =
+                new DynamoClientService(REGION, ENVIRONMENT, Optional.of(DYNAMO_ENDPOINT));
+    }
+
+    @Override
     public void afterEach(ExtensionContext context) throws Exception {
         clearDynamoTable(dynamoDB, CLIENT_REGISTRY_TABLE, CLIENT_ID_FIELD);
     }
@@ -71,6 +78,7 @@ public class ClientStoreExtension extends DynamoExtension implements AfterEachCa
                 new CreateTableRequest()
                         .withTableName(tableName)
                         .withKeySchema(new KeySchemaElement(CLIENT_ID_FIELD, HASH))
+                        .withBillingMode(BillingMode.PAY_PER_REQUEST)
                         .withAttributeDefinitions(
                                 new AttributeDefinition(CLIENT_ID_FIELD, S),
                                 new AttributeDefinition(CLIENT_NAME_FIELD, S))

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/SnsTopicExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/SnsTopicExtension.java
@@ -6,19 +6,21 @@ import com.amazonaws.services.sns.AmazonSNSClientBuilder;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
+import static java.text.MessageFormat.format;
+
 public class SnsTopicExtension implements BeforeAllCallback {
 
     protected static final String REGION = System.getenv().getOrDefault("AWS_REGION", "eu-west-2");
     protected static final String LOCALSTACK_ENDPOINT =
             System.getenv().getOrDefault("LOCALSTACK_ENDPOINT", "http://localhost:45678");
 
-    private final String topicName;
+    private final String topicNameSuffix;
     private final AmazonSNS snsClient;
 
     private String topicArn;
 
-    public SnsTopicExtension(String topicName) {
-        this.topicName = topicName;
+    public SnsTopicExtension(String topicNameSuffix) {
+        this.topicNameSuffix = topicNameSuffix;
         this.snsClient =
                 AmazonSNSClientBuilder.standard()
                         .withEndpointConfiguration(
@@ -29,10 +31,21 @@ public class SnsTopicExtension implements BeforeAllCallback {
 
     @Override
     public void beforeAll(ExtensionContext context) {
+        var topicName =
+                format(
+                        "{0}-{1}",
+                        context.getTestClass().map(Class::getSimpleName).orElse("unknown"),
+                        topicNameSuffix);
+
         topicArn = createTopic(topicName);
     }
 
+    public String getTopicArn() {
+        return topicArn;
+    }
+
     private String createTopic(String topicName) {
-        return snsClient.createTopic(topicName).getTopicArn();
+        var result = snsClient.createTopic(topicName);
+        return result.getTopicArn();
     }
 }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/UserStoreExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/UserStoreExtension.java
@@ -1,6 +1,7 @@
 package uk.gov.di.authentication.sharedtest.extensions;
 
 import com.amazonaws.services.dynamodbv2.model.AttributeDefinition;
+import com.amazonaws.services.dynamodbv2.model.BillingMode;
 import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
 import com.amazonaws.services.dynamodbv2.model.GlobalSecondaryIndex;
 import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
@@ -31,8 +32,7 @@ public class UserStoreExtension extends DynamoExtension implements AfterEachCall
     public static final String SUBJECT_ID_INDEX = "SubjectIDIndex";
     public static final String PUBLIC_SUBJECT_ID_INDEX = "PublicSubjectIDIndex";
 
-    private final DynamoService dynamoService =
-            new DynamoService(REGION, ENVIRONMENT, Optional.of(DYNAMO_ENDPOINT));
+    private DynamoService dynamoService;
 
     public boolean userExists(String email) {
         return dynamoService.userExists(email);
@@ -71,6 +71,12 @@ public class UserStoreExtension extends DynamoExtension implements AfterEachCall
     }
 
     @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+        super.beforeAll(context);
+        dynamoService = new DynamoService(REGION, ENVIRONMENT, Optional.of(DYNAMO_ENDPOINT));
+    }
+
+    @Override
     public void afterEach(ExtensionContext context) throws Exception {
         clearDynamoTable(dynamoDB, USER_CREDENTIALS_TABLE, EMAIL_FIELD);
         clearDynamoTable(dynamoDB, USER_PROFILE_TABLE, EMAIL_FIELD);
@@ -92,6 +98,7 @@ public class UserStoreExtension extends DynamoExtension implements AfterEachCall
                 new CreateTableRequest()
                         .withTableName(tableName)
                         .withKeySchema(new KeySchemaElement(EMAIL_FIELD, HASH))
+                        .withBillingMode(BillingMode.PAY_PER_REQUEST)
                         .withAttributeDefinitions(
                                 new AttributeDefinition(EMAIL_FIELD, S),
                                 new AttributeDefinition(SUBJECT_ID_FIELD, S))
@@ -108,6 +115,7 @@ public class UserStoreExtension extends DynamoExtension implements AfterEachCall
                 new CreateTableRequest()
                         .withTableName(tableName)
                         .withKeySchema(new KeySchemaElement(EMAIL_FIELD, HASH))
+                        .withBillingMode(BillingMode.PAY_PER_REQUEST)
                         .withAttributeDefinitions(
                                 new AttributeDefinition(EMAIL_FIELD, S),
                                 new AttributeDefinition(SUBJECT_ID_FIELD, S),

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
@@ -23,15 +23,21 @@ public class AuditService {
     private final Clock clock;
     private final SnsService snsService;
     private final KmsConnectionService kmsConnectionService;
+    private final ConfigurationService configurationService;
 
     public AuditService(
-            Clock clock, SnsService snsService, KmsConnectionService kmsConnectionService) {
+            Clock clock,
+            SnsService snsService,
+            KmsConnectionService kmsConnectionService,
+            ConfigurationService configurationService) {
         this.clock = clock;
         this.snsService = snsService;
         this.kmsConnectionService = kmsConnectionService;
+        this.configurationService = configurationService;
     }
 
     public AuditService(ConfigurationService configurationService) {
+        this.configurationService = configurationService;
         this.clock = Clock.systemUTC();
         this.snsService = new SnsService(configurationService);
         this.kmsConnectionService =
@@ -116,7 +122,7 @@ public class AuditService {
 
     private byte[] signPayload(byte[] payload) {
         SignRequest signRequest = new SignRequest();
-        signRequest.setKeyId(ConfigurationService.getInstance().getAuditSigningKeyAlias());
+        signRequest.setKeyId(configurationService.getAuditSigningKeyAlias());
         signRequest.setMessage(ByteBuffer.wrap(payload));
         signRequest.setSigningAlgorithm(SigningAlgorithmSpec.ECDSA_SHA_256.toString());
 

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
@@ -67,7 +67,12 @@ class AuditServiceTest {
 
     @Test
     void shouldLogAuditEvent() {
-        var auditService = new AuditService(FIXED_CLOCK, snsService, kmsConnectionService);
+        var auditService =
+                new AuditService(
+                        FIXED_CLOCK,
+                        snsService,
+                        kmsConnectionService,
+                        mock(ConfigurationService.class));
 
         auditService.submitAuditEvent(
                 TEST_EVENT_ONE,
@@ -96,7 +101,12 @@ class AuditServiceTest {
 
     @Test
     void shouldSignAuditEventPayload() throws InvalidProtocolBufferException {
-        var auditService = new AuditService(FIXED_CLOCK, snsService, kmsConnectionService);
+        var auditService =
+                new AuditService(
+                        FIXED_CLOCK,
+                        snsService,
+                        kmsConnectionService,
+                        mock(ConfigurationService.class));
 
         var signingRequestCaptor = ArgumentCaptor.forClass(SignRequest.class);
 
@@ -125,7 +135,12 @@ class AuditServiceTest {
 
     @Test
     void shouldLogAuditEventWithMetadataPairsAttached() {
-        var auditService = new AuditService(FIXED_CLOCK, snsService, kmsConnectionService);
+        var auditService =
+                new AuditService(
+                        FIXED_CLOCK,
+                        snsService,
+                        kmsConnectionService,
+                        mock(ConfigurationService.class));
 
         auditService.submitAuditEvent(
                 TEST_EVENT_ONE,


### PR DESCRIPTION
## What?

- Remove the Terraform step from integration test startup
- Ensure injected ConfigurationService is used for all dependencies in LoginHandler
- Create TokenSigner in base class rather than individual classes, to ensure consistent initialisation of the test ConfigurationService instance
- Override Redis values in the test ConfigurationService rather than get then from SSM (we'll change this later)
- Tweak the integration test dependency initialisation to ensure dependency creation before test code executed

## Why?

This is the final step on the road to speeding up the integration tests. We now have extensions that will create test dependencies (Localstack resource, Dynamo tables etc) per test class, so we no longer need to Terraform those resources. This reduces the test execution time from over 10mins to circa 2 mins.