### PR TITLE
AUT-111: Add endpoint lambda alias to warmer policy

### DIFF
--- a/ci/terraform/modules/endpoint-module/warmer.tf
+++ b/ci/terraform/modules/endpoint-module/warmer.tf
@@ -5,7 +5,8 @@ data "aws_iam_policy_document" "warmer_can_execute_endpoint_lambda" {
       "lambda:InvokeFunction"
     ]
     resources = [
-      aws_lambda_function.endpoint_lambda.arn
+      aws_lambda_function.endpoint_lambda.arn,
+      aws_lambda_alias.endpoint_lambda.arn,
     ]
     effect = "Allow"
   }


### PR DESCRIPTION
## What?

- Add endpoint lambda alias to warmer policy

## Why?

We are seeing errors with the warmer's not having permissions to execute the function using the alias ARN. Add this ARN to the policy.