### PR TITLE
AUTH-1263: Remove unnecessary logging

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandler.java
@@ -72,7 +72,6 @@ public class AuthenticateHandler
                                 boolean userHasAccount =
                                         authenticationService.userExists(loginRequest.getEmail());
                                 if (!userHasAccount) {
-                                    LOG.error("The user does not have an account");
                                     return generateApiGatewayProxyErrorResponse(
                                             400, ErrorResponse.ERROR_1010);
                                 }
@@ -81,7 +80,6 @@ public class AuthenticateHandler
                                                 loginRequest.getEmail(),
                                                 loginRequest.getPassword());
                                 if (!hasValidCredentials) {
-                                    LOG.info("Invalid login credentials entered");
                                     return generateApiGatewayProxyErrorResponse(
                                             401, ErrorResponse.ERROR_1008);
                                 }
@@ -103,7 +101,6 @@ public class AuthenticateHandler
 
                                 return generateEmptySuccessApiGatewayResponse();
                             } catch (JsonProcessingException e) {
-                                LOG.error("Request is missing parameters.");
                                 return generateApiGatewayProxyErrorResponse(
                                         400, ErrorResponse.ERROR_1001);
                             }

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandler.java
@@ -115,8 +115,6 @@ public class RemoveAccountHandler
 
                                 return generateEmptySuccessApiGatewayResponse();
                             } catch (JsonProcessingException e) {
-                                LOG.error(
-                                        "RemoveAccountRequest request is missing or contains invalid parameters.");
                                 return generateApiGatewayProxyErrorResponse(
                                         400, ErrorResponse.ERROR_1001);
                             }

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
@@ -105,15 +105,11 @@ public class SendOtpNotificationHandler
                                                 validationService.validateEmailAddress(
                                                         sendNotificationRequest.getEmail());
                                         if (emailErrorResponse.isPresent()) {
-                                            LOG.info(
-                                                    "Invalid email address. Errors are: {}",
-                                                    emailErrorResponse.get());
                                             return generateApiGatewayProxyErrorResponse(
                                                     400, emailErrorResponse.get());
                                         }
                                         if (dynamoService.userExists(
                                                 sendNotificationRequest.getEmail())) {
-                                            LOG.info("User already exists with this email address");
                                             return generateApiGatewayProxyErrorResponse(
                                                     400, ErrorResponse.ERROR_1009);
                                         }
@@ -128,9 +124,6 @@ public class SendOtpNotificationHandler
                                                 validationService.validatePhoneNumber(
                                                         sendNotificationRequest.getPhoneNumber());
                                         if (phoneNumberValidationError.isPresent()) {
-                                            LOG.info(
-                                                    "Invalid phone number. Errors are: {}",
-                                                    phoneNumberValidationError.get());
                                             return generateApiGatewayProxyErrorResponse(
                                                     400, phoneNumberValidationError.get());
                                         }
@@ -146,7 +139,6 @@ public class SendOtpNotificationHandler
                                 return generateApiGatewayProxyResponse(
                                         500, "Error sending message to queue");
                             } catch (JsonProcessingException e) {
-                                LOG.error("Error parsing request");
                                 return generateApiGatewayProxyErrorResponse(400, ERROR_1001);
                             }
                         });

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
@@ -98,7 +98,6 @@ public class UpdateEmailHandler
                                                 updateInfoRequest.getOtp(),
                                                 NotificationType.VERIFY_EMAIL);
                                 if (!isValidOtpCode) {
-                                    LOG.info("Invalid OTP code sent in request");
                                     return generateApiGatewayProxyErrorResponse(
                                             400, ErrorResponse.ERROR_1020);
                                 }
@@ -107,15 +106,11 @@ public class UpdateEmailHandler
                                                 updateInfoRequest.getExistingEmailAddress(),
                                                 updateInfoRequest.getReplacementEmailAddress());
                                 if (emailValidationErrors.isPresent()) {
-                                    LOG.info(
-                                            "Invalid email address with error: {}",
-                                            emailValidationErrors.get().getMessage());
                                     return generateApiGatewayProxyErrorResponse(
                                             400, emailValidationErrors.get());
                                 }
                                 if (dynamoService.userExists(
                                         updateInfoRequest.getReplacementEmailAddress())) {
-                                    LOG.info("An account with this email address already exists");
                                     return generateApiGatewayProxyErrorResponse(
                                             400, ErrorResponse.ERROR_1009);
                                 }
@@ -154,8 +149,6 @@ public class UpdateEmailHandler
                                         "Message successfully added to queue. Generating successful gateway response");
                                 return generateEmptySuccessApiGatewayResponse();
                             } catch (JsonProcessingException | IllegalArgumentException e) {
-                                LOG.error(
-                                        "UpdateInfo request is missing or contains invalid parameters.");
                                 return generateApiGatewayProxyErrorResponse(
                                         400, ErrorResponse.ERROR_1001);
                             }

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandler.java
@@ -96,7 +96,6 @@ public class UpdatePasswordHandler
 
                                 if (verifyPassword(
                                         currentPassword, updatePasswordRequest.getNewPassword())) {
-                                    LOG.info("New password is the same as the old password");
                                     return generateApiGatewayProxyErrorResponse(
                                             400, ErrorResponse.ERROR_1024);
                                 }
@@ -130,8 +129,6 @@ public class UpdatePasswordHandler
                                 return generateEmptySuccessApiGatewayResponse();
 
                             } catch (JsonProcessingException | IllegalArgumentException e) {
-                                LOG.error(
-                                        "UpdatePassword request is missing or contains invalid parameters.");
                                 return generateApiGatewayProxyErrorResponse(
                                         400, ErrorResponse.ERROR_1001);
                             }

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandler.java
@@ -95,7 +95,6 @@ public class UpdatePhoneNumberHandler
                                                 updatePhoneNumberRequest.getOtp(),
                                                 NotificationType.VERIFY_PHONE_NUMBER);
                                 if (!isValidOtpCode) {
-                                    LOG.info("Invalid OTP code sent in request");
                                     return generateApiGatewayProxyErrorResponse(
                                             400, ErrorResponse.ERROR_1020);
                                 }
@@ -103,9 +102,6 @@ public class UpdatePhoneNumberHandler
                                         validationService.validatePhoneNumber(
                                                 updatePhoneNumberRequest.getPhoneNumber());
                                 if (phoneValidationErrors.isPresent()) {
-                                    LOG.info(
-                                            "Invalid phone number with error: {}",
-                                            phoneValidationErrors.get().getMessage());
                                     return generateApiGatewayProxyErrorResponse(
                                             400, phoneValidationErrors.get());
                                 }
@@ -144,8 +140,6 @@ public class UpdatePhoneNumberHandler
                                         "Message successfully added to queue. Generating successful gateway response");
                                 return generateEmptySuccessApiGatewayResponse();
                             } catch (JsonProcessingException | IllegalArgumentException e) {
-                                LOG.error(
-                                        "UpdatePhoneNumber request is missing or contains invalid parameters.");
                                 return generateApiGatewayProxyErrorResponse(
                                         400, ErrorResponse.ERROR_1001);
                             }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -123,7 +123,6 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
                         IpAddressHelper.extractIpAddress(input),
                         AuditService.UNKNOWN,
                         persistentSessionId);
-                LOG.error("Invalid email address: {}", errorResponse.get());
                 return generateApiGatewayProxyErrorResponse(400, errorResponse.get());
             }
             boolean userExists = authenticationService.userExists(emailAddress);
@@ -174,7 +173,6 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
             return generateApiGatewayProxyResponse(200, checkUserExistsResponse);
 
         } catch (JsonProcessingException e) {
-            LOG.error("Error parsing UserInfo request");
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
         } catch (StateMachine.InvalidStateTransitionException e) {
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1017);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ClientInfoHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ClientInfoHandler.java
@@ -90,7 +90,6 @@ public class ClientInfoHandler
                                             input.getHeaders());
 
                             if (clientSession.isEmpty()) {
-                                LOG.info("ClientSession not found");
                                 return generateApiGatewayProxyErrorResponse(
                                         400, ErrorResponse.ERROR_1018);
                             }
@@ -113,7 +112,6 @@ public class ClientInfoHandler
                                         clientService.getClient(clientID);
 
                                 if (optionalClientRegistry.isEmpty()) {
-                                    LOG.error("ClientId: {} not found in ClientRegistry", clientID);
                                     return generateApiGatewayProxyErrorResponse(
                                             403, ErrorResponse.ERROR_1015);
                                 }
@@ -152,7 +150,6 @@ public class ClientInfoHandler
                                 return generateApiGatewayProxyResponse(200, clientInfoResponse);
 
                             } catch (ParseException | JsonProcessingException e) {
-                                LOG.error("Error when calling ClientInfo");
                                 return generateApiGatewayProxyErrorResponse(
                                         400, ErrorResponse.ERROR_1001);
                             }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -107,7 +107,6 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
             UserProfile userProfile =
                     authenticationService.getUserProfileByEmail(request.getEmail());
             if (Objects.isNull(userProfile)) {
-                LOG.error("The user does not have an account");
 
                 auditService.submitAuditEvent(
                         FrontendAuditableEvent.NO_ACCOUNT_WITH_EMAIL,
@@ -177,7 +176,6 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
 
             if (!hasValidCredentials) {
                 codeStorageService.increaseIncorrectPasswordCount(request.getEmail());
-                LOG.info("Invalid login credentials entered");
 
                 auditService.submitAuditEvent(
                         FrontendAuditableEvent.INVALID_CREDENTIALS,
@@ -238,7 +236,6 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
             return generateApiGatewayProxyResponse(
                     200, new LoginResponse(concatPhoneNumber, userContext.getSession().getState()));
         } catch (JsonProcessingException e) {
-            LOG.error("Request is missing parameters");
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
         } catch (StateMachine.InvalidStateTransitionException e) {
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1017);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
@@ -164,8 +164,6 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
             String phoneNumber = authenticationService.getPhoneNumber(email).orElse(null);
 
             if (phoneNumber == null) {
-                LOG.error("PhoneNumber is null");
-
                 auditService.submitAuditEvent(
                         FrontendAuditableEvent.MFA_MISSING_PHONE_NUMBER,
                         context.getAwsRequestId(),
@@ -231,7 +229,6 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
             return generateApiGatewayProxyResponse(
                     200, new BaseAPIResponse(userContext.getSession().getState()));
         } catch (JsonProcessingException e) {
-            LOG.error("MFA request is missing parameters");
             return generateApiGatewayProxyErrorResponse(400, ERROR_1001);
         } catch (StateMachine.InvalidStateTransitionException e) {
             return generateApiGatewayProxyErrorResponse(400, ERROR_1017);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
@@ -104,22 +104,17 @@ public class ResetPasswordHandler extends BaseFrontendHandler<ResetPasswordWithC
             Optional<ErrorResponse> errorResponse =
                     validationService.validatePassword(request.getPassword());
             if (errorResponse.isPresent()) {
-                LOG.info(
-                        "Password did not pass validation because: {}",
-                        errorResponse.get().getMessage());
                 return generateApiGatewayProxyErrorResponse(400, errorResponse.get());
             }
             Optional<String> subject =
                     codeStorageService.getSubjectWithPasswordResetCode(request.getCode());
             if (subject.isEmpty()) {
-                LOG.error("Subject is not found in Redis");
                 return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1021);
             }
             UserCredentials userCredentials =
                     authenticationService.getUserCredentialsFromSubject(subject.get());
             if (userCredentials.getPassword() != null) {
                 if (verifyPassword(userCredentials.getPassword(), request.getPassword())) {
-                    LOG.info("New password is the same as the old password");
                     return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1024);
                 }
             } else {
@@ -154,7 +149,6 @@ public class ResetPasswordHandler extends BaseFrontendHandler<ResetPasswordWithC
                     AuditService.UNKNOWN,
                     PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));
         } catch (JsonProcessingException | ConstraintViolationException e) {
-            LOG.error("Incorrect parameters in ResetPassword request");
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
         }
         LOG.info("Generating successful response");

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
@@ -118,13 +118,11 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
         LOG.info("Processing request");
         try {
             if (!userContext.getSession().validateSession(request.getEmail())) {
-                LOG.info("Invalid session");
                 return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1000);
             }
             Optional<ErrorResponse> emailErrorResponse =
                     validationService.validateEmailAddress(request.getEmail());
             if (emailErrorResponse.isPresent()) {
-                LOG.info("Email validation failed: {}", emailErrorResponse.get());
                 return generateApiGatewayProxyErrorResponse(400, emailErrorResponse.get());
             }
             String persistentSessionId =
@@ -158,7 +156,6 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
             LOG.error("Error sending message to queue", ex);
             return generateApiGatewayProxyResponse(500, "Error sending message to queue");
         } catch (JsonProcessingException e) {
-            LOG.error("Error parsing request");
             return generateApiGatewayProxyErrorResponse(400, ERROR_1001);
         } catch (StateMachine.InvalidStateTransitionException e) {
             return generateApiGatewayProxyErrorResponse(400, ERROR_1017);
@@ -198,11 +195,9 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
     private Optional<ErrorResponse> validatePasswordResetCount(
             String email, UserContext userContext) {
         if (codeStorageService.isBlockedForEmail(email, PASSWORD_RESET_BLOCKED_KEY_PREFIX)) {
-            LOG.info("User cannot request another password reset");
             return Optional.of(ErrorResponse.ERROR_1023);
         } else if (userContext.getSession().getPasswordResetCount()
                 > configurationService.getCodeMaxRetries()) {
-            LOG.info("User has requested too many password resets");
             codeStorageService.saveBlockedForEmail(
                     userContext.getSession().getEmailAddress(),
                     PASSWORD_RESET_BLOCKED_KEY_PREFIX,

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
@@ -121,7 +121,6 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
 
         try {
             if (!userContext.getSession().validateSession(request.getEmail())) {
-                LOG.info("Invalid session");
                 return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1000);
             }
             if (request.getNotificationType().equals(ACCOUNT_CREATED_CONFIRMATION)) {
@@ -156,7 +155,6 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
                     Optional<ErrorResponse> emailErrorResponse =
                             validationService.validateEmailAddress(request.getEmail());
                     if (emailErrorResponse.isPresent()) {
-                        LOG.info("Encountered emailErrorResponse: {}", emailErrorResponse.get());
                         return generateApiGatewayProxyErrorResponse(400, emailErrorResponse.get());
                     }
                     return handleNotificationRequest(
@@ -173,7 +171,6 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
                                     userContext);
 
                     if (request.getPhoneNumber() == null) {
-                        LOG.error("No phone number provided");
                         return generateApiGatewayProxyResponse(400, ERROR_1011);
                     }
                     String phoneNumber = removeWhitespaceFromPhoneNumber(request.getPhoneNumber());
@@ -194,12 +191,10 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
             LOG.error("Error sending message to queue");
             return generateApiGatewayProxyResponse(500, "Error sending message to queue");
         } catch (JsonProcessingException e) {
-            LOG.error("Error parsing request");
             return generateApiGatewayProxyErrorResponse(400, ERROR_1001);
         } catch (StateMachine.InvalidStateTransitionException e) {
             return generateApiGatewayProxyErrorResponse(400, ERROR_1017);
         } catch (ClientNotFoundException e) {
-            LOG.error("Client not found");
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1015);
         }
     }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
@@ -124,7 +124,6 @@ public class SignUpHandler extends BaseFrontendHandler<SignupRequest>
                             AuditService.UNKNOWN,
                             PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));
 
-                    LOG.info("User already exists");
                     return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1009);
                 }
                 authenticationService.signUp(
@@ -159,7 +158,6 @@ public class SignUpHandler extends BaseFrontendHandler<SignupRequest>
                 return generateApiGatewayProxyResponse(
                         200, new BaseAPIResponse(userContext.getSession().getState()));
             } else {
-                LOG.info("Invalid Password entered: {}", passwordValidationErrors.get());
                 return generateApiGatewayProxyErrorResponse(400, passwordValidationErrors.get());
             }
         } catch (JsonProcessingException e) {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
@@ -182,7 +182,6 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
                         ClientSession clientSession = userContext.getClientSession();
 
                         if (clientSession == null) {
-                            LOG.error("ClientSession not found");
                             return generateErrorResponse(ErrorResponse.ERROR_1000, context);
                         }
                         AuthenticationRequest authorizationRequest;
@@ -273,12 +272,10 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
                     }
             }
         } catch (JsonProcessingException e) {
-            LOG.error("Error parsing request");
             return generateErrorResponse(ErrorResponse.ERROR_1001, context);
         } catch (InvalidStateTransitionException e) {
             return generateErrorResponse(ErrorResponse.ERROR_1017, context);
         }
-        LOG.error("Encountered unexpected error");
         return generateErrorResponse(ErrorResponse.ERROR_1013, context);
     }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -164,7 +164,6 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                             configurationService.getCodeMaxRetries());
 
             if (validationAction == null) {
-                LOG.error("Encountered unexpected error");
                 return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1002);
             }
 
@@ -188,12 +187,10 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
             return generateSuccessResponse(session);
 
         } catch (JsonProcessingException e) {
-            LOG.error("Error parsing request");
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
         } catch (StateMachine.InvalidStateTransitionException e) {
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1017);
         } catch (ClientNotFoundException e) {
-            LOG.error("Client not found");
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1015);
         }
     }

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandler.java
@@ -11,6 +11,7 @@ import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+import com.nimbusds.openid.connect.sdk.OIDCClaimsRequest;
 import com.nimbusds.openid.connect.sdk.claims.ClaimsSetRequest;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -145,16 +146,13 @@ public class IPVAuthorisationHandler extends BaseFrontendHandler<IPVAuthorisatio
         } catch (StateMachine.InvalidStateTransitionException e) {
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1017);
         } catch (ParseException | JsonProcessingException e) {
-            LOG.error("Could not parse authentication request from client");
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
         }
     }
 
     private Optional<ClaimsSetRequest> buildIpvClaimsRequest(AuthenticationRequest authRequest) {
-        if (authRequest.getOIDCClaims() == null
-                || authRequest.getOIDCClaims().getUserInfoClaimsRequest() == null) {
-            return Optional.empty();
-        }
-        return Optional.of(authRequest.getOIDCClaims().getUserInfoClaimsRequest());
+        return Optional.ofNullable(authRequest)
+                .map(AuthenticationRequest::getOIDCClaims)
+                .map(OIDCClaimsRequest::getUserInfoClaimsRequest);
     }
 }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -110,7 +110,6 @@ public class AuthCodeHandler
                                                         sessionCookieIds.getSessionId())
                                                 .orElseThrow();
                             } catch (NoSuchElementException e) {
-                                LOG.error("SessionID not found");
                                 return generateApiGatewayProxyErrorResponse(
                                         400, ErrorResponse.ERROR_1000);
                             }
@@ -267,7 +266,6 @@ public class AuthCodeHandler
     }
 
     private APIGatewayProxyResponseEvent generateInvalidClientRedirectError(URI redirectURI) {
-        LOG.error("Invalid client redirect URI ({})", redirectURI);
         return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1016);
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ApiGatewayResponseHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ApiGatewayResponseHelper.java
@@ -38,6 +38,13 @@ public class ApiGatewayResponseHelper {
 
     public static <T> APIGatewayProxyResponseEvent generateApiGatewayProxyErrorResponse(
             int statusCode, ErrorResponse errorResponse) {
+
+        if (400 <= statusCode && statusCode <= 499) {
+            LOG.warn(errorResponse.getMessage());
+        } else {
+            LOG.error(errorResponse.getMessage());
+        }
+
         try {
             return generateApiGatewayProxyResponse(
                     statusCode, new ObjectMapper().writeValueAsString(errorResponse));


### PR DESCRIPTION
- AUTH-1263: Log error message at creation of the response
- AUTH-1263: Remove unneeded logging in `account-management-api`
- AUTH-1263: Remove unneeded logging in `frontend-api`
- AUTH-1263: Remove unneeded logging in `ipv-api`
- AUTH-1263: Remove unneeded logging in `oidc-api`

## What?

Log error response within the creation of the response, rather than having inconsistent messages across the board.
