### PR TITLE
AUTH-1427: Re-enable Splunk subscriptions for staging

### DIFF
--- a/ci/terraform/account-management/staging-overrides.tfvars
+++ b/ci/terraform/account-management/staging-overrides.tfvars
@@ -1,1 +1,0 @@
-logging_endpoint_enabled = false

--- a/ci/terraform/audit-processors/staging-overrides.tfvars
+++ b/ci/terraform/audit-processors/staging-overrides.tfvars
@@ -1,1 +1,0 @@
-logging_endpoint_enabled = false

--- a/ci/terraform/delivery-receipts/staging-overrides.tfvars
+++ b/ci/terraform/delivery-receipts/staging-overrides.tfvars
@@ -1,1 +1,0 @@
-logging_endpoint_enabled = false

--- a/ci/terraform/oidc/staging-overrides.tfvars
+++ b/ci/terraform/oidc/staging-overrides.tfvars
@@ -1,1 +1,0 @@
-logging_endpoint_enabled = false

--- a/ci/terraform/shared/staging-sizing.tfvars
+++ b/ci/terraform/shared/staging-sizing.tfvars
@@ -1,4 +1,2 @@
 redis_node_size  = "cache.t2.small"
 provision_dynamo = false
-
-logging_endpoint_enabled = false


### PR DESCRIPTION
## What?

- Remove the override flag to re-enable the Splunk CSLS filter for the staging environment.

## Why?

The issue with the staging account not being permitted has been resolved.

## Related PRs

#1592 