### PR TITLE
AUTH-1228: Add Lambda VPC endpoint

### DIFF
--- a/ci/terraform/shared/vpc.tf
+++ b/ci/terraform/shared/vpc.tf
@@ -209,6 +209,35 @@ resource "aws_vpc_endpoint_route_table_association" "s3" {
   route_table_id = aws_route_table.private_route_table[count.index].id
 }
 
+data "aws_vpc_endpoint_service" "lambda" {
+  count   = var.use_localstack ? 0 : 1
+  service = "lambda"
+}
+
+resource "aws_vpc_endpoint" "lambda" {
+  count = var.use_localstack ? 0 : 1
+
+  vpc_endpoint_type = "Interface"
+  vpc_id            = aws_vpc.authentication.id
+  service_name      = data.aws_vpc_endpoint_service.lambda[0].service_name
+
+  subnet_ids = aws_subnet.authentication.*.id
+
+  security_group_ids = [
+    aws_vpc.authentication.default_security_group_id,
+    aws_security_group.aws_endpoints.id,
+  ]
+
+  private_dns_enabled = true
+
+  depends_on = [
+    aws_vpc.authentication,
+    aws_subnet.authentication,
+  ]
+
+  tags = local.default_tags
+}
+
 resource "aws_subnet" "authentication_public" {
   count             = var.use_localstack ? 0 : length(data.aws_availability_zones.available.names)
   vpc_id            = aws_vpc.authentication.id


### PR DESCRIPTION
## What?

- The warmers need to talk to the Lambda API, so we need to add that as a VPC endpoint.

## Why?

The warmers are currently timing out as they can't contact the Lambda API, this results in our own API running very slowly which, in turn, is causing acceptance test failures.