### PR TITLE
AUTH-1174 - Create a role per lambda

### DIFF
--- a/ci/terraform/oidc/dynamo-policies.tf
+++ b/ci/terraform/oidc/dynamo-policies.tf
@@ -138,6 +138,20 @@ data "aws_iam_policy_document" "dynamo_spot_write_access_policy_document" {
   }
 }
 
+data "aws_iam_policy_document" "dynamo_spot_delete_access_policy_document" {
+  statement {
+    sid    = "AllowAccessToDynamoTables"
+    effect = "Allow"
+
+    actions = [
+      "dynamodb:DeleteItem",
+    ]
+    resources = [
+      data.aws_dynamodb_table.spot_credential_table.arn,
+    ]
+  }
+}
+
 data "aws_iam_policy_document" "dynamo_spot_read_access_policy_document" {
   statement {
     sid    = "AllowAccessToDynamoTables"
@@ -203,7 +217,15 @@ resource "aws_iam_policy" "dynamo_spot_write_access_policy" {
 resource "aws_iam_policy" "dynamo_spot_read_access_policy" {
   name_prefix = "dynamo-access-policy"
   path        = "/${var.environment}/oidc-default/"
-  description = "IAM policy for managing write permissions to the Dynamo SPOT credential table"
+  description = "IAM policy for managing read permissions to the Dynamo SPOT credential table"
 
   policy = data.aws_iam_policy_document.dynamo_spot_read_access_policy_document.json
+}
+
+resource "aws_iam_policy" "dynamo_spot_delete_access_policy" {
+  name_prefix = "dynamo-access-policy"
+  path        = "/${var.environment}/oidc-default/"
+  description = "IAM policy for managing delete permissions to the Dynamo SPOT credential table"
+
+  policy = data.aws_iam_policy_document.dynamo_spot_delete_access_policy_document.json
 }

--- a/ci/terraform/oidc/identity.tf
+++ b/ci/terraform/oidc/identity.tf
@@ -5,8 +5,9 @@ module "ipv_identity_lambda_role" {
   vpc_arn     = local.authentication_vpc_arn
 
   policies_to_attach = [
-    aws_iam_policy.dynamo_access_policy.arn,
     aws_iam_policy.dynamo_spot_read_access_policy.arn,
+    aws_iam_policy.dynamo_spot_delete_access_policy.arn,
+    aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
     aws_iam_policy.oidc_default_id_token_public_key_kms_policy.arn,
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,

--- a/ci/terraform/oidc/lambda-roles.tf
+++ b/ci/terraform/oidc/lambda-roles.tf
@@ -1,20 +1,3 @@
-module "oidc_default_role" {
-  source      = "../modules/lambda-role"
-  environment = var.environment
-  role_name   = "oidc-default-role"
-  vpc_arn     = local.authentication_vpc_arn
-
-  policies_to_attach = [
-    aws_iam_policy.oidc_default_id_token_public_key_kms_policy.arn,
-    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
-    aws_iam_policy.dynamo_access_policy.arn,
-    aws_iam_policy.lambda_sns_policy.arn,
-    aws_iam_policy.redis_parameter_policy.arn,
-    aws_iam_policy.pepper_parameter_policy.arn,
-    aws_iam_policy.ipv_capacity_parameter_policy.arn,
-  ]
-}
-
 module "oidc_sqs_role" {
   source      = "../modules/lambda-role"
   environment = var.environment

--- a/ci/terraform/oidc/token.tf
+++ b/ci/terraform/oidc/token.tf
@@ -7,7 +7,8 @@ module "oidc_token_role" {
   policies_to_attach = [
     aws_iam_policy.oidc_token_kms_signing_policy.arn,
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
-    aws_iam_policy.dynamo_access_policy.arn,
+    aws_iam_policy.dynamo_user_read_access_policy.arn,
+    aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn
   ]
 }

--- a/ci/terraform/oidc/update_profile.tf
+++ b/ci/terraform/oidc/update_profile.tf
@@ -1,3 +1,19 @@
+module "frontend_api_update_profile_role" {
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "frontend-api-update-profile-role"
+  vpc_arn     = local.authentication_vpc_arn
+
+  policies_to_attach = [
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    aws_iam_policy.dynamo_user_read_access_policy.arn,
+    aws_iam_policy.dynamo_user_write_access_policy.arn,
+    aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
+    aws_iam_policy.lambda_sns_policy.arn,
+    aws_iam_policy.redis_parameter_policy.arn,
+  ]
+}
+
 module "update_profile" {
   source = "../modules/endpoint-module"
 
@@ -29,7 +45,7 @@ module "update_profile" {
     local.authentication_oidc_redis_security_group_id,
   ]
   subnet_id                              = local.authentication_subnet_ids
-  lambda_role_arn                        = module.oidc_default_role.arn
+  lambda_role_arn                        = module.frontend_api_update_profile_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled
   logging_endpoint_arn                   = var.logging_endpoint_arn
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/userexists.tf
+++ b/ci/terraform/oidc/userexists.tf
@@ -1,3 +1,18 @@
+module "frontend_api_user_exists_role" {
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "frontend-api-user-exists-role"
+  vpc_arn     = local.authentication_vpc_arn
+
+  policies_to_attach = [
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    aws_iam_policy.dynamo_user_read_access_policy.arn,
+    aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
+    aws_iam_policy.lambda_sns_policy.arn,
+    aws_iam_policy.redis_parameter_policy.arn,
+  ]
+}
+
 module "userexists" {
   source = "../modules/endpoint-module"
 
@@ -29,7 +44,7 @@ module "userexists" {
     local.authentication_oidc_redis_security_group_id,
   ]
   subnet_id                              = local.authentication_subnet_ids
-  lambda_role_arn                        = module.oidc_default_role.arn
+  lambda_role_arn                        = module.frontend_api_user_exists_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled
   logging_endpoint_arn                   = var.logging_endpoint_arn
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -1,3 +1,18 @@
+module "oidc_userinfo_role" {
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "oidc-userinfo-role"
+  vpc_arn     = local.authentication_vpc_arn
+
+  policies_to_attach = [
+    aws_iam_policy.oidc_token_kms_signing_policy.arn,
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    aws_iam_policy.dynamo_user_read_access_policy.arn,
+    aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
+    aws_iam_policy.redis_parameter_policy.arn
+  ]
+}
+
 module "userinfo" {
   source = "../modules/endpoint-module"
 
@@ -28,7 +43,7 @@ module "userinfo" {
     local.authentication_oidc_redis_security_group_id,
   ]
   subnet_id                              = local.authentication_subnet_ids
-  lambda_role_arn                        = module.oidc_default_role.arn
+  lambda_role_arn                        = module.oidc_userinfo_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled
   logging_endpoint_arn                   = var.logging_endpoint_arn
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/verify_code.tf
+++ b/ci/terraform/oidc/verify_code.tf
@@ -1,3 +1,18 @@
+module "frontend_api_verify_code_role" {
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "frontend-api-verify-code-role"
+  vpc_arn     = local.authentication_vpc_arn
+
+  policies_to_attach = [
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    aws_iam_policy.dynamo_user_read_access_policy.arn,
+    aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
+    aws_iam_policy.lambda_sns_policy.arn,
+    aws_iam_policy.redis_parameter_policy.arn,
+  ]
+}
+
 module "verify_code" {
   source = "../modules/endpoint-module"
 
@@ -32,7 +47,7 @@ module "verify_code" {
     local.authentication_oidc_redis_security_group_id,
   ]
   subnet_id                              = local.authentication_subnet_ids
-  lambda_role_arn                        = module.oidc_default_role.arn
+  lambda_role_arn                        = module.frontend_api_verify_code_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled
   logging_endpoint_arn                   = var.logging_endpoint_arn
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn


### PR DESCRIPTION
## What?

- Restrict Token lambda to just read dynamo permissions 
- Create new roles for the UpdateProfile, UserExists and UserInfo lambdas
- Give the Identity lambda role the correct permissions

## Why?

- The token lambda will only need to read from Dynamo so we can remove it's permissions to write
- We can restrict permissions each lambda is given by assigning a role for each lambda 
- The identity lambda was previously missing permissions and had permissions to dynamo that it did not require