### PR TITLE
AUTH-1293: Add code signing configuration to Audit lambda

### DIFF
--- a/ci/tasks/deploy-audit-processors.yml
+++ b/ci/tasks/deploy-audit-processors.yml
@@ -31,7 +31,7 @@ run:
         -backend-config "region=eu-west-2"
 
       terraform apply -auto-approve \
-        -var "lambda_zip_file=../../../../audit-processors-release/audit-processors.zip" \
+        -var "lambda_zip_file=$(ls -1 ../../../../audit-processors-release/*.zip)" \
         -var "deployer_role_arn=${DEPLOYER_ROLE_ARN}" \
         -var "environment=${DEPLOY_ENVIRONMENT}" \
         -var "shared_state_bucket=${STATE_BUCKET}" \

--- a/ci/terraform/audit-processors/counter_fraud.tf
+++ b/ci/terraform/audit-processors/counter_fraud.tf
@@ -59,6 +59,8 @@ resource "aws_lambda_function" "fraud_realtime_logging_lambda" {
   s3_key            = aws_s3_bucket_object.audit_processor_release_zip.key
   s3_object_version = aws_s3_bucket_object.audit_processor_release_zip.version_id
 
+  code_signing_config_arn = local.lambda_code_signing_configuration_arn
+
   vpc_config {
     security_group_ids = [local.authentication_security_group_id]
     subnet_ids         = local.authentication_subnet_ids

--- a/ci/terraform/audit-processors/performance_analysis.tf
+++ b/ci/terraform/audit-processors/performance_analysis.tf
@@ -59,6 +59,8 @@ resource "aws_lambda_function" "performance_analysis_logging_lambda" {
   s3_key            = aws_s3_bucket_object.audit_processor_release_zip.key
   s3_object_version = aws_s3_bucket_object.audit_processor_release_zip.version_id
 
+  code_signing_config_arn = local.lambda_code_signing_configuration_arn
+
   vpc_config {
     security_group_ids = [local.authentication_security_group_id]
     subnet_ids         = local.authentication_subnet_ids

--- a/ci/terraform/audit-processors/storage.tf
+++ b/ci/terraform/audit-processors/storage.tf
@@ -57,6 +57,8 @@ resource "aws_lambda_function" "audit_processor_lambda" {
   s3_key            = aws_s3_bucket_object.audit_processor_release_zip.key
   s3_object_version = aws_s3_bucket_object.audit_processor_release_zip.version_id
 
+  code_signing_config_arn = local.lambda_code_signing_configuration_arn
+
   vpc_config {
     security_group_ids = [local.authentication_security_group_id]
     subnet_ids         = local.authentication_subnet_ids


### PR DESCRIPTION
## What?

- Add AWS code signing configuration to each of the audit lambda  functions
- Change the way in which the deployment job determines the filename  for the audit lambda ZIP file, when using AWS Signer the filename is  not consistent. It will be the only ZIP file in the release  directory though.

## Why?

We are moving from Github releases and GPG code signatures to S3 buckets and AWS Signer.

## Related PRs

https://github.com/alphagov/di-infrastructure/pull/180