### PR TITLE
AUTH-1228: Assign Security Groups to Restrict Egress from VPC

### DIFF
--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -28,7 +28,7 @@ module "ipv-callback" {
   execution_arn                          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
   lambda_zip_file                        = var.ipv_api_lambda_zip_file
   authentication_vpc_arn                 = local.authentication_vpc_arn
-  security_group_id                      = local.authentication_security_group_id
+  security_group_id                      = local.authentication_egress_security_group_id
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.oidc_default_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled

--- a/ci/terraform/oidc/shared.tf
+++ b/ci/terraform/oidc/shared.tf
@@ -16,20 +16,21 @@ data "terraform_remote_state" "shared" {
 }
 
 locals {
-  redis_key                              = "session"
-  authentication_vpc_arn                 = data.terraform_remote_state.shared.outputs.authentication_vpc_arn
-  authentication_security_group_id       = data.terraform_remote_state.shared.outputs.authentication_security_group_id
-  authentication_subnet_ids              = data.terraform_remote_state.shared.outputs.authentication_subnet_ids
-  id_token_signing_key_alias_name        = data.terraform_remote_state.shared.outputs.id_token_signing_key_alias_name
-  id_token_signing_key_arn               = data.terraform_remote_state.shared.outputs.id_token_signing_key_arn
-  audit_signing_key_alias_name           = data.terraform_remote_state.shared.outputs.audit_signing_key_alias_name
-  audit_signing_key_arn                  = data.terraform_remote_state.shared.outputs.audit_signing_key_arn
-  sms_bucket_name                        = data.terraform_remote_state.shared.outputs.sms_bucket_name
-  lambda_env_vars_encryption_kms_key_arn = data.terraform_remote_state.shared.outputs.lambda_env_vars_encryption_kms_key_arn
-  events_topic_encryption_key_arn        = data.terraform_remote_state.shared.outputs.events_topic_encryption_key_arn
-  lambda_parameter_encryption_key_id     = data.terraform_remote_state.shared.outputs.lambda_parameter_encryption_key_id
-  lambda_parameter_encryption_alias_id   = data.terraform_remote_state.shared.outputs.lambda_parameter_encryption_alias_id
-  redis_ssm_parameter_policy             = data.terraform_remote_state.shared.outputs.redis_ssm_parameter_policy
-  pepper_ssm_parameter_policy            = data.terraform_remote_state.shared.outputs.pepper_ssm_parameter_policy
-  ipv_capacity_ssm_parameter_policy      = data.terraform_remote_state.shared.outputs.ipv_capacity_ssm_parameter_policy
+  redis_key                               = "session"
+  authentication_vpc_arn                  = data.terraform_remote_state.shared.outputs.authentication_vpc_arn
+  authentication_security_group_id        = data.terraform_remote_state.shared.outputs.authentication_security_group_id
+  authentication_egress_security_group_id = data.terraform_remote_state.shared.outputs.authentication_egress_security_group_id
+  authentication_subnet_ids               = data.terraform_remote_state.shared.outputs.authentication_subnet_ids
+  id_token_signing_key_alias_name         = data.terraform_remote_state.shared.outputs.id_token_signing_key_alias_name
+  id_token_signing_key_arn                = data.terraform_remote_state.shared.outputs.id_token_signing_key_arn
+  audit_signing_key_alias_name            = data.terraform_remote_state.shared.outputs.audit_signing_key_alias_name
+  audit_signing_key_arn                   = data.terraform_remote_state.shared.outputs.audit_signing_key_arn
+  sms_bucket_name                         = data.terraform_remote_state.shared.outputs.sms_bucket_name
+  lambda_env_vars_encryption_kms_key_arn  = data.terraform_remote_state.shared.outputs.lambda_env_vars_encryption_kms_key_arn
+  events_topic_encryption_key_arn         = data.terraform_remote_state.shared.outputs.events_topic_encryption_key_arn
+  lambda_parameter_encryption_key_id      = data.terraform_remote_state.shared.outputs.lambda_parameter_encryption_key_id
+  lambda_parameter_encryption_alias_id    = data.terraform_remote_state.shared.outputs.lambda_parameter_encryption_alias_id
+  redis_ssm_parameter_policy              = data.terraform_remote_state.shared.outputs.redis_ssm_parameter_policy
+  pepper_ssm_parameter_policy             = data.terraform_remote_state.shared.outputs.pepper_ssm_parameter_policy
+  ipv_capacity_ssm_parameter_policy       = data.terraform_remote_state.shared.outputs.ipv_capacity_ssm_parameter_policy
 }

--- a/ci/terraform/oidc/sqs.tf
+++ b/ci/terraform/oidc/sqs.tf
@@ -160,7 +160,7 @@ resource "aws_lambda_function" "email_sqs_lambda" {
 
   source_code_hash = filebase64sha256(var.frontend_api_lambda_zip_file)
   vpc_config {
-    security_group_ids = [local.authentication_security_group_id]
+    security_group_ids = [local.authentication_egress_security_group_id]
     subnet_ids         = local.authentication_subnet_ids
   }
   environment {

--- a/ci/terraform/shared/outputs.tf
+++ b/ci/terraform/shared/outputs.tf
@@ -17,7 +17,11 @@ output "authentication_vpc_arn" {
 }
 
 output "authentication_security_group_id" {
-  value = aws_vpc.authentication.default_security_group_id
+  value = aws_security_group.allow_vpc_resources_only.id
+}
+
+output "authentication_egress_security_group_id" {
+  value = aws_security_group.allow_egress.id
 }
 
 output "authentication_subnet_ids" {


### PR DESCRIPTION
## What?

In shared Terraform:
- Change existing security group output from default security group to new 'VPC resources only' group
- Add another output for the security group that allows egress

In OIDC Terraform:
- Pull in new egress allowed security group in `shared.tf` (the existing security group will pick up the changed 'VPC resources only' group).
- Assign the egress security group to the SQS queue processing lambda and the IPV Callback lambda as these both need to egress (all other lambda will pick up the change to the default security group).

## Why?

We wish to restrict which lambdas can egress.

## Related PRs

#1249 