### PR TITLE
GOVSI-1166 - Persist the AccessToken in Redis

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
@@ -11,9 +11,9 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.extensions.IPVStubExtension;
 
+import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -36,10 +36,16 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
     }
 
     @Test
-    void shouldReturn200AndClientInfoResponseForValidClient() {
+    void shouldReturn200AndClientInfoResponseForValidClient() throws IOException {
+        String sessionId = "some-session-id";
+        String clientSessionId = "some-client-session-id";
+        redis.createSession(sessionId);
         var response =
                 makeRequest(
-                        Optional.empty(), Collections.EMPTY_MAP, constructQueryStringParameters());
+                        Optional.empty(),
+                        constructHeaders(
+                                Optional.of(buildSessionCookie(sessionId, clientSessionId))),
+                        constructQueryStringParameters());
 
         assertThat(response, hasStatus(302));
         assertThat(

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVTokenService.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVTokenService.java
@@ -1,5 +1,7 @@
 package uk.gov.di.authentication.ipv.services;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
@@ -11,9 +13,11 @@ import com.nimbusds.oauth2.sdk.auth.JWTAuthenticationClaimsSet;
 import com.nimbusds.oauth2.sdk.auth.PrivateKeyJWT;
 import com.nimbusds.oauth2.sdk.id.Audience;
 import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.token.AccessToken;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.RedisConnectionService;
 
 import java.io.IOException;
 import java.security.KeyPairGenerator;
@@ -31,11 +35,16 @@ import static uk.gov.di.authentication.shared.helpers.ConstructUriHelper.buildUR
 public class IPVTokenService {
 
     private final ConfigurationService configurationService;
+    private final RedisConnectionService redisConnectionService;
     private static final String TOKEN_PATH = "token";
+    public static final String IPV_ACCESS_TOKEN_PREFIX = "IPV_ACCESS_TOKEN:";
     private static final Logger LOG = LogManager.getLogger(IPVTokenService.class);
 
-    public IPVTokenService(ConfigurationService configurationService) {
+    public IPVTokenService(
+            ConfigurationService configurationService,
+            RedisConnectionService redisConnectionService) {
         this.configurationService = configurationService;
+        this.redisConnectionService = redisConnectionService;
     }
 
     public TokenRequest constructTokenRequest(String authCode) {
@@ -67,6 +76,18 @@ public class IPVTokenService {
             throw new RuntimeException(e);
         } catch (ParseException e) {
             LOG.error("Error whilst parsing TokenResponse", e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void saveAccessTokenToRedis(AccessToken accessToken, String sessionId) {
+        try {
+            redisConnectionService.saveWithExpiry(
+                    IPV_ACCESS_TOKEN_PREFIX + sessionId,
+                    new ObjectMapper().writeValueAsString(accessToken),
+                    configurationService.getAccessTokenExpiry());
+        } catch (JsonProcessingException e) {
+            LOG.error("Unable to save access token to Redis");
             throw new RuntimeException(e);
         }
     }

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVTokenServiceTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVTokenServiceTest.java
@@ -1,23 +1,32 @@
 package uk.gov.di.authentication.ipv.services;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import com.nimbusds.oauth2.sdk.TokenRequest;
 import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.token.AccessToken;
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.RedisConnectionService;
 
 import java.net.URI;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.ipv.services.IPVTokenService.IPV_ACCESS_TOKEN_PREFIX;
 import static uk.gov.di.authentication.shared.helpers.ConstructUriHelper.buildURI;
 
 class IPVTokenServiceTest {
 
     private final ConfigurationService configService = mock(ConfigurationService.class);
+    private final RedisConnectionService redisConnectionService =
+            mock(RedisConnectionService.class);
     private static final URI IPV_URI = URI.create("http://ipv");
     private static final ClientID CLIENT_ID = new ClientID("some-client-id");
     private static final AuthorizationCode AUTH_CODE = new AuthorizationCode();
@@ -25,9 +34,10 @@ class IPVTokenServiceTest {
 
     @BeforeEach
     void setUp() {
-        ipvTokenService = new IPVTokenService(configService);
+        ipvTokenService = new IPVTokenService(configService, redisConnectionService);
         when(configService.getIPVAuthorisationURI()).thenReturn(IPV_URI);
         when(configService.getIPVAuthorisationClientId()).thenReturn(CLIENT_ID.getValue());
+        when(configService.getAccessTokenExpiry()).thenReturn(300L);
     }
 
     @Test
@@ -41,5 +51,18 @@ class IPVTokenServiceTest {
         assertThat(
                 tokenRequest.getClientAuthentication().getMethod().getValue(),
                 equalTo("private_key_jwt"));
+    }
+
+    @Test
+    void shouldCallRedisWhenSavingAccessToken() throws JsonProcessingException {
+        AccessToken accessToken = new BearerAccessToken();
+        String sessionID = "session-id";
+        ipvTokenService.saveAccessTokenToRedis(accessToken, sessionID);
+
+        verify(redisConnectionService)
+                .saveWithExpiry(
+                        IPV_ACCESS_TOKEN_PREFIX + sessionID,
+                        new ObjectMapper().writeValueAsString(accessToken),
+                        300L);
     }
 }


### PR DESCRIPTION
## What?

- Once we have retrieved the AccessToken from the token endpoint then save it to Redis. Create a new prefix for the key of value `IPV_ACCESS_TOKEN:` along with the session-id which we will pull from the users cookie. Store the access token for 3 minutes.


## Why?

- So we can use the access token later to retrieve the users information from IPV 