### PR TITLE
AUTH-1427: Add missing permissions for Cloudwatch

### DIFF
--- a/ci/terraform/shared/kms.tf
+++ b/ci/terraform/shared/kms.tf
@@ -164,7 +164,9 @@ data "aws_iam_policy_document" "cloudwatch" {
     actions = [
       "kms:Encrypt*",
       "kms:Decrypt*",
-      "kms:Describe*"
+      "kms:Describe*",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
     ]
     effect = "Allow"
     principals {


### PR DESCRIPTION
## What?

- Add the `kms:ReEncrypt*` and `kms:GenerateDataKey*` actions to the cloudwatch policy.

## Why?

It seems that these permissions are now required to encrypt cloudwatch logs.
