### PR TITLE
AUTH-1213 - Sign IPV PrivateKeyJWT using KMS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -270,6 +270,7 @@ task oidcTerraform (type: Terraform) {
         allprojects.findAll {it.name == "integration-tests"}.first().tasks.getByName("test") {
             environment "API_GATEWAY_ID", json.api_gateway_root_id.value
             environment "TOKEN_SIGNING_KEY_ALIAS", json.token_signing_key_alias.value
+            environment "IPV_TOKEN_SIGNING_KEY_ALIAS", json.ipv_token_auth_key_alias.value
             environment "BASE_URL", json.base_url.value
             environment "API_KEY", json.frontend_api_key.value
             environment "FRONTEND_API_GATEWAY_ID", json.frontend_api_gateway_root_id.value
@@ -284,6 +285,7 @@ task oidcTerraform (type: Terraform) {
     dependsOn ":client-registry-api:buildZip"
     dependsOn ":frontend-api:buildZip"
     dependsOn ":oidc-api:buildZip"
+    dependsOn ":ipv-api:buildZip"
     dependsOn "sharedTerraform"
 }
 

--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -11,6 +11,7 @@ module "ipv_callback_role" {
     aws_iam_policy.dynamo_user_write_access_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
+    aws_iam_policy.ipv_token_auth_kms_policy.arn,
   ]
 }
 
@@ -32,6 +33,7 @@ module "ipv-callback" {
     LOCALSTACK_ENDPOINT            = var.use_localstack ? var.localstack_endpoint : null
     REDIS_KEY                      = local.redis_key
     DYNAMO_ENDPOINT                = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    IPV_TOKEN_SIGNING_KEY_ALIAS    = local.ipv_token_auth_key_alias_name
     IPV_AUTHORISATION_CLIENT_ID    = var.ipv_authorisation_client_id
     IPV_AUTHORISATION_CALLBACK_URI = var.ipv_authorisation_callback_uri
     IPV_AUTHORISATION_URI          = var.ipv_authorisation_uri

--- a/ci/terraform/oidc/kms-policies.tf
+++ b/ci/terraform/oidc/kms-policies.tf
@@ -35,3 +35,28 @@ resource "aws_iam_policy" "audit_signing_key_lambda_kms_signing_policy" {
 
   policy = data.aws_iam_policy_document.audit_payload_kms_signing_policy_document.json
 }
+
+### IPV Token signing key access
+
+data "aws_iam_policy_document" "ipv_token_auth_kms_policy_document" {
+  statement {
+    sid    = "AllowAccessToKmsSigningKey"
+    effect = "Allow"
+
+    actions = [
+      "kms:Sign",
+      "kms:GetPublicKey",
+    ]
+    resources = [
+      local.ipv_token_auth_signing_key_arn
+    ]
+  }
+}
+
+resource "aws_iam_policy" "ipv_token_auth_kms_policy" {
+  name_prefix = "kms-ipv-token-auth-policy"
+  path        = "/${var.environment}/ipv-token/"
+  description = "IAM policy for managing IPV authentication token KMS key access"
+
+  policy = data.aws_iam_policy_document.ipv_token_auth_kms_policy_document.json
+}

--- a/ci/terraform/oidc/outputs.tf
+++ b/ci/terraform/oidc/outputs.tf
@@ -18,6 +18,10 @@ output "token_signing_key_alias" {
   value = local.id_token_signing_key_alias_name
 }
 
+output "ipv_token_auth_key_alias" {
+  value = local.ipv_token_auth_key_alias_name
+}
+
 output "frontend_api_key" {
   value     = aws_api_gateway_api_key.di_auth_frontend_api_key.value
   sensitive = true

--- a/ci/terraform/oidc/shared.tf
+++ b/ci/terraform/oidc/shared.tf
@@ -24,6 +24,8 @@ locals {
   authentication_subnet_ids                   = data.terraform_remote_state.shared.outputs.authentication_subnet_ids
   id_token_signing_key_alias_name             = data.terraform_remote_state.shared.outputs.id_token_signing_key_alias_name
   id_token_signing_key_arn                    = data.terraform_remote_state.shared.outputs.id_token_signing_key_arn
+  ipv_token_auth_key_alias_name               = data.terraform_remote_state.shared.outputs.ipv_token_auth_signing_key_alias_name
+  ipv_token_auth_signing_key_arn              = data.terraform_remote_state.shared.outputs.ipv_token_auth_signing_key_arn
   audit_signing_key_alias_name                = data.terraform_remote_state.shared.outputs.audit_signing_key_alias_name
   audit_signing_key_arn                       = data.terraform_remote_state.shared.outputs.audit_signing_key_arn
   sms_bucket_name                             = data.terraform_remote_state.shared.outputs.sms_bucket_name

--- a/ci/terraform/shared/outputs.tf
+++ b/ci/terraform/shared/outputs.tf
@@ -72,6 +72,14 @@ output "id_token_signing_key_arn" {
   value = aws_kms_key.id_token_signing_key.arn
 }
 
+output "ipv_token_auth_signing_key_alias_name" {
+  value = aws_kms_alias.ipv_token_auth_signing_key_alias.name
+}
+
+output "ipv_token_auth_signing_key_arn" {
+  value = aws_kms_key.ipv_token_auth_signing_key.arn
+}
+
 output "audit_signing_key_alias_name" {
   value = aws_kms_alias.audit_payload_signing_key_alias.name
 }

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -52,6 +52,7 @@ test {
     environment "TERMS_CONDITIONS_VERSION", "1.0"
     environment "HEADERS_CASE_INSENSITIVE", "true"
     environment "IDENTITY_ENABLED", "false"
+    environment "IDENTITY_ENABLED", "false"
 
     doLast {
         tasks.getByName("jacocoTestReport").sourceDirectories.from(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVAuthorisationHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVAuthorisationHandlerIntegrationTest.java
@@ -114,7 +114,12 @@ class IPVAuthorisationHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
         private final IPVStubExtension ipvStubExtension;
 
         public IPVTestConfigurationService(IPVStubExtension ipvStub) {
-            super(auditTopic, notificationsQueue, auditSigningKey, tokenSigner);
+            super(
+                    auditTopic,
+                    notificationsQueue,
+                    auditSigningKey,
+                    tokenSigner,
+                    ipvPrivateKeyJwtSigner);
             this.ipvStubExtension = ipvStub;
         }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
@@ -137,5 +137,10 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
         public URI getIPVAuthorisationCallbackURI() {
             return URI.create("http://localhost/redirect");
         }
+
+        @Override
+        public String getIPVTokenSigningKeyAlias() {
+            return ipvPrivateKeyJwtSigner.getKeyAlias();
+        }
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
@@ -207,7 +207,12 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     private class UserInfoConfigurationService extends IntegrationTestConfigurationService {
 
         public UserInfoConfigurationService() {
-            super(auditTopic, notificationsQueue, auditSigningKey, tokenSigner);
+            super(
+                    auditTopic,
+                    notificationsQueue,
+                    auditSigningKey,
+                    tokenSigner,
+                    ipvPrivateKeyJwtSigner);
         }
 
         @Override

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -21,6 +21,7 @@ import uk.gov.di.authentication.shared.services.ClientSessionService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoClientService;
 import uk.gov.di.authentication.shared.services.DynamoService;
+import uk.gov.di.authentication.shared.services.KmsConnectionService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
 import uk.gov.di.authentication.shared.services.SessionService;
 
@@ -69,7 +70,9 @@ public class IPVCallbackHandler
         this.ipvAuthorisationService =
                 new IPVAuthorisationService(
                         configurationService, new RedisConnectionService(configurationService));
-        this.ipvTokenService = new IPVTokenService(configurationService);
+        this.ipvTokenService =
+                new IPVTokenService(
+                        configurationService, new KmsConnectionService(configurationService));
         this.sessionService = new SessionService(configurationService);
         this.dynamoService = new DynamoService(configurationService);
         this.clientSessionService = new ClientSessionService(configurationService);

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVTokenService.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVTokenService.java
@@ -1,7 +1,14 @@
 package uk.gov.di.authentication.ipv.services;
 
+import com.amazonaws.services.kms.model.SignRequest;
+import com.amazonaws.services.kms.model.SignResult;
+import com.amazonaws.services.kms.model.SigningAlgorithmSpec;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.impl.ECDSA;
+import com.nimbusds.jose.util.Base64URL;
+import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import com.nimbusds.oauth2.sdk.AuthorizationCodeGrant;
 import com.nimbusds.oauth2.sdk.ParseException;
@@ -11,20 +18,19 @@ import com.nimbusds.oauth2.sdk.auth.JWTAuthenticationClaimsSet;
 import com.nimbusds.oauth2.sdk.auth.PrivateKeyJWT;
 import com.nimbusds.oauth2.sdk.id.Audience;
 import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.id.JWTID;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.KmsConnectionService;
 
 import java.io.IOException;
-import java.security.KeyPairGenerator;
-import java.security.NoSuchAlgorithmException;
-import java.security.interfaces.RSAPrivateKey;
+import java.nio.ByteBuffer;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
+import java.util.Map;
 
 import static java.util.Collections.singletonList;
 import static uk.gov.di.authentication.shared.helpers.ConstructUriHelper.buildURI;
@@ -32,12 +38,17 @@ import static uk.gov.di.authentication.shared.helpers.ConstructUriHelper.buildUR
 public class IPVTokenService {
 
     private final ConfigurationService configurationService;
+    private final KmsConnectionService kmsService;
     private static final String TOKEN_PATH = "token";
+    private static final JWSAlgorithm TOKEN_ALGORITHM = JWSAlgorithm.ES256;
     public static final String IPV_ACCESS_TOKEN_PREFIX = "IPV_ACCESS_TOKEN:";
+    private static final Long PRIVATE_KEY_JWT_EXPIRY = 5L;
     private static final Logger LOG = LogManager.getLogger(IPVTokenService.class);
 
-    public IPVTokenService(ConfigurationService configurationService) {
+    public IPVTokenService(
+            ConfigurationService configurationService, KmsConnectionService kmsService) {
         this.configurationService = configurationService;
+        this.kmsService = kmsService;
     }
 
     public TokenRequest constructTokenRequest(String authCode) {
@@ -47,24 +58,24 @@ public class IPVTokenService {
                         configurationService.getIPVAuthorisationCallbackURI());
         var tokenUri =
                 buildURI(configurationService.getIPVAuthorisationURI().toString(), TOKEN_PATH);
-        LocalDateTime localDateTime = LocalDateTime.now().plusMinutes(5);
-        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
-        JWTAuthenticationClaimsSet claimsSet =
+        var expiryDate = LocalDateTime.now().plusMinutes(PRIVATE_KEY_JWT_EXPIRY);
+        var claimsSet =
                 new JWTAuthenticationClaimsSet(
                         new ClientID(configurationService.getIPVAuthorisationClientId()),
-                        new Audience(tokenUri));
-        claimsSet.getExpirationTime().setTime(expiryDate.getTime());
-        var privateKeyJWT = generatePrivateKeyJwt(claimsSet);
-        var extraParams = new HashMap<String, List<String>>();
-        extraParams.put(
-                "client_id", singletonList(configurationService.getIPVAuthorisationClientId()));
+                        singletonList(new Audience(tokenUri)),
+                        Date.from(expiryDate.atZone(ZoneId.of("UTC")).toInstant()),
+                        null,
+                        Date.from(LocalDateTime.now().atZone(ZoneId.of("UTC")).toInstant()),
+                        new JWTID());
         return new TokenRequest(
                 tokenUri,
-                privateKeyJWT,
+                generatePrivateKeyJwt(claimsSet),
                 codeGrant,
                 null,
                 singletonList(configurationService.getIPVAuthorisationCallbackURI()),
-                extraParams);
+                Map.of(
+                        "client_id",
+                        singletonList(configurationService.getIPVAuthorisationClientId())));
     }
 
     public TokenResponse sendTokenRequest(TokenRequest tokenRequest) {
@@ -84,23 +95,31 @@ public class IPVTokenService {
     }
 
     private PrivateKeyJWT generatePrivateKeyJwt(JWTAuthenticationClaimsSet claimsSet) {
-        KeyPairGenerator kpg;
-        PrivateKeyJWT privateKeyJwt;
         try {
-            kpg = KeyPairGenerator.getInstance("RSA");
-            kpg.initialize(2048);
-            var keyPair = kpg.generateKeyPair();
-            privateKeyJwt =
-                    new PrivateKeyJWT(
-                            claimsSet,
-                            JWSAlgorithm.RS512,
-                            (RSAPrivateKey) keyPair.getPrivate(),
-                            null,
-                            null);
-        } catch (NoSuchAlgorithmException | JOSEException e) {
-            LOG.error("Error whilst creating PrivateKeyJWT on the fly");
+            var jwsHeader =
+                    new JWSHeader.Builder(TOKEN_ALGORITHM)
+                            .keyID(configurationService.getIPVTokenSigningKeyAlias())
+                            .build();
+            var encodedHeader = jwsHeader.toBase64URL();
+            var encodedClaims = Base64URL.encode(claimsSet.toJWTClaimsSet().toString());
+            var message = encodedHeader + "." + encodedClaims;
+            var messageToSign = ByteBuffer.wrap(message.getBytes());
+            var signRequest = new SignRequest();
+            signRequest.setMessage(messageToSign);
+            signRequest.setKeyId(configurationService.getIPVTokenSigningKeyAlias());
+            signRequest.setSigningAlgorithm(SigningAlgorithmSpec.ECDSA_SHA_256.toString());
+            SignResult signResult = kmsService.sign(signRequest);
+            LOG.info("PrivateKeyJWT has been signed successfully");
+            var signature =
+                    Base64URL.encode(
+                                    ECDSA.transcodeSignatureToConcat(
+                                            signResult.getSignature().array(),
+                                            ECDSA.getSignatureByteArrayLength(TOKEN_ALGORITHM)))
+                            .toString();
+            return new PrivateKeyJWT(SignedJWT.parse(message + "." + signature));
+        } catch (JOSEException | java.text.ParseException e) {
+            LOG.error("Exception thrown when trying to parse SignedJWT or JWTClaimSet", e);
             throw new RuntimeException(e);
         }
-        return privateKeyJwt;
     }
 }

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVTokenServiceTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVTokenServiceTest.java
@@ -1,33 +1,59 @@
 package uk.gov.di.authentication.ipv.services;
 
+import com.amazonaws.services.kms.model.SignRequest;
+import com.amazonaws.services.kms.model.SignResult;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.crypto.impl.ECDSA;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
+import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import com.nimbusds.oauth2.sdk.GrantType;
 import com.nimbusds.oauth2.sdk.TokenRequest;
+import com.nimbusds.oauth2.sdk.auth.JWTAuthenticationClaimsSet;
+import com.nimbusds.oauth2.sdk.id.Audience;
 import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.id.JWTID;
+import com.nimbusds.oauth2.sdk.id.Subject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.KmsConnectionService;
 
 import java.net.URI;
+import java.nio.ByteBuffer;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
 
+import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.shared.helpers.ConstructUriHelper.buildURI;
+import static uk.gov.di.authentication.sharedtest.exceptions.Unchecked.unchecked;
 
 class IPVTokenServiceTest {
 
     private final ConfigurationService configService = mock(ConfigurationService.class);
+    private final KmsConnectionService kmsService = mock(KmsConnectionService.class);
     private static final URI IPV_URI = URI.create("http://ipv");
     private static final URI REDIRECT_URI = URI.create("http://redirect");
+    private static final Subject PUBLIC_SUBJECT = new Subject("public-subject");
+    private static final String BASE_URL = "https://example.com";
     private static final ClientID CLIENT_ID = new ClientID("some-client-id");
+    private static final String KEY_ID = "14342354354353";
     private static final AuthorizationCode AUTH_CODE = new AuthorizationCode();
     private IPVTokenService ipvTokenService;
 
     @BeforeEach
     void setUp() {
-        ipvTokenService = new IPVTokenService(configService);
+        ipvTokenService = new IPVTokenService(configService, kmsService);
         when(configService.getIPVAuthorisationURI()).thenReturn(IPV_URI);
         when(configService.getIPVAuthorisationClientId()).thenReturn(CLIENT_ID.getValue());
         when(configService.getAccessTokenExpiry()).thenReturn(300L);
@@ -35,7 +61,8 @@ class IPVTokenServiceTest {
     }
 
     @Test
-    void shouldConstructTokenRequest() {
+    void shouldConstructTokenRequest() throws JOSEException {
+        signJWTWithKMS();
         TokenRequest tokenRequest = ipvTokenService.constructTokenRequest(AUTH_CODE.getValue());
 
         assertThat(tokenRequest.getEndpointURI(), equalTo(buildURI(IPV_URI.toString(), "token")));
@@ -51,5 +78,37 @@ class IPVTokenServiceTest {
         assertThat(
                 tokenRequest.toHTTPRequest().getQueryParameters().get("client_id").get(0),
                 equalTo(CLIENT_ID.getValue()));
+    }
+
+    private void signJWTWithKMS() throws JOSEException {
+        var ecSigningKey =
+                new ECKeyGenerator(Curve.P_256)
+                        .keyID(KEY_ID)
+                        .algorithm(JWSAlgorithm.ES256)
+                        .generate();
+        var claimsSet =
+                new JWTAuthenticationClaimsSet(
+                        new ClientID(CLIENT_ID),
+                        singletonList(new Audience(buildURI(IPV_URI.toString(), "token"))),
+                        Date.from(
+                                LocalDateTime.now()
+                                        .plusMinutes(5)
+                                        .atZone(ZoneId.of("UTC"))
+                                        .toInstant()),
+                        null,
+                        Date.from(LocalDateTime.now().atZone(ZoneId.of("UTC")).toInstant()),
+                        new JWTID());
+        var ecdsaSigner = new ECDSASigner(ecSigningKey);
+        var jwsHeader =
+                new JWSHeader.Builder(JWSAlgorithm.ES256).keyID(ecSigningKey.getKeyID()).build();
+        var signedJWT = new SignedJWT(jwsHeader, claimsSet.toJWTClaimsSet());
+        unchecked(signedJWT::sign).accept(ecdsaSigner);
+        var signResult = new SignResult();
+        byte[] idTokenSignatureDer =
+                ECDSA.transcodeSignatureToDER(signedJWT.getSignature().decode());
+        signResult.setSignature(ByteBuffer.wrap(idTokenSignatureDer));
+        signResult.setKeyId(KEY_ID);
+        signResult.setSigningAlgorithm(JWSAlgorithm.ES256.getName());
+        when(kmsService.sign(any(SignRequest.class))).thenReturn(signResult);
     }
 }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
@@ -65,6 +65,10 @@ public abstract class HandlerIntegrationTest<Q, S> {
     protected static final TokenSigningExtension tokenSigner = new TokenSigningExtension();
 
     @RegisterExtension
+    protected static final TokenSigningExtension ipvPrivateKeyJwtSigner =
+            new TokenSigningExtension("ipv-token-auth-key");
+
+    @RegisterExtension
     protected static final ParameterStoreExtension configurationParameters =
             new ParameterStoreExtension(
                     Map.of(
@@ -80,7 +84,11 @@ public abstract class HandlerIntegrationTest<Q, S> {
 
     protected final ConfigurationService TEST_CONFIGURATION_SERVICE =
             new IntegrationTestConfigurationService(
-                    auditTopic, notificationsQueue, auditSigningKey, tokenSigner);
+                    auditTopic,
+                    notificationsQueue,
+                    auditSigningKey,
+                    tokenSigner,
+                    ipvPrivateKeyJwtSigner);
 
     protected RequestHandler<Q, S> handler;
     protected final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
@@ -142,16 +150,19 @@ public abstract class HandlerIntegrationTest<Q, S> {
         private final KmsKeyExtension auditSigningKey;
         private final TokenSigningExtension tokenSigningKey;
         private final SnsTopicExtension auditEventTopic;
+        private final TokenSigningExtension ipvPrivateKeyJwtSigner;
 
         public IntegrationTestConfigurationService(
                 SnsTopicExtension auditEventTopic,
                 SqsQueueExtension notificationQueue,
                 KmsKeyExtension auditSigningKey,
-                TokenSigningExtension tokenSigningKey) {
+                TokenSigningExtension tokenSigningKey,
+                TokenSigningExtension ipvPrivateKeyJwtSigner) {
             this.auditEventTopic = auditEventTopic;
             this.notificationQueue = notificationQueue;
             this.tokenSigningKey = tokenSigningKey;
             this.auditSigningKey = auditSigningKey;
+            this.ipvPrivateKeyJwtSigner = ipvPrivateKeyJwtSigner;
         }
 
         @Override
@@ -172,6 +183,11 @@ public abstract class HandlerIntegrationTest<Q, S> {
         @Override
         public String getTokenSigningKeyAlias() {
             return tokenSigningKey.getKeyAlias();
+        }
+
+        @Override
+        public String getIPVTokenSigningKeyAlias() {
+            return ipvPrivateKeyJwtSigner.getKeyAlias();
         }
 
         @Override

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/TokenSigningExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/TokenSigningExtension.java
@@ -24,6 +24,10 @@ public class TokenSigningExtension extends KmsKeyExtension {
         super("token-signing-key");
     }
 
+    public TokenSigningExtension(String keyAliasSuffix) {
+        super(keyAliasSuffix);
+    }
+
     @Override
     public void beforeAll(ExtensionContext context) {
         super.beforeAll(context);

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/TokenGeneratorHelper.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/TokenGeneratorHelper.java
@@ -6,11 +6,9 @@ import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jose.JWSSigner;
 import com.nimbusds.jose.crypto.ECDSASigner;
 import com.nimbusds.jose.crypto.RSASSASigner;
-import com.nimbusds.jose.jwk.Curve;
 import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.RSAKey;
-import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.ParseException;
@@ -73,18 +71,6 @@ public class TokenGeneratorHelper {
         } catch (JOSEException | ParseException e) {
             throw new RuntimeException(e);
         }
-    }
-
-    public static SignedJWT generateSignedTokenWithGeneratedKey(
-            String clientId, String issuerUrl, List<String> scopes, Subject subject)
-            throws JOSEException {
-        ECKey ecSigningKey =
-                new ECKeyGenerator(Curve.P_256)
-                        .keyID(KEY_ID)
-                        .algorithm(JWSAlgorithm.ES256)
-                        .generate();
-        ECDSASigner signer = new ECDSASigner(ecSigningKey);
-        return generateSignedToken(clientId, issuerUrl, scopes, signer, subject, KEY_ID);
     }
 
     public static SignedJWT generateSignedToken(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -119,6 +119,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return System.getenv().getOrDefault("IPV_AUTHORISATION_CLIENT_ID", "");
     }
 
+    public String getIPVTokenSigningKeyAlias() {
+        return System.getenv("IPV_TOKEN_SIGNING_KEY_ALIAS");
+    }
+
     public URI getLoginURI() {
         return URI.create(System.getenv("LOGIN_URI"));
     }


### PR DESCRIPTION
## What?

- Give the IPVCallbackHandler the right permissions to the KMS key
- Sign the PrivateKeyJWT using KMS

## Why?

- We will authenticate to the IPV token endpoint using PrivateKeyJWT. We will sign this using an EC key provided by KMS

