### PR TITLE
AUTH-1366 - Remove support links as these are no longer used

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/NotificationHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/NotificationHandler.java
@@ -96,13 +96,6 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                             emailUpdatePersonalisation.put(
                                     "contact-us-link",
                                     buildContactUsUrl("emailAddressUpdatedEmail"));
-                            emailUpdatePersonalisation.put(
-                                    "customer-support-link",
-                                    buildURI(
-                                                    configurationService.getFrontendBaseUrl(),
-                                                    configurationService
-                                                            .getCustomerSupportLinkRoute())
-                                            .toString());
                             LOG.info("Sending EMAIL_UPDATED email using Notify");
                             notificationService.sendEmail(
                                     notifyRequest.getDestination(),
@@ -116,13 +109,6 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                             Map<String, Object> accountDeletedPersonalisation = new HashMap<>();
                             accountDeletedPersonalisation.put(
                                     "contact-us-link", buildContactUsUrl("accountDeletedEmail"));
-                            accountDeletedPersonalisation.put(
-                                    "customer-support-link",
-                                    buildURI(
-                                                    configurationService.getFrontendBaseUrl(),
-                                                    configurationService
-                                                            .getCustomerSupportLinkRoute())
-                                            .toString());
                             notificationService.sendEmail(
                                     notifyRequest.getDestination(),
                                     accountDeletedPersonalisation,
@@ -136,13 +122,6 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                             phoneNumberUpdatedPersonalisation.put(
                                     "contact-us-link",
                                     buildContactUsUrl("phoneNumberUpdatedEmail"));
-                            phoneNumberUpdatedPersonalisation.put(
-                                    "customer-support-link",
-                                    buildURI(
-                                                    configurationService.getFrontendBaseUrl(),
-                                                    configurationService
-                                                            .getCustomerSupportLinkRoute())
-                                            .toString());
                             notificationService.sendEmail(
                                     notifyRequest.getDestination(),
                                     phoneNumberUpdatedPersonalisation,
@@ -155,13 +134,6 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                             Map<String, Object> passwordUpdatedPersonalisation = new HashMap<>();
                             passwordUpdatedPersonalisation.put(
                                     "contact-us-link", buildContactUsUrl("passwordUpdatedEmail"));
-                            passwordUpdatedPersonalisation.put(
-                                    "customer-support-link",
-                                    buildURI(
-                                                    configurationService.getFrontendBaseUrl(),
-                                                    configurationService
-                                                            .getCustomerSupportLinkRoute())
-                                            .toString());
                             notificationService.sendEmail(
                                     notifyRequest.getDestination(),
                                     passwordUpdatedPersonalisation,

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/NotificationHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/NotificationHandlerTest.java
@@ -35,9 +35,6 @@ public class NotificationHandlerTest {
     private static final String TEST_PHONE_NUMBER = "01234567890";
     private static final String TEMPLATE_ID = "12345667";
     private static final String FRONTEND_BASE_URL = "https://localhost:8080/frontend";
-    private static final String CUSTOMER_SUPPORT_LINK_URL =
-            "https://localhost:8080/frontend/support";
-    private static final String CUSTOMER_SUPPORT_LINK_ROUTE = "support";
     private static final String CONTACT_US_LINK_ROUTE = "contact-us";
     private final Context context = mock(Context.class);
     private final NotificationService notificationService = mock(NotificationService.class);
@@ -49,7 +46,6 @@ public class NotificationHandlerTest {
     public void setUp() {
         when(configService.getFrontendBaseUrl()).thenReturn(FRONTEND_BASE_URL);
         when(configService.getContactUsLinkRoute()).thenReturn(CONTACT_US_LINK_ROUTE);
-        when(configService.getCustomerSupportLinkRoute()).thenReturn(CUSTOMER_SUPPORT_LINK_ROUTE);
         handler = new NotificationHandler(notificationService, configService);
     }
 
@@ -108,7 +104,6 @@ public class NotificationHandlerTest {
 
         Map<String, Object> personalisation = new HashMap<>();
         personalisation.put("email-address", notifyRequest.getDestination());
-        personalisation.put("customer-support-link", CUSTOMER_SUPPORT_LINK_URL);
         personalisation.put("contact-us-link", contactUsLinkUrl);
 
         verify(notificationService).sendEmail(TEST_EMAIL_ADDRESS, personalisation, TEMPLATE_ID);
@@ -129,7 +124,6 @@ public class NotificationHandlerTest {
         handler.handleRequest(sqsEvent, context);
 
         Map<String, Object> personalisation = new HashMap<>();
-        personalisation.put("customer-support-link", CUSTOMER_SUPPORT_LINK_URL);
         personalisation.put("contact-us-link", contactUsLinkUrl);
 
         verify(notificationService).sendEmail(TEST_EMAIL_ADDRESS, personalisation, TEMPLATE_ID);
@@ -151,7 +145,6 @@ public class NotificationHandlerTest {
 
         Map<String, Object> personalisation = new HashMap<>();
         personalisation.put("contact-us-link", contactUsLinkUrl);
-        personalisation.put("customer-support-link", CUSTOMER_SUPPORT_LINK_URL);
 
         verify(notificationService).sendEmail(TEST_EMAIL_ADDRESS, personalisation, TEMPLATE_ID);
     }
@@ -170,7 +163,6 @@ public class NotificationHandlerTest {
         handler.handleRequest(sqsEvent, context);
 
         Map<String, Object> personalisation = new HashMap<>();
-        personalisation.put("customer-support-link", CUSTOMER_SUPPORT_LINK_URL);
         personalisation.put("contact-us-link", contactUsLinkUrl);
 
         verify(notificationService).sendEmail(TEST_EMAIL_ADDRESS, personalisation, TEMPLATE_ID);

--- a/ci/terraform/account-management/sqs.tf
+++ b/ci/terraform/account-management/sqs.tf
@@ -180,11 +180,10 @@ resource "aws_lambda_function" "email_sqs_lambda" {
   }
   environment {
     variables = merge(var.notify_template_map, {
-      FRONTEND_BASE_URL           = module.dns.frontend_url
-      CUSTOMER_SUPPORT_LINK_ROUTE = var.customer_support_link_route
-      CONTACT_US_LINK_ROUTE       = var.contact_us_link_route
-      NOTIFY_API_KEY              = var.notify_api_key
-      NOTIFY_URL                  = var.notify_url
+      FRONTEND_BASE_URL     = module.dns.frontend_url
+      CONTACT_US_LINK_ROUTE = var.contact_us_link_route
+      NOTIFY_API_KEY        = var.notify_api_key
+      NOTIFY_URL            = var.notify_url
     })
   }
   kms_key_arn = data.terraform_remote_state.shared.outputs.lambda_env_vars_encryption_kms_key_arn

--- a/ci/terraform/account-management/variables.tf
+++ b/ci/terraform/account-management/variables.tf
@@ -158,11 +158,6 @@ variable "lambda_min_concurrency" {
   description = "The number of lambda instance to keep 'warm'"
 }
 
-variable "customer_support_link_route" {
-  type    = string
-  default = "support"
-}
-
 variable "contact_us_link_route" {
   type    = string
   default = "contact-us"

--- a/ci/terraform/oidc/sqs.tf
+++ b/ci/terraform/oidc/sqs.tf
@@ -169,15 +169,14 @@ resource "aws_lambda_function" "email_sqs_lambda" {
   }
   environment {
     variables = merge(var.notify_template_map, {
-      FRONTEND_BASE_URL           = module.dns.frontend_url
-      ACCOUNT_MANAGEMENT_URI      = module.dns.account_management_url
-      RESET_PASSWORD_ROUTE        = var.reset_password_route
-      CUSTOMER_SUPPORT_LINK_ROUTE = var.customer_support_link_route
-      CONTACT_US_LINK_ROUTE       = var.contact_us_link_route
-      NOTIFY_API_KEY              = var.notify_api_key
-      NOTIFY_URL                  = var.notify_url
-      NOTIFY_TEST_PHONE_NUMBER    = var.notify_test_phone_number
-      SMOKETEST_SMS_BUCKET_NAME   = local.sms_bucket_name
+      FRONTEND_BASE_URL         = module.dns.frontend_url
+      ACCOUNT_MANAGEMENT_URI    = module.dns.account_management_url
+      RESET_PASSWORD_ROUTE      = var.reset_password_route
+      CONTACT_US_LINK_ROUTE     = var.contact_us_link_route
+      NOTIFY_API_KEY            = var.notify_api_key
+      NOTIFY_URL                = var.notify_url
+      NOTIFY_TEST_PHONE_NUMBER  = var.notify_test_phone_number
+      SMOKETEST_SMS_BUCKET_NAME = local.sms_bucket_name
     })
   }
   kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -149,11 +149,6 @@ variable "blocked_email_duration" {
   default = 900
 }
 
-variable "customer_support_link_route" {
-  type    = string
-  default = "support"
-}
-
 variable "contact_us_link_route" {
   type    = string
   default = "contact-us"

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandler.java
@@ -122,8 +122,6 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                             Map<String, Object> passwordResetConfirmationPersonalisation =
                                     new HashMap<>();
                             passwordResetConfirmationPersonalisation.put(
-                                    "customer-support-link", buildCustomerSupportUrl());
-                            passwordResetConfirmationPersonalisation.put(
                                     "contact-us-link",
                                     buildContactUsUrl("passwordResetConfirmationEmail"));
                             notificationService.sendEmail(
@@ -150,13 +148,6 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
             }
         }
         return null;
-    }
-
-    private String buildCustomerSupportUrl() {
-        return buildURI(
-                        configurationService.getFrontendBaseUrl(),
-                        configurationService.getCustomerSupportLinkRoute())
-                .toString();
     }
 
     private String buildContactUsUrl(String referer) {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandlerTest.java
@@ -40,9 +40,6 @@ public class NotificationHandlerTest {
     private static final String TEST_RESET_PASSWORD_LINK =
             "https://localhost:8080/frontend?reset-password?code=123456.54353464565";
     private static final String FRONTEND_BASE_URL = "https://localhost:8080/frontend";
-    private static final String CUSTOMER_SUPPORT_LINK_URL =
-            "https://localhost:8080/frontend/support";
-    private static final String CUSTOMER_SUPPORT_LINK_ROUTE = "support";
     private static final String CONTACT_US_LINK_ROUTE = "contact-us";
     private final Context context = mock(Context.class);
     private final NotificationService notificationService = mock(NotificationService.class);
@@ -56,7 +53,6 @@ public class NotificationHandlerTest {
         when(configService.getNotifyTestPhoneNumber()).thenReturn(Optional.of(NOTIFY_PHONE_NUMBER));
         when(configService.getSmoketestBucketName()).thenReturn(BUCKET_NAME);
         when(configService.getFrontendBaseUrl()).thenReturn(FRONTEND_BASE_URL);
-        when(configService.getCustomerSupportLinkRoute()).thenReturn(CUSTOMER_SUPPORT_LINK_ROUTE);
         when(configService.getContactUsLinkRoute()).thenReturn(CONTACT_US_LINK_ROUTE);
         handler = new NotificationHandler(notificationService, configService, s3Client);
     }
@@ -94,7 +90,6 @@ public class NotificationHandlerTest {
         handler.handleRequest(sqsEvent, context);
 
         Map<String, Object> personalisation = new HashMap<>();
-        personalisation.put("customer-support-link", CUSTOMER_SUPPORT_LINK_URL);
         personalisation.put("contact-us-link", contactUsLinkUrl);
 
         verify(notificationService)

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -67,10 +67,6 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return System.getenv().getOrDefault("CONTACT_US_LINK_ROUTE", "");
     }
 
-    public String getCustomerSupportLinkRoute() {
-        return System.getenv().getOrDefault("CUSTOMER_SUPPORT_LINK_ROUTE", "");
-    }
-
     public int getMaxPasswordRetries() {
         return Integer.parseInt(System.getenv().getOrDefault("PASSWORD_MAX_RETRIES", "5"));
     }


### PR DESCRIPTION
## What?

- Remove support links as these are no longer used

## Why?

- All emails now use the contact-us-link