### PR TITLE
AUTH-1228: Switch account management lambdas to new security groups

### DIFF
--- a/ci/terraform/account-management/api-gateway.tf
+++ b/ci/terraform/account-management/api-gateway.tf
@@ -85,7 +85,7 @@ resource "aws_lambda_function" "authorizer" {
   timeout          = 30
   memory_size      = 2048
   vpc_config {
-    security_group_ids = [aws_vpc.account_management_vpc.default_security_group_id]
+    security_group_ids = [aws_security_group.allow_vpc_resources_only.id]
     subnet_ids         = aws_subnet.account_management_subnets.*.id
   }
   environment {

--- a/ci/terraform/account-management/authenticate.tf
+++ b/ci/terraform/account-management/authenticate.tf
@@ -20,7 +20,7 @@ module "authenticate" {
   execution_arn                          = aws_api_gateway_rest_api.di_account_management_api.execution_arn
   lambda_zip_file                        = var.lambda_zip_file
   authentication_vpc_arn                 = aws_vpc.account_management_vpc.arn
-  security_group_id                      = aws_vpc.account_management_vpc.default_security_group_id
+  security_group_id                      = aws_security_group.allow_vpc_resources_only.id
   subnet_id                              = aws_subnet.account_management_subnets.*.id
   environment                            = var.environment
   lambda_role_arn                        = module.account_notification_default_role.arn

--- a/ci/terraform/account-management/authoriser-warmer.tf
+++ b/ci/terraform/account-management/authoriser-warmer.tf
@@ -49,7 +49,7 @@ resource "aws_lambda_function" "warmer_function" {
   source_code_hash = filebase64sha256(var.lambda_warmer_zip_file)
 
   vpc_config {
-    security_group_ids = [aws_vpc.account_management_vpc.default_security_group_id]
+    security_group_ids = [aws_security_group.allow_vpc_resources_only.id]
     subnet_ids         = aws_subnet.account_management_subnets.*.id
   }
 

--- a/ci/terraform/account-management/remove-account.tf
+++ b/ci/terraform/account-management/remove-account.tf
@@ -20,7 +20,7 @@ module "delete_account" {
   execution_arn                          = aws_api_gateway_rest_api.di_account_management_api.execution_arn
   lambda_zip_file                        = var.lambda_zip_file
   authentication_vpc_arn                 = aws_vpc.account_management_vpc.arn
-  security_group_id                      = aws_vpc.account_management_vpc.default_security_group_id
+  security_group_id                      = aws_security_group.allow_vpc_resources_only.id
   subnet_id                              = aws_subnet.account_management_subnets.*.id
   environment                            = var.environment
   lambda_role_arn                        = module.account_notification_dynamo_sqs_role.arn

--- a/ci/terraform/account-management/send_otp_notification.tf
+++ b/ci/terraform/account-management/send_otp_notification.tf
@@ -22,7 +22,7 @@ module "send_otp_notification" {
   execution_arn                          = aws_api_gateway_rest_api.di_account_management_api.execution_arn
   lambda_zip_file                        = var.lambda_zip_file
   authentication_vpc_arn                 = aws_vpc.account_management_vpc.arn
-  security_group_id                      = aws_vpc.account_management_vpc.default_security_group_id
+  security_group_id                      = aws_security_group.allow_vpc_resources_only.id
   subnet_id                              = aws_subnet.account_management_subnets.*.id
   lambda_role_arn                        = module.account_notification_dynamo_sqs_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled

--- a/ci/terraform/account-management/sqs.tf
+++ b/ci/terraform/account-management/sqs.tf
@@ -163,7 +163,7 @@ resource "aws_lambda_function" "email_sqs_lambda" {
 
   source_code_hash = filebase64sha256(var.lambda_zip_file)
   vpc_config {
-    security_group_ids = [aws_vpc.account_management_vpc.default_security_group_id]
+    security_group_ids = [aws_security_group.allow_egress.id]
     subnet_ids         = aws_subnet.account_management_subnets.*.id
   }
   environment {

--- a/ci/terraform/account-management/update-email.tf
+++ b/ci/terraform/account-management/update-email.tf
@@ -21,7 +21,7 @@ module "update_email" {
   execution_arn                          = aws_api_gateway_rest_api.di_account_management_api.execution_arn
   lambda_zip_file                        = var.lambda_zip_file
   authentication_vpc_arn                 = aws_vpc.account_management_vpc.arn
-  security_group_id                      = aws_vpc.account_management_vpc.default_security_group_id
+  security_group_id                      = aws_security_group.allow_vpc_resources_only.id
   subnet_id                              = aws_subnet.account_management_subnets.*.id
   environment                            = var.environment
   lambda_role_arn                        = module.account_notification_dynamo_sqs_role.arn

--- a/ci/terraform/account-management/update-password.tf
+++ b/ci/terraform/account-management/update-password.tf
@@ -20,7 +20,7 @@ module "update_password" {
   execution_arn                          = aws_api_gateway_rest_api.di_account_management_api.execution_arn
   lambda_zip_file                        = var.lambda_zip_file
   authentication_vpc_arn                 = aws_vpc.account_management_vpc.arn
-  security_group_id                      = aws_vpc.account_management_vpc.default_security_group_id
+  security_group_id                      = aws_security_group.allow_vpc_resources_only.id
   subnet_id                              = aws_subnet.account_management_subnets.*.id
   environment                            = var.environment
   lambda_role_arn                        = module.account_notification_dynamo_sqs_role.arn

--- a/ci/terraform/account-management/update-phone-number.tf
+++ b/ci/terraform/account-management/update-phone-number.tf
@@ -21,7 +21,7 @@ module "update_phone_number" {
   execution_arn                          = aws_api_gateway_rest_api.di_account_management_api.execution_arn
   lambda_zip_file                        = var.lambda_zip_file
   authentication_vpc_arn                 = aws_vpc.account_management_vpc.arn
-  security_group_id                      = aws_vpc.account_management_vpc.default_security_group_id
+  security_group_id                      = aws_security_group.allow_vpc_resources_only.id
   subnet_id                              = aws_subnet.account_management_subnets.*.id
   environment                            = var.environment
   lambda_role_arn                        = module.account_notification_dynamo_sqs_role.arn


### PR DESCRIPTION
## What?

- Switch the SQS Notify lambda to the "egress allowed" group
- Switch all other lambda to "VPC only" group

## Why?

We wish to restrict egress from the VPC to only those lambdas that need. We previous created the security groups in 
#1255, so we need to switch over.

## Related PRs

#1255 
#1250 (this was the same change for the OIDC server VPC)