### PR TITLE
AUTH-1159 - Add audit event coverage in integration tests

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -110,6 +110,7 @@ jobs:
           KMS_PROVIDER: local-kms
         options: >-
           --add-host "notify.internal:host-gateway"
+          --add-host "subscriber.internal:host-gateway"
         ports:
           - 45678:45678
       redis:

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/domain/AccountManagementAuditableEvent.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/domain/AccountManagementAuditableEvent.java
@@ -8,5 +8,9 @@ public enum AccountManagementAuditableEvent implements AuditableEvent {
     UPDATE_PHONE_NUMBER,
     ACCOUNT_MANAGEMENT_AUTHENTICATE,
     DELETE_ACCOUNT,
-    SEND_OTP
+    SEND_OTP;
+
+    public AuditableEvent parseFromName(String name) {
+        return valueOf(name);
+    }
 }

--- a/account-management-integration-tests/build.gradle
+++ b/account-management-integration-tests/build.gradle
@@ -20,6 +20,7 @@ dependencies {
             configurations.lambda,
             configurations.lettuce,
             "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${dependencyVersions.jackson_version}",
+            "com.google.protobuf:protobuf-java:${dependencyVersions.protobuf_version}",
             project(":client-registry-api"),
             project(":frontend-api"),
             project(":account-management-api"),

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/AuthenticateIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/AuthenticateIntegrationTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Test;
 import uk.gov.di.accountmanagement.entity.AuthenticateRequest;
 import uk.gov.di.accountmanagement.lambda.AuthenticateHandler;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
-import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 
 import java.util.List;
 import java.util.Map;
@@ -13,6 +12,8 @@ import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.ACCOUNT_MANAGEMENT_AUTHENTICATE;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceived;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertNoAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class AuthenticateIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -34,8 +35,7 @@ public class AuthenticateIntegrationTest extends ApiGatewayHandlerIntegrationTes
 
         assertThat(response, hasStatus(204));
 
-        AuditAssertionsHelper.assertEventTypesReceived(
-                auditTopic, List.of(ACCOUNT_MANAGEMENT_AUTHENTICATE));
+        assertEventTypesReceived(auditTopic, List.of(ACCOUNT_MANAGEMENT_AUTHENTICATE));
     }
 
     @Test
@@ -50,6 +50,6 @@ public class AuthenticateIntegrationTest extends ApiGatewayHandlerIntegrationTes
 
         assertThat(response, hasStatus(401));
 
-        AuditAssertionsHelper.assertNoAuditEventsReceived(auditTopic);
+        assertNoAuditEventsReceived(auditTopic);
     }
 }

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/AuthenticateIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/AuthenticateIntegrationTest.java
@@ -12,9 +12,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.ACCOUNT_MANAGEMENT_AUTHENTICATE;
-import static uk.gov.di.authentication.sharedtest.extensions.AuditSnsTopicExtension.SNS_TIMEOUT_MILLIS;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class AuthenticateIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -41,7 +39,7 @@ public class AuthenticateIntegrationTest extends ApiGatewayHandlerIntegrationTes
     }
 
     @Test
-    public void shouldCallLoginEndpointAndReturn401henUserHasInvalidCredentials() throws Exception {
+    public void shouldCallLoginEndpointAndReturn401henUserHasInvalidCredentials() {
         String email = "joe.bloggs+4@digital.cabinet-office.gov.uk";
         String password = "password-1";
         userStore.signUp(email, "wrong-password");
@@ -52,7 +50,6 @@ public class AuthenticateIntegrationTest extends ApiGatewayHandlerIntegrationTes
 
         assertThat(response, hasStatus(401));
 
-        Thread.sleep(SNS_TIMEOUT_MILLIS);
-        assertThat(auditTopic.getCountOfRequests(), equalTo(0));
+        AuditAssertionsHelper.assertNoAuditEventsReceived(auditTopic);
     }
 }

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/AuthenticateIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/AuthenticateIntegrationTest.java
@@ -5,20 +5,17 @@ import org.junit.jupiter.api.Test;
 import uk.gov.di.accountmanagement.entity.AuthenticateRequest;
 import uk.gov.di.accountmanagement.lambda.AuthenticateHandler;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasItem;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.ACCOUNT_MANAGEMENT_AUTHENTICATE;
-import static uk.gov.di.authentication.sharedtest.extensions.AuditSnsTopicExtension.SNS_TIMEOUT;
 import static uk.gov.di.authentication.sharedtest.extensions.AuditSnsTopicExtension.SNS_TIMEOUT_MILLIS;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
-import static uk.gov.di.authentication.sharedtest.matchers.AuditEventMatcher.hasEventType;
 
 public class AuthenticateIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
@@ -39,11 +36,8 @@ public class AuthenticateIntegrationTest extends ApiGatewayHandlerIntegrationTes
 
         assertThat(response, hasStatus(204));
 
-        await().atMost(SNS_TIMEOUT, SECONDS)
-                .untilAsserted(() -> assertThat(auditTopic.getCountOfRequests(), equalTo(1)));
-        assertThat(
-                auditTopic.getAuditEvents(),
-                hasItem(hasEventType(ACCOUNT_MANAGEMENT_AUTHENTICATE)));
+        AuditAssertionsHelper.assertEventTypesReceived(
+                auditTopic, List.of(ACCOUNT_MANAGEMENT_AUTHENTICATE));
     }
 
     @Test

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/AuthenticateIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/AuthenticateIntegrationTest.java
@@ -16,6 +16,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.ACCOUNT_MANAGEMENT_AUTHENTICATE;
 import static uk.gov.di.authentication.sharedtest.extensions.AuditSnsTopicExtension.SNS_TIMEOUT;
+import static uk.gov.di.authentication.sharedtest.extensions.AuditSnsTopicExtension.SNS_TIMEOUT_MILLIS;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 import static uk.gov.di.authentication.sharedtest.matchers.AuditEventMatcher.hasEventType;
 
@@ -38,8 +39,6 @@ public class AuthenticateIntegrationTest extends ApiGatewayHandlerIntegrationTes
 
         assertThat(response, hasStatus(204));
 
-        Thread.sleep(10000);
-
         await().atMost(SNS_TIMEOUT, SECONDS)
                 .untilAsserted(() -> assertThat(auditTopic.getCountOfRequests(), equalTo(1)));
         assertThat(
@@ -59,9 +58,7 @@ public class AuthenticateIntegrationTest extends ApiGatewayHandlerIntegrationTes
 
         assertThat(response, hasStatus(401));
 
-        Thread.sleep(10000);
-
-        await().atMost(SNS_TIMEOUT, SECONDS)
-                .untilAsserted(() -> assertThat(auditTopic.getCountOfRequests(), equalTo(0)));
+        Thread.sleep(SNS_TIMEOUT_MILLIS);
+        assertThat(auditTopic.getCountOfRequests(), equalTo(0));
     }
 }

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/AuthenticateIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/AuthenticateIntegrationTest.java
@@ -2,7 +2,6 @@ package uk.gov.di.accountmanagement.api;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent;
 import uk.gov.di.accountmanagement.entity.AuthenticateRequest;
 import uk.gov.di.accountmanagement.lambda.AuthenticateHandler;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
@@ -42,10 +41,7 @@ public class AuthenticateIntegrationTest extends ApiGatewayHandlerIntegrationTes
                 .untilAsserted(() -> assertThat(auditTopic.getCountOfRequests(), equalTo(1)));
         assertThat(
                 auditTopic.getAuditEvents(),
-                hasItem(
-                        hasEventType(
-                                AccountManagementAuditableEvent.class,
-                                ACCOUNT_MANAGEMENT_AUTHENTICATE)));
+                hasItem(hasEventType(ACCOUNT_MANAGEMENT_AUTHENTICATE)));
     }
 
     @Test

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdateEmailIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdateEmailIntegrationTest.java
@@ -57,8 +57,6 @@ public class UpdateEmailIntegrationTest extends ApiGatewayHandlerIntegrationTest
         assertThat(requests.get(0).getDestination(), equalTo(NEW_EMAIL_ADDRESS));
         assertThat(requests.get(0).getNotificationType(), equalTo(EMAIL_UPDATED));
 
-        Thread.sleep(10000);
-
         await().atMost(SNS_TIMEOUT, SECONDS)
                 .untilAsserted(() -> assertThat(auditTopic.getCountOfRequests(), equalTo(1)));
         assertThat(auditTopic.getAuditEvents(), hasItem(hasEventType(UPDATE_EMAIL)));

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdateEmailIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdateEmailIntegrationTest.java
@@ -7,22 +7,18 @@ import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.accountmanagement.entity.UpdateEmailRequest;
 import uk.gov.di.accountmanagement.lambda.UpdateEmailHandler;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.UPDATE_EMAIL;
 import static uk.gov.di.accountmanagement.entity.NotificationType.EMAIL_UPDATED;
-import static uk.gov.di.authentication.sharedtest.extensions.AuditSnsTopicExtension.SNS_TIMEOUT;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
-import static uk.gov.di.authentication.sharedtest.matchers.AuditEventMatcher.hasEventType;
 
 public class UpdateEmailIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
@@ -57,8 +53,6 @@ public class UpdateEmailIntegrationTest extends ApiGatewayHandlerIntegrationTest
         assertThat(requests.get(0).getDestination(), equalTo(NEW_EMAIL_ADDRESS));
         assertThat(requests.get(0).getNotificationType(), equalTo(EMAIL_UPDATED));
 
-        await().atMost(SNS_TIMEOUT, SECONDS)
-                .untilAsserted(() -> assertThat(auditTopic.getCountOfRequests(), equalTo(1)));
-        assertThat(auditTopic.getAuditEvents(), hasItem(hasEventType(UPDATE_EMAIL)));
+        AuditAssertionsHelper.assertEventTypesReceived(auditTopic, List.of(UPDATE_EMAIL));
     }
 }

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdateEmailIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdateEmailIntegrationTest.java
@@ -12,11 +12,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
+import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.UPDATE_EMAIL;
 import static uk.gov.di.accountmanagement.entity.NotificationType.EMAIL_UPDATED;
+import static uk.gov.di.authentication.sharedtest.extensions.AuditSnsTopicExtension.SNS_TIMEOUT;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
+import static uk.gov.di.authentication.sharedtest.matchers.AuditEventMatcher.hasEventType;
 
 public class UpdateEmailIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
@@ -30,7 +36,7 @@ public class UpdateEmailIntegrationTest extends ApiGatewayHandlerIntegrationTest
     }
 
     @Test
-    public void shouldCallUpdateEmailEndpointAndReturn204WhenLoginIsSuccessful() {
+    public void shouldCallUpdateEmailEndpointAndReturn204WhenLoginIsSuccessful() throws Exception {
         String publicSubjectID = userStore.signUp(EXISTING_EMAIL_ADDRESS, "password-1", SUBJECT);
         String otp = redis.generateAndSaveEmailCode(NEW_EMAIL_ADDRESS, 300);
         var response =
@@ -50,5 +56,11 @@ public class UpdateEmailIntegrationTest extends ApiGatewayHandlerIntegrationTest
         assertThat(requests, hasSize(1));
         assertThat(requests.get(0).getDestination(), equalTo(NEW_EMAIL_ADDRESS));
         assertThat(requests.get(0).getNotificationType(), equalTo(EMAIL_UPDATED));
+
+        Thread.sleep(10000);
+
+        await().atMost(SNS_TIMEOUT, SECONDS)
+                .untilAsserted(() -> assertThat(auditTopic.getCountOfRequests(), equalTo(1)));
+        assertThat(auditTopic.getAuditEvents(), hasItem(hasEventType(UPDATE_EMAIL)));
     }
 }

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdateEmailIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdateEmailIntegrationTest.java
@@ -7,7 +7,6 @@ import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.accountmanagement.entity.UpdateEmailRequest;
 import uk.gov.di.accountmanagement.lambda.UpdateEmailHandler;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
-import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 
 import java.util.List;
 import java.util.Map;
@@ -18,6 +17,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.UPDATE_EMAIL;
 import static uk.gov.di.accountmanagement.entity.NotificationType.EMAIL_UPDATED;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class UpdateEmailIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -53,6 +53,6 @@ public class UpdateEmailIntegrationTest extends ApiGatewayHandlerIntegrationTest
         assertThat(requests.get(0).getDestination(), equalTo(NEW_EMAIL_ADDRESS));
         assertThat(requests.get(0).getNotificationType(), equalTo(EMAIL_UPDATED));
 
-        AuditAssertionsHelper.assertEventTypesReceived(auditTopic, List.of(UPDATE_EMAIL));
+        assertEventTypesReceived(auditTopic, List.of(UPDATE_EMAIL));
     }
 }

--- a/audit-processors/src/main/java/uk/gov/di/authentication/audit/lambda/BaseAuditHandler.java
+++ b/audit-processors/src/main/java/uk/gov/di/authentication/audit/lambda/BaseAuditHandler.java
@@ -9,7 +9,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.audit.AuditPayload.AuditEvent;
 import uk.gov.di.audit.AuditPayload.SignedAuditEvent;
-import uk.gov.di.authentication.audit.helper.AuditEventHelper;
+import uk.gov.di.audit.helper.AuditEventHelper;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.KmsConnectionService;
 

--- a/audit-processors/src/main/java/uk/gov/di/authentication/audit/lambda/StorageSQSAuditHandler.java
+++ b/audit-processors/src/main/java/uk/gov/di/authentication/audit/lambda/StorageSQSAuditHandler.java
@@ -11,7 +11,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.audit.AuditPayload.AuditEvent;
 import uk.gov.di.audit.AuditPayload.SignedAuditEvent;
-import uk.gov.di.authentication.audit.helper.AuditEventHelper;
+import uk.gov.di.audit.helper.AuditEventHelper;
 import uk.gov.di.authentication.audit.services.S3Service;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.KmsConnectionService;

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ ext {
         aws_lambda_events_version: "3.11.0",
         nimbusds_oauth_version: "9.22",
         nimbusds_jwt_version: "9.15.1",
+        protobuf_version: "3.19.3",
         junit: "5.8.2",
         jackson_version: "2.13.1",
         glassfish_version: "3.0.3",

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/domain/ClientRegistryAuditableEvent.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/domain/ClientRegistryAuditableEvent.java
@@ -6,5 +6,9 @@ public enum ClientRegistryAuditableEvent implements AuditableEvent {
     REGISTER_CLIENT_REQUEST_RECEIVED,
     REGISTER_CLIENT_REQUEST_ERROR,
     UPDATE_CLIENT_REQUEST_RECEIVED,
-    UPDATE_CLIENT_REQUEST_ERROR
+    UPDATE_CLIENT_REQUEST_ERROR;
+
+    public AuditableEvent parseFromName(String name) {
+        return valueOf(name);
+    }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       KMS_PROVIDER: local-kms
     extra_hosts:
       - "notify.internal:host-gateway"
+      - "subscriber.internal:host-gateway"
     networks:
       - di-authentication-api-net
     ports:

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/domain/FrontendAuditableEvent.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/domain/FrontendAuditableEvent.java
@@ -26,5 +26,9 @@ public enum FrontendAuditableEvent implements AuditableEvent {
     MFA_MISMATCHED_EMAIL,
     MFA_MISSING_PHONE_NUMBER,
     MFA_CODE_SENT,
-    MFA_CODE_SENT_FOR_TEST_CLIENT
+    MFA_CODE_SENT_FOR_TEST_CLIENT;
+
+    public AuditableEvent parseFromName(String name) {
+        return valueOf(name);
+    }
 }

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -20,6 +20,7 @@ dependencies {
             configurations.lettuce,
             configurations.lambda,
             "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${dependencyVersions.jackson_version}",
+            "com.google.protobuf:protobuf-java:${dependencyVersions.protobuf_version}",
             project(":client-registry-api"),
             project(":frontend-api"),
             project(":oidc-api"),

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
@@ -14,12 +14,14 @@ import uk.gov.di.authentication.shared.entity.ResponseHeaders;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.shared.entity.SessionState;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 import uk.gov.di.authentication.sharedtest.helper.KeyPairHelper;
 
 import java.io.IOException;
 import java.net.URI;
 import java.security.KeyPair;
 import java.util.Base64;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -27,6 +29,7 @@ import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
+import static uk.gov.di.authentication.oidc.domain.OidcAuditableEvent.AUTH_CODE_ISSUED;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class AuthCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -62,6 +65,8 @@ public class AuthCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(
                 response.getHeaders().get(ResponseHeaders.LOCATION).toString(),
                 not(containsString("cookie_consent")));
+
+        AuditAssertionsHelper.assertEventTypesReceived(auditTopic, List.of(AUTH_CODE_ISSUED));
     }
 
     private AuthenticationRequest generateAuthRequest() {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
@@ -14,7 +14,6 @@ import uk.gov.di.authentication.shared.entity.ResponseHeaders;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.shared.entity.SessionState;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
-import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 import uk.gov.di.authentication.sharedtest.helper.KeyPairHelper;
 
 import java.io.IOException;
@@ -30,6 +29,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
 import static uk.gov.di.authentication.oidc.domain.OidcAuditableEvent.AUTH_CODE_ISSUED;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class AuthCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -66,7 +66,7 @@ public class AuthCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 response.getHeaders().get(ResponseHeaders.LOCATION).toString(),
                 not(containsString("cookie_consent")));
 
-        AuditAssertionsHelper.assertEventTypesReceived(auditTopic, List.of(AUTH_CODE_ISSUED));
+        assertEventTypesReceived(auditTopic, List.of(AUTH_CODE_ISSUED));
     }
 
     private AuthenticationRequest generateAuthRequest() {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -16,7 +16,6 @@ import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.shared.entity.SessionState;
 import uk.gov.di.authentication.shared.entity.ValidScopes;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
-import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 import uk.gov.di.authentication.sharedtest.helper.KeyPairHelper;
 
 import java.net.HttpCookie;
@@ -50,6 +49,7 @@ import static uk.gov.di.authentication.shared.entity.SessionState.AUTHENTICATION
 import static uk.gov.di.authentication.shared.entity.SessionState.CONSENT_REQUIRED;
 import static uk.gov.di.authentication.shared.entity.SessionState.UPLIFT_REQUIRED_CM;
 import static uk.gov.di.authentication.shared.helpers.CookieHelper.getHttpCookieFromMultiValueResponseHeaders;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceived;
 import static uk.gov.di.authentication.sharedtest.helper.JsonArrayHelper.jsonArrayOf;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
@@ -86,7 +86,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 getHeaderValueByParamName(response, ResponseHeaders.LOCATION),
                 containsString(OAuth2Error.UNAUTHORIZED_CLIENT.getCode()));
 
-        AuditAssertionsHelper.assertEventTypesReceived(
+        assertEventTypesReceived(
                 auditTopic, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_REQUEST_ERROR));
     }
 
@@ -110,7 +110,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         .isPresent(),
                 equalTo(true));
 
-        AuditAssertionsHelper.assertEventTypesReceived(
+        assertEventTypesReceived(
                 auditTopic, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
@@ -134,7 +134,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         .isPresent(),
                 equalTo(true));
 
-        AuditAssertionsHelper.assertEventTypesReceived(
+        assertEventTypesReceived(
                 auditTopic, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
@@ -169,7 +169,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(persistentCookie.isPresent(), equalTo(true));
         assertThat(persistentCookie.get().getValue(), equalTo("persistent-id-value"));
 
-        AuditAssertionsHelper.assertEventTypesReceived(
+        assertEventTypesReceived(
                 auditTopic, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
@@ -200,7 +200,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         .isPresent(),
                 equalTo(true));
 
-        AuditAssertionsHelper.assertEventTypesReceived(
+        assertEventTypesReceived(
                 auditTopic, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
@@ -221,7 +221,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 containsString(
                         "error=invalid_scope&error_description=Invalid%2C+unknown+or+malformed+scope"));
 
-        AuditAssertionsHelper.assertEventTypesReceived(
+        assertEventTypesReceived(
                 auditTopic, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_REQUEST_ERROR));
     }
 
@@ -250,7 +250,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         .isPresent(),
                 equalTo(true));
 
-        AuditAssertionsHelper.assertEventTypesReceived(
+        assertEventTypesReceived(
                 auditTopic, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
@@ -280,7 +280,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         .isPresent(),
                 equalTo(true));
 
-        AuditAssertionsHelper.assertEventTypesReceived(
+        assertEventTypesReceived(
                 auditTopic, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
@@ -315,7 +315,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(cookie.isPresent(), equalTo(true));
         assertThat(cookie.get().getValue(), not(startsWith(sessionId)));
 
-        AuditAssertionsHelper.assertEventTypesReceived(
+        assertEventTypesReceived(
                 auditTopic, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
@@ -349,7 +349,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(cookie.isPresent(), equalTo(true));
         assertThat(cookie.get().getValue(), not(startsWith(sessionId)));
 
-        AuditAssertionsHelper.assertEventTypesReceived(
+        assertEventTypesReceived(
                 auditTopic, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
@@ -369,7 +369,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 getHeaderValueByParamName(response, ResponseHeaders.LOCATION),
                 containsString(OIDCError.LOGIN_REQUIRED_CODE));
 
-        AuditAssertionsHelper.assertEventTypesReceived(
+        assertEventTypesReceived(
                 auditTopic, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_REQUEST_ERROR));
     }
 
@@ -405,7 +405,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 getHeaderValueByParamName(response, ResponseHeaders.LOCATION),
                 startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
 
-        AuditAssertionsHelper.assertEventTypesReceived(
+        assertEventTypesReceived(
                 auditTopic, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
@@ -443,7 +443,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         String newSessionId = cookie.get().getValue().split("\\.")[0];
         assertThat(redis.getSession(newSessionId).getState(), equalTo(AUTHENTICATION_REQUIRED));
 
-        AuditAssertionsHelper.assertEventTypesReceived(
+        assertEventTypesReceived(
                 auditTopic, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
@@ -484,7 +484,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         String newSessionId = cookie.get().getValue().split("\\.")[0];
         assertThat(redis.getSession(newSessionId).getState(), equalTo(UPLIFT_REQUIRED_CM));
 
-        AuditAssertionsHelper.assertEventTypesReceived(
+        assertEventTypesReceived(
                 auditTopic, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
@@ -525,7 +525,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         String newSessionId = cookie.get().getValue().split("\\.")[0];
         assertThat(redis.getSession(newSessionId).getState(), equalTo(CONSENT_REQUIRED));
 
-        AuditAssertionsHelper.assertEventTypesReceived(
+        assertEventTypesReceived(
                 auditTopic, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -16,6 +16,7 @@ import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.shared.entity.SessionState;
 import uk.gov.di.authentication.shared.entity.ValidScopes;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 import uk.gov.di.authentication.sharedtest.helper.KeyPairHelper;
 
 import java.net.HttpCookie;
@@ -39,6 +40,9 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
+import static uk.gov.di.authentication.oidc.domain.OidcAuditableEvent.AUTHORISATION_INITIATED;
+import static uk.gov.di.authentication.oidc.domain.OidcAuditableEvent.AUTHORISATION_REQUEST_ERROR;
+import static uk.gov.di.authentication.oidc.domain.OidcAuditableEvent.AUTHORISATION_REQUEST_RECEIVED;
 import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.LOW_LEVEL;
 import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.MEDIUM_LEVEL;
 import static uk.gov.di.authentication.shared.entity.SessionState.AUTHENTICATED;
@@ -66,7 +70,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     }
 
     @Test
-    void shouldReturnUnmetAuthenticationRequirementsErrorWhenUsingInvalidClient() {
+    void shouldReturnUnmetAuthenticationRequirementsErrorWhenUsingInvalidClient() throws Exception {
         var response =
                 makeRequest(
                         Optional.empty(),
@@ -81,6 +85,9 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(
                 getHeaderValueByParamName(response, ResponseHeaders.LOCATION),
                 containsString(OAuth2Error.UNAUTHORIZED_CLIENT.getCode()));
+
+        AuditAssertionsHelper.assertEventTypesReceived(
+                auditTopic, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_REQUEST_ERROR));
     }
 
     @Test
@@ -102,6 +109,9 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 getHttpCookieFromMultiValueResponseHeaders(response.getMultiValueHeaders(), "gs")
                         .isPresent(),
                 equalTo(true));
+
+        AuditAssertionsHelper.assertEventTypesReceived(
+                auditTopic, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
     @Test
@@ -123,6 +133,9 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 getHttpCookieFromMultiValueResponseHeaders(response.getMultiValueHeaders(), "gs")
                         .isPresent(),
                 equalTo(true));
+
+        AuditAssertionsHelper.assertEventTypesReceived(
+                auditTopic, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
     @Test
@@ -155,6 +168,9 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         response.getMultiValueHeaders(), "di-persistent-session-id");
         assertThat(persistentCookie.isPresent(), equalTo(true));
         assertThat(persistentCookie.get().getValue(), equalTo("persistent-id-value"));
+
+        AuditAssertionsHelper.assertEventTypesReceived(
+                auditTopic, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
     @Test
@@ -183,6 +199,9 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                                 response.getMultiValueHeaders(), "di-persistent-session-id")
                         .isPresent(),
                 equalTo(true));
+
+        AuditAssertionsHelper.assertEventTypesReceived(
+                auditTopic, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
     @Test
@@ -201,6 +220,9 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 getHeaderValueByParamName(response, ResponseHeaders.LOCATION),
                 containsString(
                         "error=invalid_scope&error_description=Invalid%2C+unknown+or+malformed+scope"));
+
+        AuditAssertionsHelper.assertEventTypesReceived(
+                auditTopic, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_REQUEST_ERROR));
     }
 
     @Test
@@ -227,6 +249,9 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                                 response.getMultiValueHeaders(), "di-persistent-session-id")
                         .isPresent(),
                 equalTo(true));
+
+        AuditAssertionsHelper.assertEventTypesReceived(
+                auditTopic, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
     @Test
@@ -254,6 +279,9 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                                 response.getMultiValueHeaders(), "di-persistent-session-id")
                         .isPresent(),
                 equalTo(true));
+
+        AuditAssertionsHelper.assertEventTypesReceived(
+                auditTopic, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
     @Test
@@ -286,6 +314,9 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 equalTo(true));
         assertThat(cookie.isPresent(), equalTo(true));
         assertThat(cookie.get().getValue(), not(startsWith(sessionId)));
+
+        AuditAssertionsHelper.assertEventTypesReceived(
+                auditTopic, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
     @Test
@@ -317,6 +348,9 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 equalTo(true));
         assertThat(cookie.isPresent(), equalTo(true));
         assertThat(cookie.get().getValue(), not(startsWith(sessionId)));
+
+        AuditAssertionsHelper.assertEventTypesReceived(
+                auditTopic, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
     @Test
@@ -334,6 +368,9 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(
                 getHeaderValueByParamName(response, ResponseHeaders.LOCATION),
                 containsString(OIDCError.LOGIN_REQUIRED_CODE));
+
+        AuditAssertionsHelper.assertEventTypesReceived(
+                auditTopic, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_REQUEST_ERROR));
     }
 
     @Test
@@ -367,6 +404,9 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(
                 getHeaderValueByParamName(response, ResponseHeaders.LOCATION),
                 startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
+
+        AuditAssertionsHelper.assertEventTypesReceived(
+                auditTopic, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
     @Test
@@ -402,6 +442,9 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
         String newSessionId = cookie.get().getValue().split("\\.")[0];
         assertThat(redis.getSession(newSessionId).getState(), equalTo(AUTHENTICATION_REQUIRED));
+
+        AuditAssertionsHelper.assertEventTypesReceived(
+                auditTopic, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
     @Test
@@ -440,6 +483,9 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         String newSessionId = cookie.get().getValue().split("\\.")[0];
         assertThat(redis.getSession(newSessionId).getState(), equalTo(UPLIFT_REQUIRED_CM));
+
+        AuditAssertionsHelper.assertEventTypesReceived(
+                auditTopic, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
     @Test
@@ -478,6 +524,9 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         String newSessionId = cookie.get().getValue().split("\\.")[0];
         assertThat(redis.getSession(newSessionId).getState(), equalTo(CONSENT_REQUIRED));
+
+        AuditAssertionsHelper.assertEventTypesReceived(
+                auditTopic, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
     private String givenAnExistingSession(SessionState initialState) throws Exception {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientInfoIntegrationTest.java
@@ -14,7 +14,6 @@ import uk.gov.di.authentication.frontendapi.entity.ClientInfoResponse;
 import uk.gov.di.authentication.frontendapi.lambda.ClientInfoHandler;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
-import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 import uk.gov.di.authentication.sharedtest.helper.KeyPairHelper;
 
 import java.io.IOException;
@@ -32,6 +31,8 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.CLIENT_INFO_FOUND;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceived;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertNoAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class ClientInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -56,7 +57,7 @@ public class ClientInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         var response = makeRequest(Optional.empty(), headers, Map.of());
         assertThat(response, hasStatus(400));
 
-        AuditAssertionsHelper.assertNoAuditEventsReceived(auditTopic);
+        assertNoAuditEventsReceived(auditTopic);
     }
 
     @Test
@@ -92,7 +93,7 @@ public class ClientInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         assertThat(clientInfoResponse.getScopes(), hasItem("openid"));
         assertThat(clientInfoResponse.getScopes(), hasSize(1));
 
-        AuditAssertionsHelper.assertEventTypesReceived(auditTopic, List.of(CLIENT_INFO_FOUND));
+        assertEventTypesReceived(auditTopic, List.of(CLIENT_INFO_FOUND));
     }
 
     private void registerClient(KeyPair keyPair) {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientInfoIntegrationTest.java
@@ -14,6 +14,7 @@ import uk.gov.di.authentication.frontendapi.entity.ClientInfoResponse;
 import uk.gov.di.authentication.frontendapi.lambda.ClientInfoHandler;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 import uk.gov.di.authentication.sharedtest.helper.KeyPairHelper;
 
 import java.io.IOException;
@@ -30,6 +31,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
+import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.CLIENT_INFO_FOUND;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class ClientInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -53,6 +55,8 @@ public class ClientInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest 
 
         var response = makeRequest(Optional.empty(), headers, Map.of());
         assertThat(response, hasStatus(400));
+
+        AuditAssertionsHelper.assertNoAuditEventsReceived(auditTopic);
     }
 
     @Test
@@ -87,6 +91,8 @@ public class ClientInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         assertThat(clientInfoResponse.getClientName(), equalTo(TEST_CLIENT_NAME));
         assertThat(clientInfoResponse.getScopes(), hasItem("openid"));
         assertThat(clientInfoResponse.getScopes(), hasSize(1));
+
+        AuditAssertionsHelper.assertEventTypesReceived(auditTopic, List.of(CLIENT_INFO_FOUND));
     }
 
     private void registerClient(KeyPair keyPair) {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientRegistrationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientRegistrationIntegrationTest.java
@@ -9,13 +9,16 @@ import uk.gov.di.authentication.clientregistry.entity.ClientRegistrationResponse
 import uk.gov.di.authentication.clientregistry.lambda.ClientRegistrationHandler;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static uk.gov.di.authentication.clientregistry.domain.ClientRegistryAuditableEvent.REGISTER_CLIENT_REQUEST_RECEIVED;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class ClientRegistrationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -51,5 +54,8 @@ public class ClientRegistrationIntegrationTest extends ApiGatewayHandlerIntegrat
 
         assertThat(response, hasStatus(200));
         assertTrue(clientStore.clientExists(clientResponse.getClientId()));
+
+        AuditAssertionsHelper.assertEventTypesReceived(
+                auditTopic, List.of(REGISTER_CLIENT_REQUEST_RECEIVED));
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientRegistrationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientRegistrationIntegrationTest.java
@@ -9,7 +9,6 @@ import uk.gov.di.authentication.clientregistry.entity.ClientRegistrationResponse
 import uk.gov.di.authentication.clientregistry.lambda.ClientRegistrationHandler;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
-import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 
 import java.util.List;
 import java.util.Map;
@@ -19,6 +18,7 @@ import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.authentication.clientregistry.domain.ClientRegistryAuditableEvent.REGISTER_CLIENT_REQUEST_RECEIVED;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class ClientRegistrationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -55,7 +55,6 @@ public class ClientRegistrationIntegrationTest extends ApiGatewayHandlerIntegrat
         assertThat(response, hasStatus(200));
         assertTrue(clientStore.clientExists(clientResponse.getClientId()));
 
-        AuditAssertionsHelper.assertEventTypesReceived(
-                auditTopic, List.of(REGISTER_CLIENT_REQUEST_RECEIVED));
+        assertEventTypesReceived(auditTopic, List.of(REGISTER_CLIENT_REQUEST_RECEIVED));
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVAuthorisationHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVAuthorisationHandlerIntegrationTest.java
@@ -18,7 +18,6 @@ import uk.gov.di.authentication.shared.entity.SessionState;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.extensions.IPVStubExtension;
-import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 
 import java.io.IOException;
 import java.net.URI;
@@ -32,6 +31,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static uk.gov.di.authentication.ipv.domain.IPVAuditableEvent.IPV_AUTHORISATION_REQUESTED;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceived;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertNoAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 class IPVAuthorisationHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -81,8 +82,7 @@ class IPVAuthorisationHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
                 body.getRedirectUri(),
                 startsWith(configurationService.getIPVAuthorisationURI() + "/authorize"));
 
-        AuditAssertionsHelper.assertEventTypesReceived(
-                auditTopic, List.of(IPV_AUTHORISATION_REQUESTED));
+        assertEventTypesReceived(auditTopic, List.of(IPV_AUTHORISATION_REQUESTED));
     }
 
     @Test
@@ -96,7 +96,7 @@ class IPVAuthorisationHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
 
         assertThat(response, hasStatus(400));
 
-        AuditAssertionsHelper.assertNoAuditEventsReceived(auditTopic);
+        assertNoAuditEventsReceived(auditTopic);
     }
 
     private AuthenticationRequest withAuthenticationRequest(String clientId) {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVAuthorisationHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVAuthorisationHandlerIntegrationTest.java
@@ -44,7 +44,7 @@ class IPVAuthorisationHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
 
     @RegisterExtension public static final IPVStubExtension ipvStub = new IPVStubExtension();
 
-    protected static final ConfigurationService configurationService =
+    protected final ConfigurationService configurationService =
             new IPVTestConfigurationService(ipvStub);
 
     @BeforeEach
@@ -104,7 +104,7 @@ class IPVAuthorisationHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
                 .build();
     }
 
-    private static class IPVTestConfigurationService extends IntegrationTestConfigurationService {
+    private class IPVTestConfigurationService extends IntegrationTestConfigurationService {
 
         private final IPVStubExtension ipvStubExtension;
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
@@ -18,6 +18,7 @@ import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.extensions.IPVStubExtension;
+import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 
 import java.io.IOException;
 import java.net.URI;
@@ -79,6 +80,8 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
         assertThat(
                 response.getHeaders().get(ResponseHeaders.LOCATION),
                 startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
+
+        AuditAssertionsHelper.assertNoAuditEventsReceived(auditTopic);
     }
 
     private void setUpDynamo() {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
@@ -18,7 +18,6 @@ import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.extensions.IPVStubExtension;
-import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 
 import java.io.IOException;
 import java.net.URI;
@@ -30,6 +29,7 @@ import java.util.Optional;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.startsWith;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertNoAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -81,7 +81,7 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                 response.getHeaders().get(ResponseHeaders.LOCATION),
                 startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
 
-        AuditAssertionsHelper.assertNoAuditEventsReceived(auditTopic);
+        assertNoAuditEventsReceived(auditTopic);
     }
 
     private void setUpDynamo() {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/JwksIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/JwksIntegrationTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.oidc.lambda.JwksHandler;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 
 import java.text.ParseException;
 import java.util.Map;
@@ -28,5 +29,7 @@ public class JwksIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         assertThat(response, hasStatus(200));
         assertThat(JWKSet.parse(response.getBody()).getKeys(), hasSize(1));
+
+        AuditAssertionsHelper.assertNoAuditEventsReceived(auditTopic);
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/JwksIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/JwksIntegrationTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.oidc.lambda.JwksHandler;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
-import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 
 import java.text.ParseException;
 import java.util.Map;
@@ -13,6 +12,7 @@ import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertNoAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class JwksIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -30,6 +30,6 @@ public class JwksIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(response, hasStatus(200));
         assertThat(JWKSet.parse(response.getBody()).getKeys(), hasSize(1));
 
-        AuditAssertionsHelper.assertNoAuditEventsReceived(auditTopic);
+        assertNoAuditEventsReceived(auditTopic);
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
@@ -18,7 +18,6 @@ import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.shared.entity.SessionState;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
-import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 
 import java.io.IOException;
 import java.net.URI;
@@ -40,6 +39,7 @@ import static uk.gov.di.authentication.shared.entity.SessionState.AUTHENTICATION
 import static uk.gov.di.authentication.shared.entity.SessionState.CONSENT_REQUIRED;
 import static uk.gov.di.authentication.shared.entity.SessionState.LOGGED_IN;
 import static uk.gov.di.authentication.shared.entity.SessionState.UPDATED_TERMS_AND_CONDITIONS;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceived;
 import static uk.gov.di.authentication.sharedtest.helper.JsonArrayHelper.jsonArrayOf;
 import static uk.gov.di.authentication.sharedtest.helper.KeyPairHelper.GENERATE_RSA_KEY_PAIR;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
@@ -115,7 +115,7 @@ public class LoginIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 objectMapper.readValue(response.getBody(), LoginResponse.class);
         assertEquals(expectedState, loginResponse.getSessionState());
 
-        AuditAssertionsHelper.assertEventTypesReceived(auditTopic, List.of(LOG_IN_SUCCESS));
+        assertEventTypesReceived(auditTopic, List.of(LOG_IN_SUCCESS));
     }
 
     private static Stream<Arguments> vectorOfTrustEndStates() {
@@ -143,6 +143,6 @@ public class LoginIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 makeRequest(Optional.of(new LoginRequest(email, password)), headers, Map.of());
         assertThat(response, hasStatus(401));
 
-        AuditAssertionsHelper.assertEventTypesReceived(auditTopic, List.of(INVALID_CREDENTIALS));
+        assertEventTypesReceived(auditTopic, List.of(INVALID_CREDENTIALS));
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.oidc.lambda.LogoutHandler;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 
 import java.io.IOException;
 import java.net.URI;
@@ -32,6 +33,7 @@ import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.hasEntry;
+import static uk.gov.di.authentication.oidc.domain.OidcAuditableEvent.LOG_OUT_SUCCESS;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.isRedirect;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.isRedirectTo;
 import static uk.gov.di.authentication.sharedtest.matchers.UriMatcher.baseUri;
@@ -74,6 +76,8 @@ public class LogoutIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         allOf(
                                 baseUri(URI.create(REDIRECT_URL)),
                                 redirectQueryParameters(hasEntry("state", STATE)))));
+
+        AuditAssertionsHelper.assertEventTypesReceived(auditTopic, List.of(LOG_OUT_SUCCESS));
     }
 
     @Test
@@ -94,6 +98,8 @@ public class LogoutIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         allOf(
                                 baseUri(TEST_CONFIGURATION_SERVICE.getDefaultLogoutURI()),
                                 redirectQueryParameters(hasEntry("state", STATE)))));
+
+        AuditAssertionsHelper.assertEventTypesReceived(auditTopic, List.of(LOG_OUT_SUCCESS));
     }
 
     @Test
@@ -122,6 +128,8 @@ public class LogoutIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                                 redirectQueryParameters(hasEntry("state", STATE)),
                                 redirectQueryParameters(
                                         hasEntry("error_code", "invalid_request")))));
+
+        AuditAssertionsHelper.assertEventTypesReceived(auditTopic, List.of(LOG_OUT_SUCCESS));
     }
 
     private SignedJWT setupClientAndSession(String sessionId, String clientSessionId)

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
@@ -18,7 +18,6 @@ import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.oidc.lambda.LogoutHandler;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
-import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 
 import java.io.IOException;
 import java.net.URI;
@@ -34,6 +33,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.hasEntry;
 import static uk.gov.di.authentication.oidc.domain.OidcAuditableEvent.LOG_OUT_SUCCESS;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.isRedirect;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.isRedirectTo;
 import static uk.gov.di.authentication.sharedtest.matchers.UriMatcher.baseUri;
@@ -77,7 +77,7 @@ public class LogoutIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                                 baseUri(URI.create(REDIRECT_URL)),
                                 redirectQueryParameters(hasEntry("state", STATE)))));
 
-        AuditAssertionsHelper.assertEventTypesReceived(auditTopic, List.of(LOG_OUT_SUCCESS));
+        assertEventTypesReceived(auditTopic, List.of(LOG_OUT_SUCCESS));
     }
 
     @Test
@@ -99,7 +99,7 @@ public class LogoutIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                                 baseUri(TEST_CONFIGURATION_SERVICE.getDefaultLogoutURI()),
                                 redirectQueryParameters(hasEntry("state", STATE)))));
 
-        AuditAssertionsHelper.assertEventTypesReceived(auditTopic, List.of(LOG_OUT_SUCCESS));
+        assertEventTypesReceived(auditTopic, List.of(LOG_OUT_SUCCESS));
     }
 
     @Test
@@ -129,7 +129,7 @@ public class LogoutIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                                 redirectQueryParameters(
                                         hasEntry("error_code", "invalid_request")))));
 
-        AuditAssertionsHelper.assertEventTypesReceived(auditTopic, List.of(LOG_OUT_SUCCESS));
+        assertEventTypesReceived(auditTopic, List.of(LOG_OUT_SUCCESS));
     }
 
     private SignedJWT setupClientAndSession(String sessionId, String clientSessionId)

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordIntegrationTest.java
@@ -7,6 +7,7 @@ import uk.gov.di.authentication.frontendapi.entity.ResetPasswordWithCodeRequest;
 import uk.gov.di.authentication.frontendapi.lambda.ResetPasswordHandler;
 import uk.gov.di.authentication.shared.entity.NotifyRequest;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 
 import java.io.IOException;
 import java.util.List;
@@ -16,6 +17,7 @@ import java.util.Optional;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
+import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.PASSWORD_RESET_SUCCESSFUL;
 import static uk.gov.di.authentication.shared.entity.NotificationType.PASSWORD_RESET_CONFIRMATION;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
@@ -50,5 +52,8 @@ public class ResetPasswordIntegrationTest extends ApiGatewayHandlerIntegrationTe
         assertThat(requests, hasSize(1));
         assertThat(requests.get(0).getDestination(), equalTo(EMAIL_ADDRESS));
         assertThat(requests.get(0).getNotificationType(), equalTo(PASSWORD_RESET_CONFIRMATION));
+
+        AuditAssertionsHelper.assertEventTypesReceived(
+                auditTopic, List.of(PASSWORD_RESET_SUCCESSFUL));
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordIntegrationTest.java
@@ -7,7 +7,6 @@ import uk.gov.di.authentication.frontendapi.entity.ResetPasswordWithCodeRequest;
 import uk.gov.di.authentication.frontendapi.lambda.ResetPasswordHandler;
 import uk.gov.di.authentication.shared.entity.NotifyRequest;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
-import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 
 import java.io.IOException;
 import java.util.List;
@@ -19,6 +18,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.PASSWORD_RESET_SUCCESSFUL;
 import static uk.gov.di.authentication.shared.entity.NotificationType.PASSWORD_RESET_CONFIRMATION;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class ResetPasswordIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -53,7 +53,6 @@ public class ResetPasswordIntegrationTest extends ApiGatewayHandlerIntegrationTe
         assertThat(requests.get(0).getDestination(), equalTo(EMAIL_ADDRESS));
         assertThat(requests.get(0).getNotificationType(), equalTo(PASSWORD_RESET_CONFIRMATION));
 
-        AuditAssertionsHelper.assertEventTypesReceived(
-                auditTopic, List.of(PASSWORD_RESET_SUCCESSFUL));
+        assertEventTypesReceived(auditTopic, List.of(PASSWORD_RESET_SUCCESSFUL));
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordRequestIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordRequestIntegrationTest.java
@@ -7,6 +7,7 @@ import uk.gov.di.authentication.frontendapi.lambda.ResetPasswordRequestHandler;
 import uk.gov.di.authentication.shared.entity.BaseAPIResponse;
 import uk.gov.di.authentication.shared.entity.NotifyRequest;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 
 import java.io.IOException;
 import java.util.List;
@@ -17,6 +18,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.PASSWORD_RESET_REQUESTED;
 import static uk.gov.di.authentication.shared.entity.NotificationType.RESET_PASSWORD;
 import static uk.gov.di.authentication.shared.entity.SessionState.AUTHENTICATION_REQUIRED;
 import static uk.gov.di.authentication.shared.entity.SessionState.NEW;
@@ -67,6 +69,9 @@ public class ResetPasswordRequestIntegrationTest extends ApiGatewayHandlerIntegr
         BaseAPIResponse resetPasswordResponse =
                 objectMapper.readValue(response.getBody(), BaseAPIResponse.class);
         assertThat(resetPasswordResponse.getSessionState(), equalTo(RESET_PASSWORD_LINK_SENT));
+
+        AuditAssertionsHelper.assertEventTypesReceived(
+                auditTopic, List.of(PASSWORD_RESET_REQUESTED));
     }
 
     @Test
@@ -90,5 +95,8 @@ public class ResetPasswordRequestIntegrationTest extends ApiGatewayHandlerIntegr
         List<NotifyRequest> requests = notificationsQueue.getMessages(NotifyRequest.class);
 
         assertThat(requests, hasSize(0));
+
+        AuditAssertionsHelper.assertEventTypesReceived(
+                auditTopic, List.of(PASSWORD_RESET_REQUESTED));
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordRequestIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordRequestIntegrationTest.java
@@ -7,7 +7,6 @@ import uk.gov.di.authentication.frontendapi.lambda.ResetPasswordRequestHandler;
 import uk.gov.di.authentication.shared.entity.BaseAPIResponse;
 import uk.gov.di.authentication.shared.entity.NotifyRequest;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
-import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 
 import java.io.IOException;
 import java.util.List;
@@ -23,6 +22,7 @@ import static uk.gov.di.authentication.shared.entity.NotificationType.RESET_PASS
 import static uk.gov.di.authentication.shared.entity.SessionState.AUTHENTICATION_REQUIRED;
 import static uk.gov.di.authentication.shared.entity.SessionState.NEW;
 import static uk.gov.di.authentication.shared.entity.SessionState.RESET_PASSWORD_LINK_SENT;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class ResetPasswordRequestIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -70,8 +70,7 @@ public class ResetPasswordRequestIntegrationTest extends ApiGatewayHandlerIntegr
                 objectMapper.readValue(response.getBody(), BaseAPIResponse.class);
         assertThat(resetPasswordResponse.getSessionState(), equalTo(RESET_PASSWORD_LINK_SENT));
 
-        AuditAssertionsHelper.assertEventTypesReceived(
-                auditTopic, List.of(PASSWORD_RESET_REQUESTED));
+        assertEventTypesReceived(auditTopic, List.of(PASSWORD_RESET_REQUESTED));
     }
 
     @Test
@@ -96,7 +95,6 @@ public class ResetPasswordRequestIntegrationTest extends ApiGatewayHandlerIntegr
 
         assertThat(requests, hasSize(0));
 
-        AuditAssertionsHelper.assertEventTypesReceived(
-                auditTopic, List.of(PASSWORD_RESET_REQUESTED));
+        assertEventTypesReceived(auditTopic, List.of(PASSWORD_RESET_REQUESTED));
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/SignupIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/SignupIntegrationTest.java
@@ -6,7 +6,6 @@ import uk.gov.di.authentication.frontendapi.entity.SignupRequest;
 import uk.gov.di.authentication.frontendapi.lambda.SignUpHandler;
 import uk.gov.di.authentication.shared.entity.BaseAPIResponse;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
-import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -20,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.CREATE_ACCOUNT;
 import static uk.gov.di.authentication.shared.entity.SessionState.EMAIL_CODE_VERIFIED;
 import static uk.gov.di.authentication.shared.entity.SessionState.TWO_FACTOR_REQUIRED;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class SignupIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -55,6 +55,6 @@ public class SignupIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(BaseAPIResponse.getSessionState(), equalTo(TWO_FACTOR_REQUIRED));
         assertTrue(userStore.userExists("joe.bloggs+5@digital.cabinet-office.gov.uk"));
 
-        AuditAssertionsHelper.assertEventTypesReceived(auditTopic, List.of(CREATE_ACCOUNT));
+        assertEventTypesReceived(auditTopic, List.of(CREATE_ACCOUNT));
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/SignupIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/SignupIntegrationTest.java
@@ -6,15 +6,18 @@ import uk.gov.di.authentication.frontendapi.entity.SignupRequest;
 import uk.gov.di.authentication.frontendapi.lambda.SignUpHandler;
 import uk.gov.di.authentication.shared.entity.BaseAPIResponse;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.CREATE_ACCOUNT;
 import static uk.gov.di.authentication.shared.entity.SessionState.EMAIL_CODE_VERIFIED;
 import static uk.gov.di.authentication.shared.entity.SessionState.TWO_FACTOR_REQUIRED;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
@@ -51,5 +54,7 @@ public class SignupIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 objectMapper.readValue(response.getBody(), BaseAPIResponse.class);
         assertThat(BaseAPIResponse.getSessionState(), equalTo(TWO_FACTOR_REQUIRED));
         assertTrue(userStore.userExists("joe.bloggs+5@digital.cabinet-office.gov.uk"));
+
+        AuditAssertionsHelper.assertEventTypesReceived(auditTopic, List.of(CREATE_ACCOUNT));
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
@@ -38,7 +38,6 @@ import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.shared.entity.ValidScopes;
 import uk.gov.di.authentication.shared.entity.VectorOfTrust;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
-import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 import uk.gov.di.authentication.sharedtest.helper.KeyPairHelper;
 
 import java.net.URI;
@@ -63,6 +62,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertNoAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -121,7 +121,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         .getClaim("vot"),
                 equalTo(vtr.get()));
 
-        AuditAssertionsHelper.assertNoAuditEventsReceived(auditTopic);
+        assertNoAuditEventsReceived(auditTopic);
     }
 
     @Test
@@ -145,7 +145,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         .getTokens()
                         .getBearerAccessToken());
 
-        AuditAssertionsHelper.assertNoAuditEventsReceived(auditTopic);
+        assertNoAuditEventsReceived(auditTopic);
     }
 
     @Test
@@ -198,7 +198,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         .getTokens()
                         .getBearerAccessToken());
 
-        AuditAssertionsHelper.assertNoAuditEventsReceived(auditTopic);
+        assertNoAuditEventsReceived(auditTopic);
     }
 
     private SignedJWT generateSignedRefreshToken(Scope scope, Subject publicSubject) {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateClientConfigIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateClientConfigIntegrationTest.java
@@ -9,13 +9,16 @@ import uk.gov.di.authentication.clientregistry.lambda.UpdateClientConfigHandler;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.shared.entity.UpdateClientConfigRequest;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static uk.gov.di.authentication.clientregistry.domain.ClientRegistryAuditableEvent.UPDATE_CLIENT_REQUEST_RECEIVED;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class UpdateClientConfigIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -59,6 +62,9 @@ public class UpdateClientConfigIntegrationTest extends ApiGatewayHandlerIntegrat
                 objectMapper.readValue(response.getBody(), ClientRegistrationResponse.class);
         assertThat(clientResponse.getClientName(), equalTo("new-client-name"));
         assertThat(clientResponse.getClientId(), equalTo(CLIENT_ID));
+
+        AuditAssertionsHelper.assertEventTypesReceived(
+                auditTopic, List.of(UPDATE_CLIENT_REQUEST_RECEIVED));
     }
 
     @Test
@@ -77,5 +83,9 @@ public class UpdateClientConfigIntegrationTest extends ApiGatewayHandlerIntegrat
         assertThat(
                 response.getBody(),
                 equalTo(OAuth2Error.INVALID_CLIENT.toJSONObject().toJSONString()));
+
+        AuditAssertionsHelper.assertEventTypesReceived(
+                auditTopic,
+                List.of(UPDATE_CLIENT_REQUEST_RECEIVED, UPDATE_CLIENT_REQUEST_RECEIVED));
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateClientConfigIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateClientConfigIntegrationTest.java
@@ -9,7 +9,6 @@ import uk.gov.di.authentication.clientregistry.lambda.UpdateClientConfigHandler;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.shared.entity.UpdateClientConfigRequest;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
-import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 
 import java.util.List;
 import java.util.Map;
@@ -19,6 +18,7 @@ import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static uk.gov.di.authentication.clientregistry.domain.ClientRegistryAuditableEvent.UPDATE_CLIENT_REQUEST_RECEIVED;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class UpdateClientConfigIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -63,8 +63,7 @@ public class UpdateClientConfigIntegrationTest extends ApiGatewayHandlerIntegrat
         assertThat(clientResponse.getClientName(), equalTo("new-client-name"));
         assertThat(clientResponse.getClientId(), equalTo(CLIENT_ID));
 
-        AuditAssertionsHelper.assertEventTypesReceived(
-                auditTopic, List.of(UPDATE_CLIENT_REQUEST_RECEIVED));
+        assertEventTypesReceived(auditTopic, List.of(UPDATE_CLIENT_REQUEST_RECEIVED));
     }
 
     @Test
@@ -84,7 +83,7 @@ public class UpdateClientConfigIntegrationTest extends ApiGatewayHandlerIntegrat
                 response.getBody(),
                 equalTo(OAuth2Error.INVALID_CLIENT.toJSONObject().toJSONString()));
 
-        AuditAssertionsHelper.assertEventTypesReceived(
+        assertEventTypesReceived(
                 auditTopic,
                 List.of(UPDATE_CLIENT_REQUEST_RECEIVED, UPDATE_CLIENT_REQUEST_RECEIVED));
     }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateProfileIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateProfileIntegrationTest.java
@@ -18,6 +18,7 @@ import uk.gov.di.authentication.shared.entity.SessionState;
 import uk.gov.di.authentication.shared.entity.ValidScopes;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 
 import java.io.IOException;
 import java.net.URI;
@@ -32,6 +33,7 @@ import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.UPDATE_PROFILE_REQUEST_RECEIVED;
 import static uk.gov.di.authentication.frontendapi.entity.UpdateProfileType.ADD_PHONE_NUMBER;
 import static uk.gov.di.authentication.frontendapi.entity.UpdateProfileType.CAPTURE_CONSENT;
 import static uk.gov.di.authentication.frontendapi.entity.UpdateProfileType.UPDATE_TERMS_CONDS;
@@ -69,6 +71,10 @@ public class UpdateProfileIntegrationTest extends ApiGatewayHandlerIntegrationTe
         BaseAPIResponse baseAPIResponse =
                 objectMapper.readValue(response.getBody(), BaseAPIResponse.class);
         assertThat(baseAPIResponse.getSessionState(), equalTo(ADDED_UNVERIFIED_PHONE_NUMBER));
+
+        AuditAssertionsHelper.assertEventTypesReceived(
+                auditTopic,
+                List.of(UPDATE_PROFILE_REQUEST_RECEIVED, UPDATE_PROFILE_REQUEST_RECEIVED));
     }
 
     @Test
@@ -101,6 +107,10 @@ public class UpdateProfileIntegrationTest extends ApiGatewayHandlerIntegrationTe
         BaseAPIResponse baseAPIResponse =
                 objectMapper.readValue(response.getBody(), BaseAPIResponse.class);
         assertThat(baseAPIResponse.getSessionState(), equalTo(CONSENT_ADDED));
+
+        AuditAssertionsHelper.assertEventTypesReceived(
+                auditTopic,
+                List.of(UPDATE_PROFILE_REQUEST_RECEIVED, UPDATE_PROFILE_REQUEST_RECEIVED));
     }
 
     @Test
@@ -123,6 +133,10 @@ public class UpdateProfileIntegrationTest extends ApiGatewayHandlerIntegrationTe
                 objectMapper.readValue(response.getBody(), BaseAPIResponse.class);
         assertThat(
                 baseAPIResponse.getSessionState(), equalTo(UPDATED_TERMS_AND_CONDITIONS_ACCEPTED));
+
+        AuditAssertionsHelper.assertEventTypesReceived(
+                auditTopic,
+                List.of(UPDATE_PROFILE_REQUEST_RECEIVED, UPDATE_PROFILE_REQUEST_RECEIVED));
     }
 
     private AuthenticationRequest setUpTest(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateProfileIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateProfileIntegrationTest.java
@@ -18,7 +18,6 @@ import uk.gov.di.authentication.shared.entity.SessionState;
 import uk.gov.di.authentication.shared.entity.ValidScopes;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
-import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 
 import java.io.IOException;
 import java.net.URI;
@@ -40,6 +39,7 @@ import static uk.gov.di.authentication.frontendapi.entity.UpdateProfileType.UPDA
 import static uk.gov.di.authentication.shared.entity.SessionState.ADDED_UNVERIFIED_PHONE_NUMBER;
 import static uk.gov.di.authentication.shared.entity.SessionState.CONSENT_ADDED;
 import static uk.gov.di.authentication.shared.entity.SessionState.UPDATED_TERMS_AND_CONDITIONS_ACCEPTED;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class UpdateProfileIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -72,7 +72,7 @@ public class UpdateProfileIntegrationTest extends ApiGatewayHandlerIntegrationTe
                 objectMapper.readValue(response.getBody(), BaseAPIResponse.class);
         assertThat(baseAPIResponse.getSessionState(), equalTo(ADDED_UNVERIFIED_PHONE_NUMBER));
 
-        AuditAssertionsHelper.assertEventTypesReceived(
+        assertEventTypesReceived(
                 auditTopic,
                 List.of(UPDATE_PROFILE_REQUEST_RECEIVED, UPDATE_PROFILE_REQUEST_RECEIVED));
     }
@@ -108,7 +108,7 @@ public class UpdateProfileIntegrationTest extends ApiGatewayHandlerIntegrationTe
                 objectMapper.readValue(response.getBody(), BaseAPIResponse.class);
         assertThat(baseAPIResponse.getSessionState(), equalTo(CONSENT_ADDED));
 
-        AuditAssertionsHelper.assertEventTypesReceived(
+        assertEventTypesReceived(
                 auditTopic,
                 List.of(UPDATE_PROFILE_REQUEST_RECEIVED, UPDATE_PROFILE_REQUEST_RECEIVED));
     }
@@ -134,7 +134,7 @@ public class UpdateProfileIntegrationTest extends ApiGatewayHandlerIntegrationTe
         assertThat(
                 baseAPIResponse.getSessionState(), equalTo(UPDATED_TERMS_AND_CONDITIONS_ACCEPTED));
 
-        AuditAssertionsHelper.assertEventTypesReceived(
+        assertEventTypesReceived(
                 auditTopic,
                 List.of(UPDATE_PROFILE_REQUEST_RECEIVED, UPDATE_PROFILE_REQUEST_RECEIVED));
     }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserExistsIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserExistsIntegrationTest.java
@@ -8,7 +8,6 @@ import uk.gov.di.authentication.frontendapi.lambda.CheckUserExistsHandler;
 import uk.gov.di.authentication.shared.entity.BaseFrontendRequest;
 import uk.gov.di.authentication.shared.entity.SessionState;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
-import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 
 import java.io.IOException;
 import java.util.List;
@@ -23,6 +22,7 @@ import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.CHECK_USER_NO_ACCOUNT_WITH_EMAIL;
 import static uk.gov.di.authentication.shared.entity.SessionState.AUTHENTICATION_REQUIRED;
 import static uk.gov.di.authentication.shared.entity.SessionState.USER_NOT_FOUND;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class UserExistsIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -52,7 +52,7 @@ public class UserExistsIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         assertThat(checkUserExistsResponse.getSessionState(), equalTo(AUTHENTICATION_REQUIRED));
         assertTrue(checkUserExistsResponse.doesUserExist());
 
-        AuditAssertionsHelper.assertEventTypesReceived(auditTopic, List.of(CHECK_USER_KNOWN_EMAIL));
+        assertEventTypesReceived(auditTopic, List.of(CHECK_USER_KNOWN_EMAIL));
     }
 
     @Test
@@ -74,7 +74,6 @@ public class UserExistsIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         assertThat(checkUserExistsResponse.getSessionState(), equalTo(USER_NOT_FOUND));
         assertFalse(checkUserExistsResponse.doesUserExist());
 
-        AuditAssertionsHelper.assertEventTypesReceived(
-                auditTopic, List.of(CHECK_USER_NO_ACCOUNT_WITH_EMAIL));
+        assertEventTypesReceived(auditTopic, List.of(CHECK_USER_NO_ACCOUNT_WITH_EMAIL));
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserExistsIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserExistsIntegrationTest.java
@@ -8,8 +8,10 @@ import uk.gov.di.authentication.frontendapi.lambda.CheckUserExistsHandler;
 import uk.gov.di.authentication.shared.entity.BaseFrontendRequest;
 import uk.gov.di.authentication.shared.entity.SessionState;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -17,6 +19,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.CHECK_USER_KNOWN_EMAIL;
+import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.CHECK_USER_NO_ACCOUNT_WITH_EMAIL;
 import static uk.gov.di.authentication.shared.entity.SessionState.AUTHENTICATION_REQUIRED;
 import static uk.gov.di.authentication.shared.entity.SessionState.USER_NOT_FOUND;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
@@ -47,6 +51,8 @@ public class UserExistsIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         assertThat(checkUserExistsResponse.getEmail(), equalTo(emailAddress));
         assertThat(checkUserExistsResponse.getSessionState(), equalTo(AUTHENTICATION_REQUIRED));
         assertTrue(checkUserExistsResponse.doesUserExist());
+
+        AuditAssertionsHelper.assertEventTypesReceived(auditTopic, List.of(CHECK_USER_KNOWN_EMAIL));
     }
 
     @Test
@@ -67,5 +73,8 @@ public class UserExistsIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         assertThat(checkUserExistsResponse.getEmail(), equalTo(emailAddress));
         assertThat(checkUserExistsResponse.getSessionState(), equalTo(USER_NOT_FOUND));
         assertFalse(checkUserExistsResponse.doesUserExist());
+
+        AuditAssertionsHelper.assertEventTypesReceived(
+                auditTopic, List.of(CHECK_USER_NO_ACCOUNT_WITH_EMAIL));
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
@@ -15,7 +15,6 @@ import uk.gov.di.authentication.oidc.lambda.UserInfoHandler;
 import uk.gov.di.authentication.shared.entity.AccessTokenStore;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
-import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 import uk.gov.di.authentication.sharedtest.helper.KeyPairHelper;
 
 import java.security.KeyPair;
@@ -33,6 +32,7 @@ import static com.nimbusds.oauth2.sdk.token.BearerTokenError.INVALID_TOKEN;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertNoAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -96,7 +96,7 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         expectedUserInfoResponse.setPhoneNumberVerified(true);
         assertThat(response.getBody(), equalTo(expectedUserInfoResponse.toJSONString()));
 
-        AuditAssertionsHelper.assertNoAuditEventsReceived(auditTopic);
+        assertNoAuditEventsReceived(auditTopic);
     }
 
     @Test
@@ -113,7 +113,7 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                                 .getHeaderMap()
                                 .get("WWW-Authenticate")));
 
-        AuditAssertionsHelper.assertNoAuditEventsReceived(auditTopic);
+        assertNoAuditEventsReceived(auditTopic);
     }
 
     private void setUpDynamo(Subject internalSubject) {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
@@ -15,6 +15,7 @@ import uk.gov.di.authentication.oidc.lambda.UserInfoHandler;
 import uk.gov.di.authentication.shared.entity.AccessTokenStore;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 import uk.gov.di.authentication.sharedtest.helper.KeyPairHelper;
 
 import java.security.KeyPair;
@@ -94,6 +95,8 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         expectedUserInfoResponse.setPhoneNumber(FORMATTED_PHONE_NUMBER);
         expectedUserInfoResponse.setPhoneNumberVerified(true);
         assertThat(response.getBody(), equalTo(expectedUserInfoResponse.toJSONString()));
+
+        AuditAssertionsHelper.assertNoAuditEventsReceived(auditTopic);
     }
 
     @Test
@@ -109,6 +112,8 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                                 .toHTTPResponse()
                                 .getHeaderMap()
                                 .get("WWW-Authenticate")));
+
+        AuditAssertionsHelper.assertNoAuditEventsReceived(auditTopic);
     }
 
     private void setUpDynamo(Subject internalSubject) {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
@@ -21,7 +21,6 @@ import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.shared.entity.SessionState;
 import uk.gov.di.authentication.shared.entity.ValidScopes;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
-import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 
 import java.io.IOException;
 import java.net.URI;
@@ -38,6 +37,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.CODE_VERIFIED;
 import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_EMAIL;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceived;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertNoAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -66,7 +67,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
                         Map.of());
         assertThat(response, hasStatus(200));
 
-        AuditAssertionsHelper.assertEventTypesReceived(auditTopic, List.of(CODE_VERIFIED));
+        assertEventTypesReceived(auditTopic, List.of(CODE_VERIFIED));
     }
 
     @Test
@@ -92,7 +93,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
                 objectMapper.readValue(response.getBody(), BaseAPIResponse.class);
         assertEquals(SessionState.EMAIL_CODE_NOT_VALID, codeResponse.getSessionState());
 
-        AuditAssertionsHelper.assertNoAuditEventsReceived(auditTopic);
+        assertNoAuditEventsReceived(auditTopic);
     }
 
     @Test
@@ -126,7 +127,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
                 objectMapper.readValue(response2.getBody(), BaseAPIResponse.class);
         assertEquals(SessionState.EMAIL_CODE_NOT_VALID, codeResponse.getSessionState());
 
-        AuditAssertionsHelper.assertEventTypesReceived(auditTopic, List.of(CODE_VERIFIED));
+        assertEventTypesReceived(auditTopic, List.of(CODE_VERIFIED));
     }
 
     @Test
@@ -155,7 +156,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
                 objectMapper.readValue(response.getBody(), BaseAPIResponse.class);
         assertEquals(SessionState.PHONE_NUMBER_CODE_VERIFIED, codeResponse.getSessionState());
 
-        AuditAssertionsHelper.assertEventTypesReceived(auditTopic, List.of(CODE_VERIFIED));
+        assertEventTypesReceived(auditTopic, List.of(CODE_VERIFIED));
     }
 
     @Test
@@ -180,7 +181,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
                 objectMapper.readValue(response.getBody(), BaseAPIResponse.class);
         assertEquals(SessionState.CONSENT_REQUIRED, codeResponse.getSessionState());
 
-        AuditAssertionsHelper.assertEventTypesReceived(auditTopic, List.of(CODE_VERIFIED));
+        assertEventTypesReceived(auditTopic, List.of(CODE_VERIFIED));
     }
 
     @Test
@@ -208,7 +209,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
                 objectMapper.readValue(response.getBody(), BaseAPIResponse.class);
         assertEquals(SessionState.PHONE_NUMBER_CODE_NOT_VALID, codeResponse.getSessionState());
 
-        AuditAssertionsHelper.assertNoAuditEventsReceived(auditTopic);
+        assertNoAuditEventsReceived(auditTopic);
     }
 
     @Test
@@ -232,7 +233,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         assertEquals(
                 SessionState.PHONE_NUMBER_CODE_MAX_RETRIES_REACHED, codeResponse.getSessionState());
 
-        AuditAssertionsHelper.assertNoAuditEventsReceived(auditTopic);
+        assertNoAuditEventsReceived(auditTopic);
     }
 
     @Test
@@ -254,7 +255,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
                 objectMapper.readValue(response.getBody(), BaseAPIResponse.class);
         assertEquals(SessionState.EMAIL_CODE_MAX_RETRIES_REACHED, codeResponse.getSessionState());
 
-        AuditAssertionsHelper.assertNoAuditEventsReceived(auditTopic);
+        assertNoAuditEventsReceived(auditTopic);
     }
 
     @Test
@@ -277,7 +278,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
                 new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1017),
                 response.getBody());
 
-        AuditAssertionsHelper.assertNoAuditEventsReceived(auditTopic);
+        assertNoAuditEventsReceived(auditTopic);
     }
 
     @Test
@@ -302,7 +303,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
                 new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1017),
                 response.getBody());
 
-        AuditAssertionsHelper.assertNoAuditEventsReceived(auditTopic);
+        assertNoAuditEventsReceived(auditTopic);
     }
 
     @Test
@@ -337,7 +338,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
                 objectMapper.readValue(response.getBody(), BaseAPIResponse.class);
         assertEquals(SessionState.MFA_CODE_VERIFIED, codeResponse.getSessionState());
 
-        AuditAssertionsHelper.assertEventTypesReceived(auditTopic, List.of(CODE_VERIFIED));
+        assertEventTypesReceived(auditTopic, List.of(CODE_VERIFIED));
     }
 
     @Test
@@ -367,7 +368,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
                 objectMapper.readValue(response.getBody(), BaseAPIResponse.class);
         assertEquals(SessionState.UPDATED_TERMS_AND_CONDITIONS, codeResponse.getSessionState());
 
-        AuditAssertionsHelper.assertEventTypesReceived(auditTopic, List.of(CODE_VERIFIED));
+        assertEventTypesReceived(auditTopic, List.of(CODE_VERIFIED));
     }
 
     @Test
@@ -389,7 +390,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
                 new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1017),
                 response.getBody());
 
-        AuditAssertionsHelper.assertNoAuditEventsReceived(auditTopic);
+        assertNoAuditEventsReceived(auditTopic);
     }
 
     private void setUpTestWithoutSignUp(String sessionId, Scope scope, SessionState sessionState)

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/domain/IPVAuditableEvent.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/domain/IPVAuditableEvent.java
@@ -4,5 +4,9 @@ import uk.gov.di.authentication.shared.domain.AuditableEvent;
 
 public enum IPVAuditableEvent implements AuditableEvent {
     IPV_AUTHORISATION_REQUESTED,
-    IPV_CAPACITY_REQUESTED
+    IPV_CAPACITY_REQUESTED;
+
+    public AuditableEvent parseFromName(String name) {
+        return valueOf(name);
+    }
 }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/domain/OidcAuditableEvent.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/domain/OidcAuditableEvent.java
@@ -7,5 +7,9 @@ public enum OidcAuditableEvent implements AuditableEvent {
     AUTHORISATION_INITIATED,
     AUTHORISATION_REQUEST_RECEIVED,
     AUTH_CODE_ISSUED,
-    LOG_OUT_SUCCESS
+    LOG_OUT_SUCCESS;
+
+    public AuditableEvent parseFromName(String name) {
+        return valueOf(name);
+    }
 }

--- a/shared-test/build.gradle
+++ b/shared-test/build.gradle
@@ -21,6 +21,7 @@ dependencies {
             configurations.ssm,
             "org.eclipse.jetty:jetty-server:11.0.7",
             "com.google.protobuf:protobuf-java:3.19.3",
+            "com.google.code.gson:gson:2.8.9",
             project(":shared")
 }
 

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/ApiGatewayHandlerIntegrationTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/ApiGatewayHandlerIntegrationTest.java
@@ -53,8 +53,7 @@ public abstract class ApiGatewayHandlerIntegrationTest {
             new SqsQueueExtension("notification-queue");
 
     @RegisterExtension
-    protected static final AuditSnsTopicExtension auditTopic =
-            new AuditSnsTopicExtension("local-events");
+    protected final AuditSnsTopicExtension auditTopic = new AuditSnsTopicExtension("local-events");
 
     @RegisterExtension
     protected static final KmsKeyExtension auditSigningKey =
@@ -77,7 +76,7 @@ public abstract class ApiGatewayHandlerIntegrationTest {
                             "local-account-management-redis-tls", "false",
                             "local-password-pepper", "pepper"));
 
-    protected static final ConfigurationService TEST_CONFIGURATION_SERVICE =
+    protected final ConfigurationService TEST_CONFIGURATION_SERVICE =
             new IntegrationTestConfigurationService(
                     auditTopic, notificationsQueue, auditSigningKey, tokenSigner);
 

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/ApiGatewayHandlerIntegrationTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/ApiGatewayHandlerIntegrationTest.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.sharedtest.extensions.AuditSnsTopicExtension;
 import uk.gov.di.authentication.sharedtest.extensions.ClientStoreExtension;
 import uk.gov.di.authentication.sharedtest.extensions.KmsKeyExtension;
 import uk.gov.di.authentication.sharedtest.extensions.ParameterStoreExtension;
@@ -52,7 +53,8 @@ public abstract class ApiGatewayHandlerIntegrationTest {
             new SqsQueueExtension("notification-queue");
 
     @RegisterExtension
-    protected static final SnsTopicExtension auditTopic = new SnsTopicExtension("local-events");
+    protected static final AuditSnsTopicExtension auditTopic =
+            new AuditSnsTopicExtension("local-events");
 
     @RegisterExtension
     protected static final KmsKeyExtension auditSigningKey =

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuditSnsTopicExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuditSnsTopicExtension.java
@@ -1,0 +1,38 @@
+package uk.gov.di.authentication.sharedtest.extensions;
+
+import com.google.gson.JsonParser;
+import uk.gov.di.audit.AuditPayload;
+import uk.gov.di.audit.helper.AuditEventHelper;
+import uk.gov.di.authentication.sharedtest.httpstub.RecordedRequest;
+
+import java.util.Base64;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class AuditSnsTopicExtension extends SnsTopicExtension {
+
+    public static final int SNS_TIMEOUT = 10; // In seconds.
+
+    public AuditSnsTopicExtension(String topicNameSuffix) {
+        super(topicNameSuffix);
+    }
+
+    public List<AuditPayload.AuditEvent> getAuditEvents() {
+        return getRecordedRequests().stream()
+                .map(RecordedRequest::getEntity)
+                .map(AuditSnsTopicExtension::mapRequest)
+                .collect(Collectors.toList());
+    }
+
+    private static AuditPayload.AuditEvent mapRequest(String json) {
+        String message = JsonParser.parseString(json).getAsJsonObject().get("Message").getAsString();
+        byte[] decodedBytes = Base64.getDecoder().decode(message);
+        Optional<AuditPayload.SignedAuditEvent> signedAuditEvent =
+                AuditEventHelper.parseToSignedAuditEvent(decodedBytes);
+        Optional<AuditPayload.AuditEvent> auditEvent =
+                AuditEventHelper.extractPayload(signedAuditEvent);
+
+        return auditEvent.get();
+    }
+}

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuditSnsTopicExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuditSnsTopicExtension.java
@@ -12,7 +12,8 @@ import java.util.stream.Collectors;
 
 public class AuditSnsTopicExtension extends SnsTopicExtension {
 
-    public static final int SNS_TIMEOUT = 10; // In seconds.
+    public static final int SNS_TIMEOUT = 1; // In seconds.
+    public static final int SNS_TIMEOUT_MILLIS = SNS_TIMEOUT * 1000;
 
     public AuditSnsTopicExtension(String topicNameSuffix) {
         super(topicNameSuffix);

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuditSnsTopicExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuditSnsTopicExtension.java
@@ -12,9 +12,6 @@ import java.util.stream.Collectors;
 
 public class AuditSnsTopicExtension extends SnsTopicExtension {
 
-    public static final int SNS_TIMEOUT = 1; // In seconds.
-    public static final int SNS_TIMEOUT_MILLIS = SNS_TIMEOUT * 1000;
-
     public AuditSnsTopicExtension(String topicNameSuffix) {
         super(topicNameSuffix);
     }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuditSnsTopicExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuditSnsTopicExtension.java
@@ -26,7 +26,8 @@ public class AuditSnsTopicExtension extends SnsTopicExtension {
     }
 
     private static AuditPayload.AuditEvent mapRequest(String json) {
-        String message = JsonParser.parseString(json).getAsJsonObject().get("Message").getAsString();
+        String message =
+                JsonParser.parseString(json).getAsJsonObject().get("Message").getAsString();
         byte[] decodedBytes = Base64.getDecoder().decode(message);
         Optional<AuditPayload.SignedAuditEvent> signedAuditEvent =
                 AuditEventHelper.parseToSignedAuditEvent(decodedBytes);

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/SnsTopicExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/SnsTopicExtension.java
@@ -3,15 +3,19 @@ package uk.gov.di.authentication.sharedtest.extensions;
 import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.sns.AmazonSNS;
 import com.amazonaws.services.sns.AmazonSNSClientBuilder;
-import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import uk.gov.di.authentication.sharedtest.httpstub.HttpStubExtension;
 
 import static java.text.MessageFormat.format;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
 
 public class SnsTopicExtension extends HttpStubExtension
-        implements BeforeAllCallback, AfterEachCallback {
+        implements BeforeAllCallback, BeforeEachCallback {
 
     protected static final String REGION = System.getenv().getOrDefault("AWS_REGION", "eu-west-2");
     protected static final String LOCALSTACK_ENDPOINT =
@@ -35,6 +39,7 @@ public class SnsTopicExtension extends HttpStubExtension
 
     @Override
     public void beforeAll(ExtensionContext context) {
+        startStub();
         var topicName =
                 format(
                         "{0}-{1}",
@@ -42,12 +47,16 @@ public class SnsTopicExtension extends HttpStubExtension
                         topicNameSuffix);
 
         topicArn = createTopic(topicName);
-        subscribeToTopic(topicArn);
         initSubscriber();
+        subscribeToTopic(topicArn);
+
+        // Wait for topic subscription message to be received, so that it doesn't pollute the tests.
+        await().atMost(5, SECONDS)
+                .untilAsserted(() -> assertThat(getCountOfRequests(), greaterThan(0)));
     }
 
     @Override
-    public void afterEach(ExtensionContext context) throws Exception {
+    public void beforeEach(ExtensionContext context) throws Exception {
         clearRequests();
     }
 
@@ -61,10 +70,9 @@ public class SnsTopicExtension extends HttpStubExtension
     }
 
     private void subscribeToTopic(String topicArn) {
-        snsClient.subscribe(
-                topicArn,
-                "http",
-                format("http://subscriber.internal:{0,number,#}/subscriber", getHttpPort()));
+        String url = format("http://subscriber.internal:{0,number,#}/subscriber", getHttpPort());
+
+        snsClient.subscribe(topicArn, "http", url);
     }
 
     private void initSubscriber() {

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/SnsTopicExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/SnsTopicExtension.java
@@ -3,10 +3,11 @@ package uk.gov.di.authentication.sharedtest.extensions;
 import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.sns.AmazonSNS;
 import com.amazonaws.services.sns.AmazonSNSClientBuilder;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import uk.gov.di.authentication.sharedtest.httpstub.HttpStubExtension;
+
+import java.util.Random;
 
 import static java.text.MessageFormat.format;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -14,8 +15,7 @@ import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 
-public class SnsTopicExtension extends HttpStubExtension
-        implements BeforeAllCallback, BeforeEachCallback {
+public class SnsTopicExtension extends HttpStubExtension implements BeforeEachCallback {
 
     protected static final String REGION = System.getenv().getOrDefault("AWS_REGION", "eu-west-2");
     protected static final String LOCALSTACK_ENDPOINT =
@@ -38,25 +38,23 @@ public class SnsTopicExtension extends HttpStubExtension
     }
 
     @Override
-    public void beforeAll(ExtensionContext context) {
+    @java.lang.SuppressWarnings("java:S2245")
+    public void beforeEach(ExtensionContext context) throws Exception {
         startStub();
         var topicName =
                 format(
-                        "{0}-{1}",
+                        "{0}-{1}-{2}",
                         context.getTestClass().map(Class::getSimpleName).orElse("unknown"),
-                        topicNameSuffix);
+                        topicNameSuffix,
+                        Integer.toString(new Random().nextInt(99999)));
 
         topicArn = createTopic(topicName);
         initSubscriber();
         subscribeToTopic(topicArn);
 
         // Wait for topic subscription message to be received, so that it doesn't pollute the tests.
-        await().atMost(5, SECONDS)
+        await().atMost(1, SECONDS)
                 .untilAsserted(() -> assertThat(getCountOfRequests(), greaterThan(0)));
-    }
-
-    @Override
-    public void beforeEach(ExtensionContext context) throws Exception {
         clearRequests();
     }
 

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/SnsTopicExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/SnsTopicExtension.java
@@ -3,12 +3,19 @@ package uk.gov.di.authentication.sharedtest.extensions;
 import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.sns.AmazonSNS;
 import com.amazonaws.services.sns.AmazonSNSClientBuilder;
+import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import uk.gov.di.authentication.sharedtest.httpstub.HttpStubExtension;
 
 import static java.text.MessageFormat.format;
 
-public class SnsTopicExtension extends BaseAwsResourceExtension implements BeforeAllCallback {
+public class SnsTopicExtension extends HttpStubExtension
+        implements BeforeAllCallback, AfterEachCallback {
+
+    protected static final String REGION = System.getenv().getOrDefault("AWS_REGION", "eu-west-2");
+    protected static final String LOCALSTACK_ENDPOINT =
+            System.getenv().getOrDefault("LOCALSTACK_ENDPOINT", "http://localhost:45678");
 
     private final String topicNameSuffix;
     private final AmazonSNS snsClient;
@@ -16,6 +23,7 @@ public class SnsTopicExtension extends BaseAwsResourceExtension implements Befor
     private String topicArn;
 
     public SnsTopicExtension(String topicNameSuffix) {
+        super();
         this.topicNameSuffix = topicNameSuffix;
         this.snsClient =
                 AmazonSNSClientBuilder.standard()
@@ -34,6 +42,13 @@ public class SnsTopicExtension extends BaseAwsResourceExtension implements Befor
                         topicNameSuffix);
 
         topicArn = createTopic(topicName);
+        subscribeToTopic(topicArn);
+        initSubscriber();
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) throws Exception {
+        clearRequests();
     }
 
     public String getTopicArn() {
@@ -43,5 +58,16 @@ public class SnsTopicExtension extends BaseAwsResourceExtension implements Befor
     private String createTopic(String topicName) {
         var result = snsClient.createTopic(topicName);
         return result.getTopicArn();
+    }
+
+    private void subscribeToTopic(String topicArn) {
+        snsClient.subscribe(
+                topicArn,
+                "http",
+                format("http://subscriber.internal:{0,number,#}/subscriber", getHttpPort()));
+    }
+
+    private void initSubscriber() {
+        register("/subscriber", 200);
     }
 }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuditAssertionsHelper.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuditAssertionsHelper.java
@@ -15,6 +15,17 @@ import static uk.gov.di.authentication.sharedtest.matchers.AuditEventMatcher.has
 public class AuditAssertionsHelper {
 
     private static final int SNS_TIMEOUT = 1;
+    public static final int SNS_TIMEOUT_MILLIS = SNS_TIMEOUT * 1000;
+
+    public static void assertNoAuditEventsReceived(AuditSnsTopicExtension auditTopic) {
+        try {
+            Thread.sleep(SNS_TIMEOUT_MILLIS);
+        } catch (InterruptedException ex) {
+            throw new RuntimeException(ex);
+        }
+
+        assertThat(auditTopic.getCountOfRequests(), equalTo(0));
+    }
 
     public static void assertEventTypesReceived(
             AuditSnsTopicExtension auditTopic, Collection<AuditableEvent> eventTypes) {
@@ -39,6 +50,7 @@ public class AuditAssertionsHelper {
                                                         auditTopic.getAuditEvents(),
                                                         hasItem(hasEventType(eventType)))));
 
+        // Check that no more events came through while we were looking for the ones we expected.
         assertThat(auditTopic.getCountOfRequests(), equalTo(eventTypes.size()));
     }
 }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuditAssertionsHelper.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuditAssertionsHelper.java
@@ -1,0 +1,44 @@
+package uk.gov.di.authentication.sharedtest.helper;
+
+import uk.gov.di.authentication.shared.domain.AuditableEvent;
+import uk.gov.di.authentication.sharedtest.extensions.AuditSnsTopicExtension;
+
+import java.util.Collection;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static uk.gov.di.authentication.sharedtest.matchers.AuditEventMatcher.hasEventType;
+
+public class AuditAssertionsHelper {
+
+    private static final int SNS_TIMEOUT = 1;
+
+    public static void assertEventTypesReceived(
+            AuditSnsTopicExtension auditTopic, Collection<AuditableEvent> eventTypes) {
+        if (eventTypes.isEmpty()) {
+            throw new RuntimeException(
+                    "Do not call assertEventTypesReceived() with an empty collection of event types; it won't wait to see if anything unexpected was received.  Instead, call Thread.sleep and then check the count of requests.");
+        }
+
+        await().atMost(SNS_TIMEOUT, SECONDS)
+                .untilAsserted(
+                        () ->
+                                assertThat(
+                                        auditTopic.getCountOfRequests(),
+                                        equalTo(eventTypes.size())));
+
+        eventTypes.forEach(
+                eventType ->
+                        await().atMost(SNS_TIMEOUT, SECONDS)
+                                .untilAsserted(
+                                        () ->
+                                                assertThat(
+                                                        auditTopic.getAuditEvents(),
+                                                        hasItem(hasEventType(eventType)))));
+
+        assertThat(auditTopic.getCountOfRequests(), equalTo(eventTypes.size()));
+    }
+}

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/httpstub/HttpStub.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/httpstub/HttpStub.java
@@ -126,6 +126,10 @@ class HttpStub {
 
     public void reset() {
         registeredResponses.clear();
+        clearRequests();
+    }
+
+    public void clearRequests() {
         recordedRequests.clear();
     }
 
@@ -148,6 +152,10 @@ class HttpStub {
 
     public int getCountOfRequests() {
         return recordedRequests.size();
+    }
+
+    public List<RecordedRequest> getRecordedRequests() {
+        return recordedRequests;
     }
 
     public static <T> T unchecked(Callable<T> callable) {

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/httpstub/HttpStubExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/httpstub/HttpStubExtension.java
@@ -61,6 +61,10 @@ public class HttpStubExtension implements AfterAllCallback {
         return httpStub.getHttpsPort();
     }
 
+    protected void startStub() {
+        httpStub.start();
+    }
+
     public void reset() {
         httpStub.reset();
     }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/httpstub/HttpStubExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/httpstub/HttpStubExtension.java
@@ -1,10 +1,14 @@
 package uk.gov.di.authentication.sharedtest.httpstub;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import jakarta.ws.rs.core.UriBuilder;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 
 import java.net.URI;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class HttpStubExtension implements AfterAllCallback {
 
@@ -61,6 +65,10 @@ public class HttpStubExtension implements AfterAllCallback {
         httpStub.reset();
     }
 
+    public void clearRequests() {
+        httpStub.clearRequests();
+    }
+
     public void register(String path, int responseStatus) {
         httpStub.register(path, responseStatus, null, "");
     }
@@ -83,6 +91,24 @@ public class HttpStubExtension implements AfterAllCallback {
 
     public URI uri(String path) {
         return baseUri().path(path).build();
+    }
+
+    public List<RecordedRequest> getRecordedRequests() {
+        return httpStub.getRecordedRequests();
+    }
+
+    public <T> List<T> getRecordedRequests(Class<T> clazz) {
+        return httpStub.getRecordedRequests().stream()
+                .map(RecordedRequest::getEntity)
+                .map(
+                        e -> {
+                            try {
+                                return ObjectMapperFactory.getInstance().readValue(e, clazz);
+                            } catch (JsonProcessingException ex) {
+                                throw new RuntimeException(ex);
+                            }
+                        })
+                .collect(Collectors.toList());
     }
 
     private UriBuilder baseUri() {

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/matchers/AuditEventMatcher.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/matchers/AuditEventMatcher.java
@@ -3,6 +3,7 @@ package uk.gov.di.authentication.sharedtest.matchers;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 import uk.gov.di.audit.AuditPayload;
+import uk.gov.di.authentication.shared.domain.AuditableEvent;
 
 import java.util.function.Function;
 
@@ -19,10 +20,9 @@ public class AuditEventMatcher<T> extends TypeSafeDiagnosingMatcher<AuditPayload
         this.expected = expected;
     }
 
-    public static <T extends Enum<T>> AuditEventMatcher<T> hasEventType(
-            Class<T> clazz, T eventType) {
-        Function<AuditPayload.AuditEvent, T> extractEventType =
-                auditEvent -> T.valueOf(clazz, auditEvent.getEventName());
+    public static AuditEventMatcher<AuditableEvent> hasEventType(AuditableEvent eventType) {
+        Function<AuditPayload.AuditEvent, AuditableEvent> extractEventType =
+                auditEvent -> eventType.parseFromName(auditEvent.getEventName());
 
         return new AuditEventMatcher<>("event name", extractEventType, eventType);
     }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/matchers/AuditEventMatcher.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/matchers/AuditEventMatcher.java
@@ -1,0 +1,52 @@
+package uk.gov.di.authentication.sharedtest.matchers;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+import uk.gov.di.audit.AuditPayload;
+
+import java.util.function.Function;
+
+public class AuditEventMatcher<T> extends TypeSafeDiagnosingMatcher<AuditPayload.AuditEvent> {
+
+    private final String name;
+    private final Function<AuditPayload.AuditEvent, T> mapper;
+    private final T expected;
+
+    private AuditEventMatcher(
+            String name, Function<AuditPayload.AuditEvent, T> mapper, T expected) {
+        this.name = name;
+        this.mapper = mapper;
+        this.expected = expected;
+    }
+
+    public static <T extends Enum<T>> AuditEventMatcher<T> hasEventType(
+            Class<T> clazz, T eventType) {
+        Function<AuditPayload.AuditEvent, T> extractEventType =
+                auditEvent -> T.valueOf(clazz, auditEvent.getEventName());
+
+        return new AuditEventMatcher<>("event name", extractEventType, eventType);
+    }
+
+    @Override
+    protected boolean matchesSafely(
+            AuditPayload.AuditEvent auditEvent, Description mismatchDescription) {
+        var actual = mapper.apply(auditEvent);
+
+        boolean matched = actual.equals(expected);
+
+        if (!matched) {
+            mismatchDescription.appendText(description(actual));
+        }
+
+        return matched;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText(description(expected));
+    }
+
+    private String description(T value) {
+        return "an audit event with " + name + ": " + value;
+    }
+}

--- a/shared/src/main/java/uk/gov/di/audit/helper/AuditEventHelper.java
+++ b/shared/src/main/java/uk/gov/di/audit/helper/AuditEventHelper.java
@@ -1,4 +1,4 @@
-package uk.gov.di.authentication.audit.helper;
+package uk.gov.di.audit.helper;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import org.apache.logging.log4j.LogManager;

--- a/shared/src/main/java/uk/gov/di/authentication/shared/domain/AuditableEvent.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/domain/AuditableEvent.java
@@ -1,3 +1,6 @@
 package uk.gov.di.authentication.shared.domain;
 
-public interface AuditableEvent {}
+public interface AuditableEvent {
+
+    AuditableEvent parseFromName(String name);
+}

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
@@ -51,7 +51,11 @@ class AuditServiceTest {
     @Captor private ArgumentCaptor<String> messageCaptor;
 
     enum TestEvents implements AuditableEvent {
-        TEST_EVENT_ONE
+        TEST_EVENT_ONE;
+
+        public AuditableEvent parseFromName(String name) {
+            return valueOf(name);
+        }
     }
 
     @BeforeEach


### PR DESCRIPTION
## What?

Verify that the expected audit events (and no unexpected ones) are received by the SNS topic in all existing integration tests.

## Why?

Gives us coverage of audit logging, and adds clarity around what gets logged in each flow.

## Notes

We had a lot of false starts on this and as a result the commit history is a bit tangled.  Although there are a lot of files, it will probably be easier to review using the overall diff.

There are three bugs flagged by Sonar:

1) An unsafe Optional.get().  I think this is acceptable in context but I don't know how to suppress the warning.
2) Catching an InterruptedException and wrapping it in a RuntimeException.  I did this to make this test helper method less annoying to use.  I don't know whether or not Sonar is right about it being unsafe, in this context.
3) Constructing new instances of java.util.Random.  We could get round this by storing a single Random in a field, but I feel this would actually look more confusing, and I don't think there is any real danger of the way it is factored now leading to wrong behaviour.