### PR TITLE
AUT-111: Correct the redirect in IPV handler

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
@@ -20,6 +20,7 @@ import uk.gov.di.authentication.ipv.lambda.IPVCallbackHandler;
 import uk.gov.di.authentication.shared.entity.LevelOfConfidence;
 import uk.gov.di.authentication.shared.entity.ResponseHeaders;
 import uk.gov.di.authentication.shared.entity.ServiceType;
+import uk.gov.di.authentication.shared.helpers.ConstructUriHelper;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.extensions.IPVStubExtension;
@@ -35,7 +36,7 @@ import java.util.Optional;
 
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.startsWith;
+import static org.hamcrest.Matchers.equalTo;
 import static uk.gov.di.authentication.shared.helpers.ClientSubjectHelper.calculatePairwiseIdentifier;
 import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertNoAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
@@ -60,7 +61,7 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
     }
 
     @Test
-    void shouldRedirectToLoginWhenSuccessfullyProcessedIpvResponse() throws IOException {
+    void shouldRedirectToAuthCodeWhenSuccessfullyProcessedIpvResponse() throws IOException {
         var sessionId = "some-session-id";
         var clientSessionId = "some-client-session-id";
         var scope = new Scope(OIDCScopeValue.OPENID);
@@ -89,7 +90,11 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
         assertThat(response, hasStatus(302));
         assertThat(
                 response.getHeaders().get(ResponseHeaders.LOCATION),
-                startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
+                equalTo(
+                        ConstructUriHelper.buildURI(
+                                        TEST_CONFIGURATION_SERVICE.getOidcApiBaseURL().get(),
+                                        "/auth-code")
+                                .toString()));
 
         assertNoAuditEventsReceived(auditTopic);
         SpotQueueAssertionHelper.assertSpotRequestReceived(

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -191,7 +191,7 @@ public class IPVCallbackHandler
                                 }
                                 var redirectURI =
                                         ConstructUriHelper.buildURI(
-                                                configurationService.getLoginURI().toString(),
+                                                configurationService.getOidcApiBaseURL().get(),
                                                 REDIRECT_PATH);
                                 return new APIGatewayProxyResponseEvent()
                                         .withStatusCode(302)

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -145,7 +145,7 @@ class IPVCallbackHandlerTest {
         var response = makeHandlerRequest(event);
 
         assertThat(response, hasStatus(302));
-        var expectedRedirectURI = new URIBuilder(LOGIN_URL).setPath("auth-code").build();
+        var expectedRedirectURI = new URIBuilder(OIDC_BASE_URL).setPath("auth-code").build();
         assertThat(response.getHeaders().get("Location"), equalTo(expectedRedirectURI.toString()));
         var expectedPairwiseSub =
                 ClientSubjectHelper.getSubject(userProfile, clientRegistry, dynamoService);


### PR DESCRIPTION
## What?

- The redirect handler is using the frontend API as the base URL rather than the OIDC API, when re-directing to the `auth-code` endpoint. 

## Why?

The `auth-code` endpoint is on the OIDC API.
