### PR TITLE
AUTH-1213 - Create new KMS key for IPV Token authentication

### DIFF
--- a/ci/terraform/shared/kms.tf
+++ b/ci/terraform/shared/kms.tf
@@ -283,3 +283,19 @@ data "aws_iam_policy_document" "events_encryption_key_permissions" {
     }
   }
 }
+
+# IPV Token Authentication KMS key
+
+resource "aws_kms_key" "ipv_token_auth_signing_key" {
+  description              = "KMS signing key for authentication to the IPV token endpoint"
+  deletion_window_in_days  = 30
+  key_usage                = "SIGN_VERIFY"
+  customer_master_key_spec = "ECC_NIST_P256"
+
+  tags = local.default_tags
+}
+
+resource "aws_kms_alias" "ipv_token_auth_signing_key_alias" {
+  name          = "alias/${var.environment}-ipv-token-auth-kms-key-alias"
+  target_key_id = aws_kms_key.id_token_signing_key.key_id
+}


### PR DESCRIPTION
## What?

-  Create new KMS key for IPV Token authentication

## Why?

- Create a new KMS key which will sign the Private key JWT. The Private Key JWT will be used to authenticate to the IPV token endpoint