### PR TITLE
GOVSI-1165: switch ipv-authorize to post

### DIFF
--- a/ci/terraform/oidc/ipv-authorize.tf
+++ b/ci/terraform/oidc/ipv-authorize.tf
@@ -4,7 +4,7 @@ module "ipv-authorize" {
 
   endpoint_name   = "ipv-authorize"
   path_part       = "ipv-authorize"
-  endpoint_method = "GET"
+  endpoint_method = "POST"
   environment     = var.environment
 
   handler_environment_variables = {


### PR DESCRIPTION
## What?

Switch ipv-authorize to post

## Why?

BaseHandler requires a body.
