### PR TITLE
BAU - Set Dynamo to consistent

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/dynamodb/DynamoDBSchemaHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/dynamodb/DynamoDBSchemaHelper.java
@@ -47,6 +47,7 @@ public class DynamoDBSchemaHelper {
         return new DynamoDBMapper(
                 dynamoDB,
                 new DynamoDBMapperConfig.Builder()
+                        .withConsistentReads(DynamoDBMapperConfig.ConsistentReads.CONSISTENT)
                         .withTableNameOverride(
                                 DynamoDBMapperConfig.TableNameOverride.withTableNameReplacement(
                                         getFullyQualifiedTableName(table)))

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoClientService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoClientService.java
@@ -41,6 +41,7 @@ public class DynamoClientService implements ClientService {
 
         DynamoDBMapperConfig clientRegistryConfig =
                 new DynamoDBMapperConfig.Builder()
+                        .withConsistentReads(DynamoDBMapperConfig.ConsistentReads.CONSISTENT)
                         .withTableNameOverride(
                                 DynamoDBMapperConfig.TableNameOverride.withTableNameReplacement(
                                         tableName))


### PR DESCRIPTION
## What?

- Set Dynamo to consistent for Client Reg and both UserProfile tables. 

## Why?

- It's important that when we update Dynamo it is made consistent. The default is eventual which means it will eventually be consistent, this isn't good enough for us.

