### PR TITLE
AUTH-1208: Pull dependencies from Artifactory instance rather than Maven Central

### DIFF
--- a/account-management-api/build.gradle
+++ b/account-management-api/build.gradle
@@ -6,10 +6,6 @@ plugins {
 group "uk.gov.di.authentication.accountmanagement"
 version "unspecified"
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     implementation configurations.lambda,
             configurations.nimbus,

--- a/account-management-integration-tests/build.gradle
+++ b/account-management-integration-tests/build.gradle
@@ -6,10 +6,6 @@ plugins {
 group "uk.gov.di"
 version "unspecified"
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     testImplementation configurations.bouncycastle,
             configurations.nimbus,

--- a/account-migrations/build.gradle
+++ b/account-migrations/build.gradle
@@ -6,11 +6,6 @@ plugins {
 group "uk.gov.di.authentication.accountmigration"
 version "unspecified"
 
-
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     implementation configurations.bouncycastle,
             configurations.lambda,

--- a/audit-processors/build.gradle
+++ b/audit-processors/build.gradle
@@ -5,10 +5,6 @@ plugins {
 group "uk.gov.di.authentication.audit"
 version "unspecified"
 
-repositories {
-    mavenCentral()
-}
-
 ext {
     dependencyVersions = [
         protobuf_version: "3.19.3",

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,13 @@
 import java.util.stream.Collectors
 
+buildscript {
+    repositories {
+        maven {
+            url 'https://gds.jfrog.io/artifactory/di-allowed-repos'
+        }
+    }
+}
+
 plugins {
     id "com.diffplug.spotless" version "6.2.0"
     id "com.avast.gradle.docker-compose" version "0.14.13"
@@ -33,7 +41,19 @@ ext {
     ] : [:]
 }
 
+repositories {
+    maven {
+        url 'https://gds.jfrog.io/artifactory/di-allowed-repos'
+    }
+}
+
 subprojects {
+    repositories {
+        maven {
+            url 'https://gds.jfrog.io/artifactory/di-allowed-repos'
+        }
+    }
+
     configurations {
         bouncycastle
         dynamodb
@@ -293,6 +313,3 @@ jacocoTestReport {
     dependsOn "test"
 }
 
-repositories {
-    mavenCentral()
-}

--- a/client-registry-api/build.gradle
+++ b/client-registry-api/build.gradle
@@ -6,10 +6,6 @@ plugins {
 group "uk.gov.di.clientregistry"
 version "unspecified"
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     implementation configurations.lambda,
             configurations.nimbus,

--- a/frontend-api/build.gradle
+++ b/frontend-api/build.gradle
@@ -6,10 +6,6 @@ plugins {
 group "uk.gov.di.authentication.frontendapi"
 version "unspecified"
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     implementation configurations.dynamodb,
             configurations.govuk_notify,

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -6,10 +6,6 @@ plugins {
 group "uk.gov.di"
 version "unspecified"
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     testImplementation configurations.tests,
             configurations.glassfish,

--- a/ipv-api/build.gradle
+++ b/ipv-api/build.gradle
@@ -6,10 +6,6 @@ plugins {
 group "uk.gov.di.authentication.ipvapi"
 version "unspecified"
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     implementation configurations.dynamodb,
             configurations.lambda,

--- a/lambda-warmer/build.gradle
+++ b/lambda-warmer/build.gradle
@@ -5,10 +5,6 @@ plugins {
 group "uk.gov.di.lambdawarmer"
 version "unspecified"
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     implementation configurations.lambda,
             "com.amazonaws:aws-java-sdk-lambda:1.12.141"

--- a/oidc-api/build.gradle
+++ b/oidc-api/build.gradle
@@ -6,10 +6,6 @@ plugins {
 group "uk.gov.di.authentication.oidc"
 version "unspecified"
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     implementation configurations.lambda,
             configurations.sqs,

--- a/shared-test/build.gradle
+++ b/shared-test/build.gradle
@@ -5,10 +5,6 @@ plugins {
 group "uk.gov.di.authentication.sharedtest"
 version "unspecified"
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
     implementation configurations.tests,
             configurations.lambda,

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -6,10 +6,6 @@ plugins {
 group "uk.gov.di"
 version "unspecified"
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
 
     implementation configurations.lambda,


### PR DESCRIPTION
We want to pull dependencies from the artifactory cache rather than directly from Maven central or gradle
