### PR TITLE
AUT-111: Move IPV Callback Handler

### DIFF
--- a/ci/terraform/oidc/api-gateway-frontend.tf
+++ b/ci/terraform/oidc/api-gateway-frontend.tf
@@ -58,8 +58,6 @@ resource "aws_api_gateway_deployment" "frontend_deployment" {
       module.reset-password-request.method_trigger_value,
       var.ipv_api_enabled ? module.ipv-authorize[0].integration_trigger_value : null,
       var.ipv_api_enabled ? module.ipv-authorize[0].method_trigger_value : null,
-      var.ipv_api_enabled ? module.ipv-callback[0].integration_trigger_value : null,
-      var.ipv_api_enabled ? module.ipv-callback[0].method_trigger_value : null,
       var.ipv_api_enabled ? module.ipv-capacity[0].integration_trigger_value : null,
       var.ipv_api_enabled ? module.ipv-capacity[0].method_trigger_value : null,
     ]))

--- a/ci/terraform/oidc/api-gateway.tf
+++ b/ci/terraform/oidc/api-gateway.tf
@@ -127,6 +127,8 @@ resource "aws_api_gateway_deployment" "deployment" {
       var.client_registry_api_enabled ? module.update[0].method_trigger_value : null,
       module.userinfo.integration_trigger_value,
       module.userinfo.method_trigger_value,
+      var.ipv_api_enabled ? module.ipv-callback[0].integration_trigger_value : null,
+      var.ipv_api_enabled ? module.ipv-callback[0].method_trigger_value : null,
     ]))
   }
 
@@ -222,6 +224,7 @@ resource "aws_api_gateway_stage" "endpoint_stage" {
     module.trustmarks,
     module.update,
     module.userinfo,
+    module.ipv-callback,
     aws_api_gateway_deployment.deployment,
   ]
 }

--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -41,9 +41,9 @@ module "ipv-callback" {
   handler_function_name = "uk.gov.di.authentication.ipv.lambda.IPVCallbackHandler::handleRequest"
 
   create_endpoint  = true
-  rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
-  root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
-  execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
+  rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
+  root_resource_id = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
+  execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
   memory_size      = var.endpoint_memory_size
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket


### PR DESCRIPTION
## What?

- Move the IPV Callback endpoint to the OIDC API Gateway

## Why?

This should be on the OIDC API as this interacts directly with the user agent (unlike the other IPV related handlers). The frontend API should never be hit by anything other than the frontend.
