### PR TITLE
AUTH-1293: Enable code-signing on the AM authenticate lambda

### DIFF
--- a/ci/tasks/deploy-acct-mgmt-api.yml
+++ b/ci/tasks/deploy-acct-mgmt-api.yml
@@ -39,7 +39,7 @@ run:
         -var 'logging_endpoint_enabled=true' \
         -var "notify_api_key=${NOTIFY_API_KEY}" \
         -var 'logging_endpoint_arn=arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod' \
-        -var 'lambda_zip_file=../../../../api-release/account-management-api.zip' \
+        -var "lambda_zip_file=$(ls -1 ../../../../api-release/*.zip)" \
         -var 'lambda_warmer_zip_file=../../../../lambda-warmer-release/lambda-warmer.zip' \
         -var "common_state_bucket=${STATE_BUCKET}" \
         -var "dns_state_bucket=${DNS_STATE_BUCKET}" \

--- a/ci/terraform/account-management/authenticate.tf
+++ b/ci/terraform/account-management/authenticate.tf
@@ -36,6 +36,7 @@ module "authenticate" {
   lambda_zip_file_version        = aws_s3_bucket_object.account_management_api_release_zip.version_id
   warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
   warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+  code_signing_config_arn        = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.vpc_arn
   security_group_ids = [


### PR DESCRIPTION
## What?

- Enable code signing on the authenticate lambda function.

## Why?

We are moving away from Github releases signed by GPG to deploying via S3 using AWS signer.

N.B. This should break the pipeline until the below is merged

## Related PRs

https://github.com/alphagov/di-infrastructure/pull/179