### PR TITLE
GOVSI-1141: log session id in account management handlers

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
@@ -17,6 +17,7 @@ import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
+import uk.gov.di.authentication.shared.helpers.RequestHeaderHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.CodeGeneratorService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -26,11 +27,13 @@ import uk.gov.di.authentication.shared.services.ValidationService;
 
 import java.util.Optional;
 
+import static uk.gov.di.authentication.shared.domain.RequestHeaders.SESSION_ID_HEADER;
 import static uk.gov.di.authentication.shared.entity.ErrorResponse.ERROR_1001;
 import static uk.gov.di.authentication.shared.entity.ErrorResponse.ERROR_1002;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateEmptySuccessApiGatewayResponse;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachSessionIdToLogs;
 import static uk.gov.di.authentication.shared.helpers.WarmerHelper.isWarming;
 import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
 
@@ -86,6 +89,10 @@ public class SendOtpNotificationHandler
         return isWarming(input)
                 .orElseGet(
                         () -> {
+                            String sessionId =
+                                    RequestHeaderHelper.getHeaderValueOrElse(
+                                            input.getHeaders(), SESSION_ID_HEADER, "");
+                            attachSessionIdToLogs(sessionId);
                             LOGGER.info("Request received in SendOtp Lambda");
                             try {
                                 SendNotificationRequest sendNotificationRequest =

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/LogLineHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/LogLineHelper.java
@@ -8,4 +8,8 @@ public class LogLineHelper {
     public static void attachSessionIdToLogs(Session session) {
         ThreadContext.put("sessionId", session.getSessionId());
     }
+
+    public static void attachSessionIdToLogs(String sessionId) {
+        ThreadContext.put("sessionId", sessionId);
+    }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/RequestHeaderHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/RequestHeaderHelper.java
@@ -53,4 +53,10 @@ public final class RequestHeaderHelper {
             return null;
         }
     }
+
+    public static String getHeaderValueOrElse(
+            Map<String, String> headers, String headerName, String orElse) {
+        String headerValue = getHeaderValueFromHeaders(headers, headerName, false);
+        return headerValue != null ? headerValue : orElse;
+    }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/RequestHeaderHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/RequestHeaderHelperTest.java
@@ -1,5 +1,6 @@
 package uk.gov.di.authentication.shared.helpers;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -11,6 +12,7 @@ import java.util.stream.Stream;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static uk.gov.di.authentication.shared.helpers.RequestHeaderHelper.getHeaderValueFromHeaders;
+import static uk.gov.di.authentication.shared.helpers.RequestHeaderHelper.getHeaderValueOrElse;
 import static uk.gov.di.authentication.shared.helpers.RequestHeaderHelper.headersContainValidHeader;
 
 class RequestHeaderHelperTest {
@@ -78,12 +80,30 @@ class RequestHeaderHelperTest {
 
     @ParameterizedTest
     @MethodSource("headersTestParameters")
-    void doIt(
+    void testGetHeaderValueFromHeaders(
             Map<String, String> headers,
             String headerName,
             boolean matchLowerCase,
             boolean expectedValidity,
             String expectedValue) {
         assertEquals(expectedValue, getHeaderValueFromHeaders(headers, headerName, matchLowerCase));
+    }
+
+    @Test
+    void testGetHeaderValueOrElse() {
+        assertEquals("headers null", getHeaderValueOrElse(null, "Session-Id", "headers null"));
+        assertEquals(
+                "headers missing",
+                getHeaderValueOrElse(Collections.emptyMap(), "Session-Id", "headers missing"));
+        assertEquals(
+                "session-id-123",
+                getHeaderValueOrElse(MAP_TWO_ENTRIES_UPPER_CASE, "Session-Id", ""));
+        assertEquals(
+                "missing",
+                getHeaderValueOrElse(MAP_TWO_ENTRIES_UPPER_CASE, "Missing-Header", "missing"));
+        assertEquals(
+                "lower case missing",
+                getHeaderValueOrElse(
+                        MAP_TWO_ENTRIES_UPPER_CASE, "session-id", "lower case missing"));
     }
 }


### PR DESCRIPTION
## What?

Log session id in account management handlers.
The session id is passed as a header to each api call from the account management frontend.
Include in audit events.

## Why?

Ability to view a single session across both frontend and account management in the logs and audit trail.

## Related PRs

https://github.com/alphagov/di-authentication-account-management/pull/249