### PR TITLE
BAU: Force dependency resolution of Log4j2 to recent version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,12 @@ subprojects {
         test_runtime
     }
 
+    configurations.all {
+        resolutionStrategy {
+            force 'org.apache.logging.log4j:log4j-api:2.15.0', 'org.apache.logging.log4j:log4j-core:2.15.0'
+        }
+    }
+
     dependencies {
         bouncycastle "org.bouncycastle:bcpkix-jdk15on:1.69"
 


### PR DESCRIPTION
This pins transitive versions of Log4j to a more recent version
