### PR TITLE
AUTH-1168 - Switch code to use consentRequired field instead of isInternalService

### DIFF
--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/entity/ClientRegistrationRequest.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/entity/ClientRegistrationRequest.java
@@ -1,6 +1,7 @@
 package uk.gov.di.authentication.clientregistry.entity;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.di.authentication.shared.entity.ServiceType;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -45,7 +46,7 @@ public class ClientRegistrationRequest {
             @JsonProperty(required = true, value = "public_key") String publicKey,
             @JsonProperty(required = true, value = "scopes") List<String> scopes,
             @JsonProperty(value = "post_logout_redirect_uris") List<String> postLogoutRedirectUris,
-            @JsonProperty(required = true, value = "service_type") String serviceType,
+            @JsonProperty(value = "service_type") String serviceType,
             @JsonProperty(required = true, value = "sector_identifier_uri")
                     String sectorIdentifierUri,
             @JsonProperty(required = true, value = "subject_type") String subjectType,
@@ -58,6 +59,9 @@ public class ClientRegistrationRequest {
         this.scopes = scopes;
         if (Objects.nonNull(postLogoutRedirectUris)) {
             this.postLogoutRedirectUris = postLogoutRedirectUris;
+        }
+        if (Objects.isNull(serviceType)) {
+            serviceType = String.valueOf(ServiceType.MANDATORY);
         }
         this.serviceType = serviceType;
         this.sectorIdentifierUri = sectorIdentifierUri;

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/entity/ClientRegistrationRequest.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/entity/ClientRegistrationRequest.java
@@ -35,6 +35,9 @@ public class ClientRegistrationRequest {
     @JsonProperty("subject_type")
     private String subjectType;
 
+    @JsonProperty("identity_verification_required")
+    private boolean identityVerificationRequired;
+
     public ClientRegistrationRequest(
             @JsonProperty(required = true, value = "client_name") String clientName,
             @JsonProperty(required = true, value = "redirect_uris") List<String> redirectUris,
@@ -45,7 +48,9 @@ public class ClientRegistrationRequest {
             @JsonProperty(required = true, value = "service_type") String serviceType,
             @JsonProperty(required = true, value = "sector_identifier_uri")
                     String sectorIdentifierUri,
-            @JsonProperty(required = true, value = "subject_type") String subjectType) {
+            @JsonProperty(required = true, value = "subject_type") String subjectType,
+            @JsonProperty(value = "identity_verification_required")
+                    boolean identityVerificationRequired) {
         this.clientName = clientName;
         this.redirectUris = redirectUris;
         this.contacts = contacts;
@@ -57,6 +62,7 @@ public class ClientRegistrationRequest {
         this.serviceType = serviceType;
         this.sectorIdentifierUri = sectorIdentifierUri;
         this.subjectType = subjectType;
+        this.identityVerificationRequired = identityVerificationRequired;
     }
 
     public String getClientName() {
@@ -93,5 +99,9 @@ public class ClientRegistrationRequest {
 
     public String getSubjectType() {
         return subjectType;
+    }
+
+    public boolean isIdentityVerificationRequired() {
+        return identityVerificationRequired;
     }
 }

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandler.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandler.java
@@ -122,7 +122,9 @@ public class ClientRegistrationHandler
                                         clientRegistrationRequest.getServiceType(),
                                         sanitiseUrl(
                                                 clientRegistrationRequest.getSectorIdentifierUri()),
-                                        clientRegistrationRequest.getSubjectType());
+                                        clientRegistrationRequest.getSubjectType(),
+                                        !clientRegistrationRequest
+                                                .isIdentityVerificationRequired());
 
                                 ClientRegistrationResponse clientRegistrationResponse =
                                         new ClientRegistrationResponse(

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandlerTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandlerTest.java
@@ -131,7 +131,7 @@ class ClientRegistrationHandlerTest {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
 
         event.setBody(
-                "{ \"client_name\": \"test-client\", \"redirect_uris\": [\"http://localhost:8080/redirect-uri\"], \"contacts\": [\"joe.bloggs@test.com\"], \"scopes\": [\"openid\"],  \"public_key\": \"some-public-key\", \"post_logout_redirect_uris\": [\"http://localhost:8080/post-logout-redirect-uri\"], \"service_type\": \"MANDATORY\", \"sector_identifier_uri\": \"https://test.com\", \"subject_type\": \"pairwise\",  \"identity_verification_required\": \"true\"}");
+                "{ \"client_name\": \"test-client\", \"redirect_uris\": [\"http://localhost:8080/redirect-uri\"], \"contacts\": [\"joe.bloggs@test.com\"], \"scopes\": [\"openid\"],  \"public_key\": \"some-public-key\", \"post_logout_redirect_uris\": [\"http://localhost:8080/post-logout-redirect-uri\"], \"sector_identifier_uri\": \"https://test.com\", \"subject_type\": \"pairwise\",  \"identity_verification_required\": \"true\"}");
         APIGatewayProxyResponseEvent result = makeHandlerRequest(event);
 
         assertThat(result, hasStatus(200));

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandlerTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandlerTest.java
@@ -109,7 +109,52 @@ class ClientRegistrationHandlerTest {
                         singletonList("http://localhost:8080/post-logout-redirect-uri"),
                         serviceType,
                         sectorIdentifierUri,
-                        subjectType);
+                        subjectType,
+                        true);
+    }
+
+    @Test
+    public void shouldSetConsentRequiredToFalseWhenIdentityVerificationIsRequired()
+            throws JsonProcessingException {
+
+        String sectorIdentifierUri = "https://test.com";
+        String subjectType = "pairwise";
+        String clientName = "test-client";
+        List<String> redirectUris = List.of("http://localhost:8080/redirect-uri");
+        List<String> contacts = List.of("joe.bloggs@test.com");
+        String serviceType = String.valueOf(MANDATORY);
+        when(configValidationService.validateClientRegistrationConfig(
+                        any(ClientRegistrationRequest.class)))
+                .thenReturn(Optional.empty());
+        when(clientService.generateClientID()).thenReturn(new ClientID(clientId));
+
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+
+        event.setBody(
+                "{ \"client_name\": \"test-client\", \"redirect_uris\": [\"http://localhost:8080/redirect-uri\"], \"contacts\": [\"joe.bloggs@test.com\"], \"scopes\": [\"openid\"],  \"public_key\": \"some-public-key\", \"post_logout_redirect_uris\": [\"http://localhost:8080/post-logout-redirect-uri\"], \"service_type\": \"MANDATORY\", \"sector_identifier_uri\": \"https://test.com\", \"subject_type\": \"pairwise\",  \"identity_verification_required\": \"true\"}");
+        APIGatewayProxyResponseEvent result = makeHandlerRequest(event);
+
+        assertThat(result, hasStatus(200));
+        ClientRegistrationResponse clientRegistrationResponseResult =
+                objectMapper.readValue(result.getBody(), ClientRegistrationResponse.class);
+        assertThat(clientRegistrationResponseResult.getClientId(), equalTo(clientId));
+        assertThat(
+                clientRegistrationResponseResult.getTokenAuthMethod(), equalTo("private_key_jwt"));
+        assertThat(clientRegistrationResponseResult.getSubjectType(), equalTo(subjectType));
+        assertThat(clientRegistrationResponseResult.getScopes(), equalTo(singletonList("openid")));
+        verify(clientService)
+                .addClient(
+                        clientId,
+                        clientName,
+                        redirectUris,
+                        contacts,
+                        singletonList("openid"),
+                        "some-public-key",
+                        singletonList("http://localhost:8080/post-logout-redirect-uri"),
+                        serviceType,
+                        sectorIdentifierUri,
+                        subjectType,
+                        false);
     }
 
     @Test
@@ -134,7 +179,7 @@ class ClientRegistrationHandlerTest {
                 .thenReturn(Optional.of(INVALID_PUBLIC_KEY));
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setBody(
-                "{ \"client_name\": \"test-client\", \"redirect_uris\": [\"http://localhost:8080/redirect-uri\"], \"contacts\": [\"joe.bloggs@test.com\"], \"scopes\": [\"openid\"],  \"public_key\": \"some-public-key\", \"post_logout_redirect_uris\": [\"http://localhost:8080/post-logout-redirect-uri\"], \"service_type\": \"MANDATORY\", \"sector_identifier_uri\": \"https://test.com\", \"subject_type\": \"public\"}");
+                "{ \"client_name\": \"test-client\", \"redirect_uris\": [\"http://localhost:8080/redirect-uri\"], \"contacts\": [\"joe.bloggs@test.com\"], \"scopes\": [\"openid\"],  \"public_key\": \"some-public-key\", \"post_logout_redirect_uris\": [\"http://localhost:8080/post-logout-redirect-uri\"], \"service_type\": \"MANDATORY\", \"sector_identifier_uri\": \"https://test.com\", \"subject_type\": \"public\", \"identity_verification_required\": \"false\"}");
         APIGatewayProxyResponseEvent result = makeHandlerRequest(event);
 
         assertThat(result, hasStatus(400));
@@ -152,7 +197,7 @@ class ClientRegistrationHandlerTest {
                 .thenReturn(Optional.of(INVALID_SCOPE));
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setBody(
-                "{ \"client_name\": \"test-client\", \"redirect_uris\": [\"http://localhost:8080/redirect-uri\"], \"contacts\": [\"joe.bloggs@test.com\"], \"scopes\": [\"openid\"],  \"public_key\": \"some-public-key\", \"post_logout_redirect_uris\": [\"http://localhost:8080/post-logout-redirect-uri\"], \"service_type\": \"MANDATORY\", \"sector_identifier_uri\": \"https://test.com\", \"subject_type\": \"public\"}");
+                "{ \"client_name\": \"test-client\", \"redirect_uris\": [\"http://localhost:8080/redirect-uri\"], \"contacts\": [\"joe.bloggs@test.com\"], \"scopes\": [\"openid\"],  \"public_key\": \"some-public-key\", \"post_logout_redirect_uris\": [\"http://localhost:8080/post-logout-redirect-uri\"], \"service_type\": \"MANDATORY\", \"sector_identifier_uri\": \"https://test.com\", \"subject_type\": \"public\", \"identity_verification_required\": \"false\"}");
         APIGatewayProxyResponseEvent result = makeHandlerRequest(event);
 
         assertThat(result, hasStatus(400));

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationServiceTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationServiceTest.java
@@ -233,7 +233,8 @@ class ClientConfigValidationServiceTest {
                 postLogoutUris,
                 serviceType,
                 sectorIdentifierUri,
-                subjectType);
+                subjectType,
+                false);
     }
 
     private UpdateClientConfigRequest generateClientUpdateRequest(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
@@ -87,6 +87,7 @@ public class AuthCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 singletonList("http://localhost/post-redirect-logout"),
                 String.valueOf(ServiceType.MANDATORY),
                 "https://test.com",
-                "public");
+                "public",
+                true);
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -553,6 +553,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 singletonList("http://localhost/post-redirect-logout"),
                 String.valueOf(ServiceType.MANDATORY),
                 "https://test.com",
-                "public");
+                "public",
+                true);
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientInfoIntegrationTest.java
@@ -100,6 +100,7 @@ public class ClientInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest 
                 singletonList("http://localhost/post-redirect-logout"),
                 String.valueOf(ServiceType.MANDATORY),
                 "https://test.com",
-                "public");
+                "public",
+                true);
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientRegistrationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientRegistrationIntegrationTest.java
@@ -41,7 +41,8 @@ public class ClientRegistrationIntegrationTest extends ApiGatewayHandlerIntegrat
                         singletonList("http://localhost/post-redirect-logout"),
                         String.valueOf(ServiceType.MANDATORY),
                         "https://test.com",
-                        "public");
+                        "public",
+                        false);
 
         var response = makeRequest(Optional.of(clientRequest), Map.of(), Map.of());
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
@@ -95,7 +95,8 @@ public class LoginIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 singletonList("http://localhost/post-redirect-logout"),
                 String.valueOf(ServiceType.MANDATORY),
                 "https://test.com",
-                "public");
+                "public",
+                true);
 
         Map<String, String> headers = new HashMap<>();
         headers.put("Session-Id", sessionId);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
@@ -155,7 +155,8 @@ public class LogoutIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 singletonList(REDIRECT_URL),
                 String.valueOf(ServiceType.MANDATORY),
                 "https://test.com",
-                "public");
+                "public",
+                true);
 
         return signedJWT;
     }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
@@ -229,7 +229,8 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 singletonList("http://localhost/post-logout-redirect"),
                 String.valueOf(ServiceType.MANDATORY),
                 "https://test.com",
-                "public");
+                "public",
+                true);
         userStore.signUp(TEST_EMAIL, "password-1", internalSubject);
         Set<String> claims = ValidScopes.getClaimsForListOfScopes(scope.toStringList());
         ClientConsent clientConsent =

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateClientConfigIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateClientConfigIntegrationTest.java
@@ -41,7 +41,8 @@ public class UpdateClientConfigIntegrationTest extends ApiGatewayHandlerIntegrat
                 singletonList("http://localhost/post-redirect-logout"),
                 String.valueOf(ServiceType.MANDATORY),
                 "https://test.com",
-                "public");
+                "public",
+                true);
 
         UpdateClientConfigRequest updateRequest = new UpdateClientConfigRequest();
         updateRequest.setClientName("new-client-name");

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateProfileIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateProfileIntegrationTest.java
@@ -152,7 +152,8 @@ public class UpdateProfileIntegrationTest extends ApiGatewayHandlerIntegrationTe
                 singletonList("http://localhost/post-redirect-logout"),
                 String.valueOf(ServiceType.MANDATORY),
                 "https://test.com",
-                "public");
+                "public",
+                true);
         Set<String> claims = ValidScopes.getClaimsForListOfScopes(scope.toStringList());
         userStore.signUp(EMAIL_ADDRESS, "password");
         userStore.updateConsent(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
@@ -126,6 +126,7 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 singletonList("http://localhost/post-redirect-logout"),
                 String.valueOf(ServiceType.MANDATORY),
                 "https://test.com",
-                "public");
+                "public",
+                true);
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
@@ -388,7 +388,8 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
                 singletonList("http://localhost/post-redirect-logout"),
                 String.valueOf(ServiceType.MANDATORY),
                 "https://test.com",
-                "public");
+                "public",
+                true);
     }
 
     private void setUpTestWithoutClientConsent(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
@@ -246,7 +246,7 @@ public class TokenHandler
                                             publicSubject,
                                             vot,
                                             userProfile.getClientConsent(),
-                                            client.isInternalService());
+                                            client.isConsentRequired());
 
                             clientSessionService.saveClientSession(
                                     authCodeExchangeData.getClientSessionId(),

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
@@ -190,7 +190,7 @@ public class TokenHandlerTest {
                         PUBLIC_SUBJECT,
                         vtr.retrieveVectorOfTrustForToken(),
                         userProfile.getClientConsent(),
-                        clientRegistry.isInternalService()))
+                        clientRegistry.isConsentRequired()))
                 .thenReturn(tokenResponse);
 
         APIGatewayProxyResponseEvent result = generateApiGatewayRequest(privateKeyJWT, authCode);
@@ -499,7 +499,7 @@ public class TokenHandlerTest {
     private ClientRegistry generateClientRegistry(KeyPair keyPair) {
         return new ClientRegistry()
                 .setClientID(CLIENT_ID)
-                .setInternalService(false)
+                .setConsentRequired(false)
                 .setClientName("test-client")
                 .setRedirectUrls(singletonList(REDIRECT_URI))
                 .setScopes(SCOPES.toStringList())

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/ClientStoreExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/ClientStoreExtension.java
@@ -36,7 +36,8 @@ public class ClientStoreExtension extends DynamoExtension implements AfterEachCa
             List<String> postLogoutRedirectUris,
             String serviceType,
             String sectorIdentifierUri,
-            String subjectType) {
+            String subjectType,
+            boolean consentRequired) {
         dynamoClientService.addClient(
                 clientID,
                 clientName,
@@ -47,7 +48,8 @@ public class ClientStoreExtension extends DynamoExtension implements AfterEachCa
                 postLogoutRedirectUris,
                 serviceType,
                 sectorIdentifierUri,
-                subjectType);
+                subjectType,
+                consentRequired);
     }
 
     public boolean clientExists(String clientID) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ClientRegistry.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ClientRegistry.java
@@ -172,7 +172,8 @@ public class ClientRegistry {
         return consentRequired;
     }
 
-    public void setConsentRequired(boolean consentRequired) {
+    public ClientRegistry setConsentRequired(boolean consentRequired) {
         this.consentRequired = consentRequired;
+        return this;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ClientService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ClientService.java
@@ -21,7 +21,8 @@ public interface ClientService {
             List<String> postLogoutRedirectUris,
             String serviceType,
             String sectorIdentifierUri,
-            String subjectType);
+            String subjectType,
+            boolean consentRequired);
 
     Optional<ClientRegistry> getClient(String clientId);
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoClientService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoClientService.java
@@ -59,7 +59,8 @@ public class DynamoClientService implements ClientService {
             List<String> postLogoutRedirectUris,
             String serviceType,
             String sectorIdentifierUri,
-            String subjectType) {
+            String subjectType,
+            boolean consentRequired) {
         ClientRegistry clientRegistry =
                 new ClientRegistry()
                         .setClientID(clientID)
@@ -71,7 +72,8 @@ public class DynamoClientService implements ClientService {
                         .setPostLogoutRedirectUrls(postLogoutRedirectUris)
                         .setServiceType(serviceType)
                         .setSectorIdentifierUri(sectorIdentifierUri)
-                        .setSubjectType(subjectType);
+                        .setSubjectType(subjectType)
+                        .setConsentRequired(consentRequired);
         clientRegistryMapper.save(clientRegistry);
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
@@ -97,12 +97,12 @@ public class TokenService {
             Subject publicSubject,
             String vot,
             List<ClientConsent> clientConsents,
-            boolean isInternalService) {
+            boolean isConsentRequired) {
         List<String> scopesForToken;
-        if (isInternalService) {
-            scopesForToken = authRequestScopes.toStringList();
-        } else {
+        if (isConsentRequired) {
             scopesForToken = calculateScopesForToken(clientConsents, clientID, authRequestScopes);
+        } else {
+            scopesForToken = authRequestScopes.toStringList();
         }
         AccessToken accessToken =
                 generateAndStoreAccessToken(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/state/StateMachine.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/state/StateMachine.java
@@ -86,7 +86,7 @@ import static uk.gov.di.authentication.shared.entity.SessionState.VERIFY_PHONE_N
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachSessionIdToLogs;
 import static uk.gov.di.authentication.shared.state.conditions.AggregateCondition.and;
 import static uk.gov.di.authentication.shared.state.conditions.ClientDoesNotRequireMfa.clientDoesNotRequireMfa;
-import static uk.gov.di.authentication.shared.state.conditions.ClientIsAnInternalService.clientIsAnInternalService;
+import static uk.gov.di.authentication.shared.state.conditions.ConsentIsNotRequired.consentIsNotRequired;
 import static uk.gov.di.authentication.shared.state.conditions.ConsentNotGiven.userHasNotGivenConsent;
 import static uk.gov.di.authentication.shared.state.conditions.CredentialTrustUpliftRequired.upliftRequired;
 import static uk.gov.di.authentication.shared.state.conditions.PhoneNumberUnverified.phoneNumberUnverified;
@@ -186,7 +186,7 @@ public class StateMachine<T, A, C> {
                                 .build(),
                         on(USER_ENTERED_VALID_MFA_CODE)
                                 .then(MFA_CODE_VERIFIED)
-                                .ifCondition(clientIsAnInternalService())
+                                .ifCondition(consentIsNotRequired())
                                 .build(),
                         on(USER_ENTERED_VALID_MFA_CODE)
                                 .then(CONSENT_REQUIRED)
@@ -224,8 +224,7 @@ public class StateMachine<T, A, C> {
                                                                 .getTermsAndConditionsVersion())))
                                 .then(UPDATED_TERMS_AND_CONDITIONS),
                         on(USER_ENTERED_VALID_CREDENTIALS)
-                                .ifCondition(
-                                        and(clientDoesNotRequireMfa(), clientIsAnInternalService()))
+                                .ifCondition(and(clientDoesNotRequireMfa(), consentIsNotRequired()))
                                 .then(AUTHENTICATED),
                         on(USER_ENTERED_VALID_CREDENTIALS)
                                 .ifCondition(
@@ -304,7 +303,7 @@ public class StateMachine<T, A, C> {
                 .allow(
                         on(USER_ENTERED_VALID_PHONE_VERIFICATION_CODE)
                                 .then(PHONE_NUMBER_CODE_VERIFIED)
-                                .ifCondition(clientIsAnInternalService()),
+                                .ifCondition(consentIsNotRequired()),
                         on(USER_ENTERED_VALID_PHONE_VERIFICATION_CODE)
                                 .then(CONSENT_REQUIRED)
                                 .ifCondition(userHasNotGivenConsent()),
@@ -372,8 +371,7 @@ public class StateMachine<T, A, C> {
                                                                 .getTermsAndConditionsVersion())))
                                 .then(UPDATED_TERMS_AND_CONDITIONS),
                         on(USER_ENTERED_VALID_CREDENTIALS)
-                                .ifCondition(
-                                        and(clientDoesNotRequireMfa(), clientIsAnInternalService()))
+                                .ifCondition(and(clientDoesNotRequireMfa(), consentIsNotRequired()))
                                 .then(AUTHENTICATED),
                         on(USER_ENTERED_VALID_CREDENTIALS)
                                 .ifCondition(
@@ -451,7 +449,7 @@ public class StateMachine<T, A, C> {
                 .allow(
                         on(USER_ACCEPTS_TERMS_AND_CONDITIONS)
                                 .then(UPDATED_TERMS_AND_CONDITIONS_ACCEPTED)
-                                .ifCondition(clientIsAnInternalService()),
+                                .ifCondition(consentIsNotRequired()),
                         on(USER_ACCEPTS_TERMS_AND_CONDITIONS)
                                 .then(CONSENT_REQUIRED)
                                 .ifCondition(userHasNotGivenConsent()),
@@ -507,7 +505,7 @@ public class StateMachine<T, A, C> {
                                                         .getTermsAndConditionsVersion())),
                         on(USER_HAS_STARTED_A_NEW_JOURNEY)
                                 .then(AUTHENTICATED)
-                                .ifCondition(clientIsAnInternalService()),
+                                .ifCondition(consentIsNotRequired()),
                         on(USER_HAS_STARTED_A_NEW_JOURNEY)
                                 .then(CONSENT_REQUIRED)
                                 .ifCondition(userHasNotGivenConsent()),

--- a/shared/src/main/java/uk/gov/di/authentication/shared/state/conditions/ConsentIsNotRequired.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/state/conditions/ConsentIsNotRequired.java
@@ -1,21 +1,20 @@
 package uk.gov.di.authentication.shared.state.conditions;
 
-import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.state.Condition;
 import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.util.Optional;
 
-public class ClientIsAnInternalService implements Condition<UserContext> {
+public class ConsentIsNotRequired implements Condition<UserContext> {
 
     @Override
     public boolean isMet(Optional<UserContext> context) {
         return context.flatMap(UserContext::getClient)
-                .map(ClientRegistry::isInternalService)
+                .map(t -> !t.isConsentRequired())
                 .orElse(false);
     }
 
-    public static ClientIsAnInternalService clientIsAnInternalService() {
-        return new ClientIsAnInternalService();
+    public static ConsentIsNotRequired consentIsNotRequired() {
+        return new ConsentIsNotRequired();
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/state/conditions/ConsentIsNotRequiredTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/state/conditions/ConsentIsNotRequiredTest.java
@@ -19,26 +19,26 @@ class ConsentIsNotRequiredTest {
     private ClientRegistry client = mock(ClientRegistry.class);
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         when(userContext.getClient()).thenReturn(Optional.of(client));
     }
 
     @Test
-    public void shouldReturnTrueIfConsentIsNotRequired() {
+    void shouldReturnTrueIfConsentIsNotRequired() {
         when(client.isConsentRequired()).thenReturn(false);
 
         assertThat(condition.isMet(Optional.of(userContext)), equalTo(true));
     }
 
     @Test
-    public void shouldReturnFalseIfConsentIsRequired() {
+    void shouldReturnFalseIfConsentIsRequired() {
         when(client.isConsentRequired()).thenReturn(true);
 
         assertThat(condition.isMet(Optional.of(userContext)), equalTo(false));
     }
 
     @Test
-    public void shouldDefaultToTrueIfClientHasNotSpecifiedWhetherConsentIsRequired() {
+    void shouldDefaultToTrueIfClientHasNotSpecifiedWhetherConsentIsRequired() {
         assertThat(condition.isMet(Optional.of(userContext)), equalTo(true));
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/state/conditions/ConsentIsNotRequiredTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/state/conditions/ConsentIsNotRequiredTest.java
@@ -12,9 +12,9 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-class ClientIsAnInternalServiceTest {
+class ConsentIsNotRequiredTest {
 
-    private final ClientIsAnInternalService condition = new ClientIsAnInternalService();
+    private final ConsentIsNotRequired condition = new ConsentIsNotRequired();
     private UserContext userContext = mock(UserContext.class);
     private ClientRegistry client = mock(ClientRegistry.class);
 
@@ -24,21 +24,21 @@ class ClientIsAnInternalServiceTest {
     }
 
     @Test
-    public void shouldReturnTrueIfClientIsAnInternalService() {
-        when(client.isInternalService()).thenReturn(true);
+    public void shouldReturnTrueIfConsentIsNotRequired() {
+        when(client.isConsentRequired()).thenReturn(false);
 
         assertThat(condition.isMet(Optional.of(userContext)), equalTo(true));
     }
 
     @Test
-    public void shouldReturnFalseIfClientIsNotAnInternalService() {
-        when(client.isInternalService()).thenReturn(false);
+    public void shouldReturnFalseIfConsentIsRequired() {
+        when(client.isConsentRequired()).thenReturn(true);
 
         assertThat(condition.isMet(Optional.of(userContext)), equalTo(false));
     }
 
     @Test
-    public void shouldReturnFalseIfClientHasNotSpecifiedWhetherTheyAreAnInternalService() {
-        assertThat(condition.isMet(Optional.of(userContext)), equalTo(false));
+    public void shouldDefaultToTrueIfClientHasNotSpecifiedWhetherConsentIsRequired() {
+        assertThat(condition.isMet(Optional.of(userContext)), equalTo(true));
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/state/journeys/ForgottenPasswordJourneyTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/state/journeys/ForgottenPasswordJourneyTest.java
@@ -287,7 +287,10 @@ public class ForgottenPasswordJourneyTest {
                                                 null)
                                         .setEffectiveVectorOfTrust(generateLowLevelVectorOfTrust()))
                         .withUserProfile(userProfile)
-                        .withClient(new ClientRegistry().setClientID(CLIENT_ID.toString()))
+                        .withClient(
+                                new ClientRegistry()
+                                        .setClientID(CLIENT_ID.toString())
+                                        .setConsentRequired(true))
                         .build();
 
         List<JourneyTransition> transitions =


### PR DESCRIPTION
## What?

- Switch code to use consentRequired field instead of isInternalService
- Add additional attribute named `identity_verification_required` to ClientRegistrationRequest to determine whether a client needs identity verification. It is not mandatory and if it is not present, it shall default to talse
- Make Service type optional in Client Reg request

## Why?

- We want to start using the consentRequired field as it will not just be internal services where consent is not required. Eventually we will remove the internal service field completely
- Add the identity_verification_required attribute to the client registration request payload as an mandatory attribute. If this is set to true then consent is not required for users of that servcie and if it is set to false then consent is required for users of that service.
- Make the ServiceType attribute in the client reg request optional. If it is not present then we will set it to Mandatory. Currently we do not support anything other than Mandatory.
