### PR TITLE
GOVSI-1161 - Fix empty vtm claim

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
@@ -105,7 +105,8 @@ public class TokenService {
         AccessToken accessToken =
                 generateAndStoreAccessToken(
                         clientID, internalSubject, scopesForToken, publicSubject);
-        AccessTokenHash accessTokenHash = AccessTokenHash.compute(accessToken, TOKEN_ALGORITHM);
+        AccessTokenHash accessTokenHash =
+                AccessTokenHash.compute(accessToken, TOKEN_ALGORITHM, null);
         SignedJWT idToken =
                 generateIDToken(
                         clientID, publicSubject, additionalTokenClaims, accessTokenHash, vot);
@@ -256,7 +257,7 @@ public class TokenService {
         idTokenClaims.setAccessTokenHash(accessTokenHash);
         idTokenClaims.putAll(additionalTokenClaims);
         idTokenClaims.setClaim("vot", vot);
-        idTokenClaims.setClaim("vtm", trustMarkUri);
+        idTokenClaims.setClaim("vtm", trustMarkUri.toString());
         try {
             return generateSignedJWT(idTokenClaims.toJWTClaimsSet());
         } catch (com.nimbusds.oauth2.sdk.ParseException e) {


### PR DESCRIPTION
## What?

- The VTM claim in the id token was empty because we were only passing in the URI object and not the string of the URI. Fix this by adding toString.
- Add extra assertions in the TokenServiceTest to perform more explicit checks of what we expect to receive in the ID token
- Pass in the curve as null to the AccessTokenHash.compute method as the method with 2 parameters we were previously using was deprecated. The null in the curve gives exactly the same behaviour as when we left that parameter out and is not used.

## Why?

- So the VTM claim is not left empty 
- We have more checks on the ID token which will flag up if anything breaks