### PR TITLE
BAU - Fix reset password count

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
@@ -179,7 +179,7 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
         if (codeStorageService.isBlockedForEmail(email, PASSWORD_RESET_BLOCKED_KEY_PREFIX)) {
             return Optional.of(ErrorResponse.ERROR_1023);
         } else if (userContext.getSession().getPasswordResetCount()
-                > configurationService.getCodeMaxRetries()) {
+                >= configurationService.getCodeMaxRetries()) {
             codeStorageService.saveBlockedForEmail(
                     userContext.getSession().getEmailAddress(),
                     PASSWORD_RESET_BLOCKED_KEY_PREFIX,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
@@ -248,7 +248,7 @@ class ResetPasswordRequestHandlerTest {
         when(session.getEmailAddress()).thenReturn(TEST_EMAIL_ADDRESS);
         when(session.getSessionId()).thenReturn(sessionId);
         when(session.validateSession(TEST_EMAIL_ADDRESS)).thenReturn(true);
-        when(session.getPasswordResetCount()).thenReturn(6);
+        when(session.getPasswordResetCount()).thenReturn(5);
 
         when(sessionService.getSessionFromRequestHeaders(anyMap()))
                 .thenReturn(Optional.of(session));


### PR DESCRIPTION
## What?

 - Fix reset password count

## Why?

- Previously a user could request 6 reset password emails. The limit should be 5. This is because we only increment the incrementPasswordResetCount once a password reset request has been successfully sent. Once this limit has reached 5 then we shouldn't allow anymore reset password emails. Previously we were checking for greater than 5 but we should be checking for equals to 5.
