### PR TITLE
AUTH-2: Return redirect URI from StartHandler

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/ClientStartInfo.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/ClientStartInfo.java
@@ -2,6 +2,7 @@ package uk.gov.di.authentication.frontendapi.entity;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.net.URI;
 import java.util.List;
 
 public class ClientStartInfo {
@@ -18,15 +19,20 @@ public class ClientStartInfo {
     @JsonProperty("cookieConsentShared")
     private boolean cookieConsentShared;
 
+    @JsonProperty("redirectUri")
+    private URI redirectUri;
+
     public ClientStartInfo(
             @JsonProperty(required = true, value = "clientName") String clientName,
             @JsonProperty(required = true, value = "scopes") List<String> scopes,
             @JsonProperty(required = true, value = "serviceType") String serviceType,
-            @JsonProperty(value = "cookieConsentShared") boolean cookieConsentShared) {
+            @JsonProperty(value = "cookieConsentShared") boolean cookieConsentShared,
+            @JsonProperty(value = "redirectUri") URI redirectUri) {
         this.clientName = clientName;
         this.scopes = scopes;
         this.serviceType = serviceType;
         this.cookieConsentShared = cookieConsentShared;
+        this.redirectUri = redirectUri;
     }
 
     public String getClientName() {
@@ -43,5 +49,9 @@ public class ClientStartInfo {
 
     public boolean getCookieConsentShared() {
         return cookieConsentShared;
+    }
+
+    public URI getRedirectUri() {
+        return redirectUri;
     }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
@@ -78,7 +78,8 @@ public class StartService {
                         clientRegistry.getClientName(),
                         scopes,
                         clientRegistry.getServiceType(),
-                        clientRegistry.isCookieConsentShared());
+                        clientRegistry.isCookieConsentShared(),
+                        authenticationRequest.getRedirectionURI());
         LOG.info(
                 "Found ClientStartInfo for ClientName: {} Scopes: {} ServiceType: {}",
                 clientRegistry.getClientName(),

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -60,6 +60,7 @@ class StartHandlerTest {
     public static final String CLIENT_SESSION_ID = "known-client-session-id";
     public static final String SESSION_ID = "some-session-id";
     public static final String PERSISTENT_ID = "some-persistent-id-value";
+    public static final URI REDIRECT_URL = URI.create("https://localhost/redirect");
 
     private StartHandler handler;
     private final Context context = mock(Context.class);
@@ -131,6 +132,7 @@ class StartHandlerTest {
         assertThat(
                 response.getClient().getCookieConsentShared(),
                 equalTo(getClientStartInfo().getCookieConsentShared()));
+        assertThat(response.getClient().getRedirectUri(), equalTo(REDIRECT_URL));
         assertThat(
                 response.getUser().isConsentRequired(), equalTo(userStartInfo.isConsentRequired()));
         assertThat(
@@ -251,7 +253,8 @@ class StartHandlerTest {
     private ClientStartInfo getClientStartInfo() {
         Scope scope = new Scope(OIDCScopeValue.OPENID.getValue());
 
-        return new ClientStartInfo(TEST_CLIENT_NAME, scope.toStringList(), "MANDATORY", false);
+        return new ClientStartInfo(
+                TEST_CLIENT_NAME, scope.toStringList(), "MANDATORY", false, REDIRECT_URL);
     }
 
     private UserStartInfo getUserStartInfo(String cookieConsent, String gaCrossDomainTrackingId) {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
@@ -111,6 +111,7 @@ class StartServiceTest {
         assertThat(clientStartInfo.getCookieConsentShared(), equalTo(cookieConsentShared));
         assertThat(clientStartInfo.getClientName(), equalTo(CLIENT_NAME));
         assertThat(clientStartInfo.getScopes(), equalTo(SCOPES.toStringList()));
+        assertThat(clientStartInfo.getRedirectUri(), equalTo(REDIRECT_URI));
     }
 
     @Test

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
@@ -37,7 +37,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     private static final String EMAIL = "joe.bloggs@digital.cabinet-office.gov.uk";
     private static final String CLIENT_ID = "test-client-id";
-    private static final String REDIRECT_URI = "http://localhost";
+    private static final URI REDIRECT_URI = URI.create("http://localhost/redirect");
     public static final String CLIENT_SESSION_ID = "a-client-session-id";
     public static final String TEST_CLIENT_NAME = "test-client-name";
 
@@ -55,10 +55,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         scope.add(OIDCScopeValue.OPENID);
         AuthenticationRequest authRequest =
                 new AuthenticationRequest.Builder(
-                                ResponseType.CODE,
-                                scope,
-                                new ClientID(CLIENT_ID),
-                                URI.create("http://localhost/redirect"))
+                                ResponseType.CODE, scope, new ClientID(CLIENT_ID), REDIRECT_URI)
                         .nonce(new Nonce())
                         .state(new State())
                         .build();
@@ -85,6 +82,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(startResponse.getClient().getServiceType(), equalTo("MANDATORY"));
         assertThat(startResponse.getClient().getCookieConsentShared(), equalTo(false));
         assertThat(startResponse.getClient().getScopes(), equalTo(scope.toStringList()));
+        assertThat(startResponse.getClient().getRedirectUri(), equalTo(REDIRECT_URI));
         assertThat(startResponse.getUser().getCookieConsent(), equalTo(null));
         assertThat(startResponse.getUser().getGaCrossDomainTrackingId(), equalTo(null));
 
@@ -105,7 +103,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         clientStore.registerClient(
                 CLIENT_ID,
                 TEST_CLIENT_NAME,
-                singletonList(REDIRECT_URI),
+                singletonList(REDIRECT_URI.toString()),
                 singletonList(EMAIL),
                 List.of("openid", "email"),
                 Base64.getMimeEncoder().encodeToString(keyPair.getPublic().getEncoded()),


### PR DESCRIPTION
## What?

- In the client info return from `StartHandler` return the `redirect_url` as specified in the authorisation request.

## Why?

This is required by the frontend in order to redirect the use back to the RP in certain error scenarios
