### PR TITLE
AUTH-1292: Add common_state_bucket variable to deploy task

### DIFF
--- a/ci/tasks/deploy-shared-api.yml
+++ b/ci/tasks/deploy-shared-api.yml
@@ -39,6 +39,7 @@ run:
         -var "test_client_email_allowlist=${TEST_CLIENT_EMAIL_ALLOWLIST}" \
         -var 'account_migration_lambda_zip_file=../../../../account-migration-release/account-migrations.zip' \
         -var "password_pepper=${PASSWORD_PEPPER}" \
+        -var "common_state_bucket=${STATE_BUCKET}" \
         -var-file ${DEPLOY_ENVIRONMENT}-stub-clients.tfvars \
         -var-file ${DEPLOY_ENVIRONMENT}-sizing.tfvars \
 


### PR DESCRIPTION
## What?

- We have a new Terraform variable,`common_state_bucket`, we need to set this in the deploy task for the shared Terraform

## Why?

The pipeline is failing due to the missing variable

## Related PRs

#1311