### PR TITLE
AUTH-1179 - Explicitly configure the maintenance window for ElastiCache

### DIFF
--- a/ci/terraform/account-management/redis.tf
+++ b/ci/terraform/account-management/redis.tf
@@ -32,7 +32,9 @@ resource "aws_elasticache_replication_group" "account_management_sessions_store"
   engine_version                = "6.x"
   parameter_group_name          = "default.redis6.x"
   port                          = 6379
-  multi_az_enabled              = true
+  maintenance_window            = "mon:02:00-mon:03:00"
+
+  multi_az_enabled = true
 
   at_rest_encryption_enabled = true
   transit_encryption_enabled = true

--- a/ci/terraform/shared/redis.tf
+++ b/ci/terraform/shared/redis.tf
@@ -33,6 +33,7 @@ resource "aws_elasticache_replication_group" "sessions_store" {
   parameter_group_name          = "default.redis6.x"
   port                          = 6379
   multi_az_enabled              = true
+  maintenance_window            = "thu:02:00-thu:03:00"
 
   at_rest_encryption_enabled = true
   transit_encryption_enabled = true


### PR DESCRIPTION
## What?

 - Explicitly configure the maintenance window for ElastiCache

## Why?

- Unless stated, ElastiCache will assign you a random 60 minute maintenance window. It is better that we configure this value ourselves for a low traffic time and so we are aware of our own maintenance period.