### PR TITLE
AUTH-1174 - Create new role per lambda

### DIFF
--- a/ci/terraform/oidc/dynamo-policies.tf
+++ b/ci/terraform/oidc/dynamo-policies.tf
@@ -41,6 +41,25 @@ data "aws_iam_policy_document" "dynamo_access_policy_document" {
   }
 }
 
+data "aws_iam_policy_document" "dynamo_user_write_policy_document" {
+  statement {
+    sid    = "AllowAccessToDynamoTables"
+    effect = "Allow"
+
+    actions = [
+      "dynamodb:BatchWriteItem",
+      "dynamodb:UpdateItem",
+      "dynamodb:PutItem",
+    ]
+    resources = [
+      data.aws_dynamodb_table.user_credentials_table.arn,
+      data.aws_dynamodb_table.user_profile_table.arn,
+      "${data.aws_dynamodb_table.user_profile_table.arn}/index/*",
+      "${data.aws_dynamodb_table.user_credentials_table.arn}/index/*",
+    ]
+  }
+}
+
 data "aws_iam_policy_document" "dynamo_user_read_policy_document" {
   statement {
     sid    = "AllowAccessToDynamoTables"
@@ -163,6 +182,14 @@ resource "aws_iam_policy" "dynamo_user_read_access_policy" {
   description = "IAM policy for managing read permissions to the Dynamo User tables"
 
   policy = data.aws_iam_policy_document.dynamo_user_read_policy_document.json
+}
+
+resource "aws_iam_policy" "dynamo_user_write_access_policy" {
+  name_prefix = "dynamo-user-write-policy"
+  path        = "/${var.environment}/oidc-shared/"
+  description = "IAM policy for managing write permissions to the Dynamo User tables"
+
+  policy = data.aws_iam_policy_document.dynamo_user_write_policy_document.json
 }
 
 resource "aws_iam_policy" "dynamo_spot_write_access_policy" {

--- a/ci/terraform/oidc/login.tf
+++ b/ci/terraform/oidc/login.tf
@@ -1,3 +1,21 @@
+module "frontend_api_login_role" {
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "frontend-api-login-role"
+  vpc_arn     = local.authentication_vpc_arn
+
+  policies_to_attach = [
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    aws_iam_policy.dynamo_user_read_access_policy.arn,
+    aws_iam_policy.dynamo_user_write_access_policy.arn,
+    aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
+    aws_iam_policy.lambda_sns_policy.arn,
+    aws_iam_policy.pepper_parameter_policy.arn,
+    aws_iam_policy.redis_parameter_policy.arn,
+  ]
+}
+
+
 module "login" {
   source = "../modules/endpoint-module"
 
@@ -29,7 +47,7 @@ module "login" {
     local.authentication_oidc_redis_security_group_id,
   ]
   subnet_id                              = local.authentication_subnet_ids
-  lambda_role_arn                        = module.oidc_default_role.arn
+  lambda_role_arn                        = module.frontend_api_login_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled
   logging_endpoint_arn                   = var.logging_endpoint_arn
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/logout.tf
+++ b/ci/terraform/oidc/logout.tf
@@ -1,3 +1,18 @@
+module "oidc_logout_role" {
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "oidc-logout-role"
+  vpc_arn     = local.authentication_vpc_arn
+
+  policies_to_attach = [
+    aws_iam_policy.oidc_default_id_token_public_key_kms_policy.arn,
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
+    aws_iam_policy.lambda_sns_policy.arn,
+    aws_iam_policy.redis_parameter_policy.arn,
+  ]
+}
+
 module "logout" {
   source = "../modules/endpoint-module"
 
@@ -30,7 +45,7 @@ module "logout" {
     local.authentication_oidc_redis_security_group_id,
   ]
   subnet_id                              = local.authentication_subnet_ids
-  lambda_role_arn                        = module.oidc_default_role.arn
+  lambda_role_arn                        = module.oidc_logout_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled
   logging_endpoint_arn                   = var.logging_endpoint_arn
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/signup.tf
+++ b/ci/terraform/oidc/signup.tf
@@ -1,3 +1,19 @@
+module "frontend_api_signup_role" {
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "frontend-api-signup-role"
+  vpc_arn     = local.authentication_vpc_arn
+
+  policies_to_attach = [
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    aws_iam_policy.dynamo_user_write_access_policy.arn,
+    aws_iam_policy.dynamo_user_read_access_policy.arn,
+    aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
+    aws_iam_policy.lambda_sns_policy.arn,
+    aws_iam_policy.redis_parameter_policy.arn,
+  ]
+}
+
 module "signup" {
   source = "../modules/endpoint-module"
 
@@ -28,7 +44,7 @@ module "signup" {
     local.authentication_oidc_redis_security_group_id,
   ]
   subnet_id                              = local.authentication_subnet_ids
-  lambda_role_arn                        = module.oidc_default_role.arn
+  lambda_role_arn                        = module.frontend_api_signup_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled
   logging_endpoint_arn                   = var.logging_endpoint_arn
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/trustmarks.tf
+++ b/ci/terraform/oidc/trustmarks.tf
@@ -1,3 +1,11 @@
+module "oidc_trustmarks_role" {
+  source = "../modules/lambda-role"
+
+  role_name   = "oidc-trustmarks-role"
+  environment = var.environment
+  vpc_arn     = local.authentication_vpc_arn
+}
+
 module "trustmarks" {
   source = "../modules/endpoint-module"
 
@@ -24,7 +32,7 @@ module "trustmarks" {
   authentication_vpc_arn                 = local.authentication_vpc_arn
   security_group_ids                     = [local.authentication_security_group_id]
   subnet_id                              = local.authentication_subnet_ids
-  lambda_role_arn                        = module.oidc_default_role.arn
+  lambda_role_arn                        = module.oidc_trustmarks_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled
   logging_endpoint_arn                   = var.logging_endpoint_arn
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn


### PR DESCRIPTION
## What?

- Create new roles for the Login, Logout, Trustmarks and Signup lambda.

- Create a new write only policy for the User tables

## Why?

- So we give the lambdas only the permissions they require. 