### PR TITLE
BAU: AWS SDK libs dependabot merge

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ apply plugin: "idea"
 ext {
     dependencyVersions = [
         jackson_version: "2.13.1",
-        aws_sdk_version: "1.12.141",
+        aws_sdk_version: "1.12.153",
         aws_lambda_core_version: "1.2.1",
         aws_lambda_events_version: "3.11.0",
         nimbusds_oauth_version: "9.22",

--- a/build.gradle
+++ b/build.gradle
@@ -120,7 +120,7 @@ subprojects {
 
         sns "com.amazonaws:aws-java-sdk-sns:${dependencyVersions.aws_sdk_version}"
 
-        sqs "software.amazon.awssdk:sqs:2.17.107"
+        sqs "software.amazon.awssdk:sqs:2.17.124"
 
         ssm "com.amazonaws:aws-java-sdk-ssm:${dependencyVersions.aws_sdk_version}"
 

--- a/lambda-warmer/build.gradle
+++ b/lambda-warmer/build.gradle
@@ -7,7 +7,7 @@ version "unspecified"
 
 dependencies {
     implementation configurations.lambda,
-            "com.amazonaws:aws-java-sdk-lambda:1.12.141"
+            "com.amazonaws:aws-java-sdk-lambda:1.12.153"
 
     runtimeOnly configurations.logging_runtime
 


### PR DESCRIPTION
## What?

Merge 3 AWS SDK library updates created by dependabot.

## Why?

So they can be released/rolled-back together.

## Related PRs

#1380 
#1379 
#1378 
