### PR TITLE
AUTH-1344 - Update loc values to be numeric

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -124,7 +124,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                                 Optional.of(CLIENT_ID),
                                 Optional.empty(),
                                 "openid",
-                                Optional.of("Pm.Cl.Cm")));
+                                Optional.of("P2.Cl.Cm")));
         assertThat(response, hasStatus(302));
         assertThat(
                 getHeaderValueByParamName(response, ResponseHeaders.LOCATION),

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
@@ -88,8 +88,8 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         return Stream.of(
                 Optional.of("Cl.Cm"),
                 Optional.of("Cl"),
-                Optional.of("Pm.Cl.Cm"),
-                Optional.of("Pm.Cl"),
+                Optional.of("P2.Cl.Cm"),
+                Optional.of("P2.Cl"),
                 Optional.empty());
     }
 
@@ -139,7 +139,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         setUpDynamo(keyPair, scope, new Subject());
         var response =
                 generateTokenRequest(
-                        keyPair, scope, Optional.of("Pm.Cl.Cm"), Optional.of(oidcClaimsRequest));
+                        keyPair, scope, Optional.of("P2.Cl.Cm"), Optional.of(oidcClaimsRequest));
 
         assertThat(response, hasStatus(200));
         JSONObject jsonResponse = JSONObjectUtils.parse(response.getBody());

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
@@ -133,7 +133,7 @@ public class TokenHandlerTest {
     }
 
     private static Stream<String> validVectorValues() {
-        return Stream.of("Cl.Cm", "Cl", "Pm.Cl.Cm", "Pm.Cl");
+        return Stream.of("Cl.Cm", "Cl", "P2.Cl.Cm", "P2.Cl");
     }
 
     @ParameterizedTest

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/LevelOfConfidence.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/LevelOfConfidence.java
@@ -5,10 +5,10 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public enum LevelOfConfidence {
-    LOW_LEVEL("Pl", false),
-    MEDIUM_LEVEL("Pm", true),
-    HIGH_LEVEL("Ph", false),
-    VERY_HIGH_LEVEL("Pv", false);
+    LOW_LEVEL("P1", false),
+    MEDIUM_LEVEL("P2", true),
+    HIGH_LEVEL("P3", false),
+    VERY_HIGH_LEVEL("P4", false);
 
     private String value;
     private boolean supported;

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/CredentialTrustLevelTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/CredentialTrustLevelTest.java
@@ -42,6 +42,6 @@ class CredentialTrustLevelTest {
     }
 
     private static Stream<String> invalidCredentialTrustLevelValues() {
-        return Stream.of("Cm", "Cm.Cl", "Cl.Cm.Cl.Cm", "Pm.Cl.Cm");
+        return Stream.of("Cm", "Cm.Cl", "Cl.Cm.Cl.Cm", "P2.Cl.Cm");
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/LevelOfConfidenceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/LevelOfConfidenceTest.java
@@ -58,17 +58,17 @@ class LevelOfConfidenceTest {
     }
 
     private static Stream<Arguments> supportedLevelOfConfidence() {
-        return Stream.of(Arguments.of("Pm", LevelOfConfidence.MEDIUM_LEVEL));
+        return Stream.of(Arguments.of("P2", LevelOfConfidence.MEDIUM_LEVEL));
     }
 
     private static Stream<Arguments> unsupportedLevelOfConfidence() {
         return Stream.of(
-                Arguments.of("Pl", LevelOfConfidence.LOW_LEVEL),
-                Arguments.of("Ph", LevelOfConfidence.HIGH_LEVEL),
-                Arguments.of("Pv", LevelOfConfidence.VERY_HIGH_LEVEL));
+                Arguments.of("P1", LevelOfConfidence.LOW_LEVEL),
+                Arguments.of("P3", LevelOfConfidence.HIGH_LEVEL),
+                Arguments.of("P4", LevelOfConfidence.VERY_HIGH_LEVEL));
     }
 
     private static Stream<Arguments> invalidLevelOfConfidence() {
-        return Stream.of(Arguments.of("Pm.Pl"), Arguments.of("Cl.Cm"), Arguments.of("Pm.Ph.Cl"));
+        return Stream.of(Arguments.of("P2.P1"), Arguments.of("Cl.Cm"), Arguments.of("P2.P3.Cl"));
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/VectorOfTrustTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/VectorOfTrustTest.java
@@ -53,7 +53,7 @@ class VectorOfTrustTest {
 
     @Test
     void shouldParseValidStringWithSingleIdentityVector() {
-        var jsonArray = jsonArrayOf("Pm.Cl.Cm");
+        var jsonArray = jsonArrayOf("P2.Cl.Cm");
         VectorOfTrust vectorOfTrust =
                 VectorOfTrust.parseFromAuthRequestAttribute(Collections.singletonList(jsonArray));
         assertThat(vectorOfTrust.getCredentialTrustLevel(), equalTo(MEDIUM_LEVEL));
@@ -62,7 +62,7 @@ class VectorOfTrustTest {
 
     @Test
     void shouldParseToLowCredentialTrustLevelAndMediumLevelOfConfidence() {
-        var jsonArray = jsonArrayOf("Pm.Cl.Cm", "Pm.Cl");
+        var jsonArray = jsonArrayOf("P2.Cl.Cm", "P2.Cl");
         VectorOfTrust vectorOfTrust =
                 VectorOfTrust.parseFromAuthRequestAttribute(Collections.singletonList(jsonArray));
         assertThat(vectorOfTrust.getCredentialTrustLevel(), equalTo(LOW_LEVEL));
@@ -71,7 +71,7 @@ class VectorOfTrustTest {
 
     @Test
     void shouldThrowWhenUnsupportedIdentityValueInVector() {
-        var jsonArray = jsonArrayOf("Pm.Cl.Cm", "Ph.Cl");
+        var jsonArray = jsonArrayOf("P2.Cl.Cm", "P3.Cl");
         assertThrows(
                 IllegalArgumentException.class,
                 () ->
@@ -81,7 +81,7 @@ class VectorOfTrustTest {
 
     @Test
     void shouldThrowWhenIdentityValueIsNotFirstValueInVector() {
-        var jsonArray = jsonArrayOf("Cl.Cm.Pm");
+        var jsonArray = jsonArrayOf("Cl.Cm.P2");
         assertThrows(
                 IllegalArgumentException.class,
                 () ->
@@ -101,7 +101,7 @@ class VectorOfTrustTest {
 
     @Test
     void shouldThrowWhenOnlyIdentityLevelIsSentInRequest() {
-        var jsonArray = jsonArrayOf("Pm");
+        var jsonArray = jsonArrayOf("P2");
         assertThrows(
                 IllegalArgumentException.class,
                 () ->
@@ -115,12 +115,12 @@ class VectorOfTrustTest {
                 IllegalArgumentException.class,
                 () ->
                         VectorOfTrust.parseFromAuthRequestAttribute(
-                                Collections.singletonList(jsonArrayOf("Pm.Cm.Cl"))));
+                                Collections.singletonList(jsonArrayOf("P2.Cm.Cl"))));
     }
 
     @Test
     void shouldThrowWhenMultipleIdentityValuesArePresentInVector() {
-        var jsonArray = jsonArrayOf("Pl.Pb");
+        var jsonArray = jsonArrayOf("P1.Pb");
         assertThrows(
                 IllegalArgumentException.class,
                 () ->
@@ -147,7 +147,7 @@ class VectorOfTrustTest {
 
     @Test
     void shouldReturnCorrectlyFormattedVectorOfTrustForTokenWhenIdentityValuesArePresent() {
-        String vectorString = "Pm.Cl.Cm";
+        String vectorString = "P2.Cl.Cm";
 
         VectorOfTrust vectorOfTrust =
                 VectorOfTrust.parseFromAuthRequestAttribute(

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuthorizationServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuthorizationServiceTest.java
@@ -147,7 +147,7 @@ class AuthorizationServiceTest {
                         REDIRECT_URI.toString(),
                         responseType,
                         scope,
-                        jsonArrayOf("Pm.Cl.Cm", "Pm.Cl"),
+                        jsonArrayOf("P2.Cl.Cm", "P2.Cl"),
                         Optional.empty());
         Optional<ErrorObject> errorObject = authorizationService.validateAuthRequest(authRequest);
 
@@ -169,7 +169,7 @@ class AuthorizationServiceTest {
                         REDIRECT_URI.toString(),
                         responseType,
                         scope,
-                        jsonArrayOf("Cm.Cl.Pl", "Pl.Cl"),
+                        jsonArrayOf("Cm.Cl.P1", "P1.Cl"),
                         Optional.empty());
         Optional<ErrorObject> errorObject = authorizationService.validateAuthRequest(authRequest);
 


### PR DESCRIPTION
## What?

- Update loc values to be numeric

## Why?

- Our level of confidence values are currently ‘Pl’, ‘Pm’, ‘Ph’ and ‘Pv’. This is being changed to P1-P4 for low/medium/high/very high.
