### PR TITLE
AUTH-1063 - Only support medium level of confidence

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -114,7 +114,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                                 Optional.of(CLIENT_ID),
                                 Optional.empty(),
                                 "openid",
-                                Optional.of("Pl.Cl.Cm")));
+                                Optional.of("Pm.Cl.Cm")));
         assertThat(response, hasStatus(302));
         assertThat(
                 getHeaderValueByParamName(response, ResponseHeaders.LOCATION),

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
@@ -84,10 +84,6 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 Optional.of("Cl"),
                 Optional.of("Pm.Cl.Cm"),
                 Optional.of("Pm.Cl"),
-                Optional.of("Pl.Cl.Cm"),
-                Optional.of("Pl.Cl"),
-                Optional.of("Ph.Cl"),
-                Optional.of("Ph.Cl.Cm"),
                 Optional.empty());
     }
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TrustMarkHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TrustMarkHandler.java
@@ -58,6 +58,6 @@ public class TrustMarkHandler
                 Arrays.asList(
                         CredentialTrustLevel.LOW_LEVEL.getValue(),
                         CredentialTrustLevel.MEDIUM_LEVEL.getValue()),
-                LevelOfConfidence.getAllLevelOfConfidenceValues());
+                LevelOfConfidence.getAllSupportedLevelOfConfidenceValues());
     }
 }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
@@ -39,7 +39,6 @@ import uk.gov.di.authentication.shared.entity.AuthCodeExchangeData;
 import uk.gov.di.authentication.shared.entity.ClientConsent;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
-import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.RefreshTokenStore;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.ValidScopes;
@@ -102,7 +101,6 @@ public class TokenHandlerTest {
     public static final String CLIENT_SESSION_ID = "a-client-session-id";
     private static final Nonce NONCE = new Nonce();
     private static final String REFRESH_TOKEN_PREFIX = "REFRESH_TOKEN:";
-    private static final String VOT = CredentialTrustLevel.MEDIUM_LEVEL.getValue();
     private final Context context = mock(Context.class);
     private final DynamoService dynamoService = mock(DynamoService.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
@@ -134,8 +132,7 @@ public class TokenHandlerTest {
     }
 
     private static Stream<String> validVectorValues() {
-        return Stream.of(
-                "Cl.Cm", "Cl", "Pm.Cl.Cm", "Pm.Cl", "Pl.Cl.Cm", "Pl.Cl", "Ph.Cl", "Ph.Cl.Cm");
+        return Stream.of("Cl.Cm", "Cl", "Pm.Cl.Cm", "Pm.Cl");
     }
 
     @ParameterizedTest

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TrustMarkHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TrustMarkHandlerTest.java
@@ -43,7 +43,7 @@ class TrustMarkHandlerTest {
                         List.of(
                                 CredentialTrustLevel.LOW_LEVEL.getValue(),
                                 CredentialTrustLevel.MEDIUM_LEVEL.getValue()),
-                        LevelOfConfidence.getAllLevelOfConfidenceValues());
+                        LevelOfConfidence.getAllSupportedLevelOfConfidenceValues());
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/LevelOfConfidence.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/LevelOfConfidence.java
@@ -5,32 +5,39 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public enum LevelOfConfidence {
-    LOW_LEVEL("Pl"),
-    MEDIUM_LEVEL("Pm"),
-    HIGH_LEVEL("Ph"),
-    VERY_HIGH_LEVEL("Pv");
+    LOW_LEVEL("Pl", false),
+    MEDIUM_LEVEL("Pm", true),
+    HIGH_LEVEL("Ph", false),
+    VERY_HIGH_LEVEL("Pv", false);
 
     private String value;
+    private boolean supported;
 
-    LevelOfConfidence(String value) {
+    LevelOfConfidence(String value, boolean supported) {
         this.value = value;
+        this.supported = supported;
     }
 
     public String getValue() {
         return value;
     }
 
-    public static LevelOfConfidence retrieveLevelOfConfidence(String vrtSet) {
+    public boolean isSupported() {
+        return supported;
+    }
 
+    public static LevelOfConfidence retrieveLevelOfConfidence(String vrtSet) {
         return Arrays.stream(values())
+                .filter(LevelOfConfidence::isSupported)
                 .filter(tl -> vrtSet.equals(tl.getValue()))
                 .findFirst()
                 .orElseThrow(
                         () -> new IllegalArgumentException("Invalid LevelOfConfidence provided"));
     }
 
-    public static List<String> getAllLevelOfConfidenceValues() {
+    public static List<String> getAllSupportedLevelOfConfidenceValues() {
         return Arrays.stream(LevelOfConfidence.values())
+                .filter(LevelOfConfidence::isSupported)
                 .map(LevelOfConfidence::getValue)
                 .collect(Collectors.toList());
     }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/LevelOfConfidenceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/LevelOfConfidenceTest.java
@@ -23,10 +23,18 @@ class LevelOfConfidenceTest {
     }
 
     @ParameterizedTest
-    @MethodSource("validLevelOfConfidence")
+    @MethodSource("supportedLevelOfConfidence")
     void shouldReturnLevelOfConfidenceForValidValue(
             String vtrSet, LevelOfConfidence expectedLevel) {
         assertThat(LevelOfConfidence.retrieveLevelOfConfidence(vtrSet), equalTo(expectedLevel));
+    }
+
+    @ParameterizedTest
+    @MethodSource("unsupportedLevelOfConfidence")
+    void shouldThrowWhenUnsupportedValueIsPassed(String vtrSet) {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> LevelOfConfidence.retrieveLevelOfConfidence(vtrSet));
     }
 
     @ParameterizedTest
@@ -38,26 +46,24 @@ class LevelOfConfidenceTest {
     }
 
     @Test
-    void shouldReturnLevelOfConfidenceValuesFromLowestToHighest() {
-        List<String> allLevelOfConfidenceValues = LevelOfConfidence.getAllLevelOfConfidenceValues();
+    void shouldReturnOnlySupportedLevelOfConfidenceValues() {
+        List<String> allLevelOfConfidenceValues =
+                LevelOfConfidence.getAllSupportedLevelOfConfidenceValues();
+
+        assertThat(allLevelOfConfidenceValues.size(), equalTo(1));
 
         assertThat(
-                allLevelOfConfidenceValues.get(0), equalTo(LevelOfConfidence.LOW_LEVEL.getValue()));
-        assertThat(
-                allLevelOfConfidenceValues.get(1),
+                allLevelOfConfidenceValues.get(0),
                 equalTo(LevelOfConfidence.MEDIUM_LEVEL.getValue()));
-        assertThat(
-                allLevelOfConfidenceValues.get(2),
-                equalTo(LevelOfConfidence.HIGH_LEVEL.getValue()));
-        assertThat(
-                allLevelOfConfidenceValues.get(3),
-                equalTo(LevelOfConfidence.VERY_HIGH_LEVEL.getValue()));
     }
 
-    private static Stream<Arguments> validLevelOfConfidence() {
+    private static Stream<Arguments> supportedLevelOfConfidence() {
+        return Stream.of(Arguments.of("Pm", LevelOfConfidence.MEDIUM_LEVEL));
+    }
+
+    private static Stream<Arguments> unsupportedLevelOfConfidence() {
         return Stream.of(
                 Arguments.of("Pl", LevelOfConfidence.LOW_LEVEL),
-                Arguments.of("Pm", LevelOfConfidence.MEDIUM_LEVEL),
                 Arguments.of("Ph", LevelOfConfidence.HIGH_LEVEL),
                 Arguments.of("Pv", LevelOfConfidence.VERY_HIGH_LEVEL));
     }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/VectorOfTrustTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/VectorOfTrustTest.java
@@ -52,21 +52,12 @@ class VectorOfTrustTest {
     }
 
     @Test
-    void shouldParseValidStringWithMultipleIdentityVectors() {
-        var jsonArray = jsonArrayOf("Pm.Cl.Cm", "Ph.Cl.Cm", "Cl.Cm");
+    void shouldParseValidStringWithSingleIdentityVector() {
+        var jsonArray = jsonArrayOf("Pm.Cl.Cm");
         VectorOfTrust vectorOfTrust =
                 VectorOfTrust.parseFromAuthRequestAttribute(Collections.singletonList(jsonArray));
         assertThat(vectorOfTrust.getCredentialTrustLevel(), equalTo(MEDIUM_LEVEL));
         assertThat(vectorOfTrust.getLevelOfConfidence(), equalTo(LevelOfConfidence.MEDIUM_LEVEL));
-    }
-
-    @Test
-    void shouldParseValidStringWithSingleIdentityVector() {
-        var jsonArray = jsonArrayOf("Ph.Cl.Cm");
-        VectorOfTrust vectorOfTrust =
-                VectorOfTrust.parseFromAuthRequestAttribute(Collections.singletonList(jsonArray));
-        assertThat(vectorOfTrust.getCredentialTrustLevel(), equalTo(MEDIUM_LEVEL));
-        assertThat(vectorOfTrust.getLevelOfConfidence(), equalTo(LevelOfConfidence.HIGH_LEVEL));
     }
 
     @Test
@@ -79,13 +70,13 @@ class VectorOfTrustTest {
     }
 
     @Test
-    void
-            shouldParseToLowCredentialTrustLevelAndMediumLevelOfConfidenceWhenMultipleIdentityLevelsExist() {
+    void shouldThrowWhenUnsupportedIdentityValueInVector() {
         var jsonArray = jsonArrayOf("Pm.Cl.Cm", "Ph.Cl");
-        VectorOfTrust vectorOfTrust =
-                VectorOfTrust.parseFromAuthRequestAttribute(Collections.singletonList(jsonArray));
-        assertThat(vectorOfTrust.getCredentialTrustLevel(), equalTo(MEDIUM_LEVEL));
-        assertThat(vectorOfTrust.getLevelOfConfidence(), equalTo(LevelOfConfidence.MEDIUM_LEVEL));
+        assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                        VectorOfTrust.parseFromAuthRequestAttribute(
+                                Collections.singletonList(jsonArray)));
     }
 
     @Test

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuthorizationServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuthorizationServiceTest.java
@@ -147,7 +147,7 @@ class AuthorizationServiceTest {
                         REDIRECT_URI.toString(),
                         responseType,
                         scope,
-                        jsonArrayOf("Pl.Cl.Cm", "Pl.Cl"),
+                        jsonArrayOf("Pm.Cl.Cm", "Pm.Cl"),
                         Optional.empty());
         Optional<ErrorObject> errorObject = authorizationService.validateAuthRequest(authRequest);
 


### PR DESCRIPTION
## What?

- Only support medium level of confidence

## Why?

- To start with, we are only going to be supporting the medium level of confidence. We might want to support others in the future, so rather than remove them add an additional attribute to the enum on whether that loc is supported or not.
