### PR TITLE
AUTH-1293: Add code signing configuration to client registry API

### DIFF
--- a/ci/tasks/deploy-oidc-api.yml
+++ b/ci/tasks/deploy-oidc-api.yml
@@ -50,7 +50,7 @@ run:
       terraform apply -auto-approve \
         -var 'oidc_api_lambda_zip_file=../../../../oidc-api-release/oidc-api.zip' \
         -var 'frontend_api_lambda_zip_file=../../../../frontend-api-release/frontend-api.zip' \
-        -var 'client_registry_api_lambda_zip_file=../../../../client-registry-api-release/client-registry-api.zip' \
+        -var "client_registry_api_lambda_zip_file=$(ls -1 ../../../../client-registry-api-release/*.zip)" \
         -var "ipv_api_lambda_zip_file=$(ls -1 ../../../../ipv-api-release/*.zip)" \
         -var 'lambda_warmer_zip_file=../../../../lambda-warmer-release/lambda-warmer.zip' \
         -var "deployer_role_arn=${DEPLOYER_ROLE_ARN}" \

--- a/ci/terraform/oidc/register.tf
+++ b/ci/terraform/oidc/register.tf
@@ -41,6 +41,7 @@ module "register" {
   lambda_zip_file_version        = aws_s3_bucket_object.client_api_release_zip.version_id
   warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
   warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+  code_signing_config_arn        = local.lambda_code_signing_configuration_arn
 
   security_group_ids                     = [local.authentication_security_group_id]
   subnet_id                              = local.authentication_subnet_ids

--- a/ci/terraform/oidc/update.tf
+++ b/ci/terraform/oidc/update.tf
@@ -41,6 +41,7 @@ module "update" {
   lambda_zip_file_version        = aws_s3_bucket_object.client_api_release_zip.version_id
   warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
   warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+  code_signing_config_arn        = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.authentication_vpc_arn
   security_group_ids = [


### PR DESCRIPTION
## What?

- Add AWS code signing configuration to each of the client registry API lambda functions
- Change the way in which the deployment job determines the filename for the lambda ZIP file, when using AWS Signer the filename is not consistent. It will be the only ZIP file in the release directory though.

## Why?

We are moving away from Github releases and GPG signing to S3 and AWS signer

## Related PRs

https://github.com/alphagov/di-infrastructure/pull/181