### PR TITLE
BAU - Save client session in auth code store

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -175,7 +175,9 @@ public class AuthCodeHandler
                                 }
                                 AuthorizationCode authCode =
                                         authorisationCodeService.generateAuthorisationCode(
-                                                clientSessionId, session.getEmailAddress());
+                                                clientSessionId,
+                                                session.getEmailAddress(),
+                                                clientSession);
 
                                 AuthenticationSuccessResponse authenticationResponse =
                                         authorizationService.generateSuccessfulAuthResponse(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -165,7 +165,8 @@ class AuthCodeHandlerTest {
 
         when(authorizationService.isClientRedirectUriValid(eq(CLIENT_ID), eq(REDIRECT_URI)))
                 .thenReturn(true);
-        when(authorisationCodeService.generateAuthorisationCode(eq(CLIENT_SESSION_ID), eq(EMAIL)))
+        when(authorisationCodeService.generateAuthorisationCode(
+                        CLIENT_SESSION_ID, EMAIL, clientSession))
                 .thenReturn(authorizationCode);
         when(authorizationService.generateSuccessfulAuthResponse(
                         any(AuthenticationRequest.class), any(AuthorizationCode.class)))

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthCodeExchangeData.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthCodeExchangeData.java
@@ -8,6 +8,8 @@ public class AuthCodeExchangeData {
 
     @JsonProperty private String email;
 
+    @JsonProperty private ClientSession clientSession;
+
     public String getClientSessionId() {
         return clientSessionId;
     }
@@ -23,6 +25,15 @@ public class AuthCodeExchangeData {
 
     public AuthCodeExchangeData setEmail(String email) {
         this.email = email;
+        return this;
+    }
+
+    public ClientSession getClientSession() {
+        return clientSession;
+    }
+
+    public AuthCodeExchangeData setClientSession(ClientSession clientSession) {
+        this.clientSession = clientSession;
         return this;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthorisationCodeService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthorisationCodeService.java
@@ -6,6 +6,7 @@ import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.entity.AuthCodeExchangeData;
+import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 
 import java.util.Optional;
@@ -30,7 +31,8 @@ public class AuthorisationCodeService {
         this.objectMapper = ObjectMapperFactory.getInstance();
     }
 
-    public AuthorizationCode generateAuthorisationCode(String clientSessionId, String email) {
+    public AuthorizationCode generateAuthorisationCode(
+            String clientSessionId, String email, ClientSession clientSession) {
         AuthorizationCode authorizationCode = new AuthorizationCode();
         try {
             redisConnectionService.saveWithExpiry(
@@ -38,7 +40,8 @@ public class AuthorisationCodeService {
                     objectMapper.writeValueAsString(
                             new AuthCodeExchangeData()
                                     .setEmail(email)
-                                    .setClientSessionId(clientSessionId)),
+                                    .setClientSessionId(clientSessionId)
+                                    .setClientSession(clientSession)),
                     authorisationCodeExpiry);
             return authorizationCode;
         } catch (JsonProcessingException e) {


### PR DESCRIPTION
## What?

- Save client session in auth code store

## Why?

- Save the client session in the auth code store so we don't have to make multiple calls to REDIS in the token handler.
- These changes will be done incrementally to avoid any drop offs for users
