### PR TITLE
AUTH-1292: Allow multiple security groups to endpoint module

### DIFF
--- a/ci/terraform/account-management/authenticate.tf
+++ b/ci/terraform/account-management/authenticate.tf
@@ -20,7 +20,7 @@ module "authenticate" {
   execution_arn                          = aws_api_gateway_rest_api.di_account_management_api.execution_arn
   lambda_zip_file                        = var.lambda_zip_file
   authentication_vpc_arn                 = aws_vpc.account_management_vpc.arn
-  security_group_id                      = aws_security_group.allow_vpc_resources_only.id
+  security_group_ids                     = [aws_security_group.allow_vpc_resources_only.id]
   subnet_id                              = aws_subnet.account_management_subnets.*.id
   environment                            = var.environment
   lambda_role_arn                        = module.account_notification_default_role.arn

--- a/ci/terraform/account-management/authenticate.tf
+++ b/ci/terraform/account-management/authenticate.tf
@@ -34,6 +34,7 @@ module "authenticate" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_security_group_ids    = [aws_security_group.allow_vpc_resources_only.id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }

--- a/ci/terraform/account-management/remove-account.tf
+++ b/ci/terraform/account-management/remove-account.tf
@@ -35,6 +35,7 @@ module "delete_account" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_security_group_ids    = [aws_security_group.allow_vpc_resources_only.id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }

--- a/ci/terraform/account-management/remove-account.tf
+++ b/ci/terraform/account-management/remove-account.tf
@@ -20,7 +20,7 @@ module "delete_account" {
   execution_arn                          = aws_api_gateway_rest_api.di_account_management_api.execution_arn
   lambda_zip_file                        = var.lambda_zip_file
   authentication_vpc_arn                 = aws_vpc.account_management_vpc.arn
-  security_group_id                      = aws_security_group.allow_vpc_resources_only.id
+  security_group_ids                     = [aws_security_group.allow_vpc_resources_only.id]
   subnet_id                              = aws_subnet.account_management_subnets.*.id
   environment                            = var.environment
   lambda_role_arn                        = module.account_notification_dynamo_sqs_role.arn

--- a/ci/terraform/account-management/send_otp_notification.tf
+++ b/ci/terraform/account-management/send_otp_notification.tf
@@ -22,7 +22,7 @@ module "send_otp_notification" {
   execution_arn                          = aws_api_gateway_rest_api.di_account_management_api.execution_arn
   lambda_zip_file                        = var.lambda_zip_file
   authentication_vpc_arn                 = aws_vpc.account_management_vpc.arn
-  security_group_id                      = aws_security_group.allow_vpc_resources_only.id
+  security_group_ids                     = [aws_security_group.allow_vpc_resources_only.id]
   subnet_id                              = aws_subnet.account_management_subnets.*.id
   lambda_role_arn                        = module.account_notification_dynamo_sqs_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled

--- a/ci/terraform/account-management/send_otp_notification.tf
+++ b/ci/terraform/account-management/send_otp_notification.tf
@@ -37,6 +37,7 @@ module "send_otp_notification" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_security_group_ids    = [aws_security_group.allow_vpc_resources_only.id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }

--- a/ci/terraform/account-management/update-email.tf
+++ b/ci/terraform/account-management/update-email.tf
@@ -21,7 +21,7 @@ module "update_email" {
   execution_arn                          = aws_api_gateway_rest_api.di_account_management_api.execution_arn
   lambda_zip_file                        = var.lambda_zip_file
   authentication_vpc_arn                 = aws_vpc.account_management_vpc.arn
-  security_group_id                      = aws_security_group.allow_vpc_resources_only.id
+  security_group_ids                     = [aws_security_group.allow_vpc_resources_only.id]
   subnet_id                              = aws_subnet.account_management_subnets.*.id
   environment                            = var.environment
   lambda_role_arn                        = module.account_notification_dynamo_sqs_role.arn

--- a/ci/terraform/account-management/update-email.tf
+++ b/ci/terraform/account-management/update-email.tf
@@ -36,6 +36,7 @@ module "update_email" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_security_group_ids    = [aws_security_group.allow_vpc_resources_only.id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }

--- a/ci/terraform/account-management/update-password.tf
+++ b/ci/terraform/account-management/update-password.tf
@@ -35,6 +35,7 @@ module "update_password" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_security_group_ids    = [aws_security_group.allow_vpc_resources_only.id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }

--- a/ci/terraform/account-management/update-password.tf
+++ b/ci/terraform/account-management/update-password.tf
@@ -20,7 +20,7 @@ module "update_password" {
   execution_arn                          = aws_api_gateway_rest_api.di_account_management_api.execution_arn
   lambda_zip_file                        = var.lambda_zip_file
   authentication_vpc_arn                 = aws_vpc.account_management_vpc.arn
-  security_group_id                      = aws_security_group.allow_vpc_resources_only.id
+  security_group_ids                     = [aws_security_group.allow_vpc_resources_only.id]
   subnet_id                              = aws_subnet.account_management_subnets.*.id
   environment                            = var.environment
   lambda_role_arn                        = module.account_notification_dynamo_sqs_role.arn

--- a/ci/terraform/account-management/update-phone-number.tf
+++ b/ci/terraform/account-management/update-phone-number.tf
@@ -21,7 +21,7 @@ module "update_phone_number" {
   execution_arn                          = aws_api_gateway_rest_api.di_account_management_api.execution_arn
   lambda_zip_file                        = var.lambda_zip_file
   authentication_vpc_arn                 = aws_vpc.account_management_vpc.arn
-  security_group_id                      = aws_security_group.allow_vpc_resources_only.id
+  security_group_ids                     = [aws_security_group.allow_vpc_resources_only.id]
   subnet_id                              = aws_subnet.account_management_subnets.*.id
   environment                            = var.environment
   lambda_role_arn                        = module.account_notification_dynamo_sqs_role.arn

--- a/ci/terraform/account-management/update-phone-number.tf
+++ b/ci/terraform/account-management/update-phone-number.tf
@@ -36,6 +36,7 @@ module "update_phone_number" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_security_group_ids    = [aws_security_group.allow_vpc_resources_only.id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }

--- a/ci/terraform/modules/endpoint-module/lambda.tf
+++ b/ci/terraform/modules/endpoint-module/lambda.tf
@@ -13,7 +13,7 @@ resource "aws_lambda_function" "endpoint_lambda" {
 
   source_code_hash = filebase64sha256(var.lambda_zip_file)
   vpc_config {
-    security_group_ids = [var.security_group_id]
+    security_group_ids = var.security_group_ids
     subnet_ids         = var.subnet_id
   }
   environment {

--- a/ci/terraform/modules/endpoint-module/variables.tf
+++ b/ci/terraform/modules/endpoint-module/variables.tf
@@ -72,6 +72,11 @@ variable "security_group_ids" {
   description = "The list of security group IDs to apply to the lambda"
 }
 
+variable "warmer_security_group_ids" {
+  type        = list(string)
+  description = "The list of security group IDs to apply to the warmer lambda"
+}
+
 variable "subnet_id" {
   type        = list(string)
   description = "The id of the subnets for the lambda"

--- a/ci/terraform/modules/endpoint-module/variables.tf
+++ b/ci/terraform/modules/endpoint-module/variables.tf
@@ -67,9 +67,9 @@ variable "authentication_vpc_arn" {
   type = string
 }
 
-variable "security_group_id" {
-  type        = string
-  description = "The id of the security for the lambda"
+variable "security_group_ids" {
+  type        = list(string)
+  description = "The list of security group IDs to apply to the lambda"
 }
 
 variable "subnet_id" {

--- a/ci/terraform/modules/endpoint-module/warmer.tf
+++ b/ci/terraform/modules/endpoint-module/warmer.tf
@@ -135,7 +135,7 @@ resource "aws_lambda_function" "warmer_function" {
   source_code_hash = filebase64sha256(var.warmer_lambda_zip_file)
 
   vpc_config {
-    security_group_ids = [var.security_group_id]
+    security_group_ids = var.security_group_ids
     subnet_ids         = var.subnet_id
   }
 

--- a/ci/terraform/modules/endpoint-module/warmer.tf
+++ b/ci/terraform/modules/endpoint-module/warmer.tf
@@ -135,7 +135,7 @@ resource "aws_lambda_function" "warmer_function" {
   source_code_hash = filebase64sha256(var.warmer_lambda_zip_file)
 
   vpc_config {
-    security_group_ids = var.security_group_ids
+    security_group_ids = var.warmer_security_group_ids
     subnet_ids         = var.subnet_id
   }
 

--- a/ci/terraform/oidc/auth-code.tf
+++ b/ci/terraform/oidc/auth-code.tf
@@ -22,7 +22,7 @@ module "auth-code" {
   execution_arn                          = aws_api_gateway_rest_api.di_authentication_api.execution_arn
   lambda_zip_file                        = var.oidc_api_lambda_zip_file
   authentication_vpc_arn                 = local.authentication_vpc_arn
-  security_group_id                      = local.authentication_security_group_id
+  security_group_ids                     = [local.authentication_security_group_id]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.oidc_default_role.arn
   environment                            = var.environment

--- a/ci/terraform/oidc/auth-code.tf
+++ b/ci/terraform/oidc/auth-code.tf
@@ -36,6 +36,7 @@ module "auth-code" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_security_group_ids    = [local.authentication_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }

--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -38,6 +38,7 @@ module "authorize" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_security_group_ids    = [local.authentication_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }

--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -25,7 +25,7 @@ module "authorize" {
   execution_arn                          = aws_api_gateway_rest_api.di_authentication_api.execution_arn
   lambda_zip_file                        = var.oidc_api_lambda_zip_file
   authentication_vpc_arn                 = local.authentication_vpc_arn
-  security_group_id                      = local.authentication_security_group_id
+  security_group_ids                     = [local.authentication_security_group_id]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.oidc_default_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled

--- a/ci/terraform/oidc/client-info.tf
+++ b/ci/terraform/oidc/client-info.tf
@@ -23,7 +23,7 @@ module "client-info" {
   execution_arn                          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
   lambda_zip_file                        = var.frontend_api_lambda_zip_file
   authentication_vpc_arn                 = local.authentication_vpc_arn
-  security_group_id                      = local.authentication_security_group_id
+  security_group_ids                     = [local.authentication_security_group_id]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.oidc_default_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled

--- a/ci/terraform/oidc/client-info.tf
+++ b/ci/terraform/oidc/client-info.tf
@@ -37,6 +37,7 @@ module "client-info" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_security_group_ids    = [local.authentication_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }

--- a/ci/terraform/oidc/ipv-authorize.tf
+++ b/ci/terraform/oidc/ipv-authorize.tf
@@ -27,7 +27,7 @@ module "ipv-authorize" {
   execution_arn                          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
   lambda_zip_file                        = var.ipv_api_lambda_zip_file
   authentication_vpc_arn                 = local.authentication_vpc_arn
-  security_group_id                      = local.authentication_security_group_id
+  security_group_ids                     = [local.authentication_security_group_id]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.oidc_default_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled

--- a/ci/terraform/oidc/ipv-authorize.tf
+++ b/ci/terraform/oidc/ipv-authorize.tf
@@ -41,6 +41,7 @@ module "ipv-authorize" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_security_group_ids    = [local.authentication_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }

--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -41,6 +41,7 @@ module "ipv-callback" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_security_group_ids    = [local.authentication_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }

--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -28,7 +28,7 @@ module "ipv-callback" {
   execution_arn                          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
   lambda_zip_file                        = var.ipv_api_lambda_zip_file
   authentication_vpc_arn                 = local.authentication_vpc_arn
-  security_group_id                      = local.authentication_egress_security_group_id
+  security_group_ids                     = [local.authentication_egress_security_group_id]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.oidc_default_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled

--- a/ci/terraform/oidc/ipv-capacity.tf
+++ b/ci/terraform/oidc/ipv-capacity.tf
@@ -27,7 +27,7 @@ module "ipv-capacity" {
   execution_arn                          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
   lambda_zip_file                        = var.ipv_api_lambda_zip_file
   authentication_vpc_arn                 = local.authentication_vpc_arn
-  security_group_id                      = local.authentication_security_group_id
+  security_group_ids                     = [local.authentication_security_group_id]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.oidc_default_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled

--- a/ci/terraform/oidc/ipv-capacity.tf
+++ b/ci/terraform/oidc/ipv-capacity.tf
@@ -40,6 +40,7 @@ module "ipv-capacity" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_security_group_ids    = [local.authentication_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }

--- a/ci/terraform/oidc/jwks.tf
+++ b/ci/terraform/oidc/jwks.tf
@@ -34,6 +34,7 @@ module "jwks" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_security_group_ids    = [local.authentication_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }

--- a/ci/terraform/oidc/jwks.tf
+++ b/ci/terraform/oidc/jwks.tf
@@ -21,7 +21,7 @@ module "jwks" {
   execution_arn                          = aws_api_gateway_rest_api.di_authentication_api.execution_arn
   lambda_zip_file                        = var.oidc_api_lambda_zip_file
   authentication_vpc_arn                 = local.authentication_vpc_arn
-  security_group_id                      = local.authentication_security_group_id
+  security_group_ids                     = [local.authentication_security_group_id]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.oidc_default_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled

--- a/ci/terraform/oidc/login.tf
+++ b/ci/terraform/oidc/login.tf
@@ -24,7 +24,7 @@ module "login" {
   execution_arn                          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
   lambda_zip_file                        = var.frontend_api_lambda_zip_file
   authentication_vpc_arn                 = local.authentication_vpc_arn
-  security_group_id                      = local.authentication_security_group_id
+  security_group_ids                     = [local.authentication_security_group_id]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.oidc_default_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled

--- a/ci/terraform/oidc/login.tf
+++ b/ci/terraform/oidc/login.tf
@@ -38,6 +38,7 @@ module "login" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_security_group_ids    = [local.authentication_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }

--- a/ci/terraform/oidc/logout.tf
+++ b/ci/terraform/oidc/logout.tf
@@ -25,7 +25,7 @@ module "logout" {
   execution_arn                          = aws_api_gateway_rest_api.di_authentication_api.execution_arn
   lambda_zip_file                        = var.oidc_api_lambda_zip_file
   authentication_vpc_arn                 = local.authentication_vpc_arn
-  security_group_id                      = local.authentication_security_group_id
+  security_group_ids                     = [local.authentication_security_group_id]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.oidc_default_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled

--- a/ci/terraform/oidc/logout.tf
+++ b/ci/terraform/oidc/logout.tf
@@ -38,6 +38,7 @@ module "logout" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_security_group_ids    = [local.authentication_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }

--- a/ci/terraform/oidc/mfa.tf
+++ b/ci/terraform/oidc/mfa.tf
@@ -37,6 +37,7 @@ module "mfa" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_security_group_ids    = [local.authentication_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }

--- a/ci/terraform/oidc/mfa.tf
+++ b/ci/terraform/oidc/mfa.tf
@@ -23,7 +23,7 @@ module "mfa" {
   execution_arn                          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
   lambda_zip_file                        = var.frontend_api_lambda_zip_file
   authentication_vpc_arn                 = local.authentication_vpc_arn
-  security_group_id                      = local.authentication_security_group_id
+  security_group_ids                     = [local.authentication_security_group_id]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.oidc_dynamo_sqs_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled

--- a/ci/terraform/oidc/register.tf
+++ b/ci/terraform/oidc/register.tf
@@ -36,6 +36,7 @@ module "register" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_security_group_ids    = [local.authentication_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }

--- a/ci/terraform/oidc/register.tf
+++ b/ci/terraform/oidc/register.tf
@@ -22,7 +22,7 @@ module "register" {
   execution_arn                          = aws_api_gateway_rest_api.di_authentication_api.execution_arn
   authentication_vpc_arn                 = local.authentication_vpc_arn
   lambda_zip_file                        = var.client_registry_api_lambda_zip_file
-  security_group_id                      = local.authentication_security_group_id
+  security_group_ids                     = [local.authentication_security_group_id]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.oidc_default_role.arn
   environment                            = var.environment

--- a/ci/terraform/oidc/reset-password-request.tf
+++ b/ci/terraform/oidc/reset-password-request.tf
@@ -26,7 +26,7 @@ module "reset-password-request" {
   execution_arn                          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
   lambda_zip_file                        = var.frontend_api_lambda_zip_file
   authentication_vpc_arn                 = local.authentication_vpc_arn
-  security_group_id                      = local.authentication_security_group_id
+  security_group_ids                     = [local.authentication_security_group_id]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.oidc_dynamo_sqs_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled

--- a/ci/terraform/oidc/reset-password-request.tf
+++ b/ci/terraform/oidc/reset-password-request.tf
@@ -40,6 +40,7 @@ module "reset-password-request" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_security_group_ids    = [local.authentication_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }

--- a/ci/terraform/oidc/reset_password.tf
+++ b/ci/terraform/oidc/reset_password.tf
@@ -25,7 +25,7 @@ module "reset_password" {
   execution_arn                          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
   lambda_zip_file                        = var.frontend_api_lambda_zip_file
   authentication_vpc_arn                 = local.authentication_vpc_arn
-  security_group_id                      = local.authentication_security_group_id
+  security_group_ids                     = [local.authentication_security_group_id]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.oidc_dynamo_sqs_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled

--- a/ci/terraform/oidc/reset_password.tf
+++ b/ci/terraform/oidc/reset_password.tf
@@ -39,6 +39,7 @@ module "reset_password" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_security_group_ids    = [local.authentication_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }

--- a/ci/terraform/oidc/send_notification.tf
+++ b/ci/terraform/oidc/send_notification.tf
@@ -22,7 +22,7 @@ module "send_notification" {
   execution_arn                          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
   lambda_zip_file                        = var.frontend_api_lambda_zip_file
   authentication_vpc_arn                 = local.authentication_vpc_arn
-  security_group_id                      = local.authentication_security_group_id
+  security_group_ids                     = [local.authentication_security_group_id]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.oidc_dynamo_sqs_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled

--- a/ci/terraform/oidc/send_notification.tf
+++ b/ci/terraform/oidc/send_notification.tf
@@ -36,6 +36,7 @@ module "send_notification" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_security_group_ids    = [local.authentication_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }

--- a/ci/terraform/oidc/signup.tf
+++ b/ci/terraform/oidc/signup.tf
@@ -37,6 +37,7 @@ module "signup" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_security_group_ids    = [local.authentication_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }

--- a/ci/terraform/oidc/signup.tf
+++ b/ci/terraform/oidc/signup.tf
@@ -23,7 +23,7 @@ module "signup" {
   execution_arn                          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
   lambda_zip_file                        = var.frontend_api_lambda_zip_file
   authentication_vpc_arn                 = local.authentication_vpc_arn
-  security_group_id                      = local.authentication_security_group_id
+  security_group_ids                     = [local.authentication_security_group_id]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.oidc_default_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled

--- a/ci/terraform/oidc/token.tf
+++ b/ci/terraform/oidc/token.tf
@@ -78,6 +78,7 @@ module "token" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_security_group_ids    = [local.authentication_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }

--- a/ci/terraform/oidc/token.tf
+++ b/ci/terraform/oidc/token.tf
@@ -65,7 +65,7 @@ module "token" {
   execution_arn                          = aws_api_gateway_rest_api.di_authentication_api.execution_arn
   lambda_zip_file                        = var.oidc_api_lambda_zip_file
   authentication_vpc_arn                 = local.authentication_vpc_arn
-  security_group_id                      = local.authentication_security_group_id
+  security_group_ids                     = [local.authentication_security_group_id]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.oidc_token_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled

--- a/ci/terraform/oidc/trustmarks.tf
+++ b/ci/terraform/oidc/trustmarks.tf
@@ -35,6 +35,7 @@ module "trustmarks" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_security_group_ids    = [local.authentication_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }

--- a/ci/terraform/oidc/trustmarks.tf
+++ b/ci/terraform/oidc/trustmarks.tf
@@ -22,7 +22,7 @@ module "trustmarks" {
   execution_arn                          = aws_api_gateway_rest_api.di_authentication_api.execution_arn
   lambda_zip_file                        = var.oidc_api_lambda_zip_file
   authentication_vpc_arn                 = local.authentication_vpc_arn
-  security_group_id                      = local.authentication_security_group_id
+  security_group_ids                     = [local.authentication_security_group_id]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.oidc_default_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled

--- a/ci/terraform/oidc/update.tf
+++ b/ci/terraform/oidc/update.tf
@@ -23,7 +23,7 @@ module "update" {
   execution_arn                          = aws_api_gateway_rest_api.di_authentication_api.execution_arn
   lambda_zip_file                        = var.client_registry_api_lambda_zip_file
   authentication_vpc_arn                 = local.authentication_vpc_arn
-  security_group_id                      = local.authentication_security_group_id
+  security_group_ids                     = [local.authentication_security_group_id]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.oidc_default_role.arn
   environment                            = var.environment

--- a/ci/terraform/oidc/update.tf
+++ b/ci/terraform/oidc/update.tf
@@ -37,6 +37,7 @@ module "update" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_security_group_ids    = [local.authentication_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }

--- a/ci/terraform/oidc/update_profile.tf
+++ b/ci/terraform/oidc/update_profile.tf
@@ -24,7 +24,7 @@ module "update_profile" {
   execution_arn                          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
   lambda_zip_file                        = var.frontend_api_lambda_zip_file
   authentication_vpc_arn                 = local.authentication_vpc_arn
-  security_group_id                      = local.authentication_security_group_id
+  security_group_ids                     = [local.authentication_security_group_id]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.oidc_default_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled

--- a/ci/terraform/oidc/update_profile.tf
+++ b/ci/terraform/oidc/update_profile.tf
@@ -38,6 +38,7 @@ module "update_profile" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_security_group_ids    = [local.authentication_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }

--- a/ci/terraform/oidc/userexists.tf
+++ b/ci/terraform/oidc/userexists.tf
@@ -38,6 +38,7 @@ module "userexists" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_security_group_ids    = [local.authentication_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }

--- a/ci/terraform/oidc/userexists.tf
+++ b/ci/terraform/oidc/userexists.tf
@@ -24,7 +24,7 @@ module "userexists" {
   execution_arn                          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
   lambda_zip_file                        = var.frontend_api_lambda_zip_file
   authentication_vpc_arn                 = local.authentication_vpc_arn
-  security_group_id                      = local.authentication_security_group_id
+  security_group_ids                     = [local.authentication_security_group_id]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.oidc_default_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -23,7 +23,7 @@ module "userinfo" {
   execution_arn                          = aws_api_gateway_rest_api.di_authentication_api.execution_arn
   lambda_zip_file                        = var.oidc_api_lambda_zip_file
   authentication_vpc_arn                 = local.authentication_vpc_arn
-  security_group_id                      = local.authentication_security_group_id
+  security_group_ids                     = [local.authentication_security_group_id]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.oidc_default_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -36,6 +36,7 @@ module "userinfo" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_security_group_ids    = [local.authentication_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }

--- a/ci/terraform/oidc/verify_code.tf
+++ b/ci/terraform/oidc/verify_code.tf
@@ -26,7 +26,7 @@ module "verify_code" {
   execution_arn                          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
   lambda_zip_file                        = var.frontend_api_lambda_zip_file
   authentication_vpc_arn                 = local.authentication_vpc_arn
-  security_group_id                      = local.authentication_security_group_id
+  security_group_ids                     = [local.authentication_security_group_id]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.oidc_default_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled

--- a/ci/terraform/oidc/verify_code.tf
+++ b/ci/terraform/oidc/verify_code.tf
@@ -40,6 +40,7 @@ module "verify_code" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_security_group_ids    = [local.authentication_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }

--- a/ci/terraform/oidc/wellknown.tf
+++ b/ci/terraform/oidc/wellknown.tf
@@ -39,6 +39,7 @@ module "openid_configuration_discovery" {
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
   warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_security_group_ids    = [local.authentication_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }

--- a/ci/terraform/oidc/wellknown.tf
+++ b/ci/terraform/oidc/wellknown.tf
@@ -26,7 +26,7 @@ module "openid_configuration_discovery" {
   execution_arn                          = aws_api_gateway_rest_api.di_authentication_api.execution_arn
   lambda_zip_file                        = var.oidc_api_lambda_zip_file
   authentication_vpc_arn                 = local.authentication_vpc_arn
-  security_group_id                      = local.authentication_security_group_id
+  security_group_ids                     = [local.authentication_security_group_id]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.openid_configuration_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled


### PR DESCRIPTION
## What?

- Change the `security_group_id` variable on the `endpoint_module` so that it can accept multiple values, so access can be aggregated across multiple security groups.

## Why?

With consolidation of VPCs and the splitting of VPC provisioning to a different Terraform deployment, it is likely that  security groups controlling access to different resources are going to be split, so we will need the ability to assign multiple security groups to a lambda.
