### PR TITLE
BAU: Refactoring 202220128 (`NotificationType`)

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandler.java
@@ -83,8 +83,7 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                             notificationService.sendEmail(
                                     notifyRequest.getDestination(),
                                     notifyPersonalisation,
-                                    notificationService.getNotificationTemplateId(
-                                            ACCOUNT_CREATED_CONFIRMATION));
+                                    ACCOUNT_CREATED_CONFIRMATION);
                             break;
                         case VERIFY_EMAIL:
                             notifyPersonalisation.put("validation-code", notifyRequest.getCode());
@@ -93,22 +92,19 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                             notificationService.sendEmail(
                                     notifyRequest.getDestination(),
                                     notifyPersonalisation,
-                                    notificationService.getNotificationTemplateId(VERIFY_EMAIL));
+                                    VERIFY_EMAIL);
                             break;
                         case VERIFY_PHONE_NUMBER:
                             notifyPersonalisation.put("validation-code", notifyRequest.getCode());
                             notificationService.sendText(
                                     notifyRequest.getDestination(),
                                     notifyPersonalisation,
-                                    notificationService.getNotificationTemplateId(
-                                            VERIFY_PHONE_NUMBER));
+                                    VERIFY_PHONE_NUMBER);
                             break;
                         case MFA_SMS:
                             notifyPersonalisation.put("validation-code", notifyRequest.getCode());
                             notificationService.sendText(
-                                    notifyRequest.getDestination(),
-                                    notifyPersonalisation,
-                                    notificationService.getNotificationTemplateId(MFA_SMS));
+                                    notifyRequest.getDestination(), notifyPersonalisation, MFA_SMS);
                             break;
                         case RESET_PASSWORD:
                             notifyPersonalisation.put(
@@ -116,7 +112,7 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                             notificationService.sendEmail(
                                     notifyRequest.getDestination(),
                                     notifyPersonalisation,
-                                    notificationService.getNotificationTemplateId(RESET_PASSWORD));
+                                    RESET_PASSWORD);
                             break;
                         case PASSWORD_RESET_CONFIRMATION:
                             Map<String, Object> passwordResetConfirmationPersonalisation =
@@ -131,8 +127,7 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                             notificationService.sendEmail(
                                     notifyRequest.getDestination(),
                                     passwordResetConfirmationPersonalisation,
-                                    notificationService.getNotificationTemplateId(
-                                            PASSWORD_RESET_CONFIRMATION));
+                                    PASSWORD_RESET_CONFIRMATION);
                             break;
                     }
                     writeTestClientOtpToS3(notifyRequest.getCode(), notifyRequest.getDestination());

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/NotificationServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/NotificationServiceTest.java
@@ -1,6 +1,7 @@
 package uk.gov.di.authentication.frontendapi.services;
 
 import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.entity.TemplateAware;
 import uk.gov.di.authentication.shared.services.NotificationService;
 import uk.gov.service.notify.NotificationClient;
 import uk.gov.service.notify.NotificationClientException;
@@ -10,6 +11,8 @@ import java.util.Map;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static uk.gov.di.authentication.frontendapi.services.NotificationServiceTest.FakeNotificationType.FAKE_EMAIL;
+import static uk.gov.di.authentication.frontendapi.services.NotificationServiceTest.FakeNotificationType.FAKE_SMS;
 
 class NotificationServiceTest {
 
@@ -19,24 +22,32 @@ class NotificationServiceTest {
     private final NotificationService notificationService =
             new NotificationService(notificationClient);
 
+    enum FakeNotificationType implements TemplateAware {
+        FAKE_EMAIL,
+        FAKE_SMS;
+
+        public String getTemplateId() {
+            return name();
+        }
+    }
+
     @Test
     public void shouldCallNotifyClientToSendEmail() throws NotificationClientException {
         Map<String, Object> emailPersonalisation = new HashMap<>();
         emailPersonalisation.put("validation-code", "some-code");
         emailPersonalisation.put("email-address", TEST_EMAIL);
-        String templateId = "email-template-id";
-        notificationService.sendEmail(TEST_EMAIL, emailPersonalisation, templateId);
 
-        verify(notificationClient).sendEmail(templateId, TEST_EMAIL, emailPersonalisation, "");
+        notificationService.sendEmail(TEST_EMAIL, emailPersonalisation, FAKE_EMAIL);
+
+        verify(notificationClient).sendEmail("FAKE_EMAIL", TEST_EMAIL, emailPersonalisation, "");
     }
 
     @Test
     public void shouldCallNotifyClientToSendText() throws NotificationClientException {
         Map<String, Object> phonePersonalisation = new HashMap<>();
         phonePersonalisation.put("validation-code", "some-code");
-        String templateId = "phone-template-id";
-        notificationService.sendText(TEST_PHONE_NUMBER, phonePersonalisation, templateId);
+        notificationService.sendText(TEST_PHONE_NUMBER, phonePersonalisation, FAKE_SMS);
 
-        verify(notificationClient).sendSms(templateId, TEST_PHONE_NUMBER, phonePersonalisation, "");
+        verify(notificationClient).sendSms("FAKE_SMS", TEST_PHONE_NUMBER, phonePersonalisation, "");
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/NotificationType.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/NotificationType.java
@@ -1,10 +1,20 @@
 package uk.gov.di.authentication.shared.entity;
 
-public enum NotificationType {
-    VERIFY_EMAIL,
-    VERIFY_PHONE_NUMBER,
-    MFA_SMS,
-    RESET_PASSWORD,
-    PASSWORD_RESET_CONFIRMATION,
-    ACCOUNT_CREATED_CONFIRMATION
+public enum NotificationType implements TemplateAware {
+    VERIFY_EMAIL("VERIFY_EMAIL_TEMPLATE_ID"),
+    VERIFY_PHONE_NUMBER("VERIFY_PHONE_NUMBER_TEMPLATE_ID"),
+    MFA_SMS("MFA_SMS_TEMPLATE_ID"),
+    RESET_PASSWORD("RESET_PASSWORD_TEMPLATE_ID"),
+    PASSWORD_RESET_CONFIRMATION("PASSWORD_RESET_CONFIRMATION_TEMPLATE_ID"),
+    ACCOUNT_CREATED_CONFIRMATION("ACCOUNT_CREATED_CONFIRMATION_TEMPLATE_ID");
+
+    private final String templateName;
+
+    NotificationType(String templateName) {
+        this.templateName = templateName;
+    }
+
+    public String getTemplateId() {
+        return System.getenv(templateName);
+    }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/TemplateAware.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/TemplateAware.java
@@ -1,0 +1,5 @@
+package uk.gov.di.authentication.shared.entity;
+
+public interface TemplateAware {
+    String getTemplateId();
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/NotificationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/NotificationService.java
@@ -1,6 +1,6 @@
 package uk.gov.di.authentication.shared.services;
 
-import uk.gov.di.authentication.shared.entity.NotificationType;
+import uk.gov.di.authentication.shared.entity.TemplateAware;
 import uk.gov.service.notify.NotificationClient;
 import uk.gov.service.notify.NotificationClientException;
 
@@ -14,32 +14,14 @@ public class NotificationService {
         this.notifyClient = notifyClient;
     }
 
-    public void sendEmail(String email, Map<String, Object> personalisation, String templateId)
+    public void sendEmail(String email, Map<String, Object> personalisation, TemplateAware type)
             throws NotificationClientException {
-        notifyClient.sendEmail(templateId, email, personalisation, "");
+        notifyClient.sendEmail(type.getTemplateId(), email, personalisation, "");
     }
 
-    public void sendText(String phoneNumber, Map<String, Object> personalisation, String templateId)
+    public void sendText(
+            String phoneNumber, Map<String, Object> personalisation, TemplateAware type)
             throws NotificationClientException {
-        notifyClient.sendSms(templateId, phoneNumber, personalisation, "");
-    }
-
-    public String getNotificationTemplateId(NotificationType notificationType) {
-        switch (notificationType) {
-            case VERIFY_EMAIL:
-                return System.getenv("VERIFY_EMAIL_TEMPLATE_ID");
-            case VERIFY_PHONE_NUMBER:
-                return System.getenv("VERIFY_PHONE_NUMBER_TEMPLATE_ID");
-            case MFA_SMS:
-                return System.getenv("MFA_SMS_TEMPLATE_ID");
-            case RESET_PASSWORD:
-                return System.getenv("RESET_PASSWORD_TEMPLATE_ID");
-            case PASSWORD_RESET_CONFIRMATION:
-                return System.getenv("PASSWORD_RESET_CONFIRMATION_TEMPLATE_ID");
-            case ACCOUNT_CREATED_CONFIRMATION:
-                return System.getenv("ACCOUNT_CREATED_CONFIRMATION_TEMPLATE_ID");
-            default:
-                throw new RuntimeException("NotificationType template ID does not exist");
-        }
+        notifyClient.sendSms(type.getTemplateId(), phoneNumber, personalisation, "");
     }
 }


### PR DESCRIPTION
Each `NotificationType` constant knows its template environment variable, and corresponding value of the lookup. We don't need a separate method to look those up.

This pushes that knowledge into the `NotificationType` enum and adds a `TemplateAware` interface to make testing interactions simpler by removing the need for a `System.getenv()` call.
