### PR TITLE
BAU: add missing notify personalisation in am verify email payload

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/NotificationHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/NotificationHandler.java
@@ -67,6 +67,7 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                             emailPersonalisation.put("validation-code", notifyRequest.getCode());
                             emailPersonalisation.put(
                                     "email-address", notifyRequest.getDestination());
+                            emailPersonalisation.put("contact-us-link", buildContactUsUrl());
                             LOG.info("Sending VERIFY_EMAIL email using Notify");
                             notificationService.sendEmail(
                                     notifyRequest.getDestination(),
@@ -172,5 +173,12 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
             }
         }
         return null;
+    }
+
+    private String buildContactUsUrl() {
+        return buildURI(
+                        configurationService.getFrontendBaseUrl(),
+                        configurationService.getContactUsLinkRoute())
+                .toString();
     }
 }

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/NotificationHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/NotificationHandlerTest.java
@@ -38,6 +38,8 @@ public class NotificationHandlerTest {
     private static final String CUSTOMER_SUPPORT_LINK_URL =
             "https://localhost:8080/frontend/support";
     private static final String CUSTOMER_SUPPORT_LINK_ROUTE = "support";
+    private static final String CONTACT_US_LINK_URL = "https://localhost:8080/frontend/contact-us";
+    private static final String CONTACT_US_LINK_ROUTE = "contact-us";
     private final Context context = mock(Context.class);
     private final NotificationService notificationService = mock(NotificationService.class);
     private final ConfigurationService configService = mock(ConfigurationService.class);
@@ -53,6 +55,8 @@ public class NotificationHandlerTest {
     public void shouldSuccessfullyProcessVerifyEmailMessageFromSQSQueue()
             throws JsonProcessingException, NotificationClientException {
         when(notificationService.getNotificationTemplateId(VERIFY_EMAIL)).thenReturn(TEMPLATE_ID);
+        when(configService.getFrontendBaseUrl()).thenReturn(FRONTEND_BASE_URL);
+        when(configService.getContactUsLinkRoute()).thenReturn(CONTACT_US_LINK_ROUTE);
 
         NotifyRequest notifyRequest = new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL, "654321");
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
@@ -63,6 +67,7 @@ public class NotificationHandlerTest {
         Map<String, Object> personalisation = new HashMap<>();
         personalisation.put("validation-code", "654321");
         personalisation.put("email-address", notifyRequest.getDestination());
+        personalisation.put("contact-us-link", CONTACT_US_LINK_URL);
 
         verify(notificationService).sendEmail(TEST_EMAIL_ADDRESS, personalisation, TEMPLATE_ID);
     }
@@ -183,6 +188,8 @@ public class NotificationHandlerTest {
     public void shouldThrowExceptionIfNotifyIsUnableToSendEmail()
             throws JsonProcessingException, NotificationClientException {
         when(notificationService.getNotificationTemplateId(VERIFY_EMAIL)).thenReturn(TEMPLATE_ID);
+        when(configService.getFrontendBaseUrl()).thenReturn(FRONTEND_BASE_URL);
+        when(configService.getContactUsLinkRoute()).thenReturn(CONTACT_US_LINK_ROUTE);
 
         NotifyRequest notifyRequest = new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL, "654321");
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
@@ -191,6 +198,8 @@ public class NotificationHandlerTest {
         Map<String, Object> personalisation = new HashMap<>();
         personalisation.put("validation-code", "654321");
         personalisation.put("email-address", notifyRequest.getDestination());
+        personalisation.put("contact-us-link", CONTACT_US_LINK_URL);
+
         Mockito.doThrow(NotificationClientException.class)
                 .when(notificationService)
                 .sendEmail(TEST_EMAIL_ADDRESS, personalisation, TEMPLATE_ID);

--- a/ci/terraform/account-management/sqs.tf
+++ b/ci/terraform/account-management/sqs.tf
@@ -180,6 +180,7 @@ resource "aws_lambda_function" "email_sqs_lambda" {
     variables = merge(var.notify_template_map, {
       FRONTEND_BASE_URL           = module.dns.frontend_url
       CUSTOMER_SUPPORT_LINK_ROUTE = var.customer_support_link_route
+      CONTACT_US_LINK_ROUTE       = var.contact_us_link_route
       NOTIFY_API_KEY              = var.notify_api_key
       NOTIFY_URL                  = var.notify_url
     })

--- a/ci/terraform/account-management/variables.tf
+++ b/ci/terraform/account-management/variables.tf
@@ -163,6 +163,11 @@ variable "customer_support_link_route" {
   default = "support"
 }
 
+variable "contact_us_link_route" {
+  type    = string
+  default = "contact-us"
+}
+
 variable "localstack_endpoint" {
   type    = string
   default = "http://localhost:45678/"


### PR DESCRIPTION
## What?

Add missing notify personalisation in am verify email payload.

## Why?

The variable name in the template was updated due to code changes in frontend, but changes were not applied to am too.