### PR TITLE
AUTH-1314 - Create bones of identity lambda and refactor UserInfo service

### DIFF
--- a/ci/terraform/oidc/identity.tf
+++ b/ci/terraform/oidc/identity.tf
@@ -1,0 +1,52 @@
+module "identity" {
+  count  = var.ipv_api_enabled ? 1 : 0
+  source = "../modules/endpoint-module"
+
+  endpoint_name   = "identity"
+  path_part       = "identity"
+  endpoint_method = "GET"
+  environment     = var.environment
+
+  handler_environment_variables = {
+    ENVIRONMENT             = var.environment
+    EVENTS_SNS_TOPIC_ARN    = aws_sns_topic.events.arn
+    AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name
+    LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
+    DYNAMO_ENDPOINT         = var.use_localstack ? var.lambda_dynamo_endpoint : null
+  }
+  handler_function_name = "uk.gov.di.authentication.oidc.lambda.IdentityHandler::handleRequest"
+
+  rest_api_id            = aws_api_gateway_rest_api.di_authentication_api.id
+  root_resource_id       = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
+  execution_arn          = aws_api_gateway_rest_api.di_authentication_api.execution_arn
+  lambda_zip_file        = var.oidc_api_lambda_zip_file
+  authentication_vpc_arn = local.authentication_vpc_arn
+  security_group_ids = [
+    local.authentication_security_group_id,
+    local.authentication_oidc_redis_security_group_id,
+  ]
+  subnet_id                              = local.authentication_subnet_ids
+  lambda_role_arn                        = module.oidc_default_role.arn
+  logging_endpoint_enabled               = var.logging_endpoint_enabled
+  logging_endpoint_arn                   = var.logging_endpoint_arn
+  cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  cloudwatch_log_retention               = var.cloudwatch_log_retention
+  lambda_env_vars_encryption_kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn
+  default_tags                           = local.default_tags
+
+  keep_lambda_warm             = var.keep_lambdas_warm
+  warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
+  warmer_lambda_zip_file       = var.lambda_warmer_zip_file
+  warmer_security_group_ids    = [local.authentication_security_group_id]
+  warmer_handler_environment_variables = {
+    LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
+  }
+
+  use_localstack = var.use_localstack
+
+  depends_on = [
+    aws_api_gateway_rest_api.di_authentication_api,
+    aws_api_gateway_resource.connect_resource,
+    aws_api_gateway_resource.wellknown_resource,
+  ]
+}

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IdentityIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IdentityIntegrationTest.java
@@ -1,0 +1,28 @@
+package uk.gov.di.authentication.api;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.oidc.lambda.IdentityHandler;
+import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
+
+public class IdentityIntegrationTest extends ApiGatewayHandlerIntegrationTest {
+
+    @BeforeEach
+    void setup() {
+        handler = new IdentityHandler(TEST_CONFIGURATION_SERVICE);
+    }
+
+    @Test
+    void shouldReturn204WhenCallingIdentityLambda() {
+
+        var response = makeRequest(Optional.empty(), Map.of(), Map.of());
+
+        assertThat(response, hasStatus(204));
+    }
+}

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IdentityIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IdentityIntegrationTest.java
@@ -1,5 +1,6 @@
 package uk.gov.di.authentication.api;
 
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.oidc.lambda.IdentityHandler;
@@ -21,7 +22,11 @@ public class IdentityIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     @Test
     void shouldReturn204WhenCallingIdentityLambda() {
 
-        var response = makeRequest(Optional.empty(), Map.of(), Map.of());
+        var response =
+                makeRequest(
+                        Optional.empty(),
+                        Map.of("Authorization", new BearerAccessToken().toAuthorizationHeader()),
+                        Map.of());
 
         assertThat(response, hasStatus(204));
     }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
@@ -36,7 +36,6 @@ import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyRespon
 
 public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
-    private static final String USERINFO_ENDPOINT = "/userinfo";
     private static final String TEST_EMAIL_ADDRESS = "joe.bloggs@digital.cabinet-office.gov.uk";
     private static final String TEST_PHONE_NUMBER = "01234567890";
     private static final String FORMATTED_PHONE_NUMBER = "+441234567890";

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/AccessTokenInfo.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/AccessTokenInfo.java
@@ -1,0 +1,31 @@
+package uk.gov.di.authentication.oidc.entity;
+
+import uk.gov.di.authentication.shared.entity.AccessTokenStore;
+
+import java.util.List;
+
+public class AccessTokenInfo {
+
+    private AccessTokenStore accessTokenStore;
+    private String publicSubject;
+    private List<String> scopes;
+
+    public AccessTokenInfo(
+            AccessTokenStore accessTokenStore, String publicSubject, List<String> scopes) {
+        this.accessTokenStore = accessTokenStore;
+        this.publicSubject = publicSubject;
+        this.scopes = scopes;
+    }
+
+    public AccessTokenStore getAccessTokenStore() {
+        return accessTokenStore;
+    }
+
+    public String getPublicSubject() {
+        return publicSubject;
+    }
+
+    public List<String> getScopes() {
+        return scopes;
+    }
+}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/IdentityHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/IdentityHandler.java
@@ -1,0 +1,39 @@
+package uk.gov.di.authentication.oidc.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateEmptySuccessApiGatewayResponse;
+import static uk.gov.di.authentication.shared.helpers.WarmerHelper.isWarming;
+
+public class IdentityHandler
+        implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+
+    private static final Logger LOG = LogManager.getLogger(IdentityHandler.class);
+    private final ConfigurationService configurationService;
+
+    public IdentityHandler() {
+        this(ConfigurationService.getInstance());
+    }
+
+    public IdentityHandler(ConfigurationService configurationService) {
+        this.configurationService = configurationService;
+    }
+
+    @Override
+    public APIGatewayProxyResponseEvent handleRequest(
+            APIGatewayProxyRequestEvent input, Context context) {
+        return isWarming(input)
+                .orElseGet(
+                        () -> {
+                            LOG.info("Request received to the IdentityHandler");
+
+                            return generateEmptySuccessApiGatewayResponse();
+                        });
+    }
+}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/IdentityHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/IdentityHandler.java
@@ -4,11 +4,16 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.nimbusds.openid.connect.sdk.UserInfoErrorResponse;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
+import static com.nimbusds.oauth2.sdk.token.BearerTokenError.MISSING_TOKEN;
+import static uk.gov.di.authentication.shared.domain.RequestHeaders.AUTHORIZATION_HEADER;
+import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateEmptySuccessApiGatewayResponse;
+import static uk.gov.di.authentication.shared.helpers.RequestHeaderHelper.headersContainValidHeader;
 import static uk.gov.di.authentication.shared.helpers.WarmerHelper.isWarming;
 
 public class IdentityHandler
@@ -32,6 +37,18 @@ public class IdentityHandler
                 .orElseGet(
                         () -> {
                             LOG.info("Request received to the IdentityHandler");
+                            if (!headersContainValidHeader(
+                                    input.getHeaders(),
+                                    AUTHORIZATION_HEADER,
+                                    configurationService.getHeadersCaseInsensitive())) {
+                                LOG.error("AccessToken is missing from request");
+                                return generateApiGatewayProxyResponse(
+                                        401,
+                                        "",
+                                        new UserInfoErrorResponse(MISSING_TOKEN)
+                                                .toHTTPResponse()
+                                                .getHeaderMap());
+                            }
 
                             return generateEmptySuccessApiGatewayResponse();
                         });

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AccessTokenService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AccessTokenService.java
@@ -1,0 +1,137 @@
+package uk.gov.di.authentication.oidc.services;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.jwt.util.DateUtils;
+import com.nimbusds.oauth2.sdk.OAuth2Error;
+import com.nimbusds.oauth2.sdk.token.AccessToken;
+import com.nimbusds.oauth2.sdk.token.AccessTokenType;
+import com.nimbusds.oauth2.sdk.token.BearerTokenError;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.oidc.entity.AccessTokenInfo;
+import uk.gov.di.authentication.shared.entity.AccessTokenStore;
+import uk.gov.di.authentication.shared.entity.ClientRegistry;
+import uk.gov.di.authentication.shared.entity.ValidScopes;
+import uk.gov.di.authentication.shared.exceptions.AccessTokenException;
+import uk.gov.di.authentication.shared.services.DynamoClientService;
+import uk.gov.di.authentication.shared.services.RedisConnectionService;
+import uk.gov.di.authentication.shared.services.TokenValidationService;
+
+import java.text.ParseException;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.CLIENT_ID;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachLogFieldToLogs;
+
+public class AccessTokenService {
+
+    private static final Logger LOG = LogManager.getLogger(AccessTokenService.class);
+    private final RedisConnectionService redisConnectionService;
+    private final DynamoClientService clientService;
+    private final TokenValidationService tokenValidationService;
+    private static final String ACCESS_TOKEN_PREFIX = "ACCESS_TOKEN:";
+    private static final String INVALID_ACCESS_TOKEN = "Invalid Access Token";
+
+    public AccessTokenService(
+            RedisConnectionService redisConnectionService,
+            DynamoClientService clientService,
+            TokenValidationService tokenValidationService) {
+        this.redisConnectionService = redisConnectionService;
+        this.clientService = clientService;
+        this.tokenValidationService = tokenValidationService;
+    }
+
+    public AccessTokenInfo parse(String authorizationHeader) throws AccessTokenException {
+        AccessToken accessToken;
+        try {
+            accessToken = AccessToken.parse(authorizationHeader, AccessTokenType.BEARER);
+        } catch (com.nimbusds.oauth2.sdk.ParseException e) {
+            LOG.error("Unable to parse AccessToken");
+            throw new AccessTokenException(
+                    "Unable to parse AccessToken", BearerTokenError.INVALID_TOKEN);
+        }
+        SignedJWT signedJWT;
+        try {
+            signedJWT = SignedJWT.parse(accessToken.getValue());
+
+            LocalDateTime localDateTime = LocalDateTime.now();
+            Date currentDateTime = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
+            if (DateUtils.isBefore(
+                    signedJWT.getJWTClaimsSet().getExpirationTime(), currentDateTime, 0)) {
+                LOG.error(
+                        "Access Token has expired. Access Token expires at: {}. CurrentDateTime is: {}",
+                        signedJWT.getJWTClaimsSet().getExpirationTime(),
+                        currentDateTime);
+                throw new AccessTokenException(
+                        INVALID_ACCESS_TOKEN, BearerTokenError.INVALID_TOKEN);
+            }
+            if (!tokenValidationService.validateAccessTokenSignature(accessToken)) {
+                LOG.error("Unable to validate AccessToken signature");
+                throw new AccessTokenException(
+                        "Unable to validate AccessToken signature", BearerTokenError.INVALID_TOKEN);
+            }
+            String clientID = signedJWT.getJWTClaimsSet().getStringClaim("client_id");
+            Optional<ClientRegistry> client = clientService.getClient(clientID);
+
+            attachLogFieldToLogs(CLIENT_ID, clientID);
+
+            if (client.isEmpty()) {
+                LOG.error("Client not found");
+                throw new AccessTokenException("Client not found", BearerTokenError.INVALID_TOKEN);
+            }
+            List<String> scopes = (List<String>) signedJWT.getJWTClaimsSet().getClaim("scope");
+            if (!areScopesValid(scopes) || !client.get().getScopes().containsAll(scopes)) {
+                LOG.error("Invalid Scopes: {}", scopes);
+                throw new AccessTokenException("Invalid Scopes", OAuth2Error.INVALID_SCOPE);
+            }
+            String subject = signedJWT.getJWTClaimsSet().getSubject();
+            Optional<AccessTokenStore> accessTokenStore = getAccessTokenStore(clientID, subject);
+            if (accessTokenStore.isEmpty()) {
+                LOG.error(
+                        "Access Token Store is empty. Access Token expires at: {}. CurrentDateTime is: {}",
+                        signedJWT.getJWTClaimsSet().getExpirationTime(),
+                        currentDateTime);
+                throw new AccessTokenException(
+                        INVALID_ACCESS_TOKEN, BearerTokenError.INVALID_TOKEN);
+            }
+            if (!accessTokenStore.get().getToken().equals(accessToken.getValue())) {
+                LOG.error(
+                        "Access Token in Access Token Store is different to Access Token sent in request");
+                throw new AccessTokenException(
+                        INVALID_ACCESS_TOKEN, BearerTokenError.INVALID_TOKEN);
+            }
+            return new AccessTokenInfo(accessTokenStore.get(), subject, scopes);
+        } catch (ParseException e) {
+            LOG.error("Unable to parse AccessToken to SignedJWT");
+            throw new AccessTokenException(
+                    "Unable to parse AccessToken to SignedJWT", BearerTokenError.INVALID_TOKEN);
+        }
+    }
+
+    private Optional<AccessTokenStore> getAccessTokenStore(String clientId, String subjectId) {
+        String result =
+                redisConnectionService.getValue(ACCESS_TOKEN_PREFIX + clientId + "." + subjectId);
+        try {
+            return Optional.ofNullable(
+                    new ObjectMapper().readValue(result, AccessTokenStore.class));
+        } catch (JsonProcessingException | IllegalArgumentException e) {
+            LOG.error("Error getting AccessToken from Redis");
+            return Optional.empty();
+        }
+    }
+
+    private boolean areScopesValid(List<String> scopes) {
+        for (String scope : scopes) {
+            if (ValidScopes.getAllValidScopes().stream().noneMatch(t -> t.equals(scope))) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/UserInfoService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/UserInfoService.java
@@ -1,171 +1,40 @@
 package uk.gov.di.authentication.oidc.services;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.nimbusds.jwt.SignedJWT;
-import com.nimbusds.jwt.util.DateUtils;
-import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.id.Subject;
-import com.nimbusds.oauth2.sdk.token.AccessToken;
-import com.nimbusds.oauth2.sdk.token.AccessTokenType;
-import com.nimbusds.oauth2.sdk.token.BearerTokenError;
 import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import uk.gov.di.authentication.shared.entity.AccessTokenStore;
-import uk.gov.di.authentication.shared.entity.ClientRegistry;
+import uk.gov.di.authentication.oidc.entity.AccessTokenInfo;
 import uk.gov.di.authentication.shared.entity.UserProfile;
-import uk.gov.di.authentication.shared.entity.ValidScopes;
-import uk.gov.di.authentication.shared.exceptions.UserInfoValidationException;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
-import uk.gov.di.authentication.shared.services.DynamoClientService;
-import uk.gov.di.authentication.shared.services.RedisConnectionService;
-import uk.gov.di.authentication.shared.services.TokenValidationService;
-
-import java.text.ParseException;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.util.Date;
-import java.util.List;
-import java.util.Optional;
-
-import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.CLIENT_ID;
-import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachLogFieldToLogs;
 
 public class UserInfoService {
 
-    private final RedisConnectionService redisConnectionService;
     private final AuthenticationService authenticationService;
-    private final TokenValidationService tokenValidationService;
-    private final DynamoClientService clientService;
-    private static final String ACCESS_TOKEN_PREFIX = "ACCESS_TOKEN:";
 
     private static final Logger LOG = LogManager.getLogger(UserInfoService.class);
 
-    public UserInfoService(
-            RedisConnectionService redisConnectionService,
-            AuthenticationService authenticationService,
-            TokenValidationService tokenValidationService,
-            DynamoClientService clientService) {
-        this.redisConnectionService = redisConnectionService;
+    public UserInfoService(AuthenticationService authenticationService) {
         this.authenticationService = authenticationService;
-        this.tokenValidationService = tokenValidationService;
-        this.clientService = clientService;
     }
 
-    public UserInfo processUserInfoRequest(String authorizationHeader)
-            throws UserInfoValidationException {
-        LOG.info("Processing UserInfo request");
-        AccessToken accessToken;
-        try {
-            accessToken = AccessToken.parse(authorizationHeader, AccessTokenType.BEARER);
-        } catch (com.nimbusds.oauth2.sdk.ParseException e) {
-            LOG.error("Unable to parse AccessToken");
-            throw new UserInfoValidationException(
-                    "Unable to parse AccessToken", BearerTokenError.INVALID_TOKEN);
-        }
-        SignedJWT signedJWT;
-        try {
-            signedJWT = SignedJWT.parse(accessToken.getValue());
-
-            LocalDateTime localDateTime = LocalDateTime.now();
-            Date currentDateTime = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
-            if (DateUtils.isBefore(
-                    signedJWT.getJWTClaimsSet().getExpirationTime(), currentDateTime, 0)) {
-                LOG.error(
-                        "Access Token has expired. Access Token expires at: {}. CurrentDateTime is: {}",
-                        signedJWT.getJWTClaimsSet().getExpirationTime(),
-                        currentDateTime);
-                throw new UserInfoValidationException(
-                        "Invalid Access Token", BearerTokenError.INVALID_TOKEN);
-            }
-            if (!tokenValidationService.validateAccessTokenSignature(accessToken)) {
-                LOG.error("Unable to validate AccessToken signature");
-                throw new UserInfoValidationException(
-                        "Unable to validate AccessToken signature", BearerTokenError.INVALID_TOKEN);
-            }
-            String clientID = signedJWT.getJWTClaimsSet().getStringClaim("client_id");
-            Optional<ClientRegistry> client = clientService.getClient(clientID);
-
-            attachLogFieldToLogs(CLIENT_ID, clientID);
-
-            if (client.isEmpty()) {
-                LOG.error("Client not found");
-                throw new UserInfoValidationException(
-                        "Client not found", BearerTokenError.INVALID_TOKEN);
-            }
-            List<String> scopes = (List<String>) signedJWT.getJWTClaimsSet().getClaim("scope");
-            if (!areScopesValid(scopes) || !client.get().getScopes().containsAll(scopes)) {
-                LOG.error("Invalid Scopes: {}", scopes);
-                throw new UserInfoValidationException("Invalid Scopes", OAuth2Error.INVALID_SCOPE);
-            }
-            String subject = signedJWT.getJWTClaimsSet().getSubject();
-            Optional<AccessTokenStore> accessTokenStore = getAccessTokenStore(clientID, subject);
-            if (accessTokenStore.isEmpty()) {
-                LOG.error(
-                        "Access Token Store is empty. Access Token expires at: {}. CurrentDateTime is: {}",
-                        signedJWT.getJWTClaimsSet().getExpirationTime(),
-                        currentDateTime);
-                throw new UserInfoValidationException(
-                        "Invalid Access Token", BearerTokenError.INVALID_TOKEN);
-            }
-            if (!accessTokenStore.get().getToken().equals(accessToken.getValue())) {
-                LOG.error(
-                        "Access Token in Access Token Store is different to Access Token sent in request");
-                throw new UserInfoValidationException(
-                        "Invalid Access Token", BearerTokenError.INVALID_TOKEN);
-            }
-            deleteAccessTokenStore(clientID, subject);
-            UserProfile userProfile =
-                    authenticationService.getUserProfileFromSubject(
-                            accessTokenStore.get().getInternalSubjectId());
-            return populateUserInfo(userProfile, subject, scopes);
-        } catch (ParseException e) {
-            LOG.error("Unable to parse AccessToken to SignedJWT");
-            throw new UserInfoValidationException(
-                    "Unable to parse AccessToken to SignedJWT", BearerTokenError.INVALID_TOKEN);
-        }
-    }
-
-    private UserInfo populateUserInfo(
-            UserProfile userProfile, String subject, List<String> scopes) {
-        UserInfo userInfo = new UserInfo(new Subject(subject));
-        if (scopes.contains("email")) {
+    public UserInfo populateUserInfo(AccessTokenInfo accessTokenInfo) {
+        LOG.info("Populating UserInfo");
+        UserProfile userProfile =
+                authenticationService.getUserProfileFromSubject(
+                        accessTokenInfo.getAccessTokenStore().getInternalSubjectId());
+        UserInfo userInfo = new UserInfo(new Subject(accessTokenInfo.getPublicSubject()));
+        if (accessTokenInfo.getScopes().contains("email")) {
             userInfo.setEmailAddress(userProfile.getEmail());
             userInfo.setEmailVerified(userProfile.isEmailVerified());
         }
-        if (scopes.contains("phone")) {
+        if (accessTokenInfo.getScopes().contains("phone")) {
             userInfo.setPhoneNumber(userProfile.getPhoneNumber());
             userInfo.setPhoneNumberVerified(userProfile.isPhoneNumberVerified());
         }
-        if (scopes.contains("govuk-account")) {
+        if (accessTokenInfo.getScopes().contains("govuk-account")) {
             userInfo.setClaim("legacy_subject_id", userProfile.getLegacySubjectID());
         }
         return userInfo;
-    }
-
-    private Optional<AccessTokenStore> getAccessTokenStore(String clientId, String subjectId) {
-        String result =
-                redisConnectionService.getValue(ACCESS_TOKEN_PREFIX + clientId + "." + subjectId);
-        try {
-            return Optional.ofNullable(
-                    new ObjectMapper().readValue(result, AccessTokenStore.class));
-        } catch (JsonProcessingException | IllegalArgumentException e) {
-            LOG.error("Error getting AccessToken from Redis");
-            return Optional.empty();
-        }
-    }
-
-    private void deleteAccessTokenStore(String clientId, String subjectId) {
-        redisConnectionService.deleteValue(ACCESS_TOKEN_PREFIX + clientId + "." + subjectId);
-    }
-
-    private boolean areScopesValid(List<String> scopes) {
-        for (String scope : scopes) {
-            if (ValidScopes.getAllValidScopes().stream().noneMatch((t) -> t.equals(scope))) {
-                return false;
-            }
-        }
-        return true;
     }
 }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/IdentityHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/IdentityHandlerTest.java
@@ -1,0 +1,32 @@
+package uk.gov.di.authentication.oidc.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
+
+class IdentityHandlerTest {
+
+    private ConfigurationService configurationService = mock(ConfigurationService.class);
+    private final Context context = mock(Context.class);
+    private IdentityHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        handler = new IdentityHandler(configurationService);
+    }
+
+    @Test
+    void shouldReturn204ForSuccessfulRequest() {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
+
+        assertThat(result, hasStatus(204));
+    }
+}

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/IdentityHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/IdentityHandlerTest.java
@@ -3,9 +3,13 @@ package uk.gov.di.authentication.oidc.lambda;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.nimbusds.oauth2.sdk.token.AccessToken;
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
@@ -24,9 +28,19 @@ class IdentityHandlerTest {
 
     @Test
     void shouldReturn204ForSuccessfulRequest() {
+        AccessToken accessToken = new BearerAccessToken();
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        event.setHeaders(Map.of("Authorization", accessToken.toAuthorizationHeader()));
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(204));
+    }
+
+    @Test
+    void shouldReturn401WhenAccessTokenIsMissing() {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
+
+        assertThat(result, hasStatus(401));
     }
 }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AccessTokenServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AccessTokenServiceTest.java
@@ -1,0 +1,272 @@
+package uk.gov.di.authentication.oidc.services;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.OAuth2Error;
+import com.nimbusds.oauth2.sdk.id.Subject;
+import com.nimbusds.oauth2.sdk.token.AccessToken;
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
+import com.nimbusds.oauth2.sdk.token.BearerTokenError;
+import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.di.authentication.oidc.entity.AccessTokenInfo;
+import uk.gov.di.authentication.shared.entity.AccessTokenStore;
+import uk.gov.di.authentication.shared.entity.ClientRegistry;
+import uk.gov.di.authentication.shared.exceptions.AccessTokenException;
+import uk.gov.di.authentication.shared.services.DynamoClientService;
+import uk.gov.di.authentication.shared.services.RedisConnectionService;
+import uk.gov.di.authentication.shared.services.TokenValidationService;
+import uk.gov.di.authentication.sharedtest.helper.TokenGeneratorHelper;
+import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Collections.singletonList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.sharedtest.logging.LogEventMatcher.withMessageContaining;
+
+class AccessTokenServiceTest {
+
+    private AccessTokenService validationService;
+    private final RedisConnectionService redisConnectionService =
+            mock(RedisConnectionService.class);
+    private final TokenValidationService tokenValidationService =
+            mock(TokenValidationService.class);
+    private final DynamoClientService clientService = mock(DynamoClientService.class);
+    private static final Subject INTERNAL_SUBJECT = new Subject("internal-subject");
+    private static final Subject SUBJECT = new Subject("some-subject");
+    private static final List<String> SCOPES =
+            List.of(
+                    OIDCScopeValue.OPENID.getValue(),
+                    OIDCScopeValue.EMAIL.getValue(),
+                    OIDCScopeValue.PHONE.getValue());
+    private static final String CLIENT_ID = "client-id";
+    private static final String BASE_URL = "http://example.com";
+    private static final String KEY_ID = "14342354354353";
+    private static final String ACCESS_TOKEN_PREFIX = "ACCESS_TOKEN:";
+    private AccessToken accessToken;
+
+    @RegisterExtension
+    public final CaptureLoggingExtension logging =
+            new CaptureLoggingExtension(AccessTokenService.class);
+
+    @AfterEach
+    void tearDown() {
+        assertThat(
+                logging.events(),
+                not(hasItem(withMessageContaining(CLIENT_ID, SUBJECT.toString()))));
+    }
+
+    @BeforeEach
+    void setUp() throws JOSEException {
+        validationService =
+                new AccessTokenService(
+                        redisConnectionService, clientService, tokenValidationService);
+        accessToken = createSignedAccessToken();
+    }
+
+    @Test
+    void shouldReturnAccessTokenInfoWhenAccessTokenIsValid()
+            throws JsonProcessingException, AccessTokenException {
+        when(tokenValidationService.validateAccessTokenSignature(accessToken)).thenReturn(true);
+        when(clientService.getClient(CLIENT_ID))
+                .thenReturn(Optional.of(generateClientRegistry(SCOPES)));
+        when(redisConnectionService.getValue(ACCESS_TOKEN_PREFIX + CLIENT_ID + "." + SUBJECT))
+                .thenReturn(
+                        new ObjectMapper()
+                                .writeValueAsString(
+                                        new AccessTokenStore(
+                                                accessToken.getValue(),
+                                                INTERNAL_SUBJECT.getValue())));
+
+        AccessTokenInfo accessTokenInfo =
+                validationService.parse(accessToken.toAuthorizationHeader());
+
+        assertThat(
+                accessTokenInfo.getAccessTokenStore().getToken(), equalTo(accessToken.getValue()));
+        assertThat(
+                accessTokenInfo.getAccessTokenStore().getInternalSubjectId(),
+                equalTo(INTERNAL_SUBJECT.getValue()));
+        assertThat(accessTokenInfo.getPublicSubject(), equalTo(SUBJECT.getValue()));
+        assertThat(accessTokenInfo.getScopes(), equalTo(SCOPES));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenTokenSignatureIsInvalid() {
+        when(tokenValidationService.validateAccessTokenSignature(accessToken)).thenReturn(false);
+
+        AccessTokenException accessTokenException =
+                assertThrows(
+                        AccessTokenException.class,
+                        () -> validationService.parse(accessToken.toAuthorizationHeader()),
+                        "Expected to throw AccessTokenException");
+
+        assertThat(
+                accessTokenException.getMessage(),
+                equalTo("Unable to validate AccessToken signature"));
+        assertThat(accessTokenException.getError(), equalTo(BearerTokenError.INVALID_TOKEN));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenTokenHasExpired() throws JOSEException {
+        accessToken = createSignedExpiredAccessToken();
+        AccessTokenException accessTokenException =
+                assertThrows(
+                        AccessTokenException.class,
+                        () -> validationService.parse(accessToken.toAuthorizationHeader()),
+                        "Expected to throw AccessTokenException");
+
+        assertThat(accessTokenException.getMessage(), equalTo("Invalid Access Token"));
+        assertThat(accessTokenException.getError(), equalTo(BearerTokenError.INVALID_TOKEN));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenClientIsNotFoundInClientRegistry() {
+        when(tokenValidationService.validateAccessTokenSignature(accessToken)).thenReturn(true);
+        when(clientService.getClient(CLIENT_ID)).thenReturn(Optional.empty());
+
+        AccessTokenException accessTokenException =
+                assertThrows(
+                        AccessTokenException.class,
+                        () -> validationService.parse(accessToken.toAuthorizationHeader()),
+                        "Expected to throw AccessTokenException");
+
+        assertThat(accessTokenException.getMessage(), equalTo("Client not found"));
+        assertThat(accessTokenException.getError(), equalTo(BearerTokenError.INVALID_TOKEN));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenScopesAreInvalid() {
+        List<String> scopes =
+                List.of(OIDCScopeValue.OPENID.getValue(), OIDCScopeValue.ADDRESS.getValue());
+        when(tokenValidationService.validateAccessTokenSignature(accessToken)).thenReturn(true);
+        when(clientService.getClient(CLIENT_ID))
+                .thenReturn(Optional.of(generateClientRegistry(scopes)));
+
+        AccessTokenException accessTokenException =
+                assertThrows(
+                        AccessTokenException.class,
+                        () -> validationService.parse(accessToken.toAuthorizationHeader()),
+                        "Expected to throw AccessTokenException");
+
+        assertThat(accessTokenException.getMessage(), equalTo("Invalid Scopes"));
+        assertThat(accessTokenException.getError(), equalTo(OAuth2Error.INVALID_SCOPE));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenAccessTokenNotFoundInRedis() {
+        when(tokenValidationService.validateAccessTokenSignature(accessToken)).thenReturn(true);
+        when(clientService.getClient(CLIENT_ID))
+                .thenReturn(Optional.of(generateClientRegistry(SCOPES)));
+        when(redisConnectionService.getValue(ACCESS_TOKEN_PREFIX + CLIENT_ID + "." + SUBJECT))
+                .thenReturn(null);
+
+        AccessTokenException accessTokenException =
+                assertThrows(
+                        AccessTokenException.class,
+                        () -> validationService.parse(accessToken.toAuthorizationHeader()),
+                        "Expected to throw AccessTokenException");
+
+        assertThat(accessTokenException.getMessage(), equalTo("Invalid Access Token"));
+        assertThat(accessTokenException.getError(), equalTo(BearerTokenError.INVALID_TOKEN));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenAccessTokenSentIsNotTheSameAsInRedis()
+            throws JOSEException, JsonProcessingException {
+        when(tokenValidationService.validateAccessTokenSignature(accessToken)).thenReturn(true);
+        when(clientService.getClient(CLIENT_ID))
+                .thenReturn(Optional.of(generateClientRegistry(SCOPES)));
+        when(redisConnectionService.getValue(ACCESS_TOKEN_PREFIX + CLIENT_ID + "." + SUBJECT))
+                .thenReturn(
+                        new ObjectMapper()
+                                .writeValueAsString(
+                                        new AccessTokenStore(
+                                                createSignedAccessToken().getValue(),
+                                                INTERNAL_SUBJECT.getValue())));
+
+        AccessTokenException accessTokenException =
+                assertThrows(
+                        AccessTokenException.class,
+                        () -> validationService.parse(accessToken.toAuthorizationHeader()),
+                        "Expected to throw AccessTokenException");
+
+        assertThat(accessTokenException.getMessage(), equalTo("Invalid Access Token"));
+        assertThat(accessTokenException.getError(), equalTo(BearerTokenError.INVALID_TOKEN));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenUnableToParseAccessToken() {
+        AccessTokenException accessTokenException =
+                assertThrows(
+                        AccessTokenException.class,
+                        () -> validationService.parse("rubbish-access-token"),
+                        "Expected to throw AccessTokenException");
+
+        assertThat(accessTokenException.getMessage(), equalTo("Unable to parse AccessToken"));
+        assertThat(accessTokenException.getError(), equalTo(BearerTokenError.INVALID_TOKEN));
+    }
+
+    private ClientRegistry generateClientRegistry(List<String> scopes) {
+        return new ClientRegistry()
+                .setRedirectUrls(singletonList("http://localhost/redirect"))
+                .setClientID(CLIENT_ID)
+                .setContacts(singletonList("joe.bloggs@digital.cabinet-office.gov.uk"))
+                .setPublicKey(null)
+                .setScopes(scopes);
+    }
+
+    private AccessToken createSignedExpiredAccessToken() throws JOSEException {
+        LocalDateTime localDateTime = LocalDateTime.now().minusMinutes(2);
+        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
+        ECKey ecSigningKey =
+                new ECKeyGenerator(Curve.P_256)
+                        .keyID(KEY_ID)
+                        .algorithm(JWSAlgorithm.ES256)
+                        .generate();
+        ECDSASigner signer = new ECDSASigner(ecSigningKey);
+        SignedJWT signedJWT =
+                TokenGeneratorHelper.generateSignedToken(
+                        CLIENT_ID,
+                        BASE_URL,
+                        SCOPES,
+                        signer,
+                        SUBJECT,
+                        ecSigningKey.getKeyID(),
+                        expiryDate);
+        return new BearerAccessToken(signedJWT.serialize());
+    }
+
+    private AccessToken createSignedAccessToken() throws JOSEException {
+        ECKey ecSigningKey =
+                new ECKeyGenerator(Curve.P_256)
+                        .keyID(KEY_ID)
+                        .algorithm(JWSAlgorithm.ES256)
+                        .generate();
+        ECDSASigner signer = new ECDSASigner(ecSigningKey);
+        SignedJWT signedJWT =
+                TokenGeneratorHelper.generateSignedToken(
+                        CLIENT_ID, BASE_URL, SCOPES, signer, SUBJECT, ecSigningKey.getKeyID());
+        return new BearerAccessToken(signedJWT.serialize());
+    }
+}

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
@@ -1,7 +1,5 @@
 package uk.gov.di.authentication.oidc.services;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.crypto.ECDSASigner;
@@ -9,55 +7,37 @@ import com.nimbusds.jose.jwk.Curve;
 import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
 import com.nimbusds.jwt.SignedJWT;
-import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
-import com.nimbusds.oauth2.sdk.token.BearerTokenError;
 import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.di.authentication.oidc.entity.AccessTokenInfo;
 import uk.gov.di.authentication.shared.entity.AccessTokenStore;
-import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.UserProfile;
-import uk.gov.di.authentication.shared.exceptions.UserInfoValidationException;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
-import uk.gov.di.authentication.shared.services.DynamoClientService;
-import uk.gov.di.authentication.shared.services.RedisConnectionService;
-import uk.gov.di.authentication.shared.services.TokenValidationService;
 import uk.gov.di.authentication.sharedtest.helper.TokenGeneratorHelper;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
 import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.util.Date;
 import java.util.List;
-import java.util.Optional;
 
-import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.sharedtest.logging.LogEventMatcher.withMessageContaining;
 
 class UserInfoServiceTest {
 
     private UserInfoService userInfoService;
-    private final RedisConnectionService redisConnectionService =
-            mock(RedisConnectionService.class);
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
-    private final TokenValidationService tokenValidationService =
-            mock(TokenValidationService.class);
-    private final DynamoClientService clientService = mock(DynamoClientService.class);
     private static final Subject INTERNAL_SUBJECT = new Subject("internal-subject");
     private static final Subject SUBJECT = new Subject("some-subject");
     private static final List<String> SCOPES =
@@ -70,7 +50,6 @@ class UserInfoServiceTest {
     private static final String PHONE_NUMBER = "01234567891";
     private static final String BASE_URL = "http://example.com";
     private static final String KEY_ID = "14342354354353";
-    private static final String ACCESS_TOKEN_PREFIX = "ACCESS_TOKEN:";
     private AccessToken accessToken;
 
     @RegisterExtension
@@ -78,175 +57,33 @@ class UserInfoServiceTest {
             new CaptureLoggingExtension(UserInfoService.class);
 
     @AfterEach
-    public void tearDown() {
+    void tearDown() {
         assertThat(
                 logging.events(),
                 not(hasItem(withMessageContaining(CLIENT_ID, SUBJECT.toString()))));
     }
 
     @BeforeEach
-    public void setUp() throws JOSEException {
-        userInfoService =
-                new UserInfoService(
-                        redisConnectionService,
-                        authenticationService,
-                        tokenValidationService,
-                        clientService);
+    void setUp() throws JOSEException {
+        userInfoService = new UserInfoService(authenticationService);
         accessToken = createSignedAccessToken();
     }
 
     @Test
-    public void shouldSuccessfullyProcessUserInfoRequest()
-            throws JsonProcessingException, UserInfoValidationException {
-        when(tokenValidationService.validateAccessTokenSignature(accessToken)).thenReturn(true);
-        when(clientService.getClient(CLIENT_ID))
-                .thenReturn(Optional.of(generateClientRegistry(SCOPES)));
-        when(redisConnectionService.getValue(ACCESS_TOKEN_PREFIX + CLIENT_ID + "." + SUBJECT))
-                .thenReturn(
-                        new ObjectMapper()
-                                .writeValueAsString(
-                                        new AccessTokenStore(
-                                                accessToken.getValue(),
-                                                INTERNAL_SUBJECT.getValue())));
+    void shouldPopulateUserInfo() {
         when(authenticationService.getUserProfileFromSubject(INTERNAL_SUBJECT.getValue()))
                 .thenReturn(generateUserprofile());
 
-        UserInfo userInfo =
-                userInfoService.processUserInfoRequest(accessToken.toAuthorizationHeader());
+        AccessTokenStore accessTokenStore =
+                new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
+        AccessTokenInfo accessTokenInfo =
+                new AccessTokenInfo(accessTokenStore, SUBJECT.getValue(), SCOPES);
+
+        UserInfo userInfo = userInfoService.populateUserInfo(accessTokenInfo);
         assertEquals(userInfo.getEmailAddress(), EMAIL);
         assertEquals(userInfo.getEmailVerified(), true);
         assertEquals(userInfo.getPhoneNumber(), PHONE_NUMBER);
         assertEquals(userInfo.getPhoneNumberVerified(), true);
-        verify(redisConnectionService, times(1))
-                .deleteValue(ACCESS_TOKEN_PREFIX + CLIENT_ID + "." + SUBJECT);
-    }
-
-    @Test
-    public void shouldThrowExceptionWhenTokenSignatureIsInvalid() {
-        when(tokenValidationService.validateAccessTokenSignature(accessToken)).thenReturn(false);
-
-        UserInfoValidationException userInfoValidationException =
-                assertThrows(
-                        UserInfoValidationException.class,
-                        () ->
-                                userInfoService.processUserInfoRequest(
-                                        accessToken.toAuthorizationHeader()),
-                        "Expected to throw UserInfoValidationException");
-
-        assertEquals(
-                userInfoValidationException.getMessage(),
-                "Unable to validate AccessToken signature");
-        assertEquals(userInfoValidationException.getError(), BearerTokenError.INVALID_TOKEN);
-    }
-
-    @Test
-    public void shouldThrowExceptionWhenTokenHasExpired() throws JOSEException {
-        accessToken = createSignedExpiredAccessToken();
-        UserInfoValidationException userInfoValidationException =
-                assertThrows(
-                        UserInfoValidationException.class,
-                        () ->
-                                userInfoService.processUserInfoRequest(
-                                        accessToken.toAuthorizationHeader()),
-                        "Expected to throw UserInfoValidationException");
-
-        assertEquals(userInfoValidationException.getMessage(), "Invalid Access Token");
-        assertEquals(userInfoValidationException.getError(), BearerTokenError.INVALID_TOKEN);
-    }
-
-    @Test
-    public void shouldThrowExceptionWhenClientIsNotFoundInClientRegistry() {
-        when(tokenValidationService.validateAccessTokenSignature(accessToken)).thenReturn(true);
-        when(clientService.getClient(CLIENT_ID)).thenReturn(Optional.empty());
-
-        UserInfoValidationException userInfoValidationException =
-                assertThrows(
-                        UserInfoValidationException.class,
-                        () ->
-                                userInfoService.processUserInfoRequest(
-                                        accessToken.toAuthorizationHeader()),
-                        "Expected to throw UserInfoValidationException");
-
-        assertEquals(userInfoValidationException.getMessage(), "Client not found");
-        assertEquals(userInfoValidationException.getError(), BearerTokenError.INVALID_TOKEN);
-    }
-
-    @Test
-    public void shouldThrowExceptionWhenScopesAreInvalid() {
-        List<String> scopes =
-                List.of(OIDCScopeValue.OPENID.getValue(), OIDCScopeValue.ADDRESS.getValue());
-        when(tokenValidationService.validateAccessTokenSignature(accessToken)).thenReturn(true);
-        when(clientService.getClient(CLIENT_ID))
-                .thenReturn(Optional.of(generateClientRegistry(scopes)));
-
-        UserInfoValidationException userInfoValidationException =
-                assertThrows(
-                        UserInfoValidationException.class,
-                        () ->
-                                userInfoService.processUserInfoRequest(
-                                        accessToken.toAuthorizationHeader()),
-                        "Expected to throw UserInfoValidationException");
-
-        assertEquals(userInfoValidationException.getMessage(), "Invalid Scopes");
-        assertEquals(userInfoValidationException.getError(), OAuth2Error.INVALID_SCOPE);
-    }
-
-    @Test
-    public void shouldThrowExceptionWhenAccessTokenNotFoundInRedis() {
-        when(tokenValidationService.validateAccessTokenSignature(accessToken)).thenReturn(true);
-        when(clientService.getClient(CLIENT_ID))
-                .thenReturn(Optional.of(generateClientRegistry(SCOPES)));
-        when(redisConnectionService.getValue(ACCESS_TOKEN_PREFIX + CLIENT_ID + "." + SUBJECT))
-                .thenReturn(null);
-
-        UserInfoValidationException userInfoValidationException =
-                assertThrows(
-                        UserInfoValidationException.class,
-                        () ->
-                                userInfoService.processUserInfoRequest(
-                                        accessToken.toAuthorizationHeader()),
-                        "Expected to throw UserInfoValidationException");
-
-        assertEquals(userInfoValidationException.getMessage(), "Invalid Access Token");
-        assertEquals(userInfoValidationException.getError(), BearerTokenError.INVALID_TOKEN);
-    }
-
-    @Test
-    public void shouldThrowExceptionWhenAccessTokenSentIsNotTheSameAsInRedis()
-            throws JsonProcessingException, JOSEException {
-        when(tokenValidationService.validateAccessTokenSignature(accessToken)).thenReturn(true);
-        when(clientService.getClient(CLIENT_ID))
-                .thenReturn(Optional.of(generateClientRegistry(SCOPES)));
-        when(redisConnectionService.getValue(ACCESS_TOKEN_PREFIX + CLIENT_ID + "." + SUBJECT))
-                .thenReturn(
-                        new ObjectMapper()
-                                .writeValueAsString(
-                                        new AccessTokenStore(
-                                                createSignedAccessToken().getValue(),
-                                                INTERNAL_SUBJECT.getValue())));
-
-        UserInfoValidationException userInfoValidationException =
-                assertThrows(
-                        UserInfoValidationException.class,
-                        () ->
-                                userInfoService.processUserInfoRequest(
-                                        accessToken.toAuthorizationHeader()),
-                        "Expected to throw UserInfoValidationException");
-
-        assertEquals(userInfoValidationException.getMessage(), "Invalid Access Token");
-        assertEquals(userInfoValidationException.getError(), BearerTokenError.INVALID_TOKEN);
-    }
-
-    @Test
-    public void shouldThrowExceptionWhenUnableToParseAccessToken() {
-        UserInfoValidationException userInfoValidationException =
-                assertThrows(
-                        UserInfoValidationException.class,
-                        () -> userInfoService.processUserInfoRequest("rubbish-access-token"),
-                        "Expected to throw UserInfoValidationException");
-
-        assertEquals(userInfoValidationException.getMessage(), "Unable to parse AccessToken");
-        assertEquals(userInfoValidationException.getError(), BearerTokenError.INVALID_TOKEN);
     }
 
     private AccessToken createSignedAccessToken() throws JOSEException {
@@ -260,36 +97,6 @@ class UserInfoServiceTest {
                 TokenGeneratorHelper.generateSignedToken(
                         CLIENT_ID, BASE_URL, SCOPES, signer, SUBJECT, ecSigningKey.getKeyID());
         return new BearerAccessToken(signedJWT.serialize());
-    }
-
-    private AccessToken createSignedExpiredAccessToken() throws JOSEException {
-        LocalDateTime localDateTime = LocalDateTime.now().minusMinutes(2);
-        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
-        ECKey ecSigningKey =
-                new ECKeyGenerator(Curve.P_256)
-                        .keyID(KEY_ID)
-                        .algorithm(JWSAlgorithm.ES256)
-                        .generate();
-        ECDSASigner signer = new ECDSASigner(ecSigningKey);
-        SignedJWT signedJWT =
-                TokenGeneratorHelper.generateSignedToken(
-                        CLIENT_ID,
-                        BASE_URL,
-                        SCOPES,
-                        signer,
-                        SUBJECT,
-                        ecSigningKey.getKeyID(),
-                        expiryDate);
-        return new BearerAccessToken(signedJWT.serialize());
-    }
-
-    private ClientRegistry generateClientRegistry(List<String> scopes) {
-        return new ClientRegistry()
-                .setRedirectUrls(singletonList("http://localhost/redirect"))
-                .setClientID(CLIENT_ID)
-                .setContacts(singletonList("joe.bloggs@digital.cabinet-office.gov.uk"))
-                .setPublicKey(null)
-                .setScopes(scopes);
     }
 
     private UserProfile generateUserprofile() {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/AccessTokenException.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/AccessTokenException.java
@@ -2,11 +2,11 @@ package uk.gov.di.authentication.shared.exceptions;
 
 import com.nimbusds.oauth2.sdk.ErrorObject;
 
-public class UserInfoValidationException extends Exception {
+public class AccessTokenException extends Exception {
 
     private final ErrorObject error;
 
-    public UserInfoValidationException(String message, ErrorObject error) {
+    public AccessTokenException(String message, ErrorObject error) {
         super(message);
         this.error = error;
     }


### PR DESCRIPTION
## What?

- Add terraform and bones of the identity lambda which will just return a 204 for now. Restrict deployment to non-prod via the var.ipv_api_enabled flag. 
- Rename the UserInfoValidationException to AccessTokenException to make it more generic so it can be used for the identity endpoint
- Move the parsing of the access token from the UserInfoService into a new AccessTokenService. This is so this code can easily be shared across UserInfo and Identity endpoints.
- Create a new AccessTokenInfo object which will be returned from the AccessTokenService. This is to prevent the need to parse the Access token again and so the information required for both UserInfo and Identity endpoints can easily be passed around.
- Stop deleting the accesstoken after it has been used. 

## Why?

- We need an identity lambda to return identity information. This is the first iteration. 
- There is common code that can be shared between UserInfo and Identity lambdas. 
- We are getting rid of the one time use of the access token so it can be used across identity and userinfo endpoints until the access token expires

