### PR TITLE
AUTH-1174 - Create separate lambda roles 

### DIFF
--- a/ci/terraform/oidc/identity.tf
+++ b/ci/terraform/oidc/identity.tf
@@ -1,3 +1,18 @@
+module "ipv_identity_lambda_role" {
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "ipv-identity-role"
+  vpc_arn     = local.authentication_vpc_arn
+
+  policies_to_attach = [
+    aws_iam_policy.dynamo_access_policy.arn,
+    aws_iam_policy.dynamo_spot_read_access_policy.arn,
+    aws_iam_policy.redis_parameter_policy.arn,
+    aws_iam_policy.oidc_default_id_token_public_key_kms_policy.arn,
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+  ]
+}
+
 module "identity" {
   count  = var.ipv_api_enabled ? 1 : 0
   source = "../modules/endpoint-module"
@@ -26,7 +41,7 @@ module "identity" {
     local.authentication_oidc_redis_security_group_id,
   ]
   subnet_id                              = local.authentication_subnet_ids
-  lambda_role_arn                        = module.identity_lambda_role.arn
+  lambda_role_arn                        = module.ipv_identity_lambda_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled
   logging_endpoint_arn                   = var.logging_endpoint_arn
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/ipv-authorize.tf
+++ b/ci/terraform/oidc/ipv-authorize.tf
@@ -1,3 +1,18 @@
+module "ipv_authorize_role" {
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "ipv-authorize-role"
+  vpc_arn     = local.authentication_vpc_arn
+
+  policies_to_attach = [
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
+    aws_iam_policy.dynamo_user_read_access_policy.arn,
+    aws_iam_policy.lambda_sns_policy.arn,
+    aws_iam_policy.redis_parameter_policy.arn,
+  ]
+}
+
 module "ipv-authorize" {
   count  = var.ipv_api_enabled ? 1 : 0
   source = "../modules/endpoint-module"
@@ -32,7 +47,7 @@ module "ipv-authorize" {
     local.authentication_oidc_redis_security_group_id,
   ]
   subnet_id                              = local.authentication_subnet_ids
-  lambda_role_arn                        = module.oidc_default_role.arn
+  lambda_role_arn                        = module.ipv_authorize_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled
   logging_endpoint_arn                   = var.logging_endpoint_arn
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -1,3 +1,18 @@
+module "ipv_callback_role" {
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "ipv-callback-role"
+  vpc_arn     = local.authentication_vpc_arn
+
+  policies_to_attach = [
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
+    aws_iam_policy.dynamo_user_read_access_policy.arn,
+    aws_iam_policy.lambda_sns_policy.arn,
+    aws_iam_policy.redis_parameter_policy.arn,
+  ]
+}
+
 module "ipv-callback" {
   count  = var.ipv_api_enabled ? 1 : 0
   source = "../modules/endpoint-module"
@@ -33,7 +48,7 @@ module "ipv-callback" {
     local.authentication_oidc_redis_security_group_id,
   ]
   subnet_id                              = local.authentication_subnet_ids
-  lambda_role_arn                        = module.oidc_default_role.arn
+  lambda_role_arn                        = module.ipv_callback_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled
   logging_endpoint_arn                   = var.logging_endpoint_arn
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/ipv-capacity.tf
+++ b/ci/terraform/oidc/ipv-capacity.tf
@@ -1,3 +1,16 @@
+module "ipv_capacity_role" {
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "ipv-capacity-role"
+  vpc_arn     = local.authentication_vpc_arn
+
+  policies_to_attach = [
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    aws_iam_policy.lambda_sns_policy.arn,
+    aws_iam_policy.ipv_capacity_parameter_policy.arn,
+  ]
+}
+
 module "ipv-capacity" {
   count  = var.ipv_api_enabled ? 1 : 0
   source = "../modules/endpoint-module"
@@ -32,7 +45,7 @@ module "ipv-capacity" {
     local.authentication_oidc_redis_security_group_id,
   ]
   subnet_id                              = local.authentication_subnet_ids
-  lambda_role_arn                        = module.oidc_default_role.arn
+  lambda_role_arn                        = module.ipv_capacity_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled
   logging_endpoint_arn                   = var.logging_endpoint_arn
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/jwks.tf
+++ b/ci/terraform/oidc/jwks.tf
@@ -1,3 +1,14 @@
+module "oidc_jwks_role" {
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "oidc-jwks-role"
+  vpc_arn     = local.authentication_vpc_arn
+
+  policies_to_attach = [
+    aws_iam_policy.oidc_default_id_token_public_key_kms_policy.arn,
+  ]
+}
+
 module "jwks" {
   source = "../modules/endpoint-module"
 
@@ -23,7 +34,7 @@ module "jwks" {
   authentication_vpc_arn                 = local.authentication_vpc_arn
   security_group_ids                     = [local.authentication_security_group_id]
   subnet_id                              = local.authentication_subnet_ids
-  lambda_role_arn                        = module.oidc_default_role.arn
+  lambda_role_arn                        = module.oidc_jwks_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled
   logging_endpoint_arn                   = var.logging_endpoint_arn
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/lambda-roles.tf
+++ b/ci/terraform/oidc/lambda-roles.tf
@@ -15,32 +15,6 @@ module "oidc_default_role" {
   ]
 }
 
-module "spot_response_role" {
-  source      = "../modules/lambda-role"
-  environment = var.environment
-  role_name   = "spot-response-role"
-  vpc_arn     = local.authentication_vpc_arn
-
-  policies_to_attach = [
-    aws_iam_policy.dynamo_spot_write_access_policy.arn,
-  ]
-}
-
-module "identity_lambda_role" {
-  source      = "../modules/lambda-role"
-  environment = var.environment
-  role_name   = "identity-role"
-  vpc_arn     = local.authentication_vpc_arn
-
-  policies_to_attach = [
-    aws_iam_policy.dynamo_access_policy.arn,
-    aws_iam_policy.dynamo_spot_read_access_policy.arn,
-    aws_iam_policy.redis_parameter_policy.arn,
-    aws_iam_policy.oidc_default_id_token_public_key_kms_policy.arn,
-    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
-  ]
-}
-
 module "oidc_sqs_role" {
   source      = "../modules/lambda-role"
   environment = var.environment

--- a/ci/terraform/oidc/spot-response.tf
+++ b/ci/terraform/oidc/spot-response.tf
@@ -1,8 +1,19 @@
+module "ipv_spot_response_role" {
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "ipv-spot-response-role"
+  vpc_arn     = local.authentication_vpc_arn
+
+  policies_to_attach = [
+    aws_iam_policy.dynamo_spot_write_access_policy.arn,
+  ]
+}
+
 resource "aws_lambda_function" "spot_response_lambda" {
   count         = var.ipv_api_enabled ? 1 : 0
   filename      = var.ipv_api_lambda_zip_file
   function_name = "${var.environment}-spot-response-lambda"
-  role          = module.spot_response_role.arn
+  role          = module.ipv_spot_response_role.arn
   handler       = "uk.gov.di.authentication.ipv-api.lambda.SPOTResponseHandler::handleRequest"
   timeout       = 30
   memory_size   = 512


### PR DESCRIPTION
## What?

- Create separate lambda roles for the IpvCallback, IpvAuthorize, IpvCapacity and JWKs lambdas. 
- Move the roles of the Identity and SpotResponse lambdas alongside the Lambda 
- Give the IPV Lambda roles a consistent naming convention 

## Why?

- So we only give the Lambdas the permissions that they need
- So the naming is consistent 