### PR TITLE
AUTH-1174 - Tidy up dynamo policies 

### DIFF
--- a/ci/terraform/oidc/dynamo-policies.tf
+++ b/ci/terraform/oidc/dynamo-policies.tf
@@ -55,19 +55,12 @@ data "aws_iam_policy_document" "dynamo_user_read_policy_document" {
   }
 }
 
-data "aws_iam_policy_document" "dynamo_client_registration_policy_document" {
+data "aws_iam_policy_document" "dynamo_client_registration_write_policy_document" {
   statement {
     sid    = "AllowAccessToDynamoTables"
     effect = "Allow"
 
     actions = [
-      "dynamodb:BatchGetItem",
-      "dynamodb:DescribeStream",
-      "dynamodb:DescribeTable",
-      "dynamodb:DeleteItem",
-      "dynamodb:Get*",
-      "dynamodb:Query",
-      "dynamodb:Scan",
       "dynamodb:BatchWriteItem",
       "dynamodb:UpdateItem",
       "dynamodb:PutItem",
@@ -139,12 +132,12 @@ data "aws_iam_policy_document" "dynamo_spot_read_access_policy_document" {
   }
 }
 
-resource "aws_iam_policy" "dynamo_client_registry_access_policy" {
+resource "aws_iam_policy" "dynamo_client_registry_write_access_policy" {
   name_prefix = "dynamo-client-registry-write-policy"
   path        = "/${var.environment}/oidc-default/"
   description = "IAM policy for managing write permissions to the Dynamo Client Registration table"
 
-  policy = data.aws_iam_policy_document.dynamo_client_registration_policy_document.json
+  policy = data.aws_iam_policy_document.dynamo_client_registration_write_policy_document.json
 }
 
 resource "aws_iam_policy" "dynamo_client_registry_read_access_policy" {

--- a/ci/terraform/oidc/dynamo-policies.tf
+++ b/ci/terraform/oidc/dynamo-policies.tf
@@ -14,33 +14,6 @@ data "aws_dynamodb_table" "spot_credential_table" {
   name = "${var.environment}-spot-credential"
 }
 
-data "aws_iam_policy_document" "dynamo_access_policy_document" {
-  statement {
-    sid    = "AllowAccessToDynamoTables"
-    effect = "Allow"
-
-    actions = [
-      "dynamodb:BatchGetItem",
-      "dynamodb:DescribeStream",
-      "dynamodb:DescribeTable",
-      "dynamodb:DeleteItem",
-      "dynamodb:Get*",
-      "dynamodb:Query",
-      "dynamodb:Scan",
-      "dynamodb:BatchWriteItem",
-      "dynamodb:UpdateItem",
-      "dynamodb:PutItem",
-    ]
-    resources = [
-      data.aws_dynamodb_table.user_credentials_table.arn,
-      data.aws_dynamodb_table.user_profile_table.arn,
-      "${data.aws_dynamodb_table.user_profile_table.arn}/index/*",
-      "${data.aws_dynamodb_table.user_credentials_table.arn}/index/*",
-      data.aws_dynamodb_table.client_registry_table.arn,
-    ]
-  }
-}
-
 data "aws_iam_policy_document" "dynamo_user_write_policy_document" {
   statement {
     sid    = "AllowAccessToDynamoTables"
@@ -164,14 +137,6 @@ data "aws_iam_policy_document" "dynamo_spot_read_access_policy_document" {
       data.aws_dynamodb_table.spot_credential_table.arn,
     ]
   }
-}
-
-resource "aws_iam_policy" "dynamo_access_policy" {
-  name_prefix = "dynamo-access-policy"
-  path        = "/${var.environment}/oidc-default/"
-  description = "IAM policy for managing Dynamo connection for a lambda"
-
-  policy = data.aws_iam_policy_document.dynamo_access_policy_document.json
 }
 
 resource "aws_iam_policy" "dynamo_client_registry_access_policy" {

--- a/ci/terraform/oidc/identity.tf
+++ b/ci/terraform/oidc/identity.tf
@@ -26,6 +26,7 @@ module "identity" {
   handler_environment_variables = {
     ENVIRONMENT             = var.environment
     EVENTS_SNS_TOPIC_ARN    = aws_sns_topic.events.arn
+    REDIS_KEY               = local.redis_key
     AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
     DYNAMO_ENDPOINT         = var.use_localstack ? var.lambda_dynamo_endpoint : null

--- a/ci/terraform/oidc/register.tf
+++ b/ci/terraform/oidc/register.tf
@@ -6,7 +6,8 @@ module "client_registry_role" {
 
   policies_to_attach = [
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
-    aws_iam_policy.dynamo_client_registry_access_policy.arn,
+    aws_iam_policy.dynamo_client_registry_write_access_policy.arn,
+    aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
   ]
 }

--- a/ci/terraform/oidc/update.tf
+++ b/ci/terraform/oidc/update.tf
@@ -6,7 +6,8 @@ module "client_update_role" {
 
   policies_to_attach = [
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
-    aws_iam_policy.dynamo_client_registry_access_policy.arn,
+    aws_iam_policy.dynamo_client_registry_write_access_policy.arn,
+    aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
   ]
 }


### PR DESCRIPTION
## What?

- There was some crossover between the different dynamo policies for the client reg table. Have one policy for writing and one policy for reading. 
- Add missing env var to the identity lambda 
- Remove unused dynamo policy 

## Why?

- Make dynamo policies clearer and explicit 