### PR TITLE
AUTH-105 -  Change SpotResponse lambda to read from SQS 

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
@@ -277,14 +277,15 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 new ObjectMapper().writeValueAsString(tokenStore),
                 900L);
         PrivateKey privateKey = keyPair.getPrivate();
-        PrivateKeyJWT privateKeyJWT =
+        JWTAuthenticationClaimsSet claimsSet =
+                new JWTAuthenticationClaimsSet(
+                        new ClientID(CLIENT_ID), new Audience(ROOT_RESOURCE_URL + TOKEN_ENDPOINT));
+        var expiryDate =
+                Date.from(LocalDateTime.now().plusMinutes(5).atZone(ZoneId.of("UTC")).toInstant());
+        claimsSet.getExpirationTime().setTime(expiryDate.getTime());
+        var privateKeyJWT =
                 new PrivateKeyJWT(
-                        new ClientID(CLIENT_ID),
-                        URI.create(ROOT_RESOURCE_URL + TOKEN_ENDPOINT),
-                        JWSAlgorithm.RS256,
-                        (RSAPrivateKey) privateKey,
-                        null,
-                        null);
+                        claimsSet, JWSAlgorithm.RS256, (RSAPrivateKey) privateKey, null, null);
         Map<String, List<String>> customParams = new HashMap<>();
         customParams.put(
                 "grant_type", Collections.singletonList(GrantType.REFRESH_TOKEN.getValue()));

--- a/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/SpotResponseIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/SpotResponseIntegrationTest.java
@@ -37,7 +37,7 @@ public class SpotResponseIntegrationTest extends ApiGatewayHandlerIntegrationTes
                                         "https://vocab.sign-in.service.gov.uk/v1/verifiableIdentityJWT",
                                         signedCredential),
                                 pairwiseIdentifier.getValue(),
-                                SPOTStatus.OK.toString())),
+                                SPOTStatus.OK)),
                 mock(Context.class));
 
         assertTrue(spotStore.getSpotCredential(pairwiseIdentifier.getValue()).isPresent());

--- a/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/SpotResponseIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/SpotResponseIntegrationTest.java
@@ -1,0 +1,78 @@
+package uk.gov.di.authentication.queuehandlers;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.nimbusds.oauth2.sdk.id.Subject;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.ipv.entity.SPOTResponse;
+import uk.gov.di.authentication.ipv.entity.SPOTStatus;
+import uk.gov.di.authentication.ipv.lambda.SPOTResponseHandler;
+import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+public class SpotResponseIntegrationTest extends ApiGatewayHandlerIntegrationTest {
+
+    private final SPOTResponseHandler handler = new SPOTResponseHandler(TEST_CONFIGURATION_SERVICE);
+
+    @Test
+    void shouldAddSpotCredentialToDBForValidResponse() {
+        var signedCredential = "some-signed-credential";
+        var pairwiseIdentifier = new Subject();
+        handler.handleRequest(
+                createSqsEvent(
+                        new SPOTResponse(
+                                Map.of(
+                                        "https://vocab.sign-in.service.gov.uk/v1/verifiableIdentityJWT",
+                                        signedCredential),
+                                pairwiseIdentifier.getValue(),
+                                SPOTStatus.OK.toString())),
+                mock(Context.class));
+
+        assertTrue(spotStore.getSpotCredential(pairwiseIdentifier.getValue()).isPresent());
+
+        assertThat(
+                spotStore
+                        .getSpotCredential(pairwiseIdentifier.getValue())
+                        .get()
+                        .getSerializedCredential(),
+                equalTo(signedCredential));
+    }
+
+    private <T> SQSEvent createSqsEvent(T... request) {
+        var event = new SQSEvent();
+        event.setRecords(
+                Arrays.stream(request)
+                        .map(
+                                r -> {
+                                    try {
+                                        var message = new SQSEvent.SQSMessage();
+                                        message.setBody(objectMapper.writeValueAsString(r));
+                                        message.setMessageId(UUID.randomUUID().toString());
+                                        message.setMd5OfBody(
+                                                DigestUtils.md5Hex(message.getBody())
+                                                        .toUpperCase(Locale.ROOT));
+                                        message.setEventSource("aws:sqs");
+                                        message.setAwsRegion("eu-west-2");
+                                        message.setEventSourceArn(
+                                                "arn:aws:sqs:eu-west-2:123456789012:queue-name");
+                                        return message;
+                                    } catch (JsonProcessingException e) {
+                                        throw new RuntimeException(e);
+                                    }
+                                })
+                        .collect(Collectors.toList()));
+        return event;
+    }
+}

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/SPOTResponse.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/SPOTResponse.java
@@ -2,26 +2,34 @@ package uk.gov.di.authentication.ipv.entity;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Map;
+
 public class SPOTResponse {
 
-    @JsonProperty private String serializedCredential;
+    @JsonProperty private Map<String, Object> claims;
 
-    @JsonProperty private String pairwiseIdentifier;
+    @JsonProperty private String sub;
+
+    @JsonProperty private String status;
 
     public SPOTResponse(
-            @JsonProperty(required = true, value = "serializedCredential")
-                    String serializedCredential,
-            @JsonProperty(required = true, value = "pairwiseIdentifier")
-                    String pairwiseIdentifier) {
-        this.serializedCredential = serializedCredential;
-        this.pairwiseIdentifier = pairwiseIdentifier;
+            @JsonProperty(value = "claim") Map<String, Object> claims,
+            @JsonProperty(required = true, value = "sub") String sub,
+            @JsonProperty(required = true, value = "status") String status) {
+        this.claims = claims;
+        this.sub = sub;
+        this.status = status;
     }
 
-    public String getSerializedCredential() {
-        return serializedCredential;
+    public Map<String, Object> getClaims() {
+        return claims;
     }
 
-    public String getPairwiseIdentifier() {
-        return pairwiseIdentifier;
+    public String getSub() {
+        return sub;
+    }
+
+    public String getStatus() {
+        return status;
     }
 }

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/SPOTResponse.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/SPOTResponse.java
@@ -10,12 +10,12 @@ public class SPOTResponse {
 
     @JsonProperty private String sub;
 
-    @JsonProperty private String status;
+    @JsonProperty private SPOTStatus status;
 
     public SPOTResponse(
             @JsonProperty(value = "claim") Map<String, Object> claims,
             @JsonProperty(required = true, value = "sub") String sub,
-            @JsonProperty(required = true, value = "status") String status) {
+            @JsonProperty(required = true, value = "status") SPOTStatus status) {
         this.claims = claims;
         this.sub = sub;
         this.status = status;
@@ -29,7 +29,7 @@ public class SPOTResponse {
         return sub;
     }
 
-    public String getStatus() {
+    public SPOTStatus getStatus() {
         return status;
     }
 }

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/SPOTStatus.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/SPOTStatus.java
@@ -1,0 +1,6 @@
+package uk.gov.di.authentication.ipv.entity;
+
+public enum SPOTStatus {
+    OK,
+    OTHER
+}

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandler.java
@@ -39,7 +39,7 @@ public class SPOTResponseHandler implements RequestHandler<SQSEvent, Object> {
         for (SQSMessage msg : event.getRecords()) {
             try {
                 var spotResponse = objectMapper.readValue(msg.getBody(), SPOTResponse.class);
-                if (!spotResponse.getStatus().equals(SPOTStatus.OK.toString())) {
+                if (spotResponse.getStatus() != SPOTStatus.OK) {
                     LOG.warn(
                             "SPOTResponse Status is not OK. Actual Status: {}",
                             spotResponse.getStatus());

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandler.java
@@ -2,18 +2,20 @@ package uk.gov.di.authentication.ipv.lambda;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
-import com.amazonaws.services.lambda.runtime.events.SNSEvent;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.ipv.entity.SPOTResponse;
+import uk.gov.di.authentication.ipv.entity.SPOTStatus;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoSpotService;
 
-import java.util.Optional;
+import java.util.NoSuchElementException;
 
-public class SPOTResponseHandler implements RequestHandler<SNSEvent, Object> {
+public class SPOTResponseHandler implements RequestHandler<SQSEvent, Object> {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final DynamoSpotService dynamoSpotService;
@@ -33,29 +35,30 @@ public class SPOTResponseHandler implements RequestHandler<SNSEvent, Object> {
     }
 
     @Override
-    public Object handleRequest(SNSEvent input, Context context) {
-        input.getRecords().stream()
-                .map(SNSEvent.SNSRecord::getSNS)
-                .map(SNSEvent.SNS::getMessage)
-                .map(this::processSPOTResponse)
-                .filter(Optional::isPresent)
-                .map(Optional::get)
-                .forEach(this::writeToDynamo);
-
-        return null;
-    }
-
-    private Optional<SPOTResponse> processSPOTResponse(String message) {
-        try {
-            return Optional.of(objectMapper.readValue(message, SPOTResponse.class));
-        } catch (JsonProcessingException e) {
-            LOG.error("Unable to deserialize SPOT response");
-            return Optional.empty();
+    public Object handleRequest(SQSEvent event, Context context) {
+        for (SQSMessage msg : event.getRecords()) {
+            try {
+                var spotResponse = objectMapper.readValue(msg.getBody(), SPOTResponse.class);
+                if (!spotResponse.getStatus().equals(SPOTStatus.OK.toString())) {
+                    LOG.warn(
+                            "SPOTResponse Status is not OK. Actual Status: {}",
+                            spotResponse.getStatus());
+                    return null;
+                }
+                dynamoSpotService.addSpotResponse(
+                        spotResponse.getSub(),
+                        spotResponse.getClaims().values().stream()
+                                .map(Object::toString)
+                                .findFirst()
+                                .orElseThrow());
+            } catch (JsonProcessingException e) {
+                LOG.error("Unable to deserialize SPOT response from SQS queue");
+                return null;
+            } catch (NoSuchElementException e) {
+                LOG.error("Status is OK but no credential is present in SPOTResponse");
+                return null;
+            }
         }
-    }
-
-    private void writeToDynamo(SPOTResponse spotResponse) {
-        dynamoSpotService.addSpotResponse(
-                spotResponse.getPairwiseIdentifier(), spotResponse.getSerializedCredential());
+        return null;
     }
 }

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandlerTest.java
@@ -1,16 +1,11 @@
 package uk.gov.di.authentication.ipv.lambda;
 
-import com.amazonaws.services.lambda.runtime.events.SNSEvent;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import uk.gov.di.authentication.ipv.entity.SPOTResponse;
 import uk.gov.di.authentication.shared.services.DynamoSpotService;
 
-import java.util.List;
-import java.util.Optional;
-
+import static java.util.Collections.singletonList;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -26,30 +21,49 @@ class SPOTResponseHandlerTest {
     }
 
     @Test
-    void shouldWriteToDynamoForSuccesssfulSPOTResponse() throws JsonProcessingException {
-        var spotResponse =
-                new SPOTResponse("this-is-a-searalized-credential", "some-pairwise-identifier");
-        var searlizedSpotResponse = new ObjectMapper().writeValueAsString(spotResponse);
+    void shouldWriteToDynamoForSuccesssfulSPOTResponse() {
+        String json =
+                "{\"sub\":\"some-pairwise-identifier\",\"status\":\"OK\","
+                        + "\"claims\":{\"http://something/v1/verifiableIdentityJWT\":\"random-searalized-credential\"}}";
 
-        handler.handleRequest(inputEvent(searlizedSpotResponse), null);
+        handler.handleRequest(generateSQSEvent(json), null);
 
         verify(dynamoSpotService)
-                .addSpotResponse("some-pairwise-identifier", "this-is-a-searalized-credential");
+                .addSpotResponse("some-pairwise-identifier", "random-searalized-credential");
     }
 
     @Test
     void shouldNotWriteToDynamoWhenLambdaReceivedInvalidSPOTResponse() {
-        handler.handleRequest(inputEvent("invalid-payload"), null);
+        handler.handleRequest(generateSQSEvent("invalid-payload"), null);
 
         verifyNoInteractions(dynamoSpotService);
     }
 
-    private SNSEvent inputEvent(String payload) {
-        return Optional.of(payload)
-                .map(new SNSEvent.SNS()::withMessage)
-                .map(new SNSEvent.SNSRecord()::withSns)
-                .map(List::of)
-                .map(new SNSEvent()::withRecords)
-                .get();
+    @Test
+    void shouldNotWriteToDynamoWhenSPOTResponseStatusIsNotOK() {
+        String json =
+                "{\"sub\":\"some-pairwise-identifier\",\"status\":\"OTHER\","
+                        + "\"claims\":{\"http://something/v1/verifiableIdentityJWT\":\"random-searalized-credential\"}}";
+
+        handler.handleRequest(generateSQSEvent(json), null);
+
+        verifyNoInteractions(dynamoSpotService);
+    }
+
+    @Test
+    void shouldNotWriteToDynamoWhenStatusIsOKButNoCredentialIsPresent() {
+        String json = "{\"sub\":\"some-pairwise-identifier\",\"status\":\"OK\"," + "\"claims\":{}}";
+
+        handler.handleRequest(generateSQSEvent(json), null);
+
+        verifyNoInteractions(dynamoSpotService);
+    }
+
+    private SQSEvent generateSQSEvent(String messageBody) {
+        SQSEvent.SQSMessage sqsMessage = new SQSEvent.SQSMessage();
+        sqsMessage.setBody(messageBody);
+        SQSEvent sqsEvent = new SQSEvent();
+        sqsEvent.setRecords(singletonList(sqsMessage));
+        return sqsEvent;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoSpotService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoSpotService.java
@@ -49,7 +49,7 @@ public class DynamoSpotService {
     }
 
     public void addSpotResponse(String subjectID, String serializedCredential) {
-        SPOTCredential spotCredential =
+        var spotCredential =
                 new SPOTCredential()
                         .setSubjectID(subjectID)
                         .setSerializedCredential(serializedCredential)


### PR DESCRIPTION
## What?

- We will be receiving SPOT responses via an SQS queue. This changes our SPOTResponseHandler to listen to an SQS queue instead of an SNS topic.
- We are currently assuming only one credential will be present when the status is OK.
- Use UTC for PrivateKeyJWT in integration test
 
## Why?

- Change the structure of the SPOT response based on the RFC - https://github.com/alphagov/digital-identity-architecture/blob/main/rfc/0013-spot-request-response-structures.md
- The token integration test was failing as the clocks moved forward on Sunday. We need to be explicit and use UTC