### PR TITLE
BAU: Metrics tweaks

### DIFF
--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -215,7 +215,8 @@ class VerifyCodeHandlerTest {
                         pair("notification-type", VERIFY_PHONE_NUMBER.name()));
 
         verify(cloudwatchMetricsService)
-                .incrementCounter("SignUpSuccess", Map.of("Environment", "unit-test"));
+                .incrementCounter(
+                        "NewAccount", Map.of("Environment", "unit-test", "Client", "client-id"));
     }
 
     @Test

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
@@ -143,7 +143,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         assertThat(response, hasStatus(204));
         assertEventTypesReceived(auditTopic, List.of(CODE_VERIFIED));
 
-        assertThat(cloudwatchMetrics.getLastValue("SignUpSuccess"), is(1.0));
+        assertThat(cloudwatchMetrics.getLastValue("NewAccount"), is(1.0));
     }
 
     @Test

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -36,6 +36,7 @@ import java.util.Objects;
 
 import static java.util.Objects.isNull;
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.CLIENT_SESSION_ID_HEADER;
+import static uk.gov.di.authentication.shared.entity.Session.AccountState.EXISTING;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.CLIENT_SESSION_ID;
@@ -192,7 +193,8 @@ public class AuthCodeHandler
                                                 "Client",
                                                 authenticationRequest.getClientID().getValue()));
 
-                                sessionService.save(session.setAuthenticated(true));
+                                sessionService.save(
+                                        session.setAuthenticated(true).setNewAccount(EXISTING));
 
                                 auditService.submitAuditEvent(
                                         OidcAuditableEvent.AUTH_CODE_ISSUED,


### PR DESCRIPTION
- Only publish "NewAccount" when phone code is verified
- Update session state to "EXISTING" once "NEW" account has sent an auth code at least once

