### PR TITLE
GOVSI-1165: make ipv-authorize return 200 rather than 302

### DIFF
--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/IPVAuthorisationResponse.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/IPVAuthorisationResponse.java
@@ -1,0 +1,22 @@
+package uk.gov.di.authentication.ipv.entity;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.di.authentication.shared.entity.BaseAPIResponse;
+import uk.gov.di.authentication.shared.entity.SessionState;
+
+public class IPVAuthorisationResponse extends BaseAPIResponse {
+
+    @JsonProperty("redirectUri")
+    private String redirectUri;
+
+    public IPVAuthorisationResponse(
+            @JsonProperty(required = true, value = "sessionState") SessionState sessionState,
+            @JsonProperty(required = true, value = "redirectUri") String redirectUri) {
+        super(sessionState);
+        this.redirectUri = redirectUri;
+    }
+
+    public String getRedirectUri() {
+        return redirectUri;
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/SessionState.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/SessionState.java
@@ -35,7 +35,8 @@ public enum SessionState {
     CONSENT_REQUIRED,
     CONSENT_ADDED,
     ACCOUNT_TEMPORARILY_LOCKED,
-    UPLIFT_REQUIRED_CM;
+    UPLIFT_REQUIRED_CM,
+    IPV_REQUIRED;
 
     public static List<SessionState> INTERRUPT_STATES =
             List.of(


### PR DESCRIPTION
## What?

Make ipv-authorize return 200 rather than 302.

- provide the redirectURI in the body along with a session state
- only one state is returned at the moment, different scenarios to be added later.

## Why?

Simpler client-side code, Axios still seems to be following the redirect under the hood even though it has been configured not to.
