### PR TITLE
GOVSI-1114: SSM extension

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ subprojects {
         s3
         sns
         sqs
+        ssm
         tests
         test_runtime
     }
@@ -90,6 +91,8 @@ subprojects {
         sns "com.amazonaws:aws-java-sdk-sns:${dependencyVersions.aws_sdk_version}"
 
         sqs "software.amazon.awssdk:sqs:2.17.73"
+
+        ssm "com.amazonaws:aws-java-sdk-ssm:${dependencyVersions.aws_sdk_version}"
 
         s3 "com.amazonaws:aws-java-sdk-s3:${dependencyVersions.aws_sdk_version}"
 

--- a/shared-test/build.gradle
+++ b/shared-test/build.gradle
@@ -18,6 +18,7 @@ dependencies {
             configurations.lettuce,
             configurations.dynamodb,
             configurations.sns,
+            configurations.ssm,
             "org.eclipse.jetty:jetty-server:11.0.7",
             "com.google.protobuf:protobuf-java:3.18.1",
             project(":shared")

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/ApiGatewayHandlerIntegrationTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/ApiGatewayHandlerIntegrationTest.java
@@ -11,6 +11,7 @@ import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.sharedtest.extensions.ClientStoreExtension;
 import uk.gov.di.authentication.sharedtest.extensions.KmsKeyExtension;
+import uk.gov.di.authentication.sharedtest.extensions.ParameterStoreExtension;
 import uk.gov.di.authentication.sharedtest.extensions.RedisExtension;
 import uk.gov.di.authentication.sharedtest.extensions.SnsTopicExtension;
 import uk.gov.di.authentication.sharedtest.extensions.SqsQueueExtension;
@@ -59,6 +60,20 @@ public abstract class ApiGatewayHandlerIntegrationTest {
 
     @RegisterExtension
     protected static final TokenSigningExtension tokenSigner = new TokenSigningExtension();
+
+    @RegisterExtension
+    protected static final ParameterStoreExtension configurationParameters =
+            new ParameterStoreExtension(
+                    Map.of(
+                            "local-session-redis-master-host", "localhost",
+                            "local-session-redis-password", "null",
+                            "local-session-redis-port", "6379",
+                            "local-session-redis-tls", "false",
+                            "local-account-management-redis-master-host", "localhost",
+                            "local-account-management-redis-password", "null",
+                            "local-account-management-redis-port", "6379",
+                            "local-account-management-redis-tls", "false",
+                            "local-password-pepper", "pepper"));
 
     protected static final ConfigurationService TEST_CONFIGURATION_SERVICE =
             new IntegrationTestConfigurationService(
@@ -169,11 +184,6 @@ public abstract class ApiGatewayHandlerIntegrationTest {
         }
 
         @Override
-        public String getRedisHost() {
-            return "localhost";
-        }
-
-        @Override
         public String getEmailQueueUri() {
             return notificationQueue.getQueueUrl();
         }
@@ -181,21 +191,6 @@ public abstract class ApiGatewayHandlerIntegrationTest {
         @Override
         public String getEventsSnsTopicArn() {
             return auditEventTopic.getTopicArn();
-        }
-
-        @Override
-        public Optional<String> getRedisPassword() {
-            return Optional.empty();
-        }
-
-        @Override
-        public int getRedisPort() {
-            return 6379;
-        }
-
-        @Override
-        public boolean getUseRedisTLS() {
-            return false;
         }
 
         @Override

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/BaseAwsResourceExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/BaseAwsResourceExtension.java
@@ -1,0 +1,7 @@
+package uk.gov.di.authentication.sharedtest.extensions;
+
+public abstract class BaseAwsResourceExtension {
+    protected static final String REGION = System.getenv().getOrDefault("AWS_REGION", "eu-west-2");
+    protected static final String LOCALSTACK_ENDPOINT =
+            System.getenv().getOrDefault("LOCALSTACK_ENDPOINT", "http://localhost:45678");
+}

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/DynamoExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/DynamoExtension.java
@@ -12,9 +12,9 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.util.Map;
 
-public abstract class DynamoExtension implements BeforeAllCallback {
+public abstract class DynamoExtension extends BaseAwsResourceExtension
+        implements BeforeAllCallback {
 
-    protected static final String REGION = System.getenv().getOrDefault("AWS_REGION", "eu-west-2");
     protected static final String ENVIRONMENT =
             System.getenv().getOrDefault("ENVIRONMENT", "local");
     protected static final String DYNAMO_ENDPOINT =

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/KmsKeyExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/KmsKeyExtension.java
@@ -14,11 +14,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import static com.amazonaws.services.kms.model.KeyUsageType.SIGN_VERIFY;
 import static java.text.MessageFormat.format;
 
-public class KmsKeyExtension implements BeforeAllCallback {
-
-    protected static final String REGION = System.getenv().getOrDefault("AWS_REGION", "eu-west-2");
-    protected static final String LOCALSTACK_ENDPOINT =
-            System.getenv().getOrDefault("LOCALSTACK_ENDPOINT", "http://localhost:45678");
+public class KmsKeyExtension extends BaseAwsResourceExtension implements BeforeAllCallback {
 
     protected AWSKMS kms;
     protected final String keyAliasSuffix;

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/ParameterStoreExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/ParameterStoreExtension.java
@@ -1,0 +1,47 @@
+package uk.gov.di.authentication.sharedtest.extensions;
+
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement;
+import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagementClient;
+import com.amazonaws.services.simplesystemsmanagement.model.PutParameterRequest;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.util.Map;
+
+import static com.amazonaws.services.simplesystemsmanagement.model.ParameterType.SecureString;
+
+public class ParameterStoreExtension implements BeforeAllCallback {
+
+    protected static final String REGION = System.getenv().getOrDefault("AWS_REGION", "eu-west-2");
+    protected static final String LOCALSTACK_ENDPOINT =
+            System.getenv().getOrDefault("LOCALSTACK_ENDPOINT", "http://localhost:45678");
+
+    private final Map<String, String> parameters;
+    private final AWSSimpleSystemsManagement ssmClient;
+
+    public ParameterStoreExtension(Map<String, String> parameters) {
+        this.parameters = parameters;
+        this.ssmClient =
+                AWSSimpleSystemsManagementClient.builder()
+                        .withEndpointConfiguration(
+                                new AwsClientBuilder.EndpointConfiguration(
+                                        LOCALSTACK_ENDPOINT, REGION))
+                        .build();
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        parameters.forEach(this::createOrOverwriteParameter);
+    }
+
+    private void createOrOverwriteParameter(String key, String value) {
+        PutParameterRequest parameterRequest =
+                new PutParameterRequest()
+                        .withName(key)
+                        .withType(SecureString)
+                        .withOverwrite(true)
+                        .withValue(value);
+        ssmClient.putParameter(parameterRequest);
+    }
+}

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/ParameterStoreExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/ParameterStoreExtension.java
@@ -11,11 +11,7 @@ import java.util.Map;
 
 import static com.amazonaws.services.simplesystemsmanagement.model.ParameterType.SecureString;
 
-public class ParameterStoreExtension implements BeforeAllCallback {
-
-    protected static final String REGION = System.getenv().getOrDefault("AWS_REGION", "eu-west-2");
-    protected static final String LOCALSTACK_ENDPOINT =
-            System.getenv().getOrDefault("LOCALSTACK_ENDPOINT", "http://localhost:45678");
+public class ParameterStoreExtension extends BaseAwsResourceExtension implements BeforeAllCallback {
 
     private final Map<String, String> parameters;
     private final AWSSimpleSystemsManagement ssmClient;

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/SnsTopicExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/SnsTopicExtension.java
@@ -8,11 +8,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 
 import static java.text.MessageFormat.format;
 
-public class SnsTopicExtension implements BeforeAllCallback {
-
-    protected static final String REGION = System.getenv().getOrDefault("AWS_REGION", "eu-west-2");
-    protected static final String LOCALSTACK_ENDPOINT =
-            System.getenv().getOrDefault("LOCALSTACK_ENDPOINT", "http://localhost:45678");
+public class SnsTopicExtension extends BaseAwsResourceExtension implements BeforeAllCallback {
 
     private final String topicNameSuffix;
     private final AmazonSNS snsClient;

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/SqsQueueExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/SqsQueueExtension.java
@@ -19,11 +19,8 @@ import java.util.stream.Collectors;
 
 import static java.text.MessageFormat.format;
 
-public class SqsQueueExtension implements BeforeAllCallback {
+public class SqsQueueExtension extends BaseAwsResourceExtension implements BeforeAllCallback {
 
-    protected static final String REGION = System.getenv().getOrDefault("AWS_REGION", "eu-west-2");
-    protected static final String LOCALSTACK_ENDPOINT =
-            System.getenv().getOrDefault("LOCALSTACK_ENDPOINT", "http://localhost:45678");
     public static final int DEFAULT_NUMBER_OF_MESSAGES = 10;
 
     private final String queueNameSuffix;

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -21,7 +21,7 @@ dependencies {
             configurations.lettuce,
             configurations.hamcrest,
             configurations.sns,
-            "com.amazonaws:aws-java-sdk-ssm:${dependencyVersions.aws_sdk_version}",
+            configurations.ssm,
             "com.googlecode.libphonenumber:libphonenumber:8.12.36",
             "com.google.protobuf:protobuf-java:3.18.1"
 


### PR DESCRIPTION
## What?

- Create an SSM Parameter Store extension to manage parameter store dependencies
- Use the extension to create resources required by the ConfigurationService

## Why?

Improves test coverage by using Localstack to provide Parameter Store values to integration tests.
