### PR TITLE
AUTH-1439: Update code validation service to support e-mail codes

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
@@ -43,7 +43,9 @@ public enum ErrorResponse {
     ERROR_1035(1035, "User entered invalid mfa code"),
     ERROR_1036(1036, "User entered invalid email verification code"),
     ERROR_1037(1037, "User entered invalid phone verification code"),
-    ERROR_1038(1038, "Invalid Authentication Request");
+    ERROR_1038(1038, "Invalid Authentication Request"),
+    ERROR_1039(1039, "User entered invalid password reset code"),
+    ERROR_1040(1040, "User entered invalid password reset code too many times");
 
     @JsonProperty("code")
     private int code;

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
@@ -26,7 +26,7 @@ public enum ErrorResponse {
     ERROR_1018(1018, "Client-Session-Id is missing or invalid"),
     ERROR_1019(1019, "Email addresses are the same"),
     ERROR_1020(1020, "Invalid OTP code"),
-    ERROR_1021(1021, "Invalid Password reset code"),
+    ERROR_1021(1021, "User entered invalid password reset code"),
     ERROR_1022(1022, "User has requested too many password resets"),
     ERROR_1023(1023, "User cannot request another password reset"),
     ERROR_1024(1024, "New password cannot be the same as current password"),
@@ -44,8 +44,7 @@ public enum ErrorResponse {
     ERROR_1036(1036, "User entered invalid email verification code"),
     ERROR_1037(1037, "User entered invalid phone verification code"),
     ERROR_1038(1038, "Invalid Authentication Request"),
-    ERROR_1039(1039, "User entered invalid password reset code"),
-    ERROR_1040(1040, "User entered invalid password reset code too many times");
+    ERROR_1039(1039, "User entered invalid password reset code too many times");
 
     @JsonProperty("code")
     private int code;

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ValidationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ValidationService.java
@@ -87,7 +87,7 @@ public class ValidationService {
                 case VERIFY_PHONE_NUMBER:
                     return Optional.of(ErrorResponse.ERROR_1034);
                 case RESET_PASSWORD_WITH_CODE:
-                    return Optional.of(ErrorResponse.ERROR_1040);
+                    return Optional.of(ErrorResponse.ERROR_1039);
             }
         }
 
@@ -99,7 +99,7 @@ public class ValidationService {
             case VERIFY_PHONE_NUMBER:
                 return Optional.of(ErrorResponse.ERROR_1037);
             case RESET_PASSWORD_WITH_CODE:
-                return Optional.of(ErrorResponse.ERROR_1039);
+                return Optional.of(ErrorResponse.ERROR_1021);
         }
         return Optional.of(ErrorResponse.ERROR_1002);
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ValidationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ValidationService.java
@@ -70,6 +70,7 @@ public class ValidationService {
                 case MFA_SMS:
                 case VERIFY_EMAIL:
                 case VERIFY_PHONE_NUMBER:
+                case RESET_PASSWORD_WITH_CODE:
                     return Optional.empty();
             }
             return Optional.of(ErrorResponse.ERROR_1002);
@@ -85,6 +86,8 @@ public class ValidationService {
                     return Optional.of(ErrorResponse.ERROR_1033);
                 case VERIFY_PHONE_NUMBER:
                     return Optional.of(ErrorResponse.ERROR_1034);
+                case RESET_PASSWORD_WITH_CODE:
+                    return Optional.of(ErrorResponse.ERROR_1040);
             }
         }
 
@@ -95,6 +98,8 @@ public class ValidationService {
                 return Optional.of(ErrorResponse.ERROR_1036);
             case VERIFY_PHONE_NUMBER:
                 return Optional.of(ErrorResponse.ERROR_1037);
+            case RESET_PASSWORD_WITH_CODE:
+                return Optional.of(ErrorResponse.ERROR_1039);
         }
         return Optional.of(ErrorResponse.ERROR_1002);
     }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/ValidationServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/ValidationServiceTest.java
@@ -2,8 +2,10 @@ package uk.gov.di.authentication.shared.services;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.Session;
 
 import java.util.Optional;
@@ -11,14 +13,20 @@ import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.shared.entity.NotificationType.MFA_SMS;
+import static uk.gov.di.authentication.shared.entity.NotificationType.RESET_PASSWORD_WITH_CODE;
 import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_EMAIL;
 import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_PHONE_NUMBER;
 
 public class ValidationServiceTest {
 
+    public static final String VALID_CODE = "123456";
+    public static final Optional<String> STORED_VALID_CODE = Optional.of(VALID_CODE);
+    public static final String INVALID_CODE = "654321";
+    private static final Optional<String> NO_CODE_STORED = Optional.empty();
     private final ValidationService validationService = new ValidationService();
 
     private static Stream<String> blankEmailAddresses() {
@@ -140,40 +148,68 @@ public class ValidationServiceTest {
                         VERIFY_PHONE_NUMBER, Optional.of("654321"), "123456", session, 5));
     }
 
-    @Test
-    void shouldReturnNoErrorWhenEmailCodeMatchesStored() {
-        assertEquals(
-                Optional.empty(),
-                validationService.validateVerificationCode(
-                        VERIFY_EMAIL, Optional.of("123456"), "123456", mock(Session.class), 5));
+    private static Stream<Arguments> emailCodeTestParameters() {
+        return Stream.of(
+                arguments(VERIFY_EMAIL, Optional.empty(), VALID_CODE, 0, STORED_VALID_CODE),
+                arguments(
+                        RESET_PASSWORD_WITH_CODE,
+                        Optional.empty(),
+                        VALID_CODE,
+                        0,
+                        STORED_VALID_CODE),
+                arguments(
+                        VERIFY_EMAIL,
+                        Optional.of(ErrorResponse.ERROR_1036),
+                        VALID_CODE,
+                        0,
+                        NO_CODE_STORED),
+                arguments(
+                        RESET_PASSWORD_WITH_CODE,
+                        Optional.of(ErrorResponse.ERROR_1039),
+                        VALID_CODE,
+                        0,
+                        NO_CODE_STORED),
+                arguments(
+                        VERIFY_EMAIL,
+                        Optional.of(ErrorResponse.ERROR_1036),
+                        INVALID_CODE,
+                        1,
+                        STORED_VALID_CODE),
+                arguments(
+                        RESET_PASSWORD_WITH_CODE,
+                        Optional.of(ErrorResponse.ERROR_1039),
+                        INVALID_CODE,
+                        1,
+                        STORED_VALID_CODE),
+                arguments(
+                        VERIFY_EMAIL,
+                        Optional.of(ErrorResponse.ERROR_1033),
+                        INVALID_CODE,
+                        6,
+                        STORED_VALID_CODE),
+                arguments(
+                        RESET_PASSWORD_WITH_CODE,
+                        Optional.of(ErrorResponse.ERROR_1040),
+                        INVALID_CODE,
+                        6,
+                        STORED_VALID_CODE));
     }
 
-    @Test
-    void shouldReturnCorrectErrorWhenStoredEmailCodeIsEmpty() {
-        assertEquals(
-                Optional.of(ErrorResponse.ERROR_1036),
-                validationService.validateVerificationCode(
-                        VERIFY_EMAIL, Optional.empty(), "123456", mock(Session.class), 5));
-    }
-
-    @Test
-    void shouldReturnCorrectErrorWhenStoredEmailCodeDoesMatchInputAndRetryLimitHasNotBeenReached() {
+    @ParameterizedTest
+    @MethodSource("emailCodeTestParameters")
+    void shouldReturnCorrectErrorForEmailValidation(
+            NotificationType notificationType,
+            Optional<ErrorResponse> expectedResult,
+            String input,
+            int previousAttempts,
+            Optional<String> storedCode) {
         Session session = mock(Session.class);
-        when(session.getRetryCount()).thenReturn(1);
-        assertEquals(
-                Optional.of(ErrorResponse.ERROR_1036),
-                validationService.validateVerificationCode(
-                        VERIFY_EMAIL, Optional.of("654321"), "123456", session, 5));
-    }
+        when(session.getRetryCount()).thenReturn(previousAttempts);
 
-    @Test
-    void shouldReturnCorrectErrorWhenStoredEmailCodeDoesMatchInputAndRetryLimitHasBeenReached() {
-        Session session = mock(Session.class);
-        when(session.getRetryCount()).thenReturn(6);
         assertEquals(
-                Optional.of(ErrorResponse.ERROR_1033),
+                expectedResult,
                 validationService.validateVerificationCode(
-                        VERIFY_EMAIL, Optional.of("654321"), "123456", session, 5));
+                        notificationType, storedCode, input, session, 5));
     }
 
     @Test

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/ValidationServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/ValidationServiceTest.java
@@ -139,7 +139,7 @@ public class ValidationServiceTest {
                         NO_CODE_STORED),
                 arguments(
                         RESET_PASSWORD_WITH_CODE,
-                        Optional.of(ErrorResponse.ERROR_1039),
+                        Optional.of(ErrorResponse.ERROR_1021),
                         VALID_CODE,
                         0,
                         NO_CODE_STORED),
@@ -163,7 +163,7 @@ public class ValidationServiceTest {
                         STORED_VALID_CODE),
                 arguments(
                         RESET_PASSWORD_WITH_CODE,
-                        Optional.of(ErrorResponse.ERROR_1039),
+                        Optional.of(ErrorResponse.ERROR_1021),
                         INVALID_CODE,
                         1,
                         STORED_VALID_CODE),
@@ -187,7 +187,7 @@ public class ValidationServiceTest {
                         STORED_VALID_CODE),
                 arguments(
                         RESET_PASSWORD_WITH_CODE,
-                        Optional.of(ErrorResponse.ERROR_1040),
+                        Optional.of(ErrorResponse.ERROR_1039),
                         INVALID_CODE,
                         6,
                         STORED_VALID_CODE));


### PR DESCRIPTION
## What?

- Allow validation of codes from the `RESET_PASSWORD_WITH_CODE` notification type
- Add specific `ErrorResponse` value for the password reset code errors.
- Refactor ValidationService email code unit tests to be parameterisable including MFA and phone number verification codes.
- Add scenarios for the new `RESET_PASSWORD_WITH_CODE` notification
type.

## Why?

Please include reason for the change and any other relevant context.

## Related PRs

#1532 