### PR TITLE
BAU: Attach whether an account is new or not to sessions

### DIFF
--- a/ci/terraform/oidc/auth-code.tf
+++ b/ci/terraform/oidc/auth-code.tf
@@ -10,6 +10,7 @@ module "oidc_auth_code_role" {
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
+    aws_iam_policy.cloudwatch_metrics_putdata_policy.arn,
   ]
 }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -37,6 +37,7 @@ import uk.gov.di.authentication.shared.state.UserContext;
 import java.util.Optional;
 
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.LOG_IN_SUCCESS;
+import static uk.gov.di.authentication.shared.entity.Session.AccountState.EXISTING;
 import static uk.gov.di.authentication.shared.entity.SessionAction.ACCOUNT_LOCK_EXPIRED;
 import static uk.gov.di.authentication.shared.entity.SessionAction.USER_ENTERED_INVALID_PASSWORD_TOO_MANY_TIMES;
 import static uk.gov.di.authentication.shared.entity.SessionAction.USER_ENTERED_VALID_CREDENTIALS;
@@ -212,7 +213,8 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
             if (credentialTrustLevel.equals(CredentialTrustLevel.LOW_LEVEL)) {
                 session.setCurrentCredentialStrength(credentialTrustLevel);
             }
-            sessionService.save(session);
+
+            sessionService.save(session.setNewAccount(EXISTING));
 
             if (nextState.equals(TWO_FACTOR_REQUIRED)) {
                 return generateApiGatewayProxyResponse(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
@@ -33,6 +33,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Optional;
 
+import static uk.gov.di.authentication.shared.entity.Session.AccountState.NEW;
 import static uk.gov.di.authentication.shared.entity.SessionAction.USER_HAS_CREATED_A_PASSWORD;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
@@ -152,6 +153,7 @@ public class SignUpHandler extends BaseFrontendHandler<SignupRequest>
                         userContext
                                 .getSession()
                                 .setState(nextState)
+                                .setNewAccount(NEW)
                                 .setEmailAddress(request.getEmail()));
 
                 LOG.info("Successfully processed request");

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
@@ -53,6 +53,7 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -166,6 +167,9 @@ class LoginHandlerTest {
                         "123.123.123.123",
                         userProfile.getPhoneNumber(),
                         persistentId);
+
+        verify(sessionService)
+                .save(argThat(session -> session.isNewAccount() == Session.AccountState.EXISTING));
     }
 
     @Test
@@ -195,6 +199,9 @@ class LoginHandlerTest {
         assertThat(
                 response.getRedactedPhoneNumber(),
                 equalTo(RedactPhoneNumberHelper.redactPhoneNumber(PHONE_NUMBER)));
+
+        verify(sessionService)
+                .save(argThat(session -> session.isNewAccount() == Session.AccountState.EXISTING));
     }
 
     @Test
@@ -224,6 +231,9 @@ class LoginHandlerTest {
         assertThat(
                 response.getRedactedPhoneNumber(),
                 equalTo(RedactPhoneNumberHelper.redactPhoneNumber(PHONE_NUMBER)));
+
+        verify(sessionService)
+                .save(argThat(session -> session.isNewAccount() == Session.AccountState.EXISTING));
     }
 
     @Test

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandlerTest.java
@@ -145,6 +145,9 @@ class SignUpHandlerTest {
                         "123.123.123.123",
                         AuditService.UNKNOWN,
                         persistentId);
+
+        verify(sessionService)
+                .save(argThat(session -> session.isNewAccount() == Session.AccountState.NEW));
     }
 
     @Test

--- a/oidc-api/build.gradle
+++ b/oidc-api/build.gradle
@@ -16,6 +16,7 @@ dependencies {
             configurations.jackson,
             configurations.nimbus,
             configurations.bouncycastle,
+            configurations.cloudwatch,
             project(":shared"),
             project(":client-registry-api")
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
@@ -10,6 +10,12 @@ import static uk.gov.di.authentication.shared.entity.SessionState.NEW;
 
 public class Session {
 
+    public enum AccountState {
+        NEW,
+        EXISTING,
+        UNKNOWN
+    }
+
     @JsonProperty("session_id")
     private String sessionId;
 
@@ -34,10 +40,14 @@ public class Session {
     @JsonProperty("current_credential_strength")
     private CredentialTrustLevel currentCredentialStrength;
 
+    @JsonProperty("is_new_account")
+    private AccountState isNewAccount;
+
     public Session(String sessionId) {
         this.sessionId = sessionId;
         this.state = NEW;
         this.clientSessions = new ArrayList<>();
+        this.isNewAccount = AccountState.UNKNOWN;
     }
 
     @JsonCreator
@@ -50,6 +60,7 @@ public class Session {
         this.clientSessions = clientSessions;
         this.state = state;
         this.emailAddress = emailAddress;
+        this.isNewAccount = AccountState.UNKNOWN;
     }
 
     public String getSessionId() {
@@ -139,6 +150,15 @@ public class Session {
 
     public Session setCurrentCredentialStrength(CredentialTrustLevel currentCredentialStrength) {
         this.currentCredentialStrength = currentCredentialStrength;
+        return this;
+    }
+
+    public AccountState isNewAccount() {
+        return isNewAccount;
+    }
+
+    public Session setNewAccount(AccountState isNewAccount) {
+        this.isNewAccount = isNewAccount;
         return this;
     }
 }


### PR DESCRIPTION
## What?

This attaches a field, `is_new_account`, to `Session`.

## Why?

It allows us to tag whether a successful login is from a new or existing account
