### PR TITLE
AUTH-1281: remove unused notify template variable

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandler.java
@@ -76,10 +76,6 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                 try {
                     switch (notifyRequest.getNotificationType()) {
                         case ACCOUNT_CREATED_CONFIRMATION:
-                            notifyPersonalisation.put(
-                                    "sign-in-page-url",
-                                    buildURI(configurationService.getAccountManagementURI())
-                                            .toString());
                             notifyPersonalisation.put("contact-us-link", buildContactUsUrl());
                             notificationService.sendEmail(
                                     notifyRequest.getDestination(),

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandlerTest.java
@@ -129,7 +129,6 @@ public class NotificationHandlerTest {
         handler.handleRequest(sqsEvent, context);
 
         Map<String, Object> personalisation = new HashMap<>();
-        personalisation.put("sign-in-page-url", accountManagementUrl);
         personalisation.put("contact-us-link", CONTACT_US_LINK_URL);
 
         verify(notificationService)

--- a/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/NotificationHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/NotificationHandlerIntegrationTest.java
@@ -132,6 +132,7 @@ public class NotificationHandlerIntegrationTest extends NotifyIntegrationTest {
         JsonNode personalisation = request.get("personalisation");
         assertThat(
                 personalisation,
-                hasFieldWithValue("sign-in-page-url", equalTo("http://localhost:3000/")));
+                hasFieldWithValue(
+                        "contact-us-link", equalTo("http://localhost:3000/frontend/contact-us")));
     }
 }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/NotifyIntegrationTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/NotifyIntegrationTest.java
@@ -99,7 +99,12 @@ public abstract class NotifyIntegrationTest {
 
         @Override
         public String getFrontendBaseUrl() {
-            return "http://localhost:3000/reset-password?code=";
+            return "http://localhost:3000/frontend/";
+        }
+
+        @Override
+        public String getContactUsLinkRoute() {
+            return "contact-us";
         }
     }
 }


### PR DESCRIPTION
## What?

Remove unused notify template variable and update the tests to reflect the change.

## Why?

An updated version of the account confirmation template was deployed which uses a different variable.  The existing one was kept in temporarily for a ZDD.

## Related PRs

#1368 
#1367 