### PR TITLE
GOVSI-1106: include jaxb libs to suppress aws java sdk warning message

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,9 @@ subprojects {
                 "com.fasterxml.jackson.core:jackson-annotations:${dependencyVersions.jackson_version}",
                 "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${dependencyVersions.jackson_version}",
                 "org.hibernate.validator:hibernate-validator:7.0.1.Final",
-                "org.glassfish:jakarta.el:4.0.2"
+                "org.glassfish:jakarta.el:4.0.2",
+                "jakarta.xml.bind:jakarta.xml.bind-api:3.0.1",
+                "com.sun.xml.bind:jaxb-impl:3.0.2"
 
         nimbus "com.nimbusds:oauth2-oidc-sdk:${dependencyVersions.nimbusds_oauth_version}",
                 "com.nimbusds:nimbus-jose-jwt:${dependencyVersions.nimbusds_jwt_version}"


### PR DESCRIPTION
## What?

Include jaxb libs to suppress aws java sdk warning message:

WARNING: JAXB is unavailable. Will fallback to SDK implementation which may be less performant.If you are using Java 9+, you will need to include javax.xml.bind:jaxb-api as a dependency.

## Why?

Remove the messages from the logs.