### PR TITLE
GOVSI-1166 - Add redirect_uri to the Token Request

### DIFF
--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -8,16 +8,17 @@ module "ipv-callback" {
   environment     = var.environment
 
   handler_environment_variables = {
-    ENVIRONMENT                 = var.environment
-    BASE_URL                    = local.frontend_api_base_url
-    EVENTS_SNS_TOPIC_ARN        = aws_sns_topic.events.arn
-    AUDIT_SIGNING_KEY_ALIAS     = local.audit_signing_key_alias_name
-    LOGIN_URI                   = module.dns.frontend_url
-    LOCALSTACK_ENDPOINT         = var.use_localstack ? var.localstack_endpoint : null
-    REDIS_KEY                   = local.redis_key
-    DYNAMO_ENDPOINT             = var.use_localstack ? var.lambda_dynamo_endpoint : null
-    IPV_AUTHORISATION_CLIENT_ID = var.ipv_authorisation_client_id
-    IPV_AUTHORISATION_URI       = var.ipv_authorisation_uri
+    ENVIRONMENT                    = var.environment
+    BASE_URL                       = local.frontend_api_base_url
+    EVENTS_SNS_TOPIC_ARN           = aws_sns_topic.events.arn
+    AUDIT_SIGNING_KEY_ALIAS        = local.audit_signing_key_alias_name
+    LOGIN_URI                      = module.dns.frontend_url
+    LOCALSTACK_ENDPOINT            = var.use_localstack ? var.localstack_endpoint : null
+    REDIS_KEY                      = local.redis_key
+    DYNAMO_ENDPOINT                = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    IPV_AUTHORISATION_CLIENT_ID    = var.ipv_authorisation_client_id
+    IPV_AUTHORISATION_CALLBACK_URI = var.ipv_authorisation_callback_uri
+    IPV_AUTHORISATION_URI          = var.ipv_authorisation_uri
   }
   handler_function_name = "uk.gov.di.authentication.ipv.lambda.IPVCallbackHandler::handleRequest"
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
@@ -88,5 +88,10 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
         public String getIPVAuthorisationClientId() {
             return "ipv-client-id";
         }
+
+        @Override
+        public URI getIPVAuthorisationCallbackURI() {
+            return URI.create("http://localhost/redirect");
+        }
     }
 }

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationService.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationService.java
@@ -64,7 +64,6 @@ public class IPVAuthorisationService {
 
     public void storeState(String sessionId, State state) {
         try {
-            LOG.info("Saving state to Redis: {}", state);
             redisConnectionService.saveWithExpiry(
                     STATE_STORAGE_PREFIX + sessionId,
                     new ObjectMapper().writeValueAsString(state),

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVTokenService.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVTokenService.java
@@ -65,7 +65,13 @@ public class IPVTokenService {
         var extraParams = new HashMap<String, List<String>>();
         extraParams.put(
                 "client_id", singletonList(configurationService.getIPVAuthorisationClientId()));
-        return new TokenRequest(tokenUri, privateKeyJWT, codeGrant, null, null, extraParams);
+        return new TokenRequest(
+                tokenUri,
+                privateKeyJWT,
+                codeGrant,
+                null,
+                singletonList(configurationService.getIPVAuthorisationCallbackURI()),
+                extraParams);
     }
 
     public TokenResponse sendTokenRequest(TokenRequest tokenRequest) {

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVTokenServiceTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVTokenServiceTest.java
@@ -3,6 +3,7 @@ package uk.gov.di.authentication.ipv.services;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import com.nimbusds.oauth2.sdk.GrantType;
 import com.nimbusds.oauth2.sdk.TokenRequest;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
@@ -28,6 +29,7 @@ class IPVTokenServiceTest {
     private final RedisConnectionService redisConnectionService =
             mock(RedisConnectionService.class);
     private static final URI IPV_URI = URI.create("http://ipv");
+    private static final URI REDIRECT_URI = URI.create("http://redirect");
     private static final ClientID CLIENT_ID = new ClientID("some-client-id");
     private static final AuthorizationCode AUTH_CODE = new AuthorizationCode();
     private IPVTokenService ipvTokenService;
@@ -38,19 +40,26 @@ class IPVTokenServiceTest {
         when(configService.getIPVAuthorisationURI()).thenReturn(IPV_URI);
         when(configService.getIPVAuthorisationClientId()).thenReturn(CLIENT_ID.getValue());
         when(configService.getAccessTokenExpiry()).thenReturn(300L);
+        when(configService.getIPVAuthorisationCallbackURI()).thenReturn(REDIRECT_URI);
     }
 
     @Test
     void shouldConstructTokenRequest() {
         TokenRequest tokenRequest = ipvTokenService.constructTokenRequest(AUTH_CODE.getValue());
 
-        assertThat(
-                tokenRequest.getCustomParameters().get("client_id").get(0),
-                equalTo(CLIENT_ID.getValue()));
         assertThat(tokenRequest.getEndpointURI(), equalTo(buildURI(IPV_URI.toString(), "token")));
         assertThat(
                 tokenRequest.getClientAuthentication().getMethod().getValue(),
                 equalTo("private_key_jwt"));
+        assertThat(
+                tokenRequest.toHTTPRequest().getQueryParameters().get("redirect_uri").get(0),
+                equalTo(REDIRECT_URI.toString()));
+        assertThat(
+                tokenRequest.toHTTPRequest().getQueryParameters().get("grant_type").get(0),
+                equalTo(GrantType.AUTHORIZATION_CODE.getValue()));
+        assertThat(
+                tokenRequest.toHTTPRequest().getQueryParameters().get("client_id").get(0),
+                equalTo(CLIENT_ID.getValue()));
     }
 
     @Test


### PR DESCRIPTION
## What?

- Add redirect_uri to the Token Request

## Why?

- The Oauth server will perform validation to ensure the redirect_uri sent in the token request is the same as the redirect_uri sent in the auth request. We need to ensure we included the redirect_uri in the token request so the it can be properly validated.