### PR TITLE
GOVSI-1154 - Build password reset link in ResetPasswordRequestHandler

### DIFF
--- a/ci/terraform/oidc/reset-password-request.tf
+++ b/ci/terraform/oidc/reset-password-request.tf
@@ -9,6 +9,8 @@ module "reset-password-request" {
   handler_environment_variables = {
     ENVIRONMENT             = var.environment
     BASE_URL                = local.frontend_api_base_url
+    FRONTEND_BASE_URL       = module.dns.frontend_url
+    RESET_PASSWORD_ROUTE    = var.reset_password_route
     SQS_ENDPOINT            = var.use_localstack ? "http://localhost:45678/" : null
     EMAIL_QUEUE_URL         = aws_sqs_queue.email_queue.id
     EVENTS_SNS_TOPIC_ARN    = aws_sns_topic.events.arn

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandler.java
@@ -16,9 +16,6 @@ import uk.gov.di.authentication.shared.services.NotificationService;
 import uk.gov.service.notify.NotificationClient;
 import uk.gov.service.notify.NotificationClientException;
 
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -115,8 +112,7 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                             break;
                         case RESET_PASSWORD:
                             notifyPersonalisation.put(
-                                    "reset-password-link",
-                                    buildResetPasswordLink(notifyRequest.getCode()));
+                                    "reset-password-link", notifyRequest.getCode());
                             notificationService.sendEmail(
                                     notifyRequest.getDestination(),
                                     notifyPersonalisation,
@@ -157,19 +153,6 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
             }
         }
         return null;
-    }
-
-    private String buildResetPasswordLink(String code) {
-        LocalDateTime localDateTime =
-                LocalDateTime.now().plusSeconds(configurationService.getCodeExpiry());
-        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
-        return buildURI(
-                        configurationService.getFrontendBaseUrl(),
-                        configurationService.getResetPasswordRoute()
-                                + code
-                                + "."
-                                + expiryDate.toInstant().toEpochMilli())
-                .toString();
     }
 
     private void writeTestClientOtpToS3(String otp, String destination) {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/ResetPasswordService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/ResetPasswordService.java
@@ -1,0 +1,31 @@
+package uk.gov.di.authentication.frontendapi.services;
+
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+
+import static uk.gov.di.authentication.shared.helpers.ConstructUriHelper.buildURI;
+
+public class ResetPasswordService {
+
+    private ConfigurationService configurationService;
+
+    public ResetPasswordService(ConfigurationService configurationService) {
+        this.configurationService = configurationService;
+    }
+
+    public String buildResetPasswordLink(String code) {
+        LocalDateTime localDateTime =
+                LocalDateTime.now().plusSeconds(configurationService.getCodeExpiry());
+        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
+        return buildURI(
+                        configurationService.getFrontendBaseUrl(),
+                        configurationService.getResetPasswordRoute()
+                                + code
+                                + "."
+                                + expiryDate.toInstant().toEpochMilli())
+                .toString();
+    }
+}

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandlerTest.java
@@ -52,14 +52,14 @@ public class NotificationHandlerTest {
     private ObjectMapper objectMapper = new ObjectMapper();
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         when(configService.getNotifyTestPhoneNumber()).thenReturn(Optional.of(NOTIFY_PHONE_NUMBER));
         when(configService.getSmoketestBucketName()).thenReturn(BUCKET_NAME);
         handler = new NotificationHandler(notificationService, configService, s3Client);
     }
 
     @Test
-    public void shouldSuccessfullyProcessEmailMessageFromSQSQueue()
+    void shouldSuccessfullyProcessEmailMessageFromSQSQueue()
             throws JsonProcessingException, NotificationClientException {
         when(notificationService.getNotificationTemplateId(VERIFY_EMAIL)).thenReturn(TEMPLATE_ID);
 
@@ -77,7 +77,7 @@ public class NotificationHandlerTest {
     }
 
     @Test
-    public void shouldSuccessfullyProcessResetPasswordConfirmationFromSQSQueue()
+    void shouldSuccessfullyProcessResetPasswordConfirmationFromSQSQueue()
             throws JsonProcessingException, NotificationClientException {
         when(notificationService.getNotificationTemplateId(PASSWORD_RESET_CONFIRMATION))
                 .thenReturn(TEMPLATE_ID);
@@ -98,7 +98,7 @@ public class NotificationHandlerTest {
     }
 
     @Test
-    public void shouldSuccessfullyProcessResetPasswordEmailFromSQSQueue()
+    void shouldSuccessfullyProcessResetPasswordEmailFromSQSQueue()
             throws JsonProcessingException, NotificationClientException {
         when(notificationService.getNotificationTemplateId(RESET_PASSWORD)).thenReturn(TEMPLATE_ID);
 
@@ -116,7 +116,7 @@ public class NotificationHandlerTest {
     }
 
     @Test
-    public void shouldSuccessfullyProcessAccountCreatedConfirmationFromSQSQueue()
+    void shouldSuccessfullyProcessAccountCreatedConfirmationFromSQSQueue()
             throws JsonProcessingException, NotificationClientException {
         String accountManagementUrl = "http://account-management/";
         String baseUrl = "http://account-management";
@@ -138,7 +138,7 @@ public class NotificationHandlerTest {
     }
 
     @Test
-    public void shouldSuccessfullyProcessPhoneMessageFromSQSQueue()
+    void shouldSuccessfullyProcessPhoneMessageFromSQSQueue()
             throws JsonProcessingException, NotificationClientException {
         when(notificationService.getNotificationTemplateId(VERIFY_PHONE_NUMBER))
                 .thenReturn(TEMPLATE_ID);
@@ -158,7 +158,7 @@ public class NotificationHandlerTest {
     }
 
     @Test
-    public void shouldThrowExceptionIfUnableToProcessMessageFromQueue() {
+    void shouldThrowExceptionIfUnableToProcessMessageFromQueue() {
         SQSEvent sqsEvent = generateSQSEvent("");
 
         RuntimeException exception =
@@ -172,7 +172,7 @@ public class NotificationHandlerTest {
     }
 
     @Test
-    public void shouldThrowExceptionIfNotifyIsUnableToSendEmail()
+    void shouldThrowExceptionIfNotifyIsUnableToSendEmail()
             throws JsonProcessingException, NotificationClientException {
         when(notificationService.getNotificationTemplateId(VERIFY_EMAIL)).thenReturn(TEMPLATE_ID);
 
@@ -199,7 +199,7 @@ public class NotificationHandlerTest {
     }
 
     @Test
-    public void shouldThrowExceptionIfNotifyIsUnableToSendText()
+    void shouldThrowExceptionIfNotifyIsUnableToSendText()
             throws JsonProcessingException, NotificationClientException {
         when(notificationService.getNotificationTemplateId(VERIFY_PHONE_NUMBER))
                 .thenReturn(TEMPLATE_ID);
@@ -227,7 +227,7 @@ public class NotificationHandlerTest {
     }
 
     @Test
-    public void shouldSuccessfullyProcessPhoneMessageFromSQSQueueAndWriteToS3WhenTestClient()
+    void shouldSuccessfullyProcessPhoneMessageFromSQSQueueAndWriteToS3WhenTestClient()
             throws JsonProcessingException, NotificationClientException {
         when(notificationService.getNotificationTemplateId(VERIFY_PHONE_NUMBER))
                 .thenReturn(TEMPLATE_ID);
@@ -248,7 +248,7 @@ public class NotificationHandlerTest {
     }
 
     @Test
-    public void shouldSuccessfullyProcessMfaessageFromSQSQueue()
+    void shouldSuccessfullyProcessMfaessageFromSQSQueue()
             throws JsonProcessingException, NotificationClientException {
         when(notificationService.getNotificationTemplateId(MFA_SMS)).thenReturn(TEMPLATE_ID);
 
@@ -266,7 +266,7 @@ public class NotificationHandlerTest {
     }
 
     @Test
-    public void shouldSuccessfullyProcessMfaMessageFromSQSQueueAndWriteToS3WhenTestClient()
+    void shouldSuccessfullyProcessMfaMessageFromSQSQueueAndWriteToS3WhenTestClient()
             throws JsonProcessingException, NotificationClientException {
         when(notificationService.getNotificationTemplateId(MFA_SMS)).thenReturn(TEMPLATE_ID);
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/ResetPasswordServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/ResetPasswordServiceTest.java
@@ -1,0 +1,42 @@
+package uk.gov.di.authentication.frontendapi.services;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.shared.helpers.ConstructUriHelper.buildURI;
+
+class ResetPasswordServiceTest {
+
+    private static final String FRONTEND_BASE_URL = "https://localhost:8080/frontend";
+    private static final String RESET_PASSWORD_PATH = "reset-password?code=";
+    private static final long CODE_EXPIRY_TIME = 900;
+    private static final String CODE = "123456";
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private ResetPasswordService resetPasswordService =
+            new ResetPasswordService(configurationService);
+
+    @BeforeEach
+    void setup() {
+        when(configurationService.getCodeExpiry()).thenReturn(CODE_EXPIRY_TIME);
+        when(configurationService.getFrontendBaseUrl()).thenReturn(FRONTEND_BASE_URL);
+        when(configurationService.getResetPasswordRoute()).thenReturn(RESET_PASSWORD_PATH);
+    }
+
+    @Test
+    public void shouldReturnPasswordResetLink() {
+        String passwordResetLink = resetPasswordService.buildResetPasswordLink(CODE);
+        String[] splitPasswordLink = passwordResetLink.split("\\.");
+
+        assertThat(splitPasswordLink.length, equalTo(2));
+        assertThat(
+                splitPasswordLink[0],
+                equalTo(buildURI(FRONTEND_BASE_URL, RESET_PASSWORD_PATH + CODE).toString()));
+        assertNotNull(splitPasswordLink[1]);
+    }
+}

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/ResetPasswordServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/ResetPasswordServiceTest.java
@@ -29,7 +29,7 @@ class ResetPasswordServiceTest {
     }
 
     @Test
-    public void shouldReturnPasswordResetLink() {
+    void shouldReturnPasswordResetLink() {
         String passwordResetLink = resetPasswordService.buildResetPasswordLink(CODE);
         String[] splitPasswordLink = passwordResetLink.split("\\.");
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordRequestIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordRequestIntegrationTest.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.authentication.shared.entity.NotificationType.RESET_PASSWORD;
 import static uk.gov.di.authentication.shared.entity.SessionState.AUTHENTICATION_REQUIRED;
 import static uk.gov.di.authentication.shared.entity.SessionState.NEW;
@@ -53,6 +54,8 @@ public class ResetPasswordRequestIntegrationTest extends ApiGatewayHandlerIntegr
         assertThat(requests, hasSize(1));
         assertThat(requests.get(0).getDestination(), equalTo(email));
         assertThat(requests.get(0).getNotificationType(), equalTo(RESET_PASSWORD));
+        assertTrue(
+                requests.get(0).getCode().startsWith("http://localhost:3000/reset-password?code="));
 
         BaseAPIResponse resetPasswordResponse =
                 objectMapper.readValue(response.getBody(), BaseAPIResponse.class);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/NotificationHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/NotificationHandlerIntegrationTest.java
@@ -98,9 +98,11 @@ public class NotificationHandlerIntegrationTest extends NotifyIntegrationTest {
     void shouldCallNotifyWhenValidResetPasswordRequestIsAddedToQueue()
             throws JsonProcessingException {
         String code = new CodeGeneratorService().twentyByteEncodedRandomCode();
+        String resetPasswordLink = "http://localhost:3000/reset-password?code=" + code;
 
         handler.handleRequest(
-                createSqsEvent(new NotifyRequest(TEST_EMAIL_ADDRESS, RESET_PASSWORD, code)),
+                createSqsEvent(
+                        new NotifyRequest(TEST_EMAIL_ADDRESS, RESET_PASSWORD, resetPasswordLink)),
                 mock(Context.class));
 
         JsonNode request = notifyStub.waitForRequest(60);
@@ -111,9 +113,7 @@ public class NotificationHandlerIntegrationTest extends NotifyIntegrationTest {
         JsonNode personalisation = request.get("personalisation");
         assertThat(
                 personalisation,
-                hasFieldWithValue(
-                        "reset-password-link",
-                        startsWith("http://localhost:3000/reset-password?code=")));
+                hasFieldWithValue("reset-password-link", startsWith(resetPasswordLink)));
         assertThat(personalisation, hasFieldWithValue("reset-password-link", containsString(code)));
     }
 

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/ApiGatewayHandlerIntegrationTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/ApiGatewayHandlerIntegrationTest.java
@@ -207,5 +207,10 @@ public abstract class ApiGatewayHandlerIntegrationTest {
         public String getTokenSigningKeyAlias() {
             return tokenSigningKey.getKeyAlias();
         }
+
+        @Override
+        public String getFrontendBaseUrl() {
+            return "http://localhost:3000/reset-password?code=";
+        }
     }
 }


### PR DESCRIPTION
## What?

- Move the building of the Password reset link to the ResetPasswordRequestHandler
- Ensure the ResetPasswordRequest lambda has the correct environment variables available
- Create a new helper service and add a method which will be used to construct the Reset password URL.

## Why?

- We will eventually want to add additional information to this link such as sessionId which we will not have available to us in the NotificationHandler.
- The ResetPasswordService helps simplifies the ResetPasswordRequestHandler and also allows for higher test coverage which we were lacking before.