### PR TITLE
BAU - Use compile only for shared

### DIFF
--- a/client-registry-api/build.gradle
+++ b/client-registry-api/build.gradle
@@ -9,8 +9,10 @@ version "unspecified"
 dependencies {
 
     compileOnly configurations.lambda,
+            configurations.sqs,
             configurations.ssm,
             configurations.sns,
+            configurations.s3,
             configurations.dynamodb
 
     implementation configurations.nimbus,

--- a/delivery-receipts-api/build.gradle
+++ b/delivery-receipts-api/build.gradle
@@ -11,6 +11,7 @@ dependencies {
             configurations.sqs,
             configurations.ssm,
             configurations.sns,
+            configurations.s3,
             configurations.dynamodb
 
     implementation configurations.govuk_notify,

--- a/ipv-api/build.gradle
+++ b/ipv-api/build.gradle
@@ -11,6 +11,7 @@ dependencies {
             configurations.sqs,
             configurations.ssm,
             configurations.sns,
+            configurations.s3,
             configurations.dynamodb
 
     implementation configurations.jackson,

--- a/oidc-api/build.gradle
+++ b/oidc-api/build.gradle
@@ -10,16 +10,16 @@ dependencies {
 
     compileOnly configurations.lambda,
             configurations.sqs,
+            configurations.ssm,
             configurations.sns,
+            configurations.s3,
             configurations.dynamodb
 
-    implementation configurations.govuk_notify,
-            configurations.jackson,
+    implementation configurations.jackson,
             configurations.nimbus,
             configurations.bouncycastle,
             configurations.cloudwatch,
-            project(":shared"),
-            project(":client-registry-api")
+            project(":shared")
 
     testImplementation configurations.tests,
             configurations.lambda_tests,

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -8,24 +8,27 @@ version "unspecified"
 
 dependencies {
 
-    implementation configurations.lambda,
-            configurations.nimbus,
-            configurations.jackson,
-            configurations.bouncycastle,
-            configurations.govuk_notify,
-            configurations.dynamodb,
-            configurations.lettuce,
-            configurations.libphonenumber,
-            configurations.hamcrest,
+    compileOnly configurations.lambda,
             configurations.sns,
             configurations.sqs,
             configurations.ssm,
+            configurations.dynamodb
+
+    implementation configurations.nimbus,
+            configurations.jackson,
+            configurations.bouncycastle,
+            configurations.govuk_notify,
+            configurations.lettuce,
+            configurations.libphonenumber,
+            configurations.hamcrest,
             configurations.cloudwatch,
             "com.google.protobuf:protobuf-java:3.19.4"
 
     testImplementation configurations.tests,
             configurations.lambda_tests,
-            project(":shared-test")
+            project(":shared-test"),
+            configurations.lambda,
+            configurations.dynamodb
     testRuntimeOnly configurations.test_runtime
 }
 


### PR DESCRIPTION
## What?

 - Use compile only for shared

## Why?

- AWS provides SDK libs at runtime so we can bring the package size down by not including these.

