### PR TITLE
Revert "Bump dependencyVersions.aws_sdk_version from 1.12.101 to 1.12.120"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ apply plugin: "idea"
 ext {
     dependencyVersions = [
         jackson_version: "2.13.0",
-        aws_sdk_version: "1.12.120",
+        aws_sdk_version: "1.12.101",
         aws_lambda_core_version: "1.2.1",
         aws_lambda_events_version: "3.11.0",
         nimbusds_oauth_version: "9.20",


### PR DESCRIPTION
Reverts alphagov/di-authentication-api#1126

This change seems to have caused a couple of acceptance tests to fail (see https://cd.gds-reliability.engineering/teams/verify/pipelines/di-authentication-deployment/jobs/acceptance-tests/builds/793).

The failing tests are:

1
When the existing account management user uses their updated password
And the existing account management user enters their updated password
Then the existing account management user is taken to password updated confirmation page            # uk.gov.di.test.acceptance.AccountManagementStepDefinitions.theExistingAccountManagementUserIsTakenToThePasswordUpdatedConfirmation()

2
When the existing account management user uses their updated password
And the existing account management user enters their updated password to delete account
Then the existing account management user is taken to the delete account page                      # uk.gov.di.test.acceptance.AccountManagementStepDefinitions.theExistingAccountManagementUserIsTakenToTheDeleteAccountPage()