### PR TITLE
BAU: Stop Sonar scanning for dependabot PRs

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -75,6 +75,7 @@ jobs:
           path: account-management-integration-tests/build/reports/tests/test/
           retention-days: 5
       - name: Run SonarCloud Analysis
+        if: ${{ github.actor != 'dependabot[bot]' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## What?

- Conditionally execute the the Sonar scan if the PR is not raised by Dependabot. 

## Why?

Dependabot PRs do not access to repository secrets so will fail the Sonar scan.
