### PR TITLE
AUTH-1364 - Add support for international numbers

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateProfileIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateProfileIntegrationTest.java
@@ -9,6 +9,8 @@ import com.nimbusds.openid.connect.sdk.Nonce;
 import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.authentication.frontendapi.entity.UpdateProfileRequest;
 import uk.gov.di.authentication.frontendapi.lambda.UpdateProfileHandler;
 import uk.gov.di.authentication.shared.entity.ClientConsent;
@@ -25,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -46,14 +49,27 @@ public class UpdateProfileIntegrationTest extends ApiGatewayHandlerIntegrationTe
         handler = new UpdateProfileHandler(TEST_CONFIGURATION_SERVICE);
     }
 
-    @Test
-    public void shouldCallUpdateProfileEndpointToUpdatePhoneNumberAndReturn200()
+    private static Stream<String> phoneNumbers() {
+        return Stream.of(
+                "+447316763843",
+                "+4407316763843",
+                "+33645453322",
+                "+447316763843",
+                "+33645453322",
+                "+33645453322",
+                "07911123456",
+                "07123456789");
+    }
+
+    @ParameterizedTest
+    @MethodSource("phoneNumbers")
+    public void shouldCallUpdateProfileEndpointToUpdatePhoneNumberAndReturn204(String phonenumber)
             throws IOException {
         String sessionId = redis.createSession();
         String clientSessionId = IdGenerator.generate();
         setUpTest(sessionId, clientSessionId);
         UpdateProfileRequest request =
-                new UpdateProfileRequest(EMAIL_ADDRESS, ADD_PHONE_NUMBER, "07123456789");
+                new UpdateProfileRequest(EMAIL_ADDRESS, ADD_PHONE_NUMBER, phonenumber);
 
         var response =
                 makeRequest(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/PhoneNumberHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/PhoneNumberHelper.java
@@ -10,9 +10,13 @@ public class PhoneNumberHelper {
     private static final Logger LOG = LogManager.getLogger(PhoneNumberHelper.class);
 
     public static String formatPhoneNumber(String phoneNumber) {
-        PhoneNumberUtil phoneUtil = PhoneNumberUtil.getInstance();
+        String defaultRegion = null;
+        if (!phoneNumber.startsWith("+")) {
+            defaultRegion = "GB";
+        }
+        var phoneUtil = PhoneNumberUtil.getInstance();
         try {
-            var parsedPhoneNumber = phoneUtil.parse(phoneNumber, "GB");
+            var parsedPhoneNumber = phoneUtil.parse(phoneNumber, defaultRegion);
             return phoneUtil.format(parsedPhoneNumber, PhoneNumberUtil.PhoneNumberFormat.E164);
         } catch (NumberParseException e) {
             LOG.warn("Error when trying to parse phone number");

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ValidationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ValidationService.java
@@ -75,12 +75,16 @@ public class ValidationService {
     }
 
     public Optional<ErrorResponse> validatePhoneNumber(String phoneNumberInput) {
-        if ((!phoneNumberInput.matches("[0-9]+")) || (phoneNumberInput.length() < 10)) {
-            return Optional.of(ErrorResponse.ERROR_1012);
+        String defaultRegion = null;
+        if (!phoneNumberInput.startsWith("+")) {
+            defaultRegion = "GB";
+            if ((!phoneNumberInput.matches("[0-9]+")) || (phoneNumberInput.length() < 10)) {
+                return Optional.of(ErrorResponse.ERROR_1012);
+            }
         }
-        PhoneNumberUtil phoneUtil = PhoneNumberUtil.getInstance();
+        var phoneUtil = PhoneNumberUtil.getInstance();
         try {
-            var phoneNumber = phoneUtil.parse(phoneNumberInput, "GB");
+            var phoneNumber = phoneUtil.parse(phoneNumberInput, defaultRegion);
             if (!phoneUtil.getNumberType(phoneNumber).equals(MOBILE)) {
                 return Optional.of(ErrorResponse.ERROR_1012);
             }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/ValidationServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/ValidationServiceTest.java
@@ -9,6 +9,8 @@ import uk.gov.di.authentication.shared.entity.Session;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -131,6 +133,29 @@ public class ValidationServiceTest {
         assertEquals(
                 Optional.of(ErrorResponse.ERROR_1012),
                 validationService.validatePhoneNumber(phoneNumber));
+    }
+
+    private static Stream<String> internationalPhoneNumbers() {
+        return Stream.of(
+                "+447316763843",
+                "+4407316763843",
+                "+33645453322",
+                "+330645453322",
+                "+447316763843",
+                "+447316763843",
+                "+33645453322",
+                "+33645453322");
+    }
+
+    @ParameterizedTest
+    @MethodSource("internationalPhoneNumbers")
+    void shouldAcceptValidInternationPhoneNumbers(String phoneNumber) {
+        assertThat(validationService.validatePhoneNumber(phoneNumber), equalTo(Optional.empty()));
+    }
+
+    @Test
+    void shouldAcceptValidBritishPhoneNumbers() {
+        assertThat(validationService.validatePhoneNumber("07911123456"), equalTo(Optional.empty()));
     }
 
     @Test


### PR DESCRIPTION
## What?

- Add support for international numbers for both sign-ups and account management. If a number is not prefixed with a +, then we assume that it is a British number.

## Why?

- So we can start supporting users with international phone numbers. 