### PR TITLE
AUTH-1357: Publish product-level metrics to CloudWatch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ ext {
     dependencyVersions = [
         jackson_version: "2.13.1",
         aws_sdk_version: "1.12.153",
+        aws_sdk_v2_version: "2.17.128",
         aws_lambda_core_version: "1.2.1",
         aws_lambda_events_version: "3.11.0",
         nimbusds_oauth_version: "9.25",
@@ -56,6 +57,7 @@ subprojects {
 
     configurations {
         bouncycastle
+        cloudwatch
         dynamodb
         glassfish
         govuk_notify
@@ -82,6 +84,8 @@ subprojects {
 
     dependencies {
         bouncycastle "org.bouncycastle:bcpkix-jdk15on:1.70"
+
+        cloudwatch "software.amazon.awssdk:cloudwatch:${dependencyVersions.aws_sdk_v2_version}"
 
         dynamodb "com.amazonaws:aws-java-sdk-dynamodb:${dependencyVersions.aws_sdk_version}"
 
@@ -120,7 +124,7 @@ subprojects {
 
         sns "com.amazonaws:aws-java-sdk-sns:${dependencyVersions.aws_sdk_version}"
 
-        sqs "software.amazon.awssdk:sqs:2.17.128"
+        sqs "software.amazon.awssdk:sqs:${dependencyVersions.aws_sdk_v2_version}"
 
         ssm "com.amazonaws:aws-java-sdk-ssm:${dependencyVersions.aws_sdk_version}"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: docker
       dockerfile: localstack.Dockerfile
     environment:
-      SERVICES: iam, ec2, sqs, s3, sts, kms, sns, ssm
+      SERVICES: iam, ec2, sqs, s3, sts, kms, sns, ssm, cloudwatch
       EDGE_PORT: "45678"
       EXTERNAL_HOSTNAME: localhost
       DEFAULT_REGION: eu-west-2

--- a/frontend-api/build.gradle
+++ b/frontend-api/build.gradle
@@ -13,9 +13,10 @@ dependencies {
             configurations.jackson,
             configurations.nimbus,
             configurations.sqs,
+            configurations.cloudwatch,
             configurations.bouncycastle,
-            project(":shared"),
-            "software.amazon.awssdk:cloudwatch:2.17.128"
+            project(":shared")
+
     runtimeOnly configurations.logging_runtime
 
     testImplementation configurations.tests,

--- a/frontend-api/build.gradle
+++ b/frontend-api/build.gradle
@@ -14,7 +14,8 @@ dependencies {
             configurations.nimbus,
             configurations.sqs,
             configurations.bouncycastle,
-            project(":shared")
+            project(":shared"),
+            "software.amazon.awssdk:cloudwatch:2.17.128"
     runtimeOnly configurations.logging_runtime
 
     testImplementation configurations.tests,

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -22,7 +22,8 @@ dependencies {
             project(":oidc-api"),
             project(":ipv-api"),
             project(":shared"),
-            project(":shared-test")
+            project(":shared-test"),
+            "software.amazon.awssdk:cloudwatch:2.17.128"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${dependencyVersions.junit}"
 }
 

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -12,6 +12,7 @@ dependencies {
             configurations.nimbus,
             configurations.bouncycastle,
             configurations.sqs,
+            configurations.cloudwatch,
             configurations.dynamodb,
             configurations.lettuce,
             configurations.lambda,
@@ -22,8 +23,8 @@ dependencies {
             project(":oidc-api"),
             project(":ipv-api"),
             project(":shared"),
-            project(":shared-test"),
-            "software.amazon.awssdk:cloudwatch:2.17.128"
+            project(":shared-test")
+
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${dependencyVersions.junit}"
 }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
@@ -34,6 +34,7 @@ import java.util.concurrent.TimeUnit;
 
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.CODE_VERIFIED;
 import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_EMAIL;
@@ -157,6 +158,8 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         assertEquals(SessionState.PHONE_NUMBER_CODE_VERIFIED, codeResponse.getSessionState());
 
         assertEventTypesReceived(auditTopic, List.of(CODE_VERIFIED));
+
+        assertThat(cloudwatchMetrics.getLastValue("SignUpSuccess"), is(1.0));
     }
 
     @Test

--- a/shared-test/build.gradle
+++ b/shared-test/build.gradle
@@ -15,11 +15,11 @@ dependencies {
             configurations.dynamodb,
             configurations.sns,
             configurations.ssm,
+            configurations.cloudwatch,
             "org.eclipse.jetty:jetty-server:11.0.7",
             "com.google.protobuf:protobuf-java:3.19.4",
             "com.google.code.gson:gson:2.8.9",
-            project(":shared"),
-            "software.amazon.awssdk:cloudwatch:2.17.128"
+            project(":shared")
 }
 
 test {

--- a/shared-test/build.gradle
+++ b/shared-test/build.gradle
@@ -18,7 +18,8 @@ dependencies {
             "org.eclipse.jetty:jetty-server:11.0.7",
             "com.google.protobuf:protobuf-java:3.19.4",
             "com.google.code.gson:gson:2.8.9",
-            project(":shared")
+            project(":shared"),
+            "software.amazon.awssdk:cloudwatch:2.17.128"
 }
 
 test {

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/ApiGatewayHandlerIntegrationTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/ApiGatewayHandlerIntegrationTest.java
@@ -11,6 +11,7 @@ import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.sharedtest.extensions.AuditSnsTopicExtension;
 import uk.gov.di.authentication.sharedtest.extensions.ClientStoreExtension;
+import uk.gov.di.authentication.sharedtest.extensions.CloudwatchMetricsExtension;
 import uk.gov.di.authentication.sharedtest.extensions.KmsKeyExtension;
 import uk.gov.di.authentication.sharedtest.extensions.ParameterStoreExtension;
 import uk.gov.di.authentication.sharedtest.extensions.RedisExtension;
@@ -59,6 +60,10 @@ public abstract class ApiGatewayHandlerIntegrationTest {
     @RegisterExtension
     protected static final KmsKeyExtension auditSigningKey =
             new KmsKeyExtension("audit-signing-key");
+
+    @RegisterExtension
+    protected static final CloudwatchMetricsExtension cloudwatchMetrics =
+            new CloudwatchMetricsExtension();
 
     @RegisterExtension
     protected static final TokenSigningExtension tokenSigner = new TokenSigningExtension();

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/CloudwatchMetricsExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/CloudwatchMetricsExtension.java
@@ -12,6 +12,7 @@ import software.amazon.awssdk.services.cloudwatch.model.MetricStat;
 import java.net.URI;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.UUID;
 
 public class CloudwatchMetricsExtension extends BaseAwsResourceExtension
         implements BeforeAllCallback {
@@ -42,7 +43,7 @@ public class CloudwatchMetricsExtension extends BaseAwsResourceExtension
                                                         .period(60)
                                                         .stat("Sum")
                                                         .build())
-                                        .id("foo")
+                                        .id(UUID.randomUUID().toString())
                                         .build())
                         .startTime(Instant.now().minus(1, ChronoUnit.DAYS))
                         .endTime(Instant.now())

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/CloudwatchMetricsExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/CloudwatchMetricsExtension.java
@@ -1,0 +1,55 @@
+package uk.gov.di.authentication.sharedtest.extensions;
+
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
+import software.amazon.awssdk.services.cloudwatch.model.GetMetricDataRequest;
+import software.amazon.awssdk.services.cloudwatch.model.Metric;
+import software.amazon.awssdk.services.cloudwatch.model.MetricDataQuery;
+import software.amazon.awssdk.services.cloudwatch.model.MetricStat;
+
+import java.net.URI;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+public class CloudwatchMetricsExtension extends BaseAwsResourceExtension
+        implements BeforeAllCallback {
+
+    protected CloudWatchClient cloudWatch;
+
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        cloudWatch =
+                CloudWatchClient.builder()
+                        .region(Region.of(REGION))
+                        .endpointOverride(URI.create(LOCALSTACK_ENDPOINT))
+                        .build();
+    }
+
+    public Double getLastValue(String name) {
+        var request =
+                GetMetricDataRequest.builder()
+                        .metricDataQueries(
+                                MetricDataQuery.builder()
+                                        .metricStat(
+                                                MetricStat.builder()
+                                                        .metric(
+                                                                Metric.builder()
+                                                                        .namespace("Authentication")
+                                                                        .metricName(name)
+                                                                        .build())
+                                                        .period(60)
+                                                        .stat("Sum")
+                                                        .build())
+                                        .id("foo")
+                                        .build())
+                        .startTime(Instant.now().minus(1, ChronoUnit.DAYS))
+                        .endTime(Instant.now())
+                        .build();
+
+        var results = cloudWatch.getMetricData(request).metricDataResults().get(0).values();
+
+        return results.get(results.size() - 1);
+    }
+}

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -19,9 +19,9 @@ dependencies {
             configurations.sns,
             configurations.sqs,
             configurations.ssm,
+            configurations.cloudwatch,
             "com.googlecode.libphonenumber:libphonenumber:8.12.42",
-            "com.google.protobuf:protobuf-java:3.19.4",
-            "software.amazon.awssdk:cloudwatch:2.17.128"
+            "com.google.protobuf:protobuf-java:3.19.4"
 
     testImplementation configurations.tests,
             configurations.lambda_tests,

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -20,7 +20,8 @@ dependencies {
             configurations.sqs,
             configurations.ssm,
             "com.googlecode.libphonenumber:libphonenumber:8.12.42",
-            "com.google.protobuf:protobuf-java:3.19.4"
+            "com.google.protobuf:protobuf-java:3.19.4",
+            "software.amazon.awssdk:cloudwatch:2.17.128"
 
     testImplementation configurations.tests,
             configurations.lambda_tests,

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsService.java
@@ -1,10 +1,12 @@
 package uk.gov.di.authentication.shared.services;
 
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
 import software.amazon.awssdk.services.cloudwatch.model.Dimension;
 import software.amazon.awssdk.services.cloudwatch.model.MetricDatum;
 import software.amazon.awssdk.services.cloudwatch.model.PutMetricDataRequest;
 
+import java.net.URI;
 import java.util.Map;
 
 import static java.util.stream.Collectors.toList;
@@ -12,6 +14,18 @@ import static java.util.stream.Collectors.toList;
 public class CloudwatchMetricsService {
 
     private final CloudWatchClient cloudwatch;
+
+    public CloudwatchMetricsService(ConfigurationService configurationService) {
+        var client =
+                CloudWatchClient.builder().region(Region.of(configurationService.getAwsRegion()));
+
+        configurationService
+                .getLocalstackEndpointUri()
+                .map(URI::create)
+                .ifPresent(client::endpointOverride);
+
+        this.cloudwatch = client.build();
+    }
 
     public CloudwatchMetricsService(CloudWatchClient cloudwatch) {
         this.cloudwatch = cloudwatch;

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsService.java
@@ -1,0 +1,46 @@
+package uk.gov.di.authentication.shared.services;
+
+import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
+import software.amazon.awssdk.services.cloudwatch.model.Dimension;
+import software.amazon.awssdk.services.cloudwatch.model.MetricDatum;
+import software.amazon.awssdk.services.cloudwatch.model.PutMetricDataRequest;
+
+import java.util.Map;
+
+import static java.util.stream.Collectors.toList;
+
+public class CloudwatchMetricsService {
+
+    private final CloudWatchClient cloudwatch;
+
+    public CloudwatchMetricsService(CloudWatchClient cloudwatch) {
+        this.cloudwatch = cloudwatch;
+    }
+
+    public void putValue(String metricName, Number metricValue, Map<String, String> dimensions) {
+        var dimensionList = dimensions.entrySet().stream().map(this::toDimension).collect(toList());
+
+        var dataPoint =
+                MetricDatum.builder()
+                        .metricName(metricName)
+                        .value(metricValue.doubleValue())
+                        .dimensions(dimensionList)
+                        .build();
+
+        var request =
+                PutMetricDataRequest.builder()
+                        .metricData(dataPoint)
+                        .namespace("Authentication")
+                        .build();
+
+        cloudwatch.putMetricData(request);
+    }
+
+    private Dimension toDimension(Map.Entry<String, String> entry) {
+        return Dimension.builder().name(entry.getKey()).value(entry.getValue()).build();
+    }
+
+    public void incrementCounter(String name, Map<String, String> dimensions) {
+        putValue(name, 1, dimensions);
+    }
+}

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsServiceTest.java
@@ -1,0 +1,57 @@
+package uk.gov.di.authentication.shared.services;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatcher;
+import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
+import software.amazon.awssdk.services.cloudwatch.model.MetricDatum;
+import software.amazon.awssdk.services.cloudwatch.model.PutMetricDataRequest;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class CloudwatchMetricsServiceTest {
+
+    @Test
+    void shouldPublishMetricValueWithDimensions() {
+        var cloudwatch = mock(CloudWatchClient.class);
+
+        var metrics = new CloudwatchMetricsService(cloudwatch);
+
+        metrics.putValue("metric-name", 10, Map.of("dimension1", "value"));
+
+        verify(cloudwatch).putMetricData(argThat(hasNameAndValue("metric-name", 10d)));
+        verify(cloudwatch).putMetricData(argThat(hasDimension("dimension1", "value")));
+    }
+
+    @Test
+    void shouldIncrementCounter() {
+        var cloudwatch = mock(CloudWatchClient.class);
+
+        var metrics = new CloudwatchMetricsService(cloudwatch);
+
+        metrics.incrementCounter("counter-name", Map.of("dimension2", "value2"));
+
+        verify(cloudwatch).putMetricData(argThat(hasNameAndValue("counter-name", 1.0d)));
+        verify(cloudwatch).putMetricData(argThat(hasDimension("dimension2", "value2")));
+    }
+
+    private ArgumentMatcher<PutMetricDataRequest> hasNameAndValue(String name, Double value) {
+        return (request) ->
+                request.metricData().stream()
+                        .filter(data -> data.metricName().equals(name))
+                        .anyMatch(data -> data.value().equals(value));
+    }
+
+    private ArgumentMatcher<PutMetricDataRequest> hasDimension(String name, String value) {
+        return (request) ->
+                request.metricData().stream()
+                        .map(MetricDatum::dimensions)
+                        .flatMap(List::stream)
+                        .filter(dimension -> dimension.name().equals(name))
+                        .anyMatch(dimension -> dimension.value().equals(value));
+    }
+}


### PR DESCRIPTION
## What?

This PR adds the capability for a handler, through `CloudWatchMetricsService`, to publish metrics into CloudWatch for analysis and dashboards

## Why?

We get a lot of platform/infrastructure-level metrics in CloudWatch for "free" but anything that's specific to our domain needs to be pushed by us.
