### PR TITLE
GOVSI-1230: update token handler log levels error -> warn

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
@@ -118,7 +118,7 @@ public class TokenHandler
                             Optional<ErrorObject> invalidRequestParamError =
                                     tokenService.validateTokenRequestParams(input.getBody());
                             if (invalidRequestParamError.isPresent()) {
-                                LOG.error(
+                                LOG.warn(
                                         "Invalid Token Request. ErrorCode: {}. ErrorDescription: {}",
                                         invalidRequestParamError.get().getCode(),
                                         invalidRequestParamError.get().getDescription());
@@ -136,7 +136,7 @@ public class TokenHandler
                             try {
                                 client = clientService.getClient(clientID).orElseThrow();
                             } catch (NoSuchElementException e) {
-                                LOG.error(
+                                LOG.warn(
                                         "Client not found in Client Registry with Client ID {}",
                                         clientID);
                                 return generateApiGatewayProxyResponse(
@@ -164,7 +164,7 @@ public class TokenHandler
                                             tokenUrl,
                                             clientID);
                             if (invalidPrivateKeyJwtError.isPresent()) {
-                                LOG.error(
+                                LOG.warn(
                                         "Private Key JWT is not valid for Client ID: {}", clientID);
                                 return generateApiGatewayProxyResponse(
                                         400,
@@ -190,7 +190,7 @@ public class TokenHandler
                                                 .getExchangeDataForCode(requestBody.get("code"))
                                                 .orElseThrow();
                             } catch (NoSuchElementException e) {
-                                LOG.error("Could not retrieve client session ID from code", e);
+                                LOG.warn("Could not retrieve client session ID from code", e);
                                 return generateApiGatewayProxyResponse(
                                         400,
                                         OAuth2Error.INVALID_GRANT.toJSONObject().toJSONString());
@@ -216,7 +216,7 @@ public class TokenHandler
                                     .getRedirectionURI()
                                     .toString()
                                     .equals(requestBody.get("redirect_uri"))) {
-                                LOG.error(
+                                LOG.warn(
                                         "Redirect URI for auth request ({}) does not match redirect URI for request body ({})",
                                         authRequest.getRedirectionURI(),
                                         requestBody.get("redirect_uri"));
@@ -308,7 +308,7 @@ public class TokenHandler
             publicSubject = new Subject(signedJwt.getJWTClaimsSet().getSubject());
             scopes = (List<String>) signedJwt.getJWTClaimsSet().getClaim("scope");
         } catch (java.text.ParseException e) {
-            LOG.error("Unable to parse RefreshToken");
+            LOG.warn("Unable to parse RefreshToken");
             return generateApiGatewayProxyResponse(
                     400,
                     new ErrorObject(OAuth2Error.INVALID_GRANT_CODE, "Invalid Refresh token")
@@ -329,7 +329,7 @@ public class TokenHandler
         try {
             tokenStore = new ObjectMapper().readValue(refreshToken.get(), RefreshTokenStore.class);
         } catch (JsonProcessingException | NoSuchElementException | IllegalArgumentException e) {
-            LOG.error("Refresh token not found with given key");
+            LOG.warn("Refresh token not found with given key");
             return generateApiGatewayProxyResponse(
                     400,
                     new ErrorObject(OAuth2Error.INVALID_GRANT_CODE, "Invalid Refresh token")
@@ -337,7 +337,7 @@ public class TokenHandler
                             .toJSONString());
         }
         if (!tokenStore.getRefreshTokens().contains(currentRefreshToken.getValue())) {
-            LOG.error("Refresh token store does not contain Refresh token in request");
+            LOG.warn("Refresh token store does not contain Refresh token in request");
             return generateApiGatewayProxyResponse(
                     400,
                     new ErrorObject(OAuth2Error.INVALID_GRANT_CODE, "Invalid Refresh token")

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenValidationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenValidationService.java
@@ -56,7 +56,7 @@ public class TokenValidationService {
         }
         LOGGER.info("Validating Refresh Token expiry");
         if (hasTokenExpired(refreshToken.getValue())) {
-            LOGGER.error("Refresh token has expired");
+            LOGGER.warn("Refresh token has expired");
             return false;
         }
         return true;
@@ -71,7 +71,7 @@ public class TokenValidationService {
                 return true;
             }
         } catch (java.text.ParseException e) {
-            LOGGER.error("Unable to parse token when checking if expired", e);
+            LOGGER.warn("Unable to parse token when checking if expired", e);
             return true;
         }
         return false;
@@ -85,7 +85,7 @@ public class TokenValidationService {
             JWSVerifier verifier = new ECDSAVerifier(getPublicJwk().toECKey());
             isVerified = signedJwt.verify(verifier);
         } catch (JOSEException | java.text.ParseException e) {
-            LOGGER.error("Unable to validate Signature of Token", e);
+            LOGGER.warn("Unable to validate Signature of Token", e);
             return false;
         }
         return isVerified;
@@ -94,11 +94,11 @@ public class TokenValidationService {
     public boolean validateRefreshTokenScopes(
             List<String> clientScopes, List<String> refreshTokenScopes) {
         if (!clientScopes.containsAll(refreshTokenScopes)) {
-            LOGGER.error("Scopes in Client Registry does not contain all scopes in Refresh Token");
+            LOGGER.warn("Scopes in Client Registry does not contain all scopes in Refresh Token");
             return false;
         }
         if (!refreshTokenScopes.contains(OIDCScopeValue.OFFLINE_ACCESS.getValue())) {
-            LOGGER.error("Scopes in Refresh Token does not contain OFFLINE_ACCESS scope");
+            LOGGER.warn("Scopes in Refresh Token does not contain OFFLINE_ACCESS scope");
             return false;
         }
         return true;


### PR DESCRIPTION
## What?

 Update token handler log levels error -> warn

## Why?

Client side errors (returning 400) should in general be logged as warn rather than error to reduce alert noise.