### PR TITLE
AUTH-1293: Add code signer configuration to all AM API Lambda

### DIFF
--- a/ci/terraform/account-management/authorizer.tf
+++ b/ci/terraform/account-management/authorizer.tf
@@ -22,6 +22,8 @@ resource "aws_lambda_function" "authorizer" {
   s3_key            = aws_s3_bucket_object.account_management_api_release_zip.key
   s3_object_version = aws_s3_bucket_object.account_management_api_release_zip.version_id
 
+  code_signing_config_arn = local.lambda_code_signing_configuration_arn
+
   publish     = true
   timeout     = 30
   memory_size = 2048

--- a/ci/terraform/account-management/remove-account.tf
+++ b/ci/terraform/account-management/remove-account.tf
@@ -37,6 +37,7 @@ module "delete_account" {
   lambda_zip_file_version        = aws_s3_bucket_object.account_management_api_release_zip.version_id
   warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
   warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+  code_signing_config_arn        = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.vpc_arn
   security_group_ids = [

--- a/ci/terraform/account-management/send_otp_notification.tf
+++ b/ci/terraform/account-management/send_otp_notification.tf
@@ -39,6 +39,7 @@ module "send_otp_notification" {
   lambda_zip_file_version        = aws_s3_bucket_object.account_management_api_release_zip.version_id
   warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
   warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+  code_signing_config_arn        = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.vpc_arn
   security_group_ids = [

--- a/ci/terraform/account-management/sqs.tf
+++ b/ci/terraform/account-management/sqs.tf
@@ -172,6 +172,8 @@ resource "aws_lambda_function" "email_sqs_lambda" {
   s3_key            = aws_s3_bucket_object.account_management_api_release_zip.key
   s3_object_version = aws_s3_bucket_object.account_management_api_release_zip.version_id
 
+  code_signing_config_arn = local.lambda_code_signing_configuration_arn
+
   vpc_config {
     security_group_ids = [local.allow_egress_security_group_id]
     subnet_ids         = local.private_subnet_ids

--- a/ci/terraform/account-management/update-email.tf
+++ b/ci/terraform/account-management/update-email.tf
@@ -40,6 +40,7 @@ module "update_email" {
   lambda_zip_file_version        = aws_s3_bucket_object.account_management_api_release_zip.version_id
   warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
   warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+  code_signing_config_arn        = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.vpc_arn
   security_group_ids = [

--- a/ci/terraform/account-management/update-password.tf
+++ b/ci/terraform/account-management/update-password.tf
@@ -37,6 +37,7 @@ module "update_password" {
   lambda_zip_file_version        = aws_s3_bucket_object.account_management_api_release_zip.version_id
   warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
   warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+  code_signing_config_arn        = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.vpc_arn
   security_group_ids = [

--- a/ci/terraform/account-management/update-phone-number.tf
+++ b/ci/terraform/account-management/update-phone-number.tf
@@ -39,6 +39,7 @@ module "update_phone_number" {
   lambda_zip_file_version        = aws_s3_bucket_object.account_management_api_release_zip.version_id
   warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
   warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+  code_signing_config_arn        = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.vpc_arn
   security_group_ids = [


### PR DESCRIPTION
## What?

- Add code signing configuration to all remaining lambda in the account management API.

## Why?

We have added, and tested, the code signing configuration against the authenticate lambda, lets add to all remaining lambda.

N.B. we are excluding the warmers, for the time being, until pipeline changes have been made to support that.

## Related PRs

#1437 