### PR TITLE
AUTH-1412 - Return a formatted APIGatewayProxyResponseEvent to silence the errors

### DIFF
--- a/delivery-receipts-api/src/main/java/uk/gov/di/authentication/deliveryreceiptsapi/lambda/NotifyCallbackHandler.java
+++ b/delivery-receipts-api/src/main/java/uk/gov/di/authentication/deliveryreceiptsapi/lambda/NotifyCallbackHandler.java
@@ -3,6 +3,7 @@ package uk.gov.di.authentication.deliveryreceiptsapi.lambda;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.i18n.phonenumbers.NumberParseException;
@@ -18,8 +19,10 @@ import java.util.Objects;
 
 import static uk.gov.di.authentication.deliveryreceiptsapi.entity.DeliveryMetricStatus.SMS_DELIVERED;
 import static uk.gov.di.authentication.deliveryreceiptsapi.entity.DeliveryMetricStatus.SMS_FAILURE;
+import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateEmptySuccessApiGatewayResponse;
 
-public class NotifyCallbackHandler implements RequestHandler<APIGatewayProxyRequestEvent, Void> {
+public class NotifyCallbackHandler
+        implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     private static final String AUTHORIZATION_HEADER = "Authorization";
     private final ConfigurationService configurationService;
@@ -43,7 +46,8 @@ public class NotifyCallbackHandler implements RequestHandler<APIGatewayProxyRequ
     }
 
     @Override
-    public Void handleRequest(APIGatewayProxyRequestEvent input, Context context) {
+    public APIGatewayProxyResponseEvent handleRequest(
+            APIGatewayProxyRequestEvent input, Context context) {
         LOG.info("Received request");
         validateBearerToken(input.getHeaders());
         NotifyDeliveryReceipt deliveryReceipt;
@@ -73,7 +77,7 @@ public class NotifyCallbackHandler implements RequestHandler<APIGatewayProxyRequ
             LOG.error("Unable to parse Notify Delivery Receipt");
             throw new RuntimeException("Unable to parse Notify Delivery Receipt");
         }
-        return null;
+        return generateEmptySuccessApiGatewayResponse();
     }
 
     private void validateBearerToken(Map<String, String> headers) {

--- a/delivery-receipts-api/src/test/java/uk/gov/di/authentication/deliveryreceiptsapi/lambda/NotifyCallbackHandlerTest.java
+++ b/delivery-receipts-api/src/test/java/uk/gov/di/authentication/deliveryreceiptsapi/lambda/NotifyCallbackHandlerTest.java
@@ -2,6 +2,7 @@ package uk.gov.di.authentication.deliveryreceiptsapi.lambda;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,6 +29,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.deliveryreceiptsapi.entity.DeliveryMetricStatus.SMS_DELIVERED;
 import static uk.gov.di.authentication.deliveryreceiptsapi.entity.DeliveryMetricStatus.SMS_FAILURE;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 class NotifyCallbackHandlerTest {
 
@@ -74,7 +76,7 @@ class NotifyCallbackHandlerTest {
         var event = new APIGatewayProxyRequestEvent();
         event.setHeaders(Map.of("Authorization", "Bearer " + BEARER_TOKEN));
         event.setBody(objectMapper.writeValueAsString(deliveryReceipt));
-        handler.handleRequest(event, context);
+        APIGatewayProxyResponseEvent response = handler.handleRequest(event, context);
 
         var counterName = SMS_DELIVERED.toString();
         if (!status.equals("delivered")) {
@@ -91,6 +93,8 @@ class NotifyCallbackHandlerTest {
                                 ENVIRONMENT,
                                 "NotifyStatus",
                                 status));
+
+        assertThat(response, hasStatus(204));
     }
 
     @Test


### PR DESCRIPTION
## What?

 Return a formatted APIGatewayProxyResponseEvent to silence the errors

## Why?

- We are still seeing Malformed Lambda proxy response in the logs. It seems the best way to silence these is to return a formatted APIGatewayProxyResponseEvent response.
