### PR TITLE
GOVSI-1158: Optimise Github Actions

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -74,6 +74,12 @@ jobs:
           name: account-management-integration-test-reports
           path: account-management-integration-tests/build/reports/tests/test/
           retention-days: 5
+      - name: Run SonarCloud Analysis
+        if: ${{ github.actor != 'dependabot[bot]' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./gradlew sonarqube
       - name: Upload Docker Container Logs
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -30,7 +30,8 @@ jobs:
       - name: Run Spotless
         run: ./gradlew --no-daemon spotlessCheck
 
-  run-tests:
+
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
@@ -49,14 +50,108 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
+      - name: Build Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            .gradle/
+            */build/
+            !*/build/reports
+            !*/build/jacoco
+          key: ${{ runner.os }}-build-${{ github.sha }}
+      - name: Run Build
+        run: ./gradlew --parallel build -x test -x account-management-integration-tests:test -x spotlessApply -x spotlessCheck
+
+  run-unit-tests:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: Build Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            .gradle/
+            */build/
+            !*/build/reports
+            !*/build/jacoco
+          key: ${{ runner.os }}-build-${{ github.sha }}
       - name: Run Unit Tests
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew --parallel test -x integration-tests:test jacocoTestReport -x account-management-integration-tests:test -x spotlessApply -x spotlessCheck
+        run: ./gradlew --parallel test jacocoTestReport -x integration-tests:test -x account-management-integration-tests:test -x spotlessApply -x spotlessCheck
+      - name: Upload Unit Test Reports
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: unit-test-reports
+          path: |
+            */build/reports/
+            !integration-tests/build/reports/
+            !account-management-integration-tests/build/reports/
+
+          retention-days: 5
+      - name: Cache Unit Test Reports
+        uses: actions/cache@v2
+        with:
+          key: ${{ runner.os }}-unit-test-reports-${{ github.sha }}
+          path: |
+            */build/jacoco/
+            */build/reports/
+            !integration-tests/build/jacoco/
+            !integration-tests/build/reports/
+            !account-management-integration-tests/build/jacoco/
+            !account-management-integration-tests/build/reports/
+
+  run-integration-tests:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: Build Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            .gradle/
+            */build/
+            !*/build/reports
+            !*/build/jacoco
+          key: ${{ runner.os }}-build-${{ github.sha }}
       - name: Run Integration Tests
         run: |
-          ./gradlew :integration-tests:test jacocoTestReport
+          ./gradlew :integration-tests:test :integration-tests:jacocoTestReport -x spotlessApply -x spotlessCheck
       - name: Upload Integration Test Reports
         uses: actions/upload-artifact@v2
         if: failure()
@@ -66,7 +161,7 @@ jobs:
           retention-days: 5
       - name: Run Account Management Integration Tests
         run: |
-          ./gradlew :account-management-integration-tests:test jacocoTestReport
+          ./gradlew :account-management-integration-tests:test :integration-tests:jacocoTestReport -x spotlessApply -x spotlessCheck
       - name: Upload Account Management Integration Test Reports
         uses: actions/upload-artifact@v2
         if: failure()
@@ -74,12 +169,6 @@ jobs:
           name: account-management-integration-test-reports
           path: account-management-integration-tests/build/reports/tests/test/
           retention-days: 5
-      - name: Run SonarCloud Analysis
-        if: ${{ github.actor != 'dependabot[bot]' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew sonarqube
       - name: Upload Docker Container Logs
         uses: actions/upload-artifact@v2
         if: failure()
@@ -91,4 +180,70 @@ jobs:
         if: always()
         run: |
           ./gradlew --no-daemon :composeDownForced
+      - name: Cache Test Reports
+        uses: actions/cache@v2
+        with:
+          key: ${{ runner.os }}-integration-test-reports-${{ github.sha }}
+          path: |
+            integration-tests/build/jacoco/
+            integration-tests/build/reports/
+            account-management-integration-tests/build/jacoco/
+            account-management-integration-tests/build/reports/
 
+  run-sonar-analysis:
+    runs-on: ubuntu-latest
+    needs:
+      - run-unit-tests
+      - run-integration-tests
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: Build Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            .gradle/
+            */build/
+            !*/build/reports
+            !*/build/jacoco
+          key: ${{ runner.os }}-build-${{ github.sha }}
+      - name: Cache Unit Test Reports
+        uses: actions/cache@v2
+        with:
+          key: ${{ runner.os }}-unit-test-reports-${{ github.sha }}
+          path: |
+            */build/jacoco/
+            */build/reports/
+            !integration-tests/build/jacoco/
+            !integration-tests/build/reports/
+            !account-management-integration-tests/build/jacoco/
+            !account-management-integration-tests/build/reports/
+      - name: Cache Test Reports
+        uses: actions/cache@v2
+        with:
+          key: ${{ runner.os }}-integration-test-reports-${{ github.sha }}
+          path: |
+            integration-tests/build/jacoco/
+            integration-tests/build/reports/
+            account-management-integration-tests/build/jacoco/
+            account-management-integration-tests/build/reports/
+      - name: Run SonarCloud Analysis
+        if: ${{ github.actor != 'dependabot[bot]' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./gradlew sonarqube --info -x test -x account-management-integration-tests:test -x spotlessApply -x spotlessCheck

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -123,6 +123,38 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
+    services:
+      localstack:
+        image: localstack/localstack:0.12.20
+        env:
+          SERVICES: "lambda, apigateway, iam, ec2, sqs, s3, sts, kms, sns, ssm"
+          EDGE_PORT: "45678"
+          EXTERNAL_HOSTNAME: localhost
+          DEFAULT_REGION: eu-west-2
+          TEST_AWS_ACCOUNT_ID: 123456789012
+          KMS_PROVIDER: local-kms
+        options: >-
+          --add-host "notify.internal:host-gateway"
+        ports:
+          - 45678:45678
+      redis:
+        image: redis:6.0.5-alpine
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379
+      dynamodb:
+        image: amazon/dynamodb-local:latest
+        options: >-
+          --health-cmd "curl http://localhost:8000"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 8000:8000
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
@@ -151,7 +183,7 @@ jobs:
           key: ${{ runner.os }}-build-${{ github.sha }}
       - name: Run Integration Tests
         run: |
-          ./gradlew :integration-tests:test :integration-tests:jacocoTestReport -x spotlessApply -x spotlessCheck
+          ./gradlew :integration-tests:test :integration-tests:jacocoTestReport -x spotlessApply -x spotlessCheck -x composeUp
       - name: Upload Integration Test Reports
         uses: actions/upload-artifact@v2
         if: failure()
@@ -161,7 +193,7 @@ jobs:
           retention-days: 5
       - name: Run Account Management Integration Tests
         run: |
-          ./gradlew :account-management-integration-tests:test :integration-tests:jacocoTestReport -x spotlessApply -x spotlessCheck
+          ./gradlew :account-management-integration-tests:test :integration-tests:jacocoTestReport -x spotlessApply -x spotlessCheck -x composeUp
       - name: Upload Account Management Integration Test Reports
         uses: actions/upload-artifact@v2
         if: failure()
@@ -169,17 +201,6 @@ jobs:
           name: account-management-integration-test-reports
           path: account-management-integration-tests/build/reports/tests/test/
           retention-days: 5
-      - name: Upload Docker Container Logs
-        uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: docker-container-logs
-          path: logs/
-          retention-days: 5
-      - name: Stop Services
-        if: always()
-        run: |
-          ./gradlew --no-daemon :composeDownForced
       - name: Cache Test Reports
         uses: actions/cache@v2
         with:
@@ -246,4 +267,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./gradlew sonarqube --info -x test -x account-management-integration-tests:test -x spotlessApply -x spotlessCheck
+        run: ./gradlew sonarqube -x test -x account-management-integration-tests:test -x spotlessApply -x spotlessCheck

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -18,18 +18,9 @@ jobs:
         with:
           java-version: '11'
           distribution: 'adopt'
-      - name: Cache Gradle packages
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+          cache: 'gradle'
       - name: Run Spotless
         run: ./gradlew --no-daemon spotlessCheck
-
 
   build:
     runs-on: ubuntu-latest
@@ -41,15 +32,7 @@ jobs:
         with:
           java-version: '11'
           distribution: 'adopt'
-      - name: Cache Gradle packages
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+          cache: 'gradle'
       - name: Build Cache
         uses: actions/cache@v2
         with:
@@ -74,15 +57,7 @@ jobs:
         with:
           java-version: '11'
           distribution: 'adopt'
-      - name: Cache Gradle packages
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+          cache: 'gradle'
       - name: Build Cache
         uses: actions/cache@v2
         with:
@@ -163,15 +138,7 @@ jobs:
         with:
           java-version: '11'
           distribution: 'adopt'
-      - name: Cache Gradle packages
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+          cache: 'gradle'
       - name: Build Cache
         uses: actions/cache@v2
         with:
@@ -224,15 +191,7 @@ jobs:
         with:
           java-version: '11'
           distribution: 'adopt'
-      - name: Cache Gradle packages
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+          cache: 'gradle'
       - name: Build Cache
         uses: actions/cache@v2
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -121,7 +121,7 @@ spotless {
 }
 
 dockerCompose {
-    buildBeforeUp = true
+    buildBeforeUp = false
     forceRecreate = false
 
     startedServices = [


### PR DESCRIPTION
## What

- Revert alphagov/di-authentication-api#1149
- Parallelise unit and integration tests into separate jobs and cache resulting reports
- Add build job and cache build
- Use GitHub actions service containers to save on Docker Compose build/up time

## Why

The problem requiring #1149 has been resolved.

Other changes required to keep total test time at around 5 mins (if not under).