### PR TITLE
AUTH-1427: Temporarily disable Splunk in staging

### DIFF
--- a/ci/tasks/deploy-acct-mgmt-api.yml
+++ b/ci/tasks/deploy-acct-mgmt-api.yml
@@ -36,7 +36,6 @@ run:
       terraform apply -auto-approve \
         -var "deployer_role_arn=${DEPLOYER_ROLE_ARN}" \
         -var "environment=${DEPLOY_ENVIRONMENT}" \
-        -var 'logging_endpoint_enabled=true' \
         -var "notify_api_key=${NOTIFY_API_KEY}" \
         -var 'logging_endpoint_arn=arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod' \
         -var "lambda_zip_file=$(ls -1 ../../../../api-release/*.zip)" \

--- a/ci/tasks/deploy-audit-processors.yml
+++ b/ci/tasks/deploy-audit-processors.yml
@@ -35,7 +35,6 @@ run:
         -var "deployer_role_arn=${DEPLOYER_ROLE_ARN}" \
         -var "environment=${DEPLOY_ENVIRONMENT}" \
         -var "shared_state_bucket=${STATE_BUCKET}" \
-        -var 'logging_endpoint_enabled=true' \
         -var 'logging_endpoint_arn=arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod' \
         -var "audit_storage_expiry_days=${AUDIT_STORE_EXPIRY_DAYS}" \
         -var-file "${DEPLOY_ENVIRONMENT}-overrides.tfvars" \

--- a/ci/tasks/deploy-delivery-receipts-api.yml
+++ b/ci/tasks/deploy-delivery-receipts-api.yml
@@ -31,7 +31,6 @@ run:
       terraform apply -auto-approve \
         -var "deployer_role_arn=${DEPLOYER_ROLE_ARN}" \
         -var "environment=${DEPLOY_ENVIRONMENT}" \
-        -var 'logging_endpoint_enabled=true' \
         -var 'logging_endpoint_arn=arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod' \
         -var "lambda_zip_file=$(ls -1 ../../../../delivery-receipts-api-release/*.zip)" \
         -var "common_state_bucket=${STATE_BUCKET}" \

--- a/ci/tasks/deploy-oidc-api.yml
+++ b/ci/tasks/deploy-oidc-api.yml
@@ -53,7 +53,6 @@ run:
         -var "deployer_role_arn=${DEPLOYER_ROLE_ARN}" \
         -var "notify_api_key=${NOTIFY_API_KEY}" \
         -var "environment=${DEPLOY_ENVIRONMENT}" \
-        -var 'logging_endpoint_enabled=true' \
         -var 'logging_endpoint_arn=arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod' \
         -var "dns_state_bucket=${DNS_STATE_BUCKET}" \
         -var "dns_state_key=${DNS_STATE_KEY}" \

--- a/ci/tasks/deploy-shared-api.yml
+++ b/ci/tasks/deploy-shared-api.yml
@@ -35,7 +35,6 @@ run:
       terraform apply -auto-approve \
         -var "deployer_role_arn=${DEPLOYER_ROLE_ARN}" \
         -var "environment=${DEPLOY_ENVIRONMENT}" \
-        -var 'logging_endpoint_enabled=true' \
         -var 'logging_endpoint_arn=arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod' \
         -var "test_client_email_allowlist=${TEST_CLIENT_EMAIL_ALLOWLIST}" \
         -var 'account_migration_lambda_zip_file=../../../../account-migration-release/account-migrations.zip' \

--- a/ci/terraform/account-management/sandpit.tfvars
+++ b/ci/terraform/account-management/sandpit.tfvars
@@ -6,3 +6,5 @@ common_state_bucket = "digital-identity-dev-tfstate"
 dns_state_bucket    = null
 dns_state_key       = null
 dns_state_role      = null
+
+logging_endpoint_enabled = false

--- a/ci/terraform/account-management/staging-overrides.tfvars
+++ b/ci/terraform/account-management/staging-overrides.tfvars
@@ -1,0 +1,1 @@
+logging_endpoint_enabled = false

--- a/ci/terraform/account-management/variables.tf
+++ b/ci/terraform/account-management/variables.tf
@@ -85,7 +85,7 @@ variable "lambda_zip_file" {
 
 variable "logging_endpoint_enabled" {
   type        = bool
-  default     = false
+  default     = true
   description = "Whether the service should ship its Lambda logs to the `logging_endpoint_arn`"
 }
 

--- a/ci/terraform/audit-processors/sandpit.tfvars
+++ b/ci/terraform/audit-processors/sandpit.tfvars
@@ -1,2 +1,4 @@
 environment         = "sandpit"
 shared_state_bucket = "digital-identity-dev-tfstate"
+
+logging_endpoint_enabled = false

--- a/ci/terraform/audit-processors/staging-overrides.tfvars
+++ b/ci/terraform/audit-processors/staging-overrides.tfvars
@@ -1,0 +1,1 @@
+logging_endpoint_enabled = false

--- a/ci/terraform/audit-processors/variables.tf
+++ b/ci/terraform/audit-processors/variables.tf
@@ -39,7 +39,7 @@ variable "localstack_endpoint" {
 
 variable "logging_endpoint_enabled" {
   type        = bool
-  default     = false
+  default     = true
   description = "Whether the service should ship its Lambda logs to the `logging_endpoint_arn`"
 }
 

--- a/ci/terraform/delivery-receipts/sandpit.tfvars
+++ b/ci/terraform/delivery-receipts/sandpit.tfvars
@@ -1,2 +1,4 @@
 environment         = "sandpit"
 common_state_bucket = "digital-identity-dev-tfstate"
+
+logging_endpoint_enabled = false

--- a/ci/terraform/delivery-receipts/staging-overrides.tfvars
+++ b/ci/terraform/delivery-receipts/staging-overrides.tfvars
@@ -1,0 +1,1 @@
+logging_endpoint_enabled = false

--- a/ci/terraform/delivery-receipts/variables.tf
+++ b/ci/terraform/delivery-receipts/variables.tf
@@ -56,7 +56,7 @@ variable "enable_api_gateway_execution_logging" {
 
 variable "logging_endpoint_enabled" {
   type        = bool
-  default     = false
+  default     = true
   description = "Whether the service should ship its Lambda logs to the `logging_endpoint_arn`"
 }
 

--- a/ci/terraform/oidc/sandpit.tfvars
+++ b/ci/terraform/oidc/sandpit.tfvars
@@ -12,6 +12,6 @@ ipv_api_enabled                     = true
 ipv_authorisation_callback_uri      = ""
 ipv_authorisation_uri               = ""
 ipv_authorisation_client_id         = ""
-
+logging_endpoint_enabled            = false
 
 enable_api_gateway_execution_request_tracing = true

--- a/ci/terraform/oidc/staging-overrides.tfvars
+++ b/ci/terraform/oidc/staging-overrides.tfvars
@@ -1,0 +1,1 @@
+logging_endpoint_enabled = false

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -115,7 +115,7 @@ variable "enable_api_gateway_execution_request_tracing" {
 
 variable "logging_endpoint_enabled" {
   type        = bool
-  default     = false
+  default     = true
   description = "Whether the service should ship its Lambda logs to the `logging_endpoint_arn`"
 }
 

--- a/ci/terraform/shared/sandpit.tfvars
+++ b/ci/terraform/shared/sandpit.tfvars
@@ -20,3 +20,5 @@ stub_rp_clients = [
     test_client = "0"
   },
 ]
+
+logging_endpoint_enabled = false

--- a/ci/terraform/shared/staging-sizing.tfvars
+++ b/ci/terraform/shared/staging-sizing.tfvars
@@ -1,2 +1,4 @@
 redis_node_size  = "cache.t2.small"
 provision_dynamo = false
+
+logging_endpoint_enabled = false

--- a/ci/terraform/shared/variables.tf
+++ b/ci/terraform/shared/variables.tf
@@ -71,7 +71,7 @@ variable "enable_api_gateway_execution_request_tracing" {
 
 variable "logging_endpoint_enabled" {
   type        = bool
-  default     = false
+  default     = true
   description = "Whether the service should ship its Lambda logs to the `logging_endpoint_arn`"
 }
 


### PR DESCRIPTION
## What?

- Remove setting of `logging_endpoint_enabled` in the pipeline tasks
- Make the default value for `logging_endpoint_enabled` true in Terraform deployments
- Override to `false` in the staging and sandpit environments in Terraform deployments

## Why?

There is, currently, an issue setting up centralised logging for the Staging account, lets disable it for the mo to allow us to move forward with the environment setup.
