### PR TITLE
AUTH-1177: Use opaque id in signed token headers rather than alias

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/JwksIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/JwksIntegrationTest.java
@@ -28,7 +28,7 @@ public class JwksIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var response = makeRequest(Optional.empty(), Map.of(), Map.of());
 
         assertThat(response, hasStatus(200));
-        assertThat(JWKSet.parse(response.getBody()).getKeys(), hasSize(1));
+        assertThat(JWKSet.parse(response.getBody()).getKeys(), hasSize(2));
 
         assertNoAuditEventsReceived(auditTopic);
     }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenValidationServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenValidationServiceTest.java
@@ -133,7 +133,7 @@ class TokenValidationServiceTest {
 
         when(kmsConnectionService.getPublicKey(any(GetPublicKeyRequest.class))).thenReturn(result);
 
-        JWK publicKeyJwk = tokenValidationService.getPublicJwk();
+        JWK publicKeyJwk = tokenValidationService.getPublicJwkWithOpaqueId();
 
         assertEquals(publicKeyJwk.getKeyID(), HASHED_KEY_ID);
         assertEquals(publicKeyJwk.getAlgorithm(), JWSAlgorithm.ES256);


### PR DESCRIPTION
## What?

Attach opaque id to signed tokens rather than internal name

## Why?

This fixes a regression with a previous PR
