### PR TITLE
GOVSI-1163: add ipv-capacity handler endpoint and lambda

### DIFF
--- a/ci/terraform/oidc/api-gateway-frontend.tf
+++ b/ci/terraform/oidc/api-gateway-frontend.tf
@@ -60,6 +60,8 @@ resource "aws_api_gateway_deployment" "frontend_deployment" {
       var.ipv_api_enabled ? module.ipv-authorize[0].method_trigger_value : null,
       var.ipv_api_enabled ? module.ipv-callback[0].integration_trigger_value : null,
       var.ipv_api_enabled ? module.ipv-callback[0].method_trigger_value : null,
+      var.ipv_api_enabled ? module.ipv-capacity[0].integration_trigger_value : null,
+      var.ipv_api_enabled ? module.ipv-capacity[0].method_trigger_value : null,
     ]))
   }
 

--- a/ci/terraform/oidc/ipv-capacity.tf
+++ b/ci/terraform/oidc/ipv-capacity.tf
@@ -1,0 +1,54 @@
+module "ipv-capacity" {
+  count  = var.ipv_api_enabled ? 1 : 0
+  source = "../modules/endpoint-module"
+
+  endpoint_name   = "ipv-capacity"
+  path_part       = "ipv-capacity"
+  endpoint_method = "GET"
+  environment     = var.environment
+
+  handler_environment_variables = {
+    ENVIRONMENT                    = var.environment
+    BASE_URL                       = local.frontend_api_base_url
+    EVENTS_SNS_TOPIC_ARN           = aws_sns_topic.events.arn
+    AUDIT_SIGNING_KEY_ALIAS        = local.audit_signing_key_alias_name
+    LOCALSTACK_ENDPOINT            = var.use_localstack ? var.localstack_endpoint : null
+    REDIS_KEY                      = local.redis_key
+    DYNAMO_ENDPOINT                = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    IPV_AUTHORISATION_URI          = var.ipv_authorisation_uri
+    IPV_AUTHORISATION_CALLBACK_URI = var.ipv_authorisation_callback_uri
+    IPV_AUTHORISATION_CLIENT_ID    = var.ipv_authorisation_client_id
+  }
+  handler_function_name = "uk.gov.di.authentication.ipv.lambda.IPVCapacityHandler::handleRequest"
+
+  create_endpoint                        = true
+  rest_api_id                            = aws_api_gateway_rest_api.di_authentication_frontend_api.id
+  root_resource_id                       = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
+  execution_arn                          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
+  lambda_zip_file                        = var.ipv_api_lambda_zip_file
+  authentication_vpc_arn                 = local.authentication_vpc_arn
+  security_group_id                      = local.authentication_security_group_id
+  subnet_id                              = local.authentication_subnet_ids
+  lambda_role_arn                        = module.oidc_default_role.arn
+  logging_endpoint_enabled               = var.logging_endpoint_enabled
+  logging_endpoint_arn                   = var.logging_endpoint_arn
+  cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  cloudwatch_log_retention               = var.cloudwatch_log_retention
+  lambda_env_vars_encryption_kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn
+  default_tags                           = local.default_tags
+
+  keep_lambda_warm             = var.keep_lambdas_warm
+  warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
+  warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_handler_environment_variables = {
+    LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
+  }
+
+  use_localstack = var.use_localstack
+
+  depends_on = [
+    aws_api_gateway_rest_api.di_authentication_frontend_api,
+    aws_api_gateway_resource.connect_resource,
+    aws_api_gateway_resource.wellknown_resource,
+  ]
+}

--- a/ci/terraform/oidc/lambda-roles.tf
+++ b/ci/terraform/oidc/lambda-roles.tf
@@ -7,14 +7,16 @@ module "oidc_default_role" {
   policies_to_attach = var.use_localstack ? [
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
-    aws_iam_policy.pepper_parameter_policy.arn
+    aws_iam_policy.pepper_parameter_policy.arn,
+    aws_iam_policy.ipv_capacity_parameter_policy.arn,
     ] : [
     aws_iam_policy.oidc_default_id_token_public_key_kms_policy[0].arn,
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy[0].arn,
     aws_iam_policy.dynamo_access_policy[0].arn,
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
-    aws_iam_policy.pepper_parameter_policy.arn
+    aws_iam_policy.pepper_parameter_policy.arn,
+    aws_iam_policy.ipv_capacity_parameter_policy.arn,
   ]
 }
 

--- a/ci/terraform/oidc/shared.tf
+++ b/ci/terraform/oidc/shared.tf
@@ -31,4 +31,5 @@ locals {
   lambda_parameter_encryption_alias_id   = data.terraform_remote_state.shared.outputs.lambda_parameter_encryption_alias_id
   redis_ssm_parameter_policy             = data.terraform_remote_state.shared.outputs.redis_ssm_parameter_policy
   pepper_ssm_parameter_policy            = data.terraform_remote_state.shared.outputs.pepper_ssm_parameter_policy
+  ipv_capacity_ssm_parameter_policy      = data.terraform_remote_state.shared.outputs.ipv_capacity_ssm_parameter_policy
 }

--- a/ci/terraform/oidc/ssm.tf
+++ b/ci/terraform/oidc/ssm.tf
@@ -19,3 +19,15 @@ resource "aws_iam_policy" "pepper_parameter_policy" {
   path        = "/${var.environment}/lambda-parameters/"
   name_prefix = "pepper-parameter-store-policy"
 }
+
+
+data "aws_iam_policy" "ipv_capacity_parameter_policy" {
+  arn = local.ipv_capacity_ssm_parameter_policy
+}
+
+resource "aws_iam_policy" "ipv_capacity_parameter_policy" {
+  policy      = data.aws_iam_policy.ipv_capacity_parameter_policy.policy
+  path        = "/${var.environment}/lambda-parameters/"
+  name_prefix = "ipv-capacity-parameter-store-policy"
+}
+

--- a/ci/terraform/shared/outputs.tf
+++ b/ci/terraform/shared/outputs.tf
@@ -117,3 +117,7 @@ output "redis_ssm_parameter_policy" {
 output "pepper_ssm_parameter_policy" {
   value = aws_iam_policy.pepper_parameter_policy.arn
 }
+
+output "ipv_capacity_ssm_parameter_policy" {
+  value = aws_iam_policy.ipv_capacity_parameter_policy.arn
+}

--- a/ci/terraform/shared/ssm.tf
+++ b/ci/terraform/shared/ssm.tf
@@ -83,6 +83,12 @@ resource "aws_ssm_parameter" "password_pepper" {
   value  = var.password_pepper
 }
 
+resource "aws_ssm_parameter" "ipv-capacity" {
+  name  = "${var.environment}-ipv-capacity"
+  type  = "String"
+  value = "0"
+}
+
 data "aws_iam_policy_document" "redis_parameter_policy" {
   statement {
     sid    = "AllowGetParameters"
@@ -174,5 +180,32 @@ resource "aws_iam_policy" "pepper_parameter_policy" {
 
 resource "aws_iam_role_policy_attachment" "lambda_iam_role_pepper_parameters" {
   policy_arn = aws_iam_policy.pepper_parameter_policy.arn
+  role       = aws_iam_role.lambda_iam_role.name
+}
+
+data "aws_iam_policy_document" "ipv_capacity_parameter_policy_document" {
+  statement {
+    sid    = "AllowGetParameters"
+    effect = "Allow"
+
+    actions = [
+      "ssm:GetParameter",
+      "ssm:GetParameters",
+    ]
+
+    resources = [
+      aws_ssm_parameter.ipv-capacity.arn
+    ]
+  }
+}
+
+resource "aws_iam_policy" "ipv_capacity_parameter_policy" {
+  policy      = data.aws_iam_policy_document.ipv_capacity_parameter_policy_document.json
+  path        = "/${var.environment}/lambda-parameters/"
+  name_prefix = "ipv-capacity-parameter-store-policy"
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_iam_role_ipv_capacity_parameters" {
+  policy_arn = aws_iam_policy.ipv_capacity_parameter_policy.arn
   role       = aws_iam_role.lambda_iam_role.name
 }

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/domain/IPVAuditableEvent.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/domain/IPVAuditableEvent.java
@@ -3,5 +3,6 @@ package uk.gov.di.authentication.ipv.domain;
 import uk.gov.di.authentication.shared.domain.AuditableEvent;
 
 public enum IPVAuditableEvent implements AuditableEvent {
-    IPV_AUTHORISATION_REQUESTED
+    IPV_AUTHORISATION_REQUESTED,
+    IPV_CAPACITY_REQUESTED
 }

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCapacityHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCapacityHandler.java
@@ -1,0 +1,70 @@
+package uk.gov.di.authentication.ipv.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.ipv.domain.IPVAuditableEvent;
+import uk.gov.di.authentication.ipv.services.IPVCapacityService;
+import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
+import static uk.gov.di.authentication.shared.helpers.WarmerHelper.isWarming;
+
+public class IPVCapacityHandler
+        implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+
+    private static final Logger LOG = LogManager.getLogger(IPVCapacityHandler.class);
+    private final ConfigurationService configurationService;
+    private final IPVCapacityService capacityService;
+    private final AuditService auditService;
+
+    public IPVCapacityHandler() {
+        this(ConfigurationService.getInstance());
+    }
+
+    public IPVCapacityHandler(
+            ConfigurationService configurationService,
+            IPVCapacityService capacityService,
+            AuditService auditService) {
+        this.configurationService = configurationService;
+        this.capacityService = capacityService;
+        this.auditService = auditService;
+    }
+
+    public IPVCapacityHandler(ConfigurationService configurationService) {
+        this.configurationService = configurationService;
+        this.capacityService = new IPVCapacityService(configurationService);
+        this.auditService = new AuditService(configurationService);
+    }
+
+    @Override
+    public APIGatewayProxyResponseEvent handleRequest(
+            APIGatewayProxyRequestEvent input, Context context) {
+        return isWarming(input)
+                .orElseGet(
+                        () -> {
+                            LOG.info("Request received to IPVCapacityHandler");
+                            auditService.submitAuditEvent(
+                                    IPVAuditableEvent.IPV_CAPACITY_REQUESTED,
+                                    context.getAwsRequestId(),
+                                    AuditService.UNKNOWN,
+                                    AuditService.UNKNOWN,
+                                    AuditService.UNKNOWN,
+                                    AuditService.UNKNOWN,
+                                    AuditService.UNKNOWN,
+                                    AuditService.UNKNOWN,
+                                    AuditService.UNKNOWN);
+                            if (capacityService.isIPVCapacityAvailable()) {
+                                LOG.info("IPV Capacity available");
+                                return generateApiGatewayProxyResponse(200, "");
+                            } else {
+                                LOG.warn("IPV Capacity unavailable");
+                                return generateApiGatewayProxyResponse(503, "");
+                            }
+                        });
+    }
+}

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVCapacityService.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVCapacityService.java
@@ -1,0 +1,19 @@
+package uk.gov.di.authentication.ipv.services;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+public class IPVCapacityService {
+
+    private static final Logger LOG = LogManager.getLogger(IPVCapacityService.class);
+    private final ConfigurationService configurationService;
+
+    public IPVCapacityService(ConfigurationService configurationService) {
+        this.configurationService = configurationService;
+    }
+
+    public boolean isIPVCapacityAvailable() {
+        return configurationService.getIPVCapacity().map(c -> c.equals("1")).orElse(false);
+    }
+}

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCapacityHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCapacityHandlerTest.java
@@ -1,0 +1,58 @@
+package uk.gov.di.authentication.ipv.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.ipv.services.IPVCapacityService;
+import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
+
+public class IPVCapacityHandlerTest {
+
+    private final Context context = mock(Context.class);
+    private final ConfigurationService configService = mock(ConfigurationService.class);
+
+    private final AuditService auditService = mock(AuditService.class);
+    private final IPVCapacityService ipvCapacityService = mock(IPVCapacityService.class);
+
+    private IPVCapacityHandler handler;
+
+    @BeforeEach
+    void setup() {
+        handler = new IPVCapacityHandler(configService, ipvCapacityService, auditService);
+    }
+
+    @Test
+    void shouldReturn200WhenIPVCapacityAvailable() throws JsonProcessingException {
+        when(ipvCapacityService.isIPVCapacityAvailable()).thenReturn(true);
+
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        APIGatewayProxyResponseEvent response = makeHandlerRequest(event);
+
+        assertThat(response, hasStatus(200));
+    }
+
+    @Test
+    void shouldReturn503WhenIPVCapacityUnavailable() throws JsonProcessingException {
+        when(ipvCapacityService.isIPVCapacityAvailable()).thenReturn(false);
+
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        APIGatewayProxyResponseEvent response = makeHandlerRequest(event);
+
+        assertThat(response, hasStatus(503));
+    }
+
+    private APIGatewayProxyResponseEvent makeHandlerRequest(APIGatewayProxyRequestEvent event) {
+        var response = handler.handleRequest(event, context);
+
+        return response;
+    }
+}

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVCapacityServiceTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVCapacityServiceTest.java
@@ -1,0 +1,36 @@
+package uk.gov.di.authentication.ipv.services;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class IPVCapacityServiceTest {
+
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private final IPVCapacityService ipvCapacityService =
+            new IPVCapacityService(configurationService);
+
+    @Test
+    void shouldReturnTrueWhenCapacityAvailableFlagIs1() {
+        when(configurationService.getIPVCapacity()).thenReturn(Optional.of("1"));
+        assertThat(ipvCapacityService.isIPVCapacityAvailable(), equalTo(true));
+    }
+
+    @Test
+    void shouldReturnTrueWhenCapacityAvailableFlagIsNot1() {
+        when(configurationService.getIPVCapacity()).thenReturn(Optional.of("hello"));
+        assertThat(ipvCapacityService.isIPVCapacityAvailable(), equalTo(false));
+    }
+
+    @Test
+    void shouldReturnFalseWhenCapacityAvailableFlagIsUnset() {
+        when(configurationService.getIPVCapacity()).thenReturn(Optional.empty());
+        assertThat(ipvCapacityService.isIPVCapacityAvailable(), equalTo(false));
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -233,6 +233,18 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return System.getenv("AUDIT_HMAC_SECRET");
     }
 
+    public Optional<String> getIPVCapacity() {
+        try {
+            var request =
+                    new GetParameterRequest()
+                            .withWithDecryption(true)
+                            .withName(format("{0}-ipv-capacity", getEnvironment()));
+            return Optional.of(getSsmClient().getParameter(request).getParameter().getValue());
+        } catch (ParameterNotFoundException e) {
+            return Optional.empty();
+        }
+    }
+
     private Map<String, String> getSsmRedisParameters() {
         if (ssmRedisParameters == null) {
             var getParametersRequest =


### PR DESCRIPTION
## What?

Add ipv-capacity handler endpoint and lambda.

- An api consumed by a service to determine whether or not IPV capacity is available.
- The handler reads a flag from an SSM variable to see if there is capacity.

## Why?

Allows us to rate limit IPV checks according to supply.
