### PR TITLE
BAU - Remove sonarcloud from tests

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -74,12 +74,6 @@ jobs:
           name: account-management-integration-test-reports
           path: account-management-integration-tests/build/reports/tests/test/
           retention-days: 5
-      - name: Run SonarCloud Analysis
-        if: ${{ github.actor != 'dependabot[bot]' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew sonarqube
       - name: Upload Docker Container Logs
         uses: actions/upload-artifact@v2
         if: failure()


### PR DESCRIPTION
## What?

 - Remove sonarcloud from tests
- This is the error which we were seeing `You are running CI analysis while Automatic Analysis is enabled. Please consider disabling one or the other.`

## Why?

- It seems to be running multiple times so remove it from the test task in github actions.