### PR TITLE
BAU: Update google-java-format from 1.12.0 to 1.13.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -139,7 +139,7 @@ subprojects {
 spotless {
     java {
         target "**/*.java"
-        googleJavaFormat("1.12.0").aosp()
+        googleJavaFormat("1.13.0").aosp()
         importOrder "", "javax", "java", "\\#"
     }
 


### PR DESCRIPTION
## What?

Update google-java-format from 1.12.0 to 1.13.0

## Why?

Spotless was refusing to run locally for me because this dependency was not up to date.