### PR TITLE
GOVSI-1166 - Store and validate state param for IPV journey

### DIFF
--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandler.java
@@ -16,7 +16,7 @@ import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.ipv.domain.IPVAuditableEvent;
 import uk.gov.di.authentication.ipv.entity.IPVAuthorisationRequest;
 import uk.gov.di.authentication.ipv.entity.IPVAuthorisationResponse;
-import uk.gov.di.authentication.ipv.services.AuthorisationResponseService;
+import uk.gov.di.authentication.ipv.services.IPVAuthorisationService;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.SessionAction;
@@ -48,7 +48,7 @@ public class IPVAuthorisationHandler extends BaseFrontendHandler<IPVAuthorisatio
 
     private static final String IPV_AUTHORIZE_ROUTE = "/authorize";
     private final AuditService auditService;
-    private final AuthorisationResponseService authorisationService;
+    private final IPVAuthorisationService authorisationService;
     private final StateMachine<SessionState, SessionAction, UserContext> stateMachine =
             userJourneyStateMachine();
 
@@ -59,7 +59,7 @@ public class IPVAuthorisationHandler extends BaseFrontendHandler<IPVAuthorisatio
             ClientService clientService,
             AuthenticationService authenticationService,
             AuditService auditService,
-            AuthorisationResponseService authorisationService) {
+            IPVAuthorisationService authorisationService) {
         super(
                 IPVAuthorisationRequest.class,
                 configurationService,
@@ -79,7 +79,7 @@ public class IPVAuthorisationHandler extends BaseFrontendHandler<IPVAuthorisatio
         super(IPVAuthorisationRequest.class, configurationService);
         this.auditService = new AuditService(configurationService);
         this.authorisationService =
-                new AuthorisationResponseService(
+                new IPVAuthorisationService(
                         configurationService, new RedisConnectionService(configurationService));
     }
 

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -62,16 +62,6 @@ public class IPVCallbackHandler
                 .orElseGet(
                         () -> {
                             LOG.info("Request received to IPVCallbackHandler");
-                            Optional<ErrorObject> errorObject =
-                                    responseService.validateResponse(
-                                            input.getQueryStringParameters());
-                            if (errorObject.isPresent()) {
-                                LOG.error(
-                                        "Error in IPV AuthorisationResponse. ErrorCode: {}. ErrorDescription: {}",
-                                        errorObject.get().getCode(),
-                                        errorObject.get().getDescription());
-                                throw new RuntimeException("Error in IPV AuthorisationResponse");
-                            }
                             CookieHelper.SessionCookieIds sessionCookieIds;
                             try {
                                 sessionCookieIds =
@@ -80,6 +70,17 @@ public class IPVCallbackHandler
                             } catch (NoSuchElementException e) {
                                 LOG.error("SessionID not found in cookie");
                                 throw new RuntimeException(e);
+                            }
+                            Optional<ErrorObject> errorObject =
+                                    responseService.validateResponse(
+                                            input.getQueryStringParameters(),
+                                            sessionCookieIds.getSessionId());
+                            if (errorObject.isPresent()) {
+                                LOG.error(
+                                        "Error in IPV AuthorisationResponse. ErrorCode: {}. ErrorDescription: {}",
+                                        errorObject.get().getCode(),
+                                        errorObject.get().getDescription());
+                                throw new RuntimeException("Error in IPV AuthorisationResponse");
                             }
                             TokenRequest tokenRequest =
                                     ipvTokenService.constructTokenRequest(

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -10,7 +10,7 @@ import com.nimbusds.oauth2.sdk.TokenResponse;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import uk.gov.di.authentication.ipv.services.AuthorisationResponseService;
+import uk.gov.di.authentication.ipv.services.IPVAuthorisationService;
 import uk.gov.di.authentication.ipv.services.IPVTokenService;
 import uk.gov.di.authentication.shared.entity.ResponseHeaders;
 import uk.gov.di.authentication.shared.helpers.CookieHelper;
@@ -29,7 +29,7 @@ public class IPVCallbackHandler
 
     private static final Logger LOG = LogManager.getLogger(IPVCallbackHandler.class);
     private final ConfigurationService configurationService;
-    private final AuthorisationResponseService responseService;
+    private final IPVAuthorisationService ipvAuthorisationService;
     private final IPVTokenService ipvTokenService;
 
     public IPVCallbackHandler() {
@@ -38,17 +38,17 @@ public class IPVCallbackHandler
 
     public IPVCallbackHandler(
             ConfigurationService configurationService,
-            AuthorisationResponseService responseService,
+            IPVAuthorisationService responseService,
             IPVTokenService ipvTokenService) {
         this.configurationService = configurationService;
-        this.responseService = responseService;
+        this.ipvAuthorisationService = responseService;
         this.ipvTokenService = ipvTokenService;
     }
 
     public IPVCallbackHandler(ConfigurationService configurationService) {
         this.configurationService = configurationService;
-        this.responseService =
-                new AuthorisationResponseService(
+        this.ipvAuthorisationService =
+                new IPVAuthorisationService(
                         configurationService, new RedisConnectionService(configurationService));
         this.ipvTokenService =
                 new IPVTokenService(
@@ -72,7 +72,7 @@ public class IPVCallbackHandler
                                 throw new RuntimeException(e);
                             }
                             Optional<ErrorObject> errorObject =
-                                    responseService.validateResponse(
+                                    ipvAuthorisationService.validateResponse(
                                             input.getQueryStringParameters(),
                                             sessionCookieIds.getSessionId());
                             if (errorObject.isPresent()) {

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -47,7 +47,9 @@ public class IPVCallbackHandler
 
     public IPVCallbackHandler(ConfigurationService configurationService) {
         this.configurationService = configurationService;
-        this.responseService = new AuthorisationResponseService();
+        this.responseService =
+                new AuthorisationResponseService(
+                        configurationService, new RedisConnectionService(configurationService));
         this.ipvTokenService =
                 new IPVTokenService(
                         configurationService, new RedisConnectionService(configurationService));

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationService.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationService.java
@@ -13,14 +13,14 @@ import uk.gov.di.authentication.shared.services.RedisConnectionService;
 import java.util.Map;
 import java.util.Optional;
 
-public class AuthorisationResponseService {
+public class IPVAuthorisationService {
 
-    private static final Logger LOG = LogManager.getLogger(AuthorisationResponseService.class);
+    private static final Logger LOG = LogManager.getLogger(IPVAuthorisationService.class);
     private final ConfigurationService configurationService;
     private final RedisConnectionService redisConnectionService;
     public static final String STATE_STORAGE_PREFIX = "state:";
 
-    public AuthorisationResponseService(
+    public IPVAuthorisationService(
             ConfigurationService configurationService,
             RedisConnectionService redisConnectionService) {
         this.configurationService = configurationService;

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandlerTest.java
@@ -15,7 +15,7 @@ import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.ipv.entity.IPVAuthorisationResponse;
-import uk.gov.di.authentication.ipv.services.AuthorisationResponseService;
+import uk.gov.di.authentication.ipv.services.IPVAuthorisationService;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.SessionState;
@@ -66,8 +66,7 @@ public class IPVAuthorisationHandlerTest {
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
     private final ClientService clientService = mock(ClientService.class);
     private final AuditService auditService = mock(AuditService.class);
-    private AuthorisationResponseService authorisationService =
-            mock(AuthorisationResponseService.class);
+    private IPVAuthorisationService authorisationService = mock(IPVAuthorisationService.class);
 
     private IPVAuthorisationHandler handler;
 

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandlerTest.java
@@ -15,6 +15,7 @@ import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.ipv.entity.IPVAuthorisationResponse;
+import uk.gov.di.authentication.ipv.services.AuthorisationResponseService;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.SessionState;
@@ -35,8 +36,11 @@ import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.sharedtest.helper.RequestEventHelper.contextWithSourceIp;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
@@ -62,6 +66,8 @@ public class IPVAuthorisationHandlerTest {
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
     private final ClientService clientService = mock(ClientService.class);
     private final AuditService auditService = mock(AuditService.class);
+    private AuthorisationResponseService authorisationService =
+            mock(AuthorisationResponseService.class);
 
     private IPVAuthorisationHandler handler;
 
@@ -76,10 +82,12 @@ public class IPVAuthorisationHandlerTest {
                         clientSessionService,
                         clientService,
                         authenticationService,
-                        auditService);
+                        auditService,
+                        authorisationService);
         when(configService.getIPVAuthorisationClientId()).thenReturn(IPV_CLIENT_ID);
         when(configService.getIPVAuthorisationCallbackURI()).thenReturn(IPV_CALLBACK_URI);
         when(configService.getIPVAuthorisationURI()).thenReturn(IPV_AUTHORISATION_URI);
+        when(configService.getSessionExpiry()).thenReturn(3600L);
     }
 
     @Test
@@ -105,6 +113,7 @@ public class IPVAuthorisationHandlerTest {
 
         assertEquals(body.getSessionState(), SessionState.IPV_REQUIRED);
         assertThat(body.getRedirectUri(), startsWith(IPV_AUTHORISATION_URI + "/authorize"));
+        verify(authorisationService).storeState(eq(session.getSessionId()), any(State.class));
     }
 
     private APIGatewayProxyResponseEvent makeHandlerRequest(APIGatewayProxyRequestEvent event) {

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -13,7 +13,7 @@ import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.oauth2.sdk.token.Tokens;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import uk.gov.di.authentication.ipv.services.AuthorisationResponseService;
+import uk.gov.di.authentication.ipv.services.IPVAuthorisationService;
 import uk.gov.di.authentication.ipv.services.IPVTokenService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
@@ -35,8 +35,7 @@ class IPVCallbackHandlerTest {
 
     private final Context context = mock(Context.class);
     private final ConfigurationService configService = mock(ConfigurationService.class);
-    private final AuthorisationResponseService responseService =
-            mock(AuthorisationResponseService.class);
+    private final IPVAuthorisationService responseService = mock(IPVAuthorisationService.class);
     private final IPVTokenService ipvTokenService = mock(IPVTokenService.class);
     private static final URI LOGIN_URL = URI.create("https://example.com");
     private static final AuthorizationCode AUTH_CODE = new AuthorizationCode();

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -60,7 +60,8 @@ class IPVCallbackHandlerTest {
         Map<String, String> responseHeaders = new HashMap<>();
         responseHeaders.put("code", AUTH_CODE.getValue());
         responseHeaders.put("state", STATE.getValue());
-        when(responseService.validateResponse(responseHeaders)).thenReturn(Optional.empty());
+        when(responseService.validateResponse(responseHeaders, SESSION_ID))
+                .thenReturn(Optional.empty());
         when(ipvTokenService.constructTokenRequest(AUTH_CODE.getValue())).thenReturn(tokenRequest);
         when(ipvTokenService.sendTokenRequest(tokenRequest)).thenReturn(successfulTokenResponse);
 
@@ -83,7 +84,7 @@ class IPVCallbackHandlerTest {
         responseHeaders.put("state", STATE.getValue());
         responseHeaders.put("error", errorObject.toString());
 
-        when(responseService.validateResponse(responseHeaders))
+        when(responseService.validateResponse(responseHeaders, SESSION_ID))
                 .thenReturn(Optional.of(new ErrorObject(errorObject.getCode())));
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationResponseServiceTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationResponseServiceTest.java
@@ -1,10 +1,15 @@
 package uk.gov.di.authentication.ipv.services;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.id.State;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.RedisConnectionService;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -13,13 +18,26 @@ import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.ipv.services.AuthorisationResponseService.STATE_STORAGE_PREFIX;
 
 class IPVAuthorisationResponseServiceTest {
 
     private static final AuthorizationCode AUTH_CODE = new AuthorizationCode();
     private static final State STATE = new State();
+    private static final Long SESSION_EXPIRY = 3600L;
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private final RedisConnectionService redisConnectionService =
+            mock(RedisConnectionService.class);
     private final AuthorisationResponseService authorisationResponseService =
-            new AuthorisationResponseService();
+            new AuthorisationResponseService(configurationService, redisConnectionService);
+
+    @BeforeEach
+    void setUp() {
+        when(configurationService.getSessionExpiry()).thenReturn(SESSION_EXPIRY);
+    }
 
     @Test
     void shouldReturnOptionalEmptyWhenNoErrorIsPresent() {
@@ -84,5 +102,17 @@ class IPVAuthorisationResponseServiceTest {
                                 new ErrorObject(
                                         OAuth2Error.INVALID_REQUEST_CODE,
                                         "No code param present in Authorisation response"))));
+    }
+
+    @Test
+    void shouldSaveStateToRedis() throws JsonProcessingException {
+        var sessionId = "session-id";
+        authorisationResponseService.storeState(sessionId, STATE);
+
+        verify(redisConnectionService)
+                .saveWithExpiry(
+                        STATE_STORAGE_PREFIX + sessionId,
+                        new ObjectMapper().writeValueAsString(STATE),
+                        SESSION_EXPIRY);
     }
 }

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationServiceTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationServiceTest.java
@@ -21,9 +21,9 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.authentication.ipv.services.AuthorisationResponseService.STATE_STORAGE_PREFIX;
+import static uk.gov.di.authentication.ipv.services.IPVAuthorisationService.STATE_STORAGE_PREFIX;
 
-class IPVAuthorisationResponseServiceTest {
+class IPVAuthorisationServiceTest {
 
     private static final AuthorizationCode AUTH_CODE = new AuthorizationCode();
     private static final State STATE = new State();
@@ -32,8 +32,8 @@ class IPVAuthorisationResponseServiceTest {
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final RedisConnectionService redisConnectionService =
             mock(RedisConnectionService.class);
-    private final AuthorisationResponseService authorisationResponseService =
-            new AuthorisationResponseService(configurationService, redisConnectionService);
+    private final IPVAuthorisationService IPVAuthorisationService =
+            new IPVAuthorisationService(configurationService, redisConnectionService);
 
     @BeforeEach
     void setUp() throws JsonProcessingException {
@@ -49,7 +49,7 @@ class IPVAuthorisationResponseServiceTest {
         responseHeaders.put("state", STATE.getValue());
 
         assertThat(
-                authorisationResponseService.validateResponse(responseHeaders, SESSION_ID),
+                IPVAuthorisationService.validateResponse(responseHeaders, SESSION_ID),
                 equalTo(Optional.empty()));
     }
 
@@ -64,14 +64,14 @@ class IPVAuthorisationResponseServiceTest {
         responseHeaders.put("error", errorObject.toString());
 
         assertThat(
-                authorisationResponseService.validateResponse(responseHeaders, SESSION_ID),
+                IPVAuthorisationService.validateResponse(responseHeaders, SESSION_ID),
                 equalTo(Optional.of(new ErrorObject(errorObject.getCode()))));
     }
 
     @Test
     void shouldReturnErrorObjectWhenResponseContainsNoQueryParams() {
         assertThat(
-                authorisationResponseService.validateResponse(Collections.emptyMap(), SESSION_ID),
+                IPVAuthorisationService.validateResponse(Collections.emptyMap(), SESSION_ID),
                 equalTo(
                         Optional.of(
                                 new ErrorObject(
@@ -85,7 +85,7 @@ class IPVAuthorisationResponseServiceTest {
         responseHeaders.put("code", AUTH_CODE.getValue());
 
         assertThat(
-                authorisationResponseService.validateResponse(responseHeaders, SESSION_ID),
+                IPVAuthorisationService.validateResponse(responseHeaders, SESSION_ID),
                 equalTo(
                         Optional.of(
                                 new ErrorObject(
@@ -99,7 +99,7 @@ class IPVAuthorisationResponseServiceTest {
         responseHeaders.put("state", STATE.getValue());
 
         assertThat(
-                authorisationResponseService.validateResponse(responseHeaders, SESSION_ID),
+                IPVAuthorisationService.validateResponse(responseHeaders, SESSION_ID),
                 equalTo(
                         Optional.of(
                                 new ErrorObject(
@@ -118,7 +118,7 @@ class IPVAuthorisationResponseServiceTest {
         responseHeaders.put("code", AUTH_CODE.getValue());
 
         assertThat(
-                authorisationResponseService.validateResponse(responseHeaders, SESSION_ID),
+                IPVAuthorisationService.validateResponse(responseHeaders, SESSION_ID),
                 equalTo(
                         Optional.of(
                                 new ErrorObject(
@@ -129,7 +129,7 @@ class IPVAuthorisationResponseServiceTest {
     @Test
     void shouldSaveStateToRedis() throws JsonProcessingException {
         var sessionId = "session-id";
-        authorisationResponseService.storeState(sessionId, STATE);
+        IPVAuthorisationService.storeState(sessionId, STATE);
 
         verify(redisConnectionService)
                 .saveWithExpiry(

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
@@ -2,6 +2,7 @@ package uk.gov.di.authentication.sharedtest.extensions;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.oauth2.sdk.id.State;
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.api.StatefulRedisConnection;
@@ -60,6 +61,10 @@ public class RedisExtension
 
     public String createSession() throws IOException {
         return createSession(IdGenerator.generate());
+    }
+
+    public void addStateToRedis(State state, String sessionId) throws JsonProcessingException {
+        redis.saveWithExpiry("state:" + sessionId, objectMapper.writeValueAsString(state), 3600);
     }
 
     public void addAuthRequestToSession(


### PR DESCRIPTION
## What?

- Store the state query param used for IPV in Redis against a prefix and the session-id as we know we will have the session-id available to us from the cookie when we receive the response. This is stored for 60 minutes but will be overwritten if a new request is made in the session. 
- Validate the State in the IPV AuthorisationResponse
- Rename the AuthorisationResponseService to IPVAuthorisationService

## Why?

- We send a state param in the authorization request to IPV. We expect the state param with the same value in the authorization response. A new state param is generated per request.
- We can use this state param to ensure that when we receive the authorization response from the intended source. If the state param has changed then it may mean that we are a target of a an attack as someone could be trying to forge the response.
- Make the service more generic as it used by the IPVAuthorisationHandler and the IPVCallbackHandler and therefore doesn't just deal with the response. Examples of this include storing the state before the request is sent and then validating the state when we receive the response back from IPV.