### PR TITLE
AUTH-1262 - Subscribe our Redis clusters to the alerts SNS topic

### DIFF
--- a/ci/terraform/account-management/redis.tf
+++ b/ci/terraform/account-management/redis.tf
@@ -33,6 +33,7 @@ resource "aws_elasticache_replication_group" "account_management_sessions_store"
   parameter_group_name          = "default.redis6.x"
   port                          = 6379
   maintenance_window            = "mon:02:00-mon:03:00"
+  notification_topic_arn        = data.aws_sns_topic.slack_events.arn
 
   multi_az_enabled = true
 

--- a/ci/terraform/shared/redis.tf
+++ b/ci/terraform/shared/redis.tf
@@ -34,6 +34,7 @@ resource "aws_elasticache_replication_group" "sessions_store" {
   port                          = 6379
   multi_az_enabled              = true
   maintenance_window            = "thu:02:00-thu:03:00"
+  notification_topic_arn        = aws_sns_topic.slack_events.arn
 
   at_rest_encryption_enabled = true
   transit_encryption_enabled = true
@@ -54,5 +55,6 @@ resource "aws_elasticache_replication_group" "sessions_store" {
   depends_on = [
     aws_vpc.authentication,
     aws_subnet.authentication,
+    aws_sns_topic.slack_events,
   ]
 }


### PR DESCRIPTION
## What?

- Subscribe our Redis clusters to the alerts SNS topic
- Use the existing SNS topic in place so we can receive slack messages for any significant events that happen in ElastiCache. The list of events that we will get alerts for are all included here https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/ElastiCacheSNS.html


## Why?

- This will let us know what is happening to our ElastiCache cluster and become aware if any downtime is caused by any ElastiCache events