### PR TITLE
AUTH-1174 -  Create a role for each lambda which talks to SQS 

### DIFF
--- a/ci/terraform/oidc/kms-policies.tf
+++ b/ci/terraform/oidc/kms-policies.tf
@@ -1,18 +1,3 @@
-module "oidc_dynamo_sqs_role" {
-  source      = "../modules/lambda-role"
-  environment = var.environment
-  role_name   = "oidc-dynamo-sqs"
-  vpc_arn     = local.authentication_vpc_arn
-
-  policies_to_attach = [
-    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
-    aws_iam_policy.dynamo_access_policy.arn,
-    aws_iam_policy.lambda_sns_policy.arn,
-    aws_iam_policy.redis_parameter_policy.arn
-  ]
-
-}
-
 ### ID Token signing key access
 
 data "aws_iam_policy_document" "kms_policy_document" {

--- a/ci/terraform/oidc/lambda-roles.tf
+++ b/ci/terraform/oidc/lambda-roles.tf
@@ -1,14 +1,3 @@
-module "oidc_sqs_role" {
-  source      = "../modules/lambda-role"
-  environment = var.environment
-  role_name   = "oidc-sqs"
-  vpc_arn     = local.authentication_vpc_arn
-
-  policies_to_attach = [
-    aws_iam_policy.lambda_sns_policy.arn
-  ]
-}
-
 module "oidc_dynamo_sqs_role" {
   source      = "../modules/lambda-role"
   environment = var.environment

--- a/ci/terraform/oidc/mfa.tf
+++ b/ci/terraform/oidc/mfa.tf
@@ -1,3 +1,18 @@
+module "frontend_api_mfa_role" {
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "frontend-api-mfa-role"
+  vpc_arn     = local.authentication_vpc_arn
+
+  policies_to_attach = [
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    aws_iam_policy.dynamo_user_read_access_policy.arn,
+    aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
+    aws_iam_policy.lambda_sns_policy.arn,
+    aws_iam_policy.redis_parameter_policy.arn
+  ]
+}
+
 module "mfa" {
   source = "../modules/endpoint-module"
 
@@ -29,7 +44,7 @@ module "mfa" {
     local.authentication_oidc_redis_security_group_id,
   ]
   subnet_id                              = local.authentication_subnet_ids
-  lambda_role_arn                        = module.oidc_dynamo_sqs_role.arn
+  lambda_role_arn                        = module.frontend_api_mfa_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled
   logging_endpoint_arn                   = var.logging_endpoint_arn
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/reset-password-request.tf
+++ b/ci/terraform/oidc/reset-password-request.tf
@@ -1,3 +1,18 @@
+module "frontend_api_reset_password_request_role" {
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "frontend-api-reset-password-request-role"
+  vpc_arn     = local.authentication_vpc_arn
+
+  policies_to_attach = [
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    aws_iam_policy.dynamo_user_read_access_policy.arn,
+    aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
+    aws_iam_policy.lambda_sns_policy.arn,
+    aws_iam_policy.redis_parameter_policy.arn
+  ]
+}
+
 module "reset-password-request" {
   source = "../modules/endpoint-module"
 
@@ -32,7 +47,7 @@ module "reset-password-request" {
     local.authentication_oidc_redis_security_group_id,
   ]
   subnet_id                              = local.authentication_subnet_ids
-  lambda_role_arn                        = module.oidc_dynamo_sqs_role.arn
+  lambda_role_arn                        = module.frontend_api_reset_password_request_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled
   logging_endpoint_arn                   = var.logging_endpoint_arn
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/reset_password.tf
+++ b/ci/terraform/oidc/reset_password.tf
@@ -1,3 +1,19 @@
+module "frontend_api_reset_password_role" {
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "frontend-api-reset-password-role"
+  vpc_arn     = local.authentication_vpc_arn
+
+  policies_to_attach = [
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    aws_iam_policy.dynamo_user_read_access_policy.arn,
+    aws_iam_policy.dynamo_user_write_access_policy.arn,
+    aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
+    aws_iam_policy.lambda_sns_policy.arn,
+    aws_iam_policy.redis_parameter_policy.arn
+  ]
+}
+
 module "reset_password" {
   source = "../modules/endpoint-module"
 
@@ -30,7 +46,7 @@ module "reset_password" {
     local.authentication_oidc_redis_security_group_id,
   ]
   subnet_id                              = local.authentication_subnet_ids
-  lambda_role_arn                        = module.oidc_dynamo_sqs_role.arn
+  lambda_role_arn                        = module.frontend_api_reset_password_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled
   logging_endpoint_arn                   = var.logging_endpoint_arn
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/send_notification.tf
+++ b/ci/terraform/oidc/send_notification.tf
@@ -1,3 +1,18 @@
+module "frontend_api_send_notification_role" {
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "frontend-api-send-notification-role"
+  vpc_arn     = local.authentication_vpc_arn
+
+  policies_to_attach = [
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    aws_iam_policy.dynamo_user_read_access_policy.arn,
+    aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
+    aws_iam_policy.lambda_sns_policy.arn,
+    aws_iam_policy.redis_parameter_policy.arn
+  ]
+}
+
 module "send_notification" {
   source = "../modules/endpoint-module"
 
@@ -28,7 +43,7 @@ module "send_notification" {
     local.authentication_oidc_redis_security_group_id,
   ]
   subnet_id                              = local.authentication_subnet_ids
-  lambda_role_arn                        = module.oidc_dynamo_sqs_role.arn
+  lambda_role_arn                        = module.frontend_api_send_notification_role.arn
   logging_endpoint_enabled               = var.logging_endpoint_enabled
   logging_endpoint_arn                   = var.logging_endpoint_arn
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn

--- a/ci/terraform/oidc/sqs.tf
+++ b/ci/terraform/oidc/sqs.tf
@@ -51,7 +51,7 @@ data "aws_iam_policy_document" "email_queue_policy_document" {
 
     principals {
       type        = "AWS"
-      identifiers = [module.oidc_dynamo_sqs_role.arn, module.frontend_api_send_notification_role.arn, module.frontend_api_mfa_role.arn]
+      identifiers = [module.oidc_dynamo_sqs_role.arn, module.frontend_api_send_notification_role.arn, module.frontend_api_mfa_role.arn, module.frontend_api_reset_password_request_role.arn]
     }
 
     actions = [

--- a/ci/terraform/oidc/sqs.tf
+++ b/ci/terraform/oidc/sqs.tf
@@ -51,7 +51,7 @@ data "aws_iam_policy_document" "email_queue_policy_document" {
 
     principals {
       type        = "AWS"
-      identifiers = [module.oidc_dynamo_sqs_role.arn, module.frontend_api_send_notification_role.arn, module.frontend_api_mfa_role.arn, module.frontend_api_reset_password_request_role.arn]
+      identifiers = [module.frontend_api_send_notification_role.arn, module.frontend_api_mfa_role.arn, module.frontend_api_reset_password_request_role.arn, module.frontend_api_reset_password_role.arn]
     }
 
     actions = [

--- a/ci/terraform/oidc/sqs.tf
+++ b/ci/terraform/oidc/sqs.tf
@@ -51,7 +51,7 @@ data "aws_iam_policy_document" "email_queue_policy_document" {
 
     principals {
       type        = "AWS"
-      identifiers = [module.oidc_sqs_role.arn, module.oidc_dynamo_sqs_role.arn]
+      identifiers = [module.oidc_dynamo_sqs_role.arn, module.frontend_api_send_notification_role.arn]
     }
 
     actions = [

--- a/ci/terraform/oidc/sqs.tf
+++ b/ci/terraform/oidc/sqs.tf
@@ -51,7 +51,7 @@ data "aws_iam_policy_document" "email_queue_policy_document" {
 
     principals {
       type        = "AWS"
-      identifiers = [module.oidc_dynamo_sqs_role.arn, module.frontend_api_send_notification_role.arn]
+      identifiers = [module.oidc_dynamo_sqs_role.arn, module.frontend_api_send_notification_role.arn, module.frontend_api_mfa_role.arn]
     }
 
     actions = [


### PR DESCRIPTION
## What?

- Create new lambda role for Send Notification, MFA, Reset Password Request and Reset Password lambdas. 
- All roles are the same except Reset Password which has additional permissions to write to the User tables in dynamo as it will be updating the passwords. 
- Ensure that each of the new roles has been added as an identifier to the email_queue_policy_document so it has permissions to write to the SQS queue
- Delete the oidc_sqs_role and oidc_dynamo_sqs_role as these are no longer used.
- Rename lambda-roles.tf to kms-policies.tf as it is now a more accurate representation of what it represents

## Why?

- So we only give the lambdas the permissions they require