### PR TITLE
AUTH-1355: add separate configuration for blocked email duration

### DIFF
--- a/ci/terraform/oidc/build-overrides.tfvars
+++ b/ci/terraform/oidc/build-overrides.tfvars
@@ -1,0 +1,1 @@
+blocked_email_duration = 30

--- a/ci/terraform/oidc/mfa.tf
+++ b/ci/terraform/oidc/mfa.tf
@@ -8,6 +8,7 @@ module "mfa" {
 
   handler_environment_variables = {
     ENVIRONMENT             = var.environment
+    BLOCKED_EMAIL_DURATION  = var.blocked_email_duration
     EMAIL_QUEUE_URL         = aws_sqs_queue.email_queue.id
     EVENTS_SNS_TOPIC_ARN    = aws_sns_topic.events.arn
     AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name

--- a/ci/terraform/oidc/reset-password-request.tf
+++ b/ci/terraform/oidc/reset-password-request.tf
@@ -11,6 +11,7 @@ module "reset-password-request" {
     BASE_URL                = local.frontend_api_base_url
     FRONTEND_BASE_URL       = module.dns.frontend_url
     RESET_PASSWORD_ROUTE    = var.reset_password_route
+    BLOCKED_EMAIL_DURATION  = var.blocked_email_duration
     SQS_ENDPOINT            = var.use_localstack ? "http://localhost:45678/" : null
     EMAIL_QUEUE_URL         = aws_sqs_queue.email_queue.id
     EVENTS_SNS_TOPIC_ARN    = aws_sns_topic.events.arn

--- a/ci/terraform/oidc/send_notification.tf
+++ b/ci/terraform/oidc/send_notification.tf
@@ -8,6 +8,7 @@ module "send_notification" {
 
   handler_environment_variables = {
     ENVIRONMENT             = var.environment
+    BLOCKED_EMAIL_DURATION  = var.blocked_email_duration
     EMAIL_QUEUE_URL         = aws_sqs_queue.email_queue.id
     EVENTS_SNS_TOPIC_ARN    = aws_sns_topic.events.arn
     AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -144,6 +144,11 @@ variable "reset_password_route" {
   default = "reset-password?code="
 }
 
+variable "blocked_email_duration" {
+  type    = number
+  default = 900
+}
+
 variable "customer_support_link_route" {
   type    = string
   default = "support"

--- a/ci/terraform/oidc/verify_code.tf
+++ b/ci/terraform/oidc/verify_code.tf
@@ -9,6 +9,7 @@ module "verify_code" {
   handler_environment_variables = {
     ENVIRONMENT                         = var.environment
     BASE_URL                            = local.frontend_api_base_url
+    BLOCKED_EMAIL_DURATION              = var.blocked_email_duration
     EVENTS_SNS_TOPIC_ARN                = aws_sns_topic.events.arn
     AUDIT_SIGNING_KEY_ALIAS             = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT                 = var.use_localstack ? var.localstack_endpoint : null

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
@@ -243,7 +243,9 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
         if (session.getCodeRequestCount() == configurationService.getCodeMaxRetries()) {
             LOG.info("User has requested too many OTP codes");
             codeStorageService.saveBlockedForEmail(
-                    email, CODE_REQUEST_BLOCKED_KEY_PREFIX, configurationService.getCodeExpiry());
+                    email,
+                    CODE_REQUEST_BLOCKED_KEY_PREFIX,
+                    configurationService.getBlockedEmailDuration());
             SessionState nextState =
                     stateMachine.transition(
                             session.getState(), SYSTEM_HAS_SENT_TOO_MANY_MFA_CODES, userContext);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
@@ -201,7 +201,7 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
             codeStorageService.saveBlockedForEmail(
                     userContext.getSession().getEmailAddress(),
                     PASSWORD_RESET_BLOCKED_KEY_PREFIX,
-                    configurationService.getCodeExpiry());
+                    configurationService.getBlockedEmailDuration());
             sessionService.save(userContext.getSession().resetPasswordResetCount());
             SessionState nextState =
                     stateMachine.transition(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
@@ -234,7 +234,9 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
         if (session.getCodeRequestCount() == configurationService.getCodeMaxRetries()) {
             LOG.info("User has requested too many OTP codes");
             codeStorageService.saveBlockedForEmail(
-                    email, CODE_REQUEST_BLOCKED_KEY_PREFIX, configurationService.getCodeExpiry());
+                    email,
+                    CODE_REQUEST_BLOCKED_KEY_PREFIX,
+                    configurationService.getBlockedEmailDuration());
             SessionState nextState =
                     stateMachine.transition(
                             session.getState(),

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -243,7 +243,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
         codeStorageService.saveBlockedForEmail(
                 session.getEmailAddress(),
                 CODE_BLOCKED_KEY_PREFIX,
-                configurationService.getCodeExpiry());
+                configurationService.getBlockedEmailDuration());
         sessionService.save(session.resetRetryCount());
     }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
@@ -72,6 +72,7 @@ public class MfaHandlerTest {
     private static final String TEST_EMAIL_ADDRESS = "test@test.com";
     private static final String CODE = "123456";
     private static final long CODE_EXPIRY_TIME = 900;
+    private static final long BLOCKED_EMAIL_DURATION = 799;
     private static final String TEST_CLIENT_ID = "test-client-id";
     private static final URI REDIRECT_URI = URI.create("http://localhost/redirect");
     private final Context context = mock(Context.class);
@@ -295,6 +296,7 @@ public class MfaHandlerTest {
     @Test
     public void shouldReturn400IfUserHasReachedTheMfaCodeRequestLimit()
             throws JsonProcessingException {
+        when(configurationService.getBlockedEmailDuration()).thenReturn(BLOCKED_EMAIL_DURATION);
         usingValidSession();
         session.setState(MFA_SMS_CODE_SENT);
         session.incrementCodeRequestCount();
@@ -316,7 +318,9 @@ public class MfaHandlerTest {
         assertEquals(SessionState.MFA_SMS_MAX_CODES_SENT, codeResponse.getSessionState());
         verify(codeStorageService)
                 .saveBlockedForEmail(
-                        TEST_EMAIL_ADDRESS, CODE_REQUEST_BLOCKED_KEY_PREFIX, CODE_EXPIRY_TIME);
+                        TEST_EMAIL_ADDRESS,
+                        CODE_REQUEST_BLOCKED_KEY_PREFIX,
+                        BLOCKED_EMAIL_DURATION);
 
         verify(auditService)
                 .submitAuditEvent(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
@@ -79,6 +79,7 @@ class SendNotificationHandlerTest {
     private static final String TEST_PHONE_NUMBER = "01234567891";
     private static final String TEST_SIX_DIGIT_CODE = "123456";
     private static final long CODE_EXPIRY_TIME = 900;
+    private static final long BLOCKED_EMAIL_DURATION = 799;
     private static final String CLIENT_ID = "client-id";
     private static final String TEST_CLIENT_ID = "test-client-id";
     private static final URI REDIRECT_URI = URI.create("http://localhost/redirect");
@@ -144,6 +145,7 @@ class SendNotificationHandlerTest {
     @BeforeEach
     void setup() {
         when(configurationService.getCodeExpiry()).thenReturn(CODE_EXPIRY_TIME);
+        when(configurationService.getBlockedEmailDuration()).thenReturn(BLOCKED_EMAIL_DURATION);
         when(codeGeneratorService.sixDigitCode()).thenReturn(TEST_SIX_DIGIT_CODE);
         when(configurationService.getCodeMaxRetries()).thenReturn(5);
         when(clientService.getClient(CLIENT_ID)).thenReturn(Optional.of(clientRegistry));
@@ -429,7 +431,9 @@ class SendNotificationHandlerTest {
         assertEquals(SessionState.EMAIL_MAX_CODES_SENT, codeResponse.getSessionState());
         verify(codeStorageService)
                 .saveBlockedForEmail(
-                        TEST_EMAIL_ADDRESS, CODE_REQUEST_BLOCKED_KEY_PREFIX, CODE_EXPIRY_TIME);
+                        TEST_EMAIL_ADDRESS,
+                        CODE_REQUEST_BLOCKED_KEY_PREFIX,
+                        BLOCKED_EMAIL_DURATION);
         verify(codeStorageService, never())
                 .saveOtpCode(
                         TEST_EMAIL_ADDRESS, TEST_SIX_DIGIT_CODE, CODE_EXPIRY_TIME, VERIFY_EMAIL);
@@ -459,7 +463,9 @@ class SendNotificationHandlerTest {
         assertEquals(SessionState.PHONE_NUMBER_MAX_CODES_SENT, codeResponse.getSessionState());
         verify(codeStorageService)
                 .saveBlockedForEmail(
-                        TEST_EMAIL_ADDRESS, CODE_REQUEST_BLOCKED_KEY_PREFIX, CODE_EXPIRY_TIME);
+                        TEST_EMAIL_ADDRESS,
+                        CODE_REQUEST_BLOCKED_KEY_PREFIX,
+                        BLOCKED_EMAIL_DURATION);
         verify(codeStorageService, never())
                 .saveOtpCode(
                         TEST_EMAIL_ADDRESS,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeRequestHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeRequestHandlerTest.java
@@ -99,6 +99,8 @@ class VerifyCodeRequestHandlerTest {
     private static final String TEST_CLIENT_CODE = "654321";
     private static final String TEST_CLIENT_EMAIL =
             "testclient.user1@digital.cabinet-office.gov.uk";
+    private static final long CODE_EXPIRY_TIME = 900;
+    private static final long BLOCKED_EMAIL_DURATION = 799;
 
     private static final URI REDIRECT_URI = URI.create("http://localhost/redirect");
     private final Context context = mock(Context.class);
@@ -389,7 +391,8 @@ class VerifyCodeRequestHandlerTest {
         final String USER_INPUT = "123456";
         session.setState(PHONE_NUMBER_CODE_NOT_VALID);
         when(configurationService.getCodeMaxRetries()).thenReturn(5);
-        when(configurationService.getCodeExpiry()).thenReturn(900L);
+        when(configurationService.getCodeExpiry()).thenReturn(CODE_EXPIRY_TIME);
+        when(configurationService.getBlockedEmailDuration()).thenReturn(BLOCKED_EMAIL_DURATION);
 
         when(validationService.validateVerificationCode(
                         eq(VERIFY_PHONE_NUMBER),
@@ -412,7 +415,8 @@ class VerifyCodeRequestHandlerTest {
         verify(authenticationService, never())
                 .updatePhoneNumberVerifiedStatus(TEST_EMAIL_ADDRESS, true);
         verify(codeStorageService)
-                .saveBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX, 900);
+                .saveBlockedForEmail(
+                        TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX, BLOCKED_EMAIL_DURATION);
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CODE_MAX_RETRIES_REACHED,
@@ -453,7 +457,8 @@ class VerifyCodeRequestHandlerTest {
 
         final String USER_INPUT = "123456";
         when(configurationService.getCodeMaxRetries()).thenReturn(5);
-        when(configurationService.getCodeExpiry()).thenReturn(900L);
+        when(configurationService.getCodeExpiry()).thenReturn(CODE_EXPIRY_TIME);
+        when(configurationService.getBlockedEmailDuration()).thenReturn(BLOCKED_EMAIL_DURATION);
         when(validationService.validateVerificationCode(
                         eq(VERIFY_EMAIL),
                         eq(Optional.of(CODE)),
@@ -472,7 +477,8 @@ class VerifyCodeRequestHandlerTest {
         assertThat(codeResponse.getSessionState(), equalTo(EMAIL_CODE_MAX_RETRIES_REACHED));
         assertThat(session.getRetryCount(), equalTo(0));
         verify(codeStorageService)
-                .saveBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX, 900);
+                .saveBlockedForEmail(
+                        TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX, BLOCKED_EMAIL_DURATION);
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CODE_MAX_RETRIES_REACHED,
@@ -598,7 +604,8 @@ class VerifyCodeRequestHandlerTest {
         session.setState(MFA_CODE_NOT_VALID);
         final String USER_INPUT = "123456";
         when(configurationService.getCodeMaxRetries()).thenReturn(5);
-        when(configurationService.getCodeExpiry()).thenReturn(900L);
+        when(configurationService.getCodeExpiry()).thenReturn(CODE_EXPIRY_TIME);
+        when(configurationService.getBlockedEmailDuration()).thenReturn(BLOCKED_EMAIL_DURATION);
         when(validationService.validateVerificationCode(
                         eq(MFA_SMS),
                         eq(Optional.of(CODE)),
@@ -617,7 +624,8 @@ class VerifyCodeRequestHandlerTest {
         assertThat(codeResponse.getSessionState(), equalTo(MFA_CODE_MAX_RETRIES_REACHED));
         assertThat(session.getRetryCount(), equalTo(0));
         verify(codeStorageService)
-                .saveBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX, 900);
+                .saveBlockedForEmail(
+                        TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX, BLOCKED_EMAIL_DURATION);
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CODE_MAX_RETRIES_REACHED,

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -52,6 +52,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return Optional.ofNullable(System.getenv("BASE_URL"));
     }
 
+    public long getBlockedEmailDuration() {
+        return Long.parseLong(System.getenv().getOrDefault("BLOCKED_EMAIL_DURATION", "900"));
+    }
+
     public long getCodeExpiry() {
         return Long.parseLong(System.getenv().getOrDefault("CODE_EXPIRY", "900"));
     }


### PR DESCRIPTION
## What?

Add separate configuration for blocked email/account locking duration.
Set this value to 30s in the build environment only.

## Why?

At the moment there is a single configuration key that covers both how long an otp is valid for, and for how long an account is locked as required, such as when a user requests too many otp codes.  These are actually separate things even though they happen to have the same value at the moment.

As this value is set to 15 mins it makes it difficult to test that account locking is working correctly, given it takes at least 15 mins to run a single test.  The idea is to be able to set this value to something much lower in test environments to make it easier to test.  We might want separate durations for otp validity and account locking to make testing as efficient as possible.

## Related PRs

Please include links to PRs in other repositories relevant to this PR.
Delete this section if not needed.