### PR TITLE
BAU - Re-add the client info terraform

### DIFF
--- a/ci/terraform/oidc/client-info.tf
+++ b/ci/terraform/oidc/client-info.tf
@@ -1,0 +1,76 @@
+module "frontend_api_client_info_role" {
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "frontend-api-client-info-role"
+  vpc_arn     = local.authentication_vpc_arn
+
+  policies_to_attach = [
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
+    aws_iam_policy.lambda_sns_policy.arn,
+    aws_iam_policy.redis_parameter_policy.arn,
+    aws_iam_policy.dynamo_user_read_access_policy.arn
+  ]
+}
+
+module "client-info" {
+  source = "../modules/endpoint-module"
+
+  endpoint_name   = "client-info"
+  path_part       = "client-info"
+  endpoint_method = "GET"
+  environment     = var.environment
+
+  handler_environment_variables = {
+    BASE_URL                 = local.frontend_api_base_url
+    EVENTS_SNS_TOPIC_ARN     = aws_sns_topic.events.arn
+    AUDIT_SIGNING_KEY_ALIAS  = local.audit_signing_key_alias_name
+    LOCALSTACK_ENDPOINT      = var.use_localstack ? var.localstack_endpoint : null
+    REDIS_KEY                = local.redis_key
+    ENVIRONMENT              = var.environment
+    DYNAMO_ENDPOINT          = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    HEADERS_CASE_INSENSITIVE = var.use_localstack ? "true" : "false"
+  }
+  handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.ClientInfoHandler::handleRequest"
+
+  rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
+  root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
+  execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
+
+  source_bucket                  = aws_s3_bucket.source_bucket.bucket
+  lambda_zip_file                = aws_s3_bucket_object.frontend_api_release_zip.key
+  lambda_zip_file_version        = aws_s3_bucket_object.frontend_api_release_zip.version_id
+  warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
+  warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+  code_signing_config_arn        = local.lambda_code_signing_configuration_arn
+
+  authentication_vpc_arn = local.authentication_vpc_arn
+  security_group_ids = [
+    local.authentication_security_group_id,
+    local.authentication_oidc_redis_security_group_id,
+  ]
+  subnet_id                              = local.authentication_subnet_ids
+  lambda_role_arn                        = module.frontend_api_client_info_role.arn
+  logging_endpoint_enabled               = var.logging_endpoint_enabled
+  logging_endpoint_arn                   = var.logging_endpoint_arn
+  cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  cloudwatch_log_retention               = var.cloudwatch_log_retention
+  lambda_env_vars_encryption_kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn
+  default_tags                           = local.default_tags
+  api_key_required                       = true
+
+  keep_lambda_warm             = var.keep_lambdas_warm
+  warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
+  warmer_security_group_ids    = [local.authentication_security_group_id]
+  warmer_handler_environment_variables = {
+    LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
+  }
+
+  use_localstack = var.use_localstack
+
+  depends_on = [
+    aws_api_gateway_rest_api.di_authentication_frontend_api,
+    aws_api_gateway_resource.connect_resource,
+    aws_api_gateway_resource.wellknown_resource,
+  ]
+}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ClientInfoHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ClientInfoHandler.java
@@ -1,0 +1,28 @@
+package uk.gov.di.authentication.frontendapi.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateEmptySuccessApiGatewayResponse;
+import static uk.gov.di.authentication.shared.helpers.WarmerHelper.isWarming;
+
+public class ClientInfoHandler
+        implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+
+    private static final Logger LOG = LogManager.getLogger(ClientInfoHandler.class);
+
+    @Override
+    public APIGatewayProxyResponseEvent handleRequest(
+            APIGatewayProxyRequestEvent input, Context context) {
+        return isWarming(input)
+                .orElseGet(
+                        () -> {
+                            LOG.info("ClientInfo request received");
+                            return generateEmptySuccessApiGatewayResponse();
+                        });
+    }
+}

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ClientInfoHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ClientInfoHandlerTest.java
@@ -1,0 +1,26 @@
+package uk.gov.di.authentication.frontendapi.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static uk.gov.di.authentication.sharedtest.helper.RequestEventHelper.contextWithSourceIp;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
+
+class ClientInfoHandlerTest {
+
+    private ClientInfoHandler handler = new ClientInfoHandler();
+    private final Context context = mock(Context.class);
+
+    @Test
+    void shouldCallClientInfoAndReturn204() {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        event.setRequestContext(contextWithSourceIp("123.123.123.123"));
+        APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
+
+        assertThat(result, hasStatus(204));
+    }
+}


### PR DESCRIPTION
## What?

- The ClientInfo lambda was renamed to Start as part of the state machine changes.
- This was fine when deploying to sandpit and build but terraform state got confused when deploying to integration. To avoid this happening in Production, re-add the ClientInfo terraform and point it to a very simple ClientInfoHandler which just returns a 204.
- Once everything is ok we can revert this PR to remove it. 

## Why?

- To prevent issues with deploying the Start lambda in Production. 