### PR TITLE
AUTH-1174 - Create separate lambda role for the Client Registry lambdas

### DIFF
--- a/ci/terraform/oidc/dynamo-policies.tf
+++ b/ci/terraform/oidc/dynamo-policies.tf
@@ -1,0 +1,135 @@
+data "aws_dynamodb_table" "user_credentials_table" {
+  name = "${var.environment}-user-credentials"
+}
+
+data "aws_dynamodb_table" "user_profile_table" {
+  name = "${var.environment}-user-profile"
+}
+
+data "aws_dynamodb_table" "client_registry_table" {
+  name = "${var.environment}-client-registry"
+}
+
+data "aws_dynamodb_table" "spot_credential_table" {
+  name = "${var.environment}-spot-credential"
+}
+
+data "aws_iam_policy_document" "dynamo_access_policy_document" {
+  count = var.use_localstack ? 0 : 1
+  statement {
+    sid    = "AllowAccessToDynamoTables"
+    effect = "Allow"
+
+    actions = [
+      "dynamodb:BatchGetItem",
+      "dynamodb:DescribeStream",
+      "dynamodb:DescribeTable",
+      "dynamodb:DeleteItem",
+      "dynamodb:Get*",
+      "dynamodb:Query",
+      "dynamodb:Scan",
+      "dynamodb:BatchWriteItem",
+      "dynamodb:UpdateItem",
+      "dynamodb:PutItem",
+    ]
+    resources = [
+      data.aws_dynamodb_table.user_credentials_table.arn,
+      data.aws_dynamodb_table.user_profile_table.arn,
+      "${data.aws_dynamodb_table.user_profile_table.arn}/index/*",
+      "${data.aws_dynamodb_table.user_credentials_table.arn}/index/*",
+      data.aws_dynamodb_table.client_registry_table.arn,
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "dynamo_client_registration_policy_document" {
+  count = var.use_localstack ? 0 : 1
+  statement {
+    sid    = "AllowAccessToDynamoTables"
+    effect = "Allow"
+
+    actions = [
+      "dynamodb:BatchGetItem",
+      "dynamodb:DescribeStream",
+      "dynamodb:DescribeTable",
+      "dynamodb:DeleteItem",
+      "dynamodb:Get*",
+      "dynamodb:Query",
+      "dynamodb:Scan",
+      "dynamodb:BatchWriteItem",
+      "dynamodb:UpdateItem",
+      "dynamodb:PutItem",
+    ]
+    resources = [
+      data.aws_dynamodb_table.client_registry_table.arn,
+    ]
+  }
+}
+
+
+data "aws_iam_policy_document" "dynamo_spot_write_access_policy_document" {
+  count = var.use_localstack ? 0 : 1
+  statement {
+    sid    = "AllowAccessToDynamoTables"
+    effect = "Allow"
+
+    actions = [
+      "dynamodb:UpdateItem",
+      "dynamodb:PutItem",
+    ]
+    resources = [
+      data.aws_dynamodb_table.spot_credential_table.arn,
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "dynamo_spot_read_access_policy_document" {
+  count = var.use_localstack ? 0 : 1
+  statement {
+    sid    = "AllowAccessToDynamoTables"
+    effect = "Allow"
+
+    actions = [
+      "dynamodb:Get*",
+    ]
+    resources = [
+      data.aws_dynamodb_table.spot_credential_table.arn,
+    ]
+  }
+}
+
+resource "aws_iam_policy" "dynamo_access_policy" {
+  count       = var.use_localstack ? 0 : 1
+  name_prefix = "dynamo-access-policy"
+  path        = "/${var.environment}/oidc-default/"
+  description = "IAM policy for managing Dynamo connection for a lambda"
+
+  policy = data.aws_iam_policy_document.dynamo_access_policy_document[0].json
+}
+
+resource "aws_iam_policy" "dynamo_client_registry_write_policy" {
+  count       = var.use_localstack ? 0 : 1
+  name_prefix = "dynamo-client-registry-write-policy"
+  path        = "/${var.environment}/oidc-default/"
+  description = "IAM policy for managing write permissions to the Dynamo Client Registration table"
+
+  policy = data.aws_iam_policy_document.dynamo_client_registration_policy_document[0].json
+}
+
+resource "aws_iam_policy" "dynamo_spot_write_access_policy" {
+  count       = var.use_localstack ? 0 : 1
+  name_prefix = "dynamo-access-policy"
+  path        = "/${var.environment}/oidc-default/"
+  description = "IAM policy for managing write permissions to the Dynamo SPOT credential table"
+
+  policy = data.aws_iam_policy_document.dynamo_spot_write_access_policy_document[0].json
+}
+
+resource "aws_iam_policy" "dynamo_spot_read_access_policy" {
+  count       = var.use_localstack ? 0 : 1
+  name_prefix = "dynamo-access-policy"
+  path        = "/${var.environment}/oidc-default/"
+  description = "IAM policy for managing write permissions to the Dynamo SPOT credential table"
+
+  policy = data.aws_iam_policy_document.dynamo_spot_read_access_policy_document[0].json
+}

--- a/ci/terraform/oidc/dynamo-policies.tf
+++ b/ci/terraform/oidc/dynamo-policies.tf
@@ -102,7 +102,7 @@ resource "aws_iam_policy" "dynamo_access_policy" {
   policy = data.aws_iam_policy_document.dynamo_access_policy_document.json
 }
 
-resource "aws_iam_policy" "dynamo_client_registry_write_policy" {
+resource "aws_iam_policy" "dynamo_client_registry_access_policy" {
   name_prefix = "dynamo-client-registry-write-policy"
   path        = "/${var.environment}/oidc-default/"
   description = "IAM policy for managing write permissions to the Dynamo Client Registration table"

--- a/ci/terraform/oidc/dynamo-policies.tf
+++ b/ci/terraform/oidc/dynamo-policies.tf
@@ -15,7 +15,6 @@ data "aws_dynamodb_table" "spot_credential_table" {
 }
 
 data "aws_iam_policy_document" "dynamo_access_policy_document" {
-  count = var.use_localstack ? 0 : 1
   statement {
     sid    = "AllowAccessToDynamoTables"
     effect = "Allow"
@@ -43,7 +42,6 @@ data "aws_iam_policy_document" "dynamo_access_policy_document" {
 }
 
 data "aws_iam_policy_document" "dynamo_client_registration_policy_document" {
-  count = var.use_localstack ? 0 : 1
   statement {
     sid    = "AllowAccessToDynamoTables"
     effect = "Allow"
@@ -68,7 +66,6 @@ data "aws_iam_policy_document" "dynamo_client_registration_policy_document" {
 
 
 data "aws_iam_policy_document" "dynamo_spot_write_access_policy_document" {
-  count = var.use_localstack ? 0 : 1
   statement {
     sid    = "AllowAccessToDynamoTables"
     effect = "Allow"
@@ -84,7 +81,6 @@ data "aws_iam_policy_document" "dynamo_spot_write_access_policy_document" {
 }
 
 data "aws_iam_policy_document" "dynamo_spot_read_access_policy_document" {
-  count = var.use_localstack ? 0 : 1
   statement {
     sid    = "AllowAccessToDynamoTables"
     effect = "Allow"
@@ -99,37 +95,33 @@ data "aws_iam_policy_document" "dynamo_spot_read_access_policy_document" {
 }
 
 resource "aws_iam_policy" "dynamo_access_policy" {
-  count       = var.use_localstack ? 0 : 1
   name_prefix = "dynamo-access-policy"
   path        = "/${var.environment}/oidc-default/"
   description = "IAM policy for managing Dynamo connection for a lambda"
 
-  policy = data.aws_iam_policy_document.dynamo_access_policy_document[0].json
+  policy = data.aws_iam_policy_document.dynamo_access_policy_document.json
 }
 
 resource "aws_iam_policy" "dynamo_client_registry_write_policy" {
-  count       = var.use_localstack ? 0 : 1
   name_prefix = "dynamo-client-registry-write-policy"
   path        = "/${var.environment}/oidc-default/"
   description = "IAM policy for managing write permissions to the Dynamo Client Registration table"
 
-  policy = data.aws_iam_policy_document.dynamo_client_registration_policy_document[0].json
+  policy = data.aws_iam_policy_document.dynamo_client_registration_policy_document.json
 }
 
 resource "aws_iam_policy" "dynamo_spot_write_access_policy" {
-  count       = var.use_localstack ? 0 : 1
   name_prefix = "dynamo-access-policy"
   path        = "/${var.environment}/oidc-default/"
   description = "IAM policy for managing write permissions to the Dynamo SPOT credential table"
 
-  policy = data.aws_iam_policy_document.dynamo_spot_write_access_policy_document[0].json
+  policy = data.aws_iam_policy_document.dynamo_spot_write_access_policy_document.json
 }
 
 resource "aws_iam_policy" "dynamo_spot_read_access_policy" {
-  count       = var.use_localstack ? 0 : 1
   name_prefix = "dynamo-access-policy"
   path        = "/${var.environment}/oidc-default/"
   description = "IAM policy for managing write permissions to the Dynamo SPOT credential table"
 
-  policy = data.aws_iam_policy_document.dynamo_spot_read_access_policy_document[0].json
+  policy = data.aws_iam_policy_document.dynamo_spot_read_access_policy_document.json
 }

--- a/ci/terraform/oidc/lambda-roles.tf
+++ b/ci/terraform/oidc/lambda-roles.tf
@@ -15,19 +15,6 @@ module "oidc_default_role" {
   ]
 }
 
-module "client_registry_role" {
-  source      = "../modules/lambda-role"
-  environment = var.environment
-  role_name   = "client-registry-role"
-  vpc_arn     = local.authentication_vpc_arn
-
-  policies_to_attach = [
-    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
-    aws_iam_policy.dynamo_client_registry_write_policy.arn,
-    aws_iam_policy.lambda_sns_policy.arn,
-  ]
-}
-
 module "spot_response_role" {
   source      = "../modules/lambda-role"
   environment = var.environment

--- a/ci/terraform/oidc/lambda-roles.tf
+++ b/ci/terraform/oidc/lambda-roles.tf
@@ -4,15 +4,10 @@ module "oidc_default_role" {
   role_name   = "oidc-default-role"
   vpc_arn     = local.authentication_vpc_arn
 
-  policies_to_attach = var.use_localstack ? [
-    aws_iam_policy.lambda_sns_policy.arn,
-    aws_iam_policy.redis_parameter_policy.arn,
-    aws_iam_policy.pepper_parameter_policy.arn,
-    aws_iam_policy.ipv_capacity_parameter_policy.arn,
-    ] : [
-    aws_iam_policy.oidc_default_id_token_public_key_kms_policy[0].arn,
-    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy[0].arn,
-    aws_iam_policy.dynamo_access_policy[0].arn,
+  policies_to_attach = [
+    aws_iam_policy.oidc_default_id_token_public_key_kms_policy.arn,
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    aws_iam_policy.dynamo_access_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
     aws_iam_policy.pepper_parameter_policy.arn,
@@ -26,11 +21,9 @@ module "client_registry_role" {
   role_name   = "client-registry-role"
   vpc_arn     = local.authentication_vpc_arn
 
-  policies_to_attach = var.use_localstack ? [
-    aws_iam_policy.lambda_sns_policy.arn,
-    ] : [
-    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy[0].arn,
-    aws_iam_policy.dynamo_client_registry_write_policy[0].arn,
+  policies_to_attach = [
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    aws_iam_policy.dynamo_client_registry_write_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
   ]
 }
@@ -41,10 +34,8 @@ module "spot_response_role" {
   role_name   = "oidc-default-role"
   vpc_arn     = local.authentication_vpc_arn
 
-  policies_to_attach = var.use_localstack ? [
-    null
-    ] : [
-    aws_iam_policy.dynamo_spot_write_access_policy[0].arn,
+  policies_to_attach = [
+    aws_iam_policy.dynamo_spot_write_access_policy.arn,
   ]
 }
 
@@ -54,14 +45,12 @@ module "identity_lambda_role" {
   role_name   = "oidc-default-role"
   vpc_arn     = local.authentication_vpc_arn
 
-  policies_to_attach = var.use_localstack ? [
-    null
-    ] : [
-    aws_iam_policy.dynamo_access_policy[0].arn,
-    aws_iam_policy.dynamo_spot_read_access_policy[0].arn,
+  policies_to_attach = [
+    aws_iam_policy.dynamo_access_policy.arn,
+    aws_iam_policy.dynamo_spot_read_access_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
-    aws_iam_policy.oidc_default_id_token_public_key_kms_policy[0].arn,
-    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy[0].arn,
+    aws_iam_policy.oidc_default_id_token_public_key_kms_policy.arn,
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
   ]
 }
 
@@ -82,12 +71,9 @@ module "oidc_dynamo_sqs_role" {
   role_name   = "oidc-dynamo-sqs"
   vpc_arn     = local.authentication_vpc_arn
 
-  policies_to_attach = var.use_localstack ? [
-    aws_iam_policy.lambda_sns_policy.arn,
-    aws_iam_policy.redis_parameter_policy.arn
-    ] : [
-    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy[0].arn,
-    aws_iam_policy.dynamo_access_policy[0].arn,
+  policies_to_attach = [
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    aws_iam_policy.dynamo_access_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn
   ]
@@ -97,7 +83,6 @@ module "oidc_dynamo_sqs_role" {
 ### ID Token signing key access
 
 data "aws_iam_policy_document" "kms_policy_document" {
-  count = var.use_localstack ? 0 : 1
   statement {
     sid       = "AllowAccessToKmsSigningKey"
     effect    = "Allow"
@@ -107,18 +92,16 @@ data "aws_iam_policy_document" "kms_policy_document" {
 }
 
 resource "aws_iam_policy" "oidc_default_id_token_public_key_kms_policy" {
-  count       = var.use_localstack ? 0 : 1
   name_prefix = "id-token-kms-policy"
   path        = "/${var.environment}/oidc-default/"
   description = "IAM policy for managing ID token public signing key access"
 
-  policy = data.aws_iam_policy_document.kms_policy_document[0].json
+  policy = data.aws_iam_policy_document.kms_policy_document.json
 }
 
 ### Audit signing key access
 
 data "aws_iam_policy_document" "audit_payload_kms_signing_policy_document" {
-  count = var.use_localstack ? 0 : 1
   statement {
     sid       = "AllowAccessToKmsAuditSigningKey"
     effect    = "Allow"
@@ -128,10 +111,9 @@ data "aws_iam_policy_document" "audit_payload_kms_signing_policy_document" {
 }
 
 resource "aws_iam_policy" "audit_signing_key_lambda_kms_signing_policy" {
-  count       = var.use_localstack ? 0 : 1
   name_prefix = "audit-payload-kms-signing-policy"
   path        = "/${var.environment}/oidc-default/"
   description = "IAM policy for managing KMS connection for a lambda which allows signing of audit payloads"
 
-  policy = data.aws_iam_policy_document.audit_payload_kms_signing_policy_document[0].json
+  policy = data.aws_iam_policy_document.audit_payload_kms_signing_policy_document.json
 }

--- a/ci/terraform/oidc/register.tf
+++ b/ci/terraform/oidc/register.tf
@@ -24,7 +24,7 @@ module "register" {
   lambda_zip_file                        = var.client_registry_api_lambda_zip_file
   security_group_ids                     = [local.authentication_security_group_id]
   subnet_id                              = local.authentication_subnet_ids
-  lambda_role_arn                        = module.oidc_default_role.arn
+  lambda_role_arn                        = module.client_registry_role.arn
   environment                            = var.environment
   logging_endpoint_enabled               = var.logging_endpoint_enabled
   logging_endpoint_arn                   = var.logging_endpoint_arn

--- a/ci/terraform/oidc/register.tf
+++ b/ci/terraform/oidc/register.tf
@@ -1,3 +1,16 @@
+module "client_registry_role" {
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "client-registry-role"
+  vpc_arn     = local.authentication_vpc_arn
+
+  policies_to_attach = [
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    aws_iam_policy.dynamo_client_registry_access_policy.arn,
+    aws_iam_policy.lambda_sns_policy.arn,
+  ]
+}
+
 module "register" {
   count  = var.client_registry_api_enabled ? 1 : 0
   source = "../modules/endpoint-module"

--- a/ci/terraform/oidc/token.tf
+++ b/ci/terraform/oidc/token.tf
@@ -4,16 +4,15 @@ module "oidc_token_role" {
   role_name   = "oidc-token"
   vpc_arn     = local.authentication_vpc_arn
 
-  policies_to_attach = var.use_localstack ? [aws_iam_policy.redis_parameter_policy.arn] : [
-    aws_iam_policy.oidc_token_kms_signing_policy[0].arn,
-    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy[0].arn,
-    aws_iam_policy.dynamo_access_policy[0].arn,
+  policies_to_attach = [
+    aws_iam_policy.oidc_token_kms_signing_policy.arn,
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    aws_iam_policy.dynamo_access_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn
   ]
 }
 
 data "aws_iam_policy_document" "kms_signing_policy_document" {
-  count = var.use_localstack ? 0 : 1
   statement {
     sid    = "AllowAccessToKmsSigningKey"
     effect = "Allow"
@@ -29,12 +28,11 @@ data "aws_iam_policy_document" "kms_signing_policy_document" {
 }
 
 resource "aws_iam_policy" "oidc_token_kms_signing_policy" {
-  count       = var.use_localstack ? 0 : 1
   name_prefix = "kms-signing-policy"
   path        = "/${var.environment}/oidc-token/"
   description = "IAM policy for managing KMS connection for a lambda which allows signing"
 
-  policy = data.aws_iam_policy_document.kms_signing_policy_document[0].json
+  policy = data.aws_iam_policy_document.kms_signing_policy_document.json
 }
 
 module "token" {

--- a/ci/terraform/oidc/update.tf
+++ b/ci/terraform/oidc/update.tf
@@ -1,3 +1,16 @@
+module "client_update_role" {
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "client-update-role"
+  vpc_arn     = local.authentication_vpc_arn
+
+  policies_to_attach = [
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    aws_iam_policy.dynamo_client_registry_access_policy.arn,
+    aws_iam_policy.lambda_sns_policy.arn,
+  ]
+}
+
 module "update" {
   count  = var.client_registry_api_enabled ? 1 : 0
   source = "../modules/endpoint-module"
@@ -28,7 +41,7 @@ module "update" {
     local.authentication_oidc_redis_security_group_id,
   ]
   subnet_id                              = local.authentication_subnet_ids
-  lambda_role_arn                        = module.client_registry_role.arn
+  lambda_role_arn                        = module.client_update_role.arn
   environment                            = var.environment
   logging_endpoint_enabled               = var.logging_endpoint_enabled
   logging_endpoint_arn                   = var.logging_endpoint_arn

--- a/ci/terraform/oidc/update.tf
+++ b/ci/terraform/oidc/update.tf
@@ -28,7 +28,7 @@ module "update" {
     local.authentication_oidc_redis_security_group_id,
   ]
   subnet_id                              = local.authentication_subnet_ids
-  lambda_role_arn                        = module.oidc_default_role.arn
+  lambda_role_arn                        = module.client_registry_role.arn
   environment                            = var.environment
   logging_endpoint_enabled               = var.logging_endpoint_enabled
   logging_endpoint_arn                   = var.logging_endpoint_arn


### PR DESCRIPTION
## What?

- Create a 2 new Lambda role which will be used by the 2 client registration lambdas UpdateClientConfigHandler and ClientRegistrationHandler. These Lambdas only require the KMS signing policy and Lambda SNS policy as part of the audit and also a new dynamo_client_registry_write_policy.
- Create a new policy called dynamo_client_registry_write_policy which will only give the UpdateClientConfigHandler and ClientRegistrationHandler permissions to the Client Registry table. Before the had access to the user tables which they did not need.
- Move Dynamo policies into a separate file as it was getting too big
- Remove localstack condition on IAM policies

## Why?
- To give lambas permissions to the things they need