### PR TITLE
BAU: Only initialise one Redis and KMS connection in token handler.

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthorisationCodeService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthorisationCodeService.java
@@ -19,6 +19,15 @@ public class AuthorisationCodeService {
     private final long authorisationCodeExpiry;
     private final ObjectMapper objectMapper;
 
+    public AuthorisationCodeService(
+            ConfigurationService configurationService,
+            RedisConnectionService redisConnectionService,
+            ObjectMapper objectMapper) {
+        this.redisConnectionService = redisConnectionService;
+        this.authorisationCodeExpiry = configurationService.getAuthCodeExpiry();
+        this.objectMapper = objectMapper;
+    }
+
     public AuthorisationCodeService(ConfigurationService configurationService) {
         this.redisConnectionService =
                 new RedisConnectionService(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/RedisConnectionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/RedisConnectionService.java
@@ -5,11 +5,12 @@ import io.lettuce.core.RedisURI;
 import io.lettuce.core.TransactionResult;
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.api.sync.RedisCommands;
-import io.lettuce.core.support.ConnectionPoolSupport;
 import org.apache.commons.pool2.impl.GenericObjectPool;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 
 import java.util.Optional;
+
+import static io.lettuce.core.support.ConnectionPoolSupport.createGenericObjectPool;
 
 public class RedisConnectionService implements AutoCloseable {
 
@@ -23,9 +24,7 @@ public class RedisConnectionService implements AutoCloseable {
         password.ifPresent(s -> builder.withPassword(s.toCharArray()));
         RedisURI redisURI = builder.build();
         this.client = RedisClient.create(redisURI);
-        this.pool =
-                ConnectionPoolSupport.createGenericObjectPool(
-                        client::connect, new GenericObjectPoolConfig());
+        this.pool = createGenericObjectPool(client::connect, new GenericObjectPoolConfig<>());
         warmUp();
     }
 


### PR DESCRIPTION
## What?

Create single redis connection and KMS connection

## Why?

Both connections "warm up" on initialisation, slowing time to action
