### PR TITLE
BAU: remove dependabot open pull requests limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,6 @@ updates:
     schedule:
       interval: daily
       time: "03:00"
-    open-pull-requests-limit: 10
     target-branch: main
     labels:
       - dependabot
@@ -14,7 +13,6 @@ updates:
     schedule:
       interval: daily
       time: "03:00"
-    open-pull-requests-limit: 10
     target-branch: main
     labels:
     - dependabot


### PR DESCRIPTION
## What?

Remove dependabot open pull requests limit

## Why?

So we can see all the available pull requests the dependabot has to offer.