### PR TITLE
AUTH-1839: Remove use of generated env file as no longer used

### DIFF
--- a/ci/tasks/deploy-oidc-api.yml
+++ b/ci/tasks/deploy-oidc-api.yml
@@ -29,7 +29,6 @@ inputs:
   - name: ipv-api-release
   - name: lambda-warmer-release
   - name: shared-terraform-outputs
-  - name: oidc-api-env-vars
 outputs:
   - name: terraform-outputs
 run:
@@ -37,8 +36,6 @@ run:
   args:
     - -euc
     - |
-      source oidc-api-env-vars/env.sh
-
       cd "api-terraform-src/ci/terraform/oidc"
       terraform init -input=false \
         -backend-config "role_arn=${DEPLOYER_ROLE_ARN}" \


### PR DESCRIPTION
## What?

- Remove the use of a generated shell script to set the, no longer used, `AM_URL` environment variable. 

## Why?

This was originally implemented inline with the way we got this value when we deployed the PaaS apps, but we now get this value using a `terraform_remote_state` data source.

## Related PRs

https://github.com/alphagov/di-infrastructure/pull/200