### PR TITLE
AUTH-1168 - Add new ConsentRequired attribute

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ClientRegistry.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ClientRegistry.java
@@ -21,6 +21,7 @@ public class ClientRegistry {
     private String subjectType;
     private boolean cookieConsentShared = false;
     private boolean isInternalService = false;
+    private boolean consentRequired = false;
     private boolean testClient = false;
     private List<String> testClientEmailAllowlist = new ArrayList<>();
 
@@ -164,5 +165,14 @@ public class ClientRegistry {
     public ClientRegistry setTestClientEmailAllowlist(List<String> testClientEmailAllowlist) {
         this.testClientEmailAllowlist = testClientEmailAllowlist;
         return this;
+    }
+
+    @DynamoDBAttribute(attributeName = "ConsentRequired")
+    public boolean isConsentRequired() {
+        return consentRequired;
+    }
+
+    public void setConsentRequired(boolean consentRequired) {
+        this.consentRequired = consentRequired;
     }
 }


### PR DESCRIPTION
## What?

 - Add new ConsentRequired attribute to ClientRegistry 
 - Default this flag to false as currently Consent isn't required for any Client in Production. It will only need to be true for the Stubs which I'll configure in a separate PR.
 
## Why?

- This will be used to identify whether we need to display the consent screen for users of a particular client. Currently, we use the InternalService flag but as there will be clients in the future which are not internal and do not need to see the consent screen then we need a name flagged for this.
- Dynamo doesn't handle renaming Attributes that well in the SDK so we need to do this incrementally. Later on, we can then remove the InternalService flag
