### PR TITLE
BAU: Allow us to ignore checked exceptions in tests

### DIFF
--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/exceptions/Unchecked.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/exceptions/Unchecked.java
@@ -1,0 +1,63 @@
+package uk.gov.di.authentication.sharedtest.exceptions;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public class Unchecked {
+
+    @FunctionalInterface
+    public interface ThrowingFunction<T, U> {
+        U apply(T input) throws Exception;
+    }
+
+    @FunctionalInterface
+    public interface ThrowingSupplier<T> {
+        T get() throws Exception;
+    }
+
+    @FunctionalInterface
+    public interface ThrowingConsumer<T> {
+        void apply(T input) throws Exception;
+    }
+
+    @FunctionalInterface
+    public interface ThrowingRunnable {
+        void run() throws Exception;
+    }
+
+    public static <T, U> Function<T, U> unchecked(ThrowingFunction<T, U> function) {
+        return t -> {
+            try {
+                return function.apply(t);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        };
+    }
+
+    public static <T> T unchecked(ThrowingSupplier<T> supplier) {
+        try {
+            return supplier.get();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static <T> Consumer<T> unchecked(ThrowingConsumer<T> consumer) {
+        return t -> {
+            try {
+                consumer.apply(t);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        };
+    }
+
+    public static void unchecked(ThrowingRunnable runnable) {
+        try {
+            runnable.run();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/TokenGeneratorHelper.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/TokenGeneratorHelper.java
@@ -29,6 +29,8 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import static uk.gov.di.authentication.sharedtest.exceptions.Unchecked.unchecked;
+
 public class TokenGeneratorHelper {
 
     private static final String KEY_ID = "14342354354353";
@@ -143,12 +145,11 @@ public class TokenGeneratorHelper {
         }
 
         JWSHeader jwsHeader = new JWSHeader.Builder(JWSAlgorithm.ES256).keyID(keyId).build();
-        try {
-            var signedJWT = new SignedJWT(jwsHeader, claimsBuilder.build());
-            signedJWT.sign(signer);
-            return signedJWT;
-        } catch (JOSEException e) {
-            throw new RuntimeException(e);
-        }
+
+        var signedJWT = new SignedJWT(jwsHeader, claimsBuilder.build());
+
+        unchecked(signedJWT::sign).accept(signer);
+
+        return signedJWT;
     }
 }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/httpstub/HttpStub.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/httpstub/HttpStub.java
@@ -13,11 +13,12 @@ import java.io.File;
 import java.io.IOException;
 import java.security.KeyStore;
 import java.util.List;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
+
+import static uk.gov.di.authentication.sharedtest.exceptions.Unchecked.unchecked;
 
 class HttpStub {
 
@@ -156,14 +157,6 @@ class HttpStub {
 
     public List<RecordedRequest> getRecordedRequests() {
         return recordedRequests;
-    }
-
-    public static <T> T unchecked(Callable<T> callable) {
-        try {
-            return callable.call();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
     }
 
     private class Handler extends AbstractHandler {

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/matchers/APIGatewayProxyResponseEventMatcher.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/matchers/APIGatewayProxyResponseEventMatcher.java
@@ -1,7 +1,6 @@
 package uk.gov.di.authentication.sharedtest.matchers;
 
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
@@ -11,6 +10,7 @@ import java.net.URI;
 import java.util.function.Function;
 
 import static org.hamcrest.Matchers.equalTo;
+import static uk.gov.di.authentication.sharedtest.exceptions.Unchecked.unchecked;
 
 public class APIGatewayProxyResponseEventMatcher<T, M extends Matcher>
         extends TypeSafeDiagnosingMatcher<APIGatewayProxyResponseEvent> {
@@ -69,13 +69,10 @@ public class APIGatewayProxyResponseEventMatcher<T, M extends Matcher>
 
     public static APIGatewayProxyResponseEventMatcher<String, Matcher<String>> hasJsonBody(
             Object body) {
-        try {
-            var expectedValue = new ObjectMapper().writeValueAsString(body);
-            return new APIGatewayProxyResponseEventMatcher<>(
-                    "body", APIGatewayProxyResponseEvent::getBody, equalTo(expectedValue));
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
+        var expectedValue = unchecked(new ObjectMapper()::writeValueAsString).apply(body);
+
+        return new APIGatewayProxyResponseEventMatcher<>(
+                "body", APIGatewayProxyResponseEvent::getBody, equalTo(expectedValue));
     }
 
     public static APIGatewayProxyResponseEventMatcher<Integer, Matcher<Integer>> isRedirect() {

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/matchers/UriMatcher.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/matchers/UriMatcher.java
@@ -1,12 +1,12 @@
 package uk.gov.di.authentication.sharedtest.matchers;
 
+import org.apache.http.client.utils.URIBuilder;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URLDecoder;
 import java.util.Arrays;
 import java.util.Map;
@@ -15,6 +15,7 @@ import java.util.stream.Collectors;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.Matchers.equalTo;
+import static uk.gov.di.authentication.sharedtest.exceptions.Unchecked.unchecked;
 
 public class UriMatcher<T> extends TypeSafeDiagnosingMatcher<URI> {
 
@@ -53,14 +54,7 @@ public class UriMatcher<T> extends TypeSafeDiagnosingMatcher<URI> {
     public static UriMatcher<URI> baseUri(URI expected) {
         return new UriMatcher<>(
                 "base URI",
-                uri -> {
-                    try {
-                        return new URI(
-                                uri.getScheme(), uri.getAuthority(), uri.getPath(), null, null);
-                    } catch (URISyntaxException e) {
-                        throw new RuntimeException(e);
-                    }
-                },
+                uri -> unchecked(new URIBuilder(uri).removeQuery().setFragment(null)::build),
                 equalTo(expected));
     }
 


### PR DESCRIPTION
## What?

Introduces `Unchecked`, a helper class that catches checked exceptions and rethrows unchecked exceptions for exception-throwing:
 - Function<T,U>
 - Consumer<T>
 - Supplier<T>
 - Runnable

## Why?

We completely control the input during test setup, so it's much safer to ignore checked exceptions, and they increase the test size without adding value.
