### PR TITLE
GOVSI-1165: tweak deployment dependencies for the ipv-authorize endpoint

### DIFF
--- a/ci/terraform/oidc/api-gateway-frontend.tf
+++ b/ci/terraform/oidc/api-gateway-frontend.tf
@@ -55,7 +55,9 @@ resource "aws_api_gateway_deployment" "frontend_deployment" {
       module.reset_password.integration_trigger_value,
       module.reset_password.method_trigger_value,
       module.reset-password-request.integration_trigger_value,
-      module.reset-password-request.method_trigger_value
+      module.reset-password-request.method_trigger_value,
+      var.ipv_api_enabled ? module.ipv-authorize[0].integration_trigger_value : null,
+      var.ipv_api_enabled ? module.ipv-authorize[0].method_trigger_value : null,
     ]))
   }
 

--- a/ci/terraform/oidc/ipv-authorize.tf
+++ b/ci/terraform/oidc/ipv-authorize.tf
@@ -1,4 +1,5 @@
 module "ipv-authorize" {
+  count  = var.ipv_api_enabled ? 1 : 0
   source = "../modules/endpoint-module"
 
   endpoint_name   = "ipv-authorize"
@@ -20,7 +21,7 @@ module "ipv-authorize" {
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.IPVAuthorisationHandler::handleRequest"
 
-  create_endpoint                        = var.environment == "build"
+  create_endpoint                        = true
   rest_api_id                            = aws_api_gateway_rest_api.di_authentication_frontend_api.id
   root_resource_id                       = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
   execution_arn                          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn

--- a/ci/terraform/oidc/production-overrides.tfvars
+++ b/ci/terraform/oidc/production-overrides.tfvars
@@ -10,3 +10,4 @@ notify_template_map = {
 cloudwatch_log_retention    = 5
 lambda_min_concurrency      = 25
 client_registry_api_enabled = false
+ipv_api_enabled             = false

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -206,6 +206,10 @@ variable "client_registry_api_enabled" {
   default = true
 }
 
+variable "ipv_api_enabled" {
+  default = true
+}
+
 variable "ipv_authorisation_uri" {
   type = string
 }


### PR DESCRIPTION
## What?

Tweak deployment dependencies for the ipv-authorize endpoint

- Forces deployment of the api-g endpoint for build and integration only.

## Why?

Endpoint was created in api-g but not deployed.

## Related PRs

#1165 