### PR TITLE
GOVSI-1166 - Call IPV token endpoint with auth code

### DIFF
--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -17,6 +17,7 @@ module "ipv-callback" {
     REDIS_KEY                   = local.redis_key
     DYNAMO_ENDPOINT             = var.use_localstack ? var.lambda_dynamo_endpoint : null
     IPV_AUTHORISATION_CLIENT_ID = var.ipv_authorisation_client_id
+    IPV_AUTHORISATION_URI       = var.ipv_authorisation_uri
   }
   handler_function_name = "uk.gov.di.authentication.ipv.lambda.IPVCallbackHandler::handleRequest"
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
@@ -1,12 +1,18 @@
 package uk.gov.di.authentication.api;
 
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import org.apache.http.client.utils.URIBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.authentication.ipv.lambda.IPVCallbackHandler;
 import uk.gov.di.authentication.shared.entity.ResponseHeaders;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.gov.di.authentication.sharedtest.extensions.IPVStubExtension;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -18,9 +24,15 @@ import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyRespon
 
 class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
+    @RegisterExtension public static final IPVStubExtension ipvStub = new IPVStubExtension();
+
+    protected static final ConfigurationService configurationService =
+            new IPVCallbackHandlerIntegrationTest.TestConfigurationService(ipvStub);
+
     @BeforeEach
     void setup() {
-        handler = new IPVCallbackHandler(TEST_CONFIGURATION_SERVICE);
+        ipvStub.init();
+        handler = new IPVCallbackHandler(configurationService);
     }
 
     @Test
@@ -44,5 +56,32 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                         "code",
                         new AuthorizationCode().getValue()));
         return queryStringParameters;
+    }
+
+    protected static class TestConfigurationService extends ConfigurationService {
+
+        private final IPVStubExtension ipvStubExtension;
+
+        public TestConfigurationService(IPVStubExtension ipvStub) {
+            this.ipvStubExtension = ipvStub;
+        }
+
+        @Override
+        public URI getIPVAuthorisationURI() {
+            try {
+                return new URIBuilder()
+                        .setHost("localhost")
+                        .setPort(ipvStubExtension.getHttpPort())
+                        .setScheme("http")
+                        .build();
+            } catch (URISyntaxException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public String getIPVAuthorisationClientId() {
+            return "ipv-client-id";
+        }
     }
 }

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVTokenService.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVTokenService.java
@@ -1,0 +1,94 @@
+package uk.gov.di.authentication.ipv.services;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import com.nimbusds.oauth2.sdk.AuthorizationCodeGrant;
+import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.oauth2.sdk.TokenRequest;
+import com.nimbusds.oauth2.sdk.TokenResponse;
+import com.nimbusds.oauth2.sdk.auth.JWTAuthenticationClaimsSet;
+import com.nimbusds.oauth2.sdk.auth.PrivateKeyJWT;
+import com.nimbusds.oauth2.sdk.id.Audience;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+import java.io.IOException;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.RSAPrivateKey;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+import static uk.gov.di.authentication.shared.helpers.ConstructUriHelper.buildURI;
+
+public class IPVTokenService {
+
+    private final ConfigurationService configurationService;
+    private static final String TOKEN_PATH = "token";
+    private static final Logger LOG = LogManager.getLogger(IPVTokenService.class);
+
+    public IPVTokenService(ConfigurationService configurationService) {
+        this.configurationService = configurationService;
+    }
+
+    public TokenRequest constructTokenRequest(String authCode) {
+        var codeGrant =
+                new AuthorizationCodeGrant(
+                        new AuthorizationCode(authCode),
+                        configurationService.getIPVAuthorisationCallbackURI());
+        var tokenUri =
+                buildURI(configurationService.getIPVAuthorisationURI().toString(), TOKEN_PATH);
+        LocalDateTime localDateTime = LocalDateTime.now().plusMinutes(5);
+        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
+        JWTAuthenticationClaimsSet claimsSet =
+                new JWTAuthenticationClaimsSet(
+                        new ClientID(configurationService.getIPVAuthorisationClientId()),
+                        new Audience(tokenUri));
+        claimsSet.getExpirationTime().setTime(expiryDate.getTime());
+        var privateKeyJWT = generatePrivateKeyJwt(claimsSet);
+        var extraParams = new HashMap<String, List<String>>();
+        extraParams.put(
+                "client_id", singletonList(configurationService.getIPVAuthorisationClientId()));
+        return new TokenRequest(tokenUri, privateKeyJWT, codeGrant, null, null, extraParams);
+    }
+
+    public TokenResponse sendTokenRequest(TokenRequest tokenRequest) {
+        try {
+            return TokenResponse.parse(tokenRequest.toHTTPRequest().send());
+        } catch (IOException e) {
+            LOG.error("Error whilst sending TokenRequest", e);
+            throw new RuntimeException(e);
+        } catch (ParseException e) {
+            LOG.error("Error whilst parsing TokenResponse", e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    private PrivateKeyJWT generatePrivateKeyJwt(JWTAuthenticationClaimsSet claimsSet) {
+        KeyPairGenerator kpg;
+        PrivateKeyJWT privateKeyJwt;
+        try {
+            kpg = KeyPairGenerator.getInstance("RSA");
+            kpg.initialize(2048);
+            var keyPair = kpg.generateKeyPair();
+            privateKeyJwt =
+                    new PrivateKeyJWT(
+                            claimsSet,
+                            JWSAlgorithm.RS512,
+                            (RSAPrivateKey) keyPair.getPrivate(),
+                            null,
+                            null);
+        } catch (NoSuchAlgorithmException | JOSEException e) {
+            LOG.error("Error whilst creating PrivateKeyJWT on the fly");
+            throw new RuntimeException(e);
+        }
+        return privateKeyJwt;
+    }
+}

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVTokenServiceTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVTokenServiceTest.java
@@ -1,0 +1,45 @@
+package uk.gov.di.authentication.ipv.services;
+
+import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import com.nimbusds.oauth2.sdk.TokenRequest;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+import java.net.URI;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.shared.helpers.ConstructUriHelper.buildURI;
+
+class IPVTokenServiceTest {
+
+    private final ConfigurationService configService = mock(ConfigurationService.class);
+    private static final URI IPV_URI = URI.create("http://ipv");
+    private static final ClientID CLIENT_ID = new ClientID("some-client-id");
+    private static final AuthorizationCode AUTH_CODE = new AuthorizationCode();
+    private IPVTokenService ipvTokenService;
+
+    @BeforeEach
+    void setUp() {
+        ipvTokenService = new IPVTokenService(configService);
+        when(configService.getIPVAuthorisationURI()).thenReturn(IPV_URI);
+        when(configService.getIPVAuthorisationClientId()).thenReturn(CLIENT_ID.getValue());
+    }
+
+    @Test
+    void shouldConstructTokenRequest() {
+        TokenRequest tokenRequest = ipvTokenService.constructTokenRequest(AUTH_CODE.getValue());
+
+        assertThat(
+                tokenRequest.getCustomParameters().get("client_id").get(0),
+                equalTo(CLIENT_ID.getValue()));
+        assertThat(tokenRequest.getEndpointURI(), equalTo(buildURI(IPV_URI.toString(), "token")));
+        assertThat(
+                tokenRequest.getClientAuthentication().getMethod().getValue(),
+                equalTo("private_key_jwt"));
+    }
+}

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/IPVStubExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/IPVStubExtension.java
@@ -1,0 +1,31 @@
+package uk.gov.di.authentication.sharedtest.extensions;
+
+import uk.gov.di.authentication.sharedtest.httpstub.HttpStubExtension;
+
+import static java.lang.String.format;
+
+public class IPVStubExtension extends HttpStubExtension {
+
+    public IPVStubExtension(int port) {
+        super(port);
+    }
+
+    public IPVStubExtension() {
+        super();
+    }
+
+    public void init() {
+        register(
+                "/token",
+                200,
+                "application/json",
+                format(
+                        "{"
+                                + "  \"access_token\": \"740e5834-3a29-46b4-9a6f-16142fde533a\","
+                                + "  \"token_type\": \"bearer\","
+                                + "  \"expires_in\": \"3600\","
+                                + "  \"uri\": \"http://localhost:%1$d\""
+                                + "}",
+                        getHttpPort()));
+    }
+}


### PR DESCRIPTION
## What?

- Once we receive an authorisation code from the IPV authorize endpoint we can use that to make a call to the TokenEndpoint. Don't yet do anything with the token response.
- Create an IPVStubExtension to allow us to mimic the IPV token endpoint for the IntegrationTest.
- Add the IPV_AUTHORISATION_URI env var to the ipv-callback.tf which will actually be the base URL for IPV. This will be renamed going forward
- Generate a PrivateKeyJWT on the fly. This key will not be validated and we can eventually swap this out with a signing key in KMS but this will allow us to test our initial integration.

## Why?

- So we have the ability to retrieve an Access token which will later be exchanged for the information we require. 