### PR TITLE
AUTH-1174 - Add ability to describe table to the SPOT table

### DIFF
--- a/ci/terraform/oidc/dynamo-policies.tf
+++ b/ci/terraform/oidc/dynamo-policies.tf
@@ -124,7 +124,11 @@ data "aws_iam_policy_document" "dynamo_spot_read_access_policy_document" {
     effect = "Allow"
 
     actions = [
+      "dynamodb:BatchGetItem",
+      "dynamodb:DescribeTable",
       "dynamodb:Get*",
+      "dynamodb:Query",
+      "dynamodb:Scan",
     ]
     resources = [
       data.aws_dynamodb_table.spot_credential_table.arn,


### PR DESCRIPTION
## What?

 - Add ability to describe table to the SPOT table

## Why?

- This is required as part of the lambda warmer
