### PR TITLE
BAU: upgrade to log4j-2.17.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ subprojects {
 
     configurations.all {
         resolutionStrategy {
-            force 'org.apache.logging.log4j:log4j-api:2.16.0', 'org.apache.logging.log4j:log4j-core:2.16.0'
+            force 'org.apache.logging.log4j:log4j-api:2.17.0', 'org.apache.logging.log4j:log4j-core:2.17.0'
         }
     }
 


### PR DESCRIPTION
## What?

Upgrade to log4j-2.17.0

## Why?

Keep on the latest version.

