### PR TITLE
BAU - Remove unused API key

### DIFF
--- a/ci/terraform/oidc/api-gateway.tf
+++ b/ci/terraform/oidc/api-gateway.tf
@@ -77,16 +77,6 @@ resource "aws_api_gateway_usage_plan" "di_auth_usage_plan" {
   ]
 }
 
-resource "aws_api_gateway_api_key" "di_auth_api_key" {
-  name = "${var.environment}-di-auth-api-key"
-}
-
-resource "aws_api_gateway_usage_plan_key" "di_auth_usage_plan_key" {
-  key_id        = aws_api_gateway_api_key.di_auth_api_key.id
-  key_type      = "API_KEY"
-  usage_plan_id = aws_api_gateway_usage_plan.di_auth_usage_plan.id
-}
-
 resource "aws_api_gateway_resource" "wellknown_resource" {
   rest_api_id = aws_api_gateway_rest_api.di_authentication_api.id
   parent_id   = aws_api_gateway_rest_api.di_authentication_api.root_resource_id

--- a/ci/terraform/oidc/outputs.tf
+++ b/ci/terraform/oidc/outputs.tf
@@ -18,11 +18,6 @@ output "token_signing_key_alias" {
   value = local.id_token_signing_key_alias_name
 }
 
-output "oidc_api_key" {
-  value     = aws_api_gateway_api_key.di_auth_api_key.value
-  sensitive = true
-}
-
 output "frontend_api_key" {
   value     = aws_api_gateway_api_key.di_auth_frontend_api_key.value
   sensitive = true

--- a/echo-int-test-vars.sh
+++ b/echo-int-test-vars.sh
@@ -6,7 +6,7 @@ export AWS_SECRET_ACCESS_KEY="mock-secret-key"
 
 pushd ci/terraform/oidc >/dev/null
 export API_GATEWAY_ID="$(terraform output -raw api_gateway_root_id)"
-export API_KEY="$(terraform output -raw oidc_api_key)"
+export API_KEY="$(terraform output -raw di-auth-frontend-api-key)"
 export FRONTEND_API_GATEWAY_ID="$(terraform output -raw frontend_api_gateway_root_id)"
 export FRONTEND_API_KEY="$(terraform output -raw frontend_api_key)"
 export RESET_PASSWORD_URL="http://localhost:3000/reset-password?code="


### PR DESCRIPTION
## What?

 - Remove unused API key

## Why?

- This API key is not used and can therefore be removed.
- We only use the di_auth_frontend_api_key which lives in api-gateway-frontend.yml.
