### PR TITLE
GOVSI-1106: add slf4j no op jar to suppress slf4j logging in lambdas

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,8 @@ subprojects {
         lettuce "org.apache.commons:commons-pool2:2.11.1",
                 "io.lettuce:lettuce-core:6.1.5.RELEASE"
 
-        logging_runtime "com.amazonaws:aws-lambda-java-log4j2:1.2.0"
+        logging_runtime "com.amazonaws:aws-lambda-java-log4j2:1.2.0",
+                "org.slf4j:slf4j-nop:1.7.32"
 
         jackson "com.fasterxml.jackson.core:jackson-core:${dependencyVersions.jackson_version}",
                 "com.fasterxml.jackson.core:jackson-databind:${dependencyVersions.jackson_version}",


### PR DESCRIPTION
## What?

Add slf4j no op jar to suppress slf4j logging in lambdas.

See: http://www.slf4j.org/codes.html#StaticLoggerBinder

## Why?

We are getting approx 40K per day SLF4J log messages even though we are not using SLF4J.  The link above shows how to silence these messages.
