### PR TITLE
AUTH-1343 - Add identity endpoint to oidc wellknown API

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/WellknownHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/WellknownHandler.java
@@ -109,6 +109,9 @@ public class WellknownHandler
                                         buildURI(baseUrl, "/logout"));
                                 providerMetadata.setCustomParameter(
                                         "trustmarks", buildURI(baseUrl, "/trustmark").toString());
+                                providerMetadata.setCustomParameter(
+                                        "identity_endpoint",
+                                        buildURI(baseUrl, "/identity").toString());
 
                                 return generateApiGatewayProxyResponse(
                                         200, providerMetadata.toString());


### PR DESCRIPTION


## What?
- Add identity endpoint to oidc wellknown API

## Why?

- This is so RPs will know the endpoint to request identity credentials
