### PR TITLE
BAU: remove unused localstack services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: docker
       dockerfile: localstack.Dockerfile
     environment:
-      SERVICES: lambda, apigateway, iam, ec2, sqs, s3, sts, kms, sns, ssm
+      SERVICES: iam, ec2, sqs, s3, sts, kms, sns, ssm
       EDGE_PORT: "45678"
       EXTERNAL_HOSTNAME: localhost
       DEFAULT_REGION: eu-west-2


### PR DESCRIPTION
## What?

Remove unused localstack services

## Why?

Not using localstack for lambda and api gateway anymore so can remove.