### PR TITLE
AUTH-1410: Make stub clients use pairwise IDs

### DIFF
--- a/ci/terraform/shared/stub-rp-clients.tf
+++ b/ci/terraform/shared/stub-rp-clients.tf
@@ -67,7 +67,7 @@ resource "aws_dynamodb_table_item" "stub_rp_client" {
       S = "MANDATORY"
     }
     SubjectType = {
-      S = "public"
+      S = "pairwise"
     }
     CookieConsentShared = {
       N = "1"


### PR DESCRIPTION
## What?

- Update stub client registrations to be `pairwise` rather than `public`

## Why?

Clients other than internal clients should be `pairwise` rather than `public`

## Related PRs

#1502 