### PR TITLE
aws-lambda-java-log4j2 update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,14 +75,14 @@ subprojects {
 
         lambda "com.amazonaws:aws-lambda-java-core:${dependencyVersions.aws_lambda_core_version}",
                 "com.amazonaws:aws-lambda-java-events:${dependencyVersions.aws_lambda_events_version}",
-                "com.amazonaws:aws-lambda-java-log4j2:1.2.0"
+                "com.amazonaws:aws-lambda-java-log4j2:1.3.0"
 
         lambda_tests "com.amazonaws:aws-lambda-java-tests:1.1.1"
 
         lettuce "org.apache.commons:commons-pool2:2.11.1",
                 "io.lettuce:lettuce-core:6.1.5.RELEASE"
 
-        logging_runtime "com.amazonaws:aws-lambda-java-log4j2:1.2.0",
+        logging_runtime "com.amazonaws:aws-lambda-java-log4j2:1.3.0",
                 "org.slf4j:slf4j-nop:1.7.32"
 
         jackson "com.fasterxml.jackson.core:jackson-core:${dependencyVersions.jackson_version}",


### PR DESCRIPTION
See https://aws.amazon.com/security/security-bulletins/AWS-2021-005/

`Customers using the aws-lambda-java-log4j2 (https://repo1.maven.org/maven2/com/amazonaws/aws-lambda-java-log4j2/) library in their functions will need to update to version 1.3.0 and redeploy.`