### PR TITLE
GOVSI-1165: add IPV authorisation handler

### DIFF
--- a/ci/tasks/deploy-oidc-api.yml
+++ b/ci/tasks/deploy-oidc-api.yml
@@ -18,6 +18,9 @@ params:
   TEST_CLIENT_VERIFY_EMAIL_OTP: ((test-client-verify-email-otp))
   TEST_CLIENT_VERIFY_PHONE_NUMBER_OTP: ((test-client-verify-phone-number-otp))
   TEST_CLIENTS_ENABLED: false
+  IPV_AUTHORISATION_URI: undefined
+  IPV_AUTHORISATION_CALLBACK_URI: undefined
+  IPV_AUTHORISATION_CLIENT_ID: undefined
 inputs:
   - name: api-src
   - name: oidc-api-release
@@ -61,6 +64,9 @@ run:
         -var "test_client_verify_phone_number_otp=${TEST_CLIENT_VERIFY_PHONE_NUMBER_OTP}" \
         -var "test_clients_enabled=${TEST_CLIENTS_ENABLED}" \
         -var "notify_test_phone_number=${NOTIFY_PHONE_NUMBER}" \
+        -var "ipv_authorisation_uri=${IPV_AUTHORISATION_URI}" \
+        -var "ipv_authorisation_callback_uri=${IPV_AUTHORISATION_CALLBACK_URI}" \
+        -var "ipv_authorisation_client_id=${IPV_AUTHORISATION_CLIENT_ID}" \
         -var-file "${DEPLOY_ENVIRONMENT}-overrides.tfvars" \
 
       terraform output --json > ../../../../terraform-outputs/${DEPLOY_ENVIRONMENT}-terraform-outputs.json

--- a/ci/terraform/oidc/ipv-authorize.tf
+++ b/ci/terraform/oidc/ipv-authorize.tf
@@ -1,0 +1,54 @@
+module "ipv-authorize" {
+  source = "../modules/endpoint-module"
+
+  endpoint_name   = "ipv-authorize"
+  path_part       = "ipv-authorize"
+  endpoint_method = "GET"
+  environment     = var.environment
+
+  handler_environment_variables = {
+    ENVIRONMENT                    = var.environment
+    BASE_URL                       = local.frontend_api_base_url
+    EVENTS_SNS_TOPIC_ARN           = aws_sns_topic.events.arn
+    AUDIT_SIGNING_KEY_ALIAS        = local.audit_signing_key_alias_name
+    LOCALSTACK_ENDPOINT            = var.use_localstack ? var.localstack_endpoint : null
+    REDIS_KEY                      = local.redis_key
+    DYNAMO_ENDPOINT                = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    IPV_AUTHORISATION_URI          = var.ipv_authorisation_uri
+    IPV_AUTHORISATION_CALLBACK_URI = var.ipv_authorisation_callback_uri
+    IPV_AUTHORISATION_CLIENT_ID    = var.ipv_authorisation_client_id
+  }
+  handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.IPVAuthorisationHandler::handleRequest"
+
+  create_endpoint                        = var.environment == "build"
+  rest_api_id                            = aws_api_gateway_rest_api.di_authentication_frontend_api.id
+  root_resource_id                       = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
+  execution_arn                          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
+  lambda_zip_file                        = var.ipv_api_lambda_zip_file
+  authentication_vpc_arn                 = local.authentication_vpc_arn
+  security_group_id                      = local.authentication_security_group_id
+  subnet_id                              = local.authentication_subnet_ids
+  lambda_role_arn                        = module.oidc_default_role.arn
+  logging_endpoint_enabled               = var.logging_endpoint_enabled
+  logging_endpoint_arn                   = var.logging_endpoint_arn
+  cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  cloudwatch_log_retention               = var.cloudwatch_log_retention
+  lambda_env_vars_encryption_kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn
+  default_tags                           = local.default_tags
+  api_key_required                       = true
+
+  keep_lambda_warm             = var.keep_lambdas_warm
+  warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
+  warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_handler_environment_variables = {
+    LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
+  }
+
+  use_localstack = var.use_localstack
+
+  depends_on = [
+    aws_api_gateway_rest_api.di_authentication_frontend_api,
+    aws_api_gateway_resource.connect_resource,
+    aws_api_gateway_resource.wellknown_resource,
+  ]
+}

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -16,6 +16,12 @@ variable "client_registry_api_lambda_zip_file" {
   type        = string
 }
 
+variable "ipv_api_lambda_zip_file" {
+  default     = "../../../ipv-api/build/distributions/client-registry-api.zip"
+  description = "Location of the ipv API Lambda ZIP file"
+  type        = string
+}
+
 variable "lambda_warmer_zip_file" {
   default     = "../../../lambda-warmer/build/distributions/lambda-warmer.zip"
   description = "Location of the Lambda Warmer ZIP file"
@@ -198,4 +204,16 @@ variable "test_clients_enabled" {
 
 variable "client_registry_api_enabled" {
   default = true
+}
+
+variable "ipv_authorisation_uri" {
+  type = string
+}
+
+variable "ipv_authorisation_callback_uri" {
+  type = string
+}
+
+variable "ipv_authorisation_client_id" {
+  type = string
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/CheckUserExistsRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/CheckUserExistsRequest.java
@@ -1,5 +1,7 @@
 package uk.gov.di.authentication.frontendapi.entity;
 
+import uk.gov.di.authentication.shared.entity.BaseFrontendRequest;
+
 public class CheckUserExistsRequest extends BaseFrontendRequest {
 
     public CheckUserExistsRequest() {}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/LoginRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/LoginRequest.java
@@ -2,6 +2,7 @@ package uk.gov.di.authentication.frontendapi.entity;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
+import uk.gov.di.authentication.shared.entity.BaseFrontendRequest;
 
 public class LoginRequest extends BaseFrontendRequest {
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/MfaRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/MfaRequest.java
@@ -1,3 +1,5 @@
 package uk.gov.di.authentication.frontendapi.entity;
 
+import uk.gov.di.authentication.shared.entity.BaseFrontendRequest;
+
 public class MfaRequest extends BaseFrontendRequest {}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/ResetPasswordRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/ResetPasswordRequest.java
@@ -1,5 +1,7 @@
 package uk.gov.di.authentication.frontendapi.entity;
 
+import uk.gov.di.authentication.shared.entity.BaseFrontendRequest;
+
 public class ResetPasswordRequest extends BaseFrontendRequest {
 
     public ResetPasswordRequest() {}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/SendNotificationRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/SendNotificationRequest.java
@@ -2,6 +2,7 @@ package uk.gov.di.authentication.frontendapi.entity;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
+import uk.gov.di.authentication.shared.entity.BaseFrontendRequest;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 
 public class SendNotificationRequest extends BaseFrontendRequest {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/SignupRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/SignupRequest.java
@@ -2,6 +2,7 @@ package uk.gov.di.authentication.frontendapi.entity;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
+import uk.gov.di.authentication.shared.entity.BaseFrontendRequest;
 
 public class SignupRequest extends BaseFrontendRequest {
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/UpdateProfileRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/UpdateProfileRequest.java
@@ -2,6 +2,7 @@ package uk.gov.di.authentication.frontendapi.entity;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
+import uk.gov.di.authentication.shared.entity.BaseFrontendRequest;
 
 public class UpdateProfileRequest extends BaseFrontendRequest {
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -16,6 +16,7 @@ import uk.gov.di.authentication.shared.entity.SessionAction;
 import uk.gov.di.authentication.shared.entity.SessionState;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
+import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -21,6 +21,7 @@ import uk.gov.di.authentication.shared.entity.SessionState;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
+import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
@@ -21,6 +21,7 @@ import uk.gov.di.authentication.shared.entity.SessionState;
 import uk.gov.di.authentication.shared.exceptions.ClientNotFoundException;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
+import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
@@ -21,6 +21,7 @@ import uk.gov.di.authentication.shared.helpers.Argon2MatcherHelper;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
+import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
@@ -21,6 +21,7 @@ import uk.gov.di.authentication.shared.entity.SessionAction;
 import uk.gov.di.authentication.shared.entity.SessionState;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
+import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
@@ -18,6 +18,7 @@ import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.SessionAction;
 import uk.gov.di.authentication.shared.entity.SessionState;
 import uk.gov.di.authentication.shared.exceptions.ClientNotFoundException;
+import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
@@ -18,6 +18,7 @@ import uk.gov.di.authentication.shared.entity.SessionState;
 import uk.gov.di.authentication.shared.entity.TermsAndConditions;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
+import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
@@ -22,6 +22,7 @@ import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.ValidScopes;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
+import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -24,6 +24,7 @@ import uk.gov.di.authentication.shared.entity.VectorOfTrust;
 import uk.gov.di.authentication.shared.exceptions.ClientNotFoundException;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
+import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserExistsIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserExistsIntegrationTest.java
@@ -2,10 +2,10 @@ package uk.gov.di.authentication.api;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import uk.gov.di.authentication.frontendapi.entity.BaseFrontendRequest;
 import uk.gov.di.authentication.frontendapi.entity.CheckUserExistsRequest;
 import uk.gov.di.authentication.frontendapi.entity.CheckUserExistsResponse;
 import uk.gov.di.authentication.frontendapi.lambda.CheckUserExistsHandler;
+import uk.gov.di.authentication.shared.entity.BaseFrontendRequest;
 import uk.gov.di.authentication.shared.entity.SessionState;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 

--- a/ipv-api/build.gradle
+++ b/ipv-api/build.gradle
@@ -1,0 +1,51 @@
+plugins {
+    id "java"
+    id "jacoco"
+}
+
+group "uk.gov.di.authentication.ipvapi"
+version "unspecified"
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation configurations.dynamodb,
+            configurations.lambda,
+            configurations.jackson,
+            configurations.nimbus,
+            project(":shared")
+    runtimeOnly configurations.logging_runtime
+
+    testImplementation configurations.tests,
+            configurations.lambda_tests,
+            project(":shared-test"),
+            project(":shared")
+
+    testRuntimeOnly configurations.test_runtime
+}
+
+test {
+    useJUnitPlatform()
+}
+
+task buildZip(type: Zip) {
+    from compileJava
+    from processResources
+    into("lib") {
+        from configurations.runtimeClasspath
+    }
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled true
+    }
+    dependsOn "test"
+}

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/domain/IPVAuditableEvent.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/domain/IPVAuditableEvent.java
@@ -1,0 +1,7 @@
+package uk.gov.di.authentication.ipv.domain;
+
+import uk.gov.di.authentication.shared.domain.AuditableEvent;
+
+public enum IPVAuditableEvent implements AuditableEvent {
+    IPV_AUTHORISATION_REQUESTED
+}

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/IPVAuthorisationRequest.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/IPVAuthorisationRequest.java
@@ -1,0 +1,5 @@
+package uk.gov.di.authentication.ipv.entity;
+
+import uk.gov.di.authentication.shared.entity.BaseFrontendRequest;
+
+public class IPVAuthorisationRequest extends BaseFrontendRequest {}

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandler.java
@@ -1,0 +1,128 @@
+package uk.gov.di.authentication.ipv.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.nimbusds.oauth2.sdk.AuthorizationRequest;
+import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.oauth2.sdk.ResponseType;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.id.State;
+import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.ipv.domain.IPVAuditableEvent;
+import uk.gov.di.authentication.ipv.entity.IPVAuthorisationRequest;
+import uk.gov.di.authentication.shared.entity.ClientRegistry;
+import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.SessionAction;
+import uk.gov.di.authentication.shared.entity.SessionState;
+import uk.gov.di.authentication.shared.helpers.IdGenerator;
+import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
+import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
+import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
+import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.shared.services.AuthenticationService;
+import uk.gov.di.authentication.shared.services.ClientService;
+import uk.gov.di.authentication.shared.services.ClientSessionService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.SessionService;
+import uk.gov.di.authentication.shared.state.StateMachine;
+import uk.gov.di.authentication.shared.state.UserContext;
+
+import java.util.Map;
+
+import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
+import static uk.gov.di.authentication.shared.state.StateMachine.userJourneyStateMachine;
+
+public class IPVAuthorisationHandler extends BaseFrontendHandler<IPVAuthorisationRequest>
+        implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+
+    private static final Logger LOG = LogManager.getLogger(IPVAuthorisationHandler.class);
+
+    private final AuditService auditService;
+    private final StateMachine<SessionState, SessionAction, UserContext> stateMachine =
+            userJourneyStateMachine();
+
+    public IPVAuthorisationHandler(
+            ConfigurationService configurationService,
+            SessionService sessionService,
+            ClientSessionService clientSessionService,
+            ClientService clientService,
+            AuthenticationService authenticationService,
+            AuditService auditService) {
+        super(
+                IPVAuthorisationRequest.class,
+                configurationService,
+                sessionService,
+                clientSessionService,
+                clientService,
+                authenticationService);
+        this.auditService = auditService;
+    }
+
+    public IPVAuthorisationHandler() {
+        this(ConfigurationService.getInstance());
+    }
+
+    public IPVAuthorisationHandler(ConfigurationService configurationService) {
+        super(IPVAuthorisationRequest.class, configurationService);
+        this.auditService = new AuditService(configurationService);
+    }
+
+    @Override
+    public APIGatewayProxyResponseEvent handleRequestWithUserContext(
+            APIGatewayProxyRequestEvent input,
+            Context context,
+            IPVAuthorisationRequest request,
+            UserContext userContext) {
+        try {
+            LOG.info("IPVAuthorisationHandler received request");
+
+            AuthenticationRequest authRequest =
+                    AuthenticationRequest.parse(
+                            userContext.getClientSession().getAuthRequestParams());
+
+            ClientID clientID = new ClientID(configurationService.getIPVAuthorisationClientId());
+
+            AuthorizationRequest ipvAuthorisationRequest =
+                    new AuthorizationRequest.Builder(
+                                    new ResponseType(ResponseType.Value.CODE), clientID)
+                            .scope(authRequest.getScope())
+                            .customParameter("nonce", IdGenerator.generate())
+                            .state(new State())
+                            .redirectionURI(configurationService.getIPVAuthorisationCallbackURI())
+                            .endpointURI(configurationService.getIPVAuthorisationURI())
+                            .build();
+
+            auditService.submitAuditEvent(
+                    IPVAuditableEvent.IPV_AUTHORISATION_REQUESTED,
+                    context.getAwsRequestId(),
+                    userContext.getSession().getSessionId(),
+                    userContext
+                            .getClient()
+                            .map(ClientRegistry::getClientID)
+                            .orElse(AuditService.UNKNOWN),
+                    AuditService.UNKNOWN,
+                    request.getEmail(),
+                    IpAddressHelper.extractIpAddress(input),
+                    AuditService.UNKNOWN,
+                    PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));
+
+            LOG.info(
+                    "IPVAuthorisationHandler successfully processed request, redirect URI {}",
+                    ipvAuthorisationRequest.toURI().toString());
+
+            return new APIGatewayProxyResponseEvent()
+                    .withStatusCode(302)
+                    .withHeaders(Map.of("Location", ipvAuthorisationRequest.toURI().toString()));
+
+        } catch (StateMachine.InvalidStateTransitionException e) {
+            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1017);
+        } catch (ParseException e) {
+            LOG.error("Could not parse authentication request from client");
+            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
+        }
+    }
+}

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandlerTest.java
@@ -1,0 +1,132 @@
+package uk.gov.di.authentication.ipv.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.nimbusds.oauth2.sdk.ResponseType;
+import com.nimbusds.oauth2.sdk.Scope;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.id.State;
+import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+import com.nimbusds.openid.connect.sdk.Nonce;
+import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.entity.ClientSession;
+import uk.gov.di.authentication.shared.entity.Session;
+import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
+import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.shared.services.AuthenticationService;
+import uk.gov.di.authentication.shared.services.ClientService;
+import uk.gov.di.authentication.shared.services.ClientSessionService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.SessionService;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.lang.String.format;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.startsWith;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.sharedtest.helper.RequestEventHelper.contextWithSourceIp;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
+
+public class IPVAuthorisationHandlerTest {
+
+    private static final String SESSION_ID = "a-session-id";
+    private static final String PERSISTENT_SESSION_ID = "a-persistent-session-id";
+    private static final String TEST_CLIENT_ID = "test-client-id";
+    private static final String IPV_CLIENT_ID = "ipv-client-id";
+
+    private static final URI REDIRECT_URI = URI.create("http://localhost/oidc/redirect");
+    private static final URI IPV_CALLBACK_URI = URI.create("http://localhost/oidc/ipv/callback");
+    private static final URI IPV_AUTHORISATION_URI = URI.create("http://localhost/ipv/authorize");
+
+    private static final String TEST_EMAIL_ADDRESS = "test@test.com";
+
+    private final Context context = mock(Context.class);
+    private final ConfigurationService configService = mock(ConfigurationService.class);
+    private final SessionService sessionService = mock(SessionService.class);
+    private final ClientSessionService clientSessionService = mock(ClientSessionService.class);
+    private final ClientSession clientSession = mock(ClientSession.class);
+    private final AuthenticationService authenticationService = mock(AuthenticationService.class);
+    private final ClientService clientService = mock(ClientService.class);
+    private final AuditService auditService = mock(AuditService.class);
+
+    private IPVAuthorisationHandler handler;
+
+    final Session session = new Session(SESSION_ID);
+
+    @BeforeEach
+    void setup() {
+        handler =
+                new IPVAuthorisationHandler(
+                        configService,
+                        sessionService,
+                        clientSessionService,
+                        clientService,
+                        authenticationService,
+                        auditService);
+        when(configService.getIPVAuthorisationClientId()).thenReturn(IPV_CLIENT_ID);
+        when(configService.getIPVAuthorisationCallbackURI()).thenReturn(IPV_CALLBACK_URI);
+        when(configService.getIPVAuthorisationURI()).thenReturn(IPV_AUTHORISATION_URI);
+    }
+
+    @Test
+    void shouldRedirectToIPV() {
+
+        usingValidSession();
+        usingValidClientSession(TEST_CLIENT_ID);
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, PERSISTENT_SESSION_ID);
+        headers.put("Session-Id", session.getSessionId());
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        event.setHeaders(headers);
+        event.setBody(format("{ \"email\": \"%s\"}", TEST_EMAIL_ADDRESS));
+        event.setRequestContext(contextWithSourceIp("123.123.123.123"));
+
+        APIGatewayProxyResponseEvent response = makeHandlerRequest(event);
+
+        assertThat(response, hasStatus(302));
+        assertThat(
+                response.getHeaders().get("Location"),
+                startsWith(IPV_AUTHORISATION_URI.toString()));
+    }
+
+    private APIGatewayProxyResponseEvent makeHandlerRequest(APIGatewayProxyRequestEvent event) {
+        var response = handler.handleRequest(event, context);
+
+        return response;
+    }
+
+    private void usingValidSession() {
+        when(sessionService.getSessionFromRequestHeaders(anyMap()))
+                .thenReturn(Optional.of(session));
+    }
+
+    private void usingValidClientSession(String clientId) {
+        when(clientSessionService.getClientSessionFromRequestHeaders(anyMap()))
+                .thenReturn(Optional.of(clientSession));
+        when(clientSession.getAuthRequestParams())
+                .thenReturn(withAuthenticationRequest(clientId).toParameters());
+    }
+
+    private AuthenticationRequest withAuthenticationRequest(String clientId) {
+        Scope scope = new Scope();
+        scope.add(OIDCScopeValue.OPENID);
+        return new AuthenticationRequest.Builder(
+                        new ResponseType(ResponseType.Value.CODE),
+                        scope,
+                        new ClientID(clientId),
+                        REDIRECT_URI)
+                .state(new State())
+                .nonce(new Nonce())
+                .build();
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -11,4 +11,5 @@ include 'shared'
 include 'shared-test'
 
 rootProject.name = 'di-authentication-api'
+include 'ipv-api'
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/BaseFrontendRequest.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/BaseFrontendRequest.java
@@ -1,4 +1,4 @@
-package uk.gov.di.authentication.frontendapi.entity;
+package uk.gov.di.authentication.shared.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/shared/src/main/java/uk/gov/di/authentication/shared/lambda/BaseFrontendHandler.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/lambda/BaseFrontendHandler.java
@@ -1,4 +1,4 @@
-package uk.gov.di.authentication.frontendapi.lambda;
+package uk.gov.di.authentication.shared.lambda;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.validation.ConstraintViolationException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import uk.gov.di.authentication.frontendapi.entity.BaseFrontendRequest;
+import uk.gov.di.authentication.shared.entity.BaseFrontendRequest;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.Session;

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -96,6 +96,18 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return Long.parseLong(System.getenv().getOrDefault("ID_TOKEN_EXPIRY", "120"));
     }
 
+    public URI getIPVAuthorisationURI() {
+        return URI.create(System.getenv().getOrDefault("IPV_AUTHORISATION_URI", ""));
+    }
+
+    public URI getIPVAuthorisationCallbackURI() {
+        return URI.create(System.getenv().getOrDefault("IPV_AUTHORISATION_CALLBACK_URI", ""));
+    }
+
+    public String getIPVAuthorisationClientId() {
+        return System.getenv().getOrDefault("IPV_AUTHORISATION_CLIENT_ID", "");
+    }
+
     public URI getLoginURI() {
         return URI.create(System.getenv("LOGIN_URI"));
     }


### PR DESCRIPTION
## What?

Add IPV authorisation handler.

Create a new endpoint for the frontend to call which redirects to IPV /authorize by building an authorization request, sending the appropriate redirect back to the frontend.

The lambda has been created in a new java module called 'ipv-api' but is effectively a frontend api call.  'BaseFrontendHandler' has been moved to shared so it can be used in the new handler.

The endpoint is only deployed to build for the time being pending proving.

## Why?

If a service requests a level of confidence requiring ID then we should redirect to the IPV service once the user is authenticated.
