### PR TITLE
BAU: Rollback to localstack 0.12.*

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,7 @@ updates:
     target-branch: main
     labels:
     - dependabot
+    ignore:
+      - dependency-name: localstack/localstack
+        versions:
+          - ">= 0.13"

--- a/build.gradle
+++ b/build.gradle
@@ -129,7 +129,7 @@ spotless {
 }
 
 dockerCompose {
-    buildBeforeUp = false
+    buildBeforeUp = true
     forceRecreate = false
 
     startedServices = [

--- a/docker/localstack.Dockerfile
+++ b/docker/localstack.Dockerfile
@@ -2,7 +2,7 @@
 #
 # Container used to run tasks requiring Localstack in the build pipeline.
 
-FROM localstack/localstack:0.13.2@sha256:e3a4c6a2a9ba3c34ac4cfeed071785b11919b7a822c1aac3154aa694e2d73854
+FROM localstack/localstack:0.12.20@sha256:ae2c8cbf90ec8dace5d34ff5690b049f030021a0c1a2f8e49bcb8cd6986fae52
 
 COPY localstack/*.sh /docker-entrypoint-initaws.d/
 


### PR DESCRIPTION
## What?

- Roll back from Localstack 0.13 to 0.12 as the former has issues running on M1 dev machines
- Configure dependabot to ignore any releases greater than or equal to 0.13
- Ensure the Gradle Docker Compose plugins triggers a docker image build before running tests (this ensures it picks up the currently configured image rather than using a cached, out of date, version when running locally)

## Why?

There are issues running integration tests on the M1 dev machines using localstack 0.13+. 0.12 works fine.
