### PR TITLE
AUTH-1168 - Set consentRequired to true for our Stub RPs

### DIFF
--- a/ci/terraform/shared/stub-rp-clients.tf
+++ b/ci/terraform/shared/stub-rp-clients.tf
@@ -72,6 +72,9 @@ resource "aws_dynamodb_table_item" "stub_rp_client" {
     CookieConsentShared = {
       N = "1"
     }
+    ConsentRequired = {
+      N = "1"
+    }
     TestClient = {
       N = var.stub_rp_clients[count.index].test_client
     }


### PR DESCRIPTION
## What?

 - Set consentRequired to true for our Stub RPs

## Why?

- The Stubs are currently the only clients where we need to display the consent screen too so ensure that there record in Dynamo is updated to reflect this following on the introduction of the ConsentRequired flag


## Related PRs

- https://github.com/alphagov/di-authentication-api/pull/1287