### PR TITLE
BAU: Remove the staging memory override

### DIFF
--- a/ci/terraform/account-management/staging-overrides.tfvars
+++ b/ci/terraform/account-management/staging-overrides.tfvars
@@ -1,1 +1,0 @@
-endpoint_memory_size = 3008

--- a/ci/terraform/audit-processors/staging-overrides.tfvars
+++ b/ci/terraform/audit-processors/staging-overrides.tfvars
@@ -1,1 +1,0 @@
-lambda_memory_size = 3008

--- a/ci/terraform/delivery-receipts/staging-overrides.tfvars
+++ b/ci/terraform/delivery-receipts/staging-overrides.tfvars
@@ -1,1 +1,0 @@
-endpoint_memory_size = 3008

--- a/ci/terraform/oidc/staging-overrides.tfvars
+++ b/ci/terraform/oidc/staging-overrides.tfvars
@@ -1,4 +1,3 @@
-endpoint_memory_size           = 3008
 ipv_api_enabled                = true
 ipv_authorisation_client_id    = "authOrchestrator"
 ipv_authorisation_uri          = "https://staging-di-ipv-core-front.london.cloudapps.digital/oauth2/debug-authorize"


### PR DESCRIPTION
## What?

- Increase the memory size for lambdas to 4GB by removing the override

## Why?

The lambdas are running quite slowly and the issue with the account has been resolved.
