### PR TITLE
AUTH-1293: Code signing for API warmers

### DIFF
--- a/ci/tasks/deploy-acct-mgmt-api.yml
+++ b/ci/tasks/deploy-acct-mgmt-api.yml
@@ -40,7 +40,7 @@ run:
         -var "notify_api_key=${NOTIFY_API_KEY}" \
         -var 'logging_endpoint_arn=arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod' \
         -var "lambda_zip_file=$(ls -1 ../../../../api-release/*.zip)" \
-        -var 'lambda_warmer_zip_file=../../../../lambda-warmer-release/lambda-warmer.zip' \
+        -var "lambda_warmer_zip_file=$(ls -1 ../../../../lambda-warmer-release/*.zip)" \
         -var "common_state_bucket=${STATE_BUCKET}" \
         -var "dns_state_bucket=${DNS_STATE_BUCKET}" \
         -var "dns_state_key=${DNS_STATE_KEY}" \

--- a/ci/tasks/deploy-oidc-api.yml
+++ b/ci/tasks/deploy-oidc-api.yml
@@ -52,7 +52,7 @@ run:
         -var "frontend_api_lambda_zip_file=$(ls -1 ../../../../frontend-api-release/*.zip)" \
         -var "client_registry_api_lambda_zip_file=$(ls -1 ../../../../client-registry-api-release/*.zip)" \
         -var "ipv_api_lambda_zip_file=$(ls -1 ../../../../ipv-api-release/*.zip)" \
-        -var 'lambda_warmer_zip_file=../../../../lambda-warmer-release/lambda-warmer.zip' \
+        -var "lambda_warmer_zip_file=$(ls -1 ../../../../lambda-warmer-release/*.zip)" \
         -var "deployer_role_arn=${DEPLOYER_ROLE_ARN}" \
         -var "notify_api_key=${NOTIFY_API_KEY}" \
         -var "environment=${DEPLOY_ENVIRONMENT}" \

--- a/ci/tasks/deploy-oidc-api.yml
+++ b/ci/tasks/deploy-oidc-api.yml
@@ -48,7 +48,7 @@ run:
         -backend-config "region=eu-west-2"
 
       terraform apply -auto-approve \
-        -var 'oidc_api_lambda_zip_file=../../../../oidc-api-release/oidc-api.zip' \
+        -var "oidc_api_lambda_zip_file=$(ls -1 ../../../../oidc-api-release/*.zip)" \
         -var "frontend_api_lambda_zip_file=$(ls -1 ../../../../frontend-api-release/*.zip)" \
         -var "client_registry_api_lambda_zip_file=$(ls -1 ../../../../client-registry-api-release/*.zip)" \
         -var "ipv_api_lambda_zip_file=$(ls -1 ../../../../ipv-api-release/*.zip)" \

--- a/ci/terraform/account-management/authorizer-warmer.tf
+++ b/ci/terraform/account-management/authorizer-warmer.tf
@@ -49,6 +49,8 @@ resource "aws_lambda_function" "warmer_function" {
   s3_key            = aws_s3_bucket_object.warmer_release_zip.key
   s3_object_version = aws_s3_bucket_object.warmer_release_zip.version_id
 
+  code_signing_config_arn = local.lambda_code_signing_configuration_arn
+
   vpc_config {
     security_group_ids = [local.allow_aws_service_access_security_group_id]
     subnet_ids         = local.private_subnet_ids

--- a/ci/terraform/modules/endpoint-module/lambda.tf
+++ b/ci/terraform/modules/endpoint-module/lambda.tf
@@ -14,6 +14,8 @@ resource "aws_lambda_function" "endpoint_lambda" {
   s3_key            = var.lambda_zip_file
   s3_object_version = var.lambda_zip_file_version
 
+  code_signing_config_arn = var.code_signing_config_arn
+
   vpc_config {
     security_group_ids = var.security_group_ids
     subnet_ids         = var.subnet_id
@@ -26,8 +28,6 @@ resource "aws_lambda_function" "endpoint_lambda" {
   kms_key_arn = var.lambda_env_vars_encryption_kms_key_arn
 
   runtime = var.handler_runtime
-
-  code_signing_config_arn = var.code_signing_config_arn
 
   tags = var.default_tags
 }

--- a/ci/terraform/modules/endpoint-module/warmer.tf
+++ b/ci/terraform/modules/endpoint-module/warmer.tf
@@ -135,6 +135,8 @@ resource "aws_lambda_function" "warmer_function" {
   s3_key            = var.warmer_lambda_zip_file
   s3_object_version = var.warmer_lambda_zip_file_version
 
+  code_signing_config_arn = var.code_signing_config_arn
+
   vpc_config {
     security_group_ids = var.warmer_security_group_ids
     subnet_ids         = var.subnet_id

--- a/ci/terraform/oidc/auth-code.tf
+++ b/ci/terraform/oidc/auth-code.tf
@@ -41,6 +41,7 @@ module "auth-code" {
   lambda_zip_file_version        = aws_s3_bucket_object.oidc_api_release_zip.version_id
   warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
   warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+  code_signing_config_arn        = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.authentication_vpc_arn
   security_group_ids = [

--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -44,6 +44,7 @@ module "authorize" {
   lambda_zip_file_version        = aws_s3_bucket_object.oidc_api_release_zip.version_id
   warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
   warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+  code_signing_config_arn        = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.authentication_vpc_arn
   security_group_ids = [

--- a/ci/terraform/oidc/identity.tf
+++ b/ci/terraform/oidc/identity.tf
@@ -42,6 +42,7 @@ module "identity" {
   lambda_zip_file_version        = aws_s3_bucket_object.oidc_api_release_zip.version_id
   warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
   warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+  code_signing_config_arn        = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.authentication_vpc_arn
   security_group_ids = [

--- a/ci/terraform/oidc/jwks.tf
+++ b/ci/terraform/oidc/jwks.tf
@@ -36,6 +36,7 @@ module "jwks" {
   lambda_zip_file_version        = aws_s3_bucket_object.oidc_api_release_zip.version_id
   warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
   warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+  code_signing_config_arn        = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn                 = local.authentication_vpc_arn
   security_group_ids                     = [local.authentication_security_group_id]

--- a/ci/terraform/oidc/logout.tf
+++ b/ci/terraform/oidc/logout.tf
@@ -44,6 +44,7 @@ module "logout" {
   lambda_zip_file_version        = aws_s3_bucket_object.oidc_api_release_zip.version_id
   warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
   warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+  code_signing_config_arn        = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.authentication_vpc_arn
   security_group_ids = [

--- a/ci/terraform/oidc/spot-response.tf
+++ b/ci/terraform/oidc/spot-response.tf
@@ -24,6 +24,8 @@ resource "aws_lambda_function" "spot_response_lambda" {
   s3_key            = aws_s3_bucket_object.ipv_api_release_zip.key
   s3_object_version = aws_s3_bucket_object.ipv_api_release_zip.version_id
 
+  code_signing_config_arn = local.lambda_code_signing_configuration_arn
+
   vpc_config {
     security_group_ids = [local.authentication_egress_security_group_id]
     subnet_ids         = local.authentication_subnet_ids

--- a/ci/terraform/oidc/token.tf
+++ b/ci/terraform/oidc/token.tf
@@ -68,6 +68,7 @@ module "token" {
   lambda_zip_file_version        = aws_s3_bucket_object.oidc_api_release_zip.version_id
   warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
   warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+  code_signing_config_arn        = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.authentication_vpc_arn
   security_group_ids = [

--- a/ci/terraform/oidc/trustmarks.tf
+++ b/ci/terraform/oidc/trustmarks.tf
@@ -34,6 +34,7 @@ module "trustmarks" {
   lambda_zip_file_version        = aws_s3_bucket_object.oidc_api_release_zip.version_id
   warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
   warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+  code_signing_config_arn        = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn                 = local.authentication_vpc_arn
   security_group_ids                     = [local.authentication_security_group_id]

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -42,6 +42,7 @@ module "userinfo" {
   lambda_zip_file_version        = aws_s3_bucket_object.oidc_api_release_zip.version_id
   warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
   warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+  code_signing_config_arn        = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.authentication_vpc_arn
   security_group_ids = [

--- a/ci/terraform/oidc/wellknown.tf
+++ b/ci/terraform/oidc/wellknown.tf
@@ -30,6 +30,7 @@ module "openid_configuration_discovery" {
   lambda_zip_file_version        = aws_s3_bucket_object.oidc_api_release_zip.version_id
   warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
   warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+  code_signing_config_arn        = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn                 = local.authentication_vpc_arn
   security_group_ids                     = [local.authentication_security_group_id]


### PR DESCRIPTION
## What?

- Add AWS code signing configuration to each of the API warmers lambda functions
- Change the way in which the deployment job determines the filename for the lambda ZIP file, when using AWS Signer the filename is not consistent. It will be the only ZIP file in the release directory though.
- Move the `code_signing_config_arn` directive in the endpoint lambda
to the same position in the resource as all other lambdas (just after
the S3 location), keep things consistent
- Add code signing profile to SPoT response lambda as this was missed.

## Why?

We are moving away from Github releases and GPG signing to S3 and AWS signer

## Related PRs

https://github.com/alphagov/di-infrastructure/pull/184