### PR TITLE
AUTH-1410: Per user salt for pairwise subject IDs

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoServiceIntegrationTest.java
@@ -1,0 +1,55 @@
+package uk.gov.di.authentication.services;
+
+import com.nimbusds.oauth2.sdk.id.Subject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.DynamoService;
+import uk.gov.di.authentication.sharedtest.extensions.UserStoreExtension;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class DynamoServiceIntegrationTest {
+
+    private static final String TEST_EMAIL = "joe.bloggs@digital.cabinet-office.gov.uk";
+
+    @RegisterExtension
+    protected static final UserStoreExtension userStore = new UserStoreExtension();
+
+    DynamoService dynamoService = new DynamoService(ConfigurationService.getInstance());
+
+    @Test
+    void getOrGenerateSaltShouldReturnNewSaltWhenUserDoesNotHaveOne() {
+        setUpDynamo();
+        UserProfile userProfile =
+                dynamoService.getUserProfileByEmailMaybe(TEST_EMAIL).orElseThrow();
+        byte[] salt = dynamoService.getOrGenerateSalt(userProfile);
+
+        assertThat(salt.length, equalTo(32));
+        assertThat(userProfile.getSalt().array(), equalTo(salt));
+        UserProfile savedProfile =
+                dynamoService.getUserProfileByEmailMaybe(TEST_EMAIL).orElseThrow();
+        assertThat(savedProfile.getSalt().array(), equalTo(salt));
+    }
+
+    @Test
+    void getOrGenerateSaltShouldReturnExistingSaltWhenOneExists() {
+        setUpDynamo();
+        byte[] existingSalt = userStore.addSalt(TEST_EMAIL);
+
+        UserProfile userProfile =
+                dynamoService.getUserProfileByEmailMaybe(TEST_EMAIL).orElseThrow();
+        byte[] salt = dynamoService.getOrGenerateSalt(userProfile);
+
+        assertThat(salt, equalTo(existingSalt));
+        UserProfile savedProfile =
+                dynamoService.getUserProfileByEmailMaybe(TEST_EMAIL).orElseThrow();
+        assertThat(existingSalt, equalTo(savedProfile.getSalt().array()));
+    }
+
+    private void setUpDynamo() {
+        userStore.signUp(TEST_EMAIL, "password-1", new Subject());
+    }
+}

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -146,6 +146,7 @@ public class IPVCallbackHandler
                                 }
                                 Subject pairwiseSubject =
                                         ClientSubjectHelper.getSubject(userProfile, clientRegistry);
+                                dynamoService.updateSalt(userProfile);
                                 String serializedCredential =
                                         ipvTokenService.sendIpvInfoRequest(
                                                 tokenResponse

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -145,8 +145,8 @@ public class IPVCallbackHandler
                                             "IPV TokenResponse was not successful");
                                 }
                                 Subject pairwiseSubject =
-                                        ClientSubjectHelper.getSubject(userProfile, clientRegistry);
-                                dynamoService.updateSalt(userProfile);
+                                        ClientSubjectHelper.getSubject(
+                                                userProfile, clientRegistry, dynamoService);
                                 String serializedCredential =
                                         ipvTokenService.sendIpvInfoRequest(
                                                 tokenResponse

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
@@ -229,6 +229,7 @@ public class TokenHandler
                                             authCodeExchangeData.getEmail());
                             Subject publicSubject =
                                     ClientSubjectHelper.getSubject(userProfile, client);
+                            dynamoService.updateSalt(userProfile);
                             Map<String, Object> additionalTokenClaims = new HashMap<>();
                             if (authRequest.getNonce() != null) {
                                 additionalTokenClaims.put("nonce", authRequest.getNonce());

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
@@ -228,8 +228,8 @@ public class TokenHandler
                                     dynamoService.getUserProfileByEmail(
                                             authCodeExchangeData.getEmail());
                             Subject publicSubject =
-                                    ClientSubjectHelper.getSubject(userProfile, client);
-                            dynamoService.updateSalt(userProfile);
+                                    ClientSubjectHelper.getSubject(
+                                            userProfile, client, dynamoService);
                             Map<String, Object> additionalTokenClaims = new HashMap<>();
                             if (authRequest.getNonce() != null) {
                                 additionalTokenClaims.put("nonce", authRequest.getNonce());

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/UserStoreExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/UserStoreExtension.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import uk.gov.di.authentication.shared.entity.ClientConsent;
 import uk.gov.di.authentication.shared.entity.TermsAndConditions;
+import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.services.DynamoService;
 
 import java.time.LocalDateTime;
@@ -48,6 +49,13 @@ public class UserStoreExtension extends DynamoExtension implements AfterEachCall
         return credentials.getPassword();
     }
 
+    public String getPublicSubjectIdForEmail(String email) {
+        return dynamoService
+                .getUserProfileByEmailMaybe(email)
+                .map(u -> u.getPublicSubjectID())
+                .orElseThrow();
+    }
+
     public Optional<String> getPhoneNumberForUser(String email) {
         return dynamoService.getPhoneNumber(email);
     }
@@ -74,6 +82,12 @@ public class UserStoreExtension extends DynamoExtension implements AfterEachCall
 
     public void setPhoneNumberVerified(String email, boolean isVerified) {
         dynamoService.updatePhoneNumberVerifiedStatus(email, isVerified);
+    }
+
+    public byte[] addSalt(String email) {
+        UserProfile userProfile = dynamoService.getUserProfileByEmailMaybe(email).orElseThrow();
+
+        return dynamoService.getOrGenerateSalt(userProfile);
     }
 
     public Optional<List<ClientConsent>> getUserConsents(String email) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/UserProfile.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/UserProfile.java
@@ -4,6 +4,7 @@ import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBAttribute;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBIndexHashKey;
 
+import java.nio.ByteBuffer;
 import java.util.List;
 
 public class UserProfile {
@@ -19,8 +20,7 @@ public class UserProfile {
     private TermsAndConditions termsAndConditions;
     private String publicSubjectID;
     private String legacySubjectID;
-
-    private String salt;
+    private ByteBuffer salt;
 
     public UserProfile() {}
 
@@ -147,12 +147,17 @@ public class UserProfile {
     }
 
     @DynamoDBAttribute(attributeName = "salt")
-    public String getSalt() {
+    public ByteBuffer getSalt() {
         return salt;
     }
 
-    public UserProfile setSalt(String salt) {
+    public UserProfile setSalt(ByteBuffer salt) {
         this.salt = salt;
+        return this;
+    }
+
+    public UserProfile setSalt(byte[] salt) {
+        this.salt = ByteBuffer.wrap(salt);
         return this;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/UserProfile.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/UserProfile.java
@@ -20,6 +20,8 @@ public class UserProfile {
     private String publicSubjectID;
     private String legacySubjectID;
 
+    private String salt;
+
     public UserProfile() {}
 
     @DynamoDBHashKey(attributeName = "Email")
@@ -141,6 +143,16 @@ public class UserProfile {
 
     public UserProfile setLegacySubjectID(String legacySubjectID) {
         this.legacySubjectID = legacySubjectID;
+        return this;
+    }
+
+    @DynamoDBAttribute(attributeName = "salt")
+    public String getSalt() {
+        return salt;
+    }
+
+    public UserProfile setSalt(String salt) {
+        this.salt = salt;
         return this;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ClientSubjectHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ClientSubjectHelper.java
@@ -6,7 +6,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.UserProfile;
-import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -14,7 +13,6 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
-import java.security.SecureRandomParameters;
 import java.util.NoSuchElementException;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
@@ -33,7 +31,9 @@ public class ClientSubjectHelper {
                     client.getSectorIdentifierUri() != null
                             ? client.getSectorIdentifierUri()
                             : returnHost(client);
-            return new Subject(calculatePairwiseIdentifier(userProfile.getSubjectID(), uri, getUserSalt(userProfile)));
+            return new Subject(
+                    calculatePairwiseIdentifier(
+                            userProfile.getSubjectID(), uri, getUserSalt(userProfile)));
         }
     }
 
@@ -55,7 +55,8 @@ public class ClientSubjectHelper {
         return redirectUri;
     }
 
-    private static String calculatePairwiseIdentifier(String subjectID, String sector, byte[] salt) {
+    private static String calculatePairwiseIdentifier(
+            String subjectID, String sector, byte[] salt) {
         try {
             var md = MessageDigest.getInstance("SHA-256");
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ClientSubjectHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ClientSubjectHelper.java
@@ -1,6 +1,5 @@
 package uk.gov.di.authentication.shared.helpers;
 
-import com.amazonaws.util.Base64;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -14,8 +13,6 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.NoSuchElementException;
-
-import static org.apache.commons.lang3.StringUtils.isBlank;
 
 public class ClientSubjectHelper {
 
@@ -78,15 +75,15 @@ public class ClientSubjectHelper {
     }
 
     private static byte[] getUserSalt(UserProfile userProfile) {
-        if (isBlank(userProfile.getSalt())) {
+        if (userProfile.getSalt() == null || userProfile.getSalt().array().length == 0) {
             userProfile.setSalt(generateNewSalt());
         }
-        return Base64.decode(userProfile.getSalt());
+        return userProfile.getSalt().array();
     }
 
-    private static String generateNewSalt() {
+    private static byte[] generateNewSalt() {
         byte[] salt = new byte[SALT_BYTES];
         SECURE_RANDOM.nextBytes(salt);
-        return Base64.encodeAsString(salt);
+        return salt;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthenticationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthenticationService.java
@@ -58,4 +58,6 @@ public interface AuthenticationService {
     void migrateLegacyPassword(String email, String password);
 
     void bulkAdd(List<UserCredentials> userCredentialsList, List<UserProfile> userProfileList);
+
+    void updateSalt(UserProfile userProfile);
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthenticationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthenticationService.java
@@ -59,5 +59,5 @@ public interface AuthenticationService {
 
     void bulkAdd(List<UserCredentials> userCredentialsList, List<UserProfile> userProfileList);
 
-    void updateSalt(UserProfile userProfile);
+    byte[] getOrGenerateSalt(UserProfile userProfile);
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -246,10 +246,6 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return Integer.parseInt(System.getenv().getOrDefault("WARMER_DELAY", "75"));
     }
 
-    public byte[] getSalt() {
-        return System.getenv().getOrDefault("SALT", "random").getBytes(StandardCharsets.UTF_8);
-    }
-
     public String getAuditHmacSecret() {
         return System.getenv("AUDIT_HMAC_SECRET");
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -12,7 +12,6 @@ import uk.gov.di.authentication.shared.configuration.AuditPublisherConfiguration
 import uk.gov.di.authentication.shared.configuration.BaseLambdaConfiguration;
 
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
@@ -246,6 +246,13 @@ public class DynamoService implements AuthenticationService {
     }
 
     @Override
+    public void updateSalt(UserProfile userProfile) {
+        userProfileMapper.save(
+                getUserProfileFromSubject(userProfile.getSubjectID())
+                        .setSalt(userProfile.getSalt()));
+    }
+
+    @Override
     public Optional<List<ClientConsent>> getUserConsents(String email) {
         return Optional.ofNullable(
                 userProfileMapper

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
@@ -20,6 +20,7 @@ import uk.gov.di.authentication.shared.helpers.Argon2EncoderHelper;
 import uk.gov.di.authentication.shared.helpers.Argon2MatcherHelper;
 import uk.gov.di.authentication.shared.helpers.PhoneNumberHelper;
 
+import java.security.SecureRandom;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.HashMap;
@@ -35,10 +36,14 @@ import static uk.gov.di.authentication.shared.dynamodb.DynamoDBSchemaHelper.Tabl
 
 public class DynamoService implements AuthenticationService {
 
+    private static final int SALT_BYTES = 32;
+
     private final DynamoDBMapper userCredentialsMapper;
     private final DynamoDBMapper userProfileMapper;
     private final AmazonDynamoDB dynamoDB;
     private final DynamoDBSchemaHelper dynamoDBSchemaHelper;
+
+    private final SecureRandom secureRandom = new SecureRandom();
 
     public DynamoService(ConfigurationService configurationService) {
         this(
@@ -246,10 +251,15 @@ public class DynamoService implements AuthenticationService {
     }
 
     @Override
-    public void updateSalt(UserProfile userProfile) {
-        userProfileMapper.save(
-                getUserProfileFromSubject(userProfile.getSubjectID())
-                        .setSalt(userProfile.getSalt()));
+    public byte[] getOrGenerateSalt(UserProfile userProfile) {
+        if (userProfile.getSalt() == null || userProfile.getSalt().array().length == 0) {
+            byte[] salt = generateNewSalt();
+            userProfile.setSalt(salt);
+            userProfileMapper.save(
+                    getUserProfileFromSubject(userProfile.getSubjectID())
+                            .setSalt(userProfile.getSalt()));
+        }
+        return userProfile.getSalt().array();
     }
 
     @Override
@@ -341,5 +351,11 @@ public class DynamoService implements AuthenticationService {
 
     private void warmUp(String tableName) {
         dynamoDB.describeTable(tableName);
+    }
+
+    private byte[] generateNewSalt() {
+        byte[] salt = new byte[SALT_BYTES];
+        secureRandom.nextBytes(salt);
+        return salt;
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ClientSubjectHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ClientSubjectHelperTest.java
@@ -9,6 +9,7 @@ import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.ValidScopes;
 
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
@@ -70,7 +71,7 @@ class ClientSubjectHelperTest {
 
         assertEquals(subject1, subject2);
         assertNotNull(userProfile.getSalt());
-        assertEquals(32, Base64.getDecoder().decode(userProfile.getSalt()).length);
+        assertEquals(32, userProfile.getSalt().array().length);
     }
 
     @Test
@@ -79,7 +80,7 @@ class ClientSubjectHelperTest {
         KeyPair keyPair = generateRsaKeyPair();
         final String SALT_VALUE = "a-pre-existing-salt-value";
         byte[] salt = SALT_VALUE.getBytes(StandardCharsets.UTF_8);
-        UserProfile userProfile = generateUserProfile(Base64.getEncoder().encodeToString(salt));
+        UserProfile userProfile = generateUserProfile(ByteBuffer.wrap(salt));
 
         ClientRegistry clientRegistry1 =
                 generateClientRegistryPairwise(
@@ -92,7 +93,7 @@ class ClientSubjectHelperTest {
         Subject subject2 = ClientSubjectHelper.getSubject(userProfile, clientRegistry2);
 
         assertEquals(subject1, subject2);
-        assertEquals(SALT_VALUE, new String(Base64.getDecoder().decode(userProfile.getSalt())));
+        assertEquals(SALT_VALUE, new String(userProfile.getSalt().array()));
     }
 
     @Test
@@ -142,7 +143,7 @@ class ClientSubjectHelperTest {
         return generateUserProfile(null);
     }
 
-    private UserProfile generateUserProfile(String salt) {
+    private UserProfile generateUserProfile(ByteBuffer salt) {
         Set<String> claims = ValidScopes.getClaimsForListOfScopes(SCOPES.toStringList());
         return new UserProfile()
                 .setEmail(TEST_EMAIL)

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ClientSubjectHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ClientSubjectHelperTest.java
@@ -53,7 +53,8 @@ class ClientSubjectHelperTest {
     }
 
     @Test
-    void shouldReturnSameSubjectIDAndGenerateNewUserSaltForMultipleClientsWithSameSectorWhenUserHasNoSalt() {
+    void
+            shouldReturnSameSubjectIDAndGenerateNewUserSaltForMultipleClientsWithSameSectorWhenUserHasNoSalt() {
         KeyPair keyPair = generateRsaKeyPair();
         UserProfile userProfile = generateUserProfile();
 
@@ -73,7 +74,8 @@ class ClientSubjectHelperTest {
     }
 
     @Test
-    void shouldReturnSameSubjectIDAndKeepExistingUserSaltForMultipleClientsWithSameSectorWhenUserHasPreexistingSalt() {
+    void
+            shouldReturnSameSubjectIDAndKeepExistingUserSaltForMultipleClientsWithSameSectorWhenUserHasPreexistingSalt() {
         KeyPair keyPair = generateRsaKeyPair();
         final String SALT_VALUE = "a-pre-existing-salt-value";
         byte[] salt = SALT_VALUE.getBytes(StandardCharsets.UTF_8);

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ClientSubjectHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ClientSubjectHelperTest.java
@@ -8,8 +8,8 @@ import uk.gov.di.authentication.shared.entity.ClientConsent;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.ValidScopes;
+import uk.gov.di.authentication.shared.services.AuthenticationService;
 
-import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
@@ -22,7 +22,9 @@ import java.util.Set;
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class ClientSubjectHelperTest {
 
@@ -35,8 +37,11 @@ class ClientSubjectHelperTest {
     private static final Scope SCOPES =
             new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL, OIDCScopeValue.OFFLINE_ACCESS);
 
+    private final AuthenticationService authenticationService = mock(AuthenticationService.class);
+
     @Test
     void shouldReturnDifferentSubjectIDForMultipleClientsWithDifferentSectors() {
+        stubAuthenticationService();
         KeyPair keyPair = generateRsaKeyPair();
         UserProfile userProfile = generateUserProfile();
 
@@ -47,15 +52,17 @@ class ClientSubjectHelperTest {
                 generateClientRegistryPairwise(
                         keyPair, "test-client-id-2", "pairwise", "https://not-test.com");
 
-        Subject subject1 = ClientSubjectHelper.getSubject(userProfile, clientRegistry1);
-        Subject subject2 = ClientSubjectHelper.getSubject(userProfile, clientRegistry2);
+        Subject subject1 =
+                ClientSubjectHelper.getSubject(userProfile, clientRegistry1, authenticationService);
+        Subject subject2 =
+                ClientSubjectHelper.getSubject(userProfile, clientRegistry2, authenticationService);
 
         assertNotEquals(subject1, subject2);
     }
 
     @Test
-    void
-            shouldReturnSameSubjectIDAndGenerateNewUserSaltForMultipleClientsWithSameSectorWhenUserHasNoSalt() {
+    void shouldReturnSameSubjectIDForMultipleClientsWithSameSector() {
+        stubAuthenticationService();
         KeyPair keyPair = generateRsaKeyPair();
         UserProfile userProfile = generateUserProfile();
 
@@ -66,34 +73,12 @@ class ClientSubjectHelperTest {
                 generateClientRegistryPairwise(
                         keyPair, "test-client-id-2", "pairwise", "https://test.com");
 
-        Subject subject1 = ClientSubjectHelper.getSubject(userProfile, clientRegistry1);
-        Subject subject2 = ClientSubjectHelper.getSubject(userProfile, clientRegistry2);
+        Subject subject1 =
+                ClientSubjectHelper.getSubject(userProfile, clientRegistry1, authenticationService);
+        Subject subject2 =
+                ClientSubjectHelper.getSubject(userProfile, clientRegistry2, authenticationService);
 
         assertEquals(subject1, subject2);
-        assertNotNull(userProfile.getSalt());
-        assertEquals(32, userProfile.getSalt().array().length);
-    }
-
-    @Test
-    void
-            shouldReturnSameSubjectIDAndKeepExistingUserSaltForMultipleClientsWithSameSectorWhenUserHasPreexistingSalt() {
-        KeyPair keyPair = generateRsaKeyPair();
-        final String SALT_VALUE = "a-pre-existing-salt-value";
-        byte[] salt = SALT_VALUE.getBytes(StandardCharsets.UTF_8);
-        UserProfile userProfile = generateUserProfile(ByteBuffer.wrap(salt));
-
-        ClientRegistry clientRegistry1 =
-                generateClientRegistryPairwise(
-                        keyPair, "test-client-id-1", "pairwise", "https://test.com");
-        ClientRegistry clientRegistry2 =
-                generateClientRegistryPairwise(
-                        keyPair, "test-client-id-2", "pairwise", "https://test.com");
-
-        Subject subject1 = ClientSubjectHelper.getSubject(userProfile, clientRegistry1);
-        Subject subject2 = ClientSubjectHelper.getSubject(userProfile, clientRegistry2);
-
-        assertEquals(subject1, subject2);
-        assertEquals(SALT_VALUE, new String(userProfile.getSalt().array()));
     }
 
     @Test
@@ -108,8 +93,10 @@ class ClientSubjectHelperTest {
                 generateClientRegistryPairwise(
                         keyPair, "test-client-id-2", "public", "https://test.com");
 
-        Subject subject1 = ClientSubjectHelper.getSubject(userProfile, clientRegistry1);
-        Subject subject2 = ClientSubjectHelper.getSubject(userProfile, clientRegistry2);
+        Subject subject1 =
+                ClientSubjectHelper.getSubject(userProfile, clientRegistry1, authenticationService);
+        Subject subject2 =
+                ClientSubjectHelper.getSubject(userProfile, clientRegistry2, authenticationService);
 
         assertEquals(subject1, subject2);
     }
@@ -140,10 +127,6 @@ class ClientSubjectHelperTest {
     }
 
     private UserProfile generateUserProfile() {
-        return generateUserProfile(null);
-    }
-
-    private UserProfile generateUserProfile(ByteBuffer salt) {
         Set<String> claims = ValidScopes.getClaimsForListOfScopes(SCOPES.toStringList());
         return new UserProfile()
                 .setEmail(TEST_EMAIL)
@@ -154,9 +137,13 @@ class ClientSubjectHelperTest {
                 .setCreated(LocalDateTime.now().toString())
                 .setUpdated(LocalDateTime.now().toString())
                 .setPublicSubjectID(PUBLIC_SUBJECT.getValue())
-                .setSalt(salt)
                 .setClientConsent(
                         new ClientConsent(
                                 CLIENT_ID, claims, LocalDateTime.now(ZoneId.of("UTC")).toString()));
+    }
+
+    private void stubAuthenticationService() {
+        when(authenticationService.getOrGenerateSalt(any(UserProfile.class)))
+                .thenReturn("a-test-salt".getBytes(StandardCharsets.UTF_8));
     }
 }


### PR DESCRIPTION
## What?

- Add a `salt` value to the `UserProfile` object
- Use this `salt` when generating the pairwise subject ID rather than system wide salt
- If the user salt is not populated then generate a new random, 32-byte, salt and add to profile.
- Ensure that new salt is saved to user profile once generated
- Add missing integration tests to Token endpoint to prove correct generation of pairwise and public subject IDs
- Add new integration test for `DynamoService` to check that `getOrGenerateSalt()` works correct and stores the correct value in Dynamo

## Why?

We should a per user salt rather than a system wide salt to limit the blast radius should a salt get leaked.
