### PR TITLE
BAU: Fix sandpit deployment

### DIFF
--- a/ci/terraform/audit-processors/sandpit.hcl
+++ b/ci/terraform/audit-processors/sandpit.hcl
@@ -1,0 +1,4 @@
+bucket  = "digital-identity-dev-tfstate"
+key     = "sandpit-audit-terraform.tfstate"
+encrypt = true
+region  = "eu-west-2"

--- a/ci/terraform/audit-processors/sandpit.tfvars
+++ b/ci/terraform/audit-processors/sandpit.tfvars
@@ -1,0 +1,2 @@
+environment         = "sandpit"
+shared_state_bucket = "digital-identity-dev-tfstate"

--- a/ci/terraform/modules/dns/dns.tf
+++ b/ci/terraform/modules/dns/dns.tf
@@ -10,10 +10,10 @@ data "terraform_remote_state" "dns" {
 }
 
 locals {
-  frontend_fqdn               = var.is_localstack ? "localhost:3000" : var.is_sandpit ? "front.sandpit.auth.ida.digital.cabinet-office.gov.uk" : lookup(data.terraform_remote_state.dns[0].outputs, "${var.environment}_frontend_url", "")
+  frontend_fqdn               = var.is_localstack ? "localhost:3000" : var.is_sandpit ? "signin.sandpit.auth.ida.digital.cabinet-office.gov.uk" : lookup(data.terraform_remote_state.dns[0].outputs, "${var.environment}_frontend_url", "")
   oidc_api_fqdn               = var.is_localstack ? "localhost:8080" : var.is_sandpit ? "api.sandpit.auth.ida.digital.cabinet-office.gov.uk" : lookup(data.terraform_remote_state.dns[0].outputs, "${var.environment}_api_url", "")
   frontend_api_fqdn           = var.is_localstack ? "localhost:8080" : var.is_sandpit ? "auth.sandpit.auth.ida.digital.cabinet-office.gov.uk" : lookup(data.terraform_remote_state.dns[0].outputs, "${var.environment}_api_frontend_url", "")
   service_domain_name         = var.is_localstack ? "localhost" : var.is_sandpit ? "sandpit.auth.ida.digital.cabinet-office.gov.uk" : lookup(data.terraform_remote_state.dns[0].outputs, "${var.environment}_service_domain", "")
-  account_management_fqdn     = var.is_localstack ? "localhost:3000" : var.is_sandpit ? "account-management.sandpit.auth.ida.digital.cabinet-office.gov.uk" : lookup(data.terraform_remote_state.dns[0].outputs, "${var.environment}_account_management_url", "")
+  account_management_fqdn     = var.is_localstack ? "localhost:3000" : var.is_sandpit ? "sandpit.auth.ida.digital.cabinet-office.gov.uk" : lookup(data.terraform_remote_state.dns[0].outputs, "${var.environment}_account_management_url", "")
   account_management_api_fqdn = var.is_localstack ? "localhost:8080" : var.is_sandpit ? "acct-mgmt-api.sandpit.auth.ida.digital.cabinet-office.gov.uk" : lookup(data.terraform_remote_state.dns[0].outputs, "${var.environment}_account_management_api_url", "")
 }

--- a/ci/terraform/shared/sandpit.tfvars
+++ b/ci/terraform/shared/sandpit.tfvars
@@ -7,3 +7,16 @@ password_pepper             = "fake-pepper"
 
 enable_api_gateway_execution_request_tracing = true
 di_tools_signing_profile_version_arn         = "arn:aws:signer:eu-west-2:706615647326:/signing-profiles/di_auth_lambda_signing_20220214175605677200000001/ZPqg7ZUgCP"
+
+stub_rp_clients = [
+  {
+    client_name = "di-auth-stub-relying-party-sandpit"
+    callback_urls = [
+      "https://di-auth-stub-relying-party-sandpit.london.cloudapps.digital/oidc/authorization-code/callback",
+    ]
+    logout_urls = [
+      "https://di-auth-stub-relying-party-sandpit.london.cloudapps.digital/signed-out",
+    ]
+    test_client = "0"
+  },
+]


### PR DESCRIPTION
## What?

- Use correct DNS names for Fargate applications
- Ensure stub clients created for sandpit

## Why?

Sandpit deployments not working properly since the migration to Fargate, also, we need some stub RP creds for the apps in PaaS.