### PR TITLE
AUTH-1315 - Set TTL on Dynamo table

### DIFF
--- a/ci/terraform/shared/dynamodb.tf
+++ b/ci/terraform/shared/dynamodb.tf
@@ -159,6 +159,11 @@ resource "aws_dynamodb_table" "spot_credential_table" {
     prevent_destroy = false
   }
 
+  ttl {
+    attribute_name = "TimeToExist"
+    enabled        = true
+  }
+
   tags = local.default_tags
 }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/SPOTCredential.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/SPOTCredential.java
@@ -7,6 +7,7 @@ public class SPOTCredential {
 
     private String subjectID;
     private String serializedCredential;
+    private long timeToExist;
 
     public SPOTCredential() {}
 
@@ -27,6 +28,16 @@ public class SPOTCredential {
 
     public SPOTCredential setSerializedCredential(String serializedCredential) {
         this.serializedCredential = serializedCredential;
+        return this;
+    }
+
+    @DynamoDBAttribute(attributeName = "TimeToExist")
+    public long getTimeToExist() {
+        return timeToExist;
+    }
+
+    public SPOTCredential setTimeToExist(long timeToExist) {
+        this.timeToExist = timeToExist;
         return this;
     }
 }


### PR DESCRIPTION
## What?

- Use the dynamo TTL (time to live) to set when an item in the table is no longer needed. We will create a new attribute called TimeToExist and set that as the ttl. We will then set this in the DynamoSpotService to the same value as the access token expiry.
- Configure the DynamoDBMapperConfig with CONSISTENT reads. By default it is set to EVENTUAL. By setting this value DynamoDB should return a response with the most up-to-date data, reflecting the ttl attribute which we have set.

## Why?

- Because the data in the SPOT table should only be accessible for the time the access token is valid for. 