### PR TITLE
AUTH-1228: Add VPC endpoints & new SGs to acct mgmt

### DIFF
--- a/ci/terraform/account-management/redis.tf
+++ b/ci/terraform/account-management/redis.tf
@@ -1,3 +1,7 @@
+locals {
+  redis_port_number = 6379
+}
+
 resource "aws_elasticache_subnet_group" "account_management_sessions_store" {
   count = var.use_localstack ? 0 : 1
 
@@ -31,7 +35,7 @@ resource "aws_elasticache_replication_group" "account_management_sessions_store"
   engine                        = "redis"
   engine_version                = "6.x"
   parameter_group_name          = "default.redis6.x"
-  port                          = 6379
+  port                          = local.redis_port_number
   maintenance_window            = "mon:02:00-mon:03:00"
   notification_topic_arn        = data.aws_sns_topic.slack_events.arn
 
@@ -42,8 +46,11 @@ resource "aws_elasticache_replication_group" "account_management_sessions_store"
   auth_token                 = random_password.redis_password.result
   apply_immediately          = true
 
-  subnet_group_name  = aws_elasticache_subnet_group.account_management_sessions_store[0].name
-  security_group_ids = [aws_vpc.account_management_vpc.default_security_group_id]
+  subnet_group_name = aws_elasticache_subnet_group.account_management_sessions_store[0].name
+  security_group_ids = [
+    aws_vpc.account_management_vpc.default_security_group_id,
+    aws_security_group.redis_security_group.id,
+  ]
 
   lifecycle {
     ignore_changes = [


### PR DESCRIPTION
## What?

- Add missing VPC endpoints for SNS, KMS and SSM to account management VPC
- Add new security group for AWS VPC endpoints that allows incoming HTTPS from the private subnet
- Add new security group for Redis that allows incoming Redis connections from the private subnet
- Add the Redis security group to the Redis cluster
- Add new security group for Lambda that do not need egress (can use VPC endpoints and Redis)
- Add new security group for Lambda that do need egress (can talk to Redis and can make HTTPS to anywhere)

## Why?

We wish to restrict the ability to egress from the VPC to only those lambda that need it. This PR puts the security groups in place, but does not assign the lamba, this will follow in another PR. 

(this PR is similar to #1249 which did the same for the OIDC API VPC)

## Related PRs

#1249 