### PR TITLE
AUTH-1292: Inject renamed common_state_bucket to Terraform

### DIFF
--- a/ci/tasks/deploy-acct-mgmt-api.yml
+++ b/ci/tasks/deploy-acct-mgmt-api.yml
@@ -41,7 +41,7 @@ run:
         -var 'logging_endpoint_arn=arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod' \
         -var 'lambda_zip_file=../../../../api-release/account-management-api.zip' \
         -var 'lambda_warmer_zip_file=../../../../lambda-warmer-release/lambda-warmer.zip' \
-        -var "shared_state_bucket=${STATE_BUCKET}" \
+        -var "common_state_bucket=${STATE_BUCKET}" \
         -var "dns_state_bucket=${DNS_STATE_BUCKET}" \
         -var "dns_state_key=${DNS_STATE_KEY}" \
         -var "dns_state_role=${DNS_DEPLOYER_ROLE_ARN}" \


### PR DESCRIPTION
## What?

- Rename the variable injected into the account management Terraform
deploy task from `shared_state_bucket` to `common_state_bucket`

## Why?

The variable was renamed in #1317 but name change wasn't reflected in deploy task.

## Related PRs

#1317 