### PR TITLE
GOVSI-1156 - Pass persistent-session-id to Splunk

### DIFF
--- a/audit-processors/src/main/java/uk/gov/di/authentication/audit/lambda/CounterFraudAuditLambda.java
+++ b/audit-processors/src/main/java/uk/gov/di/authentication/audit/lambda/CounterFraudAuditLambda.java
@@ -32,6 +32,7 @@ public class CounterFraudAuditLambda extends BaseAuditHandler {
         eventData.put("client-id", auditEvent.getClientId());
         eventData.put("timestamp", auditEvent.getTimestamp());
         eventData.put("event-name", auditEvent.getEventName());
+        eventData.put("persistent-session-id", auditEvent.getPersistentSessionId());
 
         User user = auditEvent.getUser();
 

--- a/audit-processors/src/test/java/uk/gov/di/authentication/audit/lambda/CounterFraudAuditLambdaTest.java
+++ b/audit-processors/src/test/java/uk/gov/di/authentication/audit/lambda/CounterFraudAuditLambdaTest.java
@@ -50,6 +50,7 @@ public class CounterFraudAuditLambdaTest {
                         .setClientId("test-client-id")
                         .setTimestamp("test-timestamp")
                         .setEventName("test-event-name")
+                        .setPersistentSessionId("test-persistent-session-id")
                         .build();
 
         handler.handleAuditEvent(payload);
@@ -62,6 +63,9 @@ public class CounterFraudAuditLambdaTest {
         assertThat(logEvent, hasObjectMessageProperty("client-id", "test-client-id"));
         assertThat(logEvent, hasObjectMessageProperty("timestamp", "test-timestamp"));
         assertThat(logEvent, hasObjectMessageProperty("event-name", "test-event-name"));
+        assertThat(
+                logEvent,
+                hasObjectMessageProperty("persistent-session-id", "test-persistent-session-id"));
     }
 
     @Test


### PR DESCRIPTION
## What?

- Pass the persistent-session-id to Splunk using the CounterFraudAuditHandler


## Why?

So we have visibility in Splunk