### PR TITLE
BAU: Attach client id to metrics

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -224,7 +224,9 @@ public class AuthCodeHandler
                                                 "Account",
                                                 session.isNewAccount().name(),
                                                 "Environment",
-                                                configurationService.getEnvironment()));
+                                                configurationService.getEnvironment(),
+                                                "Client",
+                                                authenticationRequest.getClientID().getValue()));
 
                                 auditService.submitAuditEvent(
                                         OidcAuditableEvent.AUTH_CODE_ISSUED,

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -211,7 +211,15 @@ class AuthCodeHandlerTest {
                         PERSISTENT_SESSION_ID);
 
         verify(cloudwatchMetricsService)
-                .incrementCounter("SignIn", Map.of("Account", "NEW", "Environment", "unit-test"));
+                .incrementCounter(
+                        "SignIn",
+                        Map.of(
+                                "Account",
+                                "NEW",
+                                "Environment",
+                                "unit-test",
+                                "Client",
+                                CLIENT_ID.getValue()));
     }
 
     @ParameterizedTest
@@ -263,7 +271,15 @@ class AuthCodeHandlerTest {
                         PERSISTENT_SESSION_ID);
 
         verify(cloudwatchMetricsService)
-                .incrementCounter("SignIn", Map.of("Account", "NEW", "Environment", "unit-test"));
+                .incrementCounter(
+                        "SignIn",
+                        Map.of(
+                                "Account",
+                                "NEW",
+                                "Environment",
+                                "unit-test",
+                                "Client",
+                                CLIENT_ID.getValue()));
     }
 
     @Test
@@ -306,7 +322,15 @@ class AuthCodeHandlerTest {
                         PERSISTENT_SESSION_ID);
 
         verify(cloudwatchMetricsService)
-                .incrementCounter("SignIn", Map.of("Account", "NEW", "Environment", "unit-test"));
+                .incrementCounter(
+                        "SignIn",
+                        Map.of(
+                                "Account",
+                                "NEW",
+                                "Environment",
+                                "unit-test",
+                                "Client",
+                                CLIENT_ID.getValue()));
     }
 
     @Test


### PR DESCRIPTION
This will let us exclude test clients from graphs

