### PR TITLE
BAU - Account for Notify sent status

### DIFF
--- a/delivery-receipts-api/src/main/java/uk/gov/di/authentication/deliveryreceiptsapi/entity/DeliveryMetricStatus.java
+++ b/delivery-receipts-api/src/main/java/uk/gov/di/authentication/deliveryreceiptsapi/entity/DeliveryMetricStatus.java
@@ -2,5 +2,6 @@ package uk.gov.di.authentication.deliveryreceiptsapi.entity;
 
 public enum DeliveryMetricStatus {
     SMS_FAILURE,
-    SMS_DELIVERED
+    SMS_DELIVERED,
+    SMS_UNDETERMINED
 }

--- a/delivery-receipts-api/src/main/java/uk/gov/di/authentication/deliveryreceiptsapi/lambda/NotifyCallbackHandler.java
+++ b/delivery-receipts-api/src/main/java/uk/gov/di/authentication/deliveryreceiptsapi/lambda/NotifyCallbackHandler.java
@@ -19,6 +19,7 @@ import java.util.Objects;
 
 import static uk.gov.di.authentication.deliveryreceiptsapi.entity.DeliveryMetricStatus.SMS_DELIVERED;
 import static uk.gov.di.authentication.deliveryreceiptsapi.entity.DeliveryMetricStatus.SMS_FAILURE;
+import static uk.gov.di.authentication.deliveryreceiptsapi.entity.DeliveryMetricStatus.SMS_UNDETERMINED;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateEmptySuccessApiGatewayResponse;
 
 public class NotifyCallbackHandler
@@ -108,6 +109,9 @@ public class NotifyCallbackHandler
         var deliveryStatus = SMS_FAILURE.toString();
         if ("delivered".equals(notifyStatus)) {
             deliveryStatus = SMS_DELIVERED.toString();
+        }
+        if ("sent".equals(notifyStatus)) {
+            deliveryStatus = SMS_UNDETERMINED.toString();
         }
         return deliveryStatus;
     }


### PR DESCRIPTION
## What?

- Account for Notify sent status

## Why?

- Mobile networks in some countries do not provide delivery information for SMS. In these cases the status we will receive is sent. We will map this to SMS_UNDERTERMINED as we have no sight on whether it has successfully been delivered or not.
