### PR TITLE
AUTh-1315 - Create SPOTResponse lambda and new Dynamo table

### DIFF
--- a/ci/terraform/oidc/spot-response.tf
+++ b/ci/terraform/oidc/spot-response.tf
@@ -2,7 +2,7 @@ resource "aws_lambda_function" "spot_response_lambda" {
   count         = var.ipv_api_enabled ? 1 : 0
   filename      = var.ipv_api_lambda_zip_file
   function_name = "${var.environment}-spot-response-lambda"
-  role          = module.oidc_default_role.arn
+  role          = module.spot_response_role.arn
   handler       = "uk.gov.di.authentication.ipv-api.lambda.SPOTResponseHandler::handleRequest"
   timeout       = 30
   memory_size   = 512
@@ -16,7 +16,10 @@ resource "aws_lambda_function" "spot_response_lambda" {
   }
   environment {
     variables = merge({
+      ENVIRONMENT       = var.environment
       FRONTEND_BASE_URL = module.dns.frontend_url
+      DYNAMO_ENDPOINT   = var.use_localstack ? var.lambda_dynamo_endpoint : null
+
     })
   }
   kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn

--- a/ci/terraform/oidc/spot-response.tf
+++ b/ci/terraform/oidc/spot-response.tf
@@ -1,0 +1,55 @@
+resource "aws_lambda_function" "spot_response_lambda" {
+  count         = var.ipv_api_enabled ? 1 : 0
+  filename      = var.ipv_api_lambda_zip_file
+  function_name = "${var.environment}-spot-response-lambda"
+  role          = module.oidc_default_role.arn
+  handler       = "uk.gov.di.authentication.ipv-api.lambda.SPOTResponseHandler::handleRequest"
+  timeout       = 30
+  memory_size   = 512
+  runtime       = "java11"
+  publish       = true
+
+  source_code_hash = filebase64sha256(var.ipv_api_lambda_zip_file)
+  vpc_config {
+    security_group_ids = [local.authentication_egress_security_group_id]
+    subnet_ids         = local.authentication_subnet_ids
+  }
+  environment {
+    variables = merge({
+      FRONTEND_BASE_URL = module.dns.frontend_url
+    })
+  }
+  kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn
+
+  tags = local.default_tags
+}
+
+resource "aws_cloudwatch_log_group" "spot_response_lambda_log_group" {
+  count = var.use_localstack || !var.ipv_api_enabled ? 0 : 1
+
+  name              = "/aws/lambda/${aws_lambda_function.spot_response_lambda[0].function_name}"
+  kms_key_id        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  retention_in_days = var.cloudwatch_log_retention
+
+  tags = local.default_tags
+
+  depends_on = [
+    aws_lambda_function.spot_response_lambda
+  ]
+}
+
+resource "aws_cloudwatch_log_subscription_filter" "spot_response_lambda_log_subscription" {
+  count           = var.logging_endpoint_enabled && var.ipv_api_enabled ? 1 : 0
+  name            = "${aws_lambda_function.spot_response_lambda[0].function_name}-log-subscription"
+  log_group_name  = aws_cloudwatch_log_group.spot_response_lambda_log_group[0].name
+  filter_pattern  = ""
+  destination_arn = var.logging_endpoint_arn
+}
+
+resource "aws_lambda_alias" "spot_response_lambda_active" {
+  count            = var.ipv_api_enabled ? 1 : 0
+  name             = "${aws_lambda_function.spot_response_lambda[0].function_name}-active"
+  description      = "Alias pointing at active version of Lambda"
+  function_name    = aws_lambda_function.spot_response_lambda[0].arn
+  function_version = aws_lambda_function.spot_response_lambda[0].version
+}

--- a/ci/terraform/shared/dynamodb.tf
+++ b/ci/terraform/shared/dynamodb.tf
@@ -134,6 +134,34 @@ resource "aws_dynamodb_table" "client_registry_table" {
   tags = local.default_tags
 }
 
+resource "aws_dynamodb_table" "spot_credential_table" {
+  name         = "${var.environment}-spot-credential"
+  billing_mode = var.provision_dynamo ? "PROVISIONED" : "PAY_PER_REQUEST"
+  hash_key     = "SubjectID"
+
+  read_capacity  = var.provision_dynamo ? var.dynamo_default_read_capacity : null
+  write_capacity = var.provision_dynamo ? var.dynamo_default_write_capacity : null
+
+  attribute {
+    name = "SubjectID"
+    type = "S"
+  }
+
+  point_in_time_recovery {
+    enabled = !var.use_localstack
+  }
+
+  server_side_encryption {
+    enabled = !var.use_localstack
+  }
+
+  lifecycle {
+    prevent_destroy = false
+  }
+
+  tags = local.default_tags
+}
+
 data "aws_iam_policy_document" "dynamo_policy_document" {
   count = var.use_localstack ? 0 : 1
   statement {

--- a/ci/terraform/shared/variables.tf
+++ b/ci/terraform/shared/variables.tf
@@ -105,6 +105,10 @@ variable "provision_dynamo" {
   default = false
 }
 
+variable "ipv_api_enabled" {
+  default = true
+}
+
 variable "dynamo_default_read_capacity" {
   type    = number
   default = 20

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/SPOTResponse.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/SPOTResponse.java
@@ -1,0 +1,27 @@
+package uk.gov.di.authentication.ipv.entity;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class SPOTResponse {
+
+    @JsonProperty private String serializedCredential;
+
+    @JsonProperty private String pairwiseIdentifier;
+
+    public SPOTResponse(
+            @JsonProperty(required = true, value = "serializedCredential")
+                    String serializedCredential,
+            @JsonProperty(required = true, value = "pairwiseIdentifier")
+                    String pairwiseIdentifier) {
+        this.serializedCredential = serializedCredential;
+        this.pairwiseIdentifier = pairwiseIdentifier;
+    }
+
+    public String getSerializedCredential() {
+        return serializedCredential;
+    }
+
+    public String getPairwiseIdentifier() {
+        return pairwiseIdentifier;
+    }
+}

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -7,7 +7,6 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
-import org.apache.http.client.utils.URIBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.ipv.entity.SPOTRequest;
@@ -16,6 +15,7 @@ import uk.gov.di.authentication.ipv.services.IPVTokenService;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ResponseHeaders;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
+import uk.gov.di.authentication.shared.helpers.ConstructUriHelper;
 import uk.gov.di.authentication.shared.helpers.CookieHelper;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -24,7 +24,6 @@ import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
 import uk.gov.di.authentication.shared.services.SessionService;
 
-import java.net.URISyntaxException;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
@@ -164,21 +163,16 @@ public class IPVCallbackHandler
                                         "Cannot retrieve auth request params from client session id");
                                 throw new RuntimeException();
                             }
-
+                            var redirectURI =
+                                    ConstructUriHelper.buildURI(
+                                            configurationService.getLoginURI().toString(),
+                                            REDIRECT_PATH);
                             return new APIGatewayProxyResponseEvent()
                                     .withStatusCode(302)
                                     .withHeaders(
-                                            Map.of(ResponseHeaders.LOCATION, buildRedirectUri()));
+                                            Map.of(
+                                                    ResponseHeaders.LOCATION,
+                                                    redirectURI.toString()));
                         });
-    }
-
-    private String buildRedirectUri() {
-        URIBuilder redirectUriBuilder =
-                new URIBuilder(configurationService.getLoginURI()).setPath(REDIRECT_PATH);
-        try {
-            return redirectUriBuilder.build().toString();
-        } catch (URISyntaxException e) {
-            throw new RuntimeException();
-        }
     }
 }

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandler.java
@@ -9,12 +9,14 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.ipv.entity.SPOTResponse;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.DynamoSpotService;
 
 import java.util.Optional;
 
 public class SPOTResponseHandler implements RequestHandler<SNSEvent, Object> {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
+    private final DynamoSpotService dynamoSpotService;
 
     private static final Logger LOG = LogManager.getLogger(SPOTResponseHandler.class);
 
@@ -22,7 +24,13 @@ public class SPOTResponseHandler implements RequestHandler<SNSEvent, Object> {
         this(ConfigurationService.getInstance());
     }
 
-    public SPOTResponseHandler(ConfigurationService configurationService) {}
+    public SPOTResponseHandler(ConfigurationService configurationService) {
+        this.dynamoSpotService = new DynamoSpotService(configurationService);
+    }
+
+    public SPOTResponseHandler(DynamoSpotService dynamoSpotService) {
+        this.dynamoSpotService = dynamoSpotService;
+    }
 
     @Override
     public Object handleRequest(SNSEvent input, Context context) {
@@ -46,5 +54,8 @@ public class SPOTResponseHandler implements RequestHandler<SNSEvent, Object> {
         }
     }
 
-    private void writeToDynamo(SPOTResponse spotResponse) {}
+    private void writeToDynamo(SPOTResponse spotResponse) {
+        dynamoSpotService.addSpotResponse(
+                spotResponse.getPairwiseIdentifier(), spotResponse.getSerializedCredential());
+    }
 }

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandler.java
@@ -3,9 +3,20 @@ package uk.gov.di.authentication.ipv.lambda;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.SNSEvent;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.ipv.entity.SPOTResponse;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
-public class SPOTResponseHandler implements RequestHandler<SNSEvent, Void> {
+import java.util.Optional;
+
+public class SPOTResponseHandler implements RequestHandler<SNSEvent, Object> {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private static final Logger LOG = LogManager.getLogger(SPOTResponseHandler.class);
 
     public SPOTResponseHandler() {
         this(ConfigurationService.getInstance());
@@ -14,7 +25,26 @@ public class SPOTResponseHandler implements RequestHandler<SNSEvent, Void> {
     public SPOTResponseHandler(ConfigurationService configurationService) {}
 
     @Override
-    public Void handleRequest(SNSEvent event, Context context) {
+    public Object handleRequest(SNSEvent input, Context context) {
+        input.getRecords().stream()
+                .map(SNSEvent.SNSRecord::getSNS)
+                .map(SNSEvent.SNS::getMessage)
+                .map(this::processSPOTResponse)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .forEach(this::writeToDynamo);
+
         return null;
     }
+
+    private Optional<SPOTResponse> processSPOTResponse(String message) {
+        try {
+            return Optional.of(objectMapper.readValue(message, SPOTResponse.class));
+        } catch (JsonProcessingException e) {
+            LOG.error("Unable to deserialize SPOT response");
+            return Optional.empty();
+        }
+    }
+
+    private void writeToDynamo(SPOTResponse spotResponse) {}
 }

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandler.java
@@ -1,0 +1,20 @@
+package uk.gov.di.authentication.ipv.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.SNSEvent;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+public class SPOTResponseHandler implements RequestHandler<SNSEvent, Void> {
+
+    public SPOTResponseHandler() {
+        this(ConfigurationService.getInstance());
+    }
+
+    public SPOTResponseHandler(ConfigurationService configurationService) {}
+
+    @Override
+    public Void handleRequest(SNSEvent event, Context context) {
+        return null;
+    }
+}

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandlerTest.java
@@ -1,0 +1,51 @@
+package uk.gov.di.authentication.ipv.lambda;
+
+import com.amazonaws.services.lambda.runtime.events.SNSEvent;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.di.authentication.ipv.entity.SPOTResponse;
+import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+class SPOTResponseHandlerTest {
+
+    @RegisterExtension
+    public final CaptureLoggingExtension logging =
+            new CaptureLoggingExtension(SPOTResponseHandlerTest.class);
+
+    private final SPOTResponseHandler handler = new SPOTResponseHandler();
+
+    @BeforeEach
+    void setup() {
+
+    }
+
+
+    @Test
+    void shouldWriteToDynamoForSuccesssfulSPOTResponse() throws JsonProcessingException {
+        var spotResponse =
+                new SPOTResponse("this-is-a-searalized-credential", "some-pairwise-identifier");
+        var searlizedSpotResponse = new ObjectMapper().writeValueAsString(spotResponse);
+
+        handler.handleRequest(inputEvent(searlizedSpotResponse), null);
+    }
+
+    @Test
+    void shouldNotWriteToDynamoWhenLambdaReceivedInvalidSPOTResponse() {
+
+    }
+
+    private SNSEvent inputEvent(String payload) {
+        return Optional.of(payload)
+                .map(new SNSEvent.SNS()::withMessage)
+                .map(new SNSEvent.SNSRecord()::withSns)
+                .map(List::of)
+                .map(new SNSEvent()::withRecords)
+                .get();
+    }
+}

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandlerTest.java
@@ -5,26 +5,25 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.authentication.ipv.entity.SPOTResponse;
-import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
+import uk.gov.di.authentication.shared.services.DynamoSpotService;
 
 import java.util.List;
 import java.util.Optional;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
 class SPOTResponseHandlerTest {
 
-    @RegisterExtension
-    public final CaptureLoggingExtension logging =
-            new CaptureLoggingExtension(SPOTResponseHandlerTest.class);
-
-    private final SPOTResponseHandler handler = new SPOTResponseHandler();
+    private SPOTResponseHandler handler;
+    private final DynamoSpotService dynamoSpotService = mock(DynamoSpotService.class);
 
     @BeforeEach
     void setup() {
-
+        handler = new SPOTResponseHandler(dynamoSpotService);
     }
-
 
     @Test
     void shouldWriteToDynamoForSuccesssfulSPOTResponse() throws JsonProcessingException {
@@ -33,11 +32,16 @@ class SPOTResponseHandlerTest {
         var searlizedSpotResponse = new ObjectMapper().writeValueAsString(spotResponse);
 
         handler.handleRequest(inputEvent(searlizedSpotResponse), null);
+
+        verify(dynamoSpotService)
+                .addSpotResponse("some-pairwise-identifier", "this-is-a-searalized-credential");
     }
 
     @Test
     void shouldNotWriteToDynamoWhenLambdaReceivedInvalidSPOTResponse() {
+        handler.handleRequest(inputEvent("invalid-payload"), null);
 
+        verifyNoInteractions(dynamoSpotService);
     }
 
     private SNSEvent inputEvent(String payload) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/SPOTCredential.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/SPOTCredential.java
@@ -1,0 +1,32 @@
+package uk.gov.di.authentication.shared.entity;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBAttribute;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
+
+public class SPOTCredential {
+
+    private String subjectID;
+    private String serializedCredential;
+
+    public SPOTCredential() {}
+
+    @DynamoDBHashKey(attributeName = "SubjectID")
+    public String getSubjectID() {
+        return subjectID;
+    }
+
+    public SPOTCredential setSubjectID(String subjectID) {
+        this.subjectID = subjectID;
+        return this;
+    }
+
+    @DynamoDBAttribute(attributeName = "SerializedCredential")
+    public String getSerializedCredential() {
+        return serializedCredential;
+    }
+
+    public SPOTCredential setSerializedCredential(String serializedCredential) {
+        this.serializedCredential = serializedCredential;
+        return this;
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoSpotService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoSpotService.java
@@ -1,0 +1,58 @@
+package uk.gov.di.authentication.shared.services;
+
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperConfig;
+import uk.gov.di.authentication.shared.entity.SPOTCredential;
+
+import java.util.Optional;
+
+public class DynamoSpotService {
+
+    private static final String SPOT_CREDENTIAL_TABLE = "spot-credential";
+    private final DynamoDBMapper spotCredentialMapper;
+    private final AmazonDynamoDB dynamoDB;
+
+    public DynamoSpotService(ConfigurationService configurationService) {
+        this(
+                configurationService.getAwsRegion(),
+                configurationService.getEnvironment(),
+                configurationService.getDynamoEndpointUri());
+    }
+
+    public DynamoSpotService(String region, String environment, Optional<String> dynamoEndpoint) {
+        dynamoDB =
+                dynamoEndpoint
+                        .map(
+                                t ->
+                                        AmazonDynamoDBClientBuilder.standard()
+                                                .withEndpointConfiguration(
+                                                        new AwsClientBuilder.EndpointConfiguration(
+                                                                t, region)))
+                        .orElse(AmazonDynamoDBClientBuilder.standard().withRegion(region))
+                        .build();
+        DynamoDBMapperConfig spotResponseConfig =
+                new DynamoDBMapperConfig.Builder()
+                        .withTableNameOverride(
+                                DynamoDBMapperConfig.TableNameOverride.withTableNameReplacement(
+                                        environment + "-" + SPOT_CREDENTIAL_TABLE))
+                        .build();
+        this.spotCredentialMapper = new DynamoDBMapper(dynamoDB, spotResponseConfig);
+        warmUp(environment + "-" + SPOT_CREDENTIAL_TABLE);
+    }
+
+    public void addSpotResponse(String subjectID, String serializedCredential) {
+        SPOTCredential spotCredential =
+                new SPOTCredential()
+                        .setSubjectID(subjectID)
+                        .setSerializedCredential(serializedCredential);
+
+        spotCredentialMapper.save(spotCredential);
+    }
+
+    private void warmUp(String tableName) {
+        dynamoDB.describeTable(tableName);
+    }
+}


### PR DESCRIPTION
## What?

- Create a SPOTResponse lambda which will read from an SNS topic, deserialize the message into the SPOTResponse object and write it to a Dynamo table. 
- Create a new Dynamo table named `spot-credential` which will hold the credential returned from SPOT. It will be stored against the Subject identifier, which we can extract from the access token (in a separate Lambda) to retrieve the credential. 
- Create a new Lambda role specific to the SPOTResponse lambda, so that Dynamo write permissions are limited to this lambda. We will set up a new role for the lambda required to read from this table. 
- The Dynamo table will be created in all environments but the lambda will only be created in environments where `ipv_api_enabled` is set to true. 

## Why?

- So we can retrieve information from SPOT, process it and write it to Dynamo. This data in Dynamo will then be read by a new Lambda (not yet created) which will access it using the subject identifier in the given access token.


## Other comments

- I have set the `prevent_destroy` on the new dynamo table for false for now in case changes are required. 
- I will need to set an expiration on the data in the SPOT table. 
- The SNS topic does not yet exist which is why no further permissions have been configured with this lambda.