### PR TITLE
AUTH-1397: use DynamoDB transactions for update email

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
@@ -249,7 +249,12 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
 
         ClientConsent clientConsentToUpdate =
                 clientConsentForClientId
-                        .map(t -> t.setClaims(claimsConsented))
+                        .map(
+                                t ->
+                                        t.setClaims(claimsConsented)
+                                                .setUpdatedTimestamp(
+                                                        LocalDateTime.now(ZoneId.of("UTC"))
+                                                                .toString()))
                         .orElse(
                                 new ClientConsent(
                                         clientId,

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoServiceIntegrationTest.java
@@ -1,12 +1,20 @@
 package uk.gov.di.authentication.services;
 
+import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.id.Subject;
+import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.di.authentication.shared.entity.ClientConsent;
+import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.entity.ValidScopes;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.sharedtest.extensions.UserStoreExtension;
+
+import java.time.LocalDateTime;
+import java.util.Set;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -14,6 +22,15 @@ import static org.hamcrest.Matchers.equalTo;
 class DynamoServiceIntegrationTest {
 
     private static final String TEST_EMAIL = "joe.bloggs@digital.cabinet-office.gov.uk";
+    private static final String UPDATED_TEST_EMAIL = "user.one@test.com";
+    private static final String CLIENT_ID = "client-id";
+    private static final LocalDateTime CREATED_DATE_TIME = LocalDateTime.now();
+    private static final Scope SCOPES =
+            new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL, OIDCScopeValue.OFFLINE_ACCESS);
+    private static final Set<String> CLAIMS =
+            ValidScopes.getClaimsForListOfScopes(SCOPES.toStringList());
+    private static final ClientConsent CLIENT_CONSENT =
+            new ClientConsent(CLIENT_ID, CLAIMS, CREATED_DATE_TIME.toString());
 
     @RegisterExtension
     protected static final UserStoreExtension userStore = new UserStoreExtension();
@@ -51,5 +68,92 @@ class DynamoServiceIntegrationTest {
 
     private void setUpDynamo() {
         userStore.signUp(TEST_EMAIL, "password-1", new Subject());
+    }
+
+    @Test
+    void shouldUpdateEmailAndDeletePreviousItems() {
+        setUpDynamo();
+
+        UserProfile userProfile =
+                dynamoService.getUserProfileByEmailMaybe(TEST_EMAIL).orElseThrow();
+        UserCredentials userCredentials = dynamoService.getUserCredentialsFromEmail(TEST_EMAIL);
+
+        testUpdateEmail(userProfile, userCredentials);
+    }
+
+    @Test
+    void shouldUpdateEmailAndDeletePreviousItemsWithSalt() {
+        setUpDynamo();
+        userStore.addSalt(TEST_EMAIL);
+
+        UserProfile userProfile =
+                dynamoService.getUserProfileByEmailMaybe(TEST_EMAIL).orElseThrow();
+
+        UserCredentials userCredentials = dynamoService.getUserCredentialsFromEmail(TEST_EMAIL);
+
+        testUpdateEmail(userProfile, userCredentials);
+    }
+
+    @Test
+    void shouldUpdateEmailAndDeletePreviousItemsWithConsents() {
+        setUpDynamo();
+
+        dynamoService.updateConsent(TEST_EMAIL, CLIENT_CONSENT);
+        UserProfile userProfile =
+                dynamoService.getUserProfileByEmailMaybe(TEST_EMAIL).orElseThrow();
+
+        UserCredentials userCredentials = dynamoService.getUserCredentialsFromEmail(TEST_EMAIL);
+
+        testUpdateEmail(userProfile, userCredentials);
+    }
+
+    @Test
+    void shouldHaveZeroConsentsAfterSignUp() {
+        setUpDynamo();
+        UserProfile userProfile = dynamoService.getUserProfileByEmail(TEST_EMAIL);
+
+        assertThat(userProfile.getClientConsent(), equalTo(null));
+    }
+
+    private void testUpdateEmail(UserProfile userProfile, UserCredentials userCredentials) {
+        dynamoService.updateEmail(TEST_EMAIL, UPDATED_TEST_EMAIL, CREATED_DATE_TIME);
+
+        UserProfile updatedUserProfile =
+                dynamoService.getUserProfileByEmailMaybe(UPDATED_TEST_EMAIL).orElseThrow();
+
+        UserCredentials updatedUserCredentials =
+                dynamoService.getUserCredentialsFromEmail(UPDATED_TEST_EMAIL);
+
+        assertThat(updatedUserProfile.getEmail(), equalTo(UPDATED_TEST_EMAIL));
+        assertThat(updatedUserCredentials.getEmail(), equalTo(UPDATED_TEST_EMAIL));
+
+        assertThat(updatedUserProfile.getUpdated(), equalTo(CREATED_DATE_TIME.toString()));
+        assertThat(updatedUserCredentials.getUpdated(), equalTo(CREATED_DATE_TIME.toString()));
+
+        compareUserProfiles(userProfile, updatedUserProfile);
+        compareUserCredentials(userCredentials, updatedUserCredentials);
+
+        assertThat(dynamoService.getUserProfileByEmail(TEST_EMAIL), equalTo(null));
+        assertThat(dynamoService.getUserCredentialsFromEmail(TEST_EMAIL), equalTo(null));
+    }
+
+    private void compareUserProfiles(UserProfile before, UserProfile after) {
+        assertThat(before.getPhoneNumber(), equalTo(after.getPhoneNumber()));
+        assertThat(before.isPhoneNumberVerified(), equalTo(after.isPhoneNumberVerified()));
+        assertThat(before.isEmailVerified(), equalTo(after.isEmailVerified()));
+        assertThat(before.getCreated(), equalTo(after.getCreated()));
+        assertThat(before.getSubjectID(), equalTo(after.getSubjectID()));
+        assertThat(before.getLegacySubjectID(), equalTo(after.getLegacySubjectID()));
+        assertThat(before.getPublicSubjectID(), equalTo(after.getPublicSubjectID()));
+        assertThat(before.getSalt(), equalTo(after.getSalt()));
+        assertThat(before.getClientConsent(), equalTo(after.getClientConsent()));
+        assertThat(before.getTermsAndConditions(), equalTo(after.getTermsAndConditions()));
+    }
+
+    private void compareUserCredentials(UserCredentials before, UserCredentials after) {
+        assertThat(before.getPassword(), equalTo(after.getPassword()));
+        assertThat(before.getMigratedPassword(), equalTo(after.getMigratedPassword()));
+        assertThat(before.getSubjectID(), equalTo(after.getSubjectID()));
+        assertThat(before.getCreated(), equalTo(after.getCreated()));
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/dynamodb/DynamoDBItem.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/dynamodb/DynamoDBItem.java
@@ -1,0 +1,7 @@
+package uk.gov.di.authentication.shared.dynamodb;
+
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+
+public interface DynamoDBItem {
+    public java.util.Map<String, AttributeValue> toItem();
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/dynamodb/DynamoDBItem.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/dynamodb/DynamoDBItem.java
@@ -3,5 +3,5 @@ package uk.gov.di.authentication.shared.dynamodb;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 
 public interface DynamoDBItem {
-    public java.util.Map<String, AttributeValue> toItem();
+    java.util.Map<String, AttributeValue> toItem();
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/dynamodb/DynamoDBSchemaHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/dynamodb/DynamoDBSchemaHelper.java
@@ -5,6 +5,7 @@ import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperConfig;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.Delete;
+import com.amazonaws.services.dynamodbv2.model.Put;
 
 import java.util.Map;
 
@@ -57,5 +58,9 @@ public class DynamoDBSchemaHelper {
         return new Delete()
                 .withTableName(getFullyQualifiedTableName(table))
                 .withKey(Map.of(table.getPrimaryKey(), attributeValue));
+    }
+
+    public Put buildPut(Table table, DynamoDBItem item) {
+        return new Put().withTableName(getFullyQualifiedTableName(table)).withItem(item.toItem());
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ClientConsent.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ClientConsent.java
@@ -2,8 +2,10 @@ package uk.gov.di.authentication.shared.entity;
 
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBAttribute;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBDocument;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 
-import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 @DynamoDBDocument
@@ -38,7 +40,6 @@ public class ClientConsent {
 
     public ClientConsent setClaims(Set<String> claims) {
         this.claims = claims;
-        this.updatedTimestamp = LocalDateTime.now().toString();
         return this;
     }
 
@@ -50,6 +51,32 @@ public class ClientConsent {
     public ClientConsent setUpdatedTimestamp(String updatedTimestamp) {
         this.updatedTimestamp = updatedTimestamp;
         return this;
+    }
+
+    AttributeValue toAttributeValue() {
+        return new AttributeValue()
+                .withM(
+                        Map.ofEntries(
+                                Map.entry("ClientId", new AttributeValue(getClientId())),
+                                Map.entry(
+                                        "UpdatedTimestamp",
+                                        new AttributeValue(getUpdatedTimestamp())),
+                                Map.entry("Claims", new AttributeValue().withSS(getClaims()))));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ClientConsent that = (ClientConsent) o;
+        return Objects.equals(clientId, that.clientId)
+                && Objects.equals(updatedTimestamp, that.updatedTimestamp)
+                && Objects.equals(claims, that.claims);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(clientId, updatedTimestamp, claims);
     }
 
     @Override

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/TermsAndConditions.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/TermsAndConditions.java
@@ -1,6 +1,10 @@
 package uk.gov.di.authentication.shared.entity;
 
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBDocument;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+
+import java.util.Map;
+import java.util.Objects;
 
 @DynamoDBDocument
 public class TermsAndConditions {
@@ -29,5 +33,26 @@ public class TermsAndConditions {
 
     public void setTimestamp(String timestamp) {
         this.timestamp = timestamp;
+    }
+
+    AttributeValue toAttributeValue() {
+        return new AttributeValue()
+                .withM(
+                        Map.ofEntries(
+                                Map.entry("version", new AttributeValue(getVersion())),
+                                Map.entry("timestamp", new AttributeValue(getTimestamp()))));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TermsAndConditions that = (TermsAndConditions) o;
+        return Objects.equals(version, that.version) && Objects.equals(timestamp, that.timestamp);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(version, timestamp);
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/UserCredentials.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/UserCredentials.java
@@ -3,8 +3,20 @@ package uk.gov.di.authentication.shared.entity;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBAttribute;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBIndexHashKey;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import uk.gov.di.authentication.shared.dynamodb.DynamoDBItem;
 
-public class UserCredentials {
+import java.util.HashMap;
+import java.util.Map;
+
+public class UserCredentials implements DynamoDBItem {
+
+    public static final String EMAIL = "Email";
+    public static final String SUBJECT_ID = "SubjectID";
+    public static final String PASSWORD = "Password";
+    public static final String CREATED = "Created";
+    public static final String UPDATED = "Updated";
+    public static final String MIGRATED_PASSWORD = "MigratedPassword";
 
     private String email;
     private String subjectID;
@@ -15,7 +27,7 @@ public class UserCredentials {
 
     public UserCredentials() {}
 
-    @DynamoDBHashKey(attributeName = "Email")
+    @DynamoDBHashKey(attributeName = EMAIL)
     public String getEmail() {
         return email;
     }
@@ -25,7 +37,7 @@ public class UserCredentials {
         return this;
     }
 
-    @DynamoDBIndexHashKey(globalSecondaryIndexName = "SubjectIDIndex", attributeName = "SubjectID")
+    @DynamoDBIndexHashKey(globalSecondaryIndexName = "SubjectIDIndex", attributeName = SUBJECT_ID)
     public String getSubjectID() {
         return subjectID;
     }
@@ -35,7 +47,7 @@ public class UserCredentials {
         return this;
     }
 
-    @DynamoDBAttribute(attributeName = "Password")
+    @DynamoDBAttribute(attributeName = PASSWORD)
     public String getPassword() {
         return password;
     }
@@ -45,7 +57,7 @@ public class UserCredentials {
         return this;
     }
 
-    @DynamoDBAttribute(attributeName = "Created")
+    @DynamoDBAttribute(attributeName = CREATED)
     public String getCreated() {
         return created;
     }
@@ -55,7 +67,7 @@ public class UserCredentials {
         return this;
     }
 
-    @DynamoDBAttribute(attributeName = "Updated")
+    @DynamoDBAttribute(attributeName = UPDATED)
     public String getUpdated() {
         return updated;
     }
@@ -65,7 +77,7 @@ public class UserCredentials {
         return this;
     }
 
-    @DynamoDBAttribute(attributeName = "MigratedPassword")
+    @DynamoDBAttribute(attributeName = MIGRATED_PASSWORD)
     public String getMigratedPassword() {
         return migratedPassword;
     }
@@ -73,5 +85,18 @@ public class UserCredentials {
     public UserCredentials setMigratedPassword(String migratedPassword) {
         this.migratedPassword = migratedPassword;
         return this;
+    }
+
+    @Override
+    public Map<String, AttributeValue> toItem() {
+        Map<String, AttributeValue> attributes = new HashMap<>();
+        if (getEmail() != null) attributes.put(EMAIL, new AttributeValue(getEmail()));
+        if (getSubjectID() != null) attributes.put(SUBJECT_ID, new AttributeValue(getSubjectID()));
+        if (getPassword() != null) attributes.put(PASSWORD, new AttributeValue(getPassword()));
+        if (getCreated() != null) attributes.put(CREATED, new AttributeValue(getCreated()));
+        if (getUpdated() != null) attributes.put(UPDATED, new AttributeValue(getUpdated()));
+        if (getMigratedPassword() != null)
+            attributes.put(MIGRATED_PASSWORD, new AttributeValue(getMigratedPassword()));
+        return attributes;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/UserCredentials.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/UserCredentials.java
@@ -11,12 +11,12 @@ import java.util.Map;
 
 public class UserCredentials implements DynamoDBItem {
 
-    public static final String EMAIL = "Email";
-    public static final String SUBJECT_ID = "SubjectID";
-    public static final String PASSWORD = "Password";
-    public static final String CREATED = "Created";
-    public static final String UPDATED = "Updated";
-    public static final String MIGRATED_PASSWORD = "MigratedPassword";
+    public static final String ATTRIBUTE_EMAIL = "Email";
+    public static final String ATTRIBUTE_SUBJECT_ID = "SubjectID";
+    public static final String ATTRIBUTE_PASSWORD = "Password";
+    public static final String ATTRIBUTE_CREATED = "Created";
+    public static final String ATTRIBUTE_UPDATED = "Updated";
+    public static final String ATTRIBUTE_MIGRATED_PASSWORD = "MigratedPassword";
 
     private String email;
     private String subjectID;
@@ -27,7 +27,7 @@ public class UserCredentials implements DynamoDBItem {
 
     public UserCredentials() {}
 
-    @DynamoDBHashKey(attributeName = EMAIL)
+    @DynamoDBHashKey(attributeName = ATTRIBUTE_EMAIL)
     public String getEmail() {
         return email;
     }
@@ -37,7 +37,9 @@ public class UserCredentials implements DynamoDBItem {
         return this;
     }
 
-    @DynamoDBIndexHashKey(globalSecondaryIndexName = "SubjectIDIndex", attributeName = SUBJECT_ID)
+    @DynamoDBIndexHashKey(
+            globalSecondaryIndexName = "SubjectIDIndex",
+            attributeName = ATTRIBUTE_SUBJECT_ID)
     public String getSubjectID() {
         return subjectID;
     }
@@ -47,7 +49,7 @@ public class UserCredentials implements DynamoDBItem {
         return this;
     }
 
-    @DynamoDBAttribute(attributeName = PASSWORD)
+    @DynamoDBAttribute(attributeName = ATTRIBUTE_PASSWORD)
     public String getPassword() {
         return password;
     }
@@ -57,7 +59,7 @@ public class UserCredentials implements DynamoDBItem {
         return this;
     }
 
-    @DynamoDBAttribute(attributeName = CREATED)
+    @DynamoDBAttribute(attributeName = ATTRIBUTE_CREATED)
     public String getCreated() {
         return created;
     }
@@ -67,7 +69,7 @@ public class UserCredentials implements DynamoDBItem {
         return this;
     }
 
-    @DynamoDBAttribute(attributeName = UPDATED)
+    @DynamoDBAttribute(attributeName = ATTRIBUTE_UPDATED)
     public String getUpdated() {
         return updated;
     }
@@ -77,7 +79,7 @@ public class UserCredentials implements DynamoDBItem {
         return this;
     }
 
-    @DynamoDBAttribute(attributeName = MIGRATED_PASSWORD)
+    @DynamoDBAttribute(attributeName = ATTRIBUTE_MIGRATED_PASSWORD)
     public String getMigratedPassword() {
         return migratedPassword;
     }
@@ -90,13 +92,17 @@ public class UserCredentials implements DynamoDBItem {
     @Override
     public Map<String, AttributeValue> toItem() {
         Map<String, AttributeValue> attributes = new HashMap<>();
-        if (getEmail() != null) attributes.put(EMAIL, new AttributeValue(getEmail()));
-        if (getSubjectID() != null) attributes.put(SUBJECT_ID, new AttributeValue(getSubjectID()));
-        if (getPassword() != null) attributes.put(PASSWORD, new AttributeValue(getPassword()));
-        if (getCreated() != null) attributes.put(CREATED, new AttributeValue(getCreated()));
-        if (getUpdated() != null) attributes.put(UPDATED, new AttributeValue(getUpdated()));
+        if (getEmail() != null) attributes.put(ATTRIBUTE_EMAIL, new AttributeValue(getEmail()));
+        if (getSubjectID() != null)
+            attributes.put(ATTRIBUTE_SUBJECT_ID, new AttributeValue(getSubjectID()));
+        if (getPassword() != null)
+            attributes.put(ATTRIBUTE_PASSWORD, new AttributeValue(getPassword()));
+        if (getCreated() != null)
+            attributes.put(ATTRIBUTE_CREATED, new AttributeValue(getCreated()));
+        if (getUpdated() != null)
+            attributes.put(ATTRIBUTE_UPDATED, new AttributeValue(getUpdated()));
         if (getMigratedPassword() != null)
-            attributes.put(MIGRATED_PASSWORD, new AttributeValue(getMigratedPassword()));
+            attributes.put(ATTRIBUTE_MIGRATED_PASSWORD, new AttributeValue(getMigratedPassword()));
         return attributes;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/UserProfile.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/UserProfile.java
@@ -205,7 +205,7 @@ public class UserProfile implements DynamoDBItem {
                     ATTRIBUTE_TERMS_AND_CONDITIONS, getTermsAndConditions().toAttributeValue());
         if (getClientConsent() != null) {
             Collection<AttributeValue> consents = new ArrayList<>();
-            getClientConsent().stream().forEach(c -> consents.add(c.toAttributeValue()));
+            getClientConsent().forEach(c -> consents.add(c.toAttributeValue()));
             attributes.put(ATTRIBUTE_CLIENT_CONSENT, new AttributeValue().withL(consents));
         }
         if (getPublicSubjectID() != null)

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/UserProfile.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/UserProfile.java
@@ -3,11 +3,30 @@ package uk.gov.di.authentication.shared.entity;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBAttribute;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBIndexHashKey;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import uk.gov.di.authentication.shared.dynamodb.DynamoDBItem;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
-public class UserProfile {
+public class UserProfile implements DynamoDBItem {
+
+    public static final String EMAIL = "Email";
+    public static final String SUBJECT_ID = "SubjectID";
+    public static final String EMAIL_VERIFIED = "EmailVerified";
+    public static final String PHONE_NUMBER = "PhoneNumber";
+    public static final String PHONE_NUMBER_VERIFIED = "PhoneNumberVerified";
+    public static final String CREATED = "Created";
+    public static final String UPDATED = "Updated";
+    public static final String TERMS_AND_CONDITIONS = "termsAndConditions";
+    public static final String CLIENT_CONSENT = "ClientConsent";
+    public static final String PUBLIC_SUBJECT_ID = "PublicSubjectID";
+    public static final String LEGACY_SUBJECT_ID = "LegacySubjectID";
+    public static final String SALT = "salt";
 
     private String email;
     private String subjectID;
@@ -24,7 +43,7 @@ public class UserProfile {
 
     public UserProfile() {}
 
-    @DynamoDBHashKey(attributeName = "Email")
+    @DynamoDBHashKey(attributeName = EMAIL)
     public String getEmail() {
         return email;
     }
@@ -34,7 +53,7 @@ public class UserProfile {
         return this;
     }
 
-    @DynamoDBIndexHashKey(globalSecondaryIndexName = "SubjectIDIndex", attributeName = "SubjectID")
+    @DynamoDBIndexHashKey(globalSecondaryIndexName = "SubjectIDIndex", attributeName = SUBJECT_ID)
     public String getSubjectID() {
         return subjectID;
     }
@@ -44,7 +63,7 @@ public class UserProfile {
         return this;
     }
 
-    @DynamoDBAttribute(attributeName = "EmailVerified")
+    @DynamoDBAttribute(attributeName = EMAIL_VERIFIED)
     public boolean isEmailVerified() {
         return emailVerified;
     }
@@ -54,7 +73,7 @@ public class UserProfile {
         return this;
     }
 
-    @DynamoDBAttribute(attributeName = "PhoneNumber")
+    @DynamoDBAttribute(attributeName = PHONE_NUMBER)
     public String getPhoneNumber() {
         return phoneNumber;
     }
@@ -64,7 +83,7 @@ public class UserProfile {
         return this;
     }
 
-    @DynamoDBAttribute(attributeName = "PhoneNumberVerified")
+    @DynamoDBAttribute(attributeName = PHONE_NUMBER_VERIFIED)
     public boolean isPhoneNumberVerified() {
         return phoneNumberVerified;
     }
@@ -74,7 +93,7 @@ public class UserProfile {
         return this;
     }
 
-    @DynamoDBAttribute(attributeName = "Created")
+    @DynamoDBAttribute(attributeName = CREATED)
     public String getCreated() {
         return created;
     }
@@ -84,7 +103,7 @@ public class UserProfile {
         return this;
     }
 
-    @DynamoDBAttribute(attributeName = "Updated")
+    @DynamoDBAttribute(attributeName = UPDATED)
     public String getUpdated() {
         return updated;
     }
@@ -94,7 +113,7 @@ public class UserProfile {
         return this;
     }
 
-    @DynamoDBAttribute(attributeName = "termsAndConditions")
+    @DynamoDBAttribute(attributeName = TERMS_AND_CONDITIONS)
     public TermsAndConditions getTermsAndConditions() {
         return termsAndConditions;
     }
@@ -104,7 +123,7 @@ public class UserProfile {
         return this;
     }
 
-    @DynamoDBAttribute(attributeName = "ClientConsent")
+    @DynamoDBAttribute(attributeName = CLIENT_CONSENT)
     public List<ClientConsent> getClientConsent() {
         return clientConsent;
     }
@@ -126,7 +145,7 @@ public class UserProfile {
 
     @DynamoDBIndexHashKey(
             globalSecondaryIndexName = "PublicSubjectIDIndex",
-            attributeName = "PublicSubjectID")
+            attributeName = PUBLIC_SUBJECT_ID)
     public String getPublicSubjectID() {
         return publicSubjectID;
     }
@@ -136,7 +155,7 @@ public class UserProfile {
         return this;
     }
 
-    @DynamoDBAttribute(attributeName = "LegacySubjectID")
+    @DynamoDBAttribute(attributeName = LEGACY_SUBJECT_ID)
     public String getLegacySubjectID() {
         return legacySubjectID;
     }
@@ -146,7 +165,7 @@ public class UserProfile {
         return this;
     }
 
-    @DynamoDBAttribute(attributeName = "salt")
+    @DynamoDBAttribute(attributeName = SALT)
     public ByteBuffer getSalt() {
         return salt;
     }
@@ -159,5 +178,33 @@ public class UserProfile {
     public UserProfile setSalt(byte[] salt) {
         this.salt = ByteBuffer.wrap(salt);
         return this;
+    }
+
+    @Override
+    public Map<String, AttributeValue> toItem() {
+        Map<String, AttributeValue> attributes = new HashMap<>();
+        if (getEmail() != null) attributes.put(EMAIL, new AttributeValue(getEmail()));
+        if (getSubjectID() != null) attributes.put(SUBJECT_ID, new AttributeValue(getSubjectID()));
+        attributes.put(EMAIL_VERIFIED, new AttributeValue().withN(isEmailVerified() ? "1" : "0"));
+        if (getPhoneNumber() != null)
+            attributes.put(PHONE_NUMBER, new AttributeValue(getPhoneNumber()));
+        attributes.put(
+                PHONE_NUMBER_VERIFIED,
+                new AttributeValue().withN(isPhoneNumberVerified() ? "1" : "0"));
+        if (getCreated() != null) attributes.put(CREATED, new AttributeValue(getCreated()));
+        if (getUpdated() != null) attributes.put(UPDATED, new AttributeValue(getUpdated()));
+        if (getTermsAndConditions() != null)
+            attributes.put(TERMS_AND_CONDITIONS, getTermsAndConditions().toAttributeValue());
+        if (getClientConsent() != null) {
+            Collection<AttributeValue> consents = new ArrayList<>();
+            getClientConsent().stream().forEach(c -> consents.add(c.toAttributeValue()));
+            attributes.put(CLIENT_CONSENT, new AttributeValue().withL(consents));
+        }
+        if (getPublicSubjectID() != null)
+            attributes.put(PUBLIC_SUBJECT_ID, new AttributeValue(getPublicSubjectID()));
+        if (getLegacySubjectID() != null)
+            attributes.put(LEGACY_SUBJECT_ID, new AttributeValue(getLegacySubjectID()));
+        if (getSalt() != null) attributes.put(SALT, new AttributeValue().withB(getSalt()));
+        return attributes;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/UserProfile.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/UserProfile.java
@@ -15,18 +15,18 @@ import java.util.Map;
 
 public class UserProfile implements DynamoDBItem {
 
-    public static final String EMAIL = "Email";
-    public static final String SUBJECT_ID = "SubjectID";
-    public static final String EMAIL_VERIFIED = "EmailVerified";
-    public static final String PHONE_NUMBER = "PhoneNumber";
-    public static final String PHONE_NUMBER_VERIFIED = "PhoneNumberVerified";
-    public static final String CREATED = "Created";
-    public static final String UPDATED = "Updated";
-    public static final String TERMS_AND_CONDITIONS = "termsAndConditions";
-    public static final String CLIENT_CONSENT = "ClientConsent";
-    public static final String PUBLIC_SUBJECT_ID = "PublicSubjectID";
-    public static final String LEGACY_SUBJECT_ID = "LegacySubjectID";
-    public static final String SALT = "salt";
+    public static final String ATTRIBUTE_EMAIL = "Email";
+    public static final String ATTRIBUTE_SUBJECT_ID = "SubjectID";
+    public static final String ATTRIBUTE_EMAIL_VERIFIED = "EmailVerified";
+    public static final String ATTRIBUTE_PHONE_NUMBER = "PhoneNumber";
+    public static final String ATTRIBUTE_PHONE_NUMBER_VERIFIED = "PhoneNumberVerified";
+    public static final String ATTRIBUTE_CREATED = "Created";
+    public static final String ATTRIBUTE_UPDATED = "Updated";
+    public static final String ATTRIBUTE_TERMS_AND_CONDITIONS = "termsAndConditions";
+    public static final String ATTRIBUTE_CLIENT_CONSENT = "ClientConsent";
+    public static final String ATTRIBUTE_PUBLIC_SUBJECT_ID = "PublicSubjectID";
+    public static final String ATTRIBUTE_LEGACY_SUBJECT_ID = "LegacySubjectID";
+    public static final String ATTRIBUTE_SALT = "salt";
 
     private String email;
     private String subjectID;
@@ -43,7 +43,7 @@ public class UserProfile implements DynamoDBItem {
 
     public UserProfile() {}
 
-    @DynamoDBHashKey(attributeName = EMAIL)
+    @DynamoDBHashKey(attributeName = ATTRIBUTE_EMAIL)
     public String getEmail() {
         return email;
     }
@@ -53,7 +53,9 @@ public class UserProfile implements DynamoDBItem {
         return this;
     }
 
-    @DynamoDBIndexHashKey(globalSecondaryIndexName = "SubjectIDIndex", attributeName = SUBJECT_ID)
+    @DynamoDBIndexHashKey(
+            globalSecondaryIndexName = "SubjectIDIndex",
+            attributeName = ATTRIBUTE_SUBJECT_ID)
     public String getSubjectID() {
         return subjectID;
     }
@@ -63,7 +65,7 @@ public class UserProfile implements DynamoDBItem {
         return this;
     }
 
-    @DynamoDBAttribute(attributeName = EMAIL_VERIFIED)
+    @DynamoDBAttribute(attributeName = ATTRIBUTE_EMAIL_VERIFIED)
     public boolean isEmailVerified() {
         return emailVerified;
     }
@@ -73,7 +75,7 @@ public class UserProfile implements DynamoDBItem {
         return this;
     }
 
-    @DynamoDBAttribute(attributeName = PHONE_NUMBER)
+    @DynamoDBAttribute(attributeName = ATTRIBUTE_PHONE_NUMBER)
     public String getPhoneNumber() {
         return phoneNumber;
     }
@@ -83,7 +85,7 @@ public class UserProfile implements DynamoDBItem {
         return this;
     }
 
-    @DynamoDBAttribute(attributeName = PHONE_NUMBER_VERIFIED)
+    @DynamoDBAttribute(attributeName = ATTRIBUTE_PHONE_NUMBER_VERIFIED)
     public boolean isPhoneNumberVerified() {
         return phoneNumberVerified;
     }
@@ -93,7 +95,7 @@ public class UserProfile implements DynamoDBItem {
         return this;
     }
 
-    @DynamoDBAttribute(attributeName = CREATED)
+    @DynamoDBAttribute(attributeName = ATTRIBUTE_CREATED)
     public String getCreated() {
         return created;
     }
@@ -103,7 +105,7 @@ public class UserProfile implements DynamoDBItem {
         return this;
     }
 
-    @DynamoDBAttribute(attributeName = UPDATED)
+    @DynamoDBAttribute(attributeName = ATTRIBUTE_UPDATED)
     public String getUpdated() {
         return updated;
     }
@@ -113,7 +115,7 @@ public class UserProfile implements DynamoDBItem {
         return this;
     }
 
-    @DynamoDBAttribute(attributeName = TERMS_AND_CONDITIONS)
+    @DynamoDBAttribute(attributeName = ATTRIBUTE_TERMS_AND_CONDITIONS)
     public TermsAndConditions getTermsAndConditions() {
         return termsAndConditions;
     }
@@ -123,7 +125,7 @@ public class UserProfile implements DynamoDBItem {
         return this;
     }
 
-    @DynamoDBAttribute(attributeName = CLIENT_CONSENT)
+    @DynamoDBAttribute(attributeName = ATTRIBUTE_CLIENT_CONSENT)
     public List<ClientConsent> getClientConsent() {
         return clientConsent;
     }
@@ -145,7 +147,7 @@ public class UserProfile implements DynamoDBItem {
 
     @DynamoDBIndexHashKey(
             globalSecondaryIndexName = "PublicSubjectIDIndex",
-            attributeName = PUBLIC_SUBJECT_ID)
+            attributeName = ATTRIBUTE_PUBLIC_SUBJECT_ID)
     public String getPublicSubjectID() {
         return publicSubjectID;
     }
@@ -155,7 +157,7 @@ public class UserProfile implements DynamoDBItem {
         return this;
     }
 
-    @DynamoDBAttribute(attributeName = LEGACY_SUBJECT_ID)
+    @DynamoDBAttribute(attributeName = ATTRIBUTE_LEGACY_SUBJECT_ID)
     public String getLegacySubjectID() {
         return legacySubjectID;
     }
@@ -165,7 +167,7 @@ public class UserProfile implements DynamoDBItem {
         return this;
     }
 
-    @DynamoDBAttribute(attributeName = SALT)
+    @DynamoDBAttribute(attributeName = ATTRIBUTE_SALT)
     public ByteBuffer getSalt() {
         return salt;
     }
@@ -183,28 +185,35 @@ public class UserProfile implements DynamoDBItem {
     @Override
     public Map<String, AttributeValue> toItem() {
         Map<String, AttributeValue> attributes = new HashMap<>();
-        if (getEmail() != null) attributes.put(EMAIL, new AttributeValue(getEmail()));
-        if (getSubjectID() != null) attributes.put(SUBJECT_ID, new AttributeValue(getSubjectID()));
-        attributes.put(EMAIL_VERIFIED, new AttributeValue().withN(isEmailVerified() ? "1" : "0"));
-        if (getPhoneNumber() != null)
-            attributes.put(PHONE_NUMBER, new AttributeValue(getPhoneNumber()));
+        if (getEmail() != null) attributes.put(ATTRIBUTE_EMAIL, new AttributeValue(getEmail()));
+        if (getSubjectID() != null)
+            attributes.put(ATTRIBUTE_SUBJECT_ID, new AttributeValue(getSubjectID()));
         attributes.put(
-                PHONE_NUMBER_VERIFIED,
+                ATTRIBUTE_EMAIL_VERIFIED,
+                new AttributeValue().withN(isEmailVerified() ? "1" : "0"));
+        if (getPhoneNumber() != null)
+            attributes.put(ATTRIBUTE_PHONE_NUMBER, new AttributeValue(getPhoneNumber()));
+        attributes.put(
+                ATTRIBUTE_PHONE_NUMBER_VERIFIED,
                 new AttributeValue().withN(isPhoneNumberVerified() ? "1" : "0"));
-        if (getCreated() != null) attributes.put(CREATED, new AttributeValue(getCreated()));
-        if (getUpdated() != null) attributes.put(UPDATED, new AttributeValue(getUpdated()));
+        if (getCreated() != null)
+            attributes.put(ATTRIBUTE_CREATED, new AttributeValue(getCreated()));
+        if (getUpdated() != null)
+            attributes.put(ATTRIBUTE_UPDATED, new AttributeValue(getUpdated()));
         if (getTermsAndConditions() != null)
-            attributes.put(TERMS_AND_CONDITIONS, getTermsAndConditions().toAttributeValue());
+            attributes.put(
+                    ATTRIBUTE_TERMS_AND_CONDITIONS, getTermsAndConditions().toAttributeValue());
         if (getClientConsent() != null) {
             Collection<AttributeValue> consents = new ArrayList<>();
             getClientConsent().stream().forEach(c -> consents.add(c.toAttributeValue()));
-            attributes.put(CLIENT_CONSENT, new AttributeValue().withL(consents));
+            attributes.put(ATTRIBUTE_CLIENT_CONSENT, new AttributeValue().withL(consents));
         }
         if (getPublicSubjectID() != null)
-            attributes.put(PUBLIC_SUBJECT_ID, new AttributeValue(getPublicSubjectID()));
+            attributes.put(ATTRIBUTE_PUBLIC_SUBJECT_ID, new AttributeValue(getPublicSubjectID()));
         if (getLegacySubjectID() != null)
-            attributes.put(LEGACY_SUBJECT_ID, new AttributeValue(getLegacySubjectID()));
-        if (getSalt() != null) attributes.put(SALT, new AttributeValue().withB(getSalt()));
+            attributes.put(ATTRIBUTE_LEGACY_SUBJECT_ID, new AttributeValue(getLegacySubjectID()));
+        if (getSalt() != null)
+            attributes.put(ATTRIBUTE_SALT, new AttributeValue().withB(getSalt()));
         return attributes;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthenticationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthenticationService.java
@@ -6,6 +6,7 @@ import uk.gov.di.authentication.shared.entity.TermsAndConditions;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -44,6 +45,8 @@ public interface AuthenticationService {
     void updateTermsAndConditions(String email, String version);
 
     void updateEmail(String currentEmail, String newEmail);
+
+    void updateEmail(String currentEmail, String newEmail, LocalDateTime updatedDateTime);
 
     void updatePassword(String email, String newPassword);
 

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/UserCredentialsTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/UserCredentialsTest.java
@@ -41,22 +41,22 @@ class UserCredentialsTest {
         Map<String, AttributeValue> userCredentialsItem = userCredentials.toItem();
 
         assertThat(
-                userCredentialsItem.get(UserCredentials.EMAIL).getS(),
+                userCredentialsItem.get(UserCredentials.ATTRIBUTE_EMAIL).getS(),
                 equalTo(userCredentials.getEmail()));
         assertThat(
-                userCredentialsItem.get(UserCredentials.PASSWORD).getS(),
+                userCredentialsItem.get(UserCredentials.ATTRIBUTE_PASSWORD).getS(),
                 equalTo(userCredentials.getPassword()));
         assertThat(
-                userCredentialsItem.get(UserCredentials.MIGRATED_PASSWORD).getS(),
+                userCredentialsItem.get(UserCredentials.ATTRIBUTE_MIGRATED_PASSWORD).getS(),
                 equalTo(userCredentials.getMigratedPassword()));
         assertThat(
-                userCredentialsItem.get(UserCredentials.SUBJECT_ID).getS(),
+                userCredentialsItem.get(UserCredentials.ATTRIBUTE_SUBJECT_ID).getS(),
                 equalTo(userCredentials.getSubjectID()));
         assertThat(
-                userCredentialsItem.get(UserCredentials.CREATED).getS(),
+                userCredentialsItem.get(UserCredentials.ATTRIBUTE_CREATED).getS(),
                 equalTo(userCredentials.getCreated()));
         assertThat(
-                userCredentialsItem.get(UserCredentials.UPDATED).getS(),
+                userCredentialsItem.get(UserCredentials.ATTRIBUTE_UPDATED).getS(),
                 equalTo(userCredentials.getUpdated()));
     }
 

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/UserCredentialsTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/UserCredentialsTest.java
@@ -1,0 +1,72 @@
+package uk.gov.di.authentication.shared.entity;
+
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.nimbusds.oauth2.sdk.id.Subject;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class UserCredentialsTest {
+
+    private static final String EMAIL = "user.one@test.com";
+    private static final String PASSWORD = "password123";
+    private static final String MIGRATED_PASSWORD = "oldpassword";
+    private static final String SUBJECT_ID = new Subject("subject-id-3").getValue();
+    private static final Date CREATED_DATE_TIME =
+            Date.from(LocalDateTime.now().atZone(ZoneId.of("UTC")).toInstant().minusSeconds(30));
+    private static final Date UPDATED_DATE_TIME =
+            Date.from(LocalDateTime.now().atZone(ZoneId.of("UTC")).toInstant());
+
+    @Test
+    void shouldCreateUserCredentials() {
+        UserCredentials userCredentials = generateUserCredentials();
+
+        assertThat(userCredentials.getEmail(), equalTo(EMAIL));
+        assertThat(userCredentials.getPassword(), equalTo(PASSWORD));
+        assertThat(userCredentials.getMigratedPassword(), equalTo(MIGRATED_PASSWORD));
+        assertThat(userCredentials.getSubjectID(), equalTo(SUBJECT_ID));
+        assertThat(userCredentials.getCreated(), equalTo(CREATED_DATE_TIME.toString()));
+        assertThat(userCredentials.getUpdated(), equalTo(UPDATED_DATE_TIME.toString()));
+    }
+
+    @Test
+    void shouldConvertUserCredentialsToItem() {
+        UserCredentials userCredentials = generateUserCredentials();
+        Map<String, AttributeValue> userCredentialsItem = userCredentials.toItem();
+
+        assertThat(
+                userCredentialsItem.get(UserCredentials.EMAIL).getS(),
+                equalTo(userCredentials.getEmail()));
+        assertThat(
+                userCredentialsItem.get(UserCredentials.PASSWORD).getS(),
+                equalTo(userCredentials.getPassword()));
+        assertThat(
+                userCredentialsItem.get(UserCredentials.MIGRATED_PASSWORD).getS(),
+                equalTo(userCredentials.getMigratedPassword()));
+        assertThat(
+                userCredentialsItem.get(UserCredentials.SUBJECT_ID).getS(),
+                equalTo(userCredentials.getSubjectID()));
+        assertThat(
+                userCredentialsItem.get(UserCredentials.CREATED).getS(),
+                equalTo(userCredentials.getCreated()));
+        assertThat(
+                userCredentialsItem.get(UserCredentials.UPDATED).getS(),
+                equalTo(userCredentials.getUpdated()));
+    }
+
+    private UserCredentials generateUserCredentials() {
+        return new UserCredentials()
+                .setEmail(EMAIL)
+                .setSubjectID(SUBJECT_ID)
+                .setPassword(PASSWORD)
+                .setMigratedPassword(MIGRATED_PASSWORD)
+                .setCreated(CREATED_DATE_TIME.toString())
+                .setUpdated(UPDATED_DATE_TIME.toString());
+    }
+}

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/UserProfileTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/UserProfileTest.java
@@ -64,33 +64,39 @@ class UserProfileTest {
         UserProfile userProfile = generateUserProfile();
         Map<String, AttributeValue> userProfileItem = userProfile.toItem();
 
-        assertThat(userProfileItem.get(UserProfile.EMAIL).getS(), equalTo(userProfile.getEmail()));
         assertThat(
-                userProfileItem.get(UserProfile.SUBJECT_ID).getS(),
+                userProfileItem.get(UserProfile.ATTRIBUTE_EMAIL).getS(),
+                equalTo(userProfile.getEmail()));
+        assertThat(
+                userProfileItem.get(UserProfile.ATTRIBUTE_SUBJECT_ID).getS(),
                 equalTo(userProfile.getSubjectID()));
         assertThat(
-                userProfileItem.get(UserProfile.EMAIL_VERIFIED).getN(),
+                userProfileItem.get(UserProfile.ATTRIBUTE_EMAIL_VERIFIED).getN(),
                 equalTo(userProfile.isEmailVerified() ? "1" : "0"));
         assertThat(
-                userProfileItem.get(UserProfile.PHONE_NUMBER).getS(),
+                userProfileItem.get(UserProfile.ATTRIBUTE_PHONE_NUMBER).getS(),
                 equalTo(userProfile.getPhoneNumber()));
         assertThat(
-                userProfileItem.get(UserProfile.PHONE_NUMBER_VERIFIED).getN(),
+                userProfileItem.get(UserProfile.ATTRIBUTE_PHONE_NUMBER_VERIFIED).getN(),
                 equalTo(userProfile.isPhoneNumberVerified() ? "1" : "0"));
         assertThat(
-                userProfileItem.get(UserProfile.CREATED).getS(), equalTo(userProfile.getCreated()));
+                userProfileItem.get(UserProfile.ATTRIBUTE_CREATED).getS(),
+                equalTo(userProfile.getCreated()));
         assertThat(
-                userProfileItem.get(UserProfile.UPDATED).getS(), equalTo(userProfile.getUpdated()));
+                userProfileItem.get(UserProfile.ATTRIBUTE_UPDATED).getS(),
+                equalTo(userProfile.getUpdated()));
         assertThat(
-                userProfileItem.get(UserProfile.TERMS_AND_CONDITIONS),
+                userProfileItem.get(UserProfile.ATTRIBUTE_TERMS_AND_CONDITIONS),
                 equalTo(userProfile.getTermsAndConditions().toAttributeValue()));
         compareClientConsentList(
-                userProfileItem.get(UserProfile.CLIENT_CONSENT).getL(),
+                userProfileItem.get(UserProfile.ATTRIBUTE_CLIENT_CONSENT).getL(),
                 userProfile.getClientConsent());
         assertThat(
-                userProfileItem.get(UserProfile.LEGACY_SUBJECT_ID).getS(),
+                userProfileItem.get(UserProfile.ATTRIBUTE_LEGACY_SUBJECT_ID).getS(),
                 equalTo(userProfile.getLegacySubjectID()));
-        assertThat(userProfileItem.get(UserProfile.SALT).getB(), equalTo(userProfile.getSalt()));
+        assertThat(
+                userProfileItem.get(UserProfile.ATTRIBUTE_SALT).getB(),
+                equalTo(userProfile.getSalt()));
     }
 
     private void compareClientConsentList(

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/UserProfileTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/UserProfileTest.java
@@ -1,0 +1,120 @@
+package uk.gov.di.authentication.shared.entity;
+
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.nimbusds.oauth2.sdk.Scope;
+import com.nimbusds.oauth2.sdk.id.Subject;
+import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class UserProfileTest {
+
+    private static final String EMAIL = "user.one@test.com";
+    private static final String PHONE_NUMBER = "01234567890";
+    private static final String CLIENT_ID = "client-id";
+    private static final Date CREATED_DATE_TIME =
+            Date.from(LocalDateTime.now().atZone(ZoneId.of("UTC")).toInstant().minusSeconds(30));
+    private static final Date UPDATED_DATE_TIME =
+            Date.from(LocalDateTime.now().atZone(ZoneId.of("UTC")).toInstant());
+    private static final String LEGACY_SUBJECT_ID = new Subject("legacy-subject-id-1").getValue();
+    private static final String PUBLIC_SUBJECT_ID = new Subject("public-subject-id-2").getValue();
+    private static final String SUBJECT_ID = new Subject("subject-id-3").getValue();
+    private static final TermsAndConditions TERMS_AND_CONDITIONS =
+            new TermsAndConditions("1.0", CREATED_DATE_TIME.toString());
+    private static final Scope SCOPES =
+            new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL, OIDCScopeValue.OFFLINE_ACCESS);
+    private static final Set<String> CLAIMS =
+            ValidScopes.getClaimsForListOfScopes(SCOPES.toStringList());
+    private static final ClientConsent CLIENT_CONSENT =
+            new ClientConsent(CLIENT_ID, CLAIMS, CREATED_DATE_TIME.toString());
+    private static final ByteBuffer SALT =
+            ByteBuffer.wrap("a-test-salt".getBytes(StandardCharsets.UTF_8));
+
+    @Test
+    void shouldCreateUserProfile() {
+
+        UserProfile userProfile = generateUserProfile();
+
+        assertThat(userProfile.getEmail(), equalTo(EMAIL));
+        assertThat(userProfile.getSubjectID(), equalTo(SUBJECT_ID));
+        assertThat(userProfile.isEmailVerified(), equalTo(true));
+        assertThat(userProfile.getPhoneNumber(), equalTo(PHONE_NUMBER));
+        assertThat(userProfile.isPhoneNumberVerified(), equalTo(true));
+        assertThat(userProfile.getCreated(), equalTo(CREATED_DATE_TIME.toString()));
+        assertThat(userProfile.getUpdated(), equalTo(UPDATED_DATE_TIME.toString()));
+        assertThat(userProfile.getTermsAndConditions(), equalTo(TERMS_AND_CONDITIONS));
+        assertThat(userProfile.getClientConsent(), equalTo(List.of(CLIENT_CONSENT)));
+        assertThat(userProfile.getLegacySubjectID(), equalTo(LEGACY_SUBJECT_ID));
+        assertThat(userProfile.getSalt(), equalTo(SALT));
+    }
+
+    @Test
+    void shouldConvertUserProfileToItem() {
+        UserProfile userProfile = generateUserProfile();
+        Map<String, AttributeValue> userProfileItem = userProfile.toItem();
+
+        assertThat(userProfileItem.get(UserProfile.EMAIL).getS(), equalTo(userProfile.getEmail()));
+        assertThat(
+                userProfileItem.get(UserProfile.SUBJECT_ID).getS(),
+                equalTo(userProfile.getSubjectID()));
+        assertThat(
+                userProfileItem.get(UserProfile.EMAIL_VERIFIED).getN(),
+                equalTo(userProfile.isEmailVerified() ? "1" : "0"));
+        assertThat(
+                userProfileItem.get(UserProfile.PHONE_NUMBER).getS(),
+                equalTo(userProfile.getPhoneNumber()));
+        assertThat(
+                userProfileItem.get(UserProfile.PHONE_NUMBER_VERIFIED).getN(),
+                equalTo(userProfile.isPhoneNumberVerified() ? "1" : "0"));
+        assertThat(
+                userProfileItem.get(UserProfile.CREATED).getS(), equalTo(userProfile.getCreated()));
+        assertThat(
+                userProfileItem.get(UserProfile.UPDATED).getS(), equalTo(userProfile.getUpdated()));
+        assertThat(
+                userProfileItem.get(UserProfile.TERMS_AND_CONDITIONS),
+                equalTo(userProfile.getTermsAndConditions().toAttributeValue()));
+        compareClientConsentList(
+                userProfileItem.get(UserProfile.CLIENT_CONSENT).getL(),
+                userProfile.getClientConsent());
+        assertThat(
+                userProfileItem.get(UserProfile.LEGACY_SUBJECT_ID).getS(),
+                equalTo(userProfile.getLegacySubjectID()));
+        assertThat(userProfileItem.get(UserProfile.SALT).getB(), equalTo(userProfile.getSalt()));
+    }
+
+    private void compareClientConsentList(
+            List<AttributeValue> attributeValueList, List<ClientConsent> clientConsents) {
+        assertThat(attributeValueList.size(), equalTo(clientConsents.size()));
+        for (int i = 0; i < attributeValueList.size(); i++) {
+            assertThat(
+                    attributeValueList.get(i), equalTo(clientConsents.get(i).toAttributeValue()));
+        }
+    }
+
+    private UserProfile generateUserProfile() {
+        return new UserProfile()
+                .setEmail(EMAIL)
+                .setEmailVerified(true)
+                .setPhoneNumber(PHONE_NUMBER)
+                .setPhoneNumberVerified(true)
+                .setPublicSubjectID(PUBLIC_SUBJECT_ID)
+                .setSubjectID(SUBJECT_ID)
+                .setLegacySubjectID(LEGACY_SUBJECT_ID)
+                .setClientConsent(CLIENT_CONSENT)
+                .setTermsAndConditions(TERMS_AND_CONDITIONS)
+                .setSalt(SALT)
+                .setCreated(CREATED_DATE_TIME.toString())
+                .setUpdated(UPDATED_DATE_TIME.toString());
+    }
+}


### PR DESCRIPTION
## What?

Use DynamoDB transactions for update email.

## Why?

Use transactions to maintain database integrity given that deletes and creates are required in two separate tables for the operation to succeed.

DynamoDB mappers only support transactions on a single table if table overrides are in use.  This means using a different api which requires converting fields to AttributeValue in order to use transactions.

## Related PRs

#1479
