### PR TITLE
AUTH-1228: Restrict egress - cleanup

### DIFF
--- a/ci/terraform/account-management/redis.tf
+++ b/ci/terraform/account-management/redis.tf
@@ -48,7 +48,6 @@ resource "aws_elasticache_replication_group" "account_management_sessions_store"
 
   subnet_group_name = aws_elasticache_subnet_group.account_management_sessions_store[0].name
   security_group_ids = [
-    aws_vpc.account_management_vpc.default_security_group_id,
     aws_security_group.redis_security_group.id,
   ]
 

--- a/ci/terraform/account-management/vpc.tf
+++ b/ci/terraform/account-management/vpc.tf
@@ -104,7 +104,6 @@ resource "aws_vpc_endpoint" "sns" {
   subnet_ids = aws_subnet.account_management_subnets.*.id
 
   security_group_ids = [
-    aws_vpc.account_management_vpc.default_security_group_id,
     aws_security_group.aws_endpoints.id,
   ]
 
@@ -133,7 +132,6 @@ resource "aws_vpc_endpoint" "kms" {
   subnet_ids = aws_subnet.account_management_subnets.*.id
 
   security_group_ids = [
-    aws_vpc.account_management_vpc.default_security_group_id,
     aws_security_group.aws_endpoints.id,
   ]
 
@@ -162,7 +160,6 @@ resource "aws_vpc_endpoint" "ssm" {
   subnet_ids = aws_subnet.account_management_subnets.*.id
 
   security_group_ids = [
-    aws_vpc.account_management_vpc.default_security_group_id,
     aws_security_group.aws_endpoints.id,
   ]
 
@@ -191,7 +188,6 @@ resource "aws_vpc_endpoint" "lambda" {
   subnet_ids = aws_subnet.account_management_subnets.*.id
 
   security_group_ids = [
-    aws_vpc.account_management_vpc.default_security_group_id,
     aws_security_group.aws_endpoints.id,
   ]
 

--- a/ci/terraform/shared/data-transfer.tf
+++ b/ci/terraform/shared/data-transfer.tf
@@ -113,7 +113,7 @@ resource "aws_lambda_function" "data_transfer_lambda" {
 
   source_code_hash = filebase64sha256(var.account_migration_lambda_zip_file)
   vpc_config {
-    security_group_ids = [aws_vpc.authentication.default_security_group_id]
+    security_group_ids = [aws_security_group.allow_vpc_resources_only.id]
     subnet_ids         = aws_subnet.authentication.*.id
   }
   environment {

--- a/ci/terraform/shared/redis.tf
+++ b/ci/terraform/shared/redis.tf
@@ -47,7 +47,6 @@ resource "aws_elasticache_replication_group" "sessions_store" {
 
   subnet_group_name = aws_elasticache_subnet_group.sessions_store[0].name
   security_group_ids = [
-    aws_vpc.authentication.default_security_group_id,
     aws_security_group.redis_security_group.id,
   ]
 

--- a/ci/terraform/shared/vpc.tf
+++ b/ci/terraform/shared/vpc.tf
@@ -62,7 +62,6 @@ resource "aws_vpc_endpoint" "sqs" {
   subnet_ids = aws_subnet.authentication.*.id
 
   security_group_ids = [
-    aws_vpc.authentication.default_security_group_id,
     aws_security_group.aws_endpoints.id,
   ]
 
@@ -113,7 +112,6 @@ resource "aws_vpc_endpoint" "sns" {
   subnet_ids = aws_subnet.authentication.*.id
 
   security_group_ids = [
-    aws_vpc.authentication.default_security_group_id,
     aws_security_group.aws_endpoints.id,
   ]
 
@@ -142,7 +140,6 @@ resource "aws_vpc_endpoint" "kms" {
   subnet_ids = aws_subnet.authentication.*.id
 
   security_group_ids = [
-    aws_vpc.authentication.default_security_group_id,
     aws_security_group.aws_endpoints.id,
   ]
 
@@ -171,7 +168,6 @@ resource "aws_vpc_endpoint" "ssm" {
   subnet_ids = aws_subnet.authentication.*.id
 
   security_group_ids = [
-    aws_vpc.authentication.default_security_group_id,
     aws_security_group.aws_endpoints.id,
   ]
 
@@ -224,7 +220,6 @@ resource "aws_vpc_endpoint" "lambda" {
   subnet_ids = aws_subnet.authentication.*.id
 
   security_group_ids = [
-    aws_vpc.authentication.default_security_group_id,
     aws_security_group.aws_endpoints.id,
   ]
 


### PR DESCRIPTION
## What?

- Remove all usages of the default "allow all" security group.

## Why?

Now all lambda, and other resources, have been assigned specific groups, we can remove references to the default security group as this is no longer required. 

