### PR TITLE
GOVSI-1154 - Add session-id and persistent-session-id to password reset link

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/ResetPasswordService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/ResetPasswordService.java
@@ -16,7 +16,8 @@ public class ResetPasswordService {
         this.configurationService = configurationService;
     }
 
-    public String buildResetPasswordLink(String code) {
+    public String buildResetPasswordLink(
+            String code, String sessionID, String persistentSessionId) {
         LocalDateTime localDateTime =
                 LocalDateTime.now().plusSeconds(configurationService.getCodeExpiry());
         Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
@@ -25,7 +26,11 @@ public class ResetPasswordService {
                         configurationService.getResetPasswordRoute()
                                 + code
                                 + "."
-                                + expiryDate.toInstant().toEpochMilli())
+                                + expiryDate.toInstant().toEpochMilli()
+                                + "."
+                                + sessionID
+                                + "."
+                                + persistentSessionId)
                 .toString();
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/ResetPasswordServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/ResetPasswordServiceTest.java
@@ -17,6 +17,8 @@ class ResetPasswordServiceTest {
     private static final String RESET_PASSWORD_PATH = "reset-password?code=";
     private static final long CODE_EXPIRY_TIME = 900;
     private static final String CODE = "123456";
+    private static final String SESSION_ID = "some-session-id";
+    private static final String PERSISTENT_SESSION_ID = "persistent-session-id";
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private ResetPasswordService resetPasswordService =
             new ResetPasswordService(configurationService);
@@ -30,13 +32,17 @@ class ResetPasswordServiceTest {
 
     @Test
     void shouldReturnPasswordResetLink() {
-        String passwordResetLink = resetPasswordService.buildResetPasswordLink(CODE);
+        String passwordResetLink =
+                resetPasswordService.buildResetPasswordLink(
+                        CODE, SESSION_ID, PERSISTENT_SESSION_ID);
         String[] splitPasswordLink = passwordResetLink.split("\\.");
 
-        assertThat(splitPasswordLink.length, equalTo(2));
+        assertThat(splitPasswordLink.length, equalTo(4));
         assertThat(
                 splitPasswordLink[0],
                 equalTo(buildURI(FRONTEND_BASE_URL, RESET_PASSWORD_PATH + CODE).toString()));
         assertNotNull(splitPasswordLink[1]);
+        assertThat(splitPasswordLink[2], equalTo(SESSION_ID));
+        assertThat(splitPasswordLink[3], equalTo(PERSISTENT_SESSION_ID));
     }
 }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/ApiGatewayHandlerIntegrationTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/ApiGatewayHandlerIntegrationTest.java
@@ -129,20 +129,29 @@ public abstract class ApiGatewayHandlerIntegrationTest {
     }
 
     protected Map<String, String> constructFrontendHeaders(String sessionId) {
-        return constructFrontendHeaders(sessionId, Optional.empty());
+        return constructFrontendHeaders(sessionId, Optional.empty(), Optional.empty());
     }
 
     protected Map<String, String> constructFrontendHeaders(
             String sessionId, String clientSessionId) {
-        return constructFrontendHeaders(sessionId, Optional.of(clientSessionId));
+        return constructFrontendHeaders(sessionId, Optional.of(clientSessionId), Optional.empty());
     }
 
     protected Map<String, String> constructFrontendHeaders(
-            String sessionId, Optional<String> clientSessionId) {
+            String sessionId, String clientSessionId, String persistentSessionId) {
+        return constructFrontendHeaders(
+                sessionId, Optional.ofNullable(clientSessionId), Optional.of(persistentSessionId));
+    }
+
+    protected Map<String, String> constructFrontendHeaders(
+            String sessionId,
+            Optional<String> clientSessionId,
+            Optional<String> persistentSessionId) {
         var headers = new HashMap<String, String>();
         headers.put("Session-Id", sessionId);
         headers.put("X-API-Key", FRONTEND_API_KEY);
         clientSessionId.ifPresent(id -> headers.put("Client-Session-Id", id));
+        persistentSessionId.ifPresent(id -> headers.put("di-persistent-session-id", id));
         return headers;
     }
 


### PR DESCRIPTION
## What?
 - Add session-id and persistent-session-id to password reset link
 
## Why?
- They will then be available to the frontend to send in the API request to the ResetPasswordHandler.
