### PR TITLE
AUTH-1263: Use context-based logging in `shared` module

### DIFF
--- a/oidc-api/src/main/resources/log4j2.xml
+++ b/oidc-api/src/main/resources/log4j2.xml
@@ -4,6 +4,8 @@
             <JsonLayout compact="true" eventEol="true" objectMessageAsJsonObject="true" >
                 <KeyValuePair key="session-id" value="$${ctx:sessionId:-unknown}"/>
                 <KeyValuePair key="persistent-session-id" value="$${ctx:persistentSessionId:-}"/>
+                <KeyValuePair key="client-session-id" value="$${ctx:clientSessionId:-}"/>
+                <KeyValuePair key="client-id" value="$${ctx:clientId:-}"/>
                 <KeyValuePair key="aws-request-id" value="$${ctx:awsRequestId:-}"/>
             </JsonLayout>
         </Lambda>

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/logging/LogEventMatcher.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/logging/LogEventMatcher.java
@@ -6,6 +6,7 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 
+import java.util.Arrays;
 import java.util.Map;
 
 public class LogEventMatcher {
@@ -65,6 +66,23 @@ public class LogEventMatcher {
             public void describeTo(Description description) {
                 description.appendText(
                         "a log event with ContextData property [" + key + ", " + value + "]");
+            }
+        };
+    }
+
+    public static Matcher<LogEvent> withMessageContaining(String... values) {
+        return new TypeSafeMatcher<>() {
+
+            @Override
+            protected boolean matchesSafely(LogEvent item) {
+                var message = item.getMessage().getFormattedMessage();
+
+                return Arrays.stream(values).anyMatch(message::contains);
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("a log event with message containing [" + Arrays.asList(values) + "]");
             }
         };
     }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/logging/LogEventMatcher.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/logging/LogEventMatcher.java
@@ -82,7 +82,8 @@ public class LogEventMatcher {
 
             @Override
             public void describeTo(Description description) {
-                description.appendText("a log event with message containing [" + Arrays.asList(values) + "]");
+                description.appendText(
+                        "a log event with message containing [" + Arrays.asList(values) + "]");
             }
         };
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/CookieHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/CookieHelper.java
@@ -63,8 +63,6 @@ public class CookieHelper {
         }
         String cookies = headers.get(cookieHeader.get());
 
-        LOG.debug("Cookies: {}", cookies);
-
         String[] cookiesList = cookies.split(";");
         String cookie =
                 Arrays.stream(cookiesList)

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/IpAddressHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/IpAddressHelper.java
@@ -21,8 +21,6 @@ public class IpAddressHelper {
                         .map(APIGatewayProxyRequestEvent::getHeaders)
                         .orElse(emptyMap());
 
-        LOG.info("Headers on request: {}", headers.keySet());
-
         if (headers.containsKey("X-Forwarded-For")) {
             return headers.get("X-Forwarded-For").split(",")[0].trim();
         }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/LogLineHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/LogLineHelper.java
@@ -3,21 +3,24 @@ package uk.gov.di.authentication.shared.helpers;
 import org.apache.logging.log4j.ThreadContext;
 import uk.gov.di.authentication.shared.entity.Session;
 
+import static uk.gov.di.authentication.shared.helpers.InputSanitiser.sanitiseBase64;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.SESSION_ID;
 
 public class LogLineHelper {
 
     public enum LogFieldName {
-        SESSION_ID("sessionId"),
-        CLIENT_SESSION_ID("clientSessionId"),
-        PERSISTENT_SESSION_ID("persistentSessionId"),
-        AWS_REQUEST_ID("awsRequestId"),
-        CLIENT_ID("clientId");
+        SESSION_ID("sessionId", true),
+        CLIENT_SESSION_ID("clientSessionId", true),
+        PERSISTENT_SESSION_ID("persistentSessionId", true),
+        AWS_REQUEST_ID("awsRequestId", false),
+        CLIENT_ID("clientId", true);
 
-        private String logFieldName;
+        private final String logFieldName;
+        private boolean isBase64;
 
-        LogFieldName(String fieldName) {
+        LogFieldName(String fieldName, boolean isBase64) {
             this.logFieldName = fieldName;
+            this.isBase64 = isBase64;
         }
 
         String getLogFieldName() {
@@ -26,7 +29,11 @@ public class LogLineHelper {
     }
 
     public static void attachLogFieldToLogs(LogFieldName logFieldName, String value) {
-        ThreadContext.put(logFieldName.getLogFieldName(), value);
+        if (logFieldName.isBase64 && sanitiseBase64(value).isEmpty()) {
+            ThreadContext.put(logFieldName.getLogFieldName(), "invalid-identifier");
+        } else {
+            ThreadContext.put(logFieldName.getLogFieldName(), value);
+        }
     }
 
     public static void updateAttachedLogFieldToLogs(LogFieldName logFieldName, String value) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/LogLineHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/LogLineHelper.java
@@ -9,8 +9,10 @@ public class LogLineHelper {
 
     public enum LogFieldName {
         SESSION_ID("sessionId"),
+        CLIENT_SESSION_ID("clientSessionId"),
         PERSISTENT_SESSION_ID("persistentSessionId"),
-        AWS_REQUEST_ID("awsRequestId");
+        AWS_REQUEST_ID("awsRequestId"),
+        CLIENT_ID("clientId");
 
         private String logFieldName;
 
@@ -25,6 +27,13 @@ public class LogLineHelper {
 
     public static void attachLogFieldToLogs(LogFieldName logFieldName, String value) {
         ThreadContext.put(logFieldName.getLogFieldName(), value);
+    }
+
+    public static void updateAttachedLogFieldToLogs(LogFieldName logFieldName, String value) {
+        if (ThreadContext.containsKey(logFieldName.getLogFieldName())) {
+            ThreadContext.remove(logFieldName.getLogFieldName());
+        }
+        attachLogFieldToLogs(logFieldName, value);
     }
 
     public static void attachSessionIdToLogs(Session session) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ClientSessionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ClientSessionService.java
@@ -12,6 +12,8 @@ import java.util.Map;
 import java.util.Optional;
 
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.CLIENT_SESSION_ID_HEADER;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.CLIENT_SESSION_ID;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachLogFieldToLogs;
 import static uk.gov.di.authentication.shared.helpers.RequestHeaderHelper.getHeaderValueFromHeaders;
 import static uk.gov.di.authentication.shared.helpers.RequestHeaderHelper.headersContainValidHeader;
 
@@ -45,40 +47,45 @@ public class ClientSessionService {
 
     public String generateClientSession(ClientSession clientSession) {
         String id = IdGenerator.generate();
+
+        attachLogFieldToLogs(CLIENT_SESSION_ID, id);
+
         try {
             redisConnectionService.saveWithExpiry(
                     CLIENT_SESSION_PREFIX.concat(id),
                     objectMapper.writeValueAsString(clientSession),
                     configurationService.getSessionExpiry());
         } catch (JsonProcessingException e) {
-            LOG.error("Error saving client session: {} to Redis", id);
+            LOG.error("Error saving client session to Redis");
             throw new RuntimeException(e);
         }
-        LOG.info("Generated new ClientSession with ID: {}", id);
+        LOG.info("Generated new ClientSession");
         return id;
     }
 
     public ClientSession getClientSession(String clientSessionId) {
+        attachLogFieldToLogs(CLIENT_SESSION_ID, clientSessionId);
+
         try {
             String result =
                     redisConnectionService.getValue(CLIENT_SESSION_PREFIX.concat(clientSessionId));
             return objectMapper.readValue(result, ClientSession.class);
         } catch (JsonProcessingException | IllegalArgumentException e) {
-            LOG.error(
-                    "Error getting client session from Redis with ClientSessionId: {}",
-                    clientSessionId);
+            LOG.error("Error getting client session from Redis");
             throw new RuntimeException(e);
         }
     }
 
     public void saveClientSession(String clientSessionId, ClientSession clientSession) {
+        attachLogFieldToLogs(CLIENT_SESSION_ID, clientSessionId);
+
         try {
             redisConnectionService.saveWithExpiry(
                     CLIENT_SESSION_PREFIX.concat(clientSessionId),
                     objectMapper.writeValueAsString(clientSession),
                     configurationService.getSessionExpiry());
         } catch (JsonProcessingException e) {
-            LOG.error("Error saving client session: {} to Redis", clientSessionId);
+            LOG.error("Error saving client session to Redis");
             throw new RuntimeException(e);
         }
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
@@ -65,6 +65,8 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static uk.gov.di.authentication.shared.helpers.ConstructUriHelper.buildURI;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.CLIENT_ID;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachLogFieldToLogs;
 
 public class TokenService {
 
@@ -242,7 +244,10 @@ public class TokenService {
             Map<String, Object> additionalTokenClaims,
             AccessTokenHash accessTokenHash,
             String vot) {
-        LOG.info("Generating IdToken for ClientId: {}", clientId);
+
+        attachLogFieldToLogs(CLIENT_ID, clientId);
+
+        LOG.info("Generating IdToken");
         URI trustMarkUri = buildURI(configService.getBaseURL().get(), "/trustmark");
         LocalDateTime localDateTime =
                 LocalDateTime.now().plusSeconds(configService.getIDTokenExpiry());
@@ -268,7 +273,10 @@ public class TokenService {
 
     private AccessToken generateAndStoreAccessToken(
             String clientId, Subject internalSubject, List<String> scopes, Subject publicSubject) {
-        LOG.info("Generating AccessToken for ClientId: {}", clientId);
+
+        attachLogFieldToLogs(CLIENT_ID, clientId);
+
+        LOG.info("Generating AccessToken");
         LocalDateTime localDateTime =
                 LocalDateTime.now().plusSeconds(configService.getAccessTokenExpiry());
         Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
@@ -304,7 +312,10 @@ public class TokenService {
 
     private RefreshToken generateAndStoreRefreshToken(
             String clientId, Subject internalSubject, List<String> scopes, Subject publicSubject) {
-        LOG.info("Generating RefreshToken for ClientId: {}", clientId);
+
+        attachLogFieldToLogs(CLIENT_ID, clientId);
+
+        LOG.info("Generating RefreshToken");
         LocalDateTime localDateTime =
                 LocalDateTime.now().plusSeconds(configService.getSessionExpiry());
         Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/LogLineHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/LogLineHelperTest.java
@@ -14,6 +14,8 @@ import static uk.gov.di.authentication.shared.helpers.LogLineHelper.updateAttach
 
 class LogLineHelperTest {
 
+    private final String identifier = IdGenerator.generate();
+
     @BeforeEach
     void setup() {
         ThreadContext.clearAll();
@@ -21,35 +23,47 @@ class LogLineHelperTest {
 
     @Test
     void shouldAttachSessionIdToThreadContextUsingAttachLogField() {
-        attachLogFieldToLogs(SESSION_ID, "session-id");
+        attachLogFieldToLogs(SESSION_ID, identifier);
 
         assertTrue(ThreadContext.containsKey(SESSION_ID.getLogFieldName()));
-        assertEquals("session-id", ThreadContext.get(SESSION_ID.getLogFieldName()));
+        assertEquals(identifier, ThreadContext.get(SESSION_ID.getLogFieldName()));
     }
 
     @Test
     void shouldAttachSessionIdToThreadContextUsingString() {
-        attachSessionIdToLogs("session-id");
+        attachSessionIdToLogs(identifier);
 
         assertTrue(ThreadContext.containsKey(SESSION_ID.getLogFieldName()));
-        assertEquals("session-id", ThreadContext.get(SESSION_ID.getLogFieldName()));
+        assertEquals(identifier, ThreadContext.get(SESSION_ID.getLogFieldName()));
     }
 
     @Test
     void shouldAttachSessionIdToThreadContextUsingSession() {
-        attachSessionIdToLogs(new Session("session-id"));
+        attachSessionIdToLogs(new Session(identifier));
 
         assertTrue(ThreadContext.containsKey(SESSION_ID.getLogFieldName()));
-        assertEquals("session-id", ThreadContext.get(SESSION_ID.getLogFieldName()));
+        assertEquals(identifier, ThreadContext.get(SESSION_ID.getLogFieldName()));
     }
 
     @Test
     void shouldUpdateAttachedSessionIdToThreadContext() {
-        attachSessionIdToLogs("session-id");
-        updateAttachedSessionIdToLogs("updated-session-id");
+        var newIdentifier = IdGenerator.generate();
+
+        attachSessionIdToLogs(identifier);
+        updateAttachedSessionIdToLogs(newIdentifier);
 
         assertTrue(ThreadContext.containsKey(SESSION_ID.getLogFieldName()));
         assertEquals(1, ThreadContext.getContext().size());
-        assertEquals("updated-session-id", ThreadContext.get(SESSION_ID.getLogFieldName()));
+        assertEquals(newIdentifier, ThreadContext.get(SESSION_ID.getLogFieldName()));
+    }
+
+    @Test
+    void shouldLogInvalidParameterIfFormatIsWrong() {
+        var badIdentifier = "not-@-b@se64-identifier";
+
+        attachSessionIdToLogs(badIdentifier);
+
+        assertTrue(ThreadContext.containsKey(SESSION_ID.getLogFieldName()));
+        assertEquals("invalid-identifier", ThreadContext.get(SESSION_ID.getLogFieldName()));
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuthorizationServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuthorizationServiceTest.java
@@ -13,9 +13,11 @@ import com.nimbusds.openid.connect.sdk.Nonce;
 import com.nimbusds.openid.connect.sdk.OIDCClaimsRequest;
 import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import com.nimbusds.openid.connect.sdk.claims.ClaimsSetRequest;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -28,6 +30,7 @@ import uk.gov.di.authentication.shared.entity.VectorOfTrust;
 import uk.gov.di.authentication.shared.exceptions.ClientNotFoundException;
 import uk.gov.di.authentication.shared.helpers.CookieHelper;
 import uk.gov.di.authentication.shared.state.UserContext;
+import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -41,6 +44,8 @@ import static java.lang.String.format;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -48,6 +53,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.sharedtest.helper.JsonArrayHelper.jsonArrayOf;
+import static uk.gov.di.authentication.sharedtest.logging.LogEventMatcher.withMessageContaining;
 
 class AuthorizationServiceTest {
 
@@ -59,9 +65,18 @@ class AuthorizationServiceTest {
     private final DynamoClientService dynamoClientService = mock(DynamoClientService.class);
     private final DynamoService dynamoService = mock(DynamoService.class);
 
+    @RegisterExtension
+    public final CaptureLoggingExtension logging =
+            new CaptureLoggingExtension(AuthorizationService.class);
+
     @BeforeEach
     void setUp() {
         authorizationService = new AuthorizationService(dynamoClientService, dynamoService);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        assertThat(logging.events(), not(hasItem(withMessageContaining(CLIENT_ID.toString()))));
     }
 
     @Test

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/ClientSessionServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/ClientSessionServiceTest.java
@@ -4,9 +4,13 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.VectorOfTrust;
+import uk.gov.di.authentication.shared.helpers.IdGenerator;
+import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
 import java.time.LocalDateTime;
 import java.util.Collections;
@@ -16,11 +20,14 @@ import java.util.Optional;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.sharedtest.logging.LogEventMatcher.withMessageContaining;
 
 class ClientSessionServiceTest {
 
@@ -32,13 +39,27 @@ class ClientSessionServiceTest {
     private final ClientSessionService clientSessionService =
             new ClientSessionService(configuration, redis);
 
+    @RegisterExtension
+    public final CaptureLoggingExtension logging =
+            new CaptureLoggingExtension(ClientSessionService.class);
+
+    private final String clientSessionId = IdGenerator.generate();
+    private final String sessionId = IdGenerator.generate();
+
+    @AfterEach
+    public void tearDown() {
+        assertThat(
+                logging.events(), not(hasItem(withMessageContaining(clientSessionId, sessionId))));
+    }
+
     @Test
     void shouldRetrieveClientSessionUsingRequestHeaders() throws JsonProcessingException {
-        when(redis.getValue("client-session-cs1")).thenReturn(generateSerialisedClientSession());
+        when(redis.getValue("client-session-" + clientSessionId))
+                .thenReturn(generateSerialisedClientSession());
 
         Optional<ClientSession> clientSessionInRedis =
                 clientSessionService.getClientSessionFromRequestHeaders(
-                        Map.of("Session-Id", "session-id", "Client-Session-Id", "cs1"));
+                        Map.of("Session-Id", sessionId, "Client-Session-Id", clientSessionId));
 
         clientSessionInRedis.ifPresentOrElse(
                 clientSession ->
@@ -50,7 +71,7 @@ class ClientSessionServiceTest {
 
     @Test
     void shouldNotRetrieveClientSessionUsingNullRequestHeaders() throws JsonProcessingException {
-        when(redis.getValue("client-session-cs1")).thenReturn(generateSerialisedClientSession());
+        when(redis.getValue(clientSessionId)).thenReturn(generateSerialisedClientSession());
 
         Optional<ClientSession> clientSessionInRedis =
                 clientSessionService.getClientSessionFromRequestHeaders(null);
@@ -60,18 +81,18 @@ class ClientSessionServiceTest {
 
     @Test
     void shouldNotRetrieveClientSessionForLowerCaseHeaderName() throws JsonProcessingException {
-        when(redis.getValue("client-session-cs1")).thenReturn(generateSerialisedClientSession());
+        when(redis.getValue(clientSessionId)).thenReturn(generateSerialisedClientSession());
 
         Optional<ClientSession> clientSessionInRedis =
                 clientSessionService.getClientSessionFromRequestHeaders(
-                        Map.of("Session-Id", "session-id", "client-Session-id", "cs1"));
+                        Map.of("Session-Id", sessionId, "client-Session-id", clientSessionId));
 
         assertTrue(clientSessionInRedis.isEmpty());
     }
 
     @Test
     void shouldNotRetrieveClientSessionWithNoHeaders() throws JsonProcessingException {
-        when(redis.getValue("client-session-cs1")).thenReturn(generateSerialisedClientSession());
+        when(redis.getValue(clientSessionId)).thenReturn(generateSerialisedClientSession());
 
         Optional<ClientSession> clientSessionInRedis =
                 clientSessionService.getClientSessionFromRequestHeaders(Collections.emptyMap());
@@ -81,7 +102,7 @@ class ClientSessionServiceTest {
 
     @Test
     void shouldNotRetrieveClientSessionWithMissingHeader() throws JsonProcessingException {
-        when(redis.getValue("client-session-cs1")).thenReturn(generateSerialisedClientSession());
+        when(redis.getValue(clientSessionId)).thenReturn(generateSerialisedClientSession());
 
         Optional<ClientSession> clientSessionInRedis =
                 clientSessionService.getClientSessionFromRequestHeaders(
@@ -92,7 +113,7 @@ class ClientSessionServiceTest {
 
     @Test
     void shouldNotRetrieveClientSessionAndThrowExceptionIfNotPresentInRedis() {
-        final Map headers = Map.of("Session-Id", "session-id", "Client-Session-Id", "cs1");
+        final Map headers = Map.of("Session-Id", sessionId, "Client-Session-Id", clientSessionId);
 
         RuntimeException exception =
                 assertThrows(

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
@@ -29,14 +29,17 @@ import com.nimbusds.openid.connect.sdk.Nonce;
 import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import com.nimbusds.openid.connect.sdk.OIDCTokenResponse;
 import com.nimbusds.openid.connect.sdk.claims.AccessTokenHash;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.authentication.shared.entity.AccessTokenStore;
 import uk.gov.di.authentication.shared.entity.ClientConsent;
 import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.RefreshTokenStore;
 import uk.gov.di.authentication.shared.entity.ValidScopes;
 import uk.gov.di.authentication.shared.helpers.TokenGeneratorHelper;
+import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
 import java.nio.ByteBuffer;
 import java.security.KeyPair;
@@ -57,6 +60,8 @@ import java.util.Set;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -65,6 +70,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.shared.helpers.ConstructUriHelper.buildURI;
+import static uk.gov.di.authentication.sharedtest.logging.LogEventMatcher.withMessageContaining;
 
 public class TokenServiceTest {
 
@@ -95,6 +101,9 @@ public class TokenServiceTest {
     private static final String REFRESH_TOKEN_PREFIX = "REFRESH_TOKEN:";
     private static final String ACCESS_TOKEN_PREFIX = "ACCESS_TOKEN:";
 
+    @RegisterExtension
+    public final CaptureLoggingExtension logging = new CaptureLoggingExtension(TokenService.class);
+
     @BeforeEach
     public void setUp() {
         Optional<String> baseUrl = Optional.of(BASE_URL);
@@ -103,6 +112,11 @@ public class TokenServiceTest {
         when(configurationService.getIDTokenExpiry()).thenReturn(120L);
         when(configurationService.getSessionExpiry()).thenReturn(300L);
         nonce = new Nonce();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        assertThat(logging.events(), not(hasItem(withMessageContaining(CLIENT_ID))));
     }
 
     @Test

--- a/shared/src/test/java/uk/gov/di/authentication/shared/state/StateMachineTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/state/StateMachineTest.java
@@ -1,6 +1,9 @@
 package uk.gov.di.authentication.shared.state;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
 import java.util.List;
 import java.util.Optional;
@@ -9,6 +12,8 @@ import static java.util.Map.entry;
 import static java.util.Map.ofEntries;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static uk.gov.di.authentication.shared.state.StateMachineTest.Action.ACTION_COMMON_TO_SOME_STATES;
 import static uk.gov.di.authentication.shared.state.StateMachineTest.Action.ACTION_THAT_CAN_OCCUR_AT_ANY_STATE;
@@ -22,6 +27,7 @@ import static uk.gov.di.authentication.shared.state.StateMachineTest.State.STATE
 import static uk.gov.di.authentication.shared.state.StateMachineTest.State.STATE_5;
 import static uk.gov.di.authentication.shared.state.StateMachineTest.State.STATE_6;
 import static uk.gov.di.authentication.shared.state.StateMachineTest.State.STATE_7;
+import static uk.gov.di.authentication.sharedtest.logging.LogEventMatcher.withMessageContaining;
 
 public class StateMachineTest {
 
@@ -43,13 +49,15 @@ public class StateMachineTest {
         ACTION_COMMON_TO_SOME_STATES
     }
 
-    private final Condition<Boolean> testCondition =
-            new Condition<Boolean>() {
-                @Override
-                public boolean isMet(Optional<Boolean> context) {
-                    return context.get().booleanValue();
-                }
-            };
+    private final Condition<Boolean> testCondition = Optional::get;
+
+    @RegisterExtension
+    public final CaptureLoggingExtension logging = new CaptureLoggingExtension(StateMachine.class);
+
+    @AfterEach
+    public void tearDown() {
+        assertThat(logging.events(), not(hasItem(withMessageContaining("unknown"))));
+    }
 
     private final StateMachine<State, Action, Boolean> stateMachine =
             new StateMachine<>(


### PR DESCRIPTION
## What?

Put well-known fields like session id, client session id, etc, into the ThreadContext rather than directly into the message

## Why?

Clean up log lines when searching
