### PR TITLE
AUTH-1281: create new configuration for the contact-us route

### DIFF
--- a/ci/terraform/oidc/sqs.tf
+++ b/ci/terraform/oidc/sqs.tf
@@ -169,6 +169,7 @@ resource "aws_lambda_function" "email_sqs_lambda" {
       ACCOUNT_MANAGEMENT_URI      = module.dns.account_management_url
       RESET_PASSWORD_ROUTE        = var.reset_password_route
       CUSTOMER_SUPPORT_LINK_ROUTE = var.customer_support_link_route
+      CONTACT_US_LINK_ROUTE       = var.contact_us_link_route
       NOTIFY_API_KEY              = var.notify_api_key
       NOTIFY_URL                  = var.notify_url
       NOTIFY_TEST_PHONE_NUMBER    = var.notify_test_phone_number

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -149,6 +149,11 @@ variable "customer_support_link_route" {
   default = "support"
 }
 
+variable "contact_us_link_route" {
+  type    = string
+  default = "contact-us"
+}
+
 variable "dns_state_bucket" {
   type = string
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandler.java
@@ -80,8 +80,7 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                                     "sign-in-page-url",
                                     buildURI(configurationService.getAccountManagementURI())
                                             .toString());
-                            notifyPersonalisation.put(
-                                    "customer-support-link", buildCustomerSupportUrl());
+                            notifyPersonalisation.put("contact-us-link", buildContactUsUrl());
                             notificationService.sendEmail(
                                     notifyRequest.getDestination(),
                                     notifyPersonalisation,
@@ -91,8 +90,7 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                             notifyPersonalisation.put("validation-code", notifyRequest.getCode());
                             notifyPersonalisation.put(
                                     "email-address", notifyRequest.getDestination());
-                            notifyPersonalisation.put(
-                                    "customer-support-link", buildCustomerSupportUrl());
+                            notifyPersonalisation.put("contact-us-link", buildContactUsUrl());
                             notificationService.sendEmail(
                                     notifyRequest.getDestination(),
                                     notifyPersonalisation,
@@ -113,8 +111,7 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                         case RESET_PASSWORD:
                             notifyPersonalisation.put(
                                     "reset-password-link", notifyRequest.getCode());
-                            notifyPersonalisation.put(
-                                    "customer-support-link", buildCustomerSupportUrl());
+                            notifyPersonalisation.put("contact-us-link", buildContactUsUrl());
                             notificationService.sendEmail(
                                     notifyRequest.getDestination(),
                                     notifyPersonalisation,
@@ -155,6 +152,13 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
         return buildURI(
                         configurationService.getFrontendBaseUrl(),
                         configurationService.getCustomerSupportLinkRoute())
+                .toString();
+    }
+
+    private String buildContactUsUrl() {
+        return buildURI(
+                        configurationService.getFrontendBaseUrl(),
+                        configurationService.getContactUsLinkRoute())
                 .toString();
     }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandlerTest.java
@@ -42,7 +42,9 @@ public class NotificationHandlerTest {
     private static final String FRONTEND_BASE_URL = "https://localhost:8080/frontend";
     private static final String CUSTOMER_SUPPORT_LINK_URL =
             "https://localhost:8080/frontend/support";
+    private static final String CONTACT_US_LINK_URL = "https://localhost:8080/frontend/contact-us";
     private static final String CUSTOMER_SUPPORT_LINK_ROUTE = "support";
+    private static final String CONTACT_US_LINK_ROUTE = "contact-us";
     private final Context context = mock(Context.class);
     private final NotificationService notificationService = mock(NotificationService.class);
     private final ConfigurationService configService = mock(ConfigurationService.class);
@@ -56,6 +58,7 @@ public class NotificationHandlerTest {
         when(configService.getSmoketestBucketName()).thenReturn(BUCKET_NAME);
         when(configService.getFrontendBaseUrl()).thenReturn(FRONTEND_BASE_URL);
         when(configService.getCustomerSupportLinkRoute()).thenReturn(CUSTOMER_SUPPORT_LINK_ROUTE);
+        when(configService.getContactUsLinkRoute()).thenReturn(CONTACT_US_LINK_ROUTE);
         handler = new NotificationHandler(notificationService, configService, s3Client);
     }
 
@@ -72,7 +75,7 @@ public class NotificationHandlerTest {
         Map<String, Object> personalisation = new HashMap<>();
         personalisation.put("validation-code", "654321");
         personalisation.put("email-address", notifyRequest.getDestination());
-        personalisation.put("customer-support-link", CUSTOMER_SUPPORT_LINK_URL);
+        personalisation.put("contact-us-link", CONTACT_US_LINK_URL);
 
         verify(notificationService).sendEmail(TEST_EMAIL_ADDRESS, personalisation, VERIFY_EMAIL);
     }
@@ -106,7 +109,7 @@ public class NotificationHandlerTest {
 
         Map<String, Object> personalisation = new HashMap<>();
         personalisation.put("reset-password-link", TEST_RESET_PASSWORD_LINK);
-        personalisation.put("customer-support-link", CUSTOMER_SUPPORT_LINK_URL);
+        personalisation.put("contact-us-link", CONTACT_US_LINK_URL);
 
         verify(notificationService).sendEmail(TEST_EMAIL_ADDRESS, personalisation, RESET_PASSWORD);
     }
@@ -117,8 +120,6 @@ public class NotificationHandlerTest {
         String accountManagementUrl = "http://account-management/";
         String baseUrl = "http://account-management";
         when(configService.getAccountManagementURI()).thenReturn(baseUrl);
-        when(configService.getFrontendBaseUrl()).thenReturn(FRONTEND_BASE_URL);
-        when(configService.getCustomerSupportLinkRoute()).thenReturn(CUSTOMER_SUPPORT_LINK_ROUTE);
 
         NotifyRequest notifyRequest =
                 new NotifyRequest(TEST_EMAIL_ADDRESS, ACCOUNT_CREATED_CONFIRMATION);
@@ -129,7 +130,7 @@ public class NotificationHandlerTest {
 
         Map<String, Object> personalisation = new HashMap<>();
         personalisation.put("sign-in-page-url", accountManagementUrl);
-        personalisation.put("customer-support-link", CUSTOMER_SUPPORT_LINK_URL);
+        personalisation.put("contact-us-link", CONTACT_US_LINK_URL);
 
         verify(notificationService)
                 .sendEmail(TEST_EMAIL_ADDRESS, personalisation, ACCOUNT_CREATED_CONFIRMATION);
@@ -176,7 +177,7 @@ public class NotificationHandlerTest {
         Map<String, Object> personalisation = new HashMap<>();
         personalisation.put("validation-code", "654321");
         personalisation.put("email-address", notifyRequest.getDestination());
-        personalisation.put("customer-support-link", CUSTOMER_SUPPORT_LINK_URL);
+        personalisation.put("contact-us-link", CONTACT_US_LINK_URL);
         Mockito.doThrow(NotificationClientException.class)
                 .when(notificationService)
                 .sendEmail(TEST_EMAIL_ADDRESS, personalisation, VERIFY_EMAIL);

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -60,6 +60,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return Integer.parseInt(System.getenv().getOrDefault("CODE_MAX_RETRIES", "5"));
     }
 
+    public String getContactUsLinkRoute() {
+        return System.getenv().getOrDefault("CONTACT_US_LINK_ROUTE", "");
+    }
+
     public String getCustomerSupportLinkRoute() {
         return System.getenv().getOrDefault("CUSTOMER_SUPPORT_LINK_ROUTE", "");
     }


### PR DESCRIPTION
## What?

Create new configuration for the contact-us route.
Update NotificationHandler to send the contact-us-link to the account create, email confirmation and password reset templates in frontend api.

## Why?

The contact-us route is separate from the support route and goes to a different page.
Three templates need to be updated to link to the contact-us page.

## Related PRs

#1367 
