### PR TITLE
AUTH-1314 - Delete identity credential after use

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/IdentityService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/IdentityService.java
@@ -24,6 +24,7 @@ public class IdentityService {
         if (spotCredential.isEmpty()) {
             throw new AccessTokenException("Invalid Access Token", BearerTokenError.INVALID_TOKEN);
         }
+        spotService.removeSpotCredential(accessTokenInfo.getPublicSubject());
         return new IdentityResponse(
                 spotCredential.get().getSubjectID(),
                 spotCredential.get().getSerializedCredential());

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/IdentityServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/IdentityServiceTest.java
@@ -1,0 +1,97 @@
+package uk.gov.di.authentication.oidc.services;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.oauth2.sdk.id.Subject;
+import com.nimbusds.oauth2.sdk.token.AccessToken;
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
+import com.nimbusds.oauth2.sdk.token.BearerTokenError;
+import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.oidc.entity.AccessTokenInfo;
+import uk.gov.di.authentication.oidc.entity.IdentityResponse;
+import uk.gov.di.authentication.shared.entity.AccessTokenStore;
+import uk.gov.di.authentication.shared.entity.SPOTCredential;
+import uk.gov.di.authentication.shared.exceptions.AccessTokenException;
+import uk.gov.di.authentication.shared.services.DynamoSpotService;
+import uk.gov.di.authentication.sharedtest.helper.SignedCredentialHelper;
+import uk.gov.di.authentication.sharedtest.helper.TokenGeneratorHelper;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class IdentityServiceTest {
+
+    private final DynamoSpotService dynamoSpotService = mock(DynamoSpotService.class);
+    private IdentityService identityService;
+    private static final Subject INTERNAL_SUBJECT = new Subject("internal-subject");
+    private static final Subject SUBJECT = new Subject("some-subject");
+    private static final List<String> SCOPES =
+            List.of(
+                    OIDCScopeValue.OPENID.getValue(),
+                    OIDCScopeValue.EMAIL.getValue(),
+                    OIDCScopeValue.PHONE.getValue());
+    private static final String CLIENT_ID = "client-id";
+    private static final String BASE_URL = "http://example.com";
+    private String serializedCredential = SignedCredentialHelper.generateCredential().serialize();
+    private SPOTCredential spotCredential =
+            new SPOTCredential()
+                    .setSubjectID(SUBJECT.getValue())
+                    .setSerializedCredential(serializedCredential);
+    private AccessToken accessToken;
+
+    @BeforeEach
+    void setUp() throws JOSEException {
+        identityService = new IdentityService(dynamoSpotService);
+        accessToken =
+                new BearerAccessToken(
+                        TokenGeneratorHelper.generateSignedTokenWithGeneratedKey(
+                                        CLIENT_ID, BASE_URL, SCOPES, SUBJECT)
+                                .serialize());
+    }
+
+    @Test
+    void shouldReturnIdentityResponseAndDeleteSpotCredential() throws AccessTokenException {
+        AccessTokenStore accessTokenStore =
+                new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
+        AccessTokenInfo accessTokenInfo =
+                new AccessTokenInfo(accessTokenStore, SUBJECT.getValue(), SCOPES);
+
+        when(dynamoSpotService.getSpotCredential(accessTokenInfo.getPublicSubject()))
+                .thenReturn(Optional.of(spotCredential));
+
+        IdentityResponse identityResponse =
+                identityService.populateIdentityResponse(accessTokenInfo);
+
+        verify(dynamoSpotService).removeSpotCredential(accessTokenInfo.getPublicSubject());
+        assertThat(identityResponse.getSub(), equalTo(accessTokenInfo.getPublicSubject()));
+        assertThat(identityResponse.getIdentityCredential(), equalTo(serializedCredential));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenSpotCredentialIsNotFound() {
+        AccessTokenStore accessTokenStore =
+                new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
+        AccessTokenInfo accessTokenInfo =
+                new AccessTokenInfo(accessTokenStore, SUBJECT.getValue(), SCOPES);
+        when(dynamoSpotService.getSpotCredential(accessTokenInfo.getPublicSubject()))
+                .thenReturn(Optional.empty());
+
+        AccessTokenException accessTokenException =
+                assertThrows(
+                        AccessTokenException.class,
+                        () -> identityService.populateIdentityResponse(accessTokenInfo));
+
+        assertThat(accessTokenException.getError(), equalTo(BearerTokenError.INVALID_TOKEN));
+        assertThat(accessTokenException.getMessage(), equalTo("Invalid Access Token"));
+        verify(dynamoSpotService, never()).removeSpotCredential(accessTokenInfo.getPublicSubject());
+    }
+}

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/SPOTStoreExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/SPOTStoreExtension.java
@@ -6,6 +6,7 @@ import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
 import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import uk.gov.di.authentication.shared.entity.SPOTCredential;
 import uk.gov.di.authentication.shared.services.DynamoSpotService;
 
 import java.util.Optional;
@@ -41,6 +42,10 @@ public class SPOTStoreExtension extends DynamoExtension implements AfterEachCall
 
     public void addCredential(String subjectID, String serializedCredential) {
         dynamoService.addSpotResponse(subjectID, serializedCredential);
+    }
+
+    public Optional<SPOTCredential> getSpotCredential(String subjectID) {
+        return dynamoService.getSpotCredential(subjectID);
     }
 
     private void createUserProfileTable(String tableName) {

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/SignedCredentialHelper.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/SignedCredentialHelper.java
@@ -1,0 +1,34 @@
+package uk.gov.di.authentication.sharedtest.helper;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+
+public class SignedCredentialHelper {
+
+    private SignedCredentialHelper() {}
+
+    public static SignedJWT generateCredential() {
+        try {
+            ECKey ecSigningKey =
+                    new ECKeyGenerator(Curve.P_256).algorithm(JWSAlgorithm.ES256).generate();
+            JWSSigner signer = new ECDSASigner(ecSigningKey);
+            JWSHeader jwsHeader =
+                    new JWSHeader.Builder(JWSAlgorithm.ES256)
+                            .keyID(ecSigningKey.getKeyID())
+                            .build();
+            var signedJWT = new SignedJWT(jwsHeader, new JWTClaimsSet.Builder().build());
+            signedJWT.sign(signer);
+            return signedJWT;
+        } catch (JOSEException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/TokenGeneratorHelper.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/TokenGeneratorHelper.java
@@ -6,9 +6,11 @@ import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jose.JWSSigner;
 import com.nimbusds.jose.crypto.ECDSASigner;
 import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.Curve;
 import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.ParseException;
@@ -24,6 +26,8 @@ import java.util.List;
 import java.util.UUID;
 
 public class TokenGeneratorHelper {
+
+    private static final String KEY_ID = "14342354354353";
 
     public static SignedJWT generateIDToken(
             String clientId, Subject subject, String issuerUrl, JWK signingKey) {
@@ -63,6 +67,18 @@ public class TokenGeneratorHelper {
         } catch (JOSEException | ParseException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public static SignedJWT generateSignedTokenWithGeneratedKey(
+            String clientId, String issuerUrl, List<String> scopes, Subject subject)
+            throws JOSEException {
+        ECKey ecSigningKey =
+                new ECKeyGenerator(Curve.P_256)
+                        .keyID(KEY_ID)
+                        .algorithm(JWSAlgorithm.ES256)
+                        .generate();
+        ECDSASigner signer = new ECDSASigner(ecSigningKey);
+        return generateSignedToken(clientId, issuerUrl, scopes, signer, subject, KEY_ID);
     }
 
     public static SignedJWT generateSignedToken(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoSpotService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoSpotService.java
@@ -62,6 +62,10 @@ public class DynamoSpotService {
         return Optional.ofNullable(spotCredentialMapper.load(SPOTCredential.class, subjectID));
     }
 
+    public void removeSpotCredential(String subjectID) {
+        spotCredentialMapper.delete(spotCredentialMapper.load(SPOTCredential.class, subjectID));
+    }
+
     private void warmUp(String tableName) {
         dynamoDB.describeTable(tableName);
     }


### PR DESCRIPTION
## What?

 - Delete identity credential after use
- Add missing tests for the IdentityService
- Create a new Helper for generating a Signed Credential

## Why?

-  The Identity credential can only be used once, therefore once we have received it from Dynamo we should make sure we delete it.
