### PR TITLE
GOVSI-1194 - Validate the auth request for claims if they exist

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ValidClaims.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ValidClaims.java
@@ -1,0 +1,21 @@
+package uk.gov.di.authentication.shared.entity;
+
+import com.nimbusds.openid.connect.sdk.claims.ClaimsSetRequest;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class ValidClaims {
+
+    protected static final Collection<ClaimsSetRequest.Entry> allowedClaims =
+            new ClaimsSetRequest().add("name").add("birthdate").add("address").getEntries();
+
+    private ValidClaims() {}
+
+    public static Set<String> getAllowedClaimNames() {
+        return allowedClaims.stream()
+                .map(ClaimsSetRequest.Entry::getClaimName)
+                .collect(Collectors.toSet());
+    }
+}

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/ValidClaimsTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/ValidClaimsTest.java
@@ -1,0 +1,29 @@
+package uk.gov.di.authentication.shared.entity;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ValidClaimsTest {
+
+    static Stream<String> suppportedClaims() {
+        return Stream.of("name", "birthdate", "address");
+    }
+
+    @Test
+    void shouldReturnCorrectNumberOfClaimsSupported() {
+        assertThat(ValidClaims.getAllowedClaimNames().size(), equalTo(3));
+    }
+
+    @ParameterizedTest
+    @MethodSource("suppportedClaims")
+    void shouldReturnNamesOfSupportedClaims(String supportedClaim) {
+        assertTrue(ValidClaims.getAllowedClaimNames().contains(supportedClaim));
+    }
+}


### PR DESCRIPTION
## What?

- Validate the auth request for claims if they exist. If no claims exist then that is fine and they can carry on. 
- We will only return an error to the RP if there are claims present in the auth request and the claims present in the auth request do not match the claims supported

## Why?

- If there are any claims in the authn request then we should validate them against the list of claims we believe will be supported in identity. These values can easily change depending on whether they are supported or not.
- The claim values will later be used in the authorization request sent to IPV.