### PR TITLE
AUTH-1347 - Send the necessary information in SPOT payload

### DIFF
--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -25,17 +25,18 @@ module "ipv-callback" {
   environment     = var.environment
 
   handler_environment_variables = {
-    ENVIRONMENT                    = var.environment
-    EVENTS_SNS_TOPIC_ARN           = aws_sns_topic.events.arn
     AUDIT_SIGNING_KEY_ALIAS        = local.audit_signing_key_alias_name
-    LOGIN_URI                      = module.dns.frontend_url
-    LOCALSTACK_ENDPOINT            = var.use_localstack ? var.localstack_endpoint : null
-    REDIS_KEY                      = local.redis_key
     DYNAMO_ENDPOINT                = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    EVENTS_SNS_TOPIC_ARN           = aws_sns_topic.events.arn
+    ENVIRONMENT                    = var.environment
     IPV_TOKEN_SIGNING_KEY_ALIAS    = local.ipv_token_auth_key_alias_name
     IPV_AUTHORISATION_CLIENT_ID    = var.ipv_authorisation_client_id
     IPV_AUTHORISATION_CALLBACK_URI = var.ipv_authorisation_callback_uri
     IPV_AUTHORISATION_URI          = var.ipv_authorisation_uri
+    LOGIN_URI                      = module.dns.frontend_url
+    LOCALSTACK_ENDPOINT            = var.use_localstack ? var.localstack_endpoint : null
+    OIDC_API_BASE_URL              = local.api_base_url
+    REDIS_KEY                      = local.redis_key
   }
   handler_function_name = "uk.gov.di.authentication.ipv.lambda.IPVCallbackHandler::handleRequest"
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/testsupport/matchers/SpotRequestMatcher.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/testsupport/matchers/SpotRequestMatcher.java
@@ -18,18 +18,16 @@ public class SpotRequestMatcher<T> extends TypeSafeDiagnosingMatcher<SPOTRequest
         this.expected = expected;
     }
 
-    public static SpotRequestMatcher<String> hasCredential(String credential) {
-        Function<SPOTRequest, String> extractCredential = SPOTRequest::getSerializedCredential;
+    public static SpotRequestMatcher<String> hasAccountId(String accountId) {
+        Function<SPOTRequest, String> extractAccountId = SPOTRequest::getLocalAccountId;
 
-        return new SpotRequestMatcher<>("serialized credential", extractCredential, credential);
+        return new SpotRequestMatcher<>("local account id", extractAccountId, accountId);
     }
 
-    public static SpotRequestMatcher<String> hasPairwiseIdentifier(String pairwiseIdentifier) {
-        Function<SPOTRequest, String> extractPairwiseIdentifier =
-                SPOTRequest::getPairwiseIdentifier;
+    public static SpotRequestMatcher<String> hasSub(String sub) {
+        Function<SPOTRequest, String> extractSub = SPOTRequest::getSub;
 
-        return new SpotRequestMatcher<>(
-                "pairwise identifier", extractPairwiseIdentifier, pairwiseIdentifier);
+        return new SpotRequestMatcher<>("sub", extractSub, sub);
     }
 
     @Override

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/LogIds.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/LogIds.java
@@ -1,0 +1,19 @@
+package uk.gov.di.authentication.ipv.entity;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class LogIds {
+
+    @JsonProperty(value = "session_id")
+    private String sessionId;
+
+    public LogIds(String sessionId) {
+        this.sessionId = sessionId;
+    }
+
+    public LogIds() {}
+
+    public String getSessionId() {
+        return sessionId;
+    }
+}

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/SPOTClaims.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/SPOTClaims.java
@@ -1,0 +1,27 @@
+package uk.gov.di.authentication.ipv.entity;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class SPOTClaims {
+
+    @JsonProperty(value = "vot")
+    private String vot;
+
+    @JsonProperty(value = "vtm")
+    private String vtm;
+
+    public SPOTClaims(String vot, String vtm) {
+        this.vot = vot;
+        this.vtm = vtm;
+    }
+
+    public SPOTClaims() {}
+
+    public String getVot() {
+        return vot;
+    }
+
+    public String getVtm() {
+        return vtm;
+    }
+}

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/SPOTRequest.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/SPOTRequest.java
@@ -4,24 +4,49 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class SPOTRequest {
 
-    @JsonProperty private String serializedCredential;
+    @JsonProperty(value = "in_claims")
+    private SPOTClaims spotClaims;
 
-    @JsonProperty private String pairwiseIdentifier;
+    @JsonProperty(value = "in_local_account_id")
+    private String localAccountId;
+
+    @JsonProperty(value = "in_salt")
+    private byte[] salt;
+
+    @JsonProperty(value = "out_sub")
+    private String sub;
+
+    @JsonProperty(value = "log_ids")
+    private LogIds logIds;
 
     public SPOTRequest(
-            @JsonProperty(required = true, value = "serializedCredential")
-                    String serializedCredential,
-            @JsonProperty(required = true, value = "pairwiseIdentifier")
-                    String pairwiseIdentifier) {
-        this.serializedCredential = serializedCredential;
-        this.pairwiseIdentifier = pairwiseIdentifier;
+            SPOTClaims spotClaims, String localAccountId, byte[] salt, String sub, LogIds logIds) {
+        this.spotClaims = spotClaims;
+        this.localAccountId = localAccountId;
+        this.salt = salt;
+        this.sub = sub;
+        this.logIds = logIds;
     }
 
-    public String getSerializedCredential() {
-        return serializedCredential;
+    public SPOTRequest() {}
+
+    public SPOTClaims getSpotClaims() {
+        return spotClaims;
     }
 
-    public String getPairwiseIdentifier() {
-        return pairwiseIdentifier;
+    public String getLocalAccountId() {
+        return localAccountId;
+    }
+
+    public byte[] getSalt() {
+        return salt;
+    }
+
+    public String getSub() {
+        return sub;
+    }
+
+    public LogIds getLogIds() {
+        return logIds;
     }
 }

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 
+import static uk.gov.di.authentication.shared.helpers.ConstructUriHelper.buildURI;
 import static uk.gov.di.authentication.shared.helpers.WarmerHelper.isWarming;
 
 public class IPVCallbackHandler
@@ -174,7 +175,12 @@ public class IPVCallbackHandler
                                         new SPOTRequest(
                                                 new SPOTClaims(
                                                         LevelOfConfidence.MEDIUM_LEVEL.getValue(),
-                                                        null),
+                                                        buildURI(
+                                                                        configurationService
+                                                                                .getOidcApiBaseURL()
+                                                                                .orElseThrow(),
+                                                                        "/trustmark")
+                                                                .toString()),
                                                 userProfile.getSubjectID(),
                                                 dynamoService.getOrGenerateSalt(userProfile),
                                                 pairwiseSubject.getValue(),

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -73,6 +73,7 @@ class IPVCallbackHandlerTest {
     private final DynamoClientService dynamoClientService = mock(DynamoClientService.class);
     private final AwsSqsClient awsSqsClient = mock(AwsSqsClient.class);
     private static final URI LOGIN_URL = URI.create("https://example.com");
+    private static final String OIDC_BASE_URL = "https://base-url.com";
     private static final AuthorizationCode AUTH_CODE = new AuthorizationCode();
     private static final String COOKIE = "Cookie";
     private static final String SESSION_ID = "a-session-id";
@@ -103,6 +104,7 @@ class IPVCallbackHandlerTest {
                         dynamoClientService,
                         awsSqsClient);
         when(configService.getLoginURI()).thenReturn(LOGIN_URL);
+        when(configService.getOidcApiBaseURL()).thenReturn(Optional.of(OIDC_BASE_URL));
     }
 
     @Test
@@ -153,7 +155,7 @@ class IPVCallbackHandlerTest {
                                         new SPOTRequest(
                                                 new SPOTClaims(
                                                         LevelOfConfidence.MEDIUM_LEVEL.getValue(),
-                                                        null),
+                                                        OIDC_BASE_URL + "/trustmark"),
                                                 SUBJECT.getValue(),
                                                 salt,
                                                 expectedPairwiseSub.getValue(),

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ClientSubjectHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ClientSubjectHelper.java
@@ -55,8 +55,7 @@ public class ClientSubjectHelper {
         return redirectUri;
     }
 
-    private static String calculatePairwiseIdentifier(
-            String subjectID, String sector, byte[] salt) {
+    public static String calculatePairwiseIdentifier(String subjectID, String sector, byte[] salt) {
         try {
             var md = MessageDigest.getInstance("SHA-256");
 


### PR DESCRIPTION
## What?

- Based on what we know now and what is documented in this RFC https://github.com/alphagov/digital-identity-architecture/blob/main/rfc/0013-spot-request-response-structures.md, form the SPOT request payload.

## Why?

- So we can send the relevant information to SPOT