### PR TITLE
AUTH-1439: Add ability to trigger code flow password reset

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/ResetPasswordRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/ResetPasswordRequest.java
@@ -4,10 +4,17 @@ import uk.gov.di.authentication.shared.entity.BaseFrontendRequest;
 
 public class ResetPasswordRequest extends BaseFrontendRequest {
 
+    private boolean useCodeFlow = false;
+
     public ResetPasswordRequest() {}
 
-    public ResetPasswordRequest(String email) {
+    public ResetPasswordRequest(String email, boolean useCodeFlow) {
         this.email = email;
+        this.useCodeFlow = useCodeFlow;
+    }
+
+    public boolean isUseCodeFlow() {
+        return useCodeFlow;
     }
 
     @Override

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordRequestIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordRequestIntegrationTest.java
@@ -14,9 +14,11 @@ import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasLength;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.authentication.shared.entity.NotificationType.RESET_PASSWORD;
+import static uk.gov.di.authentication.shared.entity.NotificationType.RESET_PASSWORD_WITH_CODE;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class ResetPasswordRequestIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -39,7 +41,7 @@ public class ResetPasswordRequestIntegrationTest extends ApiGatewayHandlerIntegr
 
         var response =
                 makeRequest(
-                        Optional.of(new ResetPasswordRequest(email)),
+                        Optional.of(new ResetPasswordRequest(email, false)),
                         constructFrontendHeaders(sessionId, null, persistentSessionId),
                         Map.of());
 
@@ -58,5 +60,32 @@ public class ResetPasswordRequestIntegrationTest extends ApiGatewayHandlerIntegr
         assertThat(resetLinkSplit.length, equalTo(4));
         assertThat(resetLinkSplit[2], equalTo(sessionId));
         assertThat(resetLinkSplit[3], equalTo(persistentSessionId));
+    }
+
+    @Test
+    public void shouldCallResetPasswordEndpointAndReturn200ForCodeFlowRequest() throws IOException {
+        String email = "joe.bloggs+3@digital.cabinet-office.gov.uk";
+        String password = "password-1";
+        String phoneNumber = "01234567890";
+        userStore.signUp(email, password);
+        userStore.addPhoneNumber(email, phoneNumber);
+        String sessionId = redis.createSession();
+        String persistentSessionId = "test-persistent-id";
+        redis.addEmailToSession(sessionId, email);
+
+        var response =
+                makeRequest(
+                        Optional.of(new ResetPasswordRequest(email, true)),
+                        constructFrontendHeaders(sessionId, null, persistentSessionId),
+                        Map.of());
+
+        assertThat(response, hasStatus(204));
+
+        List<NotifyRequest> requests = notificationsQueue.getMessages(NotifyRequest.class);
+
+        assertThat(requests, hasSize(1));
+        assertThat(requests.get(0).getDestination(), equalTo(email));
+        assertThat(requests.get(0).getNotificationType(), equalTo(RESET_PASSWORD_WITH_CODE));
+        assertThat(requests.get(0).getCode(), hasLength(6));
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java
@@ -155,6 +155,7 @@ public class CodeStorageService {
             case MFA_SMS:
                 return MFA_KEY_PREFIX;
             case RESET_PASSWORD:
+            case RESET_PASSWORD_WITH_CODE:
                 return RESET_PASSWORD_KEY_PREFIX;
         }
         throw new RuntimeException(


### PR DESCRIPTION
## What?

- Add an, optional, field to the `ResetPasswordRequest` class to indicate whether the reset password should done with a 6 digit code rather than a magic link
- Update `ResetPasswordRequestHandler` to check the new field and behave appropriately

## Why?

We are moving to a flow where a 6 digit code will be sent to the user when they request a password reset rather than a link. This makes it easier for the user to continue their RP journey after resetting their password.

With this change in place, the API changes for sending a 6 digit code in the reset password flow is complete. The frontend will just need to include the additional flag in the API call to use this flow.

No changes are required to `ResetPasswordHandler` as this will work for both flows.

*N.B. for the moment, the API will support both methods for changing password. At a later date, if no longer required, we can remove the code that sends the password change link once the frontend changes have been made to support the six digit code flow*

## Related PRs

#1536 