### PR TITLE
AUTH-1412 - Create new lambda and API for handling Notify delivery receipts callback

### DIFF
--- a/ci/tasks/deploy-delivery-receipts-api.yml
+++ b/ci/tasks/deploy-delivery-receipts-api.yml
@@ -9,9 +9,6 @@ image_resource:
 params:
   DEPLOYER_ROLE_ARN: ((deployer-role-arn-non-prod))
   DEPLOY_ENVIRONMENT: build
-  DNS_DEPLOYER_ROLE_ARN: ((deployer-role-arn-production))
-  DNS_STATE_BUCKET: ((dns-state-bucket))
-  DNS_STATE_KEY: ((dns-state-key))
   STATE_BUCKET: digital-identity-dev-tfstate
 inputs:
   - name: api-terraform-src
@@ -38,9 +35,6 @@ run:
         -var 'logging_endpoint_arn=arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod' \
         -var "lambda_zip_file=$(ls -1 ../../../../delivery-receipts-api-release/*.zip)" \
         -var "common_state_bucket=${STATE_BUCKET}" \
-        -var "dns_state_bucket=${DNS_STATE_BUCKET}" \
-        -var "dns_state_key=${DNS_STATE_KEY}" \
-        -var "dns_state_role=${DNS_DEPLOYER_ROLE_ARN}" \
         -var-file "${DEPLOY_ENVIRONMENT}-overrides.tfvars" \
         -var-file ${DEPLOY_ENVIRONMENT}-sizing.tfvars \
 

--- a/ci/tasks/deploy-delivery-receipts-api.yml
+++ b/ci/tasks/deploy-delivery-receipts-api.yml
@@ -1,0 +1,47 @@
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: hashicorp/terraform
+    tag: 1.0.4
+    username: ((docker-hub-username))
+    password: ((docker-hub-password))    
+params:
+  DEPLOYER_ROLE_ARN: ((deployer-role-arn-non-prod))
+  DEPLOY_ENVIRONMENT: build
+  DNS_DEPLOYER_ROLE_ARN: ((deployer-role-arn-production))
+  DNS_STATE_BUCKET: ((dns-state-bucket))
+  DNS_STATE_KEY: ((dns-state-key))
+  STATE_BUCKET: digital-identity-dev-tfstate
+inputs:
+  - name: api-terraform-src
+  - name: delivery-receipts-api-release
+outputs:
+  - name: terraform-outputs
+run:
+  path: /bin/sh
+  args:
+    - -euc
+    - |
+      cd "api-terraform-src/ci/terraform/delivery-receipts"
+      terraform init -input=false \
+        -backend-config "role_arn=${DEPLOYER_ROLE_ARN}" \
+        -backend-config "bucket=${STATE_BUCKET}" \
+        -backend-config "key=${DEPLOY_ENVIRONMENT}-delivery-receipts-api-terraform.tfstate" \
+        -backend-config "encrypt=true" \
+        -backend-config "region=eu-west-2"
+
+      terraform apply -auto-approve \
+        -var "deployer_role_arn=${DEPLOYER_ROLE_ARN}" \
+        -var "environment=${DEPLOY_ENVIRONMENT}" \
+        -var 'logging_endpoint_enabled=true' \
+        -var 'logging_endpoint_arn=arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod' \
+        -var "lambda_zip_file=$(ls -1 ../../../../delivery-receipts-api-release/*.zip)" \
+        -var "common_state_bucket=${STATE_BUCKET}" \
+        -var "dns_state_bucket=${DNS_STATE_BUCKET}" \
+        -var "dns_state_key=${DNS_STATE_KEY}" \
+        -var "dns_state_role=${DNS_DEPLOYER_ROLE_ARN}" \
+        -var-file "${DEPLOY_ENVIRONMENT}-overrides.tfvars" \
+        -var-file ${DEPLOY_ENVIRONMENT}-sizing.tfvars \
+
+      terraform output --json > ../../../../terraform-outputs/${DEPLOY_ENVIRONMENT}-delivery-receipts-api-terraform-outputs.json

--- a/ci/terraform/delivery-receipts/api-gateway.tf
+++ b/ci/terraform/delivery-receipts/api-gateway.tf
@@ -1,0 +1,95 @@
+resource "aws_api_gateway_rest_api" "di_authentication_delivery_receipts_api" {
+  name = "${var.environment}-di-authentication-delivery-receipts-api"
+
+  tags = local.default_tags
+}
+
+resource "aws_api_gateway_deployment" "delivery_receipts_api_deployment" {
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_delivery_receipts_api.id
+
+  triggers = {
+    redeployment = sha1(jsonencode([
+      module.notify_callback.method_trigger_value,
+      module.notify_callback.integration_trigger_value,
+    ]))
+  }
+
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+locals {
+  api_delivery_receipts_api_base_url = var.use_localstack ? "${var.aws_endpoint}/restapis/${aws_api_gateway_rest_api.di_authentication_delivery_receipts_api.id}/${var.environment}/_user_request_" : aws_api_gateway_rest_api.di_authentication_delivery_receipts_api.id
+}
+
+resource "aws_cloudwatch_log_group" "delivery_receipts_api_stage_execution_logs" {
+  count = var.use_localstack ? 0 : 1
+
+  name              = "API-Gateway-Execution-Logs_${aws_api_gateway_rest_api.di_authentication_delivery_receipts_api.id}/${var.environment}"
+  retention_in_days = var.cloudwatch_log_retention
+  kms_key_id        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+}
+
+resource "aws_cloudwatch_log_subscription_filter" "delivery_receipts_api_execution_log_subscription" {
+  count           = var.logging_endpoint_enabled ? 1 : 0
+  name            = "${var.environment}-delivery-receipts-api-execution-log-subscription"
+  log_group_name  = aws_cloudwatch_log_group.delivery_receipts_api_stage_execution_logs[0].name
+  filter_pattern  = ""
+  destination_arn = var.logging_endpoint_arn
+}
+
+resource "aws_cloudwatch_log_group" "delivery_receipts_stage_access_logs" {
+  count = var.use_localstack ? 0 : 1
+
+  name              = "${var.environment}-delivery-receipts-api-access-logs"
+  retention_in_days = var.cloudwatch_log_retention
+  kms_key_id        = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+}
+
+resource "aws_cloudwatch_log_subscription_filter" "delivery_receipts_api_access_log_subscription" {
+  count           = var.logging_endpoint_enabled ? 1 : 0
+  name            = "${var.environment}-delivery-receipts-api-access-logs-subscription"
+  log_group_name  = aws_cloudwatch_log_group.delivery_receipts_stage_access_logs[0].name
+  filter_pattern  = ""
+  destination_arn = var.logging_endpoint_arn
+}
+
+resource "aws_api_gateway_stage" "endpoint_delivery_receipts_stage" {
+  deployment_id = aws_api_gateway_deployment.delivery_receipts_api_deployment.id
+  rest_api_id   = aws_api_gateway_rest_api.di_authentication_delivery_receipts_api.id
+  stage_name    = var.environment
+
+  dynamic "access_log_settings" {
+    for_each = var.use_localstack ? [] : aws_cloudwatch_log_group.delivery_receipts_stage_access_logs
+    iterator = log_group
+    content {
+      destination_arn = log_group.value.arn
+      format          = local.access_logging_template
+    }
+  }
+
+  tags = local.default_tags
+
+  depends_on = [
+    aws_api_gateway_deployment.delivery_receipts_api_deployment,
+  ]
+}
+
+resource "aws_api_gateway_method_settings" "api_gateway_delivery_receipts_logging_settings" {
+  count = var.enable_api_gateway_execution_logging ? 1 : 0
+
+  rest_api_id = aws_api_gateway_rest_api.di_authentication_delivery_receipts_api.id
+  stage_name  = aws_api_gateway_stage.endpoint_delivery_receipts_stage.stage_name
+  method_path = "*/*"
+
+  settings {
+    metrics_enabled    = false
+    data_trace_enabled = false
+    logging_level      = "INFO"
+  }
+  depends_on = [
+    aws_api_gateway_stage.endpoint_delivery_receipts_stage
+  ]
+}

--- a/ci/terraform/delivery-receipts/core.tf
+++ b/ci/terraform/delivery-receipts/core.tf
@@ -1,0 +1,26 @@
+data "terraform_remote_state" "core" {
+  backend = "s3"
+  config = {
+    bucket                      = var.common_state_bucket
+    key                         = "${var.environment}-core-terraform.tfstate"
+    role_arn                    = var.deployer_role_arn
+    region                      = var.aws_region
+    endpoint                    = var.use_localstack ? "http://localhost:45678" : null
+    iam_endpoint                = var.use_localstack ? "http://localhost:45678" : null
+    sts_endpoint                = var.use_localstack ? "http://localhost:45678" : null
+    skip_credentials_validation = var.use_localstack
+    skip_metadata_api_check     = var.use_localstack
+    force_path_style            = var.use_localstack
+  }
+}
+
+locals {
+  vpc_arn                                    = data.terraform_remote_state.core.outputs.vpc_arn
+  vpc_id                                     = data.terraform_remote_state.core.outputs.vpc_id
+  allow_aws_service_access_security_group_id = data.terraform_remote_state.core.outputs.allow_aws_service_access_security_group_id
+  allow_egress_security_group_id             = data.terraform_remote_state.core.outputs.allow_egress_security_group_id
+  private_subnet_ids                         = data.terraform_remote_state.core.outputs.private_subnet_ids
+  private_subnet_cidr_blocks                 = data.terraform_remote_state.core.outputs.private_subnet_cidr_blocks
+  public_subnet_ids                          = data.terraform_remote_state.core.outputs.public_subnet_ids
+  public_subnet_cidr_blocks                  = data.terraform_remote_state.core.outputs.private_subnet_cidr_blocks
+}

--- a/ci/terraform/delivery-receipts/notify-callback.tf
+++ b/ci/terraform/delivery-receipts/notify-callback.tf
@@ -1,0 +1,63 @@
+module "delivery_receipts_api_notify_callback_role" {
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "delivery-receipts-api-notify-callback-role"
+  vpc_arn     = local.vpc_arn
+
+  policies_to_attach = [
+    aws_iam_policy.parameter_policy.arn
+  ]
+}
+
+module "notify_callback" {
+  source = "../modules/endpoint-module"
+
+  endpoint_name   = "notify-callback"
+  path_part       = "notify-callback"
+  endpoint_method = "POST"
+  environment     = var.environment
+
+  handler_environment_variables = {
+    ENVIRONMENT         = var.environment
+    LOCALSTACK_ENDPOINT = var.use_localstack ? var.localstack_endpoint : null
+  }
+  handler_function_name = "uk.gov.di.authentication.deliveryreceiptsapi.lambda.NotifyCallbackHandler::handleRequest"
+
+  rest_api_id      = aws_api_gateway_rest_api.di_authentication_delivery_receipts_api.id
+  root_resource_id = aws_api_gateway_rest_api.di_authentication_delivery_receipts_api.root_resource_id
+  execution_arn    = aws_api_gateway_rest_api.di_authentication_delivery_receipts_api.execution_arn
+
+  source_bucket                  = aws_s3_bucket.source_bucket.bucket
+  lambda_zip_file                = aws_s3_bucket_object.delivery_receipts_api_release_zip.key
+  lambda_zip_file_version        = aws_s3_bucket_object.delivery_receipts_api_release_zip.version_id
+  warmer_lambda_zip_file         = null
+  warmer_lambda_zip_file_version = null
+  code_signing_config_arn        = local.lambda_code_signing_configuration_arn
+
+  authentication_vpc_arn = local.vpc_arn
+  security_group_ids = [
+    local.allow_aws_service_access_security_group_id,
+  ]
+  subnet_id                              = local.private_subnet_ids
+  lambda_role_arn                        = module.delivery_receipts_api_notify_callback_role.arn
+  logging_endpoint_enabled               = var.logging_endpoint_enabled
+  logging_endpoint_arn                   = var.logging_endpoint_arn
+  cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  cloudwatch_log_retention               = var.cloudwatch_log_retention
+  lambda_env_vars_encryption_kms_key_arn = data.terraform_remote_state.shared.outputs.lambda_env_vars_encryption_kms_key_arn
+  default_tags                           = local.default_tags
+  api_key_required                       = false
+
+  keep_lambda_warm             = false
+  warmer_handler_function_name = null
+  warmer_security_group_ids    = [local.allow_aws_service_access_security_group_id]
+  warmer_handler_environment_variables = {
+    LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
+  }
+
+  use_localstack = var.use_localstack
+
+  depends_on = [
+    aws_api_gateway_rest_api.di_authentication_delivery_receipts_api,
+  ]
+}

--- a/ci/terraform/delivery-receipts/outputs.tf
+++ b/ci/terraform/delivery-receipts/outputs.tf
@@ -1,0 +1,3 @@
+output "delivery_receipts_api_gateway_root_id" {
+  value = aws_api_gateway_rest_api.di_authentication_delivery_receipts_api.id
+}

--- a/ci/terraform/delivery-receipts/s3-objects.tf
+++ b/ci/terraform/delivery-receipts/s3-objects.tf
@@ -1,0 +1,16 @@
+resource "aws_s3_bucket" "source_bucket" {
+  bucket_prefix = "${var.environment}-acct-mgmt-lambda-source-"
+
+  versioning {
+    enabled = true
+  }
+}
+
+resource "aws_s3_bucket_object" "delivery_receipts_api_release_zip" {
+  bucket = aws_s3_bucket.source_bucket.bucket
+  key    = "delivery-receipts-api-release.zip"
+
+  server_side_encryption = "AES256"
+  source                 = var.lambda_zip_file
+  source_hash            = filemd5(var.lambda_zip_file)
+}

--- a/ci/terraform/delivery-receipts/sandpit.hcl
+++ b/ci/terraform/delivery-receipts/sandpit.hcl
@@ -1,0 +1,4 @@
+bucket  = "digital-identity-dev-tfstate"
+key     = "sandpit-delivery-receipts-api-terraform.tfstate"
+encrypt = true
+region  = "eu-west-2"

--- a/ci/terraform/delivery-receipts/sandpit.tfvars
+++ b/ci/terraform/delivery-receipts/sandpit.tfvars
@@ -1,0 +1,5 @@
+environment         = "sandpit"
+dns_state_bucket    = null
+dns_state_key       = null
+dns_state_role      = null
+common_state_bucket = "digital-identity-dev-tfstate"

--- a/ci/terraform/delivery-receipts/sandpit.tfvars
+++ b/ci/terraform/delivery-receipts/sandpit.tfvars
@@ -1,5 +1,2 @@
 environment         = "sandpit"
-dns_state_bucket    = null
-dns_state_key       = null
-dns_state_role      = null
 common_state_bucket = "digital-identity-dev-tfstate"

--- a/ci/terraform/delivery-receipts/shared.tf
+++ b/ci/terraform/delivery-receipts/shared.tf
@@ -1,0 +1,20 @@
+data "terraform_remote_state" "shared" {
+  backend = "s3"
+  config = {
+    bucket                      = var.common_state_bucket
+    key                         = "${var.environment}-shared-terraform.tfstate"
+    role_arn                    = var.deployer_role_arn
+    region                      = var.aws_region
+    endpoint                    = var.use_localstack ? "http://localhost:45678" : null
+    iam_endpoint                = var.use_localstack ? "http://localhost:45678" : null
+    sts_endpoint                = var.use_localstack ? "http://localhost:45678" : null
+    skip_credentials_validation = var.use_localstack
+    skip_metadata_api_check     = var.use_localstack
+    force_path_style            = var.use_localstack
+  }
+}
+
+locals {
+  redis_key                             = "session"
+  lambda_code_signing_configuration_arn = data.terraform_remote_state.shared.outputs.lambda_code_signing_configuration_arn
+}

--- a/ci/terraform/delivery-receipts/site.tf
+++ b/ci/terraform/delivery-receipts/site.tf
@@ -1,0 +1,68 @@
+terraform {
+  required_version = ">= 1.0.4"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "= 3.63.0"
+    }
+  }
+
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  assume_role {
+    role_arn = var.deployer_role_arn
+  }
+
+  insecure = var.use_localstack
+
+  s3_force_path_style         = var.use_localstack
+  skip_credentials_validation = var.use_localstack
+  skip_metadata_api_check     = var.use_localstack
+  skip_requesting_account_id  = var.use_localstack
+
+  endpoints {
+    apigateway  = var.aws_endpoint
+    ecr         = var.aws_endpoint
+    iam         = var.aws_endpoint
+    lambda      = var.aws_endpoint
+    s3          = var.aws_endpoint
+    ec2         = var.aws_endpoint
+    sts         = var.aws_endpoint
+    elasticache = var.aws_endpoint
+  }
+}
+
+locals {
+  // Using a local rather than the default_tags option on the AWS provider, as the latter has known issues which produce errors on apply.
+  default_tags = var.use_localstack ? null : {
+    environment = var.environment
+    application = "delivery-receipts-api"
+  }
+
+  request_tracing_allowed = contains(["build", "sandpit"], var.environment)
+
+  access_logging_template = jsonencode({
+    requestId            = "$context.requestId"
+    ip                   = "$context.identity.sourceIp"
+    userAgent            = "$context.identity.userAgent"
+    requestTime          = "$context.requestTime"
+    httpMethod           = "$context.httpMethod"
+    resourcePath         = "$context.resourcePath"
+    status               = "$context.status"
+    protocol             = "$context.protocol"
+    responseLength       = "$context.responseLength"
+    integrationStatus    = "$context.integration.integrationStatus"
+    integrationLatency   = "$context.integration.latency"
+    integrationRequestId = "$context.integration.requestId"
+  })
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_partition" "current" {}

--- a/ci/terraform/delivery-receipts/ssm.tf
+++ b/ci/terraform/delivery-receipts/ssm.tf
@@ -1,0 +1,89 @@
+data "aws_iam_policy_document" "key_policy" {
+  policy_id = "key-policy-ssm"
+  statement {
+    sid = "Enable IAM User Permissions for root user"
+    actions = [
+      "kms:*",
+    ]
+    effect = "Allow"
+    principals {
+      type = "AWS"
+      identifiers = [
+        format(
+          "arn:%s:iam::%s:root",
+          data.aws_partition.current.partition,
+          data.aws_caller_identity.current.account_id
+        )
+      ]
+    }
+    resources = ["*"]
+  }
+}
+
+resource "aws_kms_key" "parameter_store_key" {
+  description             = "KMS key for delivery receipts parameter store"
+  deletion_window_in_days = 30
+  enable_key_rotation     = true
+  policy                  = data.aws_iam_policy_document.key_policy.json
+
+  customer_master_key_spec = "SYMMETRIC_DEFAULT"
+  key_usage                = "ENCRYPT_DECRYPT"
+
+  tags = local.default_tags
+}
+
+resource "aws_kms_alias" "parameter_store_key_alias" {
+  name          = "alias/${var.environment}-delivert-receipts-lambda-parameter-store-encryption-key"
+  target_key_id = aws_kms_key.parameter_store_key.id
+}
+
+resource "aws_ssm_parameter" "notify_callback_bearer_token" {
+  name   = "${var.environment}-notify-callback-bearer-token"
+  type   = "SecureString"
+  key_id = aws_kms_alias.parameter_store_key_alias.id
+  value  = random_string.notify_bearer_token.result
+}
+
+resource "random_string" "notify_bearer_token" {
+  length = 64
+
+  min_lower   = 3
+  min_numeric = 3
+  min_special = 3
+  min_upper   = 3
+}
+
+data "aws_iam_policy_document" "bearer_token_parameter_policy" {
+  statement {
+    sid    = "AllowGetParameters"
+    effect = "Allow"
+
+    actions = [
+      "ssm:GetParameter",
+      "ssm:GetParameters",
+    ]
+
+    resources = [
+      aws_ssm_parameter.notify_callback_bearer_token.arn,
+    ]
+  }
+  statement {
+    sid    = "AllowDecryptOfParameters"
+    effect = "Allow"
+
+    actions = [
+      "kms:Decrypt",
+    ]
+
+    resources = [
+      aws_kms_alias.parameter_store_key_alias.arn,
+      aws_kms_key.parameter_store_key.arn
+    ]
+  }
+}
+
+resource "aws_iam_policy" "parameter_policy" {
+  policy      = data.aws_iam_policy_document.bearer_token_parameter_policy.json
+  path        = "/${var.environment}/notify-bearer-token/"
+  name_prefix = "parameter-store-policy"
+}

--- a/ci/terraform/delivery-receipts/variables.tf
+++ b/ci/terraform/delivery-receipts/variables.tf
@@ -70,19 +70,6 @@ variable "aws_region" {
   default = "eu-west-2"
 }
 
-variable "dns_state_bucket" {
-  type = string
-}
-
-variable "dns_state_key" {
-  type = string
-}
-
-variable "dns_state_role" {
-  type = string
-}
-
-
 variable "cloudwatch_log_retention" {
   default     = 1
   type        = number

--- a/ci/terraform/delivery-receipts/variables.tf
+++ b/ci/terraform/delivery-receipts/variables.tf
@@ -1,0 +1,90 @@
+variable "deployer_role_arn" {
+  default     = ""
+  description = "The name of the AWS role to assume, leave blank when running locally"
+  type        = string
+}
+
+variable "lambda_zip_file" {
+  default     = "../../../delivery-receipts-api/build/distributions/delivery-receipts-api.zip"
+  description = "Location of the Lambda ZIP file"
+  type        = string
+}
+
+variable "keep_lambdas_warm" {
+  default = true
+  type    = bool
+}
+
+variable "lambda_min_concurrency" {
+  default     = 10
+  type        = number
+  description = "The number of lambda instance to keep 'warm'"
+}
+
+variable "common_state_bucket" {
+  type = string
+}
+
+variable "environment" {
+  type = string
+}
+
+variable "aws_endpoint" {
+  type    = string
+  default = null
+}
+
+variable "use_localstack" {
+  type    = bool
+  default = false
+}
+
+variable "localstack_endpoint" {
+  type    = string
+  default = "http://localhost:45678/"
+}
+
+variable "redis_use_tls" {
+  type    = string
+  default = "true"
+}
+
+variable "enable_api_gateway_execution_logging" {
+  default     = true
+  description = "Whether to enable logging of API gateway runs"
+}
+
+variable "logging_endpoint_enabled" {
+  type        = bool
+  default     = false
+  description = "Whether the service should ship its Lambda logs to the `logging_endpoint_arn`"
+}
+
+variable "logging_endpoint_arn" {
+  type        = string
+  default     = ""
+  description = "Amazon Resource Name (ARN) for the endpoint to ship logs to"
+}
+
+variable "aws_region" {
+  default = "eu-west-2"
+}
+
+variable "dns_state_bucket" {
+  type = string
+}
+
+variable "dns_state_key" {
+  type = string
+}
+
+variable "dns_state_role" {
+  type = string
+}
+
+
+variable "cloudwatch_log_retention" {
+  default     = 1
+  type        = number
+  description = "The number of day to retain Cloudwatch logs for"
+}

--- a/delivery-receipts-api/build.gradle
+++ b/delivery-receipts-api/build.gradle
@@ -1,0 +1,48 @@
+plugins {
+    id "java"
+    id "jacoco"
+}
+
+group "uk.gov.di.authentication.deliveryreceiptsapi"
+version "unspecified"
+
+dependencies {
+    implementation configurations.govuk_notify,
+            configurations.lambda,
+            configurations.jackson,
+            configurations.libphonenumber,
+            configurations.cloudwatch,
+            project(":shared")
+
+    runtimeOnly configurations.logging_runtime
+
+    testImplementation configurations.tests,
+            configurations.lambda_tests,
+            project(":shared-test")
+
+    testRuntimeOnly configurations.test_runtime
+}
+
+test {
+    useJUnitPlatform()
+}
+
+task buildZip(type: Zip) {
+    from compileJava
+    from processResources
+    into("lib") {
+        from configurations.runtimeClasspath
+    }
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled true
+    }
+    dependsOn "test"
+}

--- a/delivery-receipts-api/src/main/java/uk/gov/di/authentication/deliveryreceiptsapi/entity/DeliveryMetricStatus.java
+++ b/delivery-receipts-api/src/main/java/uk/gov/di/authentication/deliveryreceiptsapi/entity/DeliveryMetricStatus.java
@@ -1,0 +1,6 @@
+package uk.gov.di.authentication.deliveryreceiptsapi.entity;
+
+public enum DeliveryMetricStatus {
+    SMS_FAILURE,
+    SMS_DELIVERED
+}

--- a/delivery-receipts-api/src/main/java/uk/gov/di/authentication/deliveryreceiptsapi/entity/NotifyDeliveryReceipt.java
+++ b/delivery-receipts-api/src/main/java/uk/gov/di/authentication/deliveryreceiptsapi/entity/NotifyDeliveryReceipt.java
@@ -1,0 +1,99 @@
+package uk.gov.di.authentication.deliveryreceiptsapi.entity;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class NotifyDeliveryReceipt {
+
+    @JsonProperty("id")
+    private String id;
+
+    @JsonProperty("reference")
+    private String reference;
+
+    @JsonProperty("to")
+    private String to;
+
+    @JsonProperty("status")
+    private String status;
+
+    @JsonProperty("created_at")
+    private String created_at;
+
+    @JsonProperty("completed_at")
+    private String completed_at;
+
+    @JsonProperty("sent_at")
+    private String sent_at;
+
+    @JsonProperty("notification_type")
+    private String notification_type;
+
+    @JsonProperty("template_id")
+    private String template_id;
+
+    @JsonProperty("template_version")
+    private int template_version;
+
+    public NotifyDeliveryReceipt(
+            @JsonProperty(required = true, value = "id") String id,
+            @JsonProperty(required = true, value = "reference") String reference,
+            @JsonProperty(required = true, value = "to") String to,
+            @JsonProperty(required = true, value = "status") String status,
+            @JsonProperty(required = true, value = "created_at") String created_at,
+            @JsonProperty(required = true, value = "completed_at") String completed_at,
+            @JsonProperty(required = true, value = "sent_at") String sent_at,
+            @JsonProperty(required = true, value = "notification_type") String notification_type,
+            @JsonProperty(required = true, value = "template_id") String template_id,
+            @JsonProperty(required = true, value = "template_version") int template_version) {
+        this.id = id;
+        this.reference = reference;
+        this.to = to;
+        this.status = status;
+        this.created_at = created_at;
+        this.completed_at = completed_at;
+        this.sent_at = sent_at;
+        this.notification_type = notification_type;
+        this.template_id = template_id;
+        this.template_version = template_version;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getReference() {
+        return reference;
+    }
+
+    public String getTo() {
+        return to;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public String getCreated_at() {
+        return created_at;
+    }
+
+    public String getCompleted_at() {
+        return completed_at;
+    }
+
+    public String getSent_at() {
+        return sent_at;
+    }
+
+    public String getNotification_type() {
+        return notification_type;
+    }
+
+    public String getTemplate_id() {
+        return template_id;
+    }
+
+    public int getTemplate_version() {
+        return template_version;
+    }
+}

--- a/delivery-receipts-api/src/main/java/uk/gov/di/authentication/deliveryreceiptsapi/entity/NotifyDeliveryReceipt.java
+++ b/delivery-receipts-api/src/main/java/uk/gov/di/authentication/deliveryreceiptsapi/entity/NotifyDeliveryReceipt.java
@@ -17,44 +17,44 @@ public class NotifyDeliveryReceipt {
     private String status;
 
     @JsonProperty("created_at")
-    private String created_at;
+    private String createdAt;
 
     @JsonProperty("completed_at")
-    private String completed_at;
+    private String completedAt;
 
     @JsonProperty("sent_at")
-    private String sent_at;
+    private String sentAt;
 
     @JsonProperty("notification_type")
-    private String notification_type;
+    private String notificationType;
 
     @JsonProperty("template_id")
-    private String template_id;
+    private String templateId;
 
     @JsonProperty("template_version")
-    private int template_version;
+    private int templateVersion;
 
     public NotifyDeliveryReceipt(
             @JsonProperty(required = true, value = "id") String id,
             @JsonProperty(required = true, value = "reference") String reference,
             @JsonProperty(required = true, value = "to") String to,
             @JsonProperty(required = true, value = "status") String status,
-            @JsonProperty(required = true, value = "created_at") String created_at,
-            @JsonProperty(required = true, value = "completed_at") String completed_at,
-            @JsonProperty(required = true, value = "sent_at") String sent_at,
-            @JsonProperty(required = true, value = "notification_type") String notification_type,
-            @JsonProperty(required = true, value = "template_id") String template_id,
-            @JsonProperty(required = true, value = "template_version") int template_version) {
+            @JsonProperty(required = true, value = "created_at") String createdAt,
+            @JsonProperty(required = true, value = "completed_at") String completedAt,
+            @JsonProperty(required = true, value = "sent_at") String sentAt,
+            @JsonProperty(required = true, value = "notification_type") String notificationType,
+            @JsonProperty(required = true, value = "template_id") String templateId,
+            @JsonProperty(required = true, value = "template_version") int templateVersion) {
         this.id = id;
         this.reference = reference;
         this.to = to;
         this.status = status;
-        this.created_at = created_at;
-        this.completed_at = completed_at;
-        this.sent_at = sent_at;
-        this.notification_type = notification_type;
-        this.template_id = template_id;
-        this.template_version = template_version;
+        this.createdAt = createdAt;
+        this.completedAt = completedAt;
+        this.sentAt = sentAt;
+        this.notificationType = notificationType;
+        this.templateId = templateId;
+        this.templateVersion = templateVersion;
     }
 
     public String getId() {
@@ -73,27 +73,27 @@ public class NotifyDeliveryReceipt {
         return status;
     }
 
-    public String getCreated_at() {
-        return created_at;
+    public String getCreatedAt() {
+        return createdAt;
     }
 
-    public String getCompleted_at() {
-        return completed_at;
+    public String getCompletedAt() {
+        return completedAt;
     }
 
-    public String getSent_at() {
-        return sent_at;
+    public String getSentAt() {
+        return sentAt;
     }
 
-    public String getNotification_type() {
-        return notification_type;
+    public String getNotificationType() {
+        return notificationType;
     }
 
-    public String getTemplate_id() {
-        return template_id;
+    public String getTemplateId() {
+        return templateId;
     }
 
-    public int getTemplate_version() {
-        return template_version;
+    public int getTemplateVersion() {
+        return templateVersion;
     }
 }

--- a/delivery-receipts-api/src/main/java/uk/gov/di/authentication/deliveryreceiptsapi/lambda/NotifyCallbackHandler.java
+++ b/delivery-receipts-api/src/main/java/uk/gov/di/authentication/deliveryreceiptsapi/lambda/NotifyCallbackHandler.java
@@ -1,0 +1,116 @@
+package uk.gov.di.authentication.deliveryreceiptsapi.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.i18n.phonenumbers.NumberParseException;
+import com.google.i18n.phonenumbers.PhoneNumberUtil;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.deliveryreceiptsapi.entity.NotifyDeliveryReceipt;
+import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+import java.util.Map;
+import java.util.Objects;
+
+import static uk.gov.di.authentication.deliveryreceiptsapi.entity.DeliveryMetricStatus.SMS_DELIVERED;
+import static uk.gov.di.authentication.deliveryreceiptsapi.entity.DeliveryMetricStatus.SMS_FAILURE;
+
+public class NotifyCallbackHandler
+        implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+
+    private final ConfigurationService configurationService;
+    private final CloudwatchMetricsService cloudwatchMetricsService;
+    private static final Logger LOG = LogManager.getLogger(NotifyCallbackHandler.class);
+
+    public NotifyCallbackHandler(
+            CloudwatchMetricsService cloudwatchMetricsService,
+            ConfigurationService configurationService) {
+        this.cloudwatchMetricsService = cloudwatchMetricsService;
+        this.configurationService = configurationService;
+    }
+
+    public NotifyCallbackHandler(ConfigurationService configurationService) {
+        this.cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);
+        this.configurationService = configurationService;
+    }
+
+    public NotifyCallbackHandler() {
+        this(ConfigurationService.getInstance());
+    }
+
+    @Override
+    public APIGatewayProxyResponseEvent handleRequest(
+            APIGatewayProxyRequestEvent input, Context context) {
+        LOG.info("Received request");
+        validateBearerToken(input.getHeaders());
+        NotifyDeliveryReceipt deliveryReceipt;
+        try {
+            deliveryReceipt =
+                    new ObjectMapper().readValue(input.getBody(), NotifyDeliveryReceipt.class);
+            if (deliveryReceipt.getNotification_type().equals("sms")) {
+                var countryCode = getCountryCodeFromNumber(deliveryReceipt.getTo());
+                var deliveryStatus = getDeliveryStatus(deliveryReceipt.getStatus());
+                LOG.info(
+                        "SmsDeliveryStatus: {}, NotifyStatus: {}, CountryCode: {}",
+                        deliveryStatus,
+                        deliveryReceipt.getStatus(),
+                        countryCode);
+                cloudwatchMetricsService.incrementCounter(
+                        deliveryStatus,
+                        Map.of(
+                                "CountryCode",
+                                String.valueOf(countryCode),
+                                "Environment",
+                                configurationService.getEnvironment(),
+                                "NotifyStatus",
+                                deliveryReceipt.getStatus()));
+                LOG.info("SMS callback request processed");
+            }
+        } catch (JsonProcessingException e) {
+            LOG.error("Unable to parse Notify Delivery Receipt");
+            throw new RuntimeException("Unable to parse Notify Delivery Receipt");
+        }
+        return null;
+    }
+
+    private void validateBearerToken(Map<String, String> headers) {
+        var notifyCallbackBearerToken = configurationService.getNotifyCallbackBearerToken();
+        if (Objects.isNull(headers.get("Authorization"))
+                || !headers.get("Authorization").startsWith("Bearer ")) {
+            LOG.error("No bearer token in request");
+            throw new RuntimeException("No bearer token in request");
+        }
+        var token = headers.get("Authorization").substring(7);
+        if (!token.equals(notifyCallbackBearerToken)) {
+            LOG.error("Invalid bearer token in request");
+            throw new RuntimeException("Invalid bearer token in request");
+        }
+    }
+
+    private int getCountryCodeFromNumber(String number) {
+        String defaultRegion = null;
+        if (!number.startsWith("+")) {
+            defaultRegion = "GB";
+        }
+        var phoneUtil = PhoneNumberUtil.getInstance();
+        try {
+            return phoneUtil.parse(number, defaultRegion).getCountryCode();
+        } catch (NumberParseException e) {
+            LOG.error("Unable to parse number");
+            throw new RuntimeException("Unable to parse number");
+        }
+    }
+
+    private String getDeliveryStatus(String notifyStatus) {
+        var deliveryStatus = SMS_FAILURE.toString();
+        if (notifyStatus.equals("delivered")) {
+            deliveryStatus = SMS_DELIVERED.toString();
+        }
+        return deliveryStatus;
+    }
+}

--- a/delivery-receipts-api/src/main/resources/log4j2.xml
+++ b/delivery-receipts-api/src/main/resources/log4j2.xml
@@ -1,0 +1,16 @@
+<Configuration status="WARN">
+    <Appenders>
+        <Lambda name="Lambda">
+            <JsonLayout compact="true" eventEol="true" objectMessageAsJsonObject="true" >
+                <KeyValuePair key="session-id" value="$${ctx:sessionId:-unknown}"/>
+            </JsonLayout>
+        </Lambda>
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="Lambda"/>
+        </Root>
+        <Logger name="software.amazon.awssdk" level="WARN" />
+        <Logger name="software.amazon.awssdk.request" level="DEBUG" />
+    </Loggers>
+</Configuration>

--- a/delivery-receipts-api/src/test/java/uk/gov/di/authentication/deliveryreceiptsapi/lambda/NotifyCallbackHandlerTest.java
+++ b/delivery-receipts-api/src/test/java/uk/gov/di/authentication/deliveryreceiptsapi/lambda/NotifyCallbackHandlerTest.java
@@ -1,0 +1,163 @@
+package uk.gov.di.authentication.deliveryreceiptsapi.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import uk.gov.di.authentication.deliveryreceiptsapi.entity.NotifyDeliveryReceipt;
+import uk.gov.di.authentication.shared.helpers.IdGenerator;
+import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.deliveryreceiptsapi.entity.DeliveryMetricStatus.SMS_DELIVERED;
+import static uk.gov.di.authentication.deliveryreceiptsapi.entity.DeliveryMetricStatus.SMS_FAILURE;
+
+class NotifyCallbackHandlerTest {
+
+    private static final String BEARER_TOKEN = "1244656456457657566345";
+    private static final String ENVIRONMENT = "test";
+    private NotifyCallbackHandler handler;
+    private final Context context = mock(Context.class);
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private final CloudwatchMetricsService cloudwatchMetricsService =
+            mock(CloudwatchMetricsService.class);
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setup() {
+        when(configurationService.getNotifyCallbackBearerToken()).thenReturn(BEARER_TOKEN);
+        when(configurationService.getEnvironment()).thenReturn(ENVIRONMENT);
+        handler = new NotifyCallbackHandler(cloudwatchMetricsService, configurationService);
+    }
+
+    private static Stream<Arguments> phoneNumbers() {
+        return Stream.of(
+                Arguments.of("+447316763843", "44", "delivered"),
+                Arguments.of("+4407316763843", "44", "delivered"),
+                Arguments.of("+33645453322", "33", "delivered"),
+                Arguments.of("+330645453322", "33", "delivered"),
+                Arguments.of("+447316763843", "44", "delivered"),
+                Arguments.of("+447316763843", "44", "delivered"),
+                Arguments.of("+33645453322", "33", "delivered"),
+                Arguments.of("+33645453322", "33", "delivered"),
+                Arguments.of("07911123456", "44", "delivered"),
+                Arguments.of("+447316763843", "44", "permanent-failure"),
+                Arguments.of("+4407316763843", "44", "permanent-failure"),
+                Arguments.of("+330645453322", "33", "technical-failure"),
+                Arguments.of("+33645453322", "33", "technical-failure"),
+                Arguments.of("07911123456", "44", "temporary-failure"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("phoneNumbers")
+    void shouldCallCloudwatchMetricServiceWhenSmsReceiptIsReceived(
+            String number, String expectedCountryCode, String status)
+            throws JsonProcessingException {
+        var deliveryReceipt = createDeliveryReceipt(number, status, "sms");
+        var event = new APIGatewayProxyRequestEvent();
+        event.setHeaders(Map.of("Authorization", "Bearer " + BEARER_TOKEN));
+        event.setBody(objectMapper.writeValueAsString(deliveryReceipt));
+        handler.handleRequest(event, context);
+
+        var counterName = SMS_DELIVERED.toString();
+        if (!status.equals("delivered")) {
+            counterName = SMS_FAILURE.toString();
+        }
+
+        verify(cloudwatchMetricsService)
+                .incrementCounter(
+                        counterName,
+                        Map.of(
+                                "CountryCode",
+                                expectedCountryCode,
+                                "Environment",
+                                ENVIRONMENT,
+                                "NotifyStatus",
+                                status));
+    }
+
+    @Test
+    void shouldNotCallCloudwatchMetricWithEmailNotificationType() throws JsonProcessingException {
+        var deliveryReceipt = createDeliveryReceipt("jim@test.com", "delivered", "email");
+        var event = new APIGatewayProxyRequestEvent();
+        event.setHeaders(Map.of("Authorization", "Bearer " + BEARER_TOKEN));
+        event.setBody(objectMapper.writeValueAsString(deliveryReceipt));
+        handler.handleRequest(event, context);
+
+        verifyNoInteractions(cloudwatchMetricsService);
+    }
+
+    @Test
+    void shouldThrowIfBearerTokenIsMissing() {
+        var event = new APIGatewayProxyRequestEvent();
+        event.setHeaders(Collections.emptyMap());
+
+        var exception =
+                assertThrows(
+                        RuntimeException.class,
+                        () -> handler.handleRequest(event, context),
+                        "Expected to throw exception");
+
+        assertThat(exception.getMessage(), equalTo("No bearer token in request"));
+    }
+
+    @Test
+    void shouldThrowIfBearerTokenIsInvalid() {
+        var event = new APIGatewayProxyRequestEvent();
+        event.setHeaders(Map.of("Authorization", "Bearer gfdgfdgfdgdsfgdsf"));
+
+        var exception =
+                assertThrows(
+                        RuntimeException.class,
+                        () -> handler.handleRequest(event, context),
+                        "Expected to throw exception");
+
+        assertThat(exception.getMessage(), equalTo("Invalid bearer token in request"));
+    }
+
+    @Test
+    void shouldThrowIfBearerTokenIsNotPrefixedWithBearer() {
+        var event = new APIGatewayProxyRequestEvent();
+        event.setHeaders(Map.of("Authorization", BEARER_TOKEN));
+
+        var exception =
+                assertThrows(
+                        RuntimeException.class,
+                        () -> handler.handleRequest(event, context),
+                        "Expected to throw exception");
+
+        assertThat(exception.getMessage(), equalTo("No bearer token in request"));
+    }
+
+    private NotifyDeliveryReceipt createDeliveryReceipt(
+            String destination, String status, String notificationType) {
+        return new NotifyDeliveryReceipt(
+                IdGenerator.generate(),
+                null,
+                destination,
+                status,
+                new Date().toString(),
+                new Date().toString(),
+                new Date().toString(),
+                notificationType,
+                IdGenerator.generate(),
+                1);
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,6 +9,7 @@ include 'account-management-integration-tests'
 include 'oidc-api'
 include 'shared'
 include 'shared-test'
+include 'delivery-receipts-api'
 
 rootProject.name = 'di-authentication-api'
 include 'ipv-api'

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -132,6 +132,15 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return Optional.ofNullable(System.getenv("NOTIFY_URL"));
     }
 
+    public String getNotifyCallbackBearerToken() {
+        var request =
+                new GetParameterRequest()
+                        .withWithDecryption(true)
+                        .withName(format("{0}-notify-callback-bearer-token", getEnvironment()));
+
+        return getSsmClient().getParameter(request).getParameter().getValue();
+    }
+
     public Optional<String> getNotifyTestPhoneNumber() {
         return Optional.ofNullable(System.getenv("NOTIFY_TEST_PHONE_NUMBER"));
     }


### PR DESCRIPTION
## What?

**Code changes**
- Create new module for DeliveryReceipts which will contain a lambda which will receive delivery receipts from Notify. We are currently only interested in SMS delivery receipts.
- Validate the bearer access token and parse the response from Notify. We will then send this response to CloudwatchMetrics
- The metric name will either be SMS_FAILURE or SMS_DELIVERED. The country code will be stored in the dimensions so will be accessible

**Terraform changes**
- Create a new terraform directory and create a new API to handle the Notify Delivery Receipts.
- Generate a bearer access token and store that encrypted in parameter store.
- Do not deploy the warmers as it asynchronous and will have little benefit
- Create a new task for deploying the delivery-receipts-api

## Why?
- We want to be able to track success rate of SMS messages sent and identify any areas where there are issues


## TODO 
- Pipeline changes to deploy to Prod 
- Add an Integration test