### PR TITLE
AUTH-1347 - Keep identity feature flags consistent

### DIFF
--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -31,6 +31,7 @@ module "userinfo" {
     REDIS_KEY               = local.redis_key
     DYNAMO_ENDPOINT         = var.use_localstack ? var.lambda_dynamo_endpoint : null
     TOKEN_SIGNING_KEY_ALIAS = local.id_token_signing_key_alias_name
+    IDENTITY_ENABLED        = var.ipv_api_enabled
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.UserInfoHandler::handleRequest"
 

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -213,7 +213,7 @@ variable "client_registry_api_enabled" {
 }
 
 variable "ipv_api_enabled" {
-  default = true
+  default = false
 }
 
 variable "ipv_authorisation_uri" {

--- a/ci/terraform/shared/variables.tf
+++ b/ci/terraform/shared/variables.tf
@@ -106,7 +106,7 @@ variable "provision_dynamo" {
 }
 
 variable "ipv_api_enabled" {
-  default = true
+  default = false
 }
 
 variable "dynamo_default_read_capacity" {


### PR DESCRIPTION
## What?

- Switch the default value of ipv_api_enabled to false so IPV is disabled by default
- Make the IDENTITY_ENABLED use the ipv_api_enabled var, so that these feature flags are consistent

## Why?

- To disable IPV in all environments unless specified as we only want to enable it in our new staging env for the time being
- So that there is a single identity feature flag which is used by both terraform and the application 