### PR TITLE
BAU - Handle when no query string params are present in auth request

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -122,10 +122,10 @@ public class AuthorisationHandler
                             attachLogFieldToLogs(AWS_REQUEST_ID, context.getAwsRequestId());
                             LOG.info("Received authentication request");
 
-                            Map<String, List<String>> queryStringParameters =
-                                    getQueryStringParametersAsMap(input);
+                            Map<String, List<String>> queryStringParameters;
                             AuthenticationRequest authRequest;
                             try {
+                                queryStringParameters = getQueryStringParametersAsMap(input);
                                 authRequest = AuthenticationRequest.parse(queryStringParameters);
                             } catch (ParseException e) {
                                 if (e.getRedirectionURI() == null) {
@@ -146,6 +146,13 @@ public class AuthorisationHandler
                                         context,
                                         ipAddress,
                                         persistentSessionId);
+                            } catch (NullPointerException e) {
+                                LOG.warn(
+                                        "No query string parameters are present in the Authentication request",
+                                        e);
+                                throw new RuntimeException(
+                                        "No query string parameters are present in the Authentication request",
+                                        e);
                             }
                             Optional<ErrorObject> error =
                                     authorizationService.validateAuthRequest(authRequest);

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -41,11 +41,13 @@ import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -305,6 +307,24 @@ class AuthorisationHandlerTest {
                         "",
                         PERSISTENT_SESSION_ID,
                         pair("description", "Invalid request: Missing response_type parameter"));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenNoQueryStringParametersArePresent() {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        event.setRequestContext(
+                new ProxyRequestContext()
+                        .withIdentity(new RequestIdentity().withSourceIp("123.123.123.123")));
+
+        RuntimeException expectedException =
+                assertThrows(
+                        RuntimeException.class,
+                        () -> makeHandlerRequest(event),
+                        "Expected to throw AccessTokenException");
+
+        assertThat(
+                expectedException.getMessage(),
+                equalTo("No query string parameters are present in the Authentication request"));
     }
 
     @Test


### PR DESCRIPTION
## What?

- Previously we wasn't handling when no query string parameters are present in the auth request so it was just throwing a nullpointer. We should catch the exception when this occurs and log a relevant error message

## Why?

- So exceptions are handled and it is clear in the logs why they are thrown