### PR TITLE
BAU - AWS provides SDK libraries at runtime so we don't have to include in this bundle

### DIFF
--- a/account-management-api/build.gradle
+++ b/account-management-api/build.gradle
@@ -7,19 +7,26 @@ group "uk.gov.di.authentication.accountmanagement"
 version "unspecified"
 
 dependencies {
-    implementation configurations.lambda,
-            configurations.nimbus,
-            configurations.dynamodb,
+    compileOnly configurations.lambda,
+            configurations.sqs,
+            configurations.ssm,
+            configurations.sns,
+            configurations.s3,
+            configurations.dynamodb
+
+    implementation configurations.nimbus,
             configurations.govuk_notify,
             configurations.jackson,
-            configurations.sqs,
             project(":shared")
 
     runtimeOnly configurations.logging_runtime
 
     testImplementation configurations.tests,
             configurations.lambda_tests,
-            project(":shared-test")
+            project(":shared-test"),
+            configurations.lambda,
+            configurations.sqs,
+            configurations.dynamodb
 
     testRuntimeOnly configurations.test_runtime
 }

--- a/account-migrations/build.gradle
+++ b/account-migrations/build.gradle
@@ -7,17 +7,27 @@ group "uk.gov.di.authentication.accountmigration"
 version "unspecified"
 
 dependencies {
-    implementation configurations.bouncycastle,
-            configurations.lambda,
-            configurations.nimbus,
+
+    compileOnly configurations.lambda,
+            configurations.sqs,
+            configurations.ssm,
+            configurations.sns,
             configurations.s3,
+            configurations.dynamodb
+
+    implementation configurations.bouncycastle,
+            configurations.nimbus,
             "com.opencsv:opencsv:5.6",
             project(":shared")
 
     runtimeOnly configurations.logging_runtime
 
     testImplementation configurations.tests,
-            configurations.lambda_tests
+            configurations.lambda_tests,
+            project(":shared-test"),
+            configurations.lambda,
+            configurations.sqs,
+            configurations.dynamodb
 
     testRuntimeOnly configurations.test_runtime
 }

--- a/audit-processors/build.gradle
+++ b/audit-processors/build.gradle
@@ -12,10 +12,14 @@ ext {
 }
 
 dependencies {
-    implementation configurations.lambda,
+    compileOnly configurations.lambda,
             configurations.sqs,
+            configurations.ssm,
+            configurations.sns,
             configurations.s3,
-            project(":shared"),
+            configurations.dynamodb
+
+    implementation project(":shared"),
             "com.google.protobuf:protobuf-java:${dependencyVersions.protobuf_version}",
             "com.google.protobuf:protobuf-java-util:${dependencyVersions.protobuf_version}",
             "com.google.code.gson:gson:2.9.0"
@@ -24,7 +28,10 @@ dependencies {
 
     testImplementation configurations.tests,
             configurations.lambda_tests,
-            project(":shared-test")
+            project(":shared-test"),
+            configurations.lambda,
+            configurations.sqs,
+            configurations.dynamodb
 
     testRuntimeOnly configurations.test_runtime
 }

--- a/client-registry-api/build.gradle
+++ b/client-registry-api/build.gradle
@@ -7,9 +7,13 @@ group "uk.gov.di.clientregistry"
 version "unspecified"
 
 dependencies {
-    implementation configurations.lambda,
-            configurations.nimbus,
-            configurations.dynamodb,
+
+    compileOnly configurations.lambda,
+            configurations.ssm,
+            configurations.sns,
+            configurations.dynamodb
+
+    implementation configurations.nimbus,
             'commons-validator:commons-validator:1.7',
             project(":shared")
 
@@ -17,7 +21,10 @@ dependencies {
 
     testImplementation configurations.tests,
             configurations.lambda_tests,
-            project(":shared-test")
+            project(":shared-test"),
+            configurations.lambda,
+            configurations.sqs,
+            configurations.dynamodb
 
     testRuntimeOnly configurations.test_runtime
 }

--- a/delivery-receipts-api/build.gradle
+++ b/delivery-receipts-api/build.gradle
@@ -7,8 +7,13 @@ group "uk.gov.di.authentication.deliveryreceiptsapi"
 version "unspecified"
 
 dependencies {
+    compileOnly configurations.lambda,
+            configurations.sqs,
+            configurations.ssm,
+            configurations.sns,
+            configurations.dynamodb
+
     implementation configurations.govuk_notify,
-            configurations.lambda,
             configurations.jackson,
             configurations.libphonenumber,
             configurations.cloudwatch,
@@ -18,7 +23,9 @@ dependencies {
 
     testImplementation configurations.tests,
             configurations.lambda_tests,
-            project(":shared-test")
+            project(":shared-test"),
+            configurations.lambda,
+            configurations.dynamodb
 
     testRuntimeOnly configurations.test_runtime
 }

--- a/frontend-api/build.gradle
+++ b/frontend-api/build.gradle
@@ -7,12 +7,17 @@ group "uk.gov.di.authentication.frontendapi"
 version "unspecified"
 
 dependencies {
-    implementation configurations.dynamodb,
-            configurations.govuk_notify,
-            configurations.lambda,
+
+    compileOnly configurations.lambda,
+            configurations.sqs,
+            configurations.ssm,
+            configurations.sns,
+            configurations.s3,
+            configurations.dynamodb
+
+    implementation configurations.govuk_notify,
             configurations.jackson,
             configurations.nimbus,
-            configurations.sqs,
             configurations.cloudwatch,
             configurations.bouncycastle,
             project(":shared")
@@ -21,7 +26,10 @@ dependencies {
 
     testImplementation configurations.tests,
             configurations.lambda_tests,
-            project(":shared-test")
+            project(":shared-test"),
+            configurations.lambda,
+            configurations.sqs,
+            configurations.dynamodb
 
     testRuntimeOnly configurations.test_runtime
 }

--- a/ipv-api/build.gradle
+++ b/ipv-api/build.gradle
@@ -7,9 +7,13 @@ group "uk.gov.di.authentication.ipvapi"
 version "unspecified"
 
 dependencies {
-    implementation configurations.dynamodb,
-            configurations.lambda,
-            configurations.jackson,
+    compileOnly configurations.lambda,
+            configurations.sqs,
+            configurations.ssm,
+            configurations.sns,
+            configurations.dynamodb
+
+    implementation configurations.jackson,
             configurations.nimbus,
             project(":shared")
     runtimeOnly configurations.logging_runtime
@@ -17,7 +21,9 @@ dependencies {
     testImplementation configurations.tests,
             configurations.lambda_tests,
             project(":shared-test"),
-            project(":shared")
+            configurations.lambda,
+            configurations.sqs,
+            configurations.dynamodb
 
     testRuntimeOnly configurations.test_runtime
 }

--- a/oidc-api/build.gradle
+++ b/oidc-api/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 
     compileOnly configurations.lambda,
             configurations.sqs,
+            configurations.sns,
             configurations.dynamodb
 
     implementation configurations.govuk_notify,


### PR DESCRIPTION
## What?

- AWS provides SDK libraries at runtime so we don't have to include in this bundle

## Why?

- Reduce package size 