### PR TITLE
AUTH-1410: Grant permission to write salt to user profile

### DIFF
--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -8,6 +8,7 @@ module "ipv_callback_role" {
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.dynamo_user_read_access_policy.arn,
+    aws_iam_policy.dynamo_user_write_access_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
   ]

--- a/ci/terraform/oidc/token.tf
+++ b/ci/terraform/oidc/token.tf
@@ -8,6 +8,7 @@ module "oidc_token_role" {
     aws_iam_policy.oidc_token_kms_signing_policy.arn,
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
     aws_iam_policy.dynamo_user_read_access_policy.arn,
+    aws_iam_policy.dynamo_user_write_access_policy.arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn
   ]


### PR DESCRIPTION
## What?

- Add write permissions to user profile table to `token` and `ipv-callback` endpoints.

## Why?

The token endpoint is failing as it can't write the `salt` field to the user profile table.

## Related PRs

#1502 