### PR TITLE
BAU - Raise the WAF blocked threshold to 1000 blocked requests in 5 mins

### DIFF
--- a/ci/terraform/account-management/alerts.tf
+++ b/ci/terraform/account-management/alerts.tf
@@ -23,7 +23,7 @@ resource "aws_cloudwatch_metric_alarm" "waf_am_blocked_request_cloudwatch_alarm"
   evaluation_periods  = "1"
   metric_name         = "BlockedRequests"
   namespace           = "AWS/WAFV2"
-  period              = "3600"
+  period              = "300"
   statistic           = "Sum"
   threshold           = var.waf_alarm_blocked_reqeuest_threshold
 
@@ -33,7 +33,7 @@ resource "aws_cloudwatch_metric_alarm" "waf_am_blocked_request_cloudwatch_alarm"
     WebACL = aws_wafv2_web_acl.wafregional_web_acl_am_api[count.index].name
   }
 
-  alarm_description = "${var.waf_alarm_blocked_reqeuest_threshold} or more blocked requests have been received by the ${aws_wafv2_web_acl.wafregional_web_acl_am_api[count.index].name} in the last hour"
+  alarm_description = "${var.waf_alarm_blocked_reqeuest_threshold} or more blocked requests have been received by the ${aws_wafv2_web_acl.wafregional_web_acl_am_api[count.index].name} in the last 5 minutes"
   alarm_actions     = [data.aws_sns_topic.slack_events.arn]
 }
 

--- a/ci/terraform/account-management/variables.tf
+++ b/ci/terraform/account-management/variables.tf
@@ -147,7 +147,7 @@ variable "dlq_alarm_threshold" {
 }
 
 variable "waf_alarm_blocked_reqeuest_threshold" {
-  default     = 100
+  default     = 1000
   type        = number
   description = "The number of blocked requests caught by the WAF before a Cloudwatch alarm is generated"
 }

--- a/ci/terraform/oidc/alerts.tf
+++ b/ci/terraform/oidc/alerts.tf
@@ -25,7 +25,7 @@ resource "aws_cloudwatch_metric_alarm" "waf_oidc_blocked_request_cloudwatch_alar
   evaluation_periods  = "1"
   metric_name         = "BlockedRequests"
   namespace           = "AWS/WAFV2"
-  period              = "3600"
+  period              = "300"
   statistic           = "Sum"
   threshold           = var.waf_alarm_blocked_reqeuest_threshold
 
@@ -35,7 +35,7 @@ resource "aws_cloudwatch_metric_alarm" "waf_oidc_blocked_request_cloudwatch_alar
     WebACL = aws_wafv2_web_acl.wafregional_web_acl_oidc_api[count.index].name
   }
 
-  alarm_description = "${var.waf_alarm_blocked_reqeuest_threshold} or more blocked requests have been received by the ${aws_wafv2_web_acl.wafregional_web_acl_oidc_api[count.index].name} in the last hour"
+  alarm_description = "${var.waf_alarm_blocked_reqeuest_threshold} or more blocked requests have been received by the ${aws_wafv2_web_acl.wafregional_web_acl_oidc_api[count.index].name} in the last 5 minutes"
   alarm_actions     = [data.aws_sns_topic.slack_events.arn]
 }
 
@@ -46,7 +46,7 @@ resource "aws_cloudwatch_metric_alarm" "waf_frontend_blocked_request_cloudwatch_
   evaluation_periods  = "1"
   metric_name         = "BlockedRequests"
   namespace           = "AWS/WAFV2"
-  period              = "3600"
+  period              = "300"
   statistic           = "Sum"
   threshold           = var.waf_alarm_blocked_reqeuest_threshold
 
@@ -56,7 +56,7 @@ resource "aws_cloudwatch_metric_alarm" "waf_frontend_blocked_request_cloudwatch_
     WebACL = aws_wafv2_web_acl.wafregional_web_acl_frontend_api[count.index].name
   }
 
-  alarm_description = "${var.waf_alarm_blocked_reqeuest_threshold} or more blocked requests have been received by the ${aws_wafv2_web_acl.wafregional_web_acl_frontend_api[count.index].name} in the last hour"
+  alarm_description = "${var.waf_alarm_blocked_reqeuest_threshold} or more blocked requests have been received by the ${aws_wafv2_web_acl.wafregional_web_acl_frontend_api[count.index].name} in the last 5 minutes"
   alarm_actions     = [data.aws_sns_topic.slack_events.arn]
 }
 

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -194,7 +194,7 @@ variable "dlq_alarm_threshold" {
 }
 
 variable "waf_alarm_blocked_reqeuest_threshold" {
-  default     = 100
+  default     = 1000
   type        = number
   description = "The number of blocked requests caught by the WAF before a Cloudwatch alarm is generated"
 }


### PR DESCRIPTION
## What?

Raise the WAF blocked threshold to 1000 blocked requests in 5 mins

## Why?


- We are seeing more blocked requests and we only want to know about a large amount of blocked requests in a short period of time. This will help us identify if there is any unusual behaviour