### PR TITLE
BAU - Retrieve client session from auth code store and increase lambda warmers 

### DIFF
--- a/ci/terraform/oidc/production-overrides.tfvars
+++ b/ci/terraform/oidc/production-overrides.tfvars
@@ -9,6 +9,6 @@ notify_template_map = {
 }
 
 cloudwatch_log_retention    = 5
-lambda_min_concurrency      = 25
+lambda_min_concurrency      = 50
 client_registry_api_enabled = false
 ipv_api_enabled             = false

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
@@ -200,9 +200,7 @@ public class TokenHandler
                             }
                             updateAttachedLogFieldToLogs(
                                     CLIENT_SESSION_ID, authCodeExchangeData.getClientSessionId());
-                            ClientSession clientSession =
-                                    clientSessionService.getClientSession(
-                                            authCodeExchangeData.getClientSessionId());
+                            ClientSession clientSession = authCodeExchangeData.getClientSession();
                             AuthenticationRequest authRequest;
                             try {
                                 authRequest =

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
@@ -161,21 +161,22 @@ public class TokenHandlerTest {
                         eq(CLIENT_ID)))
                 .thenReturn(Optional.empty());
         String authCode = new AuthorizationCode().toString();
-        when(authorisationCodeService.getExchangeDataForCode(authCode))
-                .thenReturn(
-                        Optional.of(
-                                new AuthCodeExchangeData()
-                                        .setEmail(TEST_EMAIL)
-                                        .setClientSessionId(CLIENT_SESSION_ID)));
         AuthenticationRequest authenticationRequest =
                 generateAuthRequest(JsonArrayHelper.jsonArrayOf(vectorValue));
         VectorOfTrust vtr =
                 VectorOfTrust.parseFromAuthRequestAttribute(
                         authenticationRequest.getCustomParameter("vtr"));
-        when(clientSessionService.getClientSession(CLIENT_SESSION_ID))
+        when(authorisationCodeService.getExchangeDataForCode(authCode))
                 .thenReturn(
-                        new ClientSession(
-                                authenticationRequest.toParameters(), LocalDateTime.now(), vtr));
+                        Optional.of(
+                                new AuthCodeExchangeData()
+                                        .setEmail(TEST_EMAIL)
+                                        .setClientSessionId(CLIENT_SESSION_ID)
+                                        .setClientSession(
+                                                new ClientSession(
+                                                        authenticationRequest.toParameters(),
+                                                        LocalDateTime.now(),
+                                                        vtr))));
         when(dynamoService.getUserProfileByEmail(eq(TEST_EMAIL))).thenReturn(userProfile);
         when(tokenService.generateTokenResponse(
                         CLIENT_ID,
@@ -387,13 +388,12 @@ public class TokenHandlerTest {
                         Optional.of(
                                 new AuthCodeExchangeData()
                                         .setEmail(TEST_EMAIL)
-                                        .setClientSessionId(CLIENT_SESSION_ID)));
-        when(clientSessionService.getClientSession(CLIENT_SESSION_ID))
-                .thenReturn(
-                        new ClientSession(
-                                generateAuthRequest().toParameters(),
-                                LocalDateTime.now(),
-                                mock(VectorOfTrust.class)));
+                                        .setClientSessionId(CLIENT_SESSION_ID)
+                                        .setClientSession(
+                                                new ClientSession(
+                                                        generateAuthRequest().toParameters(),
+                                                        LocalDateTime.now(),
+                                                        mock(VectorOfTrust.class)))));
 
         APIGatewayProxyResponseEvent result =
                 generateApiGatewayRequest(privateKeyJWT, authCode, "http://invalid-redirect-uri");

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
@@ -166,17 +166,18 @@ public class RedisExtension
             Map<String, List<String>> authRequest,
             VectorOfTrust vtr)
             throws JsonProcessingException {
+        var clientSession = new ClientSession(authRequest, LocalDateTime.now(), vtr);
         redis.saveWithExpiry(
                 AUTH_CODE_PREFIX.concat(authCode),
                 objectMapper.writeValueAsString(
                         new AuthCodeExchangeData()
                                 .setClientSessionId(clientSessionId)
-                                .setEmail(email)),
+                                .setEmail(email)
+                                .setClientSession(clientSession)),
                 300);
         redis.saveWithExpiry(
                 CLIENT_SESSION_PREFIX.concat(clientSessionId),
-                objectMapper.writeValueAsString(
-                        new ClientSession(authRequest, LocalDateTime.now(), vtr)),
+                objectMapper.writeValueAsString(clientSession),
                 300);
     }
 


### PR DESCRIPTION
## What?

- Read client session from auth code store
- Increase lambda warmers to 50

## Why?

- To avoid calling redis twice 
- To speed up our lambdas 