### PR TITLE
GOVSI-1145 - Allow localhost to be used in the OIDC WAF when env is not prod

### DIFF
--- a/ci/terraform/oidc/api-gateway.tf
+++ b/ci/terraform/oidc/api-gateway.tf
@@ -302,6 +302,18 @@ resource "aws_wafv2_web_acl" "wafregional_web_acl_oidc_api" {
         excluded_rule {
           name = "GenericRFI_BODY"
         }
+        dynamic "excluded_rule" {
+          for_each = var.environment != "production" ? ["1"] : []
+          content {
+            name = "EC2MetaDataSSRF_BODY"
+          }
+        }
+        dynamic "excluded_rule" {
+          for_each = var.environment != "production" ? ["1"] : []
+          content {
+            name = "EC2MetaDataSSRF_QUERYARGUMENTS"
+          }
+        }
       }
     }
 


### PR DESCRIPTION
## What?

- Add a conditional rule to the OIDC WAF which will allow clients to use localhost in non-prod environments. The 2 rules which will not be enabled in non-prod are EC2MetaDataSSRF_QUERYARGUMENTS and EC2MetaDataSSRF_BODY

## Why?

- We have external clients testing against our integration and build environments. It is common for them to test using localhost which means sometimes in the request the query arguments or request body can contain 'localhost'.