### PR TITLE
GOVSI-1106: log updated session-id in authorisation handler

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -47,6 +47,7 @@ import static uk.gov.di.authentication.shared.entity.SessionAction.USER_HAS_STAR
 import static uk.gov.di.authentication.shared.entity.SessionAction.USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED;
 import static uk.gov.di.authentication.shared.entity.SessionState.INTERRUPT_STATES;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachSessionIdToLogs;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.updateAttachedSessionIdToLogs;
 import static uk.gov.di.authentication.shared.helpers.WarmerHelper.isWarming;
 import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
 import static uk.gov.di.authentication.shared.state.StateMachine.userJourneyStateMachine;
@@ -270,6 +271,7 @@ public class AuthorisationHandler
         String oldSessionId = session.getSessionId();
         sessionService.updateSessionId(session);
         session.addClientSession(clientSessionID);
+        updateAttachedSessionIdToLogs(session.getSessionId());
         LOGGER.info(
                 "Updated session id from {} to {} for client {} - client session id = {} - new",
                 oldSessionId,
@@ -295,6 +297,7 @@ public class AuthorisationHandler
                                 authorizationService.getEffectiveVectorOfTrust(
                                         authenticationRequest)));
         session.addClientSession(clientSessionID);
+        updateAttachedSessionIdToLogs(session.getSessionId());
         LOGGER.info(
                 "Created session {} for client {} - client session id = {}",
                 session.getSessionId(),

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/LogLineHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/LogLineHelper.java
@@ -12,4 +12,11 @@ public class LogLineHelper {
     public static void attachSessionIdToLogs(String sessionId) {
         ThreadContext.put("sessionId", sessionId);
     }
+
+    public static void updateAttachedSessionIdToLogs(String sessionId) {
+        if (ThreadContext.containsKey("sessionId")) {
+            ThreadContext.remove("sessionId");
+        }
+        attachSessionIdToLogs(sessionId);
+    }
 }


### PR DESCRIPTION
## What?

Log updated session-id in authorisation handler.

The authorisation is where the session-id actually gets created so the session-id can change within the lambda itself.  Change session-id logging so that the session-id logged by the logging context is the session-id most recently allocated.

## Why?

Old session-id were being logged when new ones had been created, so there was a difference between what was in the log messages and what was in the session-id field.
