### PR TITLE
AUTH-1292: Separate Security Group for OIDC Redis

### DIFF
--- a/ci/terraform/oidc/auth-code.tf
+++ b/ci/terraform/oidc/auth-code.tf
@@ -17,12 +17,15 @@ module "auth-code" {
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.AuthCodeHandler::handleRequest"
 
-  rest_api_id                            = aws_api_gateway_rest_api.di_authentication_api.id
-  root_resource_id                       = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
-  execution_arn                          = aws_api_gateway_rest_api.di_authentication_api.execution_arn
-  lambda_zip_file                        = var.oidc_api_lambda_zip_file
-  authentication_vpc_arn                 = local.authentication_vpc_arn
-  security_group_ids                     = [local.authentication_security_group_id]
+  rest_api_id            = aws_api_gateway_rest_api.di_authentication_api.id
+  root_resource_id       = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
+  execution_arn          = aws_api_gateway_rest_api.di_authentication_api.execution_arn
+  lambda_zip_file        = var.oidc_api_lambda_zip_file
+  authentication_vpc_arn = local.authentication_vpc_arn
+  security_group_ids = [
+    local.authentication_security_group_id,
+    local.authentication_oidc_redis_security_group_id,
+  ]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.oidc_default_role.arn
   environment                            = var.environment

--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -19,13 +19,16 @@ module "authorize" {
     TERMS_CONDITIONS_VERSION = var.terms_and_conditions
     HEADERS_CASE_INSENSITIVE = var.use_localstack ? "true" : "false"
   }
-  handler_function_name                  = "uk.gov.di.authentication.oidc.lambda.AuthorisationHandler::handleRequest"
-  rest_api_id                            = aws_api_gateway_rest_api.di_authentication_api.id
-  root_resource_id                       = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
-  execution_arn                          = aws_api_gateway_rest_api.di_authentication_api.execution_arn
-  lambda_zip_file                        = var.oidc_api_lambda_zip_file
-  authentication_vpc_arn                 = local.authentication_vpc_arn
-  security_group_ids                     = [local.authentication_security_group_id]
+  handler_function_name  = "uk.gov.di.authentication.oidc.lambda.AuthorisationHandler::handleRequest"
+  rest_api_id            = aws_api_gateway_rest_api.di_authentication_api.id
+  root_resource_id       = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
+  execution_arn          = aws_api_gateway_rest_api.di_authentication_api.execution_arn
+  lambda_zip_file        = var.oidc_api_lambda_zip_file
+  authentication_vpc_arn = local.authentication_vpc_arn
+  security_group_ids = [
+    local.authentication_security_group_id,
+    local.authentication_oidc_redis_security_group_id,
+  ]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.oidc_default_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled

--- a/ci/terraform/oidc/client-info.tf
+++ b/ci/terraform/oidc/client-info.tf
@@ -18,12 +18,15 @@ module "client-info" {
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.ClientInfoHandler::handleRequest"
 
-  rest_api_id                            = aws_api_gateway_rest_api.di_authentication_frontend_api.id
-  root_resource_id                       = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
-  execution_arn                          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
-  lambda_zip_file                        = var.frontend_api_lambda_zip_file
-  authentication_vpc_arn                 = local.authentication_vpc_arn
-  security_group_ids                     = [local.authentication_security_group_id]
+  rest_api_id            = aws_api_gateway_rest_api.di_authentication_frontend_api.id
+  root_resource_id       = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
+  execution_arn          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
+  lambda_zip_file        = var.frontend_api_lambda_zip_file
+  authentication_vpc_arn = local.authentication_vpc_arn
+  security_group_ids = [
+    local.authentication_security_group_id,
+    local.authentication_oidc_redis_security_group_id,
+  ]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.oidc_default_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled

--- a/ci/terraform/oidc/ipv-authorize.tf
+++ b/ci/terraform/oidc/ipv-authorize.tf
@@ -21,13 +21,16 @@ module "ipv-authorize" {
   }
   handler_function_name = "uk.gov.di.authentication.ipv.lambda.IPVAuthorisationHandler::handleRequest"
 
-  create_endpoint                        = true
-  rest_api_id                            = aws_api_gateway_rest_api.di_authentication_frontend_api.id
-  root_resource_id                       = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
-  execution_arn                          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
-  lambda_zip_file                        = var.ipv_api_lambda_zip_file
-  authentication_vpc_arn                 = local.authentication_vpc_arn
-  security_group_ids                     = [local.authentication_security_group_id]
+  create_endpoint        = true
+  rest_api_id            = aws_api_gateway_rest_api.di_authentication_frontend_api.id
+  root_resource_id       = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
+  execution_arn          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
+  lambda_zip_file        = var.ipv_api_lambda_zip_file
+  authentication_vpc_arn = local.authentication_vpc_arn
+  security_group_ids = [
+    local.authentication_security_group_id,
+    local.authentication_oidc_redis_security_group_id,
+  ]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.oidc_default_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled

--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -22,13 +22,16 @@ module "ipv-callback" {
   }
   handler_function_name = "uk.gov.di.authentication.ipv.lambda.IPVCallbackHandler::handleRequest"
 
-  create_endpoint                        = true
-  rest_api_id                            = aws_api_gateway_rest_api.di_authentication_frontend_api.id
-  root_resource_id                       = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
-  execution_arn                          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
-  lambda_zip_file                        = var.ipv_api_lambda_zip_file
-  authentication_vpc_arn                 = local.authentication_vpc_arn
-  security_group_ids                     = [local.authentication_egress_security_group_id]
+  create_endpoint        = true
+  rest_api_id            = aws_api_gateway_rest_api.di_authentication_frontend_api.id
+  root_resource_id       = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
+  execution_arn          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
+  lambda_zip_file        = var.ipv_api_lambda_zip_file
+  authentication_vpc_arn = local.authentication_vpc_arn
+  security_group_ids = [
+    local.authentication_egress_security_group_id,
+    local.authentication_oidc_redis_security_group_id,
+  ]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.oidc_default_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled

--- a/ci/terraform/oidc/ipv-capacity.tf
+++ b/ci/terraform/oidc/ipv-capacity.tf
@@ -21,13 +21,16 @@ module "ipv-capacity" {
   }
   handler_function_name = "uk.gov.di.authentication.ipv.lambda.IPVCapacityHandler::handleRequest"
 
-  create_endpoint                        = true
-  rest_api_id                            = aws_api_gateway_rest_api.di_authentication_frontend_api.id
-  root_resource_id                       = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
-  execution_arn                          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
-  lambda_zip_file                        = var.ipv_api_lambda_zip_file
-  authentication_vpc_arn                 = local.authentication_vpc_arn
-  security_group_ids                     = [local.authentication_security_group_id]
+  create_endpoint        = true
+  rest_api_id            = aws_api_gateway_rest_api.di_authentication_frontend_api.id
+  root_resource_id       = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
+  execution_arn          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
+  lambda_zip_file        = var.ipv_api_lambda_zip_file
+  authentication_vpc_arn = local.authentication_vpc_arn
+  security_group_ids = [
+    local.authentication_security_group_id,
+    local.authentication_oidc_redis_security_group_id,
+  ]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.oidc_default_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled

--- a/ci/terraform/oidc/login.tf
+++ b/ci/terraform/oidc/login.tf
@@ -19,12 +19,15 @@ module "login" {
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.LoginHandler::handleRequest"
 
-  rest_api_id                            = aws_api_gateway_rest_api.di_authentication_frontend_api.id
-  root_resource_id                       = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
-  execution_arn                          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
-  lambda_zip_file                        = var.frontend_api_lambda_zip_file
-  authentication_vpc_arn                 = local.authentication_vpc_arn
-  security_group_ids                     = [local.authentication_security_group_id]
+  rest_api_id            = aws_api_gateway_rest_api.di_authentication_frontend_api.id
+  root_resource_id       = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
+  execution_arn          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
+  lambda_zip_file        = var.frontend_api_lambda_zip_file
+  authentication_vpc_arn = local.authentication_vpc_arn
+  security_group_ids = [
+    local.authentication_security_group_id,
+    local.authentication_oidc_redis_security_group_id,
+  ]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.oidc_default_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled

--- a/ci/terraform/oidc/logout.tf
+++ b/ci/terraform/oidc/logout.tf
@@ -20,12 +20,15 @@ module "logout" {
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.LogoutHandler::handleRequest"
 
-  rest_api_id                            = aws_api_gateway_rest_api.di_authentication_api.id
-  root_resource_id                       = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
-  execution_arn                          = aws_api_gateway_rest_api.di_authentication_api.execution_arn
-  lambda_zip_file                        = var.oidc_api_lambda_zip_file
-  authentication_vpc_arn                 = local.authentication_vpc_arn
-  security_group_ids                     = [local.authentication_security_group_id]
+  rest_api_id            = aws_api_gateway_rest_api.di_authentication_api.id
+  root_resource_id       = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
+  execution_arn          = aws_api_gateway_rest_api.di_authentication_api.execution_arn
+  lambda_zip_file        = var.oidc_api_lambda_zip_file
+  authentication_vpc_arn = local.authentication_vpc_arn
+  security_group_ids = [
+    local.authentication_security_group_id,
+    local.authentication_oidc_redis_security_group_id,
+  ]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.oidc_default_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled

--- a/ci/terraform/oidc/mfa.tf
+++ b/ci/terraform/oidc/mfa.tf
@@ -18,12 +18,15 @@ module "mfa" {
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.MfaHandler::handleRequest"
 
-  rest_api_id                            = aws_api_gateway_rest_api.di_authentication_frontend_api.id
-  root_resource_id                       = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
-  execution_arn                          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
-  lambda_zip_file                        = var.frontend_api_lambda_zip_file
-  authentication_vpc_arn                 = local.authentication_vpc_arn
-  security_group_ids                     = [local.authentication_security_group_id]
+  rest_api_id            = aws_api_gateway_rest_api.di_authentication_frontend_api.id
+  root_resource_id       = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
+  execution_arn          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
+  lambda_zip_file        = var.frontend_api_lambda_zip_file
+  authentication_vpc_arn = local.authentication_vpc_arn
+  security_group_ids = [
+    local.authentication_security_group_id,
+    local.authentication_oidc_redis_security_group_id,
+  ]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.oidc_dynamo_sqs_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled

--- a/ci/terraform/oidc/reset-password-request.tf
+++ b/ci/terraform/oidc/reset-password-request.tf
@@ -21,12 +21,15 @@ module "reset-password-request" {
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.ResetPasswordRequestHandler::handleRequest"
 
-  rest_api_id                            = aws_api_gateway_rest_api.di_authentication_frontend_api.id
-  root_resource_id                       = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
-  execution_arn                          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
-  lambda_zip_file                        = var.frontend_api_lambda_zip_file
-  authentication_vpc_arn                 = local.authentication_vpc_arn
-  security_group_ids                     = [local.authentication_security_group_id]
+  rest_api_id            = aws_api_gateway_rest_api.di_authentication_frontend_api.id
+  root_resource_id       = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
+  execution_arn          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
+  lambda_zip_file        = var.frontend_api_lambda_zip_file
+  authentication_vpc_arn = local.authentication_vpc_arn
+  security_group_ids = [
+    local.authentication_security_group_id,
+    local.authentication_oidc_redis_security_group_id,
+  ]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.oidc_dynamo_sqs_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled

--- a/ci/terraform/oidc/reset_password.tf
+++ b/ci/terraform/oidc/reset_password.tf
@@ -20,12 +20,15 @@ module "reset_password" {
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.ResetPasswordHandler::handleRequest"
 
-  rest_api_id                            = aws_api_gateway_rest_api.di_authentication_frontend_api.id
-  root_resource_id                       = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
-  execution_arn                          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
-  lambda_zip_file                        = var.frontend_api_lambda_zip_file
-  authentication_vpc_arn                 = local.authentication_vpc_arn
-  security_group_ids                     = [local.authentication_security_group_id]
+  rest_api_id            = aws_api_gateway_rest_api.di_authentication_frontend_api.id
+  root_resource_id       = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
+  execution_arn          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
+  lambda_zip_file        = var.frontend_api_lambda_zip_file
+  authentication_vpc_arn = local.authentication_vpc_arn
+  security_group_ids = [
+    local.authentication_security_group_id,
+    local.authentication_oidc_redis_security_group_id,
+  ]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.oidc_dynamo_sqs_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled

--- a/ci/terraform/oidc/send_notification.tf
+++ b/ci/terraform/oidc/send_notification.tf
@@ -17,12 +17,15 @@ module "send_notification" {
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.SendNotificationHandler::handleRequest"
 
-  rest_api_id                            = aws_api_gateway_rest_api.di_authentication_frontend_api.id
-  root_resource_id                       = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
-  execution_arn                          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
-  lambda_zip_file                        = var.frontend_api_lambda_zip_file
-  authentication_vpc_arn                 = local.authentication_vpc_arn
-  security_group_ids                     = [local.authentication_security_group_id]
+  rest_api_id            = aws_api_gateway_rest_api.di_authentication_frontend_api.id
+  root_resource_id       = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
+  execution_arn          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
+  lambda_zip_file        = var.frontend_api_lambda_zip_file
+  authentication_vpc_arn = local.authentication_vpc_arn
+  security_group_ids = [
+    local.authentication_security_group_id,
+    local.authentication_oidc_redis_security_group_id,
+  ]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.oidc_dynamo_sqs_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled

--- a/ci/terraform/oidc/shared.tf
+++ b/ci/terraform/oidc/shared.tf
@@ -16,21 +16,22 @@ data "terraform_remote_state" "shared" {
 }
 
 locals {
-  redis_key                               = "session"
-  authentication_vpc_arn                  = data.terraform_remote_state.shared.outputs.authentication_vpc_arn
-  authentication_security_group_id        = data.terraform_remote_state.shared.outputs.authentication_security_group_id
-  authentication_egress_security_group_id = data.terraform_remote_state.shared.outputs.authentication_egress_security_group_id
-  authentication_subnet_ids               = data.terraform_remote_state.shared.outputs.authentication_subnet_ids
-  id_token_signing_key_alias_name         = data.terraform_remote_state.shared.outputs.id_token_signing_key_alias_name
-  id_token_signing_key_arn                = data.terraform_remote_state.shared.outputs.id_token_signing_key_arn
-  audit_signing_key_alias_name            = data.terraform_remote_state.shared.outputs.audit_signing_key_alias_name
-  audit_signing_key_arn                   = data.terraform_remote_state.shared.outputs.audit_signing_key_arn
-  sms_bucket_name                         = data.terraform_remote_state.shared.outputs.sms_bucket_name
-  lambda_env_vars_encryption_kms_key_arn  = data.terraform_remote_state.shared.outputs.lambda_env_vars_encryption_kms_key_arn
-  events_topic_encryption_key_arn         = data.terraform_remote_state.shared.outputs.events_topic_encryption_key_arn
-  lambda_parameter_encryption_key_id      = data.terraform_remote_state.shared.outputs.lambda_parameter_encryption_key_id
-  lambda_parameter_encryption_alias_id    = data.terraform_remote_state.shared.outputs.lambda_parameter_encryption_alias_id
-  redis_ssm_parameter_policy              = data.terraform_remote_state.shared.outputs.redis_ssm_parameter_policy
-  pepper_ssm_parameter_policy             = data.terraform_remote_state.shared.outputs.pepper_ssm_parameter_policy
-  ipv_capacity_ssm_parameter_policy       = data.terraform_remote_state.shared.outputs.ipv_capacity_ssm_parameter_policy
+  redis_key                                   = "session"
+  authentication_vpc_arn                      = data.terraform_remote_state.shared.outputs.authentication_vpc_arn
+  authentication_security_group_id            = data.terraform_remote_state.shared.outputs.authentication_security_group_id
+  authentication_egress_security_group_id     = data.terraform_remote_state.shared.outputs.authentication_egress_security_group_id
+  authentication_oidc_redis_security_group_id = data.terraform_remote_state.shared.outputs.authentication_oidc_redis_security_group_id
+  authentication_subnet_ids                   = data.terraform_remote_state.shared.outputs.authentication_subnet_ids
+  id_token_signing_key_alias_name             = data.terraform_remote_state.shared.outputs.id_token_signing_key_alias_name
+  id_token_signing_key_arn                    = data.terraform_remote_state.shared.outputs.id_token_signing_key_arn
+  audit_signing_key_alias_name                = data.terraform_remote_state.shared.outputs.audit_signing_key_alias_name
+  audit_signing_key_arn                       = data.terraform_remote_state.shared.outputs.audit_signing_key_arn
+  sms_bucket_name                             = data.terraform_remote_state.shared.outputs.sms_bucket_name
+  lambda_env_vars_encryption_kms_key_arn      = data.terraform_remote_state.shared.outputs.lambda_env_vars_encryption_kms_key_arn
+  events_topic_encryption_key_arn             = data.terraform_remote_state.shared.outputs.events_topic_encryption_key_arn
+  lambda_parameter_encryption_key_id          = data.terraform_remote_state.shared.outputs.lambda_parameter_encryption_key_id
+  lambda_parameter_encryption_alias_id        = data.terraform_remote_state.shared.outputs.lambda_parameter_encryption_alias_id
+  redis_ssm_parameter_policy                  = data.terraform_remote_state.shared.outputs.redis_ssm_parameter_policy
+  pepper_ssm_parameter_policy                 = data.terraform_remote_state.shared.outputs.pepper_ssm_parameter_policy
+  ipv_capacity_ssm_parameter_policy           = data.terraform_remote_state.shared.outputs.ipv_capacity_ssm_parameter_policy
 }

--- a/ci/terraform/oidc/signup.tf
+++ b/ci/terraform/oidc/signup.tf
@@ -18,12 +18,15 @@ module "signup" {
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.SignUpHandler::handleRequest"
 
-  rest_api_id                            = aws_api_gateway_rest_api.di_authentication_frontend_api.id
-  root_resource_id                       = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
-  execution_arn                          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
-  lambda_zip_file                        = var.frontend_api_lambda_zip_file
-  authentication_vpc_arn                 = local.authentication_vpc_arn
-  security_group_ids                     = [local.authentication_security_group_id]
+  rest_api_id            = aws_api_gateway_rest_api.di_authentication_frontend_api.id
+  root_resource_id       = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
+  execution_arn          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
+  lambda_zip_file        = var.frontend_api_lambda_zip_file
+  authentication_vpc_arn = local.authentication_vpc_arn
+  security_group_ids = [
+    local.authentication_security_group_id,
+    local.authentication_oidc_redis_security_group_id,
+  ]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.oidc_default_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled

--- a/ci/terraform/oidc/token.tf
+++ b/ci/terraform/oidc/token.tf
@@ -60,12 +60,15 @@ module "token" {
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.TokenHandler::handleRequest"
 
-  rest_api_id                            = aws_api_gateway_rest_api.di_authentication_api.id
-  root_resource_id                       = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
-  execution_arn                          = aws_api_gateway_rest_api.di_authentication_api.execution_arn
-  lambda_zip_file                        = var.oidc_api_lambda_zip_file
-  authentication_vpc_arn                 = local.authentication_vpc_arn
-  security_group_ids                     = [local.authentication_security_group_id]
+  rest_api_id            = aws_api_gateway_rest_api.di_authentication_api.id
+  root_resource_id       = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
+  execution_arn          = aws_api_gateway_rest_api.di_authentication_api.execution_arn
+  lambda_zip_file        = var.oidc_api_lambda_zip_file
+  authentication_vpc_arn = local.authentication_vpc_arn
+  security_group_ids = [
+    local.authentication_security_group_id,
+    local.authentication_oidc_redis_security_group_id,
+  ]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.oidc_token_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled

--- a/ci/terraform/oidc/update.tf
+++ b/ci/terraform/oidc/update.tf
@@ -18,12 +18,15 @@ module "update" {
   }
   handler_function_name = "uk.gov.di.authentication.clientregistry.lambda.UpdateClientConfigHandler::handleRequest"
 
-  rest_api_id                            = aws_api_gateway_rest_api.di_authentication_api.id
-  root_resource_id                       = aws_api_gateway_resource.register_resource.id
-  execution_arn                          = aws_api_gateway_rest_api.di_authentication_api.execution_arn
-  lambda_zip_file                        = var.client_registry_api_lambda_zip_file
-  authentication_vpc_arn                 = local.authentication_vpc_arn
-  security_group_ids                     = [local.authentication_security_group_id]
+  rest_api_id            = aws_api_gateway_rest_api.di_authentication_api.id
+  root_resource_id       = aws_api_gateway_resource.register_resource.id
+  execution_arn          = aws_api_gateway_rest_api.di_authentication_api.execution_arn
+  lambda_zip_file        = var.client_registry_api_lambda_zip_file
+  authentication_vpc_arn = local.authentication_vpc_arn
+  security_group_ids = [
+    local.authentication_security_group_id,
+    local.authentication_oidc_redis_security_group_id,
+  ]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.oidc_default_role.arn
   environment                            = var.environment

--- a/ci/terraform/oidc/update_profile.tf
+++ b/ci/terraform/oidc/update_profile.tf
@@ -19,12 +19,15 @@ module "update_profile" {
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.UpdateProfileHandler::handleRequest"
 
-  rest_api_id                            = aws_api_gateway_rest_api.di_authentication_frontend_api.id
-  root_resource_id                       = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
-  execution_arn                          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
-  lambda_zip_file                        = var.frontend_api_lambda_zip_file
-  authentication_vpc_arn                 = local.authentication_vpc_arn
-  security_group_ids                     = [local.authentication_security_group_id]
+  rest_api_id            = aws_api_gateway_rest_api.di_authentication_frontend_api.id
+  root_resource_id       = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
+  execution_arn          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
+  lambda_zip_file        = var.frontend_api_lambda_zip_file
+  authentication_vpc_arn = local.authentication_vpc_arn
+  security_group_ids = [
+    local.authentication_security_group_id,
+    local.authentication_oidc_redis_security_group_id,
+  ]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.oidc_default_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled

--- a/ci/terraform/oidc/userexists.tf
+++ b/ci/terraform/oidc/userexists.tf
@@ -19,12 +19,15 @@ module "userexists" {
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.CheckUserExistsHandler::handleRequest"
 
-  rest_api_id                            = aws_api_gateway_rest_api.di_authentication_frontend_api.id
-  root_resource_id                       = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
-  execution_arn                          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
-  lambda_zip_file                        = var.frontend_api_lambda_zip_file
-  authentication_vpc_arn                 = local.authentication_vpc_arn
-  security_group_ids                     = [local.authentication_security_group_id]
+  rest_api_id            = aws_api_gateway_rest_api.di_authentication_frontend_api.id
+  root_resource_id       = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
+  execution_arn          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
+  lambda_zip_file        = var.frontend_api_lambda_zip_file
+  authentication_vpc_arn = local.authentication_vpc_arn
+  security_group_ids = [
+    local.authentication_security_group_id,
+    local.authentication_oidc_redis_security_group_id,
+  ]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.oidc_default_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -18,12 +18,15 @@ module "userinfo" {
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.UserInfoHandler::handleRequest"
 
-  rest_api_id                            = aws_api_gateway_rest_api.di_authentication_api.id
-  root_resource_id                       = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
-  execution_arn                          = aws_api_gateway_rest_api.di_authentication_api.execution_arn
-  lambda_zip_file                        = var.oidc_api_lambda_zip_file
-  authentication_vpc_arn                 = local.authentication_vpc_arn
-  security_group_ids                     = [local.authentication_security_group_id]
+  rest_api_id            = aws_api_gateway_rest_api.di_authentication_api.id
+  root_resource_id       = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
+  execution_arn          = aws_api_gateway_rest_api.di_authentication_api.execution_arn
+  lambda_zip_file        = var.oidc_api_lambda_zip_file
+  authentication_vpc_arn = local.authentication_vpc_arn
+  security_group_ids = [
+    local.authentication_security_group_id,
+    local.authentication_oidc_redis_security_group_id,
+  ]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.oidc_default_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled

--- a/ci/terraform/oidc/verify_code.tf
+++ b/ci/terraform/oidc/verify_code.tf
@@ -21,12 +21,15 @@ module "verify_code" {
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.VerifyCodeHandler::handleRequest"
 
-  rest_api_id                            = aws_api_gateway_rest_api.di_authentication_frontend_api.id
-  root_resource_id                       = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
-  execution_arn                          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
-  lambda_zip_file                        = var.frontend_api_lambda_zip_file
-  authentication_vpc_arn                 = local.authentication_vpc_arn
-  security_group_ids                     = [local.authentication_security_group_id]
+  rest_api_id            = aws_api_gateway_rest_api.di_authentication_frontend_api.id
+  root_resource_id       = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
+  execution_arn          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
+  lambda_zip_file        = var.frontend_api_lambda_zip_file
+  authentication_vpc_arn = local.authentication_vpc_arn
+  security_group_ids = [
+    local.authentication_security_group_id,
+    local.authentication_oidc_redis_security_group_id,
+  ]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.oidc_default_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled

--- a/ci/terraform/shared/outputs.tf
+++ b/ci/terraform/shared/outputs.tf
@@ -24,6 +24,10 @@ output "authentication_egress_security_group_id" {
   value = aws_security_group.allow_egress.id
 }
 
+output "authentication_oidc_redis_security_group_id" {
+  value = aws_security_group.allow_access_to_oidc_redis.id
+}
+
 output "authentication_subnet_ids" {
   value = aws_subnet.authentication.*.id
 }

--- a/ci/terraform/shared/vpc.tf
+++ b/ci/terraform/shared/vpc.tf
@@ -357,6 +357,16 @@ resource "aws_security_group" "allow_egress" {
   }
 }
 
+resource "aws_security_group" "allow_access_to_oidc_redis" {
+  name_prefix = "${var.environment}-allow-access-to-oidc-redis-"
+  description = "Allow outgoing access to the OIDC Redis session store"
+  vpc_id      = aws_vpc.authentication.id
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
 resource "aws_security_group_rule" "allow_incoming_redis_from_private_subnet" {
   security_group_id = aws_security_group.redis_security_group.id
 
@@ -399,6 +409,16 @@ resource "aws_security_group_rule" "allow_https_to_s3" {
 
 resource "aws_security_group_rule" "allow_connection_to_redis" {
   security_group_id = aws_security_group.allow_vpc_resources_only.id
+
+  from_port                = local.redis_port_number
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.redis_security_group.id
+  to_port                  = local.redis_port_number
+  type                     = "egress"
+}
+
+resource "aws_security_group_rule" "allow_connection_to_oidc_redis" {
+  security_group_id = aws_security_group.allow_access_to_oidc_redis.id
 
   from_port                = local.redis_port_number
   protocol                 = "tcp"


### PR DESCRIPTION
## What?

- Add a separate security group for accessing the Redis session store
in the `shared` Terraform deployment.
- Add the new security group ID as an output
- Add the new Redis security group to the Lambda that need to access
the OIDC sessions store

## Why?

We are consolidating VPCs and moving where they are deployed to a separate Terraform. Currently, there is a rule associated with other the "VPC only" and "egress" security groups that allow access to Redis, however, these security groups are about to be moved.
