### PR TITLE
GOVSI-1055: Role fixes

### DIFF
--- a/ci/terraform/oidc/lambda-roles.tf
+++ b/ci/terraform/oidc/lambda-roles.tf
@@ -55,7 +55,7 @@ data "aws_iam_policy_document" "kms_policy_document" {
     sid       = "AllowAccessToKmsSigningKey"
     effect    = "Allow"
     actions   = ["kms:GetPublicKey"]
-    resources = [local.id_token_signing_key_alias_arn]
+    resources = [local.id_token_signing_key_arn]
   }
 }
 

--- a/ci/terraform/oidc/shared.tf
+++ b/ci/terraform/oidc/shared.tf
@@ -21,7 +21,7 @@ locals {
   authentication_security_group_id       = data.terraform_remote_state.shared.outputs.authentication_security_group_id
   authentication_subnet_ids              = data.terraform_remote_state.shared.outputs.authentication_subnet_ids
   id_token_signing_key_alias_name        = data.terraform_remote_state.shared.outputs.id_token_signing_key_alias_name
-  id_token_signing_key_alias_arn         = data.terraform_remote_state.shared.outputs.id_token_signing_key_alias_arn
+  id_token_signing_key_arn               = data.terraform_remote_state.shared.outputs.id_token_signing_key_arn
   audit_signing_key_alias_name           = data.terraform_remote_state.shared.outputs.audit_signing_key_alias_name
   audit_signing_key_arn                  = data.terraform_remote_state.shared.outputs.audit_signing_key_arn
   sms_bucket_name                        = data.terraform_remote_state.shared.outputs.sms_bucket_name

--- a/ci/terraform/oidc/token.tf
+++ b/ci/terraform/oidc/token.tf
@@ -23,7 +23,7 @@ data "aws_iam_policy_document" "kms_signing_policy_document" {
       "kms:GetPublicKey",
     ]
     resources = [
-      local.id_token_signing_key_alias_arn
+      local.id_token_signing_key_arn
     ]
   }
 }

--- a/ci/terraform/shared/outputs.tf
+++ b/ci/terraform/shared/outputs.tf
@@ -60,8 +60,8 @@ output "id_token_signing_key_alias_name" {
   value = aws_kms_alias.id_token_signing_key_alias.name
 }
 
-output "id_token_signing_key_alias_arn" {
-  value = aws_kms_alias.id_token_signing_key_alias.arn
+output "id_token_signing_key_arn" {
+  value = aws_kms_key.id_token_signing_key.arn
 }
 
 output "audit_signing_key_alias_name" {


### PR DESCRIPTION
- Grant permissions to use the signing key, not the alias
