### PR TITLE
GOVSI-1161 - Handle vector values for Identity

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -105,6 +105,27 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     }
 
     @Test
+    void shouldRedirectToLoginWhenNoCookieAndIdentityVectorsAreIncludedInRequest() {
+        var response =
+                makeRequest(
+                        Optional.empty(),
+                        constructHeaders(Optional.empty()),
+                        constructQueryStringParameters(
+                                Optional.of(CLIENT_ID),
+                                Optional.empty(),
+                                "openid",
+                                Optional.of("Pl.Cl.Cm")));
+        assertThat(response, hasStatus(302));
+        assertThat(
+                getHeaderValueByParamName(response, ResponseHeaders.LOCATION),
+                startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
+        assertThat(
+                getHttpCookieFromMultiValueResponseHeaders(response.getMultiValueHeaders(), "gs")
+                        .isPresent(),
+                equalTo(true));
+    }
+
+    @Test
     void shouldRedirectToLoginWithSamePersistentCookieValueInRequest() {
         var response =
                 makeRequest(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/LevelOfConfidence.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/LevelOfConfidence.java
@@ -1,0 +1,29 @@
+package uk.gov.di.authentication.shared.entity;
+
+import java.util.Arrays;
+
+public enum LevelOfConfidence {
+    LOW_LEVEL("Pl"),
+    MEDIUM_LEVEL("Pm"),
+    HIGH_LEVEL("Ph"),
+    VERY_HIGH_LEVEL("Pv");
+
+    private String value;
+
+    LevelOfConfidence(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static LevelOfConfidence retrieveLevelOfConfidence(String vrtSet) {
+
+        return Arrays.stream(values())
+                .filter(tl -> vrtSet.equals(tl.getValue()))
+                .findFirst()
+                .orElseThrow(
+                        () -> new IllegalArgumentException("Invalid LevelOfConfidence provided"));
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/VectorOfTrust.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/VectorOfTrust.java
@@ -8,11 +8,14 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
+import static java.lang.String.format;
 import static net.minidev.json.parser.JSONParser.DEFAULT_PERMISSIVE_MODE;
-import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.retrieveCredentialTrustLevel;
 
 public class VectorOfTrust {
 
@@ -21,18 +24,31 @@ public class VectorOfTrust {
     @JsonProperty("credential_trust_level")
     private final CredentialTrustLevel credentialTrustLevel;
 
+    @JsonProperty("level_of_confidence")
+    private final LevelOfConfidence levelOfConfidence;
+
+    private VectorOfTrust(CredentialTrustLevel credentialTrustLevel) {
+        this(credentialTrustLevel, null);
+    }
+
     @JsonCreator
     private VectorOfTrust(
             @JsonProperty(required = true, value = "credential_trust_level")
-                    CredentialTrustLevel credentialTrustLevel) {
+                    CredentialTrustLevel credentialTrustLevel,
+            @JsonProperty(value = "level_of_confidence") LevelOfConfidence levelOfConfidence) {
         this.credentialTrustLevel = credentialTrustLevel;
+        this.levelOfConfidence = levelOfConfidence;
     }
 
     public CredentialTrustLevel getCredentialTrustLevel() {
         return credentialTrustLevel;
     }
 
-    public static final VectorOfTrust parseFromAuthRequestAttribute(List<String> vtr) {
+    public LevelOfConfidence getLevelOfConfidence() {
+        return levelOfConfidence;
+    }
+
+    public static VectorOfTrust parseFromAuthRequestAttribute(List<String> vtr) {
         if (Objects.isNull(vtr) || vtr.isEmpty()) {
             LOGGER.info(
                     "VTR attribute is not present so defaulting to {}",
@@ -51,14 +67,76 @@ public class VectorOfTrust {
         for (int i = 0; i < vtrJsonArray.size(); i++) {
             vtrSets.add((String) vtrJsonArray.get(i));
         }
-        CredentialTrustLevel credentialTrustLevel = retrieveCredentialTrustLevel(vtrSets);
-        LOGGER.info(
-                "VTR has been processed at credentialTrustLevel {}",
-                credentialTrustLevel.getValue());
-        return new VectorOfTrust(credentialTrustLevel);
+        VectorOfTrust vectorOfTrust = parseVtrSet(vtrSets);
+        LOGGER.info("VTR has been processed at vectorOfTrust: {}", vectorOfTrust.toString());
+
+        return vectorOfTrust;
     }
 
     public static VectorOfTrust getDefaults() {
         return new VectorOfTrust(CredentialTrustLevel.getDefault());
+    }
+
+    private static VectorOfTrust parseVtrSet(List<String> vtrSet) {
+        List<VectorOfTrust> vectorOfTrusts = new ArrayList<>();
+        for (String vtr : vtrSet) {
+            LevelOfConfidence loc = null;
+            CredentialTrustLevel ctl;
+            String[] splitVtr = vtr.split("\\.");
+
+            List<String> levelOfConfidence =
+                    Arrays.stream(splitVtr)
+                            .filter((a) -> a.startsWith("P"))
+                            .collect(Collectors.toList());
+            if (splitVtr.length > 3 || (splitVtr.length == 3 && levelOfConfidence.isEmpty())) {
+                throw new IllegalArgumentException(
+                        format("Invalid number of attributes in VTR, %s", vtr));
+            }
+            if (!levelOfConfidence.isEmpty()) {
+                if (levelOfConfidence.size() > 1 || !vtr.startsWith("P")) {
+                    throw new IllegalArgumentException(
+                            format("Invalid Identity vector value exists in VTS: %s", vtr));
+                }
+                loc = LevelOfConfidence.retrieveLevelOfConfidence(levelOfConfidence.get(0));
+                ctl =
+                        CredentialTrustLevel.retrieveCredentialTrustLevel(
+                                List.of(vtr.substring(vtr.indexOf(".") + 1)));
+            } else {
+                ctl = CredentialTrustLevel.retrieveCredentialTrustLevel(List.of(vtr));
+            }
+            vectorOfTrusts.add(new VectorOfTrust(ctl, loc));
+        }
+
+        return vectorOfTrusts.stream()
+                .filter(vot -> vot.getLevelOfConfidence() != null)
+                .min(
+                        Comparator.comparing(
+                                        VectorOfTrust::getLevelOfConfidence,
+                                        Comparator.nullsFirst(Comparator.naturalOrder()))
+                                .thenComparing(
+                                        VectorOfTrust::getCredentialTrustLevel,
+                                        Comparator.nullsFirst(Comparator.naturalOrder())))
+                .orElseGet(
+                        () ->
+                                vectorOfTrusts.stream()
+                                        .min(
+                                                Comparator.comparing(
+                                                        VectorOfTrust::getCredentialTrustLevel,
+                                                        Comparator.nullsFirst(
+                                                                Comparator.naturalOrder())))
+                                        .orElseThrow(
+                                                () ->
+                                                        new IllegalArgumentException(
+                                                                "Invalid VTR attribute")));
+    }
+
+    @Override
+    public String toString() {
+        return "VectorOfTrust{"
+                + "credentialTrustLevel="
+                + credentialTrustLevel
+                + ", levelOfConfidence="
+                + levelOfConfidence
+                + '}';
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthorizationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthorizationService.java
@@ -142,7 +142,10 @@ public class AuthorizationService {
             VectorOfTrust vectorOfTrust =
                     VectorOfTrust.parseFromAuthRequestAttribute(authRequestVtr);
         } catch (IllegalArgumentException e) {
-            LOGGER.warn("vtr in AuthRequest is not valid. vtr in request: {}", authRequestVtr);
+            LOGGER.warn(
+                    "vtr in AuthRequest is not valid. vtr in request: {}. IllegalArgumentException: {}",
+                    authRequestVtr,
+                    e);
             return Optional.of(
                     new ErrorObject(OAuth2Error.INVALID_REQUEST_CODE, "Request vtr not valid"));
         }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/CredentialTrustLevelTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/CredentialTrustLevelTest.java
@@ -1,8 +1,12 @@
 package uk.gov.di.authentication.shared.entity;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -17,25 +21,19 @@ class CredentialTrustLevelTest {
         assertThat(LOW_LEVEL, lessThan(MEDIUM_LEVEL));
     }
 
-    @Test
-    void valuesShouldBeParsable() {
+    @ParameterizedTest
+    @MethodSource("validCredentialTrustLevelValues")
+    void valuesShouldBeParsable(List<String> vtrSet, CredentialTrustLevel expectedValue) {
         assertThat(
-                CredentialTrustLevel.retrieveCredentialTrustLevel(List.of("Cl")),
-                equalTo(LOW_LEVEL));
-        assertThat(
-                CredentialTrustLevel.retrieveCredentialTrustLevel(List.of("Cl.Cm")),
-                equalTo(MEDIUM_LEVEL));
-        assertThat(
-                CredentialTrustLevel.retrieveCredentialTrustLevel(List.of("Cl", "Cl.Cm")),
-                equalTo(LOW_LEVEL));
-        assertThat(
-                CredentialTrustLevel.retrieveCredentialTrustLevel(List.of("Cl.Cm", "Cl")),
-                equalTo(LOW_LEVEL));
-        assertThat(
-                CredentialTrustLevel.retrieveCredentialTrustLevel(List.of("Cm.Cl")),
-                equalTo(MEDIUM_LEVEL));
-        assertThat(
-                CredentialTrustLevel.retrieveCredentialTrustLevel(List.of("Cm.Cl", "Cl")),
-                equalTo(LOW_LEVEL));
+                CredentialTrustLevel.retrieveCredentialTrustLevel(vtrSet), equalTo(expectedValue));
+    }
+
+    private static Stream<Arguments> validCredentialTrustLevelValues() {
+        return Stream.of(
+                Arguments.of(List.of("Cl"), LOW_LEVEL),
+                Arguments.of(List.of("Cl.Cm"), MEDIUM_LEVEL),
+                Arguments.of(List.of("Cl", "Cl.Cm"), LOW_LEVEL),
+                Arguments.of(List.of("Cl.Cm", "Cl"), LOW_LEVEL),
+                Arguments.of(List.of("Cm.Cl"), MEDIUM_LEVEL));
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/LevelOfConfidenceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/LevelOfConfidenceTest.java
@@ -1,0 +1,52 @@
+package uk.gov.di.authentication.shared.entity;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static uk.gov.di.authentication.shared.entity.LevelOfConfidence.HIGH_LEVEL;
+import static uk.gov.di.authentication.shared.entity.LevelOfConfidence.LOW_LEVEL;
+import static uk.gov.di.authentication.shared.entity.LevelOfConfidence.MEDIUM_LEVEL;
+import static uk.gov.di.authentication.shared.entity.LevelOfConfidence.VERY_HIGH_LEVEL;
+
+class LevelOfConfidenceTest {
+
+    @ParameterizedTest
+    @MethodSource("validLevelOfConfidence")
+    void shouldReturnLevelOfConfidenceForValidValue(
+            String vtrSet, LevelOfConfidence expectedLevel) {
+        assertThat(LevelOfConfidence.retrieveLevelOfConfidence(vtrSet), equalTo(expectedLevel));
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidLevelOfConfidence")
+    void shouldThrowWhenInvalidValueIsPassed(String vtrSet, String message) {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> LevelOfConfidence.retrieveLevelOfConfidence(vtrSet),
+                message);
+    }
+
+    private static Stream<Arguments> validLevelOfConfidence() {
+        return Stream.of(
+                Arguments.of("Pl", LOW_LEVEL),
+                Arguments.of("Pm", MEDIUM_LEVEL),
+                Arguments.of("Ph", HIGH_LEVEL),
+                Arguments.of("Pv", VERY_HIGH_LEVEL));
+    }
+
+    private static Stream<Arguments> invalidLevelOfConfidence() {
+        return Stream.of(
+                Arguments.of("Cl.Pl", "Should throw when LevelOfConfidence is not first in String"),
+                Arguments.of(
+                        "Cl.Cm", "Should throw when no LevelOfConfidence is included in String"),
+                Arguments.of(
+                        "Pm.Ph.Cl",
+                        "Should throw when multiple LevelOfConfidence is included in single String"));
+    }
+}

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/VectorOfTrustTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/VectorOfTrustTest.java
@@ -14,7 +14,7 @@ import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.MEDIUM
 
 class VectorOfTrustTest {
     @Test
-    public void shouldParseValidStringWithSingleVector() {
+    void shouldParseValidStringWithSingleVector() {
         JSONArray jsonArray = new JSONArray();
         jsonArray.add("Cl.Cm");
         VectorOfTrust vectorOfTrust =
@@ -24,7 +24,7 @@ class VectorOfTrustTest {
     }
 
     @Test
-    public void shouldReturnDefaultVectorWhenEmptyListIsPassedIn() {
+    void shouldReturnDefaultVectorWhenEmptyListIsPassedIn() {
         VectorOfTrust vectorOfTrust =
                 VectorOfTrust.parseFromAuthRequestAttribute(new ArrayList<>());
         assertThat(
@@ -33,7 +33,7 @@ class VectorOfTrustTest {
     }
 
     @Test
-    public void shouldReturnLowestVectorWhenMultipleSetsAreIsPassedIn() {
+    void shouldReturnLowestVectorWhenMultipleSetsAreIsPassedIn() {
         JSONArray jsonArray = new JSONArray();
         jsonArray.add("Cl.Cm");
         jsonArray.add("Cl");
@@ -44,7 +44,7 @@ class VectorOfTrustTest {
     }
 
     @Test
-    public void shouldParseValidStringWithMultipleVectors() {
+    void shouldParseValidStringWithMultipleVectors() {
         JSONArray jsonArray = new JSONArray();
         jsonArray.add("Cl");
         VectorOfTrust vectorOfTrust =
@@ -54,7 +54,89 @@ class VectorOfTrustTest {
     }
 
     @Test
-    public void shouldParseValidStringAndReThrowIfInvalidValueIsPresent() {
+    void shouldParseValidStringWithMultipleIdentityVectors() {
+        JSONArray jsonArray = new JSONArray();
+        jsonArray.add("Pm.Cl.Cm");
+        jsonArray.add("Ph.Cl.Cm");
+        jsonArray.add("Cl.Cm");
+        VectorOfTrust vectorOfTrust =
+                VectorOfTrust.parseFromAuthRequestAttribute(
+                        Collections.singletonList(jsonArray.toJSONString()));
+        assertThat(vectorOfTrust.getCredentialTrustLevel(), equalTo(MEDIUM_LEVEL));
+        assertThat(vectorOfTrust.getLevelOfConfidence(), equalTo(LevelOfConfidence.MEDIUM_LEVEL));
+    }
+
+    @Test
+    void shouldParseValidStringWithSingleIdentityVector() {
+        JSONArray jsonArray = new JSONArray();
+        jsonArray.add("Ph.Cl.Cm");
+        VectorOfTrust vectorOfTrust =
+                VectorOfTrust.parseFromAuthRequestAttribute(
+                        Collections.singletonList(jsonArray.toJSONString()));
+        assertThat(vectorOfTrust.getCredentialTrustLevel(), equalTo(MEDIUM_LEVEL));
+        assertThat(vectorOfTrust.getLevelOfConfidence(), equalTo(LevelOfConfidence.HIGH_LEVEL));
+    }
+
+    @Test
+    void shouldParseToLowCredentialTrustLevelAndMediumLevelOfConfidence() {
+        JSONArray jsonArray = new JSONArray();
+        jsonArray.add("Pm.Cl.Cm");
+        jsonArray.add("Pm.Cl");
+        VectorOfTrust vectorOfTrust =
+                VectorOfTrust.parseFromAuthRequestAttribute(
+                        Collections.singletonList(jsonArray.toJSONString()));
+        assertThat(vectorOfTrust.getCredentialTrustLevel(), equalTo(LOW_LEVEL));
+        assertThat(vectorOfTrust.getLevelOfConfidence(), equalTo(LevelOfConfidence.MEDIUM_LEVEL));
+    }
+
+    @Test
+    void
+            shouldParseToLowCredentialTrustLevelAndMediumLevelOfConfidenceWhenMultipleIdentityLevelsExist() {
+        JSONArray jsonArray = new JSONArray();
+        jsonArray.add("Pm.Cl.Cm");
+        jsonArray.add("Ph.Cl");
+        VectorOfTrust vectorOfTrust =
+                VectorOfTrust.parseFromAuthRequestAttribute(
+                        Collections.singletonList(jsonArray.toJSONString()));
+        assertThat(vectorOfTrust.getCredentialTrustLevel(), equalTo(MEDIUM_LEVEL));
+        assertThat(vectorOfTrust.getLevelOfConfidence(), equalTo(LevelOfConfidence.MEDIUM_LEVEL));
+    }
+
+    @Test
+    void shouldThrowWhenIdentityValueIsNotFirstValueInVector() {
+        JSONArray jsonArray = new JSONArray();
+        jsonArray.add("Cl.Cm.Pm");
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        VectorOfTrust.parseFromAuthRequestAttribute(
+                                Collections.singletonList(jsonArray.toJSONString())));
+    }
+
+    @Test
+    void shouldThrowWhenOnlyIdentityLevelIsSentInRequest() {
+        JSONArray jsonArray = new JSONArray();
+        jsonArray.add("Pm");
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        VectorOfTrust.parseFromAuthRequestAttribute(
+                                Collections.singletonList(jsonArray.toJSONString())));
+    }
+
+    @Test
+    void shouldParseVectorWhenCredentialTrustLevelsAreOrderedDifferently() {
+        JSONArray jsonArray = new JSONArray();
+        jsonArray.add("Pm.Cm.Cl");
+        VectorOfTrust vectorOfTrust =
+                VectorOfTrust.parseFromAuthRequestAttribute(
+                        Collections.singletonList(jsonArray.toJSONString()));
+        assertThat(vectorOfTrust.getCredentialTrustLevel(), equalTo(MEDIUM_LEVEL));
+        assertThat(vectorOfTrust.getLevelOfConfidence(), equalTo(LevelOfConfidence.MEDIUM_LEVEL));
+    }
+
+    @Test
+    void shouldParseValidStringAndReThrowIfInvalidValueIsPresent() {
         JSONArray jsonArray = new JSONArray();
         jsonArray.add("Pl.Pb");
         assertThrows(
@@ -65,7 +147,7 @@ class VectorOfTrustTest {
     }
 
     @Test
-    public void shouldThrowIfOnlyCmIsPresent() {
+    void shouldThrowIfOnlyCmIsPresent() {
         JSONArray jsonArray = new JSONArray();
         jsonArray.add("Cm");
         assertThrows(
@@ -76,7 +158,7 @@ class VectorOfTrustTest {
     }
 
     @Test
-    public void shouldThrowIfEmptyListIsPresent() {
+    void shouldThrowIfEmptyListIsPresent() {
         assertThrows(
                 IllegalArgumentException.class,
                 () -> VectorOfTrust.parseFromAuthRequestAttribute(Collections.singletonList("")));

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/VectorOfTrustTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/VectorOfTrustTest.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.LOW_LEVEL;
 import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.MEDIUM_LEVEL;
@@ -21,6 +22,7 @@ class VectorOfTrustTest {
                 VectorOfTrust.parseFromAuthRequestAttribute(
                         Collections.singletonList(jsonArray.toJSONString()));
         assertThat(vectorOfTrust.getCredentialTrustLevel(), equalTo(MEDIUM_LEVEL));
+        assertNull(vectorOfTrust.getLevelOfConfidence());
     }
 
     @Test
@@ -30,6 +32,7 @@ class VectorOfTrustTest {
         assertThat(
                 vectorOfTrust.getCredentialTrustLevel(),
                 equalTo(CredentialTrustLevel.getDefault()));
+        assertNull(vectorOfTrust.getLevelOfConfidence());
     }
 
     @Test
@@ -41,6 +44,7 @@ class VectorOfTrustTest {
                 VectorOfTrust.parseFromAuthRequestAttribute(
                         Collections.singletonList(jsonArray.toJSONString()));
         assertThat(vectorOfTrust.getCredentialTrustLevel(), equalTo(LOW_LEVEL));
+        assertNull(vectorOfTrust.getLevelOfConfidence());
     }
 
     @Test
@@ -51,6 +55,7 @@ class VectorOfTrustTest {
                 VectorOfTrust.parseFromAuthRequestAttribute(
                         Collections.singletonList(jsonArray.toJSONString()));
         assertThat(vectorOfTrust.getCredentialTrustLevel(), equalTo(LOW_LEVEL));
+        assertNull(vectorOfTrust.getLevelOfConfidence());
     }
 
     @Test


### PR DESCRIPTION
## What?

- Support additional vector values for Identity. These are - 
 Pl - Low
Pm - Medium 
Ph - High
Pv - Very High

- Although Identity will only support Medium from day one, if multiple vectors are passed in the AuthnRequest and an identity value is present, we find the vector with the lowest identity value. If there are multiple vectors with the same identity value, then we next find the CredentialTrustLevel with the lowest trust level and that vector will then construct our VectorOfTrust which will be stored against the ClientSession.
- Amend the VectorsOfTrust object which will now take in the LevelOfConfidence in it's constructor, alongside the CredentialTrustLevel. The LevelOfConfidence is optional, so if an identity vector is not sent in the request then it will be null in the VectorsOfTrust object.
- Validate that when an identity value exists in a vector then it should be the first value in the vector and be the only identity value in that Vector.

An Example of a request with identity vector values - `['Pm.Cl.Cm', 'Ph.Cl.Cm']` In this example this request will be processed at Medium Level of Identity and Medium Level of Confidence. 

- The VectorsOfTrustTest demonstrates which vectors the applications accepts and what they are processed as. 

## Why?

- To allow authentication to accept Authentication requests where the VTR contains Identity levels. These values are stored in the ClientSession and once a user has been authorized, we will use these values to work out where to send the user to next. 

