### PR TITLE
AUTH-1439: Reset password refactor

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/ResetPasswordCompletionRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/ResetPasswordCompletionRequest.java
@@ -3,18 +3,17 @@ package uk.gov.di.authentication.frontendapi.entity;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
 
-public class ResetPasswordWithCodeRequest {
-    @JsonProperty(required = true, value = "code")
-    @NotNull
+public class ResetPasswordCompletionRequest {
+    @JsonProperty(value = "code")
     private String code;
 
     @JsonProperty(required = true, value = "password")
     @NotNull
     private String password;
 
-    public ResetPasswordWithCodeRequest() {}
+    public ResetPasswordCompletionRequest() {}
 
-    public ResetPasswordWithCodeRequest(String code, String password) {
+    public ResetPasswordCompletionRequest(String code, String password) {
         this.code = code;
         this.password = password;
     }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
@@ -10,7 +10,7 @@ import jakarta.validation.ConstraintViolationException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
-import uk.gov.di.authentication.frontendapi.entity.ResetPasswordWithCodeRequest;
+import uk.gov.di.authentication.frontendapi.entity.ResetPasswordCompletionRequest;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.NotificationType;
@@ -36,10 +36,11 @@ import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.util.Optional;
 
+import static java.util.Objects.nonNull;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateEmptySuccessApiGatewayResponse;
 
-public class ResetPasswordHandler extends BaseFrontendHandler<ResetPasswordWithCodeRequest>
+public class ResetPasswordHandler extends BaseFrontendHandler<ResetPasswordCompletionRequest>
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     private final AuthenticationService authenticationService;
@@ -60,7 +61,7 @@ public class ResetPasswordHandler extends BaseFrontendHandler<ResetPasswordWithC
             ClientService clientService,
             AuditService auditService) {
         super(
-                ResetPasswordWithCodeRequest.class,
+                ResetPasswordCompletionRequest.class,
                 configurationService,
                 sessionService,
                 clientSessionService,
@@ -77,7 +78,7 @@ public class ResetPasswordHandler extends BaseFrontendHandler<ResetPasswordWithC
     }
 
     public ResetPasswordHandler(ConfigurationService configurationService) {
-        super(ResetPasswordWithCodeRequest.class, configurationService);
+        super(ResetPasswordCompletionRequest.class, configurationService);
         this.authenticationService = new DynamoService(configurationService);
         this.sqsClient =
                 new AwsSqsClient(
@@ -93,7 +94,7 @@ public class ResetPasswordHandler extends BaseFrontendHandler<ResetPasswordWithC
     public APIGatewayProxyResponseEvent handleRequestWithUserContext(
             APIGatewayProxyRequestEvent input,
             Context context,
-            ResetPasswordWithCodeRequest request,
+            ResetPasswordCompletionRequest request,
             UserContext userContext) {
         LOG.info("Request received to ResetPasswordHandler");
         try {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
@@ -155,17 +155,22 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
             code = codeGeneratorService.sixDigitCode();
             notifyText = code;
             notificationType = RESET_PASSWORD_WITH_CODE;
+            codeStorageService.saveOtpCode(
+                    resetPasswordRequest.getEmail(),
+                    code,
+                    configurationService.getCodeExpiry(),
+                    notificationType);
         } else {
             code = codeGeneratorService.twentyByteEncodedRandomCode();
             notifyText =
                     resetPasswordService.buildResetPasswordLink(
                             code, userContext.getSession().getSessionId(), persistentSessionId);
             notificationType = RESET_PASSWORD;
+            codeStorageService.savePasswordResetCode(
+                    subjectId, code, configurationService.getCodeExpiry(), notificationType);
         }
         NotifyRequest notifyRequest =
                 new NotifyRequest(resetPasswordRequest.getEmail(), notificationType, notifyText);
-        codeStorageService.savePasswordResetCode(
-                subjectId, code, configurationService.getCodeExpiry(), notificationType);
         sessionService.save(userContext.getSession().incrementPasswordResetCount());
         sqsClient.send(serialiseRequest(notifyRequest));
         LOG.info("Successfully processed request");

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
@@ -183,8 +183,8 @@ class ResetPasswordRequestHandlerTest {
 
         verify(awsSqsClient).send(serialisedRequest);
         verify(codeStorageService)
-                .savePasswordResetCode(
-                        subject.getValue(),
+                .saveOtpCode(
+                        TEST_EMAIL_ADDRESS,
                         TEST_SIX_DIGIT_CODE,
                         CODE_EXPIRY_TIME,
                         RESET_PASSWORD_WITH_CODE);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordIntegrationTest.java
@@ -3,7 +3,7 @@ package uk.gov.di.authentication.api;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import uk.gov.di.authentication.frontendapi.entity.ResetPasswordWithCodeRequest;
+import uk.gov.di.authentication.frontendapi.entity.ResetPasswordCompletionRequest;
 import uk.gov.di.authentication.frontendapi.lambda.ResetPasswordHandler;
 import uk.gov.di.authentication.shared.entity.NotifyRequest;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
@@ -41,7 +41,7 @@ public class ResetPasswordIntegrationTest extends ApiGatewayHandlerIntegrationTe
 
         var response =
                 makeRequest(
-                        Optional.of(new ResetPasswordWithCodeRequest(CODE, PASSWORD)),
+                        Optional.of(new ResetPasswordCompletionRequest(CODE, PASSWORD)),
                         constructFrontendHeaders(sessionId),
                         Map.of());
 


### PR DESCRIPTION
## What?

- Rename `ResetPasswordWithCodeRequest` to `ResetPasswordCompletionRequest` (as going forward the code won't be included).
- Make `code` optional.
- Update `PasswordResetHandler` to work without a provided code. This will be used in the journey when a user is sent a six-digit code rather than a link.
- When issuing a 6 digit code for password resets, save using the OTP save method, so it can be verified by the `VerifyCodeHandler` (which requires this).

## Why?

These are further changes required to enable the reset password with code and continue journey.

## Related PRs

#1532 
#1536 
#1542 