### PR TITLE
AUTH-1290 - Ship blocked WAF requests to cloudwatch

### DIFF
--- a/ci/terraform/account-management/api-gateway.tf
+++ b/ci/terraform/account-management/api-gateway.tf
@@ -131,14 +131,6 @@ resource "aws_cloudwatch_log_group" "lambda_log_group" {
   ]
 }
 
-resource "aws_cloudwatch_log_group" "account_management_waf_logs" {
-  count = var.use_localstack ? 0 : 1
-
-  name              = "aws-waf-logs-account-management-${var.environment}"
-  retention_in_days = var.cloudwatch_log_retention
-  kms_key_id        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
-}
-
 resource "aws_iam_policy" "api_gateway_logging_policy" {
   name        = "${var.environment}-account-management-api-gateway-logging"
   path        = "/"
@@ -223,6 +215,22 @@ resource "aws_cloudwatch_log_subscription_filter" "account_management_access_log
   count           = var.logging_endpoint_enabled ? 1 : 0
   name            = "${var.environment}-account-management_-api-access-logs-subscription"
   log_group_name  = aws_cloudwatch_log_group.account_management_access_logs[0].name
+  filter_pattern  = ""
+  destination_arn = var.logging_endpoint_arn
+}
+
+resource "aws_cloudwatch_log_group" "account_management_waf_logs" {
+  count = var.use_localstack ? 0 : 1
+
+  name              = "aws-waf-logs-account-management-${var.environment}"
+  retention_in_days = var.cloudwatch_log_retention
+  kms_key_id        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+}
+
+resource "aws_cloudwatch_log_subscription_filter" "account_management_waf_log_subscription" {
+  count           = var.logging_endpoint_enabled ? 1 : 0
+  name            = "${var.environment}-account-management-api-waf-logs-subscription"
+  log_group_name  = aws_cloudwatch_log_group.account_management_waf_logs[0].name
   filter_pattern  = ""
   destination_arn = var.logging_endpoint_arn
 }

--- a/ci/terraform/account-management/api-gateway.tf
+++ b/ci/terraform/account-management/api-gateway.tf
@@ -131,6 +131,14 @@ resource "aws_cloudwatch_log_group" "lambda_log_group" {
   ]
 }
 
+resource "aws_cloudwatch_log_group" "account_management_waf_logs" {
+  count = var.use_localstack ? 0 : 1
+
+  name              = "aws-waf-logs-account-management-${var.environment}"
+  retention_in_days = var.cloudwatch_log_retention
+  kms_key_id        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+}
+
 resource "aws_iam_policy" "api_gateway_logging_policy" {
   name        = "${var.environment}-account-management-api-gateway-logging"
   path        = "/"
@@ -364,5 +372,31 @@ resource "aws_wafv2_web_acl_association" "waf_association_am_api" {
   depends_on = [
     aws_api_gateway_stage.stage,
     aws_wafv2_web_acl.wafregional_web_acl_am_api
+  ]
+}
+
+resource "aws_wafv2_web_acl_logging_configuration" "waf_logging_config_am_api" {
+  count                   = var.use_localstack ? 0 : 1
+  log_destination_configs = [aws_cloudwatch_log_group.account_management_waf_logs[count.index].arn]
+  resource_arn            = aws_wafv2_web_acl.wafregional_web_acl_am_api[count.index].arn
+
+  logging_filter {
+    default_behavior = "DROP"
+
+    filter {
+      behavior = "KEEP"
+
+      condition {
+        action_condition {
+          action = "BLOCK"
+        }
+      }
+
+      requirement = "MEETS_ANY"
+    }
+  }
+
+  depends_on = [
+    aws_cloudwatch_log_group.account_management_waf_logs
   ]
 }

--- a/ci/terraform/oidc/api-gateway-frontend.tf
+++ b/ci/terraform/oidc/api-gateway-frontend.tf
@@ -122,6 +122,14 @@ resource "aws_cloudwatch_log_group" "frontend_waf_logs" {
   kms_key_id        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
 }
 
+resource "aws_cloudwatch_log_subscription_filter" "frontend_api_waf_log_subscription" {
+  count           = var.logging_endpoint_enabled ? 1 : 0
+  name            = "${var.environment}-frontend-api-waf-logs-subscription"
+  log_group_name  = aws_cloudwatch_log_group.frontend_waf_logs[0].name
+  filter_pattern  = ""
+  destination_arn = var.logging_endpoint_arn
+}
+
 resource "aws_api_gateway_stage" "endpoint_frontend_stage" {
   deployment_id = aws_api_gateway_deployment.frontend_deployment.id
   rest_api_id   = aws_api_gateway_rest_api.di_authentication_frontend_api.id

--- a/ci/terraform/oidc/api-gateway-frontend.tf
+++ b/ci/terraform/oidc/api-gateway-frontend.tf
@@ -114,6 +114,14 @@ resource "aws_cloudwatch_log_subscription_filter" "frontend_api_access_log_subsc
   destination_arn = var.logging_endpoint_arn
 }
 
+resource "aws_cloudwatch_log_group" "frontend_waf_logs" {
+  count = var.use_localstack ? 0 : 1
+
+  name              = "aws-waf-logs-frontend-${var.environment}"
+  retention_in_days = var.cloudwatch_log_retention
+  kms_key_id        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+}
+
 resource "aws_api_gateway_stage" "endpoint_frontend_stage" {
   deployment_id = aws_api_gateway_deployment.frontend_deployment.id
   rest_api_id   = aws_api_gateway_rest_api.di_authentication_frontend_api.id
@@ -261,5 +269,31 @@ resource "aws_wafv2_web_acl_association" "waf_association_frontend_api" {
   depends_on = [
     aws_api_gateway_stage.endpoint_frontend_stage,
     aws_wafv2_web_acl.wafregional_web_acl_frontend_api
+  ]
+}
+
+resource "aws_wafv2_web_acl_logging_configuration" "waf_logging_config_frontend_api" {
+  count                   = var.use_localstack ? 0 : 1
+  log_destination_configs = [aws_cloudwatch_log_group.frontend_waf_logs[count.index].arn]
+  resource_arn            = aws_wafv2_web_acl.wafregional_web_acl_frontend_api[count.index].arn
+
+  logging_filter {
+    default_behavior = "DROP"
+
+    filter {
+      behavior = "KEEP"
+
+      condition {
+        action_condition {
+          action = "BLOCK"
+        }
+      }
+
+      requirement = "MEETS_ANY"
+    }
+  }
+
+  depends_on = [
+    aws_cloudwatch_log_group.frontend_waf_logs
   ]
 }

--- a/ci/terraform/oidc/api-gateway.tf
+++ b/ci/terraform/oidc/api-gateway.tf
@@ -181,6 +181,14 @@ resource "aws_cloudwatch_log_group" "oidc_stage_access_logs" {
   kms_key_id        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
 }
 
+resource "aws_cloudwatch_log_subscription_filter" "oidc_access_log_subscription" {
+  count           = var.logging_endpoint_enabled ? 1 : 0
+  name            = "${var.environment}-oidc-api-access-logs-subscription"
+  log_group_name  = aws_cloudwatch_log_group.oidc_stage_access_logs[0].name
+  filter_pattern  = ""
+  destination_arn = var.logging_endpoint_arn
+}
+
 resource "aws_cloudwatch_log_group" "oidc_waf_logs" {
   count = var.use_localstack ? 0 : 1
 
@@ -189,10 +197,10 @@ resource "aws_cloudwatch_log_group" "oidc_waf_logs" {
   kms_key_id        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
 }
 
-resource "aws_cloudwatch_log_subscription_filter" "oidc_access_log_subscription" {
+resource "aws_cloudwatch_log_subscription_filter" "oidc_waf_log_subscription" {
   count           = var.logging_endpoint_enabled ? 1 : 0
-  name            = "${var.environment}-oidc-api-access-logs-subscription"
-  log_group_name  = aws_cloudwatch_log_group.oidc_stage_access_logs[0].name
+  name            = "${var.environment}-oidc-api-waf-logs-subscription"
+  log_group_name  = aws_cloudwatch_log_group.oidc_waf_logs[0].name
   filter_pattern  = ""
   destination_arn = var.logging_endpoint_arn
 }


### PR DESCRIPTION
## What?

- Send the blocked WAF requests to cloudwatch so we can monitor and track such requests.

## Why?

- When the WAF blocks a request, we can only view it up to 3 hours after in the AWS console. This isn't ideal if we receive blocked requests during the night or at the weekend, as they would have disappeared by the time we come to look for them.
- We want the logs in the new Log group to send to Splunk. To do this we require a aws_cloudwatch_log_subscription_filter for each new log group