### PR TITLE
AUTH-1261: S3 deployment for endpoint Lambdas

### DIFF
--- a/ci/terraform/account-management/authenticate.tf
+++ b/ci/terraform/account-management/authenticate.tf
@@ -14,11 +14,17 @@ module "authenticate" {
   }
   handler_function_name = "uk.gov.di.accountmanagement.lambda.AuthenticateHandler::handleRequest"
 
-  authorizer_id          = aws_api_gateway_authorizer.di_account_management_api.id
-  rest_api_id            = aws_api_gateway_rest_api.di_account_management_api.id
-  root_resource_id       = aws_api_gateway_rest_api.di_account_management_api.root_resource_id
-  execution_arn          = aws_api_gateway_rest_api.di_account_management_api.execution_arn
-  lambda_zip_file        = var.lambda_zip_file
+  authorizer_id    = aws_api_gateway_authorizer.di_account_management_api.id
+  rest_api_id      = aws_api_gateway_rest_api.di_account_management_api.id
+  root_resource_id = aws_api_gateway_rest_api.di_account_management_api.root_resource_id
+  execution_arn    = aws_api_gateway_rest_api.di_account_management_api.execution_arn
+
+  source_bucket                  = aws_s3_bucket.source_bucket.bucket
+  lambda_zip_file                = aws_s3_bucket_object.account_management_api_release_zip.key
+  lambda_zip_file_version        = aws_s3_bucket_object.account_management_api_release_zip.version_id
+  warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
+  warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+
   authentication_vpc_arn = local.vpc_arn
   security_group_ids = [
     local.allow_aws_service_access_security_group_id,
@@ -36,7 +42,6 @@ module "authenticate" {
 
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
-  warmer_lambda_zip_file       = var.lambda_warmer_zip_file
   warmer_security_group_ids    = [local.allow_aws_service_access_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency

--- a/ci/terraform/account-management/remove-account.tf
+++ b/ci/terraform/account-management/remove-account.tf
@@ -14,11 +14,17 @@ module "delete_account" {
   }
   handler_function_name = "uk.gov.di.accountmanagement.lambda.RemoveAccountHandler::handleRequest"
 
-  authorizer_id          = aws_api_gateway_authorizer.di_account_management_api.id
-  rest_api_id            = aws_api_gateway_rest_api.di_account_management_api.id
-  root_resource_id       = aws_api_gateway_rest_api.di_account_management_api.root_resource_id
-  execution_arn          = aws_api_gateway_rest_api.di_account_management_api.execution_arn
-  lambda_zip_file        = var.lambda_zip_file
+  authorizer_id    = aws_api_gateway_authorizer.di_account_management_api.id
+  rest_api_id      = aws_api_gateway_rest_api.di_account_management_api.id
+  root_resource_id = aws_api_gateway_rest_api.di_account_management_api.root_resource_id
+  execution_arn    = aws_api_gateway_rest_api.di_account_management_api.execution_arn
+
+  source_bucket                  = aws_s3_bucket.source_bucket.bucket
+  lambda_zip_file                = aws_s3_bucket_object.account_management_api_release_zip.key
+  lambda_zip_file_version        = aws_s3_bucket_object.account_management_api_release_zip.version_id
+  warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
+  warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+
   authentication_vpc_arn = local.vpc_arn
   security_group_ids = [
     local.allow_aws_service_access_security_group_id,
@@ -37,7 +43,6 @@ module "delete_account" {
 
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
-  warmer_lambda_zip_file       = var.lambda_warmer_zip_file
   warmer_security_group_ids    = [local.allow_aws_service_access_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency

--- a/ci/terraform/account-management/s3-objects.tf
+++ b/ci/terraform/account-management/s3-objects.tf
@@ -1,0 +1,26 @@
+resource "aws_s3_bucket" "source_bucket" {
+  bucket_prefix = "${var.environment}-acct-mgmt-lambda-source-"
+
+  versioning {
+    enabled = true
+  }
+}
+
+resource "aws_s3_bucket_object" "account_management_api_release_zip" {
+  bucket = aws_s3_bucket.source_bucket.bucket
+  key    = "account-management-api-release.zip"
+
+  server_side_encryption = "AES256"
+  source                 = var.lambda_zip_file
+  source_hash            = filemd5(var.lambda_zip_file)
+}
+
+
+resource "aws_s3_bucket_object" "warmer_release_zip" {
+  bucket = aws_s3_bucket.source_bucket.bucket
+  key    = "warmer-release.zip"
+
+  server_side_encryption = "AES256"
+  source                 = var.lambda_warmer_zip_file
+  source_hash            = filemd5(var.lambda_warmer_zip_file)
+}

--- a/ci/terraform/account-management/send_otp_notification.tf
+++ b/ci/terraform/account-management/send_otp_notification.tf
@@ -17,10 +17,16 @@ module "send_otp_notification" {
   }
   handler_function_name = "uk.gov.di.accountmanagement.lambda.SendOtpNotificationHandler::handleRequest"
 
-  rest_api_id            = aws_api_gateway_rest_api.di_account_management_api.id
-  root_resource_id       = aws_api_gateway_rest_api.di_account_management_api.root_resource_id
-  execution_arn          = aws_api_gateway_rest_api.di_account_management_api.execution_arn
-  lambda_zip_file        = var.lambda_zip_file
+  rest_api_id      = aws_api_gateway_rest_api.di_account_management_api.id
+  root_resource_id = aws_api_gateway_rest_api.di_account_management_api.root_resource_id
+  execution_arn    = aws_api_gateway_rest_api.di_account_management_api.execution_arn
+
+  source_bucket                  = aws_s3_bucket.source_bucket.bucket
+  lambda_zip_file                = aws_s3_bucket_object.account_management_api_release_zip.key
+  lambda_zip_file_version        = aws_s3_bucket_object.account_management_api_release_zip.version_id
+  warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
+  warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+
   authentication_vpc_arn = local.vpc_arn
   security_group_ids = [
     local.allow_aws_service_access_security_group_id,
@@ -39,7 +45,6 @@ module "send_otp_notification" {
 
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
-  warmer_lambda_zip_file       = var.lambda_warmer_zip_file
   warmer_security_group_ids    = [local.allow_aws_service_access_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency

--- a/ci/terraform/account-management/update-email.tf
+++ b/ci/terraform/account-management/update-email.tf
@@ -15,11 +15,17 @@ module "update_email" {
   }
   handler_function_name = "uk.gov.di.accountmanagement.lambda.UpdateEmailHandler::handleRequest"
 
-  authorizer_id          = aws_api_gateway_authorizer.di_account_management_api.id
-  rest_api_id            = aws_api_gateway_rest_api.di_account_management_api.id
-  root_resource_id       = aws_api_gateway_rest_api.di_account_management_api.root_resource_id
-  execution_arn          = aws_api_gateway_rest_api.di_account_management_api.execution_arn
-  lambda_zip_file        = var.lambda_zip_file
+  authorizer_id    = aws_api_gateway_authorizer.di_account_management_api.id
+  rest_api_id      = aws_api_gateway_rest_api.di_account_management_api.id
+  root_resource_id = aws_api_gateway_rest_api.di_account_management_api.root_resource_id
+  execution_arn    = aws_api_gateway_rest_api.di_account_management_api.execution_arn
+
+  source_bucket                  = aws_s3_bucket.source_bucket.bucket
+  lambda_zip_file                = aws_s3_bucket_object.account_management_api_release_zip.key
+  lambda_zip_file_version        = aws_s3_bucket_object.account_management_api_release_zip.version_id
+  warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
+  warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+
   authentication_vpc_arn = local.vpc_arn
   security_group_ids = [
     local.allow_aws_service_access_security_group_id,
@@ -38,7 +44,6 @@ module "update_email" {
 
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
-  warmer_lambda_zip_file       = var.lambda_warmer_zip_file
   warmer_security_group_ids    = [local.allow_aws_service_access_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency

--- a/ci/terraform/account-management/update-password.tf
+++ b/ci/terraform/account-management/update-password.tf
@@ -14,11 +14,17 @@ module "update_password" {
   }
   handler_function_name = "uk.gov.di.accountmanagement.lambda.UpdatePasswordHandler::handleRequest"
 
-  authorizer_id          = aws_api_gateway_authorizer.di_account_management_api.id
-  rest_api_id            = aws_api_gateway_rest_api.di_account_management_api.id
-  root_resource_id       = aws_api_gateway_rest_api.di_account_management_api.root_resource_id
-  execution_arn          = aws_api_gateway_rest_api.di_account_management_api.execution_arn
-  lambda_zip_file        = var.lambda_zip_file
+  authorizer_id    = aws_api_gateway_authorizer.di_account_management_api.id
+  rest_api_id      = aws_api_gateway_rest_api.di_account_management_api.id
+  root_resource_id = aws_api_gateway_rest_api.di_account_management_api.root_resource_id
+  execution_arn    = aws_api_gateway_rest_api.di_account_management_api.execution_arn
+
+  source_bucket                  = aws_s3_bucket.source_bucket.bucket
+  lambda_zip_file                = aws_s3_bucket_object.account_management_api_release_zip.key
+  lambda_zip_file_version        = aws_s3_bucket_object.account_management_api_release_zip.version_id
+  warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
+  warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+
   authentication_vpc_arn = local.vpc_arn
   security_group_ids = [
     local.allow_aws_service_access_security_group_id,
@@ -37,7 +43,6 @@ module "update_password" {
 
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
-  warmer_lambda_zip_file       = var.lambda_warmer_zip_file
   warmer_security_group_ids    = [local.allow_aws_service_access_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency

--- a/ci/terraform/account-management/update-phone-number.tf
+++ b/ci/terraform/account-management/update-phone-number.tf
@@ -15,11 +15,17 @@ module "update_phone_number" {
   }
   handler_function_name = "uk.gov.di.accountmanagement.lambda.UpdatePhoneNumberHandler::handleRequest"
 
-  authorizer_id          = aws_api_gateway_authorizer.di_account_management_api.id
-  rest_api_id            = aws_api_gateway_rest_api.di_account_management_api.id
-  root_resource_id       = aws_api_gateway_rest_api.di_account_management_api.root_resource_id
-  execution_arn          = aws_api_gateway_rest_api.di_account_management_api.execution_arn
-  lambda_zip_file        = var.lambda_zip_file
+  authorizer_id    = aws_api_gateway_authorizer.di_account_management_api.id
+  rest_api_id      = aws_api_gateway_rest_api.di_account_management_api.id
+  root_resource_id = aws_api_gateway_rest_api.di_account_management_api.root_resource_id
+  execution_arn    = aws_api_gateway_rest_api.di_account_management_api.execution_arn
+
+  source_bucket                  = aws_s3_bucket.source_bucket.bucket
+  lambda_zip_file                = aws_s3_bucket_object.account_management_api_release_zip.key
+  lambda_zip_file_version        = aws_s3_bucket_object.account_management_api_release_zip.version_id
+  warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
+  warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+
   authentication_vpc_arn = local.vpc_arn
   security_group_ids = [
     local.allow_aws_service_access_security_group_id,
@@ -38,7 +44,6 @@ module "update_phone_number" {
 
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
-  warmer_lambda_zip_file       = var.lambda_warmer_zip_file
   warmer_security_group_ids    = [local.allow_aws_service_access_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency

--- a/ci/terraform/modules/endpoint-module/lambda.tf
+++ b/ci/terraform/modules/endpoint-module/lambda.tf
@@ -1,5 +1,4 @@
 resource "aws_lambda_function" "endpoint_lambda" {
-  filename      = var.lambda_zip_file
   function_name = replace("${var.environment}-${var.endpoint_name}-lambda", ".", "")
   role          = var.lambda_role_arn
   handler       = var.handler_function_name
@@ -11,7 +10,10 @@ resource "aws_lambda_function" "endpoint_lambda" {
     mode = "Active"
   }
 
-  source_code_hash = filebase64sha256(var.lambda_zip_file)
+  s3_bucket         = var.source_bucket
+  s3_key            = var.lambda_zip_file
+  s3_object_version = var.lambda_zip_file_version
+
   vpc_config {
     security_group_ids = var.security_group_ids
     subnet_ids         = var.subnet_id

--- a/ci/terraform/modules/endpoint-module/variables.tf
+++ b/ci/terraform/modules/endpoint-module/variables.tf
@@ -30,7 +30,15 @@ variable "endpoint_method" {
   type = string
 }
 
+variable "source_bucket" {
+  type = string
+}
+
 variable "lambda_zip_file" {
+  type = string
+}
+
+variable "lambda_zip_file_version" {
   type = string
 }
 
@@ -114,6 +122,11 @@ variable "keep_lambda_warm" {
 }
 
 variable "warmer_lambda_zip_file" {
+  type    = string
+  default = null
+}
+
+variable "warmer_lambda_zip_file_version" {
   type    = string
   default = null
 }

--- a/ci/terraform/modules/endpoint-module/warmer.tf
+++ b/ci/terraform/modules/endpoint-module/warmer.tf
@@ -121,7 +121,6 @@ resource "aws_iam_role_policy_attachment" "lambda_warmer_ogs" {
 resource "aws_lambda_function" "warmer_function" {
   count = var.keep_lambda_warm && var.warmer_handler_function_name != null ? 1 : 0
 
-  filename      = var.warmer_lambda_zip_file
   function_name = replace("${var.environment}-${var.endpoint_name}-lambda-warmer", ".", "")
   role          = aws_iam_role.lambda_warmer_role[0].arn
   handler       = var.warmer_handler_function_name
@@ -132,7 +131,9 @@ resource "aws_lambda_function" "warmer_function" {
     mode = "Active"
   }
 
-  source_code_hash = filebase64sha256(var.warmer_lambda_zip_file)
+  s3_bucket         = var.source_bucket
+  s3_key            = var.warmer_lambda_zip_file
+  s3_object_version = var.warmer_lambda_zip_file_version
 
   vpc_config {
     security_group_ids = var.warmer_security_group_ids

--- a/ci/terraform/oidc/auth-code.tf
+++ b/ci/terraform/oidc/auth-code.tf
@@ -32,10 +32,16 @@ module "auth-code" {
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.AuthCodeHandler::handleRequest"
 
-  rest_api_id            = aws_api_gateway_rest_api.di_authentication_api.id
-  root_resource_id       = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
-  execution_arn          = aws_api_gateway_rest_api.di_authentication_api.execution_arn
-  lambda_zip_file        = var.oidc_api_lambda_zip_file
+  rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
+  root_resource_id = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
+  execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
+
+  source_bucket                  = aws_s3_bucket.source_bucket.bucket
+  lambda_zip_file                = aws_s3_bucket_object.oidc_api_release_zip.key
+  lambda_zip_file_version        = aws_s3_bucket_object.oidc_api_release_zip.version_id
+  warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
+  warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+
   authentication_vpc_arn = local.authentication_vpc_arn
   security_group_ids = [
     local.authentication_security_group_id,
@@ -53,7 +59,6 @@ module "auth-code" {
 
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
-  warmer_lambda_zip_file       = var.lambda_warmer_zip_file
   warmer_security_group_ids    = [local.authentication_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency

--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -34,11 +34,17 @@ module "authorize" {
     TERMS_CONDITIONS_VERSION = var.terms_and_conditions
     HEADERS_CASE_INSENSITIVE = var.use_localstack ? "true" : "false"
   }
-  handler_function_name  = "uk.gov.di.authentication.oidc.lambda.AuthorisationHandler::handleRequest"
-  rest_api_id            = aws_api_gateway_rest_api.di_authentication_api.id
-  root_resource_id       = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
-  execution_arn          = aws_api_gateway_rest_api.di_authentication_api.execution_arn
-  lambda_zip_file        = var.oidc_api_lambda_zip_file
+  handler_function_name = "uk.gov.di.authentication.oidc.lambda.AuthorisationHandler::handleRequest"
+  rest_api_id           = aws_api_gateway_rest_api.di_authentication_api.id
+  root_resource_id      = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
+  execution_arn         = aws_api_gateway_rest_api.di_authentication_api.execution_arn
+
+  source_bucket                  = aws_s3_bucket.source_bucket.bucket
+  lambda_zip_file                = aws_s3_bucket_object.oidc_api_release_zip.key
+  lambda_zip_file_version        = aws_s3_bucket_object.oidc_api_release_zip.version_id
+  warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
+  warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+
   authentication_vpc_arn = local.authentication_vpc_arn
   security_group_ids = [
     local.authentication_security_group_id,
@@ -55,7 +61,6 @@ module "authorize" {
 
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
-  warmer_lambda_zip_file       = var.lambda_warmer_zip_file
   warmer_security_group_ids    = [local.authentication_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency

--- a/ci/terraform/oidc/client-info.tf
+++ b/ci/terraform/oidc/client-info.tf
@@ -32,10 +32,16 @@ module "client-info" {
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.ClientInfoHandler::handleRequest"
 
-  rest_api_id            = aws_api_gateway_rest_api.di_authentication_frontend_api.id
-  root_resource_id       = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
-  execution_arn          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
-  lambda_zip_file        = var.frontend_api_lambda_zip_file
+  rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
+  root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
+  execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
+
+  source_bucket                  = aws_s3_bucket.source_bucket.bucket
+  lambda_zip_file                = aws_s3_bucket_object.frontend_api_release_zip.key
+  lambda_zip_file_version        = aws_s3_bucket_object.frontend_api_release_zip.version_id
+  warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
+  warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+
   authentication_vpc_arn = local.authentication_vpc_arn
   security_group_ids = [
     local.authentication_security_group_id,
@@ -53,7 +59,6 @@ module "client-info" {
 
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
-  warmer_lambda_zip_file       = var.lambda_warmer_zip_file
   warmer_security_group_ids    = [local.authentication_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency

--- a/ci/terraform/oidc/identity.tf
+++ b/ci/terraform/oidc/identity.tf
@@ -32,10 +32,16 @@ module "identity" {
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.IdentityHandler::handleRequest"
 
-  rest_api_id            = aws_api_gateway_rest_api.di_authentication_api.id
-  root_resource_id       = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
-  execution_arn          = aws_api_gateway_rest_api.di_authentication_api.execution_arn
-  lambda_zip_file        = var.oidc_api_lambda_zip_file
+  rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
+  root_resource_id = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
+  execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
+
+  source_bucket                  = aws_s3_bucket.source_bucket.bucket
+  lambda_zip_file                = aws_s3_bucket_object.oidc_api_release_zip.key
+  lambda_zip_file_version        = aws_s3_bucket_object.oidc_api_release_zip.version_id
+  warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
+  warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+
   authentication_vpc_arn = local.authentication_vpc_arn
   security_group_ids = [
     local.authentication_security_group_id,
@@ -52,7 +58,6 @@ module "identity" {
 
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
-  warmer_lambda_zip_file       = var.lambda_warmer_zip_file
   warmer_security_group_ids    = [local.authentication_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency

--- a/ci/terraform/oidc/ipv-authorize.tf
+++ b/ci/terraform/oidc/ipv-authorize.tf
@@ -36,11 +36,17 @@ module "ipv-authorize" {
   }
   handler_function_name = "uk.gov.di.authentication.ipv.lambda.IPVAuthorisationHandler::handleRequest"
 
-  create_endpoint        = true
-  rest_api_id            = aws_api_gateway_rest_api.di_authentication_frontend_api.id
-  root_resource_id       = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
-  execution_arn          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
-  lambda_zip_file        = var.ipv_api_lambda_zip_file
+  create_endpoint  = true
+  rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
+  root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
+  execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
+
+  source_bucket                  = aws_s3_bucket.source_bucket.bucket
+  lambda_zip_file                = aws_s3_bucket_object.ipv_api_release_zip.key
+  lambda_zip_file_version        = aws_s3_bucket_object.ipv_api_release_zip.version_id
+  warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
+  warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+
   authentication_vpc_arn = local.authentication_vpc_arn
   security_group_ids = [
     local.authentication_security_group_id,
@@ -58,7 +64,6 @@ module "ipv-authorize" {
 
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
-  warmer_lambda_zip_file       = var.lambda_warmer_zip_file
   warmer_security_group_ids    = [local.authentication_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency

--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -37,11 +37,17 @@ module "ipv-callback" {
   }
   handler_function_name = "uk.gov.di.authentication.ipv.lambda.IPVCallbackHandler::handleRequest"
 
-  create_endpoint        = true
-  rest_api_id            = aws_api_gateway_rest_api.di_authentication_frontend_api.id
-  root_resource_id       = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
-  execution_arn          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
-  lambda_zip_file        = var.ipv_api_lambda_zip_file
+  create_endpoint  = true
+  rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
+  root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
+  execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
+
+  source_bucket                  = aws_s3_bucket.source_bucket.bucket
+  lambda_zip_file                = aws_s3_bucket_object.ipv_api_release_zip.key
+  lambda_zip_file_version        = aws_s3_bucket_object.ipv_api_release_zip.version_id
+  warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
+  warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+
   authentication_vpc_arn = local.authentication_vpc_arn
   security_group_ids = [
     local.authentication_egress_security_group_id,
@@ -58,7 +64,6 @@ module "ipv-callback" {
 
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
-  warmer_lambda_zip_file       = var.lambda_warmer_zip_file
   warmer_security_group_ids    = [local.authentication_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency

--- a/ci/terraform/oidc/ipv-capacity.tf
+++ b/ci/terraform/oidc/ipv-capacity.tf
@@ -34,11 +34,17 @@ module "ipv-capacity" {
   }
   handler_function_name = "uk.gov.di.authentication.ipv.lambda.IPVCapacityHandler::handleRequest"
 
-  create_endpoint        = true
-  rest_api_id            = aws_api_gateway_rest_api.di_authentication_frontend_api.id
-  root_resource_id       = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
-  execution_arn          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
-  lambda_zip_file        = var.ipv_api_lambda_zip_file
+  create_endpoint  = true
+  rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
+  root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
+  execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
+
+  source_bucket                  = aws_s3_bucket.source_bucket.bucket
+  lambda_zip_file                = aws_s3_bucket_object.ipv_api_release_zip.key
+  lambda_zip_file_version        = aws_s3_bucket_object.ipv_api_release_zip.version_id
+  warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
+  warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+
   authentication_vpc_arn = local.authentication_vpc_arn
   security_group_ids = [
     local.authentication_security_group_id,
@@ -55,7 +61,6 @@ module "ipv-capacity" {
 
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
-  warmer_lambda_zip_file       = var.lambda_warmer_zip_file
   warmer_security_group_ids    = [local.authentication_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency

--- a/ci/terraform/oidc/jwks.tf
+++ b/ci/terraform/oidc/jwks.tf
@@ -27,10 +27,16 @@ module "jwks" {
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.JwksHandler::handleRequest"
 
-  rest_api_id                            = aws_api_gateway_rest_api.di_authentication_api.id
-  root_resource_id                       = aws_api_gateway_resource.wellknown_resource.id
-  execution_arn                          = aws_api_gateway_rest_api.di_authentication_api.execution_arn
-  lambda_zip_file                        = var.oidc_api_lambda_zip_file
+  rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
+  root_resource_id = aws_api_gateway_resource.wellknown_resource.id
+  execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
+
+  source_bucket                  = aws_s3_bucket.source_bucket.bucket
+  lambda_zip_file                = aws_s3_bucket_object.oidc_api_release_zip.key
+  lambda_zip_file_version        = aws_s3_bucket_object.oidc_api_release_zip.version_id
+  warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
+  warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+
   authentication_vpc_arn                 = local.authentication_vpc_arn
   security_group_ids                     = [local.authentication_security_group_id]
   subnet_id                              = local.authentication_subnet_ids
@@ -44,7 +50,6 @@ module "jwks" {
 
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
-  warmer_lambda_zip_file       = var.lambda_warmer_zip_file
   warmer_security_group_ids    = [local.authentication_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency

--- a/ci/terraform/oidc/login.tf
+++ b/ci/terraform/oidc/login.tf
@@ -37,10 +37,16 @@ module "login" {
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.LoginHandler::handleRequest"
 
-  rest_api_id            = aws_api_gateway_rest_api.di_authentication_frontend_api.id
-  root_resource_id       = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
-  execution_arn          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
-  lambda_zip_file        = var.frontend_api_lambda_zip_file
+  rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
+  root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
+  execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
+
+  source_bucket                  = aws_s3_bucket.source_bucket.bucket
+  lambda_zip_file                = aws_s3_bucket_object.frontend_api_release_zip.key
+  lambda_zip_file_version        = aws_s3_bucket_object.frontend_api_release_zip.version_id
+  warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
+  warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+
   authentication_vpc_arn = local.authentication_vpc_arn
   security_group_ids = [
     local.authentication_security_group_id,
@@ -58,7 +64,6 @@ module "login" {
 
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
-  warmer_lambda_zip_file       = var.lambda_warmer_zip_file
   warmer_security_group_ids    = [local.authentication_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency

--- a/ci/terraform/oidc/logout.tf
+++ b/ci/terraform/oidc/logout.tf
@@ -35,10 +35,16 @@ module "logout" {
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.LogoutHandler::handleRequest"
 
-  rest_api_id            = aws_api_gateway_rest_api.di_authentication_api.id
-  root_resource_id       = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
-  execution_arn          = aws_api_gateway_rest_api.di_authentication_api.execution_arn
-  lambda_zip_file        = var.oidc_api_lambda_zip_file
+  rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
+  root_resource_id = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
+  execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
+
+  source_bucket                  = aws_s3_bucket.source_bucket.bucket
+  lambda_zip_file                = aws_s3_bucket_object.oidc_api_release_zip.key
+  lambda_zip_file_version        = aws_s3_bucket_object.oidc_api_release_zip.version_id
+  warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
+  warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+
   authentication_vpc_arn = local.authentication_vpc_arn
   security_group_ids = [
     local.authentication_security_group_id,
@@ -55,7 +61,6 @@ module "logout" {
 
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
-  warmer_lambda_zip_file       = var.lambda_warmer_zip_file
   warmer_security_group_ids    = [local.authentication_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency

--- a/ci/terraform/oidc/mfa.tf
+++ b/ci/terraform/oidc/mfa.tf
@@ -19,10 +19,16 @@ module "mfa" {
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.MfaHandler::handleRequest"
 
-  rest_api_id            = aws_api_gateway_rest_api.di_authentication_frontend_api.id
-  root_resource_id       = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
-  execution_arn          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
-  lambda_zip_file        = var.frontend_api_lambda_zip_file
+  rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
+  root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
+  execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
+
+  source_bucket                  = aws_s3_bucket.source_bucket.bucket
+  lambda_zip_file                = aws_s3_bucket_object.frontend_api_release_zip.key
+  lambda_zip_file_version        = aws_s3_bucket_object.frontend_api_release_zip.version_id
+  warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
+  warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+
   authentication_vpc_arn = local.authentication_vpc_arn
   security_group_ids = [
     local.authentication_security_group_id,
@@ -40,7 +46,6 @@ module "mfa" {
 
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
-  warmer_lambda_zip_file       = var.lambda_warmer_zip_file
   warmer_security_group_ids    = [local.authentication_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency

--- a/ci/terraform/oidc/register.tf
+++ b/ci/terraform/oidc/register.tf
@@ -29,12 +29,18 @@ module "register" {
   }
   handler_function_name = "uk.gov.di.authentication.clientregistry.lambda.ClientRegistrationHandler::handleRequest"
 
-  create_endpoint                        = false
-  rest_api_id                            = aws_api_gateway_rest_api.di_authentication_api.id
-  root_resource_id                       = aws_api_gateway_resource.register_resource.id
-  execution_arn                          = aws_api_gateway_rest_api.di_authentication_api.execution_arn
-  authentication_vpc_arn                 = local.authentication_vpc_arn
-  lambda_zip_file                        = var.client_registry_api_lambda_zip_file
+  create_endpoint        = false
+  rest_api_id            = aws_api_gateway_rest_api.di_authentication_api.id
+  root_resource_id       = aws_api_gateway_resource.register_resource.id
+  execution_arn          = aws_api_gateway_rest_api.di_authentication_api.execution_arn
+  authentication_vpc_arn = local.authentication_vpc_arn
+
+  source_bucket                  = aws_s3_bucket.source_bucket.bucket
+  lambda_zip_file                = aws_s3_bucket_object.client_api_release_zip.key
+  lambda_zip_file_version        = aws_s3_bucket_object.client_api_release_zip.version_id
+  warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
+  warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+
   security_group_ids                     = [local.authentication_security_group_id]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.client_registry_role.arn
@@ -48,7 +54,6 @@ module "register" {
 
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
-  warmer_lambda_zip_file       = var.lambda_warmer_zip_file
   warmer_security_group_ids    = [local.authentication_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency

--- a/ci/terraform/oidc/reset-password-request.tf
+++ b/ci/terraform/oidc/reset-password-request.tf
@@ -22,10 +22,16 @@ module "reset-password-request" {
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.ResetPasswordRequestHandler::handleRequest"
 
-  rest_api_id            = aws_api_gateway_rest_api.di_authentication_frontend_api.id
-  root_resource_id       = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
-  execution_arn          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
-  lambda_zip_file        = var.frontend_api_lambda_zip_file
+  rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
+  root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
+  execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
+
+  source_bucket                  = aws_s3_bucket.source_bucket.bucket
+  lambda_zip_file                = aws_s3_bucket_object.frontend_api_release_zip.key
+  lambda_zip_file_version        = aws_s3_bucket_object.frontend_api_release_zip.version_id
+  warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
+  warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+
   authentication_vpc_arn = local.authentication_vpc_arn
   security_group_ids = [
     local.authentication_security_group_id,
@@ -43,7 +49,6 @@ module "reset-password-request" {
 
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
-  warmer_lambda_zip_file       = var.lambda_warmer_zip_file
   warmer_security_group_ids    = [local.authentication_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency

--- a/ci/terraform/oidc/reset_password.tf
+++ b/ci/terraform/oidc/reset_password.tf
@@ -20,10 +20,16 @@ module "reset_password" {
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.ResetPasswordHandler::handleRequest"
 
-  rest_api_id            = aws_api_gateway_rest_api.di_authentication_frontend_api.id
-  root_resource_id       = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
-  execution_arn          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
-  lambda_zip_file        = var.frontend_api_lambda_zip_file
+  rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
+  root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
+  execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
+
+  source_bucket                  = aws_s3_bucket.source_bucket.bucket
+  lambda_zip_file                = aws_s3_bucket_object.frontend_api_release_zip.key
+  lambda_zip_file_version        = aws_s3_bucket_object.frontend_api_release_zip.version_id
+  warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
+  warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+
   authentication_vpc_arn = local.authentication_vpc_arn
   security_group_ids = [
     local.authentication_security_group_id,
@@ -41,7 +47,6 @@ module "reset_password" {
 
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
-  warmer_lambda_zip_file       = var.lambda_warmer_zip_file
   warmer_security_group_ids    = [local.authentication_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency

--- a/ci/terraform/oidc/s3-objects.tf
+++ b/ci/terraform/oidc/s3-objects.tf
@@ -1,0 +1,52 @@
+resource "aws_s3_bucket" "source_bucket" {
+  bucket_prefix = "${var.environment}-lambda-source-"
+
+  versioning {
+    enabled = true
+  }
+}
+
+resource "aws_s3_bucket_object" "oidc_api_release_zip" {
+  bucket = aws_s3_bucket.source_bucket.bucket
+  key    = "oidc-api-release.zip"
+
+  server_side_encryption = "AES256"
+  source                 = var.oidc_api_lambda_zip_file
+  source_hash            = filemd5(var.oidc_api_lambda_zip_file)
+}
+
+resource "aws_s3_bucket_object" "client_api_release_zip" {
+  bucket = aws_s3_bucket.source_bucket.bucket
+  key    = "client-api-release.zip"
+
+  server_side_encryption = "AES256"
+  source                 = var.client_registry_api_lambda_zip_file
+  source_hash            = filemd5(var.client_registry_api_lambda_zip_file)
+}
+
+resource "aws_s3_bucket_object" "frontend_api_release_zip" {
+  bucket = aws_s3_bucket.source_bucket.bucket
+  key    = "frontend-api-release.zip"
+
+  server_side_encryption = "AES256"
+  source                 = var.frontend_api_lambda_zip_file
+  source_hash            = filemd5(var.frontend_api_lambda_zip_file)
+}
+
+resource "aws_s3_bucket_object" "warmer_release_zip" {
+  bucket = aws_s3_bucket.source_bucket.bucket
+  key    = "warmer-release.zip"
+
+  server_side_encryption = "AES256"
+  source                 = var.lambda_warmer_zip_file
+  source_hash            = filemd5(var.lambda_warmer_zip_file)
+}
+
+resource "aws_s3_bucket_object" "ipv_api_release_zip" {
+  bucket = aws_s3_bucket.source_bucket.bucket
+  key    = "ipv-api-release.zip"
+
+  server_side_encryption = "AES256"
+  source                 = var.ipv_api_lambda_zip_file
+  source_hash            = filemd5(var.ipv_api_lambda_zip_file)
+}

--- a/ci/terraform/oidc/send_notification.tf
+++ b/ci/terraform/oidc/send_notification.tf
@@ -18,10 +18,16 @@ module "send_notification" {
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.SendNotificationHandler::handleRequest"
 
-  rest_api_id            = aws_api_gateway_rest_api.di_authentication_frontend_api.id
-  root_resource_id       = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
-  execution_arn          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
-  lambda_zip_file        = var.frontend_api_lambda_zip_file
+  rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
+  root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
+  execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
+
+  source_bucket                  = aws_s3_bucket.source_bucket.bucket
+  lambda_zip_file                = aws_s3_bucket_object.frontend_api_release_zip.key
+  lambda_zip_file_version        = aws_s3_bucket_object.frontend_api_release_zip.version_id
+  warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
+  warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+
   authentication_vpc_arn = local.authentication_vpc_arn
   security_group_ids = [
     local.authentication_security_group_id,
@@ -39,7 +45,6 @@ module "send_notification" {
 
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
-  warmer_lambda_zip_file       = var.lambda_warmer_zip_file
   warmer_security_group_ids    = [local.authentication_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency

--- a/ci/terraform/oidc/signup.tf
+++ b/ci/terraform/oidc/signup.tf
@@ -34,10 +34,16 @@ module "signup" {
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.SignUpHandler::handleRequest"
 
-  rest_api_id            = aws_api_gateway_rest_api.di_authentication_frontend_api.id
-  root_resource_id       = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
-  execution_arn          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
-  lambda_zip_file        = var.frontend_api_lambda_zip_file
+  rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
+  root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
+  execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
+
+  source_bucket                  = aws_s3_bucket.source_bucket.bucket
+  lambda_zip_file                = aws_s3_bucket_object.frontend_api_release_zip.key
+  lambda_zip_file_version        = aws_s3_bucket_object.frontend_api_release_zip.version_id
+  warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
+  warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+
   authentication_vpc_arn = local.authentication_vpc_arn
   security_group_ids = [
     local.authentication_security_group_id,
@@ -55,8 +61,8 @@ module "signup" {
 
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
-  warmer_lambda_zip_file       = var.lambda_warmer_zip_file
-  warmer_security_group_ids    = [local.authentication_security_group_id]
+
+  warmer_security_group_ids = [local.authentication_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
   }

--- a/ci/terraform/oidc/token.tf
+++ b/ci/terraform/oidc/token.tf
@@ -59,10 +59,16 @@ module "token" {
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.TokenHandler::handleRequest"
 
-  rest_api_id            = aws_api_gateway_rest_api.di_authentication_api.id
-  root_resource_id       = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
-  execution_arn          = aws_api_gateway_rest_api.di_authentication_api.execution_arn
-  lambda_zip_file        = var.oidc_api_lambda_zip_file
+  rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
+  root_resource_id = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
+  execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
+
+  source_bucket                  = aws_s3_bucket.source_bucket.bucket
+  lambda_zip_file                = aws_s3_bucket_object.oidc_api_release_zip.key
+  lambda_zip_file_version        = aws_s3_bucket_object.oidc_api_release_zip.version_id
+  warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
+  warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+
   authentication_vpc_arn = local.authentication_vpc_arn
   security_group_ids = [
     local.authentication_security_group_id,
@@ -79,7 +85,6 @@ module "token" {
 
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
-  warmer_lambda_zip_file       = var.lambda_warmer_zip_file
   warmer_security_group_ids    = [local.authentication_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency

--- a/ci/terraform/oidc/trustmarks.tf
+++ b/ci/terraform/oidc/trustmarks.tf
@@ -25,10 +25,16 @@ module "trustmarks" {
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.TrustMarkHandler::handleRequest"
 
-  rest_api_id                            = aws_api_gateway_rest_api.di_authentication_api.id
-  root_resource_id                       = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
-  execution_arn                          = aws_api_gateway_rest_api.di_authentication_api.execution_arn
-  lambda_zip_file                        = var.oidc_api_lambda_zip_file
+  rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
+  root_resource_id = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
+  execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
+
+  source_bucket                  = aws_s3_bucket.source_bucket.bucket
+  lambda_zip_file                = aws_s3_bucket_object.oidc_api_release_zip.key
+  lambda_zip_file_version        = aws_s3_bucket_object.oidc_api_release_zip.version_id
+  warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
+  warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+
   authentication_vpc_arn                 = local.authentication_vpc_arn
   security_group_ids                     = [local.authentication_security_group_id]
   subnet_id                              = local.authentication_subnet_ids
@@ -42,7 +48,6 @@ module "trustmarks" {
 
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
-  warmer_lambda_zip_file       = var.lambda_warmer_zip_file
   warmer_security_group_ids    = [local.authentication_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency

--- a/ci/terraform/oidc/update.tf
+++ b/ci/terraform/oidc/update.tf
@@ -31,10 +31,16 @@ module "update" {
   }
   handler_function_name = "uk.gov.di.authentication.clientregistry.lambda.UpdateClientConfigHandler::handleRequest"
 
-  rest_api_id            = aws_api_gateway_rest_api.di_authentication_api.id
-  root_resource_id       = aws_api_gateway_resource.register_resource.id
-  execution_arn          = aws_api_gateway_rest_api.di_authentication_api.execution_arn
-  lambda_zip_file        = var.client_registry_api_lambda_zip_file
+  rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
+  root_resource_id = aws_api_gateway_resource.register_resource.id
+  execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
+
+  source_bucket                  = aws_s3_bucket.source_bucket.bucket
+  lambda_zip_file                = aws_s3_bucket_object.client_api_release_zip.key
+  lambda_zip_file_version        = aws_s3_bucket_object.client_api_release_zip.version_id
+  warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
+  warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+
   authentication_vpc_arn = local.authentication_vpc_arn
   security_group_ids = [
     local.authentication_security_group_id,
@@ -52,7 +58,6 @@ module "update" {
 
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
-  warmer_lambda_zip_file       = var.lambda_warmer_zip_file
   warmer_security_group_ids    = [local.authentication_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency

--- a/ci/terraform/oidc/update_profile.tf
+++ b/ci/terraform/oidc/update_profile.tf
@@ -35,10 +35,16 @@ module "update_profile" {
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.UpdateProfileHandler::handleRequest"
 
-  rest_api_id            = aws_api_gateway_rest_api.di_authentication_frontend_api.id
-  root_resource_id       = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
-  execution_arn          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
-  lambda_zip_file        = var.frontend_api_lambda_zip_file
+  rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
+  root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
+  execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
+
+  source_bucket                  = aws_s3_bucket.source_bucket.bucket
+  lambda_zip_file                = aws_s3_bucket_object.frontend_api_release_zip.key
+  lambda_zip_file_version        = aws_s3_bucket_object.frontend_api_release_zip.version_id
+  warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
+  warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+
   authentication_vpc_arn = local.authentication_vpc_arn
   security_group_ids = [
     local.authentication_security_group_id,
@@ -56,7 +62,6 @@ module "update_profile" {
 
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
-  warmer_lambda_zip_file       = var.lambda_warmer_zip_file
   warmer_security_group_ids    = [local.authentication_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency

--- a/ci/terraform/oidc/userexists.tf
+++ b/ci/terraform/oidc/userexists.tf
@@ -34,10 +34,16 @@ module "userexists" {
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.CheckUserExistsHandler::handleRequest"
 
-  rest_api_id            = aws_api_gateway_rest_api.di_authentication_frontend_api.id
-  root_resource_id       = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
-  execution_arn          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
-  lambda_zip_file        = var.frontend_api_lambda_zip_file
+  rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
+  root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
+  execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
+
+  source_bucket                  = aws_s3_bucket.source_bucket.bucket
+  lambda_zip_file                = aws_s3_bucket_object.frontend_api_release_zip.key
+  lambda_zip_file_version        = aws_s3_bucket_object.frontend_api_release_zip.version_id
+  warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
+  warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+
   authentication_vpc_arn = local.authentication_vpc_arn
   security_group_ids = [
     local.authentication_security_group_id,
@@ -55,7 +61,6 @@ module "userexists" {
 
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
-  warmer_lambda_zip_file       = var.lambda_warmer_zip_file
   warmer_security_group_ids    = [local.authentication_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -33,10 +33,16 @@ module "userinfo" {
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.UserInfoHandler::handleRequest"
 
-  rest_api_id            = aws_api_gateway_rest_api.di_authentication_api.id
-  root_resource_id       = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
-  execution_arn          = aws_api_gateway_rest_api.di_authentication_api.execution_arn
-  lambda_zip_file        = var.oidc_api_lambda_zip_file
+  rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
+  root_resource_id = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
+  execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
+
+  source_bucket                  = aws_s3_bucket.source_bucket.bucket
+  lambda_zip_file                = aws_s3_bucket_object.oidc_api_release_zip.key
+  lambda_zip_file_version        = aws_s3_bucket_object.oidc_api_release_zip.version_id
+  warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
+  warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+
   authentication_vpc_arn = local.authentication_vpc_arn
   security_group_ids = [
     local.authentication_security_group_id,
@@ -53,7 +59,6 @@ module "userinfo" {
 
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
-  warmer_lambda_zip_file       = var.lambda_warmer_zip_file
   warmer_security_group_ids    = [local.authentication_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency

--- a/ci/terraform/oidc/verify_code.tf
+++ b/ci/terraform/oidc/verify_code.tf
@@ -37,10 +37,16 @@ module "verify_code" {
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.VerifyCodeHandler::handleRequest"
 
-  rest_api_id            = aws_api_gateway_rest_api.di_authentication_frontend_api.id
-  root_resource_id       = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
-  execution_arn          = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
-  lambda_zip_file        = var.frontend_api_lambda_zip_file
+  rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
+  root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
+  execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
+
+  source_bucket                  = aws_s3_bucket.source_bucket.bucket
+  lambda_zip_file                = aws_s3_bucket_object.frontend_api_release_zip.key
+  lambda_zip_file_version        = aws_s3_bucket_object.frontend_api_release_zip.version_id
+  warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
+  warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+
   authentication_vpc_arn = local.authentication_vpc_arn
   security_group_ids = [
     local.authentication_security_group_id,
@@ -58,7 +64,6 @@ module "verify_code" {
 
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
-  warmer_lambda_zip_file       = var.lambda_warmer_zip_file
   warmer_security_group_ids    = [local.authentication_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency

--- a/ci/terraform/oidc/wellknown.tf
+++ b/ci/terraform/oidc/wellknown.tf
@@ -21,10 +21,16 @@ module "openid_configuration_discovery" {
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.WellknownHandler::handleRequest"
 
-  rest_api_id                            = aws_api_gateway_rest_api.di_authentication_api.id
-  root_resource_id                       = aws_api_gateway_resource.wellknown_resource.id
-  execution_arn                          = aws_api_gateway_rest_api.di_authentication_api.execution_arn
-  lambda_zip_file                        = var.oidc_api_lambda_zip_file
+  rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
+  root_resource_id = aws_api_gateway_resource.wellknown_resource.id
+  execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
+
+  source_bucket                  = aws_s3_bucket.source_bucket.bucket
+  lambda_zip_file                = aws_s3_bucket_object.oidc_api_release_zip.key
+  lambda_zip_file_version        = aws_s3_bucket_object.oidc_api_release_zip.version_id
+  warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
+  warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+
   authentication_vpc_arn                 = local.authentication_vpc_arn
   security_group_ids                     = [local.authentication_security_group_id]
   subnet_id                              = local.authentication_subnet_ids
@@ -38,7 +44,6 @@ module "openid_configuration_discovery" {
 
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
-  warmer_lambda_zip_file       = var.lambda_warmer_zip_file
   warmer_security_group_ids    = [local.authentication_security_group_id]
   warmer_handler_environment_variables = {
     LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency


### PR DESCRIPTION
## What?

- Add a versioned S3 bucket into the OIDC Terraform, this will be used to store lambda source ZIP files
- Use Terraform to copy up the provided ZIP files to the new bucket
- Change the `endpoint-module` to use S3 bucket, key and version
parameters as the lambda, and warmer, source rather than a local file name.
- Update all calls to `endpoint-module` in OIDC module to pass correct parameters.
- Add a versioned S3 bucket to the account management terraform
- Use Terraform to copy the account management API and warmer source ZIP files to the new AM bucket
- Update all account management `endpoint-module` usages to pass the S3 parameters

## Why?

By using an S3 to store the source code, we reduced the amount of work the deployment has to do by only needing to upload the ZIP file once. This should significantly reduce the deployment time of the APIs.

This PR only addresses the endpoint lambda, a subsequent PR will be raised to make similar changes to the SQS, authoriser and audit lambda.
