### PR TITLE
AUTH-1366 - Make support links consistent

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/NotificationHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/NotificationHandler.java
@@ -67,7 +67,9 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                             emailPersonalisation.put("validation-code", notifyRequest.getCode());
                             emailPersonalisation.put(
                                     "email-address", notifyRequest.getDestination());
-                            emailPersonalisation.put("contact-us-link", buildContactUsUrl());
+                            emailPersonalisation.put(
+                                    "contact-us-link",
+                                    buildContactUsUrl("confirmEmailAddressEmail"));
                             LOG.info("Sending VERIFY_EMAIL email using Notify");
                             notificationService.sendEmail(
                                     notifyRequest.getDestination(),
@@ -92,6 +94,9 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                             emailUpdatePersonalisation.put(
                                     "email-address", notifyRequest.getDestination());
                             emailUpdatePersonalisation.put(
+                                    "contact-us-link",
+                                    buildContactUsUrl("emailAddressUpdatedEmail"));
+                            emailUpdatePersonalisation.put(
                                     "customer-support-link",
                                     buildURI(
                                                     configurationService.getFrontendBaseUrl(),
@@ -110,6 +115,8 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                             LOG.info("Sending DELETE_ACCOUNT email using Notify");
                             Map<String, Object> accountDeletedPersonalisation = new HashMap<>();
                             accountDeletedPersonalisation.put(
+                                    "contact-us-link", buildContactUsUrl("accountDeletedEmail"));
+                            accountDeletedPersonalisation.put(
                                     "customer-support-link",
                                     buildURI(
                                                     configurationService.getFrontendBaseUrl(),
@@ -127,6 +134,9 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                             LOG.info("Sending PHONE_NUMBER_UPDATED email using Notify");
                             Map<String, Object> phoneNumberUpdatedPersonalisation = new HashMap<>();
                             phoneNumberUpdatedPersonalisation.put(
+                                    "contact-us-link",
+                                    buildContactUsUrl("phoneNumberUpdatedEmail"));
+                            phoneNumberUpdatedPersonalisation.put(
                                     "customer-support-link",
                                     buildURI(
                                                     configurationService.getFrontendBaseUrl(),
@@ -143,6 +153,8 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                         case PASSWORD_UPDATED:
                             LOG.info("Sending PASSWORD_UPDATED email using Notify");
                             Map<String, Object> passwordUpdatedPersonalisation = new HashMap<>();
+                            passwordUpdatedPersonalisation.put(
+                                    "contact-us-link", buildContactUsUrl("passwordUpdatedEmail"));
                             passwordUpdatedPersonalisation.put(
                                     "customer-support-link",
                                     buildURI(
@@ -175,10 +187,12 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
         return null;
     }
 
-    private String buildContactUsUrl() {
+    private String buildContactUsUrl(String referer) {
+        var queryParam = Map.of("referer", referer);
         return buildURI(
                         configurationService.getFrontendBaseUrl(),
-                        configurationService.getContactUsLinkRoute())
+                        configurationService.getContactUsLinkRoute(),
+                        queryParam)
                 .toString();
     }
 }

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/NotificationHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/NotificationHandlerTest.java
@@ -38,7 +38,6 @@ public class NotificationHandlerTest {
     private static final String CUSTOMER_SUPPORT_LINK_URL =
             "https://localhost:8080/frontend/support";
     private static final String CUSTOMER_SUPPORT_LINK_ROUTE = "support";
-    private static final String CONTACT_US_LINK_URL = "https://localhost:8080/frontend/contact-us";
     private static final String CONTACT_US_LINK_ROUTE = "contact-us";
     private final Context context = mock(Context.class);
     private final NotificationService notificationService = mock(NotificationService.class);
@@ -48,6 +47,9 @@ public class NotificationHandlerTest {
 
     @BeforeEach
     public void setUp() {
+        when(configService.getFrontendBaseUrl()).thenReturn(FRONTEND_BASE_URL);
+        when(configService.getContactUsLinkRoute()).thenReturn(CONTACT_US_LINK_ROUTE);
+        when(configService.getCustomerSupportLinkRoute()).thenReturn(CUSTOMER_SUPPORT_LINK_ROUTE);
         handler = new NotificationHandler(notificationService, configService);
     }
 
@@ -55,10 +57,10 @@ public class NotificationHandlerTest {
     public void shouldSuccessfullyProcessVerifyEmailMessageFromSQSQueue()
             throws JsonProcessingException, NotificationClientException {
         when(notificationService.getNotificationTemplateId(VERIFY_EMAIL)).thenReturn(TEMPLATE_ID);
-        when(configService.getFrontendBaseUrl()).thenReturn(FRONTEND_BASE_URL);
-        when(configService.getContactUsLinkRoute()).thenReturn(CONTACT_US_LINK_ROUTE);
 
         NotifyRequest notifyRequest = new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL, "654321");
+        var contactUsLinkUrl =
+                "https://localhost:8080/frontend/contact-us?referer=confirmEmailAddressEmail";
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
 
@@ -67,7 +69,7 @@ public class NotificationHandlerTest {
         Map<String, Object> personalisation = new HashMap<>();
         personalisation.put("validation-code", "654321");
         personalisation.put("email-address", notifyRequest.getDestination());
-        personalisation.put("contact-us-link", CONTACT_US_LINK_URL);
+        personalisation.put("contact-us-link", contactUsLinkUrl);
 
         verify(notificationService).sendEmail(TEST_EMAIL_ADDRESS, personalisation, TEMPLATE_ID);
     }
@@ -95,10 +97,10 @@ public class NotificationHandlerTest {
     public void shouldSuccessfullyProcessUpdateEmailMessageFromSQSQueue()
             throws JsonProcessingException, NotificationClientException {
         when(notificationService.getNotificationTemplateId(EMAIL_UPDATED)).thenReturn(TEMPLATE_ID);
-        when(configService.getFrontendBaseUrl()).thenReturn(FRONTEND_BASE_URL);
-        when(configService.getCustomerSupportLinkRoute()).thenReturn(CUSTOMER_SUPPORT_LINK_ROUTE);
 
         NotifyRequest notifyRequest = new NotifyRequest(TEST_EMAIL_ADDRESS, EMAIL_UPDATED);
+        var contactUsLinkUrl =
+                "https://localhost:8080/frontend/contact-us?referer=emailAddressUpdatedEmail";
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
 
@@ -107,6 +109,7 @@ public class NotificationHandlerTest {
         Map<String, Object> personalisation = new HashMap<>();
         personalisation.put("email-address", notifyRequest.getDestination());
         personalisation.put("customer-support-link", CUSTOMER_SUPPORT_LINK_URL);
+        personalisation.put("contact-us-link", contactUsLinkUrl);
 
         verify(notificationService).sendEmail(TEST_EMAIL_ADDRESS, personalisation, TEMPLATE_ID);
     }
@@ -116,10 +119,10 @@ public class NotificationHandlerTest {
             throws JsonProcessingException, NotificationClientException {
         when(notificationService.getNotificationTemplateId(PASSWORD_UPDATED))
                 .thenReturn(TEMPLATE_ID);
-        when(configService.getFrontendBaseUrl()).thenReturn(FRONTEND_BASE_URL);
-        when(configService.getCustomerSupportLinkRoute()).thenReturn(CUSTOMER_SUPPORT_LINK_ROUTE);
 
         NotifyRequest notifyRequest = new NotifyRequest(TEST_EMAIL_ADDRESS, PASSWORD_UPDATED);
+        var contactUsLinkUrl =
+                "https://localhost:8080/frontend/contact-us?referer=passwordUpdatedEmail";
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
 
@@ -127,6 +130,7 @@ public class NotificationHandlerTest {
 
         Map<String, Object> personalisation = new HashMap<>();
         personalisation.put("customer-support-link", CUSTOMER_SUPPORT_LINK_URL);
+        personalisation.put("contact-us-link", contactUsLinkUrl);
 
         verify(notificationService).sendEmail(TEST_EMAIL_ADDRESS, personalisation, TEMPLATE_ID);
     }
@@ -136,16 +140,17 @@ public class NotificationHandlerTest {
             throws JsonProcessingException, NotificationClientException {
         when(notificationService.getNotificationTemplateId(PHONE_NUMBER_UPDATED))
                 .thenReturn(TEMPLATE_ID);
-        when(configService.getFrontendBaseUrl()).thenReturn(FRONTEND_BASE_URL);
-        when(configService.getCustomerSupportLinkRoute()).thenReturn(CUSTOMER_SUPPORT_LINK_ROUTE);
 
         NotifyRequest notifyRequest = new NotifyRequest(TEST_EMAIL_ADDRESS, PHONE_NUMBER_UPDATED);
+        var contactUsLinkUrl =
+                "https://localhost:8080/frontend/contact-us?referer=phoneNumberUpdatedEmail";
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
 
         handler.handleRequest(sqsEvent, context);
 
         Map<String, Object> personalisation = new HashMap<>();
+        personalisation.put("contact-us-link", contactUsLinkUrl);
         personalisation.put("customer-support-link", CUSTOMER_SUPPORT_LINK_URL);
 
         verify(notificationService).sendEmail(TEST_EMAIL_ADDRESS, personalisation, TEMPLATE_ID);
@@ -155,10 +160,10 @@ public class NotificationHandlerTest {
     public void shouldSuccessfullyProcessDeleteAccountMessageFromSQSQueue()
             throws JsonProcessingException, NotificationClientException {
         when(notificationService.getNotificationTemplateId(DELETE_ACCOUNT)).thenReturn(TEMPLATE_ID);
-        when(configService.getFrontendBaseUrl()).thenReturn(FRONTEND_BASE_URL);
-        when(configService.getCustomerSupportLinkRoute()).thenReturn(CUSTOMER_SUPPORT_LINK_ROUTE);
 
         NotifyRequest notifyRequest = new NotifyRequest(TEST_EMAIL_ADDRESS, DELETE_ACCOUNT);
+        var contactUsLinkUrl =
+                "https://localhost:8080/frontend/contact-us?referer=accountDeletedEmail";
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
 
@@ -166,6 +171,7 @@ public class NotificationHandlerTest {
 
         Map<String, Object> personalisation = new HashMap<>();
         personalisation.put("customer-support-link", CUSTOMER_SUPPORT_LINK_URL);
+        personalisation.put("contact-us-link", contactUsLinkUrl);
 
         verify(notificationService).sendEmail(TEST_EMAIL_ADDRESS, personalisation, TEMPLATE_ID);
     }
@@ -188,17 +194,17 @@ public class NotificationHandlerTest {
     public void shouldThrowExceptionIfNotifyIsUnableToSendEmail()
             throws JsonProcessingException, NotificationClientException {
         when(notificationService.getNotificationTemplateId(VERIFY_EMAIL)).thenReturn(TEMPLATE_ID);
-        when(configService.getFrontendBaseUrl()).thenReturn(FRONTEND_BASE_URL);
-        when(configService.getContactUsLinkRoute()).thenReturn(CONTACT_US_LINK_ROUTE);
 
         NotifyRequest notifyRequest = new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL, "654321");
+        var contactUsLinkUrl =
+                "https://localhost:8080/frontend/contact-us?referer=confirmEmailAddressEmail";
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
 
         Map<String, Object> personalisation = new HashMap<>();
         personalisation.put("validation-code", "654321");
         personalisation.put("email-address", notifyRequest.getDestination());
-        personalisation.put("contact-us-link", CONTACT_US_LINK_URL);
+        personalisation.put("contact-us-link", contactUsLinkUrl);
 
         Mockito.doThrow(NotificationClientException.class)
                 .when(notificationService)

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/queuehandlers/NotificationHandlerIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/queuehandlers/NotificationHandlerIntegrationTest.java
@@ -42,6 +42,12 @@ public class NotificationHandlerIntegrationTest extends NotifyIntegrationTest {
         assertThat(
                 personalisation, hasFieldWithValue("email-address", equalTo(TEST_EMAIL_ADDRESS)));
         assertThat(personalisation, hasFieldWithValue("validation-code", equalTo(CODE)));
+        assertThat(
+                personalisation,
+                hasFieldWithValue(
+                        "contact-us-link",
+                        equalTo(
+                                "http://localhost:3000/frontend/contact-us?referer=confirmEmailAddressEmail")));
     }
 
     @Test

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandler.java
@@ -76,7 +76,8 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                 try {
                     switch (notifyRequest.getNotificationType()) {
                         case ACCOUNT_CREATED_CONFIRMATION:
-                            notifyPersonalisation.put("contact-us-link", buildContactUsUrl());
+                            notifyPersonalisation.put(
+                                    "contact-us-link", buildContactUsUrl("accountCreatedEmail"));
                             notificationService.sendEmail(
                                     notifyRequest.getDestination(),
                                     notifyPersonalisation,
@@ -86,7 +87,9 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                             notifyPersonalisation.put("validation-code", notifyRequest.getCode());
                             notifyPersonalisation.put(
                                     "email-address", notifyRequest.getDestination());
-                            notifyPersonalisation.put("contact-us-link", buildContactUsUrl());
+                            notifyPersonalisation.put(
+                                    "contact-us-link",
+                                    buildContactUsUrl("confirmEmailAddressEmail"));
                             notificationService.sendEmail(
                                     notifyRequest.getDestination(),
                                     notifyPersonalisation,
@@ -107,7 +110,9 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                         case RESET_PASSWORD:
                             notifyPersonalisation.put(
                                     "reset-password-link", notifyRequest.getCode());
-                            notifyPersonalisation.put("contact-us-link", buildContactUsUrl());
+                            notifyPersonalisation.put(
+                                    "contact-us-link",
+                                    buildContactUsUrl("passwordResetRequestEmail"));
                             notificationService.sendEmail(
                                     notifyRequest.getDestination(),
                                     notifyPersonalisation,
@@ -118,6 +123,9 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                                     new HashMap<>();
                             passwordResetConfirmationPersonalisation.put(
                                     "customer-support-link", buildCustomerSupportUrl());
+                            passwordResetConfirmationPersonalisation.put(
+                                    "contact-us-link",
+                                    buildContactUsUrl("passwordResetConfirmationEmail"));
                             notificationService.sendEmail(
                                     notifyRequest.getDestination(),
                                     passwordResetConfirmationPersonalisation,
@@ -151,10 +159,12 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                 .toString();
     }
 
-    private String buildContactUsUrl() {
+    private String buildContactUsUrl(String referer) {
+        var queryParam = Map.of("referer", referer);
         return buildURI(
                         configurationService.getFrontendBaseUrl(),
-                        configurationService.getContactUsLinkRoute())
+                        configurationService.getContactUsLinkRoute(),
+                        queryParam)
                 .toString();
     }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandlerTest.java
@@ -42,7 +42,6 @@ public class NotificationHandlerTest {
     private static final String FRONTEND_BASE_URL = "https://localhost:8080/frontend";
     private static final String CUSTOMER_SUPPORT_LINK_URL =
             "https://localhost:8080/frontend/support";
-    private static final String CONTACT_US_LINK_URL = "https://localhost:8080/frontend/contact-us";
     private static final String CUSTOMER_SUPPORT_LINK_ROUTE = "support";
     private static final String CONTACT_US_LINK_ROUTE = "contact-us";
     private final Context context = mock(Context.class);
@@ -50,7 +49,7 @@ public class NotificationHandlerTest {
     private final ConfigurationService configService = mock(ConfigurationService.class);
     private final AmazonS3 s3Client = mock(AmazonS3.class);
     private NotificationHandler handler;
-    private ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @BeforeEach
     void setUp() {
@@ -69,13 +68,15 @@ public class NotificationHandlerTest {
         NotifyRequest notifyRequest = new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL, "654321");
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
+        var contactUsLinkUrl =
+                "https://localhost:8080/frontend/contact-us?referer=confirmEmailAddressEmail";
 
         handler.handleRequest(sqsEvent, context);
 
         Map<String, Object> personalisation = new HashMap<>();
         personalisation.put("validation-code", "654321");
         personalisation.put("email-address", notifyRequest.getDestination());
-        personalisation.put("contact-us-link", CONTACT_US_LINK_URL);
+        personalisation.put("contact-us-link", contactUsLinkUrl);
 
         verify(notificationService).sendEmail(TEST_EMAIL_ADDRESS, personalisation, VERIFY_EMAIL);
     }
@@ -87,11 +88,14 @@ public class NotificationHandlerTest {
                 new NotifyRequest(TEST_EMAIL_ADDRESS, PASSWORD_RESET_CONFIRMATION);
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
+        var contactUsLinkUrl =
+                "https://localhost:8080/frontend/contact-us?referer=passwordResetConfirmationEmail";
 
         handler.handleRequest(sqsEvent, context);
 
         Map<String, Object> personalisation = new HashMap<>();
         personalisation.put("customer-support-link", CUSTOMER_SUPPORT_LINK_URL);
+        personalisation.put("contact-us-link", contactUsLinkUrl);
 
         verify(notificationService)
                 .sendEmail(TEST_EMAIL_ADDRESS, personalisation, PASSWORD_RESET_CONFIRMATION);
@@ -104,12 +108,14 @@ public class NotificationHandlerTest {
                 new NotifyRequest(TEST_EMAIL_ADDRESS, RESET_PASSWORD, TEST_RESET_PASSWORD_LINK);
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
+        var contactUsLinkUrl =
+                "https://localhost:8080/frontend/contact-us?referer=passwordResetRequestEmail";
 
         handler.handleRequest(sqsEvent, context);
 
         Map<String, Object> personalisation = new HashMap<>();
         personalisation.put("reset-password-link", TEST_RESET_PASSWORD_LINK);
-        personalisation.put("contact-us-link", CONTACT_US_LINK_URL);
+        personalisation.put("contact-us-link", contactUsLinkUrl);
 
         verify(notificationService).sendEmail(TEST_EMAIL_ADDRESS, personalisation, RESET_PASSWORD);
     }
@@ -117,8 +123,9 @@ public class NotificationHandlerTest {
     @Test
     void shouldSuccessfullyProcessAccountCreatedConfirmationFromSQSQueue()
             throws JsonProcessingException, NotificationClientException {
-        String accountManagementUrl = "http://account-management/";
         String baseUrl = "http://account-management";
+        var contactUsLinkUrl =
+                "https://localhost:8080/frontend/contact-us?referer=accountCreatedEmail";
         when(configService.getAccountManagementURI()).thenReturn(baseUrl);
 
         NotifyRequest notifyRequest =
@@ -129,7 +136,7 @@ public class NotificationHandlerTest {
         handler.handleRequest(sqsEvent, context);
 
         Map<String, Object> personalisation = new HashMap<>();
-        personalisation.put("contact-us-link", CONTACT_US_LINK_URL);
+        personalisation.put("contact-us-link", contactUsLinkUrl);
 
         verify(notificationService)
                 .sendEmail(TEST_EMAIL_ADDRESS, personalisation, ACCOUNT_CREATED_CONFIRMATION);
@@ -172,11 +179,13 @@ public class NotificationHandlerTest {
         NotifyRequest notifyRequest = new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL, "654321");
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
+        var contactUsLinkUrl =
+                "https://localhost:8080/frontend/contact-us?referer=confirmEmailAddressEmail";
 
         Map<String, Object> personalisation = new HashMap<>();
         personalisation.put("validation-code", "654321");
         personalisation.put("email-address", notifyRequest.getDestination());
-        personalisation.put("contact-us-link", CONTACT_US_LINK_URL);
+        personalisation.put("contact-us-link", contactUsLinkUrl);
         Mockito.doThrow(NotificationClientException.class)
                 .when(notificationService)
                 .sendEmail(TEST_EMAIL_ADDRESS, personalisation, VERIFY_EMAIL);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/NotificationHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/NotificationHandlerIntegrationTest.java
@@ -133,6 +133,8 @@ public class NotificationHandlerIntegrationTest extends NotifyIntegrationTest {
         assertThat(
                 personalisation,
                 hasFieldWithValue(
-                        "contact-us-link", equalTo("http://localhost:3000/frontend/contact-us")));
+                        "contact-us-link",
+                        equalTo(
+                                "http://localhost:3000/frontend/contact-us?referer=accountCreatedEmail")));
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ConstructUriHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ConstructUriHelper.java
@@ -1,20 +1,47 @@
 package uk.gov.di.authentication.shared.helpers;
 
+import org.apache.http.client.utils.URIBuilder;
+
 import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
 import java.util.Objects;
 
 public class ConstructUriHelper {
 
-    public static URI buildURI(String baseUrl, String path) {
+    public static URI buildURI(String baseUrl, String path, Map<String, String> queryParams) {
         if (!baseUrl.endsWith("/")) {
             baseUrl = baseUrl + "/";
         }
-        return Objects.isNull(path)
-                ? URI.create(baseUrl)
-                : URI.create(baseUrl + path.replaceAll("^/+", ""));
+        var uri =
+                Objects.isNull(path)
+                        ? URI.create(baseUrl)
+                        : URI.create(baseUrl + path.replaceAll("^/+", ""));
+
+        if (Objects.nonNull(queryParams)) {
+            return appendQueryParams(uri, queryParams);
+        } else {
+            return uri;
+        }
+    }
+
+    public static URI buildURI(String baseUrl, String path) {
+        return buildURI(baseUrl, path, null);
     }
 
     public static URI buildURI(String baseUrl) {
-        return buildURI(baseUrl, null);
+        return buildURI(baseUrl, null, null);
+    }
+
+    private static URI appendQueryParams(URI uri, Map<String, String> queryParams) {
+        try {
+            var uriBuilder = new URIBuilder(uri);
+            for (String key : queryParams.keySet()) {
+                uriBuilder.addParameter(key, queryParams.get(key));
+            }
+            return uriBuilder.build();
+        } catch (URISyntaxException e) {
+            throw new RuntimeException("Unable to build URI", e);
+        }
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ConstructUriHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ConstructUriHelper.java
@@ -17,11 +17,16 @@ public class ConstructUriHelper {
                 Objects.isNull(path)
                         ? URI.create(baseUrl)
                         : URI.create(baseUrl + path.replaceAll("^/+", ""));
-
-        if (Objects.nonNull(queryParams)) {
-            return appendQueryParams(uri, queryParams);
-        } else {
-            return uri;
+        try {
+            var uriBuilder = new URIBuilder(uri);
+            if (Objects.nonNull(queryParams)) {
+                for (Map.Entry<String, String> entry : queryParams.entrySet()) {
+                    uriBuilder.addParameter(entry.getKey(), entry.getValue());
+                }
+            }
+            return uriBuilder.build();
+        } catch (URISyntaxException e) {
+            throw new RuntimeException("Unable to build URI", e);
         }
     }
 
@@ -31,17 +36,5 @@ public class ConstructUriHelper {
 
     public static URI buildURI(String baseUrl) {
         return buildURI(baseUrl, null, null);
-    }
-
-    private static URI appendQueryParams(URI uri, Map<String, String> queryParams) {
-        try {
-            var uriBuilder = new URIBuilder(uri);
-            for (String key : queryParams.keySet()) {
-                uriBuilder.addParameter(key, queryParams.get(key));
-            }
-            return uriBuilder.build();
-        } catch (URISyntaxException e) {
-            throw new RuntimeException("Unable to build URI", e);
-        }
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ConstructUriHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ConstructUriHelperTest.java
@@ -1,0 +1,80 @@
+package uk.gov.di.authentication.shared.helpers;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class ConstructUriHelperTest {
+
+    @Test
+    void shouldBuildUriWhenOnlyBaseUrlIsPresent() {
+        var baseUrl = "https://GOV.UK";
+
+        var uri = ConstructUriHelper.buildURI(baseUrl);
+
+        assertThat(uri.toString(), equalTo("https://GOV.UK/"));
+    }
+
+    @Test
+    void shouldBuildUriWhenOnlyBaseUrlAndPathIsPresent() {
+        var baseUrl = "https://GOV.UK";
+        var path = "information";
+
+        var uri = ConstructUriHelper.buildURI(baseUrl, path);
+
+        assertThat(uri.toString(), equalTo("https://GOV.UK/information"));
+    }
+
+    @Test
+    void shouldBuildUriWhenPathAlreadyHasALeadingSlash() {
+        var baseUrl = "https://GOV.UK";
+        var path = "/information";
+
+        var uri = ConstructUriHelper.buildURI(baseUrl, path);
+
+        assertThat(uri.toString(), equalTo("https://GOV.UK/information"));
+    }
+
+    @Test
+    void shouldBuildUriWhenPathAndBaseUrlBothHaveASlash() {
+        var baseUrl = "https://GOV.UK/";
+        var path = "/information";
+
+        var uri = ConstructUriHelper.buildURI(baseUrl, path);
+
+        assertThat(uri.toString(), equalTo("https://GOV.UK/information"));
+    }
+
+    @Test
+    void shouldBuildUriWhenSingleQueryParamIsPresent() {
+        var baseUrl = "https://GOV.UK/";
+        var path = "/information";
+        var queryParams = Map.of("referer", "emailConfirmationEmail");
+
+        var uri = ConstructUriHelper.buildURI(baseUrl, path, queryParams);
+
+        assertThat(
+                uri.toString(),
+                equalTo("https://GOV.UK/information?referer=emailConfirmationEmail"));
+    }
+
+    @Test
+    void shouldBuildUriWhenMultipleQueryParamsArePresent() {
+        var baseUrl = "https://GOV.UK/";
+        var path = "/information";
+        var queryParams = new HashMap<String, String>();
+        queryParams.put("referer", "emailConfirmationEmail");
+        queryParams.put("extraInformation", "true");
+
+        var uri = ConstructUriHelper.buildURI(baseUrl, path, queryParams);
+
+        assertThat(
+                uri.toString(),
+                equalTo(
+                        "https://GOV.UK/information?referer=emailConfirmationEmail&extraInformation=true"));
+    }
+}

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ConstructUriHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ConstructUriHelperTest.java
@@ -1,9 +1,13 @@
 package uk.gov.di.authentication.shared.helpers;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -19,31 +23,16 @@ class ConstructUriHelperTest {
         assertThat(uri.toString(), equalTo("https://GOV.UK/"));
     }
 
-    @Test
-    void shouldBuildUriWhenOnlyBaseUrlAndPathIsPresent() {
-        var baseUrl = "https://GOV.UK";
-        var path = "information";
-
-        var uri = ConstructUriHelper.buildURI(baseUrl, path);
-
-        assertThat(uri.toString(), equalTo("https://GOV.UK/information"));
+    private static Stream<Arguments> validVectorValues() {
+        return Stream.of(
+                Arguments.of("https://GOV.UK", "/information"),
+                Arguments.of("https://GOV.UK/", "/information"),
+                Arguments.of("https://GOV.UK", "information"));
     }
 
-    @Test
-    void shouldBuildUriWhenPathAlreadyHasALeadingSlash() {
-        var baseUrl = "https://GOV.UK";
-        var path = "/information";
-
-        var uri = ConstructUriHelper.buildURI(baseUrl, path);
-
-        assertThat(uri.toString(), equalTo("https://GOV.UK/information"));
-    }
-
-    @Test
-    void shouldBuildUriWhenPathAndBaseUrlBothHaveASlash() {
-        var baseUrl = "https://GOV.UK/";
-        var path = "/information";
-
+    @ParameterizedTest
+    @MethodSource("validVectorValues")
+    void shouldBuildUriWithPath(String baseUrl, String path) {
         var uri = ConstructUriHelper.buildURI(baseUrl, path);
 
         assertThat(uri.toString(), equalTo("https://GOV.UK/information"));
@@ -76,5 +65,15 @@ class ConstructUriHelperTest {
                 uri.toString(),
                 equalTo(
                         "https://GOV.UK/information?referer=emailConfirmationEmail&extraInformation=true"));
+    }
+
+    @Test
+    void shouldBuildUriWhenOnlyQueryParamAndBaseUrlArePreent() {
+        var baseUrl = "https://GOV.UK/";
+        var queryParams = Map.of("referer", "emailConfirmationEmail");
+
+        var uri = ConstructUriHelper.buildURI(baseUrl, null, queryParams);
+
+        assertThat(uri.toString(), equalTo("https://GOV.UK/?referer=emailConfirmationEmail"));
     }
 }


### PR DESCRIPTION
## What?

- Allow the ConstructUriHelper to accept query params and add unit tests 
- Add referer query param onto the contact-us link in the support emails
- Add the contact-us-link to the account management emails
- Where we are using the `customer-support-link` keep that alongside the `contact-us-link` for now to avoid any issues with the emails. 

## Why?

- So the support emails all have the same link 
- So we can track what email the user clicks the support link from