### PR TITLE
Auth 1261 s3 for lambda deployment

### DIFF
--- a/ci/terraform/account-management/api-gateway.tf
+++ b/ci/terraform/account-management/api-gateway.tf
@@ -75,12 +75,15 @@ EOF
 }
 
 resource "aws_lambda_function" "authorizer" {
-  filename         = var.lambda_zip_file
   function_name    = "${var.environment}-api_gateway_authorizer"
   role             = module.account_notification_default_role.arn
   handler          = "uk.gov.di.accountmanagement.lambda.AuthoriseAccessTokenHandler::handleRequest"
   runtime          = "java11"
-  source_code_hash = filebase64sha256(var.lambda_zip_file)
+
+  s3_bucket         = aws_s3_bucket.source_bucket.bucket
+  s3_key            = aws_s3_bucket_object.account_management_api_release_zip.key
+  s3_object_version = aws_s3_bucket_object.account_management_api_release_zip.version_id
+
   publish          = true
   timeout          = 30
   memory_size      = 2048

--- a/ci/terraform/account-management/authoriser-warmer.tf
+++ b/ci/terraform/account-management/authoriser-warmer.tf
@@ -35,7 +35,6 @@ resource "aws_iam_policy" "lambda_warmer_policy" {
 resource "aws_lambda_function" "warmer_function" {
   count = var.keep_lambdas_warm ? 1 : 0
 
-  filename      = var.lambda_warmer_zip_file
   function_name = "${aws_lambda_function.authorizer.function_name}-lambda-warmer"
   role          = module.lambda_warmer_role[0].arn
   handler       = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
@@ -46,7 +45,9 @@ resource "aws_lambda_function" "warmer_function" {
     mode = "Active"
   }
 
-  source_code_hash = filebase64sha256(var.lambda_warmer_zip_file)
+  s3_bucket         = aws_s3_bucket.source_bucket.bucket
+  s3_key            = aws_s3_bucket_object.warmer_release_zip.key
+  s3_object_version = aws_s3_bucket_object.warmer_release_zip.version_id
 
   vpc_config {
     security_group_ids = [local.allow_aws_service_access_security_group_id]

--- a/ci/terraform/account-management/sqs.tf
+++ b/ci/terraform/account-management/sqs.tf
@@ -152,7 +152,6 @@ resource "aws_lambda_event_source_mapping" "lambda_sqs_mapping" {
 }
 
 resource "aws_lambda_function" "email_sqs_lambda" {
-  filename      = var.lambda_zip_file
   function_name = "${var.environment}-account-management-sqs-lambda"
   role          = module.account_management_sqs_role.arn
   handler       = "uk.gov.di.accountmanagement.lambda.NotificationHandler::handleRequest"
@@ -161,7 +160,10 @@ resource "aws_lambda_function" "email_sqs_lambda" {
   runtime       = "java11"
   publish       = true
 
-  source_code_hash = filebase64sha256(var.lambda_zip_file)
+  s3_bucket         = aws_s3_bucket.source_bucket.bucket
+  s3_key            = aws_s3_bucket_object.account_management_api_release_zip.key
+  s3_object_version = aws_s3_bucket_object.account_management_api_release_zip.version_id
+
   vpc_config {
     security_group_ids = [local.allow_egress_security_group_id]
     subnet_ids         = local.private_subnet_ids

--- a/ci/terraform/audit-processors/counter_fraud.tf
+++ b/ci/terraform/audit-processors/counter_fraud.tf
@@ -44,7 +44,6 @@ resource "random_password" "hmac_key" {
 }
 
 resource "aws_lambda_function" "fraud_realtime_logging_lambda" {
-  filename      = var.lambda_zip_file
   function_name = "${var.environment}-fraud-realtime-logging-lambda"
   role          = module.fraud_realtime_logging_role.arn
   handler       = "uk.gov.di.authentication.audit.lambda.CounterFraudAuditLambda::handleRequest"
@@ -56,7 +55,10 @@ resource "aws_lambda_function" "fraud_realtime_logging_lambda" {
     mode = "Active"
   }
 
-  source_code_hash = filebase64sha256(var.lambda_zip_file)
+  s3_bucket         = aws_s3_bucket.source_bucket.bucket
+  s3_key            = aws_s3_bucket_object.audit_processor_release_zip.key
+  s3_object_version = aws_s3_bucket_object.audit_processor_release_zip.version_id
+
   vpc_config {
     security_group_ids = [local.authentication_security_group_id]
     subnet_ids         = local.authentication_subnet_ids

--- a/ci/terraform/audit-processors/performance_analysis.tf
+++ b/ci/terraform/audit-processors/performance_analysis.tf
@@ -44,7 +44,6 @@ resource "random_password" "performance_analysis_hmac_key" {
 }
 
 resource "aws_lambda_function" "performance_analysis_logging_lambda" {
-  filename      = var.lambda_zip_file
   function_name = "${var.environment}-performance-analysis-logging-lambda"
   role          = module.performance_analysis_logging_role.arn
   handler       = "uk.gov.di.authentication.audit.lambda.PerformanceAnalysisAuditLambda::handleRequest"
@@ -56,7 +55,10 @@ resource "aws_lambda_function" "performance_analysis_logging_lambda" {
     mode = "Active"
   }
 
-  source_code_hash = filebase64sha256(var.lambda_zip_file)
+  s3_bucket         = aws_s3_bucket.source_bucket.bucket
+  s3_key            = aws_s3_bucket_object.audit_processor_release_zip.key
+  s3_object_version = aws_s3_bucket_object.audit_processor_release_zip.version_id
+
   vpc_config {
     security_group_ids = [local.authentication_security_group_id]
     subnet_ids         = local.authentication_subnet_ids

--- a/ci/terraform/audit-processors/s3-objects.tf
+++ b/ci/terraform/audit-processors/s3-objects.tf
@@ -1,0 +1,16 @@
+resource "aws_s3_bucket" "source_bucket" {
+  bucket_prefix = "${var.environment}-audit-lambda-source-"
+
+  versioning {
+    enabled = true
+  }
+}
+
+resource "aws_s3_bucket_object" "audit_processor_release_zip" {
+  bucket = aws_s3_bucket.source_bucket.bucket
+  key    = "audit-processor-release.zip"
+
+  server_side_encryption = "AES256"
+  source                 = var.lambda_zip_file
+  source_hash            = filemd5(var.lambda_zip_file)
+}

--- a/ci/terraform/audit-processors/storage.tf
+++ b/ci/terraform/audit-processors/storage.tf
@@ -42,7 +42,6 @@ resource "aws_iam_policy" "audit_payload_kms_verification" {
 }
 
 resource "aws_lambda_function" "audit_processor_lambda" {
-  filename      = var.lambda_zip_file
   function_name = "${var.environment}-audit-storage-lambda"
   role          = module.audit_storage_lambda_role.arn
   handler       = "uk.gov.di.authentication.audit.lambda.StorageSQSAuditHandler::handleRequest"
@@ -54,7 +53,10 @@ resource "aws_lambda_function" "audit_processor_lambda" {
     mode = "Active"
   }
 
-  source_code_hash = filebase64sha256(var.lambda_zip_file)
+  s3_bucket         = aws_s3_bucket.source_bucket.bucket
+  s3_key            = aws_s3_bucket_object.audit_processor_release_zip.key
+  s3_object_version = aws_s3_bucket_object.audit_processor_release_zip.version_id
+
   vpc_config {
     security_group_ids = [local.authentication_security_group_id]
     subnet_ids         = local.authentication_subnet_ids

--- a/ci/terraform/oidc/spot-response.tf
+++ b/ci/terraform/oidc/spot-response.tf
@@ -11,7 +11,7 @@ module "ipv_spot_response_role" {
 
 resource "aws_lambda_function" "spot_response_lambda" {
   count         = var.ipv_api_enabled ? 1 : 0
-  filename      = var.ipv_api_lambda_zip_file
+
   function_name = "${var.environment}-spot-response-lambda"
   role          = module.ipv_spot_response_role.arn
   handler       = "uk.gov.di.authentication.ipv-api.lambda.SPOTResponseHandler::handleRequest"
@@ -20,7 +20,10 @@ resource "aws_lambda_function" "spot_response_lambda" {
   runtime       = "java11"
   publish       = true
 
-  source_code_hash = filebase64sha256(var.ipv_api_lambda_zip_file)
+  s3_bucket         = aws_s3_bucket.source_bucket.bucket
+  s3_key            = aws_s3_bucket_object.ipv_api_release_zip.key
+  s3_object_version = aws_s3_bucket_object.ipv_api_release_zip.version_id
+
   vpc_config {
     security_group_ids = [local.authentication_egress_security_group_id]
     subnet_ids         = local.authentication_subnet_ids

--- a/ci/terraform/oidc/sqs.tf
+++ b/ci/terraform/oidc/sqs.tf
@@ -149,7 +149,6 @@ resource "aws_lambda_event_source_mapping" "lambda_sqs_mapping" {
 }
 
 resource "aws_lambda_function" "email_sqs_lambda" {
-  filename      = var.frontend_api_lambda_zip_file
   function_name = "${var.environment}-email-notification-sqs-lambda"
   role          = module.oidc_email_role.arn
   handler       = "uk.gov.di.authentication.frontendapi.lambda.NotificationHandler::handleRequest"
@@ -158,7 +157,10 @@ resource "aws_lambda_function" "email_sqs_lambda" {
   runtime       = "java11"
   publish       = true
 
-  source_code_hash = filebase64sha256(var.frontend_api_lambda_zip_file)
+  s3_bucket         = aws_s3_bucket.source_bucket.bucket
+  s3_key            = aws_s3_bucket_object.frontend_api_release_zip.key
+  s3_object_version = aws_s3_bucket_object.frontend_api_release_zip.version_id
+
   vpc_config {
     security_group_ids = [local.authentication_egress_security_group_id]
     subnet_ids         = local.authentication_subnet_ids


### PR DESCRIPTION
## What?

- Use the S3 bucket source for the frontend SQS processor
- Use the S3 bucket source for the IPV SPoT processor
- Use the S3 bucket source for the Account Management SQS processor
- Use the S3 bucket source for the Account Management authoriser and warmer
- Create a version S3 bucket in the Audit Processor Terraform
- Use Terraform to upload the lambda source ZIP file to the bucket
- Update Lambda function resources to pull source from the S3 bucket rather than from local ZIP file.

## Why?

In #1421 we update all the endpoint lambda to use this method and can see it has halved the deploy time. This PR changes all other lambda to use the same deployment method.

*N.B.* we are deliberately not changing the data transfer lambda in the `shared` Terraform as there is a story to remove that lambda from the deployment.

## Related PRs

#1421 