### PR TITLE
GOVSI-1165: update ipv-api zip file name

### DIFF
--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -17,7 +17,7 @@ variable "client_registry_api_lambda_zip_file" {
 }
 
 variable "ipv_api_lambda_zip_file" {
-  default     = "../../../ipv-api/build/distributions/client-registry-api.zip"
+  default     = "../../../ipv-api/build/distributions/ipv-api.zip"
   description = "Location of the ipv API Lambda ZIP file"
   type        = string
 }


### PR DESCRIPTION
## What?

Update ipv-api zip file name

## Why?

ipv-api zip file config was pointing to the client-registry zip file.

## Related PRs

#1165 