### PR TITLE
AUTH-1314 - Add functionality to the Identity lambda

### DIFF
--- a/ci/terraform/oidc/identity.tf
+++ b/ci/terraform/oidc/identity.tf
@@ -26,7 +26,7 @@ module "identity" {
     local.authentication_oidc_redis_security_group_id,
   ]
   subnet_id                              = local.authentication_subnet_ids
-  lambda_role_arn                        = module.oidc_default_role.arn
+  lambda_role_arn                        = module.identity_lambda_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled
   logging_endpoint_arn                   = var.logging_endpoint_arn
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IdentityIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IdentityIntegrationTest.java
@@ -1,18 +1,40 @@
 package uk.gov.di.authentication.api;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.id.Subject;
+import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.oidc.lambda.IdentityHandler;
+import uk.gov.di.authentication.shared.entity.AccessTokenStore;
+import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.gov.di.authentication.sharedtest.helper.KeyPairHelper;
 
+import java.security.KeyPair;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Date;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 
+import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class IdentityIntegrationTest extends ApiGatewayHandlerIntegrationTest {
+
+    private static final String CLIENT_ID = "client-id-one";
+    private static final String ACCESS_TOKEN_PREFIX = "ACCESS_TOKEN:";
+    private static final String TEST_EMAIL_ADDRESS = "joe.bloggs@digital.cabinet-office.gov.uk";
 
     @BeforeEach
     void setup() {
@@ -20,14 +42,59 @@ public class IdentityIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     }
 
     @Test
-    void shouldReturn204WhenCallingIdentityLambda() {
+    void shouldReturn204WhenCallingIdentityLambda() throws JsonProcessingException {
+        Subject internalSubject = new Subject();
+        Subject publicSubject = new Subject();
+        LocalDateTime localDateTime = LocalDateTime.now().plusMinutes(10);
+        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
+        List<String> scopes = new ArrayList<>();
+        scopes.add("email");
+        scopes.add("phone");
+        scopes.add("openid");
+        JWTClaimsSet claimsSet =
+                new JWTClaimsSet.Builder()
+                        .claim("scope", scopes)
+                        .issuer("issuer-id")
+                        .expirationTime(expiryDate)
+                        .issueTime(
+                                Date.from(LocalDateTime.now().atZone(ZoneId.of("UTC")).toInstant()))
+                        .claim("client_id", "client-id-one")
+                        .subject(publicSubject.getValue())
+                        .jwtID(UUID.randomUUID().toString())
+                        .build();
+        SignedJWT signedJWT = tokenSigner.signJwt(claimsSet);
+        AccessToken accessToken = new BearerAccessToken(signedJWT.serialize());
+        AccessTokenStore accessTokenStore =
+                new AccessTokenStore(accessToken.getValue(), internalSubject.getValue());
+        String accessTokenStoreString = new ObjectMapper().writeValueAsString(accessTokenStore);
+        redis.addToRedis(
+                ACCESS_TOKEN_PREFIX + CLIENT_ID + "." + publicSubject,
+                accessTokenStoreString,
+                300L);
+        setUpDynamo();
 
         var response =
                 makeRequest(
                         Optional.empty(),
-                        Map.of("Authorization", new BearerAccessToken().toAuthorizationHeader()),
+                        Map.of("Authorization", accessToken.toAuthorizationHeader()),
                         Map.of());
 
         assertThat(response, hasStatus(204));
+    }
+
+    private void setUpDynamo() {
+        KeyPair keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        clientStore.registerClient(
+                CLIENT_ID,
+                "test-client",
+                singletonList("redirect-url"),
+                singletonList(TEST_EMAIL_ADDRESS),
+                List.of("openid", "email", "phone"),
+                Base64.getMimeEncoder().encodeToString(keyPair.getPublic().getEncoded()),
+                singletonList("http://localhost/post-redirect-logout"),
+                String.valueOf(ServiceType.MANDATORY),
+                "https://test.com",
+                "public",
+                true);
     }
 }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/IdentityErrorResponse.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/IdentityErrorResponse.java
@@ -1,0 +1,49 @@
+package uk.gov.di.authentication.oidc.entity;
+
+import com.nimbusds.common.contenttype.ContentType;
+import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.ErrorResponse;
+import com.nimbusds.oauth2.sdk.http.HTTPResponse;
+import com.nimbusds.oauth2.sdk.token.TokenSchemeError;
+
+public class IdentityErrorResponse implements ErrorResponse {
+
+    private final ErrorObject error;
+
+    public IdentityErrorResponse(final ErrorObject error) {
+        if (error == null) throw new IllegalArgumentException("The error must not be null");
+
+        this.error = error;
+    }
+
+    @Override
+    public ErrorObject getErrorObject() {
+        return error;
+    }
+
+    @Override
+    public boolean indicatesSuccess() {
+        return false;
+    }
+
+    @Override
+    public HTTPResponse toHTTPResponse() {
+        HTTPResponse httpResponse;
+
+        if (error != null && error.getHTTPStatusCode() > 0) {
+            httpResponse = new HTTPResponse(error.getHTTPStatusCode());
+        } else {
+            httpResponse = new HTTPResponse(HTTPResponse.SC_BAD_REQUEST);
+        }
+
+        // Add the WWW-Authenticate header
+        if (error instanceof TokenSchemeError) {
+            httpResponse.setWWWAuthenticate(((TokenSchemeError) error).toWWWAuthenticateHeader());
+        } else if (error != null) {
+            httpResponse.setEntityContentType(ContentType.APPLICATION_JSON);
+            httpResponse.setContent(error.toJSONObject().toJSONString());
+        }
+
+        return httpResponse;
+    }
+}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/IdentityResponse.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/IdentityResponse.java
@@ -1,0 +1,28 @@
+package uk.gov.di.authentication.oidc.entity;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class IdentityResponse {
+
+    @JsonProperty("sub")
+    private String sub;
+
+    @JsonProperty("identityCredential")
+    private String identityCredential;
+
+    public IdentityResponse(
+            @JsonProperty(required = true, value = "sub") String sub,
+            @JsonProperty(required = true, value = "identityCredential")
+                    String identityCredential) {
+        this.sub = sub;
+        this.identityCredential = identityCredential;
+    }
+
+    public String getSub() {
+        return sub;
+    }
+
+    public String getIdentityCredential() {
+        return identityCredential;
+    }
+}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/IdentityHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/IdentityHandler.java
@@ -7,12 +7,21 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import com.nimbusds.openid.connect.sdk.UserInfoErrorResponse;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.oidc.entity.AccessTokenInfo;
+import uk.gov.di.authentication.oidc.entity.IdentityErrorResponse;
+import uk.gov.di.authentication.oidc.services.AccessTokenService;
+import uk.gov.di.authentication.shared.exceptions.AccessTokenException;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.DynamoClientService;
+import uk.gov.di.authentication.shared.services.KmsConnectionService;
+import uk.gov.di.authentication.shared.services.RedisConnectionService;
+import uk.gov.di.authentication.shared.services.TokenValidationService;
 
 import static com.nimbusds.oauth2.sdk.token.BearerTokenError.MISSING_TOKEN;
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.AUTHORIZATION_HEADER;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateEmptySuccessApiGatewayResponse;
+import static uk.gov.di.authentication.shared.helpers.RequestHeaderHelper.getHeaderValueFromHeaders;
 import static uk.gov.di.authentication.shared.helpers.RequestHeaderHelper.headersContainValidHeader;
 import static uk.gov.di.authentication.shared.helpers.WarmerHelper.isWarming;
 
@@ -21,6 +30,7 @@ public class IdentityHandler
 
     private static final Logger LOG = LogManager.getLogger(IdentityHandler.class);
     private final ConfigurationService configurationService;
+    private final AccessTokenService accessTokenService;
 
     public IdentityHandler() {
         this(ConfigurationService.getInstance());
@@ -28,6 +38,19 @@ public class IdentityHandler
 
     public IdentityHandler(ConfigurationService configurationService) {
         this.configurationService = configurationService;
+        this.accessTokenService =
+                new AccessTokenService(
+                        new RedisConnectionService(configurationService),
+                        new DynamoClientService(configurationService),
+                        new TokenValidationService(
+                                configurationService,
+                                new KmsConnectionService(configurationService)));
+    }
+
+    public IdentityHandler(
+            ConfigurationService configurationService, AccessTokenService accessTokenService) {
+        this.configurationService = configurationService;
+        this.accessTokenService = accessTokenService;
     }
 
     @Override
@@ -46,6 +69,24 @@ public class IdentityHandler
                                         401,
                                         "",
                                         new UserInfoErrorResponse(MISSING_TOKEN)
+                                                .toHTTPResponse()
+                                                .getHeaderMap());
+                            }
+                            try {
+                                AccessTokenInfo accessTokenInfo =
+                                        accessTokenService.parse(
+                                                getHeaderValueFromHeaders(
+                                                        input.getHeaders(),
+                                                        AUTHORIZATION_HEADER,
+                                                        configurationService
+                                                                .getHeadersCaseInsensitive()));
+                            } catch (AccessTokenException e) {
+                                LOG.error(
+                                        "AccessTokenException. Sending back IdentityErrorResponse");
+                                return generateApiGatewayProxyResponse(
+                                        401,
+                                        "",
+                                        new IdentityErrorResponse(e.getError())
                                                 .toHTTPResponse()
                                                 .getHeaderMap());
                             }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/IdentityService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/IdentityService.java
@@ -1,0 +1,31 @@
+package uk.gov.di.authentication.oidc.services;
+
+import com.nimbusds.oauth2.sdk.token.BearerTokenError;
+import uk.gov.di.authentication.oidc.entity.AccessTokenInfo;
+import uk.gov.di.authentication.oidc.entity.IdentityResponse;
+import uk.gov.di.authentication.shared.entity.SPOTCredential;
+import uk.gov.di.authentication.shared.exceptions.AccessTokenException;
+import uk.gov.di.authentication.shared.services.DynamoSpotService;
+
+import java.util.Optional;
+
+public class IdentityService {
+
+    private final DynamoSpotService spotService;
+
+    public IdentityService(DynamoSpotService spotService) {
+        this.spotService = spotService;
+    }
+
+    public IdentityResponse populateIdentityResponse(AccessTokenInfo accessTokenInfo)
+            throws AccessTokenException {
+        Optional<SPOTCredential> spotCredential =
+                spotService.getSpotCredential(accessTokenInfo.getPublicSubject());
+        if (spotCredential.isEmpty()) {
+            throw new AccessTokenException("Invalid Access Token", BearerTokenError.INVALID_TOKEN);
+        }
+        return new IdentityResponse(
+                spotCredential.get().getSubjectID(),
+                spotCredential.get().getSerializedCredential());
+    }
+}

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/IdentityHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/IdentityHandlerTest.java
@@ -7,23 +7,33 @@ import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.oidc.entity.IdentityErrorResponse;
+import uk.gov.di.authentication.oidc.services.AccessTokenService;
+import uk.gov.di.authentication.shared.exceptions.AccessTokenException;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
+import java.util.List;
 import java.util.Map;
 
+import static com.nimbusds.oauth2.sdk.token.BearerTokenError.INVALID_TOKEN;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 class IdentityHandlerTest {
 
     private ConfigurationService configurationService = mock(ConfigurationService.class);
+    private final AccessTokenService accessTokenService = mock(AccessTokenService.class);
+    private static final Map<String, List<String>> INVALID_TOKEN_RESPONSE =
+            new IdentityErrorResponse(INVALID_TOKEN).toHTTPResponse().getHeaderMap();
     private final Context context = mock(Context.class);
     private IdentityHandler handler;
 
     @BeforeEach
     void setUp() {
-        handler = new IdentityHandler(configurationService);
+        handler = new IdentityHandler(configurationService, accessTokenService);
     }
 
     @Test
@@ -42,5 +52,19 @@ class IdentityHandlerTest {
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(401));
+    }
+
+    @Test
+    void shouldReturn401WhenBearerTokenIsNotParseable() throws AccessTokenException {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        event.setHeaders(Map.of("Authorization", "this-is-not-a-valid-token"));
+        AccessTokenException accessTokenException =
+                new AccessTokenException("Unable to parse AccessToken", INVALID_TOKEN);
+        when(accessTokenService.parse("this-is-not-a-valid-token")).thenThrow(accessTokenException);
+
+        APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
+
+        assertThat(result, hasStatus(401));
+        assertEquals(INVALID_TOKEN_RESPONSE, result.getMultiValueHeaders());
     }
 }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandlerTest.java
@@ -79,10 +79,9 @@ public class UserInfoHandlerTest {
     void shouldReturn401WhenBearerTokenIsNotParseable() throws AccessTokenException {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setHeaders(Map.of("Authorization", "this-is-not-a-valid-token"));
-        AccessTokenException userInfoValidationException =
+        AccessTokenException accessTokenException =
                 new AccessTokenException("Unable to parse AccessToken", INVALID_TOKEN);
-        when(accessTokenService.parse("this-is-not-a-valid-token"))
-                .thenThrow(userInfoValidationException);
+        when(accessTokenService.parse("this-is-not-a-valid-token")).thenThrow(accessTokenException);
 
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/ApiGatewayHandlerIntegrationTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/ApiGatewayHandlerIntegrationTest.java
@@ -13,6 +13,7 @@ import uk.gov.di.authentication.sharedtest.extensions.ClientStoreExtension;
 import uk.gov.di.authentication.sharedtest.extensions.KmsKeyExtension;
 import uk.gov.di.authentication.sharedtest.extensions.ParameterStoreExtension;
 import uk.gov.di.authentication.sharedtest.extensions.RedisExtension;
+import uk.gov.di.authentication.sharedtest.extensions.SPOTStoreExtension;
 import uk.gov.di.authentication.sharedtest.extensions.SnsTopicExtension;
 import uk.gov.di.authentication.sharedtest.extensions.SqsQueueExtension;
 import uk.gov.di.authentication.sharedtest.extensions.TokenSigningExtension;
@@ -92,6 +93,9 @@ public abstract class ApiGatewayHandlerIntegrationTest {
 
     @RegisterExtension
     protected static final ClientStoreExtension clientStore = new ClientStoreExtension();
+
+    @RegisterExtension
+    protected static final SPOTStoreExtension spotStore = new SPOTStoreExtension();
 
     protected APIGatewayProxyResponseEvent makeRequest(
             Optional<Object> body, Map<String, String> headers, Map<String, String> queryString) {

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/SPOTStoreExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/SPOTStoreExtension.java
@@ -1,0 +1,55 @@
+package uk.gov.di.authentication.sharedtest.extensions;
+
+import com.amazonaws.services.dynamodbv2.model.AttributeDefinition;
+import com.amazonaws.services.dynamodbv2.model.BillingMode;
+import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
+import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import uk.gov.di.authentication.shared.services.DynamoSpotService;
+
+import java.util.Optional;
+
+import static com.amazonaws.services.dynamodbv2.model.KeyType.HASH;
+import static com.amazonaws.services.dynamodbv2.model.ScalarAttributeType.S;
+
+public class SPOTStoreExtension extends DynamoExtension implements AfterEachCallback {
+
+    public static final String SUBJECT_ID_FIELD = "SubjectID";
+    public static final String SPOT_TABLE = "local-spot-credential";
+
+    private DynamoSpotService dynamoService;
+
+    @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+        super.beforeAll(context);
+        dynamoService =
+                new DynamoSpotService(REGION, ENVIRONMENT, Optional.of(DYNAMO_ENDPOINT), 300);
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) throws Exception {
+        clearDynamoTable(dynamoDB, SPOT_TABLE, SUBJECT_ID_FIELD);
+    }
+
+    @Override
+    protected void createTables() {
+        if (!tableExists(SPOT_TABLE)) {
+            createUserProfileTable(SPOT_TABLE);
+        }
+    }
+
+    public void addCredential(String subjectID, String serializedCredential) {
+        dynamoService.addSpotResponse(subjectID, serializedCredential);
+    }
+
+    private void createUserProfileTable(String tableName) {
+        CreateTableRequest request =
+                new CreateTableRequest()
+                        .withTableName(tableName)
+                        .withKeySchema(new KeySchemaElement(SUBJECT_ID_FIELD, HASH))
+                        .withBillingMode(BillingMode.PAY_PER_REQUEST)
+                        .withAttributeDefinitions(new AttributeDefinition(SUBJECT_ID_FIELD, S));
+        dynamoDB.createTable(request);
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoSpotService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoSpotService.java
@@ -58,6 +58,10 @@ public class DynamoSpotService {
         spotCredentialMapper.save(spotCredential);
     }
 
+    public Optional<SPOTCredential> getSpotCredential(String subjectID) {
+        return Optional.ofNullable(spotCredentialMapper.load(SPOTCredential.class, subjectID));
+    }
+
     private void warmUp(String tableName) {
         dynamoDB.describeTable(tableName);
     }


### PR DESCRIPTION
## What - Code changes?

 - Parse the access token in the IdentityHandler
 - Return Identity response from Identity lambda which is populated from the SPOT table 
- Create a IdentityErrorResponse which will be returned to the RP in the case of an error. This is more or less the same as the UserInfoErrorResponse
- Add a SPOTStoreExtension for the Integration test
 

## What - Terraform changes?

 - Restrict permissions to the Identity lambda for reading from the SPOT table
- Give the SpotResponse lambda the permissions to write to the SPOT table. (The permissions were created in a previous PR but never assigned)


## Why?

- So the identity lambda can validate an access token and return the required identity information to the RP