### PR TITLE
AUTH-1174 - Create new Lambda role for authorize

### DIFF
--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -1,3 +1,18 @@
+module "oidc_authorize_role" {
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "oidc-authorize-role"
+  vpc_arn     = local.authentication_vpc_arn
+
+  policies_to_attach = [
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    aws_iam_policy.dynamo_user_read_access_policy.arn,
+    aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
+    aws_iam_policy.lambda_sns_policy.arn,
+    aws_iam_policy.redis_parameter_policy.arn,
+  ]
+}
+
 module "authorize" {
   source = "../modules/endpoint-module"
 
@@ -30,7 +45,7 @@ module "authorize" {
     local.authentication_oidc_redis_security_group_id,
   ]
   subnet_id                              = local.authentication_subnet_ids
-  lambda_role_arn                        = module.oidc_default_role.arn
+  lambda_role_arn                        = module.oidc_authorize_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled
   logging_endpoint_arn                   = var.logging_endpoint_arn
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/dynamo-policies.tf
+++ b/ci/terraform/oidc/dynamo-policies.tf
@@ -41,6 +41,28 @@ data "aws_iam_policy_document" "dynamo_access_policy_document" {
   }
 }
 
+data "aws_iam_policy_document" "dynamo_user_read_policy_document" {
+  statement {
+    sid    = "AllowAccessToDynamoTables"
+    effect = "Allow"
+
+    actions = [
+      "dynamodb:BatchGetItem",
+      "dynamodb:DescribeStream",
+      "dynamodb:DescribeTable",
+      "dynamodb:Get*",
+      "dynamodb:Query",
+      "dynamodb:Scan",
+    ]
+    resources = [
+      data.aws_dynamodb_table.user_credentials_table.arn,
+      data.aws_dynamodb_table.user_profile_table.arn,
+      "${data.aws_dynamodb_table.user_profile_table.arn}/index/*",
+      "${data.aws_dynamodb_table.user_credentials_table.arn}/index/*",
+    ]
+  }
+}
+
 data "aws_iam_policy_document" "dynamo_client_registration_policy_document" {
   statement {
     sid    = "AllowAccessToDynamoTables"
@@ -64,6 +86,23 @@ data "aws_iam_policy_document" "dynamo_client_registration_policy_document" {
   }
 }
 
+data "aws_iam_policy_document" "dynamo_client_registration_read_policy_document" {
+  statement {
+    sid    = "AllowAccessToDynamoTables"
+    effect = "Allow"
+
+    actions = [
+      "dynamodb:BatchGetItem",
+      "dynamodb:DescribeTable",
+      "dynamodb:Get*",
+      "dynamodb:Query",
+      "dynamodb:Scan",
+    ]
+    resources = [
+      data.aws_dynamodb_table.client_registry_table.arn,
+    ]
+  }
+}
 
 data "aws_iam_policy_document" "dynamo_spot_write_access_policy_document" {
   statement {
@@ -108,6 +147,22 @@ resource "aws_iam_policy" "dynamo_client_registry_access_policy" {
   description = "IAM policy for managing write permissions to the Dynamo Client Registration table"
 
   policy = data.aws_iam_policy_document.dynamo_client_registration_policy_document.json
+}
+
+resource "aws_iam_policy" "dynamo_client_registry_read_access_policy" {
+  name_prefix = "dynamo-client-registry-read-policy"
+  path        = "/${var.environment}/oidc-shared/"
+  description = "IAM policy for managing read permissions to the Dynamo Client Registration table"
+
+  policy = data.aws_iam_policy_document.dynamo_client_registration_read_policy_document.json
+}
+
+resource "aws_iam_policy" "dynamo_user_read_access_policy" {
+  name_prefix = "dynamo-user-read-policy"
+  path        = "/${var.environment}/oidc-shared/"
+  description = "IAM policy for managing read permissions to the Dynamo User tables"
+
+  policy = data.aws_iam_policy_document.dynamo_user_read_policy_document.json
 }
 
 resource "aws_iam_policy" "dynamo_spot_write_access_policy" {


### PR DESCRIPTION
## What?

- Limit the permissions given to the authorize lambda but creating a new role specific to it.
- Create new policies for read access to the client registration and user tables. The majority of the lambdas only need READ access.

## Why?

- Authorize had a lot of permissions which it didn't require. Ensure that we only give it the permissions that the Authorize lambda requires. 