### PR TITLE
AUTH-1477: Provide opaque signing key id

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenValidationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenValidationService.java
@@ -31,6 +31,8 @@ import java.time.ZoneId;
 import java.util.Date;
 import java.util.List;
 
+import static uk.gov.di.authentication.shared.helpers.HashHelper.hashSha256String;
+
 public class TokenValidationService {
 
     private final ConfigurationService configService;
@@ -114,7 +116,7 @@ public class TokenValidationService {
 
         ECKey jwk =
                 new ECKey.Builder(Curve.P_256, (ECPublicKey) publicKey)
-                        .keyID(configService.getTokenSigningKeyAlias())
+                        .keyID(hashSha256String(publicKeyResult.getKeyId()))
                         .keyUse(KeyUse.SIGNATURE)
                         .algorithm(new Algorithm(JWSAlgorithm.ES256.getName()))
                         .build();


### PR DESCRIPTION
## What?

This makes the public key id provided in the `jwks.json` endpoint opaque rather than the value we get from the cloud provider.

## Why?

The underlying public key might change so providing an alias is no good, and hashing the key id gives a distinct identifier for the actual public key.

