### PR TITLE
GOVSI-1161 - Update ID token VOT value and enforce ordering of CredentialTrustLevel

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
@@ -235,8 +235,7 @@ public class TokenHandler
                             String vot =
                                     clientSession
                                             .getEffectiveVectorOfTrust()
-                                            .getCredentialTrustLevel()
-                                            .getValue();
+                                            .retrieveVectorOfTrustForToken();
 
                             OIDCTokenResponse tokenResponse =
                                     tokenService.generateTokenResponse(

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
@@ -165,7 +165,8 @@ public class RedisExtension
             String authCode,
             String clientSessionId,
             String email,
-            Map<String, List<String>> authRequest)
+            Map<String, List<String>> authRequest,
+            VectorOfTrust vtr)
             throws JsonProcessingException {
         redis.saveWithExpiry(
                 AUTH_CODE_PREFIX.concat(authCode),
@@ -177,8 +178,7 @@ public class RedisExtension
         redis.saveWithExpiry(
                 CLIENT_SESSION_PREFIX.concat(clientSessionId),
                 objectMapper.writeValueAsString(
-                        new ClientSession(
-                                authRequest, LocalDateTime.now(), VectorOfTrust.getDefaults())),
+                        new ClientSession(authRequest, LocalDateTime.now(), vtr)),
                 300);
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/CredentialTrustLevel.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/CredentialTrustLevel.java
@@ -39,6 +39,14 @@ public enum CredentialTrustLevel {
                 .orElseThrow(() -> new IllegalArgumentException("Invalid CredentialTrustLevel"));
     }
 
+    public static CredentialTrustLevel retrieveCredentialTrustLevel(String vtrSets) {
+
+        return Arrays.stream(values())
+                .filter(tl -> vtrSets.equals(tl.getValue()))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Invalid CredentialTrustLevel"));
+    }
+
     public static CredentialTrustLevel getDefault() {
         return MEDIUM_LEVEL;
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/CredentialTrustLevel.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/CredentialTrustLevel.java
@@ -1,8 +1,6 @@
 package uk.gov.di.authentication.shared.entity;
 
 import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
 
 public enum CredentialTrustLevel {
     LOW_LEVEL("Cl"),
@@ -16,27 +14,6 @@ public enum CredentialTrustLevel {
 
     public String getValue() {
         return value;
-    }
-
-    public static CredentialTrustLevel retrieveCredentialTrustLevel(List<String> vtrSets) {
-
-        return Arrays.stream(values())
-                .filter(
-                        tl ->
-                                vtrSets.stream()
-                                        .anyMatch(
-                                                set ->
-                                                        new HashSet<>(
-                                                                        Arrays.asList(
-                                                                                set.split("\\.")))
-                                                                .equals(
-                                                                        new HashSet<>(
-                                                                                Arrays.asList(
-                                                                                        tl.getValue()
-                                                                                                .split(
-                                                                                                        "\\."))))))
-                .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("Invalid CredentialTrustLevel"));
     }
 
     public static CredentialTrustLevel retrieveCredentialTrustLevel(String vtrSets) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/VectorOfTrust.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/VectorOfTrust.java
@@ -72,6 +72,14 @@ public class VectorOfTrust {
         return new VectorOfTrust(CredentialTrustLevel.getDefault());
     }
 
+    public String retrieveVectorOfTrustForToken() {
+        if (Objects.isNull(levelOfConfidence)) {
+            return credentialTrustLevel.getValue();
+        } else {
+            return levelOfConfidence.getValue() + "." + credentialTrustLevel.getValue();
+        }
+    }
+
     private static VectorOfTrust parseVtrSet(JSONArray vtrJsonArray) {
         List<VectorOfTrust> vectorOfTrusts = new ArrayList<>();
         for (Object obj : vtrJsonArray) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/VectorOfTrust.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/VectorOfTrust.java
@@ -14,7 +14,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import static java.lang.String.format;
 import static net.minidev.json.parser.JSONParser.DEFAULT_PERMISSIVE_MODE;
 
 public class VectorOfTrust {
@@ -63,11 +62,7 @@ public class VectorOfTrust {
             LOGGER.error("Error when parsing vtr attribute", e);
             throw new IllegalArgumentException("Invalid VTR attribute", e);
         }
-        List<String> vtrSets = new ArrayList<>();
-        for (int i = 0; i < vtrJsonArray.size(); i++) {
-            vtrSets.add((String) vtrJsonArray.get(i));
-        }
-        VectorOfTrust vectorOfTrust = parseVtrSet(vtrSets);
+        VectorOfTrust vectorOfTrust = parseVtrSet(vtrJsonArray);
         LOGGER.info("VTR has been processed at vectorOfTrust: {}", vectorOfTrust.toString());
 
         return vectorOfTrust;
@@ -77,34 +72,27 @@ public class VectorOfTrust {
         return new VectorOfTrust(CredentialTrustLevel.getDefault());
     }
 
-    private static VectorOfTrust parseVtrSet(List<String> vtrSet) {
+    private static VectorOfTrust parseVtrSet(JSONArray vtrJsonArray) {
         List<VectorOfTrust> vectorOfTrusts = new ArrayList<>();
-        for (String vtr : vtrSet) {
-            LevelOfConfidence loc = null;
-            CredentialTrustLevel ctl;
-            String[] splitVtr = vtr.split("\\.");
+        for (Object obj : vtrJsonArray) {
+            String vtr = (String) obj;
+            var splitVtr = vtr.split("\\.");
 
-            List<String> levelOfConfidence =
+            List<LevelOfConfidence> levelOfConfidence =
                     Arrays.stream(splitVtr)
-                            .filter((a) -> a.startsWith("P"))
+                            .filter(a -> a.startsWith("P"))
+                            .map(LevelOfConfidence::retrieveLevelOfConfidence)
                             .collect(Collectors.toList());
-            if (splitVtr.length > 3 || (splitVtr.length == 3 && levelOfConfidence.isEmpty())) {
-                throw new IllegalArgumentException(
-                        format("Invalid number of attributes in VTR, %s", vtr));
-            }
-            if (!levelOfConfidence.isEmpty()) {
-                if (levelOfConfidence.size() > 1 || !vtr.startsWith("P")) {
-                    throw new IllegalArgumentException(
-                            format("Invalid Identity vector value exists in VTS: %s", vtr));
-                }
-                loc = LevelOfConfidence.retrieveLevelOfConfidence(levelOfConfidence.get(0));
-                ctl =
-                        CredentialTrustLevel.retrieveCredentialTrustLevel(
-                                List.of(vtr.substring(vtr.indexOf(".") + 1)));
+            if (levelOfConfidence.isEmpty()) {
+                var ctl = CredentialTrustLevel.retrieveCredentialTrustLevel(vtr);
+                vectorOfTrusts.add(new VectorOfTrust(ctl));
             } else {
-                ctl = CredentialTrustLevel.retrieveCredentialTrustLevel(List.of(vtr));
+                var loc = levelOfConfidence.get(0);
+                var ctl =
+                        CredentialTrustLevel.retrieveCredentialTrustLevel(
+                                vtr.substring(vtr.indexOf(".") + 1));
+                vectorOfTrusts.add(new VectorOfTrust(ctl, loc));
             }
-            vectorOfTrusts.add(new VectorOfTrust(ctl, loc));
         }
 
         return vectorOfTrusts.stream()

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/CredentialTrustLevelTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/CredentialTrustLevelTest.java
@@ -5,12 +5,12 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.List;
 import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThan;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.LOW_LEVEL;
 import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.MEDIUM_LEVEL;
 
@@ -23,17 +23,25 @@ class CredentialTrustLevelTest {
 
     @ParameterizedTest
     @MethodSource("validCredentialTrustLevelValues")
-    void valuesShouldBeParsable(List<String> vtrSet, CredentialTrustLevel expectedValue) {
+    void valuesShouldBeParsable(String vtrSet, CredentialTrustLevel expectedValue) {
         assertThat(
                 CredentialTrustLevel.retrieveCredentialTrustLevel(vtrSet), equalTo(expectedValue));
     }
 
+    @ParameterizedTest
+    @MethodSource("invalidCredentialTrustLevelValues")
+    void shouldThrowWhenInvalidValueIsPassed(String vtrSet) {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> CredentialTrustLevel.retrieveCredentialTrustLevel(vtrSet),
+                "Expected to throw exception");
+    }
+
     private static Stream<Arguments> validCredentialTrustLevelValues() {
-        return Stream.of(
-                Arguments.of(List.of("Cl"), LOW_LEVEL),
-                Arguments.of(List.of("Cl.Cm"), MEDIUM_LEVEL),
-                Arguments.of(List.of("Cl", "Cl.Cm"), LOW_LEVEL),
-                Arguments.of(List.of("Cl.Cm", "Cl"), LOW_LEVEL),
-                Arguments.of(List.of("Cm.Cl"), MEDIUM_LEVEL));
+        return Stream.of(Arguments.of("Cl", LOW_LEVEL), Arguments.of("Cl.Cm", MEDIUM_LEVEL));
+    }
+
+    private static Stream<String> invalidCredentialTrustLevelValues() {
+        return Stream.of("Cm", "Cm.Cl", "Cl.Cm.Cl.Cm", "Pm.Cl.Cm");
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/LevelOfConfidenceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/LevelOfConfidenceTest.java
@@ -1,5 +1,6 @@
 package uk.gov.di.authentication.shared.entity;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -8,13 +9,17 @@ import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.lessThan;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static uk.gov.di.authentication.shared.entity.LevelOfConfidence.HIGH_LEVEL;
-import static uk.gov.di.authentication.shared.entity.LevelOfConfidence.LOW_LEVEL;
-import static uk.gov.di.authentication.shared.entity.LevelOfConfidence.MEDIUM_LEVEL;
-import static uk.gov.di.authentication.shared.entity.LevelOfConfidence.VERY_HIGH_LEVEL;
 
 class LevelOfConfidenceTest {
+
+    @Test
+    void valuesShouldBeComparable() {
+        assertThat(LevelOfConfidence.LOW_LEVEL, lessThan(LevelOfConfidence.MEDIUM_LEVEL));
+        assertThat(LevelOfConfidence.MEDIUM_LEVEL, lessThan(LevelOfConfidence.HIGH_LEVEL));
+        assertThat(LevelOfConfidence.HIGH_LEVEL, lessThan(LevelOfConfidence.VERY_HIGH_LEVEL));
+    }
 
     @ParameterizedTest
     @MethodSource("validLevelOfConfidence")
@@ -25,28 +30,21 @@ class LevelOfConfidenceTest {
 
     @ParameterizedTest
     @MethodSource("invalidLevelOfConfidence")
-    void shouldThrowWhenInvalidValueIsPassed(String vtrSet, String message) {
+    void shouldThrowWhenInvalidValueIsPassed(String vtrSet) {
         assertThrows(
                 IllegalArgumentException.class,
-                () -> LevelOfConfidence.retrieveLevelOfConfidence(vtrSet),
-                message);
+                () -> LevelOfConfidence.retrieveLevelOfConfidence(vtrSet));
     }
 
     private static Stream<Arguments> validLevelOfConfidence() {
         return Stream.of(
-                Arguments.of("Pl", LOW_LEVEL),
-                Arguments.of("Pm", MEDIUM_LEVEL),
-                Arguments.of("Ph", HIGH_LEVEL),
-                Arguments.of("Pv", VERY_HIGH_LEVEL));
+                Arguments.of("Pl", LevelOfConfidence.LOW_LEVEL),
+                Arguments.of("Pm", LevelOfConfidence.MEDIUM_LEVEL),
+                Arguments.of("Ph", LevelOfConfidence.HIGH_LEVEL),
+                Arguments.of("Pv", LevelOfConfidence.VERY_HIGH_LEVEL));
     }
 
     private static Stream<Arguments> invalidLevelOfConfidence() {
-        return Stream.of(
-                Arguments.of("Cl.Pl", "Should throw when LevelOfConfidence is not first in String"),
-                Arguments.of(
-                        "Cl.Cm", "Should throw when no LevelOfConfidence is included in String"),
-                Arguments.of(
-                        "Pm.Ph.Cl",
-                        "Should throw when multiple LevelOfConfidence is included in single String"));
+        return Stream.of(Arguments.of("Pm.Pl"), Arguments.of("Cl.Cm"), Arguments.of("Pm.Ph.Cl"));
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/VectorOfTrustTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/VectorOfTrustTest.java
@@ -179,4 +179,27 @@ class VectorOfTrustTest {
                 IllegalArgumentException.class,
                 () -> VectorOfTrust.parseFromAuthRequestAttribute(Collections.singletonList("")));
     }
+
+    @Test
+    void shouldReturnCorrectlyFormattedVectorOfTrustForTokenWhenIdentityValuesArePresent() {
+        String vectorString = "Pm.Cl.Cm";
+        JSONArray jsonArray = new JSONArray();
+        jsonArray.add(vectorString);
+        VectorOfTrust vectorOfTrust =
+                VectorOfTrust.parseFromAuthRequestAttribute(
+                        Collections.singletonList(jsonArray.toJSONString()));
+        assertThat(vectorOfTrust.retrieveVectorOfTrustForToken(), equalTo(vectorString));
+    }
+
+    @Test
+    void
+            shouldReturnCorrectlyFormattedVectorOfTrustForTokenWhenOnlyCredentialTrustLevelIsPresent() {
+        String vectorString = "Cl.Cm";
+        JSONArray jsonArray = new JSONArray();
+        jsonArray.add(vectorString);
+        VectorOfTrust vectorOfTrust =
+                VectorOfTrust.parseFromAuthRequestAttribute(
+                        Collections.singletonList(jsonArray.toJSONString()));
+        assertThat(vectorOfTrust.retrieveVectorOfTrustForToken(), equalTo(vectorString));
+    }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/VectorOfTrustTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/VectorOfTrustTest.java
@@ -119,6 +119,17 @@ class VectorOfTrustTest {
     }
 
     @Test
+    void shouldThrowWhenTooManyValuesInVector() {
+        JSONArray jsonArray = new JSONArray();
+        jsonArray.add("Cl.Cm.Cl");
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        VectorOfTrust.parseFromAuthRequestAttribute(
+                                Collections.singletonList(jsonArray.toJSONString())));
+    }
+
+    @Test
     void shouldThrowWhenOnlyIdentityLevelIsSentInRequest() {
         JSONArray jsonArray = new JSONArray();
         jsonArray.add("Pm");
@@ -130,18 +141,18 @@ class VectorOfTrustTest {
     }
 
     @Test
-    void shouldParseVectorWhenCredentialTrustLevelsAreOrderedDifferently() {
+    void shouldThrowWhenCredentialTrustLevelsAreOrderedIncorrectly() {
         JSONArray jsonArray = new JSONArray();
         jsonArray.add("Pm.Cm.Cl");
-        VectorOfTrust vectorOfTrust =
-                VectorOfTrust.parseFromAuthRequestAttribute(
-                        Collections.singletonList(jsonArray.toJSONString()));
-        assertThat(vectorOfTrust.getCredentialTrustLevel(), equalTo(MEDIUM_LEVEL));
-        assertThat(vectorOfTrust.getLevelOfConfidence(), equalTo(LevelOfConfidence.MEDIUM_LEVEL));
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        VectorOfTrust.parseFromAuthRequestAttribute(
+                                Collections.singletonList(jsonArray.toJSONString())));
     }
 
     @Test
-    void shouldParseValidStringAndReThrowIfInvalidValueIsPresent() {
+    void shouldThrowWhenMultipleIdentityValuesArePresentInVector() {
         JSONArray jsonArray = new JSONArray();
         jsonArray.add("Pl.Pb");
         assertThrows(

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuthorizationServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuthorizationServiceTest.java
@@ -120,7 +120,7 @@ class AuthorizationServiceTest {
         Scope scope = new Scope();
         scope.add(OIDCScopeValue.OPENID);
         JSONArray jsonArray = new JSONArray();
-        jsonArray.add("Pl.Cm.Cl");
+        jsonArray.add("Pl.Cl.Cm");
         jsonArray.add("Pl.Cl");
         when(dynamoClientService.getClient(clientID.toString()))
                 .thenReturn(
@@ -461,7 +461,7 @@ class AuthorizationServiceTest {
     private AuthenticationRequest generateAuthRequest(
             ClientID clientID, String redirectUri, ResponseType responseType, Scope scope) {
         JSONArray jsonArray = new JSONArray();
-        jsonArray.add("Cm.Cl");
+        jsonArray.add("Cl.Cm");
         jsonArray.add("Cl");
         State state = new State();
         Nonce nonce = new Nonce();


### PR DESCRIPTION
## What?

- Update the ID token to include LevelOfConfidence value if that is what has been requested. 
- Only accept the medium Credential trust level when it is ordered ['Cl.Cm'] and return an error when it is received ['Cm.Cl'] to make it completely explicit

## Why?

- The ID token was previously only populating the VOT value with CredentialTrustLevel. Now we have the LevelOfConfidence, if that has been requested we need to ensure the entire VectorOfTrust value is in the vot claim in the ID Token. 
- Add additional tests 