### PR TITLE
BAU - Return consentRequired from SignUp

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/SignUpResponse.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/SignUpResponse.java
@@ -1,0 +1,18 @@
+package uk.gov.di.authentication.frontendapi.entity;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class SignUpResponse {
+
+    @JsonProperty(value = "consentRequired")
+    private boolean consentRequired;
+
+    public SignUpResponse(
+            @JsonProperty(value = "consentRequired", required = true) boolean consentRequired) {
+        this.consentRequired = consentRequired;
+    }
+
+    public boolean isConsentRequired() {
+        return consentRequired;
+    }
+}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
@@ -4,11 +4,14 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
+import uk.gov.di.authentication.frontendapi.entity.SignUpResponse;
 import uk.gov.di.authentication.frontendapi.entity.SignupRequest;
+import uk.gov.di.authentication.shared.conditions.ConsentHelper;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.TermsAndConditions;
@@ -30,7 +33,7 @@ import java.util.Optional;
 
 import static uk.gov.di.authentication.shared.entity.Session.AccountState.NEW;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
-import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateEmptySuccessApiGatewayResponse;
+import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.CLIENT_ID;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.PERSISTENT_SESSION_ID;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachLogFieldToLogs;
@@ -119,6 +122,7 @@ public class SignUpHandler extends BaseFrontendHandler<SignupRequest>
                     new TermsAndConditions(
                             configurationService.getTermsAndConditionsVersion(),
                             LocalDateTime.now(ZoneId.of("UTC")).toString()));
+            var consentRequired = ConsentHelper.userHasNotGivenConsent(userContext);
 
             auditService.submitAuditEvent(
                     FrontendAuditableEvent.CREATE_ACCOUNT,
@@ -141,7 +145,11 @@ public class SignUpHandler extends BaseFrontendHandler<SignupRequest>
                             .setNewAccount(NEW));
 
             LOG.info("Successfully processed request");
-            return generateEmptySuccessApiGatewayResponse();
+            try {
+                return generateApiGatewayProxyResponse(200, new SignUpResponse(consentRequired));
+            } catch (JsonProcessingException e) {
+                return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
+            }
         } else {
             return generateApiGatewayProxyErrorResponse(400, passwordValidationErrors.get());
         }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/SignupIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/SignupIntegrationTest.java
@@ -1,37 +1,91 @@
 package uk.gov.di.authentication.api;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.oauth2.sdk.ResponseType;
+import com.nimbusds.oauth2.sdk.Scope;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+import com.nimbusds.openid.connect.sdk.Nonce;
+import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import uk.gov.di.authentication.frontendapi.entity.SignUpResponse;
 import uk.gov.di.authentication.frontendapi.entity.SignupRequest;
 import uk.gov.di.authentication.frontendapi.lambda.SignUpHandler;
+import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 
 import java.io.IOException;
+import java.net.URI;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Stream;
 
+import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.CREATE_ACCOUNT;
 import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceived;
+import static uk.gov.di.authentication.sharedtest.helper.KeyPairHelper.GENERATE_RSA_KEY_PAIR;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class SignupIntegrationTest extends ApiGatewayHandlerIntegrationTest {
+
+    private static final String CLIENT_ID = "test-client-id";
+    private static final String REDIRECT_URI = "http://localhost/redirect";
+    public static final String CLIENT_SESSION_ID = "a-client-session-id";
 
     @BeforeEach
     void setup() {
         handler = new SignUpHandler(TEST_CONFIGURATION_SERVICE);
     }
 
-    @Test
-    void shouldReturn200WhenValidSignUpRequest() throws IOException {
+    private static Stream<Boolean> consentValues() {
+        return Stream.of(true, false);
+    }
+
+    @ParameterizedTest
+    @MethodSource("consentValues")
+    void shouldReturn200WhenValidSignUpRequest(boolean consentRequired) throws IOException {
         String sessionId = redis.createSession();
 
         Map<String, String> headers = new HashMap<>();
         headers.put("Session-Id", sessionId);
+        headers.put("Client-Session-Id", CLIENT_SESSION_ID);
         headers.put("X-API-Key", FRONTEND_API_KEY);
+
+        Scope scope = new Scope();
+        scope.add(OIDCScopeValue.OPENID);
+
+        AuthenticationRequest authRequest =
+                new AuthenticationRequest.Builder(
+                                ResponseType.CODE,
+                                scope,
+                                new ClientID(CLIENT_ID),
+                                URI.create(REDIRECT_URI))
+                        .nonce(new Nonce())
+                        .build();
+
+        redis.createClientSession(CLIENT_SESSION_ID, authRequest.toParameters());
+
+        clientStore.registerClient(
+                CLIENT_ID,
+                "The test client",
+                singletonList(REDIRECT_URI),
+                singletonList("test-client@test.com"),
+                singletonList(scope.toString()),
+                Base64.getMimeEncoder()
+                        .encodeToString(GENERATE_RSA_KEY_PAIR().getPublic().getEncoded()),
+                singletonList("http://localhost/post-redirect-logout"),
+                String.valueOf(ServiceType.MANDATORY),
+                "https://test.com",
+                "public",
+                consentRequired);
 
         var response =
                 makeRequest(
@@ -42,7 +96,11 @@ public class SignupIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         headers,
                         Map.of());
 
-        assertThat(response, hasStatus(204));
+        assertThat(response, hasStatus(200));
+        SignUpResponse signUpResponse =
+                new ObjectMapper().readValue(response.getBody(), SignUpResponse.class);
+        assertThat(signUpResponse.isConsentRequired(), equalTo(consentRequired));
+
         assertTrue(userStore.userExists("joe.bloggs+5@digital.cabinet-office.gov.uk"));
 
         assertEventTypesReceived(auditTopic, List.of(CREATE_ACCOUNT));


### PR DESCRIPTION
## What?

 - Return consentRequired from SignUp

## Why?

- When a client requires consent and a is registering for the first time, we need to tell the frontend to show the consent screen. Currently there is no way for the frontend.
