### PR TITLE
AUTH-1480 -  Validation refactor

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
@@ -24,7 +24,6 @@ import uk.gov.di.authentication.shared.services.CodeGeneratorService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
-import uk.gov.di.authentication.shared.services.ValidationService;
 
 import java.util.Optional;
 
@@ -44,7 +43,6 @@ public class SendOtpNotificationHandler
     private static final Logger LOG = LogManager.getLogger(SendOtpNotificationHandler.class);
 
     private final ConfigurationService configurationService;
-    private final ValidationService validationService;
     private final AwsSqsClient sqsClient;
     private final CodeGeneratorService codeGeneratorService;
     private final CodeStorageService codeStorageService;
@@ -54,14 +52,12 @@ public class SendOtpNotificationHandler
 
     public SendOtpNotificationHandler(
             ConfigurationService configurationService,
-            ValidationService validationService,
             AwsSqsClient sqsClient,
             CodeGeneratorService codeGeneratorService,
             CodeStorageService codeStorageService,
             DynamoService dynamoService,
             AuditService auditService) {
         this.configurationService = configurationService;
-        this.validationService = validationService;
         this.sqsClient = sqsClient;
         this.codeGeneratorService = codeGeneratorService;
         this.codeStorageService = codeStorageService;
@@ -76,7 +72,6 @@ public class SendOtpNotificationHandler
                         configurationService.getAwsRegion(),
                         configurationService.getEmailQueueUri(),
                         configurationService.getSqsEndpointUri());
-        this.validationService = new ValidationService();
         this.codeGeneratorService = new CodeGeneratorService();
         this.codeStorageService =
                 new CodeStorageService(new RedisConnectionService(configurationService));
@@ -107,7 +102,7 @@ public class SendOtpNotificationHandler
                                     case VERIFY_EMAIL:
                                         LOG.info("NotificationType is VERIFY_EMAIL");
                                         Optional<ErrorResponse> emailErrorResponse =
-                                                validationService.validateEmailAddress(
+                                                ValidationHelper.validateEmailAddress(
                                                         sendNotificationRequest.getEmail());
                                         if (emailErrorResponse.isPresent()) {
                                             return generateApiGatewayProxyErrorResponse(

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
@@ -21,11 +21,11 @@ import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.helpers.RequestBodyHelper;
 import uk.gov.di.authentication.shared.helpers.RequestHeaderHelper;
+import uk.gov.di.authentication.shared.helpers.ValidationHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
-import uk.gov.di.authentication.shared.services.ValidationService;
 
 import java.util.Map;
 import java.util.Optional;
@@ -42,7 +42,6 @@ public class UpdateEmailHandler
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final DynamoService dynamoService;
     private final AwsSqsClient sqsClient;
-    private final ValidationService validationService;
     private final CodeStorageService codeStorageService;
     private static final Logger LOG = LogManager.getLogger(UpdateEmailHandler.class);
     private final AuditService auditService;
@@ -54,12 +53,10 @@ public class UpdateEmailHandler
     public UpdateEmailHandler(
             DynamoService dynamoService,
             AwsSqsClient sqsClient,
-            ValidationService validationService,
             CodeStorageService codeStorageService,
             AuditService auditService) {
         this.dynamoService = dynamoService;
         this.sqsClient = sqsClient;
-        this.validationService = validationService;
         this.codeStorageService = codeStorageService;
         this.auditService = auditService;
     }
@@ -71,7 +68,6 @@ public class UpdateEmailHandler
                         configurationService.getAwsRegion(),
                         configurationService.getEmailQueueUri(),
                         configurationService.getSqsEndpointUri());
-        this.validationService = new ValidationService();
         this.codeStorageService =
                 new CodeStorageService(new RedisConnectionService(configurationService));
         this.auditService = new AuditService(configurationService);
@@ -102,7 +98,7 @@ public class UpdateEmailHandler
                                             400, ErrorResponse.ERROR_1020);
                                 }
                                 Optional<ErrorResponse> emailValidationErrors =
-                                        validationService.validateEmailAddressUpdate(
+                                        ValidationHelper.validateEmailAddressUpdate(
                                                 updateInfoRequest.getExistingEmailAddress(),
                                                 updateInfoRequest.getReplacementEmailAddress());
                                 if (emailValidationErrors.isPresent()) {

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandler.java
@@ -21,14 +21,12 @@ import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.helpers.RequestBodyHelper;
 import uk.gov.di.authentication.shared.helpers.RequestHeaderHelper;
-import uk.gov.di.authentication.shared.helpers.ValidationHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
 
 import java.util.Map;
-import java.util.Optional;
 
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.SESSION_ID_HEADER;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
@@ -96,13 +94,6 @@ public class UpdatePhoneNumberHandler
                                 if (!isValidOtpCode) {
                                     return generateApiGatewayProxyErrorResponse(
                                             400, ErrorResponse.ERROR_1020);
-                                }
-                                Optional<ErrorResponse> phoneValidationErrors =
-                                        ValidationHelper.validatePhoneNumber(
-                                                updatePhoneNumberRequest.getPhoneNumber());
-                                if (phoneValidationErrors.isPresent()) {
-                                    return generateApiGatewayProxyErrorResponse(
-                                            400, phoneValidationErrors.get());
                                 }
                                 UserProfile userProfile =
                                         dynamoService.getUserProfileByEmail(

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdatePhoneNumberIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdatePhoneNumberIntegrationTest.java
@@ -119,27 +119,6 @@ class UpdatePhoneNumberIntegrationTest extends ApiGatewayHandlerIntegrationTest 
     }
 
     @Test
-    void shouldReturn400WhenPhoneNumberIsInvalid() {
-        String publicSubjectID = userStore.signUp(TEST_EMAIL, "password-1", SUBJECT);
-        String otp = redis.generateAndSavePhoneNumberCode(TEST_EMAIL, 300);
-        String badPhoneNumber = "This is not a valid phone number";
-
-        var response =
-                makeRequest(
-                        Optional.of(new UpdatePhoneNumberRequest(TEST_EMAIL, badPhoneNumber, otp)),
-                        Collections.emptyMap(),
-                        Collections.emptyMap(),
-                        Collections.emptyMap(),
-                        Map.of("principalId", publicSubjectID));
-
-        assertThat(response, hasStatus(HttpStatus.SC_BAD_REQUEST));
-
-        assertNoNotificationsReceived(notificationsQueue);
-
-        assertNoAuditEventsReceived(auditTopic);
-    }
-
-    @Test
     void shouldThrowExceptionWhenUserAttemptsToUpdateDifferentAccount() {
         userStore.signUp(TEST_EMAIL, "password-1", SUBJECT);
         String otherSubjectID =

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -15,6 +15,7 @@ import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
+import uk.gov.di.authentication.shared.helpers.ValidationHelper;
 import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
@@ -22,7 +23,6 @@ import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SessionService;
-import uk.gov.di.authentication.shared.services.ValidationService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.util.Optional;
@@ -40,7 +40,6 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
 
     private static final Logger LOG = LogManager.getLogger(CheckUserExistsHandler.class);
 
-    private final ValidationService validationService;
     private final AuditService auditService;
 
     public CheckUserExistsHandler(
@@ -49,7 +48,6 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
             ClientSessionService clientSessionService,
             ClientService clientService,
             AuthenticationService authenticationService,
-            ValidationService validationService,
             AuditService auditService) {
         super(
                 CheckUserExistsRequest.class,
@@ -58,7 +56,6 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
                 clientSessionService,
                 clientService,
                 authenticationService);
-        this.validationService = validationService;
         this.auditService = auditService;
     }
 
@@ -68,7 +65,6 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
 
     public CheckUserExistsHandler(ConfigurationService configurationService) {
         super(CheckUserExistsRequest.class, configurationService);
-        this.validationService = new ValidationService();
         this.auditService = new AuditService(configurationService);
     }
 
@@ -91,7 +87,7 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
 
             String emailAddress = request.getEmail().toLowerCase();
             Optional<ErrorResponse> errorResponse =
-                    validationService.validateEmailAddress(emailAddress);
+                    ValidationHelper.validateEmailAddress(emailAddress);
             String persistentSessionId =
                     PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders());
             if (errorResponse.isPresent()) {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
@@ -21,7 +21,6 @@ import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SessionService;
-import uk.gov.di.authentication.shared.services.ValidationService;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
 import java.util.HashMap;
@@ -49,7 +48,6 @@ class CheckUserExistsHandlerTest {
 
     private final Context context = mock(Context.class);
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
-    private final ValidationService validationService = mock(ValidationService.class);
     private final AuditService auditService = mock(AuditService.class);
     private final SessionService sessionService = mock(SessionService.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
@@ -66,12 +64,12 @@ class CheckUserExistsHandlerTest {
             new CaptureLoggingExtension(CheckUserExistsHandler.class);
 
     @AfterEach
-    public void tearDown() {
+    void tearDown() {
         assertThat(logging.events(), not(hasItem(withMessageContaining(session.getSessionId()))));
     }
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         when(context.getAwsRequestId()).thenReturn("aws-session-id");
 
         handler =
@@ -81,13 +79,12 @@ class CheckUserExistsHandlerTest {
                         clientSessionService,
                         clientService,
                         authenticationService,
-                        validationService,
                         auditService);
         reset(authenticationService);
     }
 
     @Test
-    public void shouldReturn200IfUserExists() throws JsonProcessingException {
+    void shouldReturn200IfUserExists() throws JsonProcessingException {
         usingValidSession();
         String persistentId = "some-persistent-id-value";
         Map<String, String> headers = new HashMap<>();
@@ -114,16 +111,16 @@ class CheckUserExistsHandlerTest {
                         FrontendAuditableEvent.CHECK_USER_KNOWN_EMAIL,
                         "aws-session-id",
                         session.getSessionId(),
-                        "",
-                        auditService.UNKNOWN,
+                        AuditService.UNKNOWN,
+                        AuditService.UNKNOWN,
                         "joe.bloggs@digital.cabinet-office.gov.uk",
                         "123.123.123.123",
-                        "",
+                        AuditService.UNKNOWN,
                         persistentId);
     }
 
     @Test
-    public void shouldReturn200IfUserDoesNotExist() throws JsonProcessingException {
+    void shouldReturn200IfUserDoesNotExist() throws JsonProcessingException {
         usingValidSession();
         when(authenticationService.userExists(eq("joe.bloggs@digital.cabinet-office.gov.uk")))
                 .thenReturn(false);
@@ -147,8 +144,8 @@ class CheckUserExistsHandlerTest {
                         FrontendAuditableEvent.CHECK_USER_NO_ACCOUNT_WITH_EMAIL,
                         "aws-session-id",
                         session.getSessionId(),
-                        "",
-                        auditService.UNKNOWN,
+                        AuditService.UNKNOWN,
+                        AuditService.UNKNOWN,
                         "joe.bloggs@digital.cabinet-office.gov.uk",
                         "123.123.123.123",
                         AuditService.UNKNOWN,
@@ -156,7 +153,7 @@ class CheckUserExistsHandlerTest {
     }
 
     @Test
-    public void shouldReturn400IfRequestIsMissingEmail() {
+    void shouldReturn400IfRequestIsMissingEmail() {
         usingValidSession();
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
@@ -171,7 +168,7 @@ class CheckUserExistsHandlerTest {
     }
 
     @Test
-    public void shouldReturn400IfRequestIsMissingSessionId() {
+    void shouldReturn400IfRequestIsMissingSessionId() {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setBody("{ \"email\": \"joe.bloggs@digital.cabinet-office.gov.uk\" }");
 
@@ -184,10 +181,8 @@ class CheckUserExistsHandlerTest {
     }
 
     @Test
-    public void shouldReturn400IfEmailAddressIsInvalid() {
+    void shouldReturn400IfEmailAddressIsInvalid() {
         usingValidSession();
-        when(validationService.validateEmailAddress(eq("joe.bloggs")))
-                .thenReturn(Optional.of(ErrorResponse.ERROR_1004));
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setBody("{ \"email\": \"joe.bloggs\" }");
@@ -203,40 +198,8 @@ class CheckUserExistsHandlerTest {
                         FrontendAuditableEvent.CHECK_USER_INVALID_EMAIL,
                         "aws-session-id",
                         session.getSessionId(),
-                        "",
-                        auditService.UNKNOWN,
-                        "joe.bloggs",
-                        "123.123.123.123",
                         AuditService.UNKNOWN,
-                        PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE);
-    }
-
-    @Test
-    public void shouldReturn200IfUserTransitionsFromUserNotFoundAndUserDoesNotExist()
-            throws JsonProcessingException {
-        usingValidSession();
-        when(authenticationService.userExists(eq("joe.bloggs"))).thenReturn(false);
-
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        event.setBody("{ \"email\": \"joe.bloggs\" }");
-        event.setHeaders(Map.of("Session-Id", session.getSessionId()));
-        event.setRequestContext(contextWithSourceIp("123.123.123.123"));
-
-        APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
-
-        assertEquals(200, result.getStatusCode());
-        CheckUserExistsResponse checkUserExistsResponse =
-                objectMapper.readValue(result.getBody(), CheckUserExistsResponse.class);
-        assertEquals("joe.bloggs", checkUserExistsResponse.getEmail());
-        assertFalse(checkUserExistsResponse.doesUserExist());
-
-        verify(auditService)
-                .submitAuditEvent(
-                        FrontendAuditableEvent.CHECK_USER_NO_ACCOUNT_WITH_EMAIL,
-                        "aws-session-id",
-                        session.getSessionId(),
-                        "",
-                        auditService.UNKNOWN,
+                        AuditService.UNKNOWN,
                         "joe.bloggs",
                         "123.123.123.123",
                         AuditService.UNKNOWN,

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ValidationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ValidationService.java
@@ -5,56 +5,8 @@ import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.Session;
 
 import java.util.Optional;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class ValidationService {
-
-    private static final Pattern EMAIL_NOTIFY_REGEX =
-            Pattern.compile("^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~\\-]+@([^.@][^@\\s]+)$");
-    private static final Pattern HOSTNAME_REGEX =
-            Pattern.compile("^(xn|[a-z0-9]+)(-?-[a-z0-9]+)*$", Pattern.CASE_INSENSITIVE);
-    private static final Pattern TLD_PART_REGEX =
-            Pattern.compile("^([a-z]{2,63}|xn--([a-z0-9]+-)*[a-z0-9]+)$", Pattern.CASE_INSENSITIVE);
-
-    public Optional<ErrorResponse> validateEmailAddressUpdate(
-            String existingEmail, String replacementEmail) {
-        if (existingEmail.equals(replacementEmail)) {
-            return Optional.of(ErrorResponse.ERROR_1019);
-        }
-        Optional<ErrorResponse> existingEmailError = validateEmailAddress(existingEmail);
-        if (existingEmailError.isPresent()) {
-            return existingEmailError;
-        }
-        return validateEmailAddress(replacementEmail);
-    }
-
-    public Optional<ErrorResponse> validateEmailAddress(String email) {
-        if (email == null || email.isBlank()) {
-            return Optional.of(ErrorResponse.ERROR_1003);
-        }
-        Matcher matcher = EMAIL_NOTIFY_REGEX.matcher(email);
-        if (!matcher.matches()) {
-            return Optional.of(ErrorResponse.ERROR_1004);
-        }
-        if (email.contains("..")) {
-            return Optional.of(ErrorResponse.ERROR_1004);
-        }
-        var hostname = matcher.group(1);
-        String[] parts = hostname.split("\\.");
-        if (parts.length < 2) {
-            return Optional.of(ErrorResponse.ERROR_1004);
-        }
-        for (String part : parts) {
-            if (!HOSTNAME_REGEX.matcher(part).matches()) {
-                return Optional.of(ErrorResponse.ERROR_1004);
-            }
-        }
-        if (!TLD_PART_REGEX.matcher(parts[parts.length - 1]).matches()) {
-            return Optional.of(ErrorResponse.ERROR_1004);
-        }
-        return Optional.empty();
-    }
 
     public Optional<ErrorResponse> validateVerificationCode(
             NotificationType type,

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ValidationHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ValidationHelperTest.java
@@ -12,6 +12,7 @@ import java.util.stream.Stream;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ValidationHelperTest {
 
@@ -72,5 +73,110 @@ class ValidationHelperTest {
     @MethodSource("validPasswords")
     void shouldAcceptValidPassword(String password) {
         assertEquals(Optional.empty(), ValidationHelper.validatePassword(password));
+    }
+
+    private static Stream<String> blankEmailAddresses() {
+        return Stream.of("", "  ", "\t\t", System.lineSeparator() + System.lineSeparator(), null);
+    }
+
+    @ParameterizedTest
+    @MethodSource("blankEmailAddresses")
+    void shouldRejectBlankEmail(String emailAddress) {
+
+        assertEquals(
+                Optional.of(ErrorResponse.ERROR_1003),
+                ValidationHelper.validateEmailAddress(emailAddress));
+    }
+
+    private static Stream<String> invalidEmailAddresses() {
+        return Stream.of(
+                "test.example.gov.uk",
+                "test@example@gov.uk",
+                "test@examplegovuk",
+                "testµ@example.gov.uk",
+                "email@123.123.123.123",
+                "email@[123.123.123.123]",
+                "plainaddress",
+                "@no-local-part.com",
+                "Outlook Contact <outlook-contact@domain.com>",
+                "no-at.domain.com",
+                "no-tld@domain",
+                ";beginning-semicolon@domain.co.uk",
+                "middle-semicolon@domain.co;uk",
+                "trailing-semicolon@domain.com;",
+                "\"email+leading-quotes@domain.com",
+                "email+middle\"-quotes@domain.com",
+                "quoted-local-part\"@domain.com",
+                "\"quoted@domain.com\"",
+                "lots-of-dots@domain..gov..uk",
+                "two-dots..in-local@domain.com",
+                "multiple@domains@domain.com",
+                "spaces in local@domain.com",
+                "spaces-in-domain@dom ain.com",
+                "underscores-in-domain@dom_ain.com",
+                "pipe-in-domain@example.com|gov.uk",
+                "comma,in-local@gov.uk",
+                "comma-in-domain@domain,gov.uk",
+                "pound-sign-in-local£@domain.com",
+                "local-with-’-apostrophe@domain.com",
+                "local-with-”-quotes@domain.com",
+                "domain-starts-with-a-dot@.domain.com",
+                "brackets(in)local@domain.com",
+                "incorrect-punycode@xn---something.com");
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidEmailAddresses")
+    void shouldRejectMalformattedEmail(String emailAddress) {
+
+        assertEquals(
+                Optional.of(ErrorResponse.ERROR_1004),
+                ValidationHelper.validateEmailAddress(emailAddress));
+    }
+
+    private static Stream<String> validEmailAddresses() {
+        return Stream.of(
+                "test@example.gov.uk",
+                "test@example.com",
+                "test@example.info",
+                "email@domain.com",
+                "email@domain.COM",
+                "firstname.lastname@domain.com",
+                "firstname.o\'lastname@domain.com",
+                "email@subdomain.domain.com",
+                "firstname+lastname@domain.com");
+    }
+
+    @ParameterizedTest
+    @MethodSource("validEmailAddresses")
+    void shouldAcceptValidEmail(String emailAddress) {
+
+        assertTrue(ValidationHelper.validateEmailAddress(emailAddress).isEmpty());
+    }
+
+    @Test
+    void shouldReturnErrorWhenEmailAddressesAreTheSame() {
+        String email = "joe.bloggs@digital.cabinet-office.gov.uk";
+        assertEquals(
+                Optional.of(ErrorResponse.ERROR_1019),
+                ValidationHelper.validateEmailAddressUpdate(email, email));
+    }
+
+    @Test
+    void shouldReturnErrorWhenExistingEmailIsInvalid() {
+        String existingEmail = "joe.bloggs";
+        String replacementEmail = "joe.bloggs@digital.cabinet-office.gov.uk";
+        assertEquals(
+                Optional.of(ErrorResponse.ERROR_1004),
+                ValidationHelper.validateEmailAddressUpdate(existingEmail, replacementEmail));
+    }
+
+    @Test
+    void shouldReturnErrorWhenReplacementEmailIsInvalid() {
+        String existingEmail = "joe.bloggs@digital.cabinet-office.gov.uk";
+        String replacementEmail = "joe.bloggs";
+        assertEquals(
+                Optional.of(ErrorResponse.ERROR_1004),
+                ValidationHelper.validateEmailAddressUpdate(existingEmail, replacementEmail));
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/ValidationServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/ValidationServiceTest.java
@@ -1,6 +1,5 @@
 package uk.gov.di.authentication.shared.services;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -12,7 +11,6 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -28,85 +26,6 @@ public class ValidationServiceTest {
     public static final String INVALID_CODE = "654321";
     private static final Optional<String> NO_CODE_STORED = Optional.empty();
     private final ValidationService validationService = new ValidationService();
-
-    private static Stream<String> blankEmailAddresses() {
-        return Stream.of("", "  ", "\t\t", System.lineSeparator() + System.lineSeparator(), null);
-    }
-
-    @ParameterizedTest
-    @MethodSource("blankEmailAddresses")
-    void shouldRejectBlankEmail(String emailAddress) {
-
-        assertEquals(
-                Optional.of(ErrorResponse.ERROR_1003),
-                validationService.validateEmailAddress(emailAddress));
-    }
-
-    private static Stream<String> invalidEmailAddresses() {
-        return Stream.of(
-                "test.example.gov.uk",
-                "test@example@gov.uk",
-                "test@examplegovuk",
-                "testµ@example.gov.uk",
-                "email@123.123.123.123",
-                "email@[123.123.123.123]",
-                "plainaddress",
-                "@no-local-part.com",
-                "Outlook Contact <outlook-contact@domain.com>",
-                "no-at.domain.com",
-                "no-tld@domain",
-                ";beginning-semicolon@domain.co.uk",
-                "middle-semicolon@domain.co;uk",
-                "trailing-semicolon@domain.com;",
-                "\"email+leading-quotes@domain.com",
-                "email+middle\"-quotes@domain.com",
-                "quoted-local-part\"@domain.com",
-                "\"quoted@domain.com\"",
-                "lots-of-dots@domain..gov..uk",
-                "two-dots..in-local@domain.com",
-                "multiple@domains@domain.com",
-                "spaces in local@domain.com",
-                "spaces-in-domain@dom ain.com",
-                "underscores-in-domain@dom_ain.com",
-                "pipe-in-domain@example.com|gov.uk",
-                "comma,in-local@gov.uk",
-                "comma-in-domain@domain,gov.uk",
-                "pound-sign-in-local£@domain.com",
-                "local-with-’-apostrophe@domain.com",
-                "local-with-”-quotes@domain.com",
-                "domain-starts-with-a-dot@.domain.com",
-                "brackets(in)local@domain.com",
-                "incorrect-punycode@xn---something.com");
-    }
-
-    @ParameterizedTest
-    @MethodSource("invalidEmailAddresses")
-    void shouldRejectMalformattedEmail(String emailAddress) {
-
-        assertEquals(
-                Optional.of(ErrorResponse.ERROR_1004),
-                validationService.validateEmailAddress(emailAddress));
-    }
-
-    private static Stream<String> validEmailAddresses() {
-        return Stream.of(
-                "test@example.gov.uk",
-                "test@example.com",
-                "test@example.info",
-                "email@domain.com",
-                "email@domain.COM",
-                "firstname.lastname@domain.com",
-                "firstname.o\'lastname@domain.com",
-                "email@subdomain.domain.com",
-                "firstname+lastname@domain.com");
-    }
-
-    @ParameterizedTest
-    @MethodSource("validEmailAddresses")
-    void shouldAcceptValidEmail(String emailAddress) {
-
-        assertTrue(validationService.validateEmailAddress(emailAddress).isEmpty());
-    }
 
     private static Stream<Arguments> validateCodeTestParameters() {
         return Stream.of(
@@ -208,31 +127,5 @@ public class ValidationServiceTest {
                 expectedResult,
                 validationService.validateVerificationCode(
                         notificationType, storedCode, input, session, 5));
-    }
-
-    @Test
-    void shouldReturnErrorWhenEmailAddressesAreTheSame() {
-        String email = "joe.bloggs@digital.cabinet-office.gov.uk";
-        assertEquals(
-                Optional.of(ErrorResponse.ERROR_1019),
-                validationService.validateEmailAddressUpdate(email, email));
-    }
-
-    @Test
-    void shouldReturnErrorWhenExistingEmailIsInvalid() {
-        String existingEmail = "joe.bloggs";
-        String replacementEmail = "joe.bloggs@digital.cabinet-office.gov.uk";
-        assertEquals(
-                Optional.of(ErrorResponse.ERROR_1004),
-                validationService.validateEmailAddressUpdate(existingEmail, replacementEmail));
-    }
-
-    @Test
-    void shouldReturnErrorWhenReplacementEmailIsInvalid() {
-        String existingEmail = "joe.bloggs@digital.cabinet-office.gov.uk";
-        String replacementEmail = "joe.bloggs";
-        assertEquals(
-                Optional.of(ErrorResponse.ERROR_1004),
-                validationService.validateEmailAddressUpdate(existingEmail, replacementEmail));
     }
 }


### PR DESCRIPTION
## What?

- Move email validation to ValidationHelper
- Remove phone number validation out of UpdatePhoneNumberHandler

## Why?

- We can avoid the need to instantiate the ValidationService by moving the email validation into static methods. We shouldn't to create an instance of a class to call them
- The SendOtpNotificationHandler is called before the UpdatePhoneNumberHandler and we validate the phone number there. We don't need to perform the same validation in both lambdas