### PR TITLE
AUTH-1293: Code signing for frontend API

### DIFF
--- a/ci/tasks/deploy-oidc-api.yml
+++ b/ci/tasks/deploy-oidc-api.yml
@@ -49,7 +49,7 @@ run:
 
       terraform apply -auto-approve \
         -var 'oidc_api_lambda_zip_file=../../../../oidc-api-release/oidc-api.zip' \
-        -var 'frontend_api_lambda_zip_file=../../../../frontend-api-release/frontend-api.zip' \
+        -var "frontend_api_lambda_zip_file=$(ls -1 ../../../../frontend-api-release/*.zip)" \
         -var "client_registry_api_lambda_zip_file=$(ls -1 ../../../../client-registry-api-release/*.zip)" \
         -var "ipv_api_lambda_zip_file=$(ls -1 ../../../../ipv-api-release/*.zip)" \
         -var 'lambda_warmer_zip_file=../../../../lambda-warmer-release/lambda-warmer.zip' \

--- a/ci/terraform/oidc/client-info.tf
+++ b/ci/terraform/oidc/client-info.tf
@@ -41,6 +41,7 @@ module "client-info" {
   lambda_zip_file_version        = aws_s3_bucket_object.frontend_api_release_zip.version_id
   warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
   warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+  code_signing_config_arn        = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.authentication_vpc_arn
   security_group_ids = [

--- a/ci/terraform/oidc/login.tf
+++ b/ci/terraform/oidc/login.tf
@@ -46,6 +46,7 @@ module "login" {
   lambda_zip_file_version        = aws_s3_bucket_object.frontend_api_release_zip.version_id
   warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
   warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+  code_signing_config_arn        = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.authentication_vpc_arn
   security_group_ids = [

--- a/ci/terraform/oidc/mfa.tf
+++ b/ci/terraform/oidc/mfa.tf
@@ -43,6 +43,7 @@ module "mfa" {
   lambda_zip_file_version        = aws_s3_bucket_object.frontend_api_release_zip.version_id
   warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
   warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+  code_signing_config_arn        = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.authentication_vpc_arn
   security_group_ids = [

--- a/ci/terraform/oidc/reset-password-request.tf
+++ b/ci/terraform/oidc/reset-password-request.tf
@@ -46,6 +46,7 @@ module "reset-password-request" {
   lambda_zip_file_version        = aws_s3_bucket_object.frontend_api_release_zip.version_id
   warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
   warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+  code_signing_config_arn        = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.authentication_vpc_arn
   security_group_ids = [

--- a/ci/terraform/oidc/reset_password.tf
+++ b/ci/terraform/oidc/reset_password.tf
@@ -45,6 +45,7 @@ module "reset_password" {
   lambda_zip_file_version        = aws_s3_bucket_object.frontend_api_release_zip.version_id
   warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
   warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+  code_signing_config_arn        = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.authentication_vpc_arn
   security_group_ids = [

--- a/ci/terraform/oidc/send_notification.tf
+++ b/ci/terraform/oidc/send_notification.tf
@@ -42,6 +42,7 @@ module "send_notification" {
   lambda_zip_file_version        = aws_s3_bucket_object.frontend_api_release_zip.version_id
   warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
   warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+  code_signing_config_arn        = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.authentication_vpc_arn
   security_group_ids = [

--- a/ci/terraform/oidc/signup.tf
+++ b/ci/terraform/oidc/signup.tf
@@ -43,6 +43,7 @@ module "signup" {
   lambda_zip_file_version        = aws_s3_bucket_object.frontend_api_release_zip.version_id
   warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
   warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+  code_signing_config_arn        = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.authentication_vpc_arn
   security_group_ids = [

--- a/ci/terraform/oidc/sqs.tf
+++ b/ci/terraform/oidc/sqs.tf
@@ -161,6 +161,8 @@ resource "aws_lambda_function" "email_sqs_lambda" {
   s3_key            = aws_s3_bucket_object.frontend_api_release_zip.key
   s3_object_version = aws_s3_bucket_object.frontend_api_release_zip.version_id
 
+  code_signing_config_arn = local.lambda_code_signing_configuration_arn
+
   vpc_config {
     security_group_ids = [local.authentication_egress_security_group_id]
     subnet_ids         = local.authentication_subnet_ids

--- a/ci/terraform/oidc/update_profile.tf
+++ b/ci/terraform/oidc/update_profile.tf
@@ -44,6 +44,7 @@ module "update_profile" {
   lambda_zip_file_version        = aws_s3_bucket_object.frontend_api_release_zip.version_id
   warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
   warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+  code_signing_config_arn        = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.authentication_vpc_arn
   security_group_ids = [

--- a/ci/terraform/oidc/userexists.tf
+++ b/ci/terraform/oidc/userexists.tf
@@ -43,6 +43,7 @@ module "userexists" {
   lambda_zip_file_version        = aws_s3_bucket_object.frontend_api_release_zip.version_id
   warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
   warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+  code_signing_config_arn        = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.authentication_vpc_arn
   security_group_ids = [

--- a/ci/terraform/oidc/verify_code.tf
+++ b/ci/terraform/oidc/verify_code.tf
@@ -48,6 +48,7 @@ module "verify_code" {
   lambda_zip_file_version        = aws_s3_bucket_object.frontend_api_release_zip.version_id
   warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
   warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+  code_signing_config_arn        = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.authentication_vpc_arn
   security_group_ids = [


### PR DESCRIPTION
## What?

- Add AWS code signing configuration to each of the frontend API lambda functions
- Change the way in which the deployment job determines the filename for the lambda ZIP file, when using AWS Signer the filename is not consistent. It will be the only ZIP file in the release directory though.

## Why?

We are moving away from Github releases and GPG signing to S3 and AWS signer

## Related PRs

https://github.com/alphagov/di-infrastructure/pull/182