### PR TITLE
BAU: AWS provides SDK libraries at runtime, do not bundle

### DIFF
--- a/oidc-api/build.gradle
+++ b/oidc-api/build.gradle
@@ -7,19 +7,24 @@ group "uk.gov.di.authentication.oidc"
 version "unspecified"
 
 dependencies {
-    implementation configurations.lambda,
+
+    compileOnly configurations.lambda,
             configurations.sqs,
-            configurations.govuk_notify,
+            configurations.dynamodb
+
+    implementation configurations.govuk_notify,
             configurations.jackson,
             configurations.nimbus,
-            configurations.dynamodb,
             configurations.bouncycastle,
             project(":shared"),
             project(":client-registry-api")
 
     testImplementation configurations.tests,
             configurations.lambda_tests,
-            project(":shared-test")
+            project(":shared-test"),
+            configurations.lambda,
+            configurations.sqs,
+            configurations.dynamodb
     testRuntimeOnly configurations.test_runtime
 }
 


### PR DESCRIPTION
## What?

Pull in AWS SDK libraries at runtime

## Why?

Shrink the size of the deployable jar.

