### PR TITLE
AUTH-1230: Reduce `error` to `warn` for user input issues

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthoriseAccessTokenHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthoriseAccessTokenHandler.java
@@ -86,7 +86,7 @@ public class AuthoriseAccessTokenHandler
                 Date currentDateTime =
                         Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
                 if (DateUtils.isBefore(claimsSet.getExpirationTime(), currentDateTime, 0)) {
-                    LOG.error(
+                    LOG.warn(
                             "Access Token expires at: {}. CurrentDateTime is: {}",
                             claimsSet.getExpirationTime(),
                             currentDateTime);
@@ -95,7 +95,7 @@ public class AuthoriseAccessTokenHandler
                 boolean isAccessTokenSignatureValid =
                         tokenValidationService.validateAccessTokenSignature(accessToken);
                 if (!isAccessTokenSignatureValid) {
-                    LOG.error("Access Token signature is not valid");
+                    LOG.warn("Access Token signature is not valid");
                     throw new RuntimeException("Unauthorized");
                 }
                 LOG.info("Successfully validated Access Token signature");
@@ -103,24 +103,24 @@ public class AuthoriseAccessTokenHandler
                 List<String> scopeList = claimsSet.getStringListClaim("scope");
                 if (scopeList == null
                         || !scopeList.contains(CustomScopeValue.ACCOUNT_MANAGEMENT.getValue())) {
-                    LOG.error("Access Token scope is not valid or missing");
+                    LOG.warn("Access Token scope is not valid or missing");
                     throw new RuntimeException("Unauthorized");
                 }
                 LOG.info("Successfully validated Access Token scope");
                 String clientId = claimsSet.getStringClaim("client_id");
                 if (clientId == null) {
-                    LOG.error("Access Token client_id is missing");
+                    LOG.warn("Access Token client_id is missing");
                     throw new RuntimeException("Unauthorized");
                 }
                 if (!clientService.isValidClient(clientId)) {
-                    LOG.error(
+                    LOG.warn(
                             "Access Token client_id does not exist in Dynamo. ClientId {}",
                             clientId);
                     throw new RuntimeException("Unauthorized");
                 }
                 String subject = claimsSet.getSubject();
                 if (subject == null) {
-                    LOG.error("Access Token subject is missing");
+                    LOG.warn("Access Token subject is missing");
                     throw new RuntimeException("Unauthorized");
                 }
                 try {
@@ -143,7 +143,7 @@ public class AuthoriseAccessTokenHandler
                         AuthPolicy.PolicyDocument.getAllowAllPolicy(
                                 region, awsAccountId, restApiId, stage));
             } catch (ParseException | java.text.ParseException e) {
-                LOG.error("Unable to parse Access Token");
+                LOG.warn("Unable to parse Access Token");
                 throw new RuntimeException("Unauthorized");
             }
         }

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandler.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandler.java
@@ -88,7 +88,7 @@ public class ClientRegistrationHandler
                                         validationService.validateClientRegistrationConfig(
                                                 clientRegistrationRequest);
                                 if (errorResponse.isPresent()) {
-                                    LOG.error(
+                                    LOG.warn(
                                             "Invalid Client registration request. Failed validation. Error Code: {}. Error description: {}",
                                             errorResponse.get().getCode(),
                                             errorResponse.get().getDescription());
@@ -141,7 +141,7 @@ public class ClientRegistrationHandler
                                 return generateApiGatewayProxyResponse(
                                         200, clientRegistrationResponse);
                             } catch (JsonProcessingException e) {
-                                LOG.error(
+                                LOG.warn(
                                         "Invalid Client registration request. Missing parameters from request");
                                 auditService.submitAuditEvent(
                                         REGISTER_CLIENT_REQUEST_ERROR,

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandler.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandler.java
@@ -99,7 +99,7 @@ public class UpdateClientConfigHandler
                                             ipAddress,
                                             AuditService.UNKNOWN,
                                             AuditService.UNKNOWN);
-                                    LOG.error("Invalid client id");
+                                    LOG.warn("Invalid client id");
                                     return generateApiGatewayProxyResponse(
                                             400,
                                             OAuth2Error.INVALID_CLIENT
@@ -110,7 +110,7 @@ public class UpdateClientConfigHandler
                                         validationService.validateClientUpdateConfig(
                                                 updateClientConfigRequest);
                                 if (errorResponse.isPresent()) {
-                                    LOG.error(
+                                    LOG.warn(
                                             "Failed validation. ErrorCode: {}. ErrorDescription: {}",
                                             errorResponse.get().getCode(),
                                             errorResponse.get().getDescription());
@@ -154,7 +154,7 @@ public class UpdateClientConfigHandler
                                         ipAddress,
                                         AuditService.UNKNOWN,
                                         AuditService.UNKNOWN);
-                                LOG.error(
+                                LOG.warn(
                                         "Invalid Client registration request. Missing parameters from request");
                                 return generateApiGatewayProxyResponse(
                                         400,

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
@@ -143,7 +143,7 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
             }
 
             if (!userContext.getSession().validateSession(email)) {
-                LOG.error("Email does not match Email in Request");
+                LOG.warn("Email does not match Email in Request");
 
                 auditService.submitAuditEvent(
                         FrontendAuditableEvent.MFA_MISMATCHED_EMAIL,
@@ -233,7 +233,7 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
         } catch (StateMachine.InvalidStateTransitionException e) {
             return generateApiGatewayProxyErrorResponse(400, ERROR_1017);
         } catch (ClientNotFoundException e) {
-            LOG.error("Client not found");
+            LOG.warn("Client not found");
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1015);
         }
     }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
@@ -161,7 +161,7 @@ public class SignUpHandler extends BaseFrontendHandler<SignupRequest>
                 return generateApiGatewayProxyErrorResponse(400, passwordValidationErrors.get());
             }
         } catch (JsonProcessingException e) {
-            LOG.error("Error parsing request");
+            LOG.warn("Error parsing request");
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
         } catch (StateMachine.InvalidStateTransitionException e) {
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1017);

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -142,7 +142,7 @@ public class AuthCodeHandler
                                 authenticationRequest = AuthenticationRequest.parse(authRequest);
                             } catch (ParseException e) {
                                 if (e.getRedirectionURI() == null) {
-                                    LOG.error(
+                                    LOG.warn(
                                             "Authentication request could not be parsed: redirect URI or Client ID is missing from auth request",
                                             e);
                                     // TODO - We need to come up with a strategy to handle uncaught
@@ -157,7 +157,7 @@ public class AuthCodeHandler
                                                 e.getState(),
                                                 e.getResponseMode(),
                                                 e.getErrorObject());
-                                LOG.error("Authentication request could not be parsed", e);
+                                LOG.warn("Authentication request could not be parsed", e);
                                 return new APIGatewayProxyResponseEvent()
                                         .withStatusCode(302)
                                         .withHeaders(
@@ -274,7 +274,7 @@ public class AuthCodeHandler
         AuthenticationErrorResponse errorResponse =
                 authorizationService.generateAuthenticationErrorResponse(
                         authenticationRequest, OAuth2Error.INVALID_CLIENT);
-        LOG.error("Client not found");
+        LOG.warn("Client not found");
         return new APIGatewayProxyResponseEvent()
                 .withStatusCode(302)
                 .withHeaders(Map.of(ResponseHeaders.LOCATION, errorResponse.toURI().toString()));

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -129,7 +129,7 @@ public class AuthorisationHandler
                                 authRequest = AuthenticationRequest.parse(queryStringParameters);
                             } catch (ParseException e) {
                                 if (e.getRedirectionURI() == null) {
-                                    LOG.error(
+                                    LOG.warn(
                                             "Authentication request could not be parsed: redirect URI or Client ID is missing from auth request");
                                     // TODO - We need to come up with a strategy to handle uncaught
                                     // exceptions
@@ -137,7 +137,7 @@ public class AuthorisationHandler
                                             "Redirect URI or ClientID is missing from auth request",
                                             e);
                                 }
-                                LOG.error("Authentication request could not be parsed", e);
+                                LOG.warn("Authentication request could not be parsed", e);
                                 return generateErrorResponse(
                                         e.getRedirectionURI(),
                                         e.getState(),

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/IdentityHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/IdentityHandler.java
@@ -70,7 +70,7 @@ public class IdentityHandler
                                     input.getHeaders(),
                                     AUTHORIZATION_HEADER,
                                     configurationService.getHeadersCaseInsensitive())) {
-                                LOG.error("AccessToken is missing from request");
+                                LOG.warn("AccessToken is missing from request");
                                 return generateApiGatewayProxyResponse(
                                         401,
                                         "",
@@ -91,7 +91,7 @@ public class IdentityHandler
                                 identityResponse =
                                         identityService.populateIdentityResponse(accessTokenInfo);
                             } catch (AccessTokenException e) {
-                                LOG.error(
+                                LOG.warn(
                                         "AccessTokenException. Sending back IdentityErrorResponse");
                                 return generateApiGatewayProxyResponse(
                                         401,
@@ -105,7 +105,7 @@ public class IdentityHandler
                             try {
                                 return generateApiGatewayProxyResponse(200, identityResponse);
                             } catch (JsonProcessingException e) {
-                                LOG.error("Unable to searlize the IdentityResponse");
+                                LOG.warn("Unable to serialize the IdentityResponse");
                                 throw new RuntimeException(e);
                             }
                         });

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
@@ -127,7 +127,7 @@ public class LogoutHandler
         LOG.info("LogoutHandler processing request");
 
         if (!session.getClientSessions().contains(sessionCookieIds.getClientSessionId())) {
-            LOG.error("Client Session ID does not exist");
+            LOG.warn("Client Session ID does not exist");
             return generateErrorLogoutResponse(
                     Optional.empty(),
                     new ErrorObject(OAuth2Error.INVALID_REQUEST_CODE, "invalid session"),
@@ -153,7 +153,7 @@ public class LogoutHandler
 
         if (idTokenHint.isPresent()) {
             if (!doesIDTokenExistInSession(idTokenHint.get(), session)) {
-                LOG.error("ID token does not exist");
+                LOG.warn("ID token does not exist");
                 return generateErrorLogoutResponse(
                         Optional.empty(),
                         new ErrorObject(
@@ -165,7 +165,7 @@ public class LogoutHandler
                         Optional.of(session.getSessionId()));
             }
             if (!tokenValidationService.isTokenSignatureValid(idTokenHint.get())) {
-                LOG.error("Unable to validate ID token signature");
+                LOG.warn("Unable to validate ID token signature");
                 return generateErrorLogoutResponse(
                         Optional.empty(),
                         new ErrorObject(
@@ -181,7 +181,7 @@ public class LogoutHandler
                 SignedJWT idToken = SignedJWT.parse(idTokenHint.get());
                 audience = idToken.getJWTClaimsSet().getAudience().stream().findFirst();
             } catch (ParseException e) {
-                LOG.error("Unable to parse id_token_hint into SignedJWT");
+                LOG.warn("Unable to parse id_token_hint into SignedJWT");
                 return generateErrorLogoutResponse(
                         Optional.empty(),
                         new ErrorObject(OAuth2Error.INVALID_REQUEST_CODE, "invalid id_token_hint"),
@@ -216,7 +216,7 @@ public class LogoutHandler
         LOG.info("Validating ClientID");
         Optional<ClientRegistry> clientRegistry = dynamoClientService.getClient(clientID);
         if (clientRegistry.isEmpty()) {
-            LOG.error("Client not found in ClientRegistry");
+            LOG.warn("Client not found in ClientRegistry");
             return generateErrorLogoutResponse(
                     state,
                     new ErrorObject(OAuth2Error.UNAUTHORIZED_CLIENT_CODE, "client not found"),
@@ -230,7 +230,7 @@ public class LogoutHandler
                 .map(
                         uri -> {
                             if (!clientRegistry.get().getPostLogoutRedirectUrls().contains(uri)) {
-                                LOG.error(
+                                LOG.warn(
                                         "Client registry does not contain PostLogoutRedirectUri which was sent in the logout request. Value is {}",
                                         uri);
                                 return generateErrorLogoutResponse(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
@@ -204,7 +204,7 @@ public class TokenHandler
                                         AuthenticationRequest.parse(
                                                 clientSession.getAuthRequestParams());
                             } catch (ParseException e) {
-                                LOG.error(
+                                LOG.warn(
                                         "Could not parse authentication request from client session",
                                         e);
                                 throw new RuntimeException(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TrustMarkHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TrustMarkHandler.java
@@ -43,7 +43,7 @@ public class TrustMarkHandler
                                 return generateApiGatewayProxyResponse(
                                         200, createTrustMarkResponse());
                             } catch (JsonProcessingException | NoSuchElementException e) {
-                                LOG.error("Unable to generate TrustMark response", e);
+                                LOG.warn("Unable to generate TrustMark response", e);
                                 return generateApiGatewayProxyResponse(
                                         400,
                                         OAuth2Error.INVALID_REQUEST.toJSONObject().toJSONString());

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandler.java
@@ -75,7 +75,7 @@ public class UserInfoHandler
                                     input.getHeaders(),
                                     AUTHORIZATION_HEADER,
                                     configurationService.getHeadersCaseInsensitive())) {
-                                LOG.error("AccessToken is missing from request");
+                                LOG.warn("AccessToken is missing from request");
                                 return generateApiGatewayProxyResponse(
                                         401,
                                         "",
@@ -95,7 +95,7 @@ public class UserInfoHandler
                                                 false);
                                 userInfo = userInfoService.populateUserInfo(accessTokenInfo);
                             } catch (AccessTokenException e) {
-                                LOG.error(
+                                LOG.warn(
                                         "AccessTokenException. Sending back UserInfoErrorResponse");
                                 return generateApiGatewayProxyResponse(
                                         401,

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/VectorOfTrust.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/VectorOfTrust.java
@@ -59,7 +59,7 @@ public class VectorOfTrust {
         try {
             vtrJsonArray = (JSONArray) parser.parse(vtr.get(0));
         } catch (net.minidev.json.parser.ParseException | ClassCastException e) {
-            LOG.error("Error when parsing vtr attribute", e);
+            LOG.warn("Error when parsing vtr attribute", e);
             throw new IllegalArgumentException("Invalid VTR attribute", e);
         }
         VectorOfTrust vectorOfTrust = parseVtrSet(vtrJsonArray);

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ClientSubjectHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ClientSubjectHelper.java
@@ -38,7 +38,7 @@ public class ClientSubjectHelper {
         try {
             redirectUri = clientRegistry.getRedirectUrls().stream().findFirst().orElseThrow();
         } catch (NoSuchElementException e) {
-            LOG.error("Client Registry contains no redirect URLs");
+            LOG.warn("Client Registry contains no redirect URLs");
             throw new RuntimeException(e);
         }
         try {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/PhoneNumberHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/PhoneNumberHelper.java
@@ -15,7 +15,7 @@ public class PhoneNumberHelper {
             var parsedPhoneNumber = phoneUtil.parse(phoneNumber, "GB");
             return phoneUtil.format(parsedPhoneNumber, PhoneNumberUtil.PhoneNumberFormat.E164);
         } catch (NumberParseException e) {
-            LOG.error("Error when trying to parse phone number");
+            LOG.warn("Error when trying to parse phone number");
             throw new RuntimeException(e);
         }
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/RequestBodyHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/RequestBodyHelper.java
@@ -27,10 +27,10 @@ public class RequestBodyHelper {
     public static void validatePrincipal(
             Subject subjectFromEmail, Map<String, Object> authorizerParams) {
         if (!authorizerParams.containsKey("principalId")) {
-            LOG.error("principalId is missing");
+            LOG.warn("principalId is missing");
             throw new RuntimeException("principalId is missing");
         } else if (!subjectFromEmail.getValue().equals(authorizerParams.get("principalId"))) {
-            LOG.error(
+            LOG.warn(
                     "Subject ID: {} does not match principalId: {}",
                     subjectFromEmail,
                     authorizerParams.get("principalId"));

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/RequestHeaderHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/RequestHeaderHelper.java
@@ -14,7 +14,7 @@ public final class RequestHeaderHelper {
     public static boolean headersContainValidHeader(
             Map<String, String> headers, String headerName, boolean matchLowerCase) {
         if (headers == null || headers.isEmpty()) {
-            LOG.error("All headers are missing or empty when looking for header {}", headerName);
+            LOG.warn("All headers are missing or empty when looking for header {}", headerName);
             return false;
         } else if (!matchLowerCase && headers.containsKey(headerName)) {
             LOG.info("Found header {}, matchLowerCase={}", headerName, matchLowerCase);
@@ -22,7 +22,7 @@ public final class RequestHeaderHelper {
         } else if (matchLowerCase
                 && (headers.containsKey(headerName)
                         && headers.containsKey(headerName.toLowerCase()))) {
-            LOG.error(
+            LOG.warn(
                     "Found both headers {} and lowercase version, matchLowerCase={}",
                     headerName,
                     matchLowerCase);

--- a/shared/src/main/java/uk/gov/di/authentication/shared/lambda/BaseFrontendHandler.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/lambda/BaseFrontendHandler.java
@@ -98,7 +98,7 @@ public abstract class BaseFrontendHandler<T>
         Optional<ClientSession> clientSession =
                 clientSessionService.getClientSessionFromRequestHeaders(input.getHeaders());
         if (session.isEmpty()) {
-            LOG.error("Session cannot be found");
+            LOG.warn("Session cannot be found");
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1000);
         } else {
             attachSessionIdToLogs(session.get());
@@ -107,7 +107,7 @@ public abstract class BaseFrontendHandler<T>
         try {
             request = objectMapper.readValue(input.getBody(), clazz);
         } catch (JsonProcessingException | ConstraintViolationException e) {
-            LOG.error("Request is missing parameters.");
+            LOG.warn("Request is missing parameters.");
             onRequestValidationError(context);
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
         }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ClientSessionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ClientSessionService.java
@@ -107,7 +107,7 @@ public class ClientSessionService {
                         CLIENT_SESSION_ID_HEADER,
                         configurationService.getHeadersCaseInsensitive());
         if (clientSessionId == null) {
-            LOG.error("Value not found for Client-Session-Id header");
+            LOG.warn("Value not found for Client-Session-Id header");
             return Optional.empty();
         }
         try {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/SessionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/SessionService.java
@@ -71,7 +71,7 @@ public class SessionService {
     public Optional<Session> getSessionFromRequestHeaders(Map<String, String> headers) {
         if (!headersContainValidHeader(
                 headers, SESSION_ID_HEADER, configurationService.getHeadersCaseInsensitive())) {
-            LOG.error("Headers are missing Session-Id header");
+            LOG.warn("Headers are missing Session-Id header");
             return Optional.empty();
         }
         String sessionId =
@@ -80,7 +80,7 @@ public class SessionService {
                         SESSION_ID_HEADER,
                         configurationService.getHeadersCaseInsensitive());
         if (sessionId == null) {
-            LOG.error("Value not found for Session-Id header");
+            LOG.warn("Value not found for Session-Id header");
             return Optional.empty();
         }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
@@ -176,16 +176,16 @@ public class TokenService {
         try {
             privateKeyJWT = PrivateKeyJWT.parse(requestString);
         } catch (ParseException e) {
-            LOG.error("Could not parse Private Key JWT");
+            LOG.warn("Could not parse Private Key JWT");
             return Optional.of(OAuth2Error.INVALID_CLIENT);
         }
         if (hasPrivateKeyJwtExpired(privateKeyJWT.getClientAssertion())) {
-            LOG.error("PrivateKeyJWT has expired");
+            LOG.warn("PrivateKeyJWT has expired");
             return Optional.of(OAuth2Error.INVALID_GRANT);
         }
         if (Objects.isNull(privateKeyJWT.getClientID())
                 || !privateKeyJWT.getClientID().toString().equals(clientID)) {
-            LOG.error("Invalid ClientID in PrivateKeyJWT");
+            LOG.warn("Invalid ClientID in PrivateKeyJWT");
             return Optional.of(OAuth2Error.INVALID_CLIENT);
         }
         ClientAuthenticationVerifier<?> authenticationVerifier =
@@ -195,7 +195,7 @@ public class TokenService {
         try {
             authenticationVerifier.verify(privateKeyJWT, null, null);
         } catch (InvalidClientException | JOSEException e) {
-            LOG.error("Unable to Verify Signature of Private Key JWT", e);
+            LOG.warn("Unable to Verify Signature of Private Key JWT", e);
             return Optional.of(OAuth2Error.INVALID_CLIENT);
         }
         return Optional.empty();
@@ -209,7 +209,7 @@ public class TokenService {
                         .findFirst()
                         .orElse(null);
         if (clientConsent == null) {
-            LOG.error("Client consent is empty for user");
+            LOG.warn("Client consent is empty for user");
             throw new RuntimeException("Client consent is empty for user");
         }
         Set<String> claimsFromAuthnRequest =
@@ -234,7 +234,7 @@ public class TokenService {
         try {
             RefreshToken refreshToken = new RefreshToken(requestBody.get("refresh_token"));
         } catch (IllegalArgumentException e) {
-            LOG.error("Invalid RefreshToken", e);
+            LOG.warn("Invalid RefreshToken", e);
             return Optional.of(
                     new ErrorObject(OAuth2Error.INVALID_REQUEST_CODE, "Invalid refresh token"));
         }
@@ -416,7 +416,7 @@ public class TokenService {
                 return true;
             }
         } catch (java.text.ParseException e) {
-            LOG.error("Unable to parse PrivateKeyJwt when checking if expired", e);
+            LOG.warn("Unable to parse PrivateKeyJwt when checking if expired", e);
             return true;
         }
         return false;

--- a/shared/src/main/java/uk/gov/di/authentication/shared/state/conditions/ClientDoesNotRequireMfa.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/state/conditions/ClientDoesNotRequireMfa.java
@@ -28,7 +28,7 @@ public class ClientDoesNotRequireMfa implements Condition<UserContext> {
                                     try {
                                         return AuthenticationRequest.parse(t);
                                     } catch (ParseException e) {
-                                        LOG.error("Unable to parse AuthRequest", e);
+                                        LOG.warn("Unable to parse AuthRequest", e);
                                         throw new RuntimeException(e);
                                     }
                                 })

--- a/shared/src/main/java/uk/gov/di/authentication/shared/state/conditions/ConsentNotGiven.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/state/conditions/ConsentNotGiven.java
@@ -28,7 +28,7 @@ public class ConsentNotGiven implements Condition<UserContext> {
                                     try {
                                         return AuthenticationRequest.parse(t);
                                     } catch (ParseException e) {
-                                        LOG.error("Unable to parse AuthRequest", e);
+                                        LOG.warn("Unable to parse AuthRequest", e);
                                         throw new RuntimeException(e);
                                     }
                                 })


### PR DESCRIPTION
## What?

Reduce `error` to `warn` where the problem is caused by user input.

## Why?

We want to have separate measurements for errors on our end, and errors caused by things like malformed input.
