### PR TITLE
AUTH-1427: Parameterise memory size for delivery-receipts API

### DIFF
--- a/ci/terraform/delivery-receipts/notify-callback.tf
+++ b/ci/terraform/delivery-receipts/notify-callback.tf
@@ -27,6 +27,7 @@ module "notify_callback" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_delivery_receipts_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_delivery_receipts_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_delivery_receipts_api.execution_arn
+  memory_size      = var.endpoint_memory_size
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.delivery_receipts_api_release_zip.key

--- a/ci/terraform/delivery-receipts/variables.tf
+++ b/ci/terraform/delivery-receipts/variables.tf
@@ -75,3 +75,8 @@ variable "cloudwatch_log_retention" {
   type        = number
   description = "The number of day to retain Cloudwatch logs for"
 }
+
+variable "endpoint_memory_size" {
+  default = 4096
+  type    = number
+}


### PR DESCRIPTION
## What?

- Add new variable `endpoint_memory_size` to Terraform (default 4096)
- Pass this value to endpoint module
- Override the value to 3008 for staging environment

## Why?

Not all environments need to have 4GB allocations. This was missed from earlier RP

## Related PRs

https://github.com/alphagov/di-authentication-api/pull/1603