### PR TITLE
GOVSI-1154 - Expect a valid session when the ResetPasswordHandler is called

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
@@ -18,19 +18,22 @@ import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.helpers.Argon2MatcherHelper;
 import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
+import uk.gov.di.authentication.shared.services.ClientService;
+import uk.gov.di.authentication.shared.services.ClientSessionService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
+import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.services.ValidationService;
+import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.util.Optional;
 
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateEmptySuccessApiGatewayResponse;
-import static uk.gov.di.authentication.shared.helpers.WarmerHelper.isWarming;
 
-public class ResetPasswordHandler
+public class ResetPasswordHandler extends BaseFrontendHandler<ResetPasswordWithCodeRequest>
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     private final AuthenticationService authenticationService;
@@ -45,7 +48,18 @@ public class ResetPasswordHandler
             AuthenticationService authenticationService,
             AwsSqsClient sqsClient,
             CodeStorageService codeStorageService,
-            ValidationService validationService) {
+            ValidationService validationService,
+            ConfigurationService configurationService,
+            SessionService sessionService,
+            ClientSessionService clientSessionService,
+            ClientService clientService) {
+        super(
+                ResetPasswordWithCodeRequest.class,
+                configurationService,
+                sessionService,
+                clientSessionService,
+                clientService,
+                authenticationService);
         this.authenticationService = authenticationService;
         this.sqsClient = sqsClient;
         this.codeStorageService = codeStorageService;
@@ -57,6 +71,7 @@ public class ResetPasswordHandler
     }
 
     public ResetPasswordHandler(ConfigurationService configurationService) {
+        super(ResetPasswordWithCodeRequest.class, configurationService);
         this.authenticationService = new DynamoService(configurationService);
         this.sqsClient =
                 new AwsSqsClient(
@@ -69,77 +84,58 @@ public class ResetPasswordHandler
     }
 
     @Override
-    public APIGatewayProxyResponseEvent handleRequest(
-            APIGatewayProxyRequestEvent input, Context context) {
-        return isWarming(input)
-                .orElseGet(
-                        () -> {
-                            LOGGER.info("Request received to ResetPasswordHandler");
-                            try {
-                                ResetPasswordWithCodeRequest resetPasswordWithCodeRequest =
-                                        objectMapper.readValue(
-                                                input.getBody(),
-                                                ResetPasswordWithCodeRequest.class);
-                                Optional<ErrorResponse> errorResponse =
-                                        validationService.validatePassword(
-                                                resetPasswordWithCodeRequest.getPassword());
-                                if (errorResponse.isPresent()) {
-                                    LOGGER.info(
-                                            "Password did not pass validation because: {}",
-                                            errorResponse.get().getMessage());
-                                    return generateApiGatewayProxyErrorResponse(
-                                            400, errorResponse.get());
-                                }
-                                Optional<String> subject =
-                                        codeStorageService.getSubjectWithPasswordResetCode(
-                                                resetPasswordWithCodeRequest.getCode());
-                                if (subject.isEmpty()) {
-                                    LOGGER.error("Subject is not found in Redis");
-                                    return generateApiGatewayProxyErrorResponse(
-                                            400, ErrorResponse.ERROR_1021);
-                                }
-                                UserCredentials userCredentials =
-                                        authenticationService.getUserCredentialsFromSubject(
-                                                subject.get());
-                                if (userCredentials.getPassword() != null) {
-                                    if (verifyPassword(
-                                            userCredentials.getPassword(),
-                                            resetPasswordWithCodeRequest.getPassword())) {
-                                        LOGGER.info("New password is the same as the old password");
-                                        return generateApiGatewayProxyErrorResponse(
-                                                400, ErrorResponse.ERROR_1024);
-                                    }
-                                } else {
-                                    LOGGER.info("Resetting password for migrated user");
-                                }
-                                codeStorageService.deleteSubjectWithPasswordResetCode(
-                                        resetPasswordWithCodeRequest.getCode());
-                                authenticationService.updatePassword(
-                                        userCredentials.getEmail(),
-                                        resetPasswordWithCodeRequest.getPassword());
+    public APIGatewayProxyResponseEvent handleRequestWithUserContext(
+            APIGatewayProxyRequestEvent input,
+            Context context,
+            ResetPasswordWithCodeRequest request,
+            UserContext userContext) {
+        LOGGER.info("Request received to ResetPasswordHandler");
+        try {
+            Optional<ErrorResponse> errorResponse =
+                    validationService.validatePassword(request.getPassword());
+            if (errorResponse.isPresent()) {
+                LOGGER.info(
+                        "Password did not pass validation because: {}",
+                        errorResponse.get().getMessage());
+                return generateApiGatewayProxyErrorResponse(400, errorResponse.get());
+            }
+            Optional<String> subject =
+                    codeStorageService.getSubjectWithPasswordResetCode(request.getCode());
+            if (subject.isEmpty()) {
+                LOGGER.error("Subject is not found in Redis");
+                return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1021);
+            }
+            UserCredentials userCredentials =
+                    authenticationService.getUserCredentialsFromSubject(subject.get());
+            if (userCredentials.getPassword() != null) {
+                if (verifyPassword(userCredentials.getPassword(), request.getPassword())) {
+                    LOGGER.info("New password is the same as the old password");
+                    return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1024);
+                }
+            } else {
+                LOGGER.info("Resetting password for migrated user");
+            }
+            codeStorageService.deleteSubjectWithPasswordResetCode(request.getCode());
+            authenticationService.updatePassword(userCredentials.getEmail(), request.getPassword());
 
-                                int incorrectPasswordCount =
-                                        codeStorageService.getIncorrectPasswordCount(
-                                                userCredentials.getEmail());
-                                if (incorrectPasswordCount != 0) {
-                                    codeStorageService.deleteIncorrectPasswordCount(
-                                            userCredentials.getEmail());
-                                }
+            int incorrectPasswordCount =
+                    codeStorageService.getIncorrectPasswordCount(userCredentials.getEmail());
+            if (incorrectPasswordCount != 0) {
+                codeStorageService.deleteIncorrectPasswordCount(userCredentials.getEmail());
+            }
 
-                                NotifyRequest notifyRequest =
-                                        new NotifyRequest(
-                                                userCredentials.getEmail(),
-                                                NotificationType.PASSWORD_RESET_CONFIRMATION);
-                                LOGGER.info("Placing message on queue");
-                                sqsClient.send(serialiseRequest(notifyRequest));
-                            } catch (JsonProcessingException | ConstraintViolationException e) {
-                                LOGGER.error("Incorrect parameters in ResetPassword request");
-                                return generateApiGatewayProxyErrorResponse(
-                                        400, ErrorResponse.ERROR_1001);
-                            }
-                            LOGGER.info("Generating successful response");
-                            return generateEmptySuccessApiGatewayResponse();
-                        });
+            NotifyRequest notifyRequest =
+                    new NotifyRequest(
+                            userCredentials.getEmail(),
+                            NotificationType.PASSWORD_RESET_CONFIRMATION);
+            LOGGER.info("Placing message on queue");
+            sqsClient.send(serialiseRequest(notifyRequest));
+        } catch (JsonProcessingException | ConstraintViolationException e) {
+            LOGGER.error("Incorrect parameters in ResetPassword request");
+            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
+        }
+        LOGGER.info("Generating successful response");
+        return generateEmptySuccessApiGatewayResponse();
     }
 
     private String serialiseRequest(Object request) throws JsonProcessingException {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandlerTest.java
@@ -11,16 +11,24 @@ import uk.gov.di.authentication.frontendapi.services.AwsSqsClient;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.NotifyRequest;
+import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.helpers.Argon2EncoderHelper;
+import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
+import uk.gov.di.authentication.shared.services.ClientService;
+import uk.gov.di.authentication.shared.services.ClientSessionService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.services.ValidationService;
 
+import java.util.Map;
 import java.util.Optional;
 
 import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -35,18 +43,30 @@ class ResetPasswordHandlerTest {
     private final AwsSqsClient sqsClient = mock(AwsSqsClient.class);
     private final CodeStorageService codeStorageService = mock(CodeStorageService.class);
     private final ValidationService validationService = mock(ValidationService.class);
+    private final SessionService sessionService = mock(SessionService.class);
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private final ClientService clientService = mock(ClientService.class);
+    private final ClientSessionService clientSessionService = mock(ClientSessionService.class);
     private final Context context = mock(Context.class);
     private static final String CODE = "12345678901";
     private static final String NEW_PASSWORD = "Pa55word!";
     private static final String SUBJECT = "some-subject";
     private static final String EMAIL = "joe.bloggs@digital.cabinet-office.gov.uk";
     private ResetPasswordHandler handler;
+    private final Session session = new Session(IdGenerator.generate()).setEmailAddress(EMAIL);
 
     @BeforeEach
     public void setUp() {
         handler =
                 new ResetPasswordHandler(
-                        authenticationService, sqsClient, codeStorageService, validationService);
+                        authenticationService,
+                        sqsClient,
+                        codeStorageService,
+                        validationService,
+                        configurationService,
+                        sessionService,
+                        clientSessionService,
+                        clientService);
     }
 
     @Test
@@ -55,9 +75,11 @@ class ResetPasswordHandlerTest {
                 .thenReturn(Optional.of(SUBJECT));
         when(authenticationService.getUserCredentialsFromSubject(SUBJECT))
                 .thenReturn(generateUserCredentials());
+        usingValidSession();
         NotifyRequest notifyRequest =
                 new NotifyRequest(EMAIL, NotificationType.PASSWORD_RESET_CONFIRMATION);
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        event.setHeaders(Map.of("Session-Id", session.getSessionId()));
         event.setBody(format("{ \"code\": \"%s\", \"password\": \"%s\"}", CODE, NEW_PASSWORD));
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
@@ -73,10 +95,12 @@ class ResetPasswordHandlerTest {
                 .thenReturn(Optional.of(SUBJECT));
         when(authenticationService.getUserCredentialsFromSubject(SUBJECT))
                 .thenReturn(generateMigratedUserCredentials());
+        usingValidSession();
         NotifyRequest notifyRequest =
                 new NotifyRequest(EMAIL, NotificationType.PASSWORD_RESET_CONFIRMATION);
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setBody(format("{ \"code\": \"%s\", \"password\": \"%s\"}", CODE, NEW_PASSWORD));
+        event.setHeaders(Map.of("Session-Id", session.getSessionId()));
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(204));
@@ -87,8 +111,10 @@ class ResetPasswordHandlerTest {
 
     @Test
     public void shouldReturn400ForRequestIsMissingParameters() {
+        usingValidSession();
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setBody(format("{ \"code\": \"%s\"}", CODE));
+        event.setHeaders(Map.of("Session-Id", session.getSessionId()));
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(400));
@@ -97,11 +123,13 @@ class ResetPasswordHandlerTest {
 
     @Test
     public void shouldReturn400IfPasswordFailsValidation() {
+        usingValidSession();
         String invalidPassword = "password";
         when(validationService.validatePassword(invalidPassword))
                 .thenReturn(Optional.of(ErrorResponse.ERROR_1007));
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setBody(format("{ \"code\": \"%s\", \"password\": \"%s\"}", CODE, "password"));
+        event.setHeaders(Map.of("Session-Id", session.getSessionId()));
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(400));
@@ -112,6 +140,7 @@ class ResetPasswordHandlerTest {
     @Test
     public void shouldReturn400IfNewPasswordEqualsExistingPassword()
             throws JsonProcessingException {
+        usingValidSession();
         when(codeStorageService.getSubjectWithPasswordResetCode(CODE))
                 .thenReturn(Optional.of(SUBJECT));
         when(authenticationService.getUserCredentialsFromSubject(SUBJECT))
@@ -120,6 +149,7 @@ class ResetPasswordHandlerTest {
                 new NotifyRequest(EMAIL, NotificationType.PASSWORD_RESET_CONFIRMATION);
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setBody(format("{ \"code\": \"%s\", \"password\": \"%s\"}", CODE, NEW_PASSWORD));
+        event.setHeaders(Map.of("Session-Id", session.getSessionId()));
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(400));
@@ -131,10 +161,12 @@ class ResetPasswordHandlerTest {
 
     @Test
     public void shouldReturn400WhenCodeIsInvalid() {
+        usingValidSession();
         when(codeStorageService.getSubjectWithPasswordResetCode(CODE)).thenReturn(Optional.empty());
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setBody(format("{ \"code\": \"%s\", \"password\": \"%s\"}", CODE, NEW_PASSWORD));
+        event.setHeaders(Map.of("Session-Id", session.getSessionId()));
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(400));
@@ -144,20 +176,37 @@ class ResetPasswordHandlerTest {
 
     @Test
     public void shouldDeleteIncorrectPasswordCountOnSuccessfulRequest() {
+        usingValidSession();
         when(codeStorageService.getSubjectWithPasswordResetCode(CODE))
                 .thenReturn(Optional.of(SUBJECT));
         when(codeStorageService.getIncorrectPasswordCount(EMAIL)).thenReturn(2);
         when(authenticationService.getUserCredentialsFromSubject(SUBJECT))
                 .thenReturn(generateUserCredentials());
-        NotifyRequest notifyRequest =
-                new NotifyRequest(EMAIL, NotificationType.PASSWORD_RESET_CONFIRMATION);
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setBody(format("{ \"code\": \"%s\", \"password\": \"%s\"}", CODE, NEW_PASSWORD));
+        event.setHeaders(Map.of("Session-Id", session.getSessionId()));
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(204));
         verify(codeStorageService, times(1)).deleteSubjectWithPasswordResetCode(CODE);
         verify(codeStorageService, times(1)).deleteIncorrectPasswordCount(EMAIL);
+    }
+
+    @Test
+    public void shouldReturn400WhenUserHasInvalidSession() {
+        when(codeStorageService.getSubjectWithPasswordResetCode(CODE))
+                .thenReturn(Optional.of(SUBJECT));
+        when(authenticationService.getUserCredentialsFromSubject(SUBJECT))
+                .thenReturn(generateUserCredentials());
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        event.setHeaders(Map.of("Session-Id", session.getSessionId()));
+        event.setBody(format("{ \"code\": \"%s\", \"password\": \"%s\"}", CODE, NEW_PASSWORD));
+        APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
+
+        assertThat(result, hasStatus(400));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1000));
+        verify(authenticationService, never()).updatePassword(EMAIL, NEW_PASSWORD);
+        verify(codeStorageService, never()).deleteSubjectWithPasswordResetCode(CODE);
     }
 
     private UserCredentials generateUserCredentials() {
@@ -173,5 +222,10 @@ class ResetPasswordHandlerTest {
                 .setEmail(EMAIL)
                 .setMigratedPassword("old-password1")
                 .setSubjectID(SUBJECT);
+    }
+
+    private void usingValidSession() {
+        when(sessionService.getSessionFromRequestHeaders(anyMap()))
+                .thenReturn(Optional.of(session));
     }
 }


### PR DESCRIPTION
## What?

- Expect a valid session-id to be included in the request made to the ResetPasswordHandler. Make use of the BasefrontendHandler to handle this for us. 

## Why?

- Previously we had no way to determine the session of a user when a reset password request is made. A session id will now be added to the request made to the ResetPasswordHandler and therefore we can slightly refactor this to make use of the BaseFrontendHandler to prevent us duplicating code and make it consistent with other frontend lambdas.
- The session-id will be allow us to tie a string of requests together and ensure that the request is made by a user with a valid session.

## Related PRs

- Dependent on https://github.com/alphagov/di-authentication-frontend/pull/414 being deployed first