### PR TITLE
GOVSI-1161 - Update Trustmark handler with LevelOfConfidence values

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/TrustMarkResponse.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/TrustMarkResponse.java
@@ -14,13 +14,18 @@ public class TrustMarkResponse {
     @JsonProperty("C")
     private List<String> c;
 
+    @JsonProperty("P")
+    private List<String> p;
+
     public TrustMarkResponse(
             @JsonProperty(required = true, value = "idp") String idp,
             @JsonProperty(required = true, value = "trustmark_provider") String trustMark,
-            @JsonProperty(required = true, value = "C") List<String> c) {
+            @JsonProperty(required = true, value = "C") List<String> c,
+            @JsonProperty(required = true, value = "P") List<String> p) {
         this.idp = idp;
         this.trustMark = trustMark;
         this.c = c;
+        this.p = p;
     }
 
     public String getIdp() {
@@ -33,5 +38,9 @@ public class TrustMarkResponse {
 
     public List<String> getC() {
         return c;
+    }
+
+    public List<String> getP() {
+        return p;
     }
 }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TrustMarkHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TrustMarkHandler.java
@@ -10,6 +10,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.oidc.entity.TrustMarkResponse;
 import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
+import uk.gov.di.authentication.shared.entity.LevelOfConfidence;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.util.Arrays;
@@ -56,6 +57,7 @@ public class TrustMarkHandler
                 configurationService.getBaseURL().orElseThrow(),
                 Arrays.asList(
                         CredentialTrustLevel.LOW_LEVEL.getValue(),
-                        CredentialTrustLevel.MEDIUM_LEVEL.getValue()));
+                        CredentialTrustLevel.MEDIUM_LEVEL.getValue()),
+                LevelOfConfidence.getAllLevelOfConfidenceValues());
     }
 }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TrustMarkHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TrustMarkHandlerTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.oidc.entity.TrustMarkResponse;
 import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
+import uk.gov.di.authentication.shared.entity.LevelOfConfidence;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.util.List;
@@ -41,7 +42,8 @@ class TrustMarkHandlerTest {
                         configurationService.getBaseURL().orElseThrow(),
                         List.of(
                                 CredentialTrustLevel.LOW_LEVEL.getValue(),
-                                CredentialTrustLevel.MEDIUM_LEVEL.getValue()));
+                                CredentialTrustLevel.MEDIUM_LEVEL.getValue()),
+                        LevelOfConfidence.getAllLevelOfConfidenceValues());
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
@@ -54,5 +56,6 @@ class TrustMarkHandlerTest {
         assertEquals(response.getIdp(), trustMarkResponse.getIdp());
         assertEquals(response.getTrustMark(), trustMarkResponse.getTrustMark());
         assertEquals(response.getC(), trustMarkResponse.getC());
+        assertEquals(response.getP(), trustMarkResponse.getP());
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/LevelOfConfidence.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/LevelOfConfidence.java
@@ -1,6 +1,8 @@
 package uk.gov.di.authentication.shared.entity;
 
 import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public enum LevelOfConfidence {
     LOW_LEVEL("Pl"),
@@ -25,5 +27,11 @@ public enum LevelOfConfidence {
                 .findFirst()
                 .orElseThrow(
                         () -> new IllegalArgumentException("Invalid LevelOfConfidence provided"));
+    }
+
+    public static List<String> getAllLevelOfConfidenceValues() {
+        return Arrays.stream(LevelOfConfidence.values())
+                .map(LevelOfConfidence::getValue)
+                .collect(Collectors.toList());
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/LevelOfConfidenceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/LevelOfConfidenceTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.List;
 import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -34,6 +35,23 @@ class LevelOfConfidenceTest {
         assertThrows(
                 IllegalArgumentException.class,
                 () -> LevelOfConfidence.retrieveLevelOfConfidence(vtrSet));
+    }
+
+    @Test
+    void shouldReturnLevelOfConfidenceValuesFromLowestToHighest() {
+        List<String> allLevelOfConfidenceValues = LevelOfConfidence.getAllLevelOfConfidenceValues();
+
+        assertThat(
+                allLevelOfConfidenceValues.get(0), equalTo(LevelOfConfidence.LOW_LEVEL.getValue()));
+        assertThat(
+                allLevelOfConfidenceValues.get(1),
+                equalTo(LevelOfConfidence.MEDIUM_LEVEL.getValue()));
+        assertThat(
+                allLevelOfConfidenceValues.get(2),
+                equalTo(LevelOfConfidence.HIGH_LEVEL.getValue()));
+        assertThat(
+                allLevelOfConfidenceValues.get(3),
+                equalTo(LevelOfConfidence.VERY_HIGH_LEVEL.getValue()));
     }
 
     private static Stream<Arguments> validLevelOfConfidence() {


### PR DESCRIPTION
## What?

- Update Trustmark handler with LevelOfConfidence values

## Why?

- So we can correctly display the LevelOfConfidence values we support