### PR TITLE
AUTH-1253: log aws request id and psid to logging context

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -46,6 +46,9 @@ import static uk.gov.di.authentication.oidc.entity.RequestParameters.GA;
 import static uk.gov.di.authentication.shared.entity.SessionAction.USER_HAS_STARTED_A_NEW_JOURNEY;
 import static uk.gov.di.authentication.shared.entity.SessionAction.USER_HAS_STARTED_A_NEW_JOURNEY_WITH_LOGIN_REQUIRED;
 import static uk.gov.di.authentication.shared.entity.SessionState.INTERRUPT_STATES;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.AWS_REQUEST_ID;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.PERSISTENT_SESSION_ID;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachLogFieldToLogs;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachSessionIdToLogs;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.updateAttachedSessionIdToLogs;
 import static uk.gov.di.authentication.shared.helpers.WarmerHelper.isWarming;
@@ -112,6 +115,8 @@ public class AuthorisationHandler
                                     ipAddress,
                                     AuditService.UNKNOWN,
                                     persistentSessionId);
+                            attachLogFieldToLogs(PERSISTENT_SESSION_ID, persistentSessionId);
+                            attachLogFieldToLogs(AWS_REQUEST_ID, context.getAwsRequestId());
                             LOGGER.info("Received authentication request");
 
                             Map<String, List<String>> queryStringParameters =

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/logging/LogEventMatcher.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/logging/LogEventMatcher.java
@@ -50,4 +50,22 @@ public class LogEventMatcher {
             }
         };
     }
+
+    public static Matcher<LogEvent> hasContextData(String key, String value) {
+        return new TypeSafeMatcher<>() {
+
+            @Override
+            @SuppressWarnings("unchecked")
+            protected boolean matchesSafely(LogEvent item) {
+                return item.getContextData().containsKey(key)
+                        && item.getContextData().getValue(key).equals(value);
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText(
+                        "a log event with ContextData property [" + key + ", " + value + "]");
+            }
+        };
+    }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/LogLineHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/LogLineHelper.java
@@ -3,19 +3,41 @@ package uk.gov.di.authentication.shared.helpers;
 import org.apache.logging.log4j.ThreadContext;
 import uk.gov.di.authentication.shared.entity.Session;
 
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.SESSION_ID;
+
 public class LogLineHelper {
 
+    public enum LogFieldName {
+        SESSION_ID("sessionId"),
+        PERSISTENT_SESSION_ID("persistentSessionId"),
+        AWS_REQUEST_ID("awsRequestId");
+
+        private String logFieldName;
+
+        LogFieldName(String fieldName) {
+            this.logFieldName = fieldName;
+        }
+
+        String getLogFieldName() {
+            return logFieldName;
+        }
+    }
+
+    public static void attachLogFieldToLogs(LogFieldName logFieldName, String value) {
+        ThreadContext.put(logFieldName.getLogFieldName(), value);
+    }
+
     public static void attachSessionIdToLogs(Session session) {
-        ThreadContext.put("sessionId", session.getSessionId());
+        attachLogFieldToLogs(SESSION_ID, session.getSessionId());
     }
 
     public static void attachSessionIdToLogs(String sessionId) {
-        ThreadContext.put("sessionId", sessionId);
+        attachLogFieldToLogs(SESSION_ID, sessionId);
     }
 
     public static void updateAttachedSessionIdToLogs(String sessionId) {
-        if (ThreadContext.containsKey("sessionId")) {
-            ThreadContext.remove("sessionId");
+        if (ThreadContext.containsKey(SESSION_ID.getLogFieldName())) {
+            ThreadContext.remove(SESSION_ID.getLogFieldName());
         }
         attachSessionIdToLogs(sessionId);
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/PersistentIdHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/PersistentIdHelper.java
@@ -27,4 +27,10 @@ public class PersistentIdHelper {
                 .flatMap(InputSanitiser::sanitiseBase64)
                 .orElse(PERSISTENT_ID_UNKNOWN_VALUE);
     }
+
+    public static String getExistingOrCreateNewPersistentSessionId(Map<String, String> headers) {
+        return CookieHelper.parsePersistentCookie(headers)
+                .flatMap(InputSanitiser::sanitiseBase64)
+                .orElse(IdGenerator.generate());
+    }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthorizationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthorizationService.java
@@ -23,8 +23,7 @@ import uk.gov.di.authentication.shared.entity.ValidClaims;
 import uk.gov.di.authentication.shared.entity.ValidScopes;
 import uk.gov.di.authentication.shared.entity.VectorOfTrust;
 import uk.gov.di.authentication.shared.exceptions.ClientNotFoundException;
-import uk.gov.di.authentication.shared.helpers.CookieHelper;
-import uk.gov.di.authentication.shared.helpers.IdGenerator;
+import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.net.URI;
@@ -237,7 +236,7 @@ public class AuthorizationService {
     }
 
     public String getExistingOrCreateNewPersistentSessionId(Map<String, String> headers) {
-        return CookieHelper.parsePersistentCookie(headers).orElse(IdGenerator.generate());
+        return PersistentIdHelper.getExistingOrCreateNewPersistentSessionId(headers);
     }
 
     public boolean isValidCookieConsentValue(String cookieConsent) {

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/LogLineHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/LogLineHelperTest.java
@@ -1,0 +1,55 @@
+package uk.gov.di.authentication.shared.helpers;
+
+import org.apache.logging.log4j.ThreadContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.entity.Session;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.SESSION_ID;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachLogFieldToLogs;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachSessionIdToLogs;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.updateAttachedSessionIdToLogs;
+
+class LogLineHelperTest {
+
+    @BeforeEach
+    void setup() {
+        ThreadContext.clearAll();
+    }
+
+    @Test
+    void shouldAttachSessionIdToThreadContextUsingAttachLogField() {
+        attachLogFieldToLogs(SESSION_ID, "session-id");
+
+        assertTrue(ThreadContext.containsKey(SESSION_ID.getLogFieldName()));
+        assertEquals("session-id", ThreadContext.get(SESSION_ID.getLogFieldName()));
+    }
+
+    @Test
+    void shouldAttachSessionIdToThreadContextUsingString() {
+        attachSessionIdToLogs("session-id");
+
+        assertTrue(ThreadContext.containsKey(SESSION_ID.getLogFieldName()));
+        assertEquals("session-id", ThreadContext.get(SESSION_ID.getLogFieldName()));
+    }
+
+    @Test
+    void shouldAttachSessionIdToThreadContextUsingSession() {
+        attachSessionIdToLogs(new Session("session-id"));
+
+        assertTrue(ThreadContext.containsKey(SESSION_ID.getLogFieldName()));
+        assertEquals("session-id", ThreadContext.get(SESSION_ID.getLogFieldName()));
+    }
+
+    @Test
+    void shouldUpdateAttachedSessionIdToThreadContext() {
+        attachSessionIdToLogs("session-id");
+        updateAttachedSessionIdToLogs("updated-session-id");
+
+        assertTrue(ThreadContext.containsKey(SESSION_ID.getLogFieldName()));
+        assertEquals(1, ThreadContext.getContext().size());
+        assertEquals("updated-session-id", ThreadContext.get(SESSION_ID.getLogFieldName()));
+    }
+}

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/PersistentIdHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/PersistentIdHelperTest.java
@@ -2,12 +2,14 @@ package uk.gov.di.authentication.shared.helpers;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
 
 class PersistentIdHelperTest {
 
@@ -56,5 +58,28 @@ class PersistentIdHelperTest {
         String persistentId = PersistentIdHelper.extractPersistentIdFromCookieHeader(inputHeaders);
 
         assertThat(persistentId, equalTo(PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE));
+    }
+
+    @Test
+    void shouldReturnExistingPersistentIdFromGetExistingOrCreateWhenExists() {
+        String cookieString =
+                "Version=1; di-persistent-session-id=a-persistent-id;gs=session-id.456;cookies_preferences_set={\"analytics\":true};name=ts";
+        Map<String, String> inputHeaders = Map.of(CookieHelper.REQUEST_COOKIE_HEADER, cookieString);
+        String persistentId =
+                PersistentIdHelper.getExistingOrCreateNewPersistentSessionId(inputHeaders);
+
+        assertThat(persistentId, equalTo("a-persistent-id"));
+    }
+
+    @Test
+    void shouldGenerateNewPersistentIdFromGetExistingOrCreateWhenMissing() {
+        String cookieString =
+                "Version=1; gs=session-id.456;cookies_preferences_set={\"analytics\":true};name=ts";
+        Map<String, String> inputHeaders = Map.of(CookieHelper.REQUEST_COOKIE_HEADER, cookieString);
+        String persistentId =
+                PersistentIdHelper.getExistingOrCreateNewPersistentSessionId(inputHeaders);
+
+        assertThat(persistentId, not(equalTo("a-persistent-id")));
+        assertThat(Base64.getUrlDecoder().decode(persistentId).length, equalTo(20));
     }
 }


### PR DESCRIPTION
## What?

Log aws request id and psid to logging context.

## Why?

Use the aws request id to exclude smoke tester traffic from queries and reports.