### PR TITLE
AUTH-1357: Remove CloudWatch metrics feature toggle

### DIFF
--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -51,7 +51,6 @@ test {
     environment "STUB_RELYING_PARTY_REDIRECT_URI", "https://di-auth-stub-relying-party-build.london.cloudapps.digital/"
     environment "TERMS_CONDITIONS_VERSION", "1.0"
     environment "HEADERS_CASE_INSENSITIVE", "true"
-    environment "ENABLE_METRICS", "true"
 
     doLast {
         tasks.getByName("jacocoTestReport").sourceDirectories.from(

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/logging/LogEventMatcher.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/logging/LogEventMatcher.java
@@ -8,6 +8,7 @@ import org.hamcrest.TypeSafeMatcher;
 
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Optional;
 
 public class LogEventMatcher {
 
@@ -84,6 +85,43 @@ public class LogEventMatcher {
             public void describeTo(Description description) {
                 description.appendText(
                         "a log event with message containing [" + Arrays.asList(values) + "]");
+            }
+        };
+    }
+
+    public static Matcher<LogEvent> withMessage(String value) {
+        return new TypeSafeMatcher<>() {
+
+            @Override
+            protected boolean matchesSafely(LogEvent item) {
+                var message = item.getMessage().getFormattedMessage();
+
+                return value.equals(message);
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("a log event with message [" + value + "]");
+            }
+        };
+    }
+
+    public static Matcher<LogEvent> withExceptionMessage(String message) {
+        return new TypeSafeMatcher<>() {
+
+            @Override
+            protected boolean matchesSafely(LogEvent item) {
+                return Optional.of(item)
+                        .map(LogEvent::getThrown)
+                        .map(Throwable::getMessage)
+                        .filter(message::equals)
+                        .isPresent();
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText(
+                        "a log event containing an exception with message [" + message + "]");
             }
         };
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsService.java
@@ -32,11 +32,6 @@ public class CloudwatchMetricsService {
     }
 
     public void putValue(String metricName, Number metricValue, Map<String, String> dimensions) {
-
-        if (!enabled()) {
-            return;
-        }
-
         var dimensionList = dimensions.entrySet().stream().map(this::toDimension).collect(toList());
 
         var dataPoint =
@@ -61,9 +56,5 @@ public class CloudwatchMetricsService {
 
     public void incrementCounter(String name, Map<String, String> dimensions) {
         putValue(name, 1, dimensions);
-    }
-
-    protected boolean enabled() {
-        return System.getenv("ENABLE_METRICS") != null;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsService.java
@@ -1,5 +1,7 @@
 package uk.gov.di.authentication.shared.services;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
 import software.amazon.awssdk.services.cloudwatch.model.Dimension;
@@ -12,6 +14,8 @@ import java.util.Map;
 import static java.util.stream.Collectors.toList;
 
 public class CloudwatchMetricsService {
+
+    private static final Logger LOG = LogManager.getLogger(CloudwatchMetricsService.class);
 
     private final CloudWatchClient cloudwatch;
 
@@ -47,7 +51,11 @@ public class CloudwatchMetricsService {
                         .namespace("Authentication")
                         .build();
 
-        cloudwatch.putMetricData(request);
+        try {
+            cloudwatch.putMetricData(request);
+        } catch (Exception e) {
+            LOG.error("Could not publish metrics", e);
+        }
     }
 
     private Dimension toDimension(Map.Entry<String, String> entry) {

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsServiceTest.java
@@ -19,13 +19,7 @@ class CloudwatchMetricsServiceTest {
     void shouldPublishMetricValueWithDimensions() {
         var cloudwatch = mock(CloudWatchClient.class);
 
-        var metrics =
-                new CloudwatchMetricsService(cloudwatch) {
-                    @Override
-                    protected boolean enabled() {
-                        return true;
-                    }
-                };
+        var metrics = new CloudwatchMetricsService(cloudwatch);
 
         metrics.putValue("metric-name", 10, Map.of("dimension1", "value"));
 
@@ -37,13 +31,7 @@ class CloudwatchMetricsServiceTest {
     void shouldIncrementCounter() {
         var cloudwatch = mock(CloudWatchClient.class);
 
-        var metrics =
-                new CloudwatchMetricsService(cloudwatch) {
-                    @Override
-                    protected boolean enabled() {
-                        return true;
-                    }
-                };
+        var metrics = new CloudwatchMetricsService(cloudwatch);
 
         metrics.incrementCounter("counter-name", Map.of("dimension2", "value2"));
 

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsServiceTest.java
@@ -1,19 +1,31 @@
 package uk.gov.di.authentication.shared.services;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.ArgumentMatcher;
 import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
 import software.amazon.awssdk.services.cloudwatch.model.MetricDatum;
 import software.amazon.awssdk.services.cloudwatch.model.PutMetricDataRequest;
+import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
 import java.util.List;
 import java.util.Map;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.sharedtest.logging.LogEventMatcher.withExceptionMessage;
+import static uk.gov.di.authentication.sharedtest.logging.LogEventMatcher.withMessageContaining;
 
 class CloudwatchMetricsServiceTest {
+
+    @RegisterExtension
+    public final CaptureLoggingExtension logging =
+            new CaptureLoggingExtension(CloudwatchMetricsService.class);
 
     @Test
     void shouldPublishMetricValueWithDimensions() {
@@ -37,6 +49,21 @@ class CloudwatchMetricsServiceTest {
 
         verify(cloudwatch).putMetricData(argThat(hasNameAndValue("counter-name", 1.0d)));
         verify(cloudwatch).putMetricData(argThat(hasDimension("dimension2", "value2")));
+    }
+
+    @Test
+    void shouldLogErrorAndContinueIfProblemPublishingMetric() {
+        var cloudwatch = mock(CloudWatchClient.class);
+
+        var metrics = new CloudwatchMetricsService(cloudwatch);
+
+        when(cloudwatch.putMetricData(any(PutMetricDataRequest.class)))
+                .thenThrow(new RuntimeException("Cloudwatch problem"));
+
+        metrics.incrementCounter("counter-name", Map.of("dimension2", "value2"));
+
+        assertThat(logging.events(), hasItem(withMessageContaining("Could not publish metrics")));
+        assertThat(logging.events(), hasItem(withExceptionMessage("Cloudwatch problem")));
     }
 
     private ArgumentMatcher<PutMetricDataRequest> hasNameAndValue(String name, Double value) {


### PR DESCRIPTION
This PR removes the feature toggle, enabling the change for all versions of the lambda, and also enables the cloudwatch service to catch-and-continue if there are any exceptions thrown.

Metrics are a good indicator but are not full-fidelity, that is what the audit stream is for.

