### PR TITLE
AUTH-1293: Add code signing config

### DIFF
--- a/ci/tasks/deploy-oidc-api.yml
+++ b/ci/tasks/deploy-oidc-api.yml
@@ -51,7 +51,7 @@ run:
         -var 'oidc_api_lambda_zip_file=../../../../oidc-api-release/oidc-api.zip' \
         -var 'frontend_api_lambda_zip_file=../../../../frontend-api-release/frontend-api.zip' \
         -var 'client_registry_api_lambda_zip_file=../../../../client-registry-api-release/client-registry-api.zip' \
-        -var 'ipv_api_lambda_zip_file=../../../../ipv-api-release/ipv-api.zip' \
+        -var "ipv_api_lambda_zip_file=$(ls -1 ../../../../ipv-api-release/*.zip)" \
         -var 'lambda_warmer_zip_file=../../../../lambda-warmer-release/lambda-warmer.zip' \
         -var "deployer_role_arn=${DEPLOYER_ROLE_ARN}" \
         -var "notify_api_key=${NOTIFY_API_KEY}" \

--- a/ci/tasks/deploy-shared-api.yml
+++ b/ci/tasks/deploy-shared-api.yml
@@ -13,6 +13,7 @@ params:
   PASSWORD_PEPPER: ((build-password-pepper))
   STATE_BUCKET: digital-identity-dev-tfstate
   TEST_CLIENT_EMAIL_ALLOWLIST: ((test-client-email-allowlist))
+  DI_TOOLS_SIGNING_PROFILE_VERSION_ARN: ((di-tools-signing-profile-version-arn))
 inputs:
   - name: api-terraform-src
   - name: account-migration-release
@@ -40,6 +41,7 @@ run:
         -var 'account_migration_lambda_zip_file=../../../../account-migration-release/account-migrations.zip' \
         -var "password_pepper=${PASSWORD_PEPPER}" \
         -var "common_state_bucket=${STATE_BUCKET}" \
+        -var "di_tools_signing_profile_version_arn=${DI_TOOLS_SIGNING_PROFILE_VERSION_ARN}" \
         -var-file ${DEPLOY_ENVIRONMENT}-stub-clients.tfvars \
         -var-file ${DEPLOY_ENVIRONMENT}-sizing.tfvars \
 

--- a/ci/terraform/account-management/shared.tf
+++ b/ci/terraform/account-management/shared.tf
@@ -1,4 +1,3 @@
-
 data "terraform_remote_state" "shared" {
   backend = "s3"
   config = {
@@ -13,4 +12,8 @@ data "terraform_remote_state" "shared" {
     skip_metadata_api_check     = var.use_localstack
     force_path_style            = var.use_localstack
   }
+}
+
+locals {
+  lambda_code_signing_configuration_arn = data.terraform_remote_state.shared.outputs.lambda_code_signing_configuration_arn
 }

--- a/ci/terraform/audit-processors/shared.tf
+++ b/ci/terraform/audit-processors/shared.tf
@@ -28,6 +28,7 @@ locals {
   authentication_vpc_arn                 = data.terraform_remote_state.shared.outputs.authentication_vpc_arn
   lambda_env_vars_encryption_kms_key_arn = data.terraform_remote_state.shared.outputs.lambda_env_vars_encryption_kms_key_arn
   events_topic_encryption_key_arn        = data.terraform_remote_state.shared.outputs.events_topic_encryption_key_arn
+  lambda_code_signing_configuration_arn  = data.terraform_remote_state.shared.outputs.lambda_code_signing_configuration_arn
 }
 
 data "aws_sns_topic" "event_stream" {

--- a/ci/terraform/modules/endpoint-module/lambda.tf
+++ b/ci/terraform/modules/endpoint-module/lambda.tf
@@ -27,6 +27,8 @@ resource "aws_lambda_function" "endpoint_lambda" {
 
   runtime = var.handler_runtime
 
+  code_signing_config_arn = var.code_signing_config_arn
+
   tags = var.default_tags
 }
 

--- a/ci/terraform/modules/endpoint-module/variables.tf
+++ b/ci/terraform/modules/endpoint-module/variables.tf
@@ -180,3 +180,7 @@ variable "lambda_log_alarm_threshold" {
 variable "lambda_env_vars_encryption_kms_key_arn" {
   type = string
 }
+
+variable "code_signing_config_arn" {
+  default = null
+}

--- a/ci/terraform/oidc/ipv-authorize.tf
+++ b/ci/terraform/oidc/ipv-authorize.tf
@@ -46,6 +46,7 @@ module "ipv-authorize" {
   lambda_zip_file_version        = aws_s3_bucket_object.ipv_api_release_zip.version_id
   warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
   warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+  code_signing_config_arn        = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.authentication_vpc_arn
   security_group_ids = [

--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -47,6 +47,7 @@ module "ipv-callback" {
   lambda_zip_file_version        = aws_s3_bucket_object.ipv_api_release_zip.version_id
   warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
   warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+  code_signing_config_arn        = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.authentication_vpc_arn
   security_group_ids = [

--- a/ci/terraform/oidc/ipv-capacity.tf
+++ b/ci/terraform/oidc/ipv-capacity.tf
@@ -44,6 +44,7 @@ module "ipv-capacity" {
   lambda_zip_file_version        = aws_s3_bucket_object.ipv_api_release_zip.version_id
   warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
   warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+  code_signing_config_arn        = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.authentication_vpc_arn
   security_group_ids = [

--- a/ci/terraform/oidc/shared.tf
+++ b/ci/terraform/oidc/shared.tf
@@ -34,4 +34,5 @@ locals {
   redis_ssm_parameter_policy                  = data.terraform_remote_state.shared.outputs.redis_ssm_parameter_policy
   pepper_ssm_parameter_policy                 = data.terraform_remote_state.shared.outputs.pepper_ssm_parameter_policy
   ipv_capacity_ssm_parameter_policy           = data.terraform_remote_state.shared.outputs.ipv_capacity_ssm_parameter_policy
+  lambda_code_signing_configuration_arn       = data.terraform_remote_state.shared.outputs.lambda_code_signing_configuration_arn
 }

--- a/ci/terraform/shared/code-signing-config.tf
+++ b/ci/terraform/shared/code-signing-config.tf
@@ -1,0 +1,13 @@
+resource "aws_lambda_code_signing_config" "code_signing_config" {
+  allowed_publishers {
+    signing_profile_version_arns = [
+      var.di_tools_signing_profile_version_arn
+    ]
+  }
+
+  description = "${var.environment}-code-signing-config"
+
+  policies {
+    untrusted_artifact_on_deployment = "Enforce"
+  }
+}

--- a/ci/terraform/shared/outputs.tf
+++ b/ci/terraform/shared/outputs.tf
@@ -129,3 +129,7 @@ output "pepper_ssm_parameter_policy" {
 output "ipv_capacity_ssm_parameter_policy" {
   value = aws_iam_policy.ipv_capacity_parameter_policy.arn
 }
+
+output "lambda_code_signing_configuration_arn" {
+  value = aws_lambda_code_signing_config.code_signing_config.arn
+}

--- a/ci/terraform/shared/sandpit.tfvars
+++ b/ci/terraform/shared/sandpit.tfvars
@@ -6,3 +6,4 @@ test_client_email_allowlist = "testclient.user1@digital.cabinet-office.gov.uk,te
 password_pepper             = "fake-pepper"
 
 enable_api_gateway_execution_request_tracing = true
+di_tools_signing_profile_version_arn         = "arn:aws:signer:eu-west-2:706615647326:/signing-profiles/di_auth_lambda_signing_20220214175605677200000001/ZPqg7ZUgCP"

--- a/ci/terraform/shared/variables.tf
+++ b/ci/terraform/shared/variables.tf
@@ -139,3 +139,7 @@ variable "password_pepper" {
 variable "common_state_bucket" {
   type = string
 }
+
+variable "di_tools_signing_profile_version_arn" {
+  description = "The AWS Signer profile version to use from the `di-tools-prod` account"
+}


### PR DESCRIPTION
## What?

- Add a Lambda Code Signing Config (CSC) to the shared Terraform.
- The allowed_publisher will be passed in as a variable from the pipeline (this will be signing profile from the `di-tools-prod` account).
- The allowed public in the sandpit shall be the signing profile form `di-tools-dev` account).
- Add the ARN of CSC to the shared Terraform outputs, to be used by the other API terraforms.
- Add a variable to the endpoint module to take an, optional, CSC to apply to the lambda. Default should be `null`.
- Pass the CSC ARN to the IPV API lambdas
- Update how the IPV API filename is determined, in the deploy task, as the filename won't be fixed when we switch to the AWS signed bucket. The release ZIP file will be the ONLY ZIP file in the S3 bucket resource.

## Why?

By adding a code signing configuration we are limiting which ZIP files can be used as valid source code for our lambdas. This PR only attaches the config to IPV API currently to test the theory.

## Related PRs

https://github.com/alphagov/di-infrastructure/pull/178