### PR TITLE
AUTH-1412 - Return Void from the NotifyCallbackHandler

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Run Unit Tests
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew --parallel test jacocoTestReport -x integration-tests:test -x account-management-integration-tests:test -x spotlessApply -x spotlessCheck
+        run: ./gradlew --parallel test jacocoTestReport -x integration-tests:test -x account-management-integration-tests:test -x delivery-receipts-integration-tests:test -x spotlessApply -x spotlessCheck
       - name: Upload Unit Test Reports
         uses: actions/upload-artifact@v2
         if: failure()
@@ -80,6 +80,7 @@ jobs:
             */build/reports/
             !integration-tests/build/reports/
             !account-management-integration-tests/build/reports/
+            !delivery-receipts-integration-tests/build/reports/
 
           retention-days: 5
       - name: Cache Unit Test Reports
@@ -93,6 +94,8 @@ jobs:
             !integration-tests/build/reports/
             !account-management-integration-tests/build/jacoco/
             !account-management-integration-tests/build/reports/
+            !delivery-receipts-integration-tests/build/jacoco/
+            !delivery-receipts-integration-tests/build/reports/
 
   run-integration-tests:
     runs-on: ubuntu-latest
@@ -161,13 +164,23 @@ jobs:
           retention-days: 5
       - name: Run Account Management Integration Tests
         run: |
-          ./gradlew :account-management-integration-tests:test :integration-tests:jacocoTestReport -x spotlessApply -x spotlessCheck -x composeUp
+          ./gradlew :account-management-integration-tests:test :account-management-integration-tests:jacocoTestReport -x spotlessApply -x spotlessCheck -x composeUp
       - name: Upload Account Management Integration Test Reports
         uses: actions/upload-artifact@v2
         if: failure()
         with:
           name: account-management-integration-test-reports
           path: account-management-integration-tests/build/reports/tests/test/
+          retention-days: 5
+      - name: Run Delivery Receipts Integration Tests
+        run: |
+          ./gradlew :delivery-receipts-integration-tests:test :delivery-receipts-integration-tests:jacocoTestReport -x spotlessApply -x spotlessCheck -x composeUp
+      - name: Upload Account Management Integration Test Reports
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: delivery-receipts-integration-test-reports
+          path: delivery-receipts-integration-tests/build/reports/tests/test/
           retention-days: 5
       - name: Cache Test Reports
         uses: actions/cache@v2
@@ -178,6 +191,8 @@ jobs:
             integration-tests/build/reports/
             account-management-integration-tests/build/jacoco/
             account-management-integration-tests/build/reports/
+            delivery-receipts-integration-tests/build/jacoco/
+            delivery--receipts-integration-tests/build/reports/
 
   run-sonar-analysis:
     runs-on: ubuntu-latest
@@ -213,6 +228,8 @@ jobs:
             !integration-tests/build/reports/
             !account-management-integration-tests/build/jacoco/
             !account-management-integration-tests/build/reports/
+            !delivery-receipts-integration-tests/build/jacoco/
+            !delivery-receipts-integration-tests/build/reports/
       - name: Cache Test Reports
         uses: actions/cache@v2
         with:
@@ -222,6 +239,8 @@ jobs:
             integration-tests/build/reports/
             account-management-integration-tests/build/jacoco/
             account-management-integration-tests/build/reports/
+            delivery-receipts-integration-tests/build/jacoco/
+            delivery-receipts-integration-tests/build/reports/
       - name: Run SonarCloud Analysis
         if: ${{ github.actor != 'dependabot[bot]' }}
         env:

--- a/delivery-receipts-api/src/main/java/uk/gov/di/authentication/deliveryreceiptsapi/lambda/NotifyCallbackHandler.java
+++ b/delivery-receipts-api/src/main/java/uk/gov/di/authentication/deliveryreceiptsapi/lambda/NotifyCallbackHandler.java
@@ -3,7 +3,6 @@ package uk.gov.di.authentication.deliveryreceiptsapi.lambda;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
-import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.i18n.phonenumbers.NumberParseException;
@@ -20,8 +19,7 @@ import java.util.Objects;
 import static uk.gov.di.authentication.deliveryreceiptsapi.entity.DeliveryMetricStatus.SMS_DELIVERED;
 import static uk.gov.di.authentication.deliveryreceiptsapi.entity.DeliveryMetricStatus.SMS_FAILURE;
 
-public class NotifyCallbackHandler
-        implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+public class NotifyCallbackHandler implements RequestHandler<APIGatewayProxyRequestEvent, Void> {
 
     private static final String AUTHORIZATION_HEADER = "Authorization";
     private final ConfigurationService configurationService;
@@ -45,8 +43,7 @@ public class NotifyCallbackHandler
     }
 
     @Override
-    public APIGatewayProxyResponseEvent handleRequest(
-            APIGatewayProxyRequestEvent input, Context context) {
+    public Void handleRequest(APIGatewayProxyRequestEvent input, Context context) {
         LOG.info("Received request");
         validateBearerToken(input.getHeaders());
         NotifyDeliveryReceipt deliveryReceipt;

--- a/delivery-receipts-api/src/test/java/uk/gov/di/authentication/deliveryreceiptsapi/lambda/NotifyCallbackHandlerTest.java
+++ b/delivery-receipts-api/src/test/java/uk/gov/di/authentication/deliveryreceiptsapi/lambda/NotifyCallbackHandlerTest.java
@@ -115,6 +115,7 @@ class NotifyCallbackHandlerTest {
                         () -> handler.handleRequest(event, context),
                         "Expected to throw exception");
 
+        verifyNoInteractions(cloudwatchMetricsService);
         assertThat(exception.getMessage(), equalTo("No bearer token in request"));
     }
 
@@ -129,6 +130,7 @@ class NotifyCallbackHandlerTest {
                         () -> handler.handleRequest(event, context),
                         "Expected to throw exception");
 
+        verifyNoInteractions(cloudwatchMetricsService);
         assertThat(exception.getMessage(), equalTo("Invalid bearer token in request"));
     }
 
@@ -143,6 +145,7 @@ class NotifyCallbackHandlerTest {
                         () -> handler.handleRequest(event, context),
                         "Expected to throw exception");
 
+        verifyNoInteractions(cloudwatchMetricsService);
         assertThat(exception.getMessage(), equalTo("No bearer token in request"));
     }
 

--- a/delivery-receipts-integration-tests/build.gradle
+++ b/delivery-receipts-integration-tests/build.gradle
@@ -1,0 +1,54 @@
+plugins {
+    id "java"
+    id "jacoco"
+}
+
+group "uk.gov.di"
+version "unspecified"
+
+dependencies {
+    testImplementation configurations.nimbus,
+            configurations.glassfish,
+            configurations.tests,
+            configurations.lambda,
+            configurations.lettuce,
+            project(":delivery-receipts-api"),
+            project(":shared"),
+            project(":shared-test")
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${dependencyVersions.junit}"
+}
+
+test {
+    useJUnitPlatform()
+    filter {
+        includeTestsMatching "*"
+    }
+
+    environment "AWS_ACCESS_KEY_ID", "mock-access-key"
+    environment "AWS_REGION", "eu-west-2"
+    environment "AWS_SECRET_ACCESS_KEY", "mock-secret-key "
+    environment "ENVIRONMENT", "local"
+    environment "HEADERS_CASE_INSENSITIVE", "true"
+    environment "LOCALSTACK_ENDPOINT", "http://localhost:45678"
+
+    testLogging {
+        showStandardStreams = false
+    }
+
+    doLast {
+        tasks.getByName("jacocoTestReport").sourceDirectories.from(
+                project(":account-management-api").sourceSets.main.java,
+                project(":shared").sourceSets.main.java)
+
+        tasks.getByName("jacocoTestReport").classDirectories.from(
+                project(":account-management-api").sourceSets.main.output,
+                project(":shared").sourceSets.main.output)
+    }
+    dependsOn ":composeUp"
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled true
+    }
+}

--- a/delivery-receipts-integration-tests/src/test/java/uk/gov/di/deliveryreceipts/NotifyCallbackHandlerIntegrationTest.java
+++ b/delivery-receipts-integration-tests/src/test/java/uk/gov/di/deliveryreceipts/NotifyCallbackHandlerIntegrationTest.java
@@ -1,0 +1,80 @@
+package uk.gov.di.deliveryreceipts;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.di.authentication.deliveryreceiptsapi.entity.DeliveryMetricStatus;
+import uk.gov.di.authentication.deliveryreceiptsapi.entity.NotifyDeliveryReceipt;
+import uk.gov.di.authentication.deliveryreceiptsapi.lambda.NotifyCallbackHandler;
+import uk.gov.di.authentication.shared.helpers.IdGenerator;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.sharedtest.extensions.CloudwatchMetricsExtension;
+import uk.gov.di.authentication.sharedtest.extensions.ParameterStoreExtension;
+
+import java.util.Date;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.mock;
+
+public class NotifyCallbackHandlerIntegrationTest {
+
+    private static final String BEARER_TOKEN = "notify-test-@bearer-token";
+    private final Context context = mock(Context.class);
+    private NotifyCallbackHandler handler;
+
+    @RegisterExtension
+    private static final CloudwatchMetricsExtension cloudwatchMetrics =
+            new CloudwatchMetricsExtension();
+
+    @RegisterExtension
+    private static final ParameterStoreExtension configurationParameters =
+            new ParameterStoreExtension(Map.of("local-notify-callback-bearer-token", BEARER_TOKEN));
+
+    @BeforeEach
+    void setup() {
+        handler = new NotifyCallbackHandler(new ConfigurationService());
+    }
+
+    @Test
+    void shouldAddToCloudwatchWhenSmsDeliveryReceiptIsReceived() {
+        makeRequest(
+                new NotifyDeliveryReceipt(
+                        IdGenerator.generate(),
+                        null,
+                        "+447316763843",
+                        "delivered",
+                        new Date().toString(),
+                        new Date().toString(),
+                        new Date().toString(),
+                        "sms",
+                        IdGenerator.generate(),
+                        1),
+                Map.of("Authorization", "Bearer " + BEARER_TOKEN));
+
+        assertThat(
+                cloudwatchMetrics.getLastValue(DeliveryMetricStatus.SMS_DELIVERED.toString()),
+                is(1.0));
+    }
+
+    private void makeRequest(NotifyDeliveryReceipt body, Map<String, String> headers) {
+        var request = new APIGatewayProxyRequestEvent();
+        request.withHeaders(headers)
+                .withRequestContext(
+                        new APIGatewayProxyRequestEvent.ProxyRequestContext()
+                                .withRequestId(UUID.randomUUID().toString()));
+
+        try {
+            request.withBody(new ObjectMapper().writeValueAsString(body));
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Could not serialise test body", e);
+        }
+        handler.handleRequest(request, context);
+    }
+}

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -39,7 +39,7 @@ startup() {
 
 run-integration-tests() {
   run_integration_tests_start_seconds=$SECONDS
-  ./gradlew :integration-tests:test :account-management-integration-tests:test :composeDownForced
+  ./gradlew :integration-tests:test :account-management-integration-tests:test :delivery-receipts-integration-tests:test :composeDownForced
   EXIT_CODE=$?
   record_timings "run-integration-tests" $run_integration_tests_start_seconds $SECONDS false
   return ${EXIT_CODE}

--- a/settings.gradle
+++ b/settings.gradle
@@ -13,4 +13,5 @@ include 'delivery-receipts-api'
 
 rootProject.name = 'di-authentication-api'
 include 'ipv-api'
+include 'delivery-receipts-integration-tests'
 


### PR DESCRIPTION
## What?

- Return Void from the NotifyCallbackHandler
- Add Integration tests for the NotifyCallbackHandler

## Why?

- The NotifyCallbackHandler is asynchronous and therefore the return type can be Void. This is to prevent the Malformed Lambda proxy response showing in the logs
- To increase test coverage
