### PR TITLE
BAU - Remove Notify and client reg dependency from OIDC api

### DIFF
--- a/account-migrations/build.gradle
+++ b/account-migrations/build.gradle
@@ -17,7 +17,8 @@ dependencies {
     runtimeOnly configurations.logging_runtime
 
     testImplementation configurations.tests,
-            configurations.lambda_tests
+            configurations.lambda_tests,
+            project(":shared-test")
 
     testRuntimeOnly configurations.test_runtime
 }

--- a/frontend-api/build.gradle
+++ b/frontend-api/build.gradle
@@ -7,12 +7,14 @@ group "uk.gov.di.authentication.frontendapi"
 version "unspecified"
 
 dependencies {
-    implementation configurations.dynamodb,
-            configurations.govuk_notify,
-            configurations.lambda,
+
+    compileOnly configurations.lambda,
+            configurations.sqs,
+            configurations.dynamodb
+
+    implementation configurations.govuk_notify,
             configurations.jackson,
             configurations.nimbus,
-            configurations.sqs,
             configurations.cloudwatch,
             configurations.bouncycastle,
             project(":shared")
@@ -21,7 +23,10 @@ dependencies {
 
     testImplementation configurations.tests,
             configurations.lambda_tests,
-            project(":shared-test")
+            project(":shared-test"),
+            configurations.lambda,
+            configurations.sqs,
+            configurations.dynamodb
 
     testRuntimeOnly configurations.test_runtime
 }

--- a/oidc-api/build.gradle
+++ b/oidc-api/build.gradle
@@ -12,13 +12,11 @@ dependencies {
             configurations.sqs,
             configurations.dynamodb
 
-    implementation configurations.govuk_notify,
-            configurations.jackson,
+    implementation configurations.jackson,
             configurations.nimbus,
             configurations.bouncycastle,
             configurations.cloudwatch,
-            project(":shared"),
-            project(":client-registry-api")
+            project(":shared")
 
     testImplementation configurations.tests,
             configurations.lambda_tests,

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -8,24 +8,28 @@ version "unspecified"
 
 dependencies {
 
-    implementation configurations.lambda,
-            configurations.nimbus,
+    compileOnly configurations.lambda,
+            configurations.sqs,
+            configurations.sns,
+            configurations.ssm,
+            configurations.dynamodb
+
+    implementation configurations.nimbus,
             configurations.jackson,
             configurations.bouncycastle,
             configurations.govuk_notify,
-            configurations.dynamodb,
             configurations.lettuce,
             configurations.libphonenumber,
             configurations.hamcrest,
-            configurations.sns,
-            configurations.sqs,
-            configurations.ssm,
             configurations.cloudwatch,
             "com.google.protobuf:protobuf-java:3.19.4"
 
     testImplementation configurations.tests,
             configurations.lambda_tests,
-            project(":shared-test")
+            project(":shared-test"),
+            configurations.lambda,
+            configurations.sqs,
+            configurations.dynamodb
     testRuntimeOnly configurations.test_runtime
 }
 


### PR DESCRIPTION
## What?

 - Remove Notify and client reg dependency from OIDC api
 - AWS provides SDK libraries at runtime so we don't have to include these in the bundle
 
## Why?

- These dependencies are not used and can be removed to reduce the size of the package
