### PR TITLE
GOVSI-1165: store IPV host only in configuration

### DIFF
--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandler.java
@@ -36,6 +36,7 @@ import uk.gov.di.authentication.shared.state.UserContext;
 import static uk.gov.di.authentication.shared.entity.SessionState.IPV_REQUIRED;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
+import static uk.gov.di.authentication.shared.helpers.ConstructUriHelper.buildURI;
 import static uk.gov.di.authentication.shared.state.StateMachine.userJourneyStateMachine;
 
 public class IPVAuthorisationHandler extends BaseFrontendHandler<IPVAuthorisationRequest>
@@ -43,6 +44,7 @@ public class IPVAuthorisationHandler extends BaseFrontendHandler<IPVAuthorisatio
 
     private static final Logger LOG = LogManager.getLogger(IPVAuthorisationHandler.class);
 
+    private static final String IPV_AUTHORIZE_ROUTE = "/authorize";
     private final AuditService auditService;
     private final StateMachine<SessionState, SessionAction, UserContext> stateMachine =
             userJourneyStateMachine();
@@ -95,7 +97,12 @@ public class IPVAuthorisationHandler extends BaseFrontendHandler<IPVAuthorisatio
                             .customParameter("nonce", IdGenerator.generate())
                             .state(new State())
                             .redirectionURI(configurationService.getIPVAuthorisationCallbackURI())
-                            .endpointURI(configurationService.getIPVAuthorisationURI())
+                            .endpointURI(
+                                    buildURI(
+                                            configurationService
+                                                    .getIPVAuthorisationURI()
+                                                    .toString(),
+                                            IPV_AUTHORIZE_ROUTE))
                             .build();
 
             auditService.submitAuditEvent(

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandlerTest.java
@@ -50,7 +50,7 @@ public class IPVAuthorisationHandlerTest {
 
     private static final URI REDIRECT_URI = URI.create("http://localhost/oidc/redirect");
     private static final URI IPV_CALLBACK_URI = URI.create("http://localhost/oidc/ipv/callback");
-    private static final URI IPV_AUTHORISATION_URI = URI.create("http://localhost/ipv/authorize");
+    private static final URI IPV_AUTHORISATION_URI = URI.create("http://localhost/ipv");
 
     private static final String TEST_EMAIL_ADDRESS = "test@test.com";
 
@@ -104,7 +104,7 @@ public class IPVAuthorisationHandlerTest {
                 new ObjectMapper().readValue(response.getBody(), IPVAuthorisationResponse.class);
 
         assertEquals(body.getSessionState(), SessionState.IPV_REQUIRED);
-        assertThat(body.getRedirectUri(), startsWith(IPV_AUTHORISATION_URI.toString()));
+        assertThat(body.getRedirectUri(), startsWith(IPV_AUTHORISATION_URI + "/authorize"));
     }
 
     private APIGatewayProxyResponseEvent makeHandlerRequest(APIGatewayProxyRequestEvent event) {


### PR DESCRIPTION
## What?

Store IPV host only in configuration rather than the authorize uri.

## Why?

The configuration value can them be reused elsewhere to hit other IPV endpoints, 'token' for example, rather than having separate configuration for each endpoint.

Will look to rename the configuration and environment variable to reflect this change in a later refactoring.