### PR TITLE
GOVSI-1165: switch on ipv-authorize endpoint in build and int

### DIFF
--- a/ci/terraform/oidc/api-gateway-frontend.tf
+++ b/ci/terraform/oidc/api-gateway-frontend.tf
@@ -56,6 +56,8 @@ resource "aws_api_gateway_deployment" "frontend_deployment" {
       module.reset_password.method_trigger_value,
       module.reset-password-request.integration_trigger_value,
       module.reset-password-request.method_trigger_value,
+      var.ipv_api_enabled ? module.ipv-authorize[0].integration_trigger_value : null,
+      var.ipv_api_enabled ? module.ipv-authorize[0].method_trigger_value : null,
     ]))
   }
 

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -207,7 +207,7 @@ variable "client_registry_api_enabled" {
 }
 
 variable "ipv_api_enabled" {
-  default = false
+  default = true
 }
 
 variable "ipv_authorisation_uri" {


### PR DESCRIPTION
## What?

Switch on ipv-authorize endpoint in build and int

## Why?

Terraform cycle has been resolved in the pipeline so now switching-on.

## Related PRs

#1179 
#1180 