### PR TITLE
AUTH-1427: Parameterise memory size

### DIFF
--- a/ci/terraform/account-management/authenticate.tf
+++ b/ci/terraform/account-management/authenticate.tf
@@ -29,6 +29,7 @@ module "authenticate" {
   rest_api_id      = aws_api_gateway_rest_api.di_account_management_api.id
   root_resource_id = aws_api_gateway_rest_api.di_account_management_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_account_management_api.execution_arn
+  memory_size      = var.endpoint_memory_size
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.account_management_api_release_zip.key

--- a/ci/terraform/account-management/remove-account.tf
+++ b/ci/terraform/account-management/remove-account.tf
@@ -31,6 +31,7 @@ module "delete_account" {
   rest_api_id      = aws_api_gateway_rest_api.di_account_management_api.id
   root_resource_id = aws_api_gateway_rest_api.di_account_management_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_account_management_api.execution_arn
+  memory_size      = var.endpoint_memory_size
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.account_management_api_release_zip.key

--- a/ci/terraform/account-management/send_otp_notification.tf
+++ b/ci/terraform/account-management/send_otp_notification.tf
@@ -33,6 +33,7 @@ module "send_otp_notification" {
   rest_api_id      = aws_api_gateway_rest_api.di_account_management_api.id
   root_resource_id = aws_api_gateway_rest_api.di_account_management_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_account_management_api.execution_arn
+  memory_size      = var.endpoint_memory_size
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.account_management_api_release_zip.key

--- a/ci/terraform/account-management/staging-overrides.tfvars
+++ b/ci/terraform/account-management/staging-overrides.tfvars
@@ -1,0 +1,1 @@
+endpoint_memory_size = 3008

--- a/ci/terraform/account-management/update-email.tf
+++ b/ci/terraform/account-management/update-email.tf
@@ -34,6 +34,7 @@ module "update_email" {
   rest_api_id      = aws_api_gateway_rest_api.di_account_management_api.id
   root_resource_id = aws_api_gateway_rest_api.di_account_management_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_account_management_api.execution_arn
+  memory_size      = var.endpoint_memory_size
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.account_management_api_release_zip.key

--- a/ci/terraform/account-management/update-password.tf
+++ b/ci/terraform/account-management/update-password.tf
@@ -31,6 +31,7 @@ module "update_password" {
   rest_api_id      = aws_api_gateway_rest_api.di_account_management_api.id
   root_resource_id = aws_api_gateway_rest_api.di_account_management_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_account_management_api.execution_arn
+  memory_size      = var.endpoint_memory_size
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.account_management_api_release_zip.key

--- a/ci/terraform/account-management/update-phone-number.tf
+++ b/ci/terraform/account-management/update-phone-number.tf
@@ -33,6 +33,7 @@ module "update_phone_number" {
   rest_api_id      = aws_api_gateway_rest_api.di_account_management_api.id
   root_resource_id = aws_api_gateway_rest_api.di_account_management_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_account_management_api.execution_arn
+  memory_size      = var.endpoint_memory_size
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.account_management_api_release_zip.key

--- a/ci/terraform/account-management/variables.tf
+++ b/ci/terraform/account-management/variables.tf
@@ -167,3 +167,8 @@ variable "localstack_endpoint" {
   type    = string
   default = "http://localhost:45678/"
 }
+
+variable "endpoint_memory_size" {
+  default = 4096
+  type    = number
+}

--- a/ci/terraform/audit-processors/counter_fraud.tf
+++ b/ci/terraform/audit-processors/counter_fraud.tf
@@ -48,7 +48,7 @@ resource "aws_lambda_function" "fraud_realtime_logging_lambda" {
   role          = module.fraud_realtime_logging_role.arn
   handler       = "uk.gov.di.authentication.audit.lambda.CounterFraudAuditLambda::handleRequest"
   timeout       = 30
-  memory_size   = 4096
+  memory_size   = var.lambda_memory_size
   publish       = true
 
   tracing_config {

--- a/ci/terraform/audit-processors/performance_analysis.tf
+++ b/ci/terraform/audit-processors/performance_analysis.tf
@@ -48,7 +48,7 @@ resource "aws_lambda_function" "performance_analysis_logging_lambda" {
   role          = module.performance_analysis_logging_role.arn
   handler       = "uk.gov.di.authentication.audit.lambda.PerformanceAnalysisAuditLambda::handleRequest"
   timeout       = 30
-  memory_size   = 4096
+  memory_size   = var.lambda_memory_size
   publish       = true
 
   tracing_config {

--- a/ci/terraform/audit-processors/staging-overrides.tfvars
+++ b/ci/terraform/audit-processors/staging-overrides.tfvars
@@ -1,0 +1,1 @@
+lambda_memory_size = 3008

--- a/ci/terraform/audit-processors/storage.tf
+++ b/ci/terraform/audit-processors/storage.tf
@@ -46,7 +46,7 @@ resource "aws_lambda_function" "audit_processor_lambda" {
   role          = module.audit_storage_lambda_role.arn
   handler       = "uk.gov.di.authentication.audit.lambda.StorageSQSAuditHandler::handleRequest"
   timeout       = 30
-  memory_size   = 4096
+  memory_size   = var.lambda_memory_size
   publish       = true
 
   tracing_config {

--- a/ci/terraform/audit-processors/variables.tf
+++ b/ci/terraform/audit-processors/variables.tf
@@ -54,3 +54,8 @@ variable "audit_storage_expiry_days" {
   description = "How long before files in the audit store are expired (default: 7 years)"
   default     = 7 * 365
 }
+
+variable "lambda_memory_size" {
+  default = 4096
+  type    = number
+}

--- a/ci/terraform/modules/endpoint-module/lambda.tf
+++ b/ci/terraform/modules/endpoint-module/lambda.tf
@@ -3,7 +3,7 @@ resource "aws_lambda_function" "endpoint_lambda" {
   role          = var.lambda_role_arn
   handler       = var.handler_function_name
   timeout       = 30
-  memory_size   = 4096
+  memory_size   = var.memory_size
   publish       = true
 
   tracing_config {

--- a/ci/terraform/modules/endpoint-module/variables.tf
+++ b/ci/terraform/modules/endpoint-module/variables.tf
@@ -184,3 +184,7 @@ variable "lambda_env_vars_encryption_kms_key_arn" {
 variable "code_signing_config_arn" {
   default = null
 }
+
+variable "memory_size" {
+  type    = number
+}

--- a/ci/terraform/modules/endpoint-module/variables.tf
+++ b/ci/terraform/modules/endpoint-module/variables.tf
@@ -186,5 +186,5 @@ variable "code_signing_config_arn" {
 }
 
 variable "memory_size" {
-  type    = number
+  type = number
 }

--- a/ci/terraform/oidc/auth-code.tf
+++ b/ci/terraform/oidc/auth-code.tf
@@ -35,6 +35,7 @@ module "auth-code" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
+  memory_size      = var.endpoint_memory_size
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.oidc_api_release_zip.key

--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -37,7 +37,7 @@ module "authorize" {
   rest_api_id           = aws_api_gateway_rest_api.di_authentication_api.id
   root_resource_id      = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
   execution_arn         = aws_api_gateway_rest_api.di_authentication_api.execution_arn
-  memory_size      = var.endpoint_memory_size
+  memory_size           = var.endpoint_memory_size
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.oidc_api_release_zip.key

--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -37,6 +37,7 @@ module "authorize" {
   rest_api_id           = aws_api_gateway_rest_api.di_authentication_api.id
   root_resource_id      = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
   execution_arn         = aws_api_gateway_rest_api.di_authentication_api.execution_arn
+  memory_size      = var.endpoint_memory_size
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.oidc_api_release_zip.key

--- a/ci/terraform/oidc/ipv-authorize.tf
+++ b/ci/terraform/oidc/ipv-authorize.tf
@@ -39,6 +39,7 @@ module "ipv-authorize" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
+  memory_size      = var.endpoint_memory_size
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.ipv_api_release_zip.key

--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -44,6 +44,7 @@ module "ipv-callback" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
+  memory_size      = var.endpoint_memory_size
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.ipv_api_release_zip.key

--- a/ci/terraform/oidc/ipv-capacity.tf
+++ b/ci/terraform/oidc/ipv-capacity.tf
@@ -37,6 +37,7 @@ module "ipv-capacity" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
+  memory_size      = var.endpoint_memory_size
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.ipv_api_release_zip.key

--- a/ci/terraform/oidc/jwks.tf
+++ b/ci/terraform/oidc/jwks.tf
@@ -29,6 +29,7 @@ module "jwks" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
   root_resource_id = aws_api_gateway_resource.wellknown_resource.id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
+  memory_size      = var.endpoint_memory_size
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.oidc_api_release_zip.key

--- a/ci/terraform/oidc/login.tf
+++ b/ci/terraform/oidc/login.tf
@@ -39,6 +39,7 @@ module "login" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
+  memory_size      = var.endpoint_memory_size
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.frontend_api_release_zip.key

--- a/ci/terraform/oidc/logout.tf
+++ b/ci/terraform/oidc/logout.tf
@@ -37,6 +37,7 @@ module "logout" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
+  memory_size      = var.endpoint_memory_size
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.oidc_api_release_zip.key

--- a/ci/terraform/oidc/mfa.tf
+++ b/ci/terraform/oidc/mfa.tf
@@ -37,6 +37,7 @@ module "mfa" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
+  memory_size      = var.endpoint_memory_size
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.frontend_api_release_zip.key

--- a/ci/terraform/oidc/register.tf
+++ b/ci/terraform/oidc/register.tf
@@ -34,6 +34,7 @@ module "register" {
   root_resource_id       = aws_api_gateway_resource.register_resource.id
   execution_arn          = aws_api_gateway_rest_api.di_authentication_api.execution_arn
   authentication_vpc_arn = local.authentication_vpc_arn
+  memory_size            = var.endpoint_memory_size
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.client_api_release_zip.key

--- a/ci/terraform/oidc/reset-password-request.tf
+++ b/ci/terraform/oidc/reset-password-request.tf
@@ -39,6 +39,7 @@ module "reset-password-request" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
+  memory_size      = var.endpoint_memory_size
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.frontend_api_release_zip.key

--- a/ci/terraform/oidc/reset_password.tf
+++ b/ci/terraform/oidc/reset_password.tf
@@ -38,6 +38,7 @@ module "reset_password" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
+  memory_size      = var.endpoint_memory_size
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.frontend_api_release_zip.key

--- a/ci/terraform/oidc/send_notification.tf
+++ b/ci/terraform/oidc/send_notification.tf
@@ -36,6 +36,7 @@ module "send_notification" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
+  memory_size      = var.endpoint_memory_size
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.frontend_api_release_zip.key

--- a/ci/terraform/oidc/signup.tf
+++ b/ci/terraform/oidc/signup.tf
@@ -36,6 +36,7 @@ module "signup" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
+  memory_size      = var.endpoint_memory_size
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.frontend_api_release_zip.key

--- a/ci/terraform/oidc/staging-overrides.tfvars
+++ b/ci/terraform/oidc/staging-overrides.tfvars
@@ -1,0 +1,1 @@
+endpoint_memory_size = 3008

--- a/ci/terraform/oidc/start.tf
+++ b/ci/terraform/oidc/start.tf
@@ -35,6 +35,7 @@ module "start" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
+  memory_size      = var.endpoint_memory_size
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.frontend_api_release_zip.key

--- a/ci/terraform/oidc/token.tf
+++ b/ci/terraform/oidc/token.tf
@@ -63,6 +63,7 @@ module "token" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
+  memory_size      = var.endpoint_memory_size
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.oidc_api_release_zip.key

--- a/ci/terraform/oidc/trustmarks.tf
+++ b/ci/terraform/oidc/trustmarks.tf
@@ -28,6 +28,7 @@ module "trustmarks" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
+  memory_size      = var.endpoint_memory_size
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.oidc_api_release_zip.key

--- a/ci/terraform/oidc/update.tf
+++ b/ci/terraform/oidc/update.tf
@@ -34,6 +34,7 @@ module "update" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
   root_resource_id = aws_api_gateway_resource.register_resource.id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
+  memory_size      = var.endpoint_memory_size
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.client_api_release_zip.key

--- a/ci/terraform/oidc/update_profile.tf
+++ b/ci/terraform/oidc/update_profile.tf
@@ -37,6 +37,7 @@ module "update_profile" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
+  memory_size      = var.endpoint_memory_size
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.frontend_api_release_zip.key

--- a/ci/terraform/oidc/userexists.tf
+++ b/ci/terraform/oidc/userexists.tf
@@ -36,6 +36,7 @@ module "userexists" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
+  memory_size      = var.endpoint_memory_size
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.frontend_api_release_zip.key

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -37,6 +37,7 @@ module "userinfo" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
+  memory_size      = var.endpoint_memory_size
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.oidc_api_release_zip.key

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -227,3 +227,8 @@ variable "ipv_authorisation_callback_uri" {
 variable "ipv_authorisation_client_id" {
   type = string
 }
+
+variable "endpoint_memory_size" {
+  default = 4096
+  type    = number
+}

--- a/ci/terraform/oidc/verify_code.tf
+++ b/ci/terraform/oidc/verify_code.tf
@@ -41,6 +41,7 @@ module "verify_code" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
+  memory_size      = var.endpoint_memory_size
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.frontend_api_release_zip.key

--- a/ci/terraform/oidc/wellknown.tf
+++ b/ci/terraform/oidc/wellknown.tf
@@ -24,6 +24,7 @@ module "openid_configuration_discovery" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
   root_resource_id = aws_api_gateway_resource.wellknown_resource.id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
+  memory_size      = var.endpoint_memory_size
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.oidc_api_release_zip.key


### PR DESCRIPTION
## What?

- Parameterise the memory size for the endpoint module lambda (default 4096)
- Parameterise the memory size for audit lambda functions (default 4096)
- Override the memory size parameters in staging to be 3008

## Why?

Not all environments need to have 4GB allocations.
