### PR TITLE
Bump Spotless to 6.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 import java.util.stream.Collectors
 
 plugins {
-    id "com.diffplug.spotless" version "5.17.1"
+    id "com.diffplug.spotless" version "6.0.0"
     id "com.avast.gradle.docker-compose" version "0.14.9"
     id "org.sonarqube" version "3.3"
     id "jacoco"
@@ -281,4 +281,8 @@ jacocoTestReport {
         xml.enabled true
     }
     dependsOn "test"
+}
+
+repositories {
+    mavenCentral()
 }


### PR DESCRIPTION
As part of the upgrade, all projects now need the `repositories`
directive.

In this case, all but the top-level `build.gradle` supported this, so we
can add it to align with all the other projects.
