### PR TITLE
AUTH-1416 - Move CookieConsent and GaTrackingId logic to Start lambda

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/RequestParameters.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/RequestParameters.java
@@ -1,0 +1,6 @@
+package uk.gov.di.authentication.frontendapi.entity;
+
+public interface RequestParameters {
+    String COOKIE_CONSENT = "cookie_consent";
+    String GA = "_ga";
+}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/UserStartInfo.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/UserStartInfo.java
@@ -16,15 +16,25 @@ public class UserStartInfo {
     @JsonProperty("authenticated")
     private boolean authenticated;
 
+    @JsonProperty("cookieConsent")
+    private String cookieConsent;
+
+    @JsonProperty("gaCrossDomainTrackingId")
+    private String gaCrossDomainTrackingId;
+
     public UserStartInfo(
             @JsonProperty(required = true, value = "consentRequired") boolean consentRequired,
             @JsonProperty(required = true, value = "upliftRequired") boolean upliftRequired,
             @JsonProperty(required = true, value = "identityRequired") boolean identityRequired,
-            @JsonProperty(required = true, value = "authenticated") boolean authenticated) {
+            @JsonProperty(required = true, value = "authenticated") boolean authenticated,
+            @JsonProperty(value = "cookieConsent") String cookieConsent,
+            @JsonProperty(value = "gaCrossDomainTrackingId") String gaCrossDomainTrackingId) {
         this.consentRequired = consentRequired;
         this.upliftRequired = upliftRequired;
         this.identityRequired = identityRequired;
         this.authenticated = authenticated;
+        this.cookieConsent = cookieConsent;
+        this.gaCrossDomainTrackingId = gaCrossDomainTrackingId;
     }
 
     public boolean isConsentRequired() {
@@ -41,5 +51,13 @@ public class UserStartInfo {
 
     public boolean isAuthenticated() {
         return authenticated;
+    }
+
+    public String getCookieConsent() {
+        return cookieConsent;
+    }
+
+    public String getGaCrossDomainTrackingId() {
+        return gaCrossDomainTrackingId;
     }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -93,7 +93,21 @@ public class StartHandler
                                                 session.get(), clientSession.get());
                                 var clientStartInfo =
                                         startService.buildClientStartInfo(userContext);
-                                var userStartInfo = startService.buildUserStartInfo(userContext);
+
+                                String cookieConsent =
+                                        startService.getCookieConsentValue(
+                                                userContext
+                                                        .getClientSession()
+                                                        .getAuthRequestParams(),
+                                                userContext.getClient().get().getClientID());
+                                String gaTrackingId =
+                                        startService.getGATrackingId(
+                                                userContext
+                                                        .getClientSession()
+                                                        .getAuthRequestParams());
+                                var userStartInfo =
+                                        startService.buildUserStartInfo(
+                                                userContext, cookieConsent, gaTrackingId);
 
                                 var startResponse =
                                         new StartResponse(userStartInfo, clientStartInfo);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -94,13 +94,13 @@ public class StartHandler
                                 var clientStartInfo =
                                         startService.buildClientStartInfo(userContext);
 
-                                String cookieConsent =
+                                var cookieConsent =
                                         startService.getCookieConsentValue(
                                                 userContext
                                                         .getClientSession()
                                                         .getAuthRequestParams(),
                                                 userContext.getClient().get().getClientID());
-                                String gaTrackingId =
+                                var gaTrackingId =
                                         startService.getGATrackingId(
                                                 userContext
                                                         .getClientSession()

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
@@ -98,6 +98,8 @@ public class StartService {
                 consentRequired,
                 uplift,
                 identityRequired,
-                userContext.getSession().isAuthenticated());
+                userContext.getSession().isAuthenticated(),
+                null,
+                null);
     }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
@@ -9,21 +9,31 @@ import uk.gov.di.authentication.frontendapi.entity.UserStartInfo;
 import uk.gov.di.authentication.shared.conditions.ConsentHelper;
 import uk.gov.di.authentication.shared.conditions.IdentityHelper;
 import uk.gov.di.authentication.shared.conditions.UpliftHelper;
+import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.Session;
+import uk.gov.di.authentication.shared.exceptions.ClientNotFoundException;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
+import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
+
+import static uk.gov.di.authentication.frontendapi.entity.RequestParameters.COOKIE_CONSENT;
+import static uk.gov.di.authentication.frontendapi.entity.RequestParameters.GA;
 
 public class StartService {
 
     private final ClientService clientService;
     private final DynamoService dynamoService;
     private static final String CLIENT_ID_PARAM = "client_id";
+    public static final String COOKIE_CONSENT_ACCEPT = "accept";
+    public static final String COOKIE_CONSENT_REJECT = "reject";
+    public static final String COOKIE_CONSENT_NOT_ENGAGED = "not-engaged";
     private static final Logger LOG = LogManager.getLogger(StartService.class);
 
     public StartService(ClientService clientService, DynamoService dynamoService) {
@@ -78,7 +88,8 @@ public class StartService {
         return clientInfo;
     }
 
-    public UserStartInfo buildUserStartInfo(UserContext userContext) {
+    public UserStartInfo buildUserStartInfo(
+            UserContext userContext, String cookieConsent, String gaTrackingId) {
         var consentRequired = ConsentHelper.userHasNotGivenConsent(userContext);
         var uplift = false;
         if (Objects.nonNull(userContext.getSession().getCurrentCredentialStrength())) {
@@ -89,17 +100,58 @@ public class StartService {
                         userContext.getClientSession().getAuthRequestParams());
 
         LOG.info(
-                "Found UserStartInfo for ConsentRequired: {} UpliftRequired: {} IdentityRequired: {}",
+                "Found UserStartInfo for ConsentRequired: {} UpliftRequired: {} IdentityRequired: {}. CookieConsent: {}. GATrackingId: {}",
                 consentRequired,
                 uplift,
-                identityRequired);
+                identityRequired,
+                cookieConsent,
+                gaTrackingId);
 
         return new UserStartInfo(
                 consentRequired,
                 uplift,
                 identityRequired,
                 userContext.getSession().isAuthenticated(),
-                null,
-                null);
+                cookieConsent,
+                gaTrackingId);
+    }
+
+    public String getGATrackingId(Map<String, List<String>> authRequestParameters) {
+        if (authRequestParameters.containsKey(GA)) {
+            String gaId = authRequestParameters.get(GA).get(0);
+            LOG.info("GA value present in request {}", gaId);
+            return gaId;
+        }
+        return null;
+    }
+
+    public String getCookieConsentValue(
+            Map<String, List<String>> authRequestParameters, String clientID) {
+        try {
+            if (validCookieConsentValueIsPresent(authRequestParameters)
+                    && isClientCookieConsentShared(clientID)) {
+                LOG.info("Sharing cookie_consent");
+                return authRequestParameters.get(COOKIE_CONSENT).get(0);
+            }
+            return null;
+        } catch (ClientNotFoundException e) {
+            throw new RuntimeException("Client not found", e);
+        }
+    }
+
+    private boolean isClientCookieConsentShared(String clientID) throws ClientNotFoundException {
+        return clientService
+                .getClient(clientID)
+                .map(ClientRegistry::isCookieConsentShared)
+                .orElseThrow(() -> new ClientNotFoundException(clientID));
+    }
+
+    private boolean validCookieConsentValueIsPresent(
+            Map<String, List<String>> authRequestParameters) {
+        return authRequestParameters.containsKey(COOKIE_CONSENT)
+                && !authRequestParameters.get(COOKIE_CONSENT).isEmpty()
+                && authRequestParameters.get(COOKIE_CONSENT).get(0) != null
+                && List.of(COOKIE_CONSENT_ACCEPT, COOKIE_CONSENT_REJECT, COOKIE_CONSENT_NOT_ENGAGED)
+                        .contains(authRequestParameters.get(COOKIE_CONSENT).get(0));
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -234,6 +234,6 @@ class StartHandlerTest {
     }
 
     private UserStartInfo getUserStartInfo() {
-        return new UserStartInfo(true, false, false, true);
+        return new UserStartInfo(true, false, false, true, null, null);
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
@@ -85,6 +85,8 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(startResponse.getClient().getServiceType(), equalTo("MANDATORY"));
         assertThat(startResponse.getClient().getCookieConsentShared(), equalTo(false));
         assertThat(startResponse.getClient().getScopes(), equalTo(scope.toStringList()));
+        assertThat(startResponse.getUser().getCookieConsent(), equalTo(null));
+        assertThat(startResponse.getUser().getGaCrossDomainTrackingId(), equalTo(null));
 
         assertEventTypesReceived(auditTopic, List.of(START_INFO_FOUND));
     }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/RequestParameters.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/RequestParameters.java
@@ -1,6 +1,0 @@
-package uk.gov.di.authentication.oidc.entity;
-
-public interface RequestParameters {
-    String COOKIE_CONSENT = "cookie_consent";
-    String GA = "_ga";
-}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthorizationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthorizationService.java
@@ -36,9 +36,6 @@ public class AuthorizationService {
 
     public static final String VTR_PARAM = "vtr";
     private final DynamoClientService dynamoClientService;
-    public static final String COOKIE_CONSENT_ACCEPT = "accept";
-    public static final String COOKIE_CONSENT_REJECT = "reject";
-    public static final String COOKIE_CONSENT_NOT_ENGAGED = "not-engaged";
 
     private static final Logger LOG = LogManager.getLogger(AuthorizationService.class);
 
@@ -57,13 +54,6 @@ public class AuthorizationService {
             throw new ClientNotFoundException(clientID.toString());
         }
         return client.get().getRedirectUrls().contains(redirectURI.toString());
-    }
-
-    public boolean isClientCookieConsentShared(ClientID clientID) throws ClientNotFoundException {
-        return dynamoClientService
-                .getClient(clientID.toString())
-                .map(ClientRegistry::isCookieConsentShared)
-                .orElseThrow();
     }
 
     public AuthenticationSuccessResponse generateSuccessfulAuthResponse(
@@ -197,10 +187,5 @@ public class AuthorizationService {
 
     public String getExistingOrCreateNewPersistentSessionId(Map<String, String> headers) {
         return PersistentIdHelper.getExistingOrCreateNewPersistentSessionId(headers);
-    }
-
-    public boolean isValidCookieConsentValue(String cookieConsent) {
-        return List.of(COOKIE_CONSENT_ACCEPT, COOKIE_CONSENT_REJECT, COOKIE_CONSENT_NOT_ENGAGED)
-                .contains(cookieConsent);
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuthorizationServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuthorizationServiceTest.java
@@ -18,9 +18,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.CustomScopeValue;
 import uk.gov.di.authentication.shared.exceptions.ClientNotFoundException;
@@ -32,7 +29,6 @@ import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Stream;
 
 import static java.lang.String.format;
 import static java.util.Collections.singletonList;
@@ -441,24 +437,6 @@ class AuthorizationServiceTest {
                 authorizationService.getExistingOrCreateNewPersistentSessionId(requestCookieHeader);
 
         assertEquals(persistentSessionId, "some-persistent-id");
-    }
-
-    @ParameterizedTest
-    @MethodSource("cookieConsentValues")
-    void shouldValidateCookieConsentValue(String cookieConsentValue, boolean expectedResult) {
-        assertThat(
-                authorizationService.isValidCookieConsentValue(cookieConsentValue),
-                equalTo(expectedResult));
-    }
-
-    private static Stream<Arguments> cookieConsentValues() {
-        return Stream.of(
-                Arguments.of("accept", true),
-                Arguments.of("reject", true),
-                Arguments.of("not-engaged", true),
-                Arguments.of("Accept", false),
-                Arguments.of("some-value", false),
-                Arguments.of("", false));
     }
 
     private ClientRegistry generateClientRegistry(String redirectURI, String clientID) {


### PR DESCRIPTION
## What?

- Return cookie consent and ga cross tracking ID from start
- Remove cookie consent and ga tracking ID logic from authorize

## Why?

- Authorize contains a lot of logic which makes it difficult to understand what it is doing. We can simplify logic by moving the CookieConsent and the GATrackingID to the Start lambda. 