### PR TITLE
GOVSI-1165: remove ipv-authorize from deployment to fix cycle

### DIFF
--- a/ci/terraform/oidc/api-gateway-frontend.tf
+++ b/ci/terraform/oidc/api-gateway-frontend.tf
@@ -56,8 +56,6 @@ resource "aws_api_gateway_deployment" "frontend_deployment" {
       module.reset_password.method_trigger_value,
       module.reset-password-request.integration_trigger_value,
       module.reset-password-request.method_trigger_value,
-      var.ipv_api_enabled ? module.ipv-authorize[0].integration_trigger_value : null,
-      var.ipv_api_enabled ? module.ipv-authorize[0].method_trigger_value : null,
     ]))
   }
 


### PR DESCRIPTION
## What?

Remove ipv-authorize from deployment to fix cycle

## Why?

There is still one resource with a cycle when deploying the stage, so removing the stage deployment trigger.

## Related PRs

#1179 