### PR TITLE
AUT-111: Configure IPV endpoints separately

### DIFF
--- a/ci/tasks/deploy-oidc-api.yml
+++ b/ci/tasks/deploy-oidc-api.yml
@@ -18,9 +18,6 @@ params:
   TEST_CLIENT_VERIFY_EMAIL_OTP: ((test-client-verify-email-otp))
   TEST_CLIENT_VERIFY_PHONE_NUMBER_OTP: ((test-client-verify-phone-number-otp))
   TEST_CLIENTS_ENABLED: false
-  IPV_AUTHORISATION_URI: undefined
-  IPV_AUTHORISATION_CALLBACK_URI: undefined
-  IPV_AUTHORISATION_CLIENT_ID: undefined
 inputs:
   - name: api-terraform-src
   - name: oidc-api-release
@@ -62,9 +59,6 @@ run:
         -var "test_client_verify_phone_number_otp=${TEST_CLIENT_VERIFY_PHONE_NUMBER_OTP}" \
         -var "test_clients_enabled=${TEST_CLIENTS_ENABLED}" \
         -var "notify_test_phone_number=${NOTIFY_PHONE_NUMBER}" \
-        -var "ipv_authorisation_uri=${IPV_AUTHORISATION_URI}" \
-        -var "ipv_authorisation_callback_uri=${IPV_AUTHORISATION_CALLBACK_URI}" \
-        -var "ipv_authorisation_client_id=${IPV_AUTHORISATION_CLIENT_ID}" \
         -var-file "${DEPLOY_ENVIRONMENT}-overrides.tfvars" \
 
       terraform output --json > ../../../../terraform-outputs/${DEPLOY_ENVIRONMENT}-terraform-outputs.json

--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -33,6 +33,7 @@ module "ipv-callback" {
     IPV_AUTHORISATION_CLIENT_ID    = var.ipv_authorisation_client_id
     IPV_AUTHORISATION_CALLBACK_URI = var.ipv_authorisation_callback_uri
     IPV_AUTHORISATION_URI          = var.ipv_authorisation_uri
+    IPV_TOKEN_URI                  = var.ipv_token_uri
     LOGIN_URI                      = module.dns.frontend_url
     LOCALSTACK_ENDPOINT            = var.use_localstack ? var.localstack_endpoint : null
     OIDC_API_BASE_URL              = local.api_base_url

--- a/ci/terraform/oidc/staging-overrides.tfvars
+++ b/ci/terraform/oidc/staging-overrides.tfvars
@@ -3,3 +3,4 @@ ipv_api_enabled                = true
 ipv_authorisation_client_id    = "authOrchestrator"
 ipv_authorisation_uri          = "https://staging-di-ipv-core-front.london.cloudapps.digital/oauth2/debug-authorize"
 ipv_authorisation_callback_uri = "https://oidc.staging.account.gov.uk/ipv-callback"
+ipv_token_uri                  = "https://18zwbqzm0k.execute-api.eu-west-2.amazonaws.com/staging/token"

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -217,15 +217,23 @@ variable "ipv_api_enabled" {
 }
 
 variable "ipv_authorisation_uri" {
-  type = string
+  type    = string
+  default = "undefined"
 }
 
 variable "ipv_authorisation_callback_uri" {
-  type = string
+  type    = string
+  default = "undefined"
 }
 
 variable "ipv_authorisation_client_id" {
-  type = string
+  type    = string
+  default = "undefined"
+}
+
+variable "ipv_token_uri" {
+  type    = string
+  default = "undefined"
 }
 
 variable "endpoint_memory_size" {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVAuthorisationHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVAuthorisationHandlerIntegrationTest.java
@@ -77,7 +77,7 @@ class IPVAuthorisationHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
 
         assertThat(
                 body.getRedirectUri(),
-                startsWith(configurationService.getIPVAuthorisationURI() + "/authorize"));
+                startsWith(configurationService.getIPVAuthorisationURI().toString()));
 
         assertEventTypesReceived(auditTopic, List.of(IPV_AUTHORISATION_REQUESTED));
     }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
@@ -141,12 +141,13 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
         }
 
         @Override
-        public URI getIPVAuthorisationURI() {
+        public URI getIPVTokenURI() {
             try {
                 return new URIBuilder()
                         .setHost("localhost")
                         .setPort(ipvStubExtension.getHttpPort())
                         .setScheme("http")
+                        .setPath("/token")
                         .build();
             } catch (URISyntaxException e) {
                 throw new RuntimeException(e);

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandler.java
@@ -38,14 +38,12 @@ import java.util.Optional;
 
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
-import static uk.gov.di.authentication.shared.helpers.ConstructUriHelper.buildURI;
 
 public class IPVAuthorisationHandler extends BaseFrontendHandler<IPVAuthorisationRequest>
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     private static final Logger LOG = LogManager.getLogger(IPVAuthorisationHandler.class);
 
-    private static final String IPV_AUTHORIZE_ROUTE = "/authorize";
     private final AuditService auditService;
     private final IPVAuthorisationService authorisationService;
 
@@ -102,12 +100,7 @@ public class IPVAuthorisationHandler extends BaseFrontendHandler<IPVAuthorisatio
                             .customParameter("nonce", IdGenerator.generate())
                             .state(state)
                             .redirectionURI(configurationService.getIPVAuthorisationCallbackURI())
-                            .endpointURI(
-                                    buildURI(
-                                            configurationService
-                                                    .getIPVAuthorisationURI()
-                                                    .toString(),
-                                            IPV_AUTHORIZE_ROUTE));
+                            .endpointURI(configurationService.getIPVAuthorisationURI());
             claimsSetRequest.ifPresent(
                     t -> authRequestBuilder.customParameter("claims", t.toJSONString()));
 

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVTokenService.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVTokenService.java
@@ -38,7 +38,6 @@ public class IPVTokenService {
 
     private final ConfigurationService configurationService;
     private final KmsConnectionService kmsService;
-    private static final String TOKEN_PATH = "token";
     private static final JWSAlgorithm TOKEN_ALGORITHM = JWSAlgorithm.ES256;
     public static final String IPV_ACCESS_TOKEN_PREFIX = "IPV_ACCESS_TOKEN:";
     private static final Long PRIVATE_KEY_JWT_EXPIRY = 5L;

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVTokenService.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVTokenService.java
@@ -33,7 +33,6 @@ import java.util.Date;
 import java.util.Map;
 
 import static java.util.Collections.singletonList;
-import static uk.gov.di.authentication.shared.helpers.ConstructUriHelper.buildURI;
 
 public class IPVTokenService {
 
@@ -56,8 +55,7 @@ public class IPVTokenService {
                 new AuthorizationCodeGrant(
                         new AuthorizationCode(authCode),
                         configurationService.getIPVAuthorisationCallbackURI());
-        var tokenUri =
-                buildURI(configurationService.getIPVAuthorisationURI().toString(), TOKEN_PATH);
+        var tokenUri = configurationService.getIPVTokenURI();
         var expiryDate = LocalDateTime.now().plusMinutes(PRIVATE_KEY_JWT_EXPIRY);
         var claimsSet =
                 new JWTAuthenticationClaimsSet(
@@ -72,7 +70,7 @@ public class IPVTokenService {
                 generatePrivateKeyJwt(claimsSet),
                 codeGrant,
                 null,
-                singletonList(configurationService.getIPVAuthorisationCallbackURI()),
+                singletonList(configurationService.getIPVTokenURI()),
                 Map.of(
                         "client_id",
                         singletonList(configurationService.getIPVAuthorisationClientId())));

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandlerTest.java
@@ -59,7 +59,7 @@ public class IPVAuthorisationHandlerTest {
 
     private static final URI REDIRECT_URI = URI.create("http://localhost/oidc/redirect");
     private static final URI IPV_CALLBACK_URI = URI.create("http://localhost/oidc/ipv/callback");
-    private static final URI IPV_AUTHORISATION_URI = URI.create("http://localhost/ipv");
+    private static final URI IPV_AUTHORISATION_URI = URI.create("http://localhost/ipv/authorize");
 
     private static final String TEST_EMAIL_ADDRESS = "test@test.com";
 
@@ -123,7 +123,7 @@ public class IPVAuthorisationHandlerTest {
         IPVAuthorisationResponse body =
                 new ObjectMapper().readValue(response.getBody(), IPVAuthorisationResponse.class);
 
-        assertThat(body.getRedirectUri(), startsWith(IPV_AUTHORISATION_URI + "/authorize"));
+        assertThat(body.getRedirectUri(), startsWith(IPV_AUTHORISATION_URI.toString()));
         assertThat(
                 splitQuery(body.getRedirectUri()).get("claims"),
                 equalTo(claimsSetRequest.toJSONString()));

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVTokenServiceTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVTokenServiceTest.java
@@ -42,7 +42,7 @@ class IPVTokenServiceTest {
 
     private final ConfigurationService configService = mock(ConfigurationService.class);
     private final KmsConnectionService kmsService = mock(KmsConnectionService.class);
-    private static final URI IPV_URI = URI.create("http://ipv");
+    private static final URI IPV_URI = URI.create("http://ipv/token");
     private static final URI REDIRECT_URI = URI.create("http://redirect");
     private static final Subject PUBLIC_SUBJECT = new Subject("public-subject");
     private static final String BASE_URL = "https://example.com";
@@ -54,7 +54,7 @@ class IPVTokenServiceTest {
     @BeforeEach
     void setUp() {
         ipvTokenService = new IPVTokenService(configService, kmsService);
-        when(configService.getIPVAuthorisationURI()).thenReturn(IPV_URI);
+        when(configService.getIPVTokenURI()).thenReturn(IPV_URI);
         when(configService.getIPVAuthorisationClientId()).thenReturn(CLIENT_ID.getValue());
         when(configService.getAccessTokenExpiry()).thenReturn(300L);
         when(configService.getIPVAuthorisationCallbackURI()).thenReturn(REDIRECT_URI);
@@ -65,7 +65,7 @@ class IPVTokenServiceTest {
         signJWTWithKMS();
         TokenRequest tokenRequest = ipvTokenService.constructTokenRequest(AUTH_CODE.getValue());
 
-        assertThat(tokenRequest.getEndpointURI(), equalTo(buildURI(IPV_URI.toString(), "token")));
+        assertThat(tokenRequest.getEndpointURI(), equalTo(IPV_URI));
         assertThat(
                 tokenRequest.getClientAuthentication().getMethod().getValue(),
                 equalTo("private_key_jwt"));

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -107,6 +107,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return URI.create(System.getenv().getOrDefault("IPV_AUTHORISATION_URI", ""));
     }
 
+    public URI getIPVTokenURI() {
+        return URI.create(System.getenv().getOrDefault("IPV_TOKEN_URI", ""));
+    }
+
     public URI getIPVAuthorisationCallbackURI() {
         return URI.create(System.getenv().getOrDefault("IPV_AUTHORISATION_CALLBACK_URI", ""));
     }


### PR DESCRIPTION
## What?

- Create a new configuration value to store the IPV token endpoint and keep this separate from the IPV Authorisation endpoint
- Remove injection of non-secret values from CI task, use override files and default values instead.
- Add a new Terraform variable for IPV token endpoint 
- Inject new `IPV_TOKEN_URI` environment variable to IPV Callback endpoint.

## Why?

We need to handle these separate as, currently, these endpoints are not on the same host. Plus, there are multiple options for the `authorize` endpoint in staging so, simply, appending `/authorize` to a base URL doesn't work.
