### PR TITLE
AUTH-1412 - Add override files for integration and production

### DIFF
--- a/ci/tasks/deploy-delivery-receipts-api.yml
+++ b/ci/tasks/deploy-delivery-receipts-api.yml
@@ -36,6 +36,5 @@ run:
         -var "lambda_zip_file=$(ls -1 ../../../../delivery-receipts-api-release/*.zip)" \
         -var "common_state_bucket=${STATE_BUCKET}" \
         -var-file "${DEPLOY_ENVIRONMENT}-overrides.tfvars" \
-        -var-file ${DEPLOY_ENVIRONMENT}-sizing.tfvars \
 
       terraform output --json > ../../../../terraform-outputs/${DEPLOY_ENVIRONMENT}-delivery-receipts-api-terraform-outputs.json

--- a/ci/terraform/delivery-receipts/production-overrides.tfvars
+++ b/ci/terraform/delivery-receipts/production-overrides.tfvars
@@ -1,0 +1,2 @@
+cloudwatch_log_retention = 5
+lambda_min_concurrency   = 25


### PR DESCRIPTION
## What?

- Add override files for integration and production
- Remove the sizing.tfvars from the deploy task as we don't require redis
## Why?

- Required to deploy to integration and prod 
- We will not be deploying to build so do not require a build overrirde files

