### PR TITLE
AUTH-1169: Add integration tests for UpdatePasswordHandler

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandler.java
@@ -44,14 +44,7 @@ public class UpdatePasswordHandler
     private static final Logger LOG = LogManager.getLogger(UpdatePasswordHandler.class);
 
     public UpdatePasswordHandler() {
-        ConfigurationService configurationService = ConfigurationService.getInstance();
-        this.dynamoService = new DynamoService(ConfigurationService.getInstance());
-        this.sqsClient =
-                new AwsSqsClient(
-                        configurationService.getAwsRegion(),
-                        configurationService.getEmailQueueUri(),
-                        configurationService.getSqsEndpointUri());
-        this.auditService = new AuditService(configurationService);
+        this(ConfigurationService.getInstance());
     }
 
     public UpdatePasswordHandler(
@@ -59,6 +52,16 @@ public class UpdatePasswordHandler
         this.dynamoService = dynamoService;
         this.sqsClient = sqsClient;
         this.auditService = auditService;
+    }
+
+    public UpdatePasswordHandler(ConfigurationService configurationService) {
+        this.dynamoService = new DynamoService(ConfigurationService.getInstance());
+        this.sqsClient =
+                new AwsSqsClient(
+                        configurationService.getAwsRegion(),
+                        configurationService.getEmailQueueUri(),
+                        configurationService.getSqsEndpointUri());
+        this.auditService = new AuditService(configurationService);
     }
 
     @Override

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdatePasswordIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdatePasswordIntegrationTest.java
@@ -1,0 +1,122 @@
+package uk.gov.di.accountmanagement.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.oauth2.sdk.id.Subject;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.accountmanagement.entity.NotifyRequest;
+import uk.gov.di.accountmanagement.entity.UpdatePasswordRequest;
+import uk.gov.di.accountmanagement.lambda.UpdatePasswordHandler;
+import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.UPDATE_PASSWORD;
+import static uk.gov.di.accountmanagement.entity.NotificationType.PASSWORD_UPDATED;
+import static uk.gov.di.accountmanagement.testsupport.helpers.NotificationAssertionHelper.assertNoNotificationsReceived;
+import static uk.gov.di.accountmanagement.testsupport.helpers.NotificationAssertionHelper.assertNotificationsReceived;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceived;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertNoAuditEventsReceived;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
+
+public class UpdatePasswordIntegrationTest extends ApiGatewayHandlerIntegrationTest {
+
+    private static final String TEST_EMAIL = "joe.bloggs+3@digital.cabinet-office.gov.uk";
+    private static final Subject SUBJECT = new Subject();
+
+    @BeforeEach
+    void setup() {
+        handler = new UpdatePasswordHandler(TEST_CONFIGURATION_SERVICE);
+    }
+
+    @Test
+    void shouldSendNotificationAndReturn204WhenUpdatingPasswordIsSuccessful() {
+        String publicSubjectID = userStore.signUp(TEST_EMAIL, "password-1", SUBJECT);
+
+        var response =
+                makeRequest(
+                        Optional.of(new UpdatePasswordRequest(TEST_EMAIL, "password-2")),
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        Map.of("principalId", publicSubjectID));
+
+        assertThat(response, hasStatus(HttpStatus.SC_NO_CONTENT));
+
+        assertNotificationsReceived(
+                notificationsQueue, List.of(new NotifyRequest(TEST_EMAIL, PASSWORD_UPDATED)));
+
+        assertEventTypesReceived(auditTopic, List.of(UPDATE_PASSWORD));
+    }
+
+    @Test
+    void shouldReturn400WhenNewPasswordIsSameAsOldPassword() throws Exception {
+        String publicSubjectID = userStore.signUp(TEST_EMAIL, "password-1", SUBJECT);
+
+        var response =
+                makeRequest(
+                        Optional.of(new UpdatePasswordRequest(TEST_EMAIL, "password-1")),
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        Map.of("principalId", publicSubjectID));
+
+        assertThat(response, hasStatus(HttpStatus.SC_BAD_REQUEST));
+        assertThat(
+                response, hasBody(new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1024)));
+
+        assertNoNotificationsReceived(notificationsQueue);
+
+        assertNoAuditEventsReceived(auditTopic);
+    }
+
+    @Test
+    void shouldThrowExceptionWhenUserAttemptsToUpdateDifferentAccount() {
+        String correctSubjectID = userStore.signUp(TEST_EMAIL, "password-1", SUBJECT);
+        String otherSubjectID =
+                userStore.signUp(
+                        "other.user@digital.cabinet-office.gov.uk", "password-2", new Subject());
+
+        Exception ex =
+                assertThrows(
+                        RuntimeException.class,
+                        () ->
+                                makeRequest(
+                                        Optional.of(
+                                                new UpdatePasswordRequest(
+                                                        TEST_EMAIL, "password-2")),
+                                        Collections.emptyMap(),
+                                        Collections.emptyMap(),
+                                        Collections.emptyMap(),
+                                        Map.of("principalId", otherSubjectID)));
+
+        assertThat(ex.getMessage(), is("Subject ID does not match principalId"));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenSubjectIdMissing() {
+        userStore.signUp(TEST_EMAIL, "password-1", SUBJECT);
+
+        Exception ex =
+                assertThrows(
+                        RuntimeException.class,
+                        () ->
+                                makeRequest(
+                                        Optional.of(
+                                                new UpdatePasswordRequest(
+                                                        TEST_EMAIL, "password-2")),
+                                        Collections.emptyMap(),
+                                        Collections.emptyMap()));
+
+        assertThat(ex.getMessage(), is("principalId is missing"));
+    }
+}

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdatePasswordIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdatePasswordIntegrationTest.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.UPDATE_PASSWORD;
 import static uk.gov.di.accountmanagement.entity.NotificationType.PASSWORD_UPDATED;
@@ -41,6 +42,7 @@ public class UpdatePasswordIntegrationTest extends ApiGatewayHandlerIntegrationT
     @Test
     void shouldSendNotificationAndReturn204WhenUpdatingPasswordIsSuccessful() {
         String publicSubjectID = userStore.signUp(TEST_EMAIL, "password-1", SUBJECT);
+        String hashedOriginalPassword = userStore.getPasswordForUser(TEST_EMAIL);
 
         var response =
                 makeRequest(
@@ -51,6 +53,7 @@ public class UpdatePasswordIntegrationTest extends ApiGatewayHandlerIntegrationT
                         Map.of("principalId", publicSubjectID));
 
         assertThat(response, hasStatus(HttpStatus.SC_NO_CONTENT));
+        assertThat(userStore.getPasswordForUser(TEST_EMAIL), not(is(hashedOriginalPassword)));
 
         assertNotificationsReceived(
                 notificationsQueue, List.of(new NotifyRequest(TEST_EMAIL, PASSWORD_UPDATED)));

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/UserStoreExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/UserStoreExtension.java
@@ -38,6 +38,11 @@ public class UserStoreExtension extends DynamoExtension implements AfterEachCall
         return dynamoService.userExists(email);
     }
 
+    public String getPasswordForUser(String email) {
+        var credentials = dynamoService.getUserCredentialsFromEmail(email);
+        return credentials.getPassword();
+    }
+
     public Optional<String> getPhoneNumberForUser(String email) {
         return dynamoService.getPhoneNumber(email);
     }


### PR DESCRIPTION
## What?

Add integration tests for UpdatePasswordHandler

## Why?

Adds missing test coverage.

## Note

In particular, please check that I'm using the correct terminology in the second commit.