### PR TITLE
AUTH-1427: Override delivery-receipts memory size in staging

### DIFF
--- a/ci/terraform/delivery-receipts/staging-overrides.tfvars
+++ b/ci/terraform/delivery-receipts/staging-overrides.tfvars
@@ -1,0 +1,1 @@
+endpoint_memory_size = 3008


### PR DESCRIPTION
## What?

- Set `endpoint_memory_size` to 3008 in staging environment.

## Why?

Missed from earlier PR

## Related PRs

#1605 