### PR TITLE
BAU - Return the SubjectType that we have actually updated in the DB

### DIFF
--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/entity/ClientRegistrationResponse.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/entity/ClientRegistrationResponse.java
@@ -25,7 +25,7 @@ public class ClientRegistrationResponse {
     private final List<String> postLogoutRedirectUris;
 
     @JsonProperty("subject_type")
-    private final String subjectType = "Public";
+    private final String subjectType;
 
     @JsonProperty("token_endpoint_auth_method")
     private final String tokenAuthMethod = "private_key_jwt";
@@ -43,7 +43,8 @@ public class ClientRegistrationResponse {
             @JsonProperty(required = true, value = "contacts") List<String> contacts,
             @JsonProperty(required = true, value = "scopes") List<String> scopes,
             @JsonProperty(value = "post_logout_redirect_uris") List<String> postLogoutRedirectUris,
-            @JsonProperty(required = true, value = "service_type") String serviceType) {
+            @JsonProperty(required = true, value = "service_type") String serviceType,
+            @JsonProperty(required = true, value = "subject_type") String subjectType) {
         this.clientName = clientName;
         this.clientId = clientId;
         this.redirectUris = redirectUris;
@@ -51,6 +52,7 @@ public class ClientRegistrationResponse {
         this.scopes = scopes;
         this.postLogoutRedirectUris = postLogoutRedirectUris;
         this.serviceType = serviceType;
+        this.subjectType = subjectType;
     }
 
     public String getClientName() {

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandler.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandler.java
@@ -128,7 +128,8 @@ public class ClientRegistrationHandler
                                                 clientRegistrationRequest.getScopes(),
                                                 clientRegistrationRequest
                                                         .getPostLogoutRedirectUris(),
-                                                clientRegistrationRequest.getServiceType());
+                                                clientRegistrationRequest.getServiceType(),
+                                                clientRegistrationRequest.getSubjectType());
                                 LOGGER.info("Generating successful Client registration response");
                                 return generateApiGatewayProxyResponse(
                                         200, clientRegistrationResponse);

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandler.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandler.java
@@ -137,7 +137,8 @@ public class UpdateClientConfigHandler
                                                 clientRegistry.getContacts(),
                                                 clientRegistry.getScopes(),
                                                 clientRegistry.getPostLogoutRedirectUrls(),
-                                                clientRegistry.getServiceType());
+                                                clientRegistry.getServiceType(),
+                                                clientRegistry.getSubjectType());
                                 LOGGER.info("Client with ClientId {} has been updated", clientId);
                                 return generateApiGatewayProxyResponse(
                                         200, clientRegistrationResponse);

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandlerTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandlerTest.java
@@ -63,7 +63,7 @@ class ClientRegistrationHandlerTest {
             throws JsonProcessingException {
         String clientId = UUID.randomUUID().toString();
         String sectorIdentifierUri = "https://test.com";
-        String subjectType = "public";
+        String subjectType = "pairwise";
         String clientName = "test-client";
         List<String> redirectUris = List.of("http://localhost:8080/redirect-uri");
         List<String> contacts = List.of("joe.bloggs@test.com");
@@ -76,7 +76,7 @@ class ClientRegistrationHandlerTest {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
 
         event.setBody(
-                "{ \"client_name\": \"test-client\", \"redirect_uris\": [\"http://localhost:8080/redirect-uri\"], \"contacts\": [\"joe.bloggs@test.com\"], \"scopes\": [\"openid\"],  \"public_key\": \"some-public-key\", \"post_logout_redirect_uris\": [\"http://localhost:8080/post-logout-redirect-uri\"], \"service_type\": \"MANDATORY\", \"sector_identifier_uri\": \"https://test.com\", \"subject_type\": \"public\"}");
+                "{ \"client_name\": \"test-client\", \"redirect_uris\": [\"http://localhost:8080/redirect-uri\"], \"contacts\": [\"joe.bloggs@test.com\"], \"scopes\": [\"openid\"],  \"public_key\": \"some-public-key\", \"post_logout_redirect_uris\": [\"http://localhost:8080/post-logout-redirect-uri\"], \"service_type\": \"MANDATORY\", \"sector_identifier_uri\": \"https://test.com\", \"subject_type\": \"pairwise\"}");
         APIGatewayProxyResponseEvent result = makeHandlerRequest(event);
 
         assertThat(result, hasStatus(200));
@@ -85,7 +85,7 @@ class ClientRegistrationHandlerTest {
         assertThat(clientRegistrationResponseResult.getClientId(), equalTo(clientId));
         assertThat(
                 clientRegistrationResponseResult.getTokenAuthMethod(), equalTo("private_key_jwt"));
-        assertThat(clientRegistrationResponseResult.getSubjectType(), equalTo("Public"));
+        assertThat(clientRegistrationResponseResult.getSubjectType(), equalTo(subjectType));
         assertThat(clientRegistrationResponseResult.getScopes(), equalTo(singletonList("openid")));
         verify(clientService)
                 .addClient(

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandlerTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandlerTest.java
@@ -204,6 +204,7 @@ class UpdateClientConfigHandlerTest {
         clientRegistry.setClientID(CLIENT_ID);
         clientRegistry.setPublicKey("public-key");
         clientRegistry.setScopes(SCOPES);
+        clientRegistry.setSubjectType("Public");
         clientRegistry.setRedirectUrls(singletonList("http://localhost/redirect"));
         clientRegistry.setContacts(singletonList("contant-name"));
         clientRegistry.setPostLogoutRedirectUrls(singletonList("localhost/logout"));


### PR DESCRIPTION
## What?

 - Return the SubjectType that we have actually updated in the DB
- We need to add validation to the SubjectType in both the RegistrationHandler and UpdateClientConfigHandler

## Why?

- We were hardcoding the response to Public even though we were updating the DB with the value sent in the request
