### PR TITLE
BAU - Rename BASE_URL to OIDC_API_BASE_URL

### DIFF
--- a/account-management-integration-tests/build.gradle
+++ b/account-management-integration-tests/build.gradle
@@ -36,7 +36,7 @@ test {
     environment "AWS_ACCESS_KEY_ID", "mock-access-key"
     environment "AWS_REGION", "eu-west-2"
     environment "AWS_SECRET_ACCESS_KEY", "mock-secret-key "
-    environment "BASE_URL", "http://localhost"
+    environment "OIDC_API_BASE_URL", "http://localhost"
     environment "DYNAMO_ENDPOINT", "http://localhost:8000"
     environment "ENVIRONMENT", "local"
     environment "HEADERS_CASE_INSENSITIVE", "true"

--- a/build.gradle
+++ b/build.gradle
@@ -271,7 +271,7 @@ task oidcTerraform (type: Terraform) {
             environment "API_GATEWAY_ID", json.api_gateway_root_id.value
             environment "TOKEN_SIGNING_KEY_ALIAS", json.token_signing_key_alias.value
             environment "IPV_TOKEN_SIGNING_KEY_ALIAS", json.ipv_token_auth_key_alias.value
-            environment "BASE_URL", json.base_url.value
+            environment "OIDC_API_BASE_URL", json.base_url.value
             environment "API_KEY", json.frontend_api_key.value
             environment "FRONTEND_API_GATEWAY_ID", json.frontend_api_gateway_root_id.value
             environment "FRONTEND_API_KEY", json.frontend_api_key.value
@@ -307,7 +307,7 @@ task acctMgmtTerraform (type: Terraform) {
         def json = outputs()
         allprojects.findAll {it.name == "account-management-integration-tests"}.first().tasks.getByName("test") {
             environment "API_GATEWAY_ID", json.api_gateway_root_id.value
-            environment "BASE_URL", json.base_url.value
+            environment "OIDC_API_BASE_URL", json.base_url.value
             environment "EMAIL_QUEUE_URL", json.email_queue.value
         }
     }

--- a/ci/terraform/account-management/authenticate.tf
+++ b/ci/terraform/account-management/authenticate.tf
@@ -18,7 +18,6 @@ module "authenticate" {
   endpoint_method = "POST"
   handler_environment_variables = {
     ENVIRONMENT             = var.environment
-    BASE_URL                = local.oidc_api_base_url
     DYNAMO_ENDPOINT         = var.use_localstack ? var.lambda_dynamo_endpoint : null
     LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
     EVENTS_SNS_TOPIC_ARN    = data.aws_sns_topic.events.arn

--- a/ci/terraform/oidc/auth-code.tf
+++ b/ci/terraform/oidc/auth-code.tf
@@ -22,7 +22,6 @@ module "auth-code" {
   endpoint_method = "GET"
 
   handler_environment_variables = {
-    BASE_URL                 = local.api_base_url
     EVENTS_SNS_TOPIC_ARN     = aws_sns_topic.events.arn
     AUDIT_SIGNING_KEY_ALIAS  = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT      = var.use_localstack ? var.localstack_endpoint : null

--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -22,7 +22,6 @@ module "authorize" {
   environment     = var.environment
 
   handler_environment_variables = {
-    BASE_URL                 = local.api_base_url
     DOMAIN_NAME              = module.dns.service_domain_name
     EVENTS_SNS_TOPIC_ARN     = aws_sns_topic.events.arn
     AUDIT_SIGNING_KEY_ALIAS  = local.audit_signing_key_alias_name

--- a/ci/terraform/oidc/ipv-authorize.tf
+++ b/ci/terraform/oidc/ipv-authorize.tf
@@ -24,7 +24,6 @@ module "ipv-authorize" {
 
   handler_environment_variables = {
     ENVIRONMENT                    = var.environment
-    BASE_URL                       = local.frontend_api_base_url
     EVENTS_SNS_TOPIC_ARN           = aws_sns_topic.events.arn
     AUDIT_SIGNING_KEY_ALIAS        = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT            = var.use_localstack ? var.localstack_endpoint : null

--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -26,7 +26,6 @@ module "ipv-callback" {
 
   handler_environment_variables = {
     ENVIRONMENT                    = var.environment
-    BASE_URL                       = local.frontend_api_base_url
     EVENTS_SNS_TOPIC_ARN           = aws_sns_topic.events.arn
     AUDIT_SIGNING_KEY_ALIAS        = local.audit_signing_key_alias_name
     LOGIN_URI                      = module.dns.frontend_url

--- a/ci/terraform/oidc/ipv-capacity.tf
+++ b/ci/terraform/oidc/ipv-capacity.tf
@@ -22,7 +22,6 @@ module "ipv-capacity" {
 
   handler_environment_variables = {
     ENVIRONMENT                    = var.environment
-    BASE_URL                       = local.frontend_api_base_url
     EVENTS_SNS_TOPIC_ARN           = aws_sns_topic.events.arn
     AUDIT_SIGNING_KEY_ALIAS        = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT            = var.use_localstack ? var.localstack_endpoint : null

--- a/ci/terraform/oidc/jwks.tf
+++ b/ci/terraform/oidc/jwks.tf
@@ -18,7 +18,6 @@ module "jwks" {
   environment     = var.environment
 
   handler_environment_variables = {
-    BASE_URL                 = local.api_base_url
     EVENTS_SNS_TOPIC_ARN     = aws_sns_topic.events.arn
     AUDIT_SIGNING_KEY_ALIAS  = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT      = var.use_localstack ? var.localstack_endpoint : null

--- a/ci/terraform/oidc/login.tf
+++ b/ci/terraform/oidc/login.tf
@@ -26,7 +26,6 @@ module "login" {
 
   handler_environment_variables = {
     ENVIRONMENT              = var.environment
-    BASE_URL                 = local.frontend_api_base_url
     EVENTS_SNS_TOPIC_ARN     = aws_sns_topic.events.arn
     AUDIT_SIGNING_KEY_ALIAS  = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT      = var.use_localstack ? var.localstack_endpoint : null

--- a/ci/terraform/oidc/logout.tf
+++ b/ci/terraform/oidc/logout.tf
@@ -23,7 +23,6 @@ module "logout" {
 
   handler_environment_variables = {
     DEFAULT_LOGOUT_URI      = "${module.dns.frontend_url}signed-out"
-    BASE_URL                = local.api_base_url
     EVENTS_SNS_TOPIC_ARN    = aws_sns_topic.events.arn
     AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null

--- a/ci/terraform/oidc/register.tf
+++ b/ci/terraform/oidc/register.tf
@@ -22,7 +22,6 @@ module "register" {
 
   handler_environment_variables = {
     ENVIRONMENT             = var.environment
-    BASE_URL                = local.api_base_url
     DYNAMO_ENDPOINT         = var.use_localstack ? var.lambda_dynamo_endpoint : null
     EVENTS_SNS_TOPIC_ARN    = aws_sns_topic.events.arn
     AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name

--- a/ci/terraform/oidc/reset-password-request.tf
+++ b/ci/terraform/oidc/reset-password-request.tf
@@ -23,7 +23,6 @@ module "reset-password-request" {
 
   handler_environment_variables = {
     ENVIRONMENT             = var.environment
-    BASE_URL                = local.frontend_api_base_url
     FRONTEND_BASE_URL       = module.dns.frontend_url
     RESET_PASSWORD_ROUTE    = var.reset_password_route
     BLOCKED_EMAIL_DURATION  = var.blocked_email_duration

--- a/ci/terraform/oidc/reset_password.tf
+++ b/ci/terraform/oidc/reset_password.tf
@@ -23,7 +23,6 @@ module "reset_password" {
   environment     = var.environment
 
   handler_environment_variables = {
-    BASE_URL                 = local.frontend_api_base_url
     DYNAMO_ENDPOINT          = var.use_localstack ? var.lambda_dynamo_endpoint : null
     LOCALSTACK_ENDPOINT      = var.use_localstack ? var.localstack_endpoint : null
     EMAIL_QUEUE_URL          = aws_sqs_queue.email_queue.id

--- a/ci/terraform/oidc/signup.tf
+++ b/ci/terraform/oidc/signup.tf
@@ -24,7 +24,6 @@ module "signup" {
 
   handler_environment_variables = {
     ENVIRONMENT              = var.environment
-    BASE_URL                 = local.frontend_api_base_url
     EVENTS_SNS_TOPIC_ARN     = aws_sns_topic.events.arn
     AUDIT_SIGNING_KEY_ALIAS  = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT      = var.use_localstack ? var.localstack_endpoint : null

--- a/ci/terraform/oidc/start.tf
+++ b/ci/terraform/oidc/start.tf
@@ -22,7 +22,6 @@ module "start" {
   environment     = var.environment
 
   handler_environment_variables = {
-    BASE_URL                 = local.frontend_api_base_url
     EVENTS_SNS_TOPIC_ARN     = aws_sns_topic.events.arn
     AUDIT_SIGNING_KEY_ALIAS  = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT      = var.use_localstack ? var.localstack_endpoint : null

--- a/ci/terraform/oidc/token.tf
+++ b/ci/terraform/oidc/token.tf
@@ -47,7 +47,7 @@ module "token" {
 
   handler_environment_variables = {
     ENVIRONMENT              = var.environment
-    BASE_URL                 = local.api_base_url
+    OIDC_API_BASE_URL        = local.api_base_url
     DYNAMO_ENDPOINT          = var.use_localstack ? var.lambda_dynamo_endpoint : null
     EVENTS_SNS_TOPIC_ARN     = aws_sns_topic.events.arn
     AUDIT_SIGNING_KEY_ALIAS  = local.audit_signing_key_alias_name

--- a/ci/terraform/oidc/trustmarks.tf
+++ b/ci/terraform/oidc/trustmarks.tf
@@ -16,7 +16,7 @@ module "trustmarks" {
 
   handler_environment_variables = {
     ENVIRONMENT              = var.environment
-    BASE_URL                 = local.api_base_url
+    OIDC_API_BASE_URL        = local.api_base_url
     EVENTS_SNS_TOPIC_ARN     = aws_sns_topic.events.arn
     AUDIT_SIGNING_KEY_ALIAS  = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT      = var.use_localstack ? var.localstack_endpoint : null

--- a/ci/terraform/oidc/update.tf
+++ b/ci/terraform/oidc/update.tf
@@ -24,7 +24,6 @@ module "update" {
 
   handler_environment_variables = {
     ENVIRONMENT             = var.environment
-    BASE_URL                = local.api_base_url
     DYNAMO_ENDPOINT         = var.use_localstack ? var.lambda_dynamo_endpoint : null
     EVENTS_SNS_TOPIC_ARN    = aws_sns_topic.events.arn
     AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name

--- a/ci/terraform/oidc/update_profile.tf
+++ b/ci/terraform/oidc/update_profile.tf
@@ -24,7 +24,6 @@ module "update_profile" {
 
   handler_environment_variables = {
     ENVIRONMENT              = var.environment
-    BASE_URL                 = local.frontend_api_base_url
     EVENTS_SNS_TOPIC_ARN     = aws_sns_topic.events.arn
     AUDIT_SIGNING_KEY_ALIAS  = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT      = var.use_localstack ? var.localstack_endpoint : null

--- a/ci/terraform/oidc/userexists.tf
+++ b/ci/terraform/oidc/userexists.tf
@@ -23,7 +23,6 @@ module "userexists" {
 
   handler_environment_variables = {
     ENVIRONMENT              = var.environment
-    BASE_URL                 = local.frontend_api_base_url
     EVENTS_SNS_TOPIC_ARN     = aws_sns_topic.events.arn
     AUDIT_SIGNING_KEY_ALIAS  = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT      = var.use_localstack ? var.localstack_endpoint : null

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -24,7 +24,6 @@ module "userinfo" {
 
   handler_environment_variables = {
     ENVIRONMENT             = var.environment
-    BASE_URL                = local.api_base_url
     EVENTS_SNS_TOPIC_ARN    = aws_sns_topic.events.arn
     AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null

--- a/ci/terraform/oidc/verify_code.tf
+++ b/ci/terraform/oidc/verify_code.tf
@@ -25,7 +25,6 @@ module "verify_code" {
 
   handler_environment_variables = {
     ENVIRONMENT                         = var.environment
-    BASE_URL                            = local.frontend_api_base_url
     BLOCKED_EMAIL_DURATION              = var.blocked_email_duration
     EVENTS_SNS_TOPIC_ARN                = aws_sns_topic.events.arn
     AUDIT_SIGNING_KEY_ALIAS             = local.audit_signing_key_alias_name

--- a/ci/terraform/oidc/wellknown.tf
+++ b/ci/terraform/oidc/wellknown.tf
@@ -16,7 +16,7 @@ module "openid_configuration_discovery" {
 
   handler_environment_variables = {
     ENVIRONMENT         = var.environment
-    BASE_URL            = local.api_base_url
+    OIDC_API_BASE_URL   = local.api_base_url
     LOCALSTACK_ENDPOINT = var.use_localstack ? var.localstack_endpoint : null
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.WellknownHandler::handleRequest"

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -37,7 +37,7 @@ test {
     environment "AWS_ACCESS_KEY_ID", "mock-access-key"
     environment "AWS_REGION", "eu-west-2"
     environment "AWS_SECRET_ACCESS_KEY", "mock-secret-key "
-    environment "BASE_URL", "http://localhost"
+    environment "OIDC_API_BASE_URL", "http://localhost"
     environment "DEFAULT_LOGOUT_URI", "http://localhost:3000/signed-out"
     environment "DOMAIN_NAME", "localhost"
     environment "DYNAMO_ENDPOINT", "http://localhost:8000"

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
@@ -151,7 +151,7 @@ public class TokenHandler
                             }
                             String baseUrl =
                                     configurationService
-                                            .getBaseURL()
+                                            .getOidcApiBaseURL()
                                             .orElseThrow(
                                                     () -> {
                                                         LOG.error(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TrustMarkHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TrustMarkHandler.java
@@ -53,8 +53,8 @@ public class TrustMarkHandler
 
     private TrustMarkResponse createTrustMarkResponse() {
         return new TrustMarkResponse(
-                configurationService.getBaseURL().orElseThrow(),
-                configurationService.getBaseURL().orElseThrow(),
+                configurationService.getOidcApiBaseURL().orElseThrow(),
+                configurationService.getOidcApiBaseURL().orElseThrow(),
                 Arrays.asList(
                         CredentialTrustLevel.LOW_LEVEL.getValue(),
                         CredentialTrustLevel.MEDIUM_LEVEL.getValue()),

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/WellknownHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/WellknownHandler.java
@@ -38,7 +38,7 @@ public class WellknownHandler
 
     public WellknownHandler(ConfigurationService configService) {
         this.configService = configService;
-        baseUrl = configService.getBaseURL().orElseThrow();
+        baseUrl = configService.getOidcApiBaseURL().orElseThrow();
         providerMetadata =
                 new OIDCProviderMetadata(
                         new Issuer(baseUrl),
@@ -48,10 +48,10 @@ public class WellknownHandler
 
     public WellknownHandler() {
         this.configService = ConfigurationService.getInstance();
-        baseUrl = configService.getBaseURL().orElseThrow();
+        baseUrl = configService.getOidcApiBaseURL().orElseThrow();
         providerMetadata =
                 new OIDCProviderMetadata(
-                        new Issuer(configService.getBaseURL().get()),
+                        new Issuer(configService.getOidcApiBaseURL().get()),
                         List.of(SubjectType.PUBLIC, SubjectType.PAIRWISE),
                         buildURI(baseUrl, "/.well-known/jwks.json"));
     }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
@@ -118,7 +118,7 @@ public class TokenHandlerTest {
 
     @BeforeEach
     public void setUp() {
-        when(configurationService.getBaseURL()).thenReturn(Optional.of(BASE_URI));
+        when(configurationService.getOidcApiBaseURL()).thenReturn(Optional.of(BASE_URI));
         when(configurationService.getSessionExpiry()).thenReturn(1234L);
         handler =
                 new TokenHandler(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TrustMarkHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TrustMarkHandlerTest.java
@@ -31,15 +31,15 @@ class TrustMarkHandlerTest {
     public void setUp() {
         handler = new TrustMarkHandler(configurationService);
         Optional<String> baseUrl = Optional.of(BASE_URL);
-        when(configurationService.getBaseURL()).thenReturn(baseUrl);
+        when(configurationService.getOidcApiBaseURL()).thenReturn(baseUrl);
     }
 
     @Test
     public void shouldReturn200WhenRequestIsSuccessful() throws JsonProcessingException {
         TrustMarkResponse trustMarkResponse =
                 new TrustMarkResponse(
-                        configurationService.getBaseURL().orElseThrow(),
-                        configurationService.getBaseURL().orElseThrow(),
+                        configurationService.getOidcApiBaseURL().orElseThrow(),
+                        configurationService.getOidcApiBaseURL().orElseThrow(),
                         List.of(
                                 CredentialTrustLevel.LOW_LEVEL.getValue(),
                                 CredentialTrustLevel.MEDIUM_LEVEL.getValue()),

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/WellknownHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/WellknownHandlerTest.java
@@ -30,7 +30,7 @@ class WellknownHandlerTest {
 
     @Test
     void shouldReturn200WhenRequestIsSuccessful() throws ParseException {
-        when(configService.getBaseURL()).thenReturn(Optional.of("http://localhost:8080"));
+        when(configService.getOidcApiBaseURL()).thenReturn(Optional.of("http://localhost:8080"));
         handler = new WellknownHandler(configService);
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
@@ -63,7 +63,7 @@ class WellknownHandlerTest {
 
     @Test
     void shouldThrowExceptionWhenBaseUrlIsMissing() {
-        when(configService.getBaseURL()).thenReturn(Optional.empty());
+        when(configService.getOidcApiBaseURL()).thenReturn(Optional.empty());
 
         assertThrows(
                 NoSuchElementException.class,

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -47,10 +47,6 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return Long.parseLong(System.getenv().getOrDefault("AUTH_CODE_EXPIRY", "300"));
     }
 
-    public Optional<String> getBaseURL() {
-        return Optional.ofNullable(System.getenv("BASE_URL"));
-    }
-
     public long getBlockedEmailDuration() {
         return Long.parseLong(System.getenv().getOrDefault("BLOCKED_EMAIL_DURATION", "900"));
     }
@@ -146,6 +142,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
 
     public Optional<String> getNotifyTestPhoneNumber() {
         return Optional.ofNullable(System.getenv("NOTIFY_TEST_PHONE_NUMBER"));
+    }
+
+    public Optional<String> getOidcApiBaseURL() {
+        return Optional.ofNullable(System.getenv("OIDC_API_BASE_URL"));
     }
 
     public Optional<String> getPasswordPepper() {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
@@ -249,13 +249,13 @@ public class TokenService {
             String vot) {
 
         LOG.info("Generating IdToken");
-        URI trustMarkUri = buildURI(configService.getBaseURL().get(), "/trustmark");
+        URI trustMarkUri = buildURI(configService.getOidcApiBaseURL().get(), "/trustmark");
         LocalDateTime localDateTime =
                 LocalDateTime.now().plusSeconds(configService.getIDTokenExpiry());
         Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
         IDTokenClaimsSet idTokenClaims =
                 new IDTokenClaimsSet(
-                        new Issuer(configService.getBaseURL().get()),
+                        new Issuer(configService.getOidcApiBaseURL().get()),
                         publicSubject,
                         List.of(new Audience(clientId)),
                         expiryDate,
@@ -290,7 +290,7 @@ public class TokenService {
         JWTClaimsSet.Builder claimSetBuilder =
                 new JWTClaimsSet.Builder()
                         .claim("scope", scopes)
-                        .issuer(configService.getBaseURL().get())
+                        .issuer(configService.getOidcApiBaseURL().get())
                         .expirationTime(expiryDate)
                         .issueTime(
                                 Date.from(LocalDateTime.now().atZone(ZoneId.of("UTC")).toInstant()))
@@ -333,7 +333,7 @@ public class TokenService {
         JWTClaimsSet claimsSet =
                 new JWTClaimsSet.Builder()
                         .claim("scope", scopes)
-                        .issuer(configService.getBaseURL().get())
+                        .issuer(configService.getOidcApiBaseURL().get())
                         .expirationTime(expiryDate)
                         .issueTime(
                                 Date.from(LocalDateTime.now().atZone(ZoneId.of("UTC")).toInstant()))

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
@@ -114,7 +114,7 @@ public class TokenServiceTest {
     @BeforeEach
     void setUp() {
         Optional<String> baseUrl = Optional.of(BASE_URL);
-        when(configurationService.getBaseURL()).thenReturn(baseUrl);
+        when(configurationService.getOidcApiBaseURL()).thenReturn(baseUrl);
         when(configurationService.getAccessTokenExpiry()).thenReturn(300L);
         when(configurationService.getIDTokenExpiry()).thenReturn(120L);
         when(configurationService.getSessionExpiry()).thenReturn(300L);

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenValidationServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenValidationServiceTest.java
@@ -55,7 +55,7 @@ class TokenValidationServiceTest {
     @BeforeEach
     void setUp() throws JOSEException {
         Optional<String> baseUrl = Optional.of(BASE_URL);
-        when(configurationService.getBaseURL()).thenReturn(baseUrl);
+        when(configurationService.getOidcApiBaseURL()).thenReturn(baseUrl);
         ecJWK = generateECKeyPair();
         signer = new ECDSASigner(ecJWK);
         when(configurationService.getTokenSigningKeyAlias()).thenReturn(KEY_ID);


### PR DESCRIPTION
## What?

- Make it clear what base url we are getting and remove it from all the lambdas which don't require it.
- This is so we can be clear what the BASE_URL is for

## Why?

- I want to pull the oidc api base url in the IPV callback lambda so I can construct the trustmark URI. This makes it clear what BASE URL is stored in config, 