### PR TITLE
AUT-109: Add auditing in IPV callback handler

### DIFF
--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/domain/IPVAuditableEvent.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/domain/IPVAuditableEvent.java
@@ -4,7 +4,12 @@ import uk.gov.di.authentication.shared.domain.AuditableEvent;
 
 public enum IPVAuditableEvent implements AuditableEvent {
     IPV_AUTHORISATION_REQUESTED,
+    IPV_AUTHORISATION_RESPONSE_RECEIVED,
+    IPV_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
+    IPV_UNSUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
+    IPV_SUCCESSFUL_IDENTITY_RESPONSE_RECEIVED,
     IPV_CAPACITY_REQUESTED,
+    IPV_SPOT_REQUESTED,
     SPOT_RESPONSE_RECEIVED;
 
     public AuditableEvent parseFromName(String name) {


### PR DESCRIPTION
## What?

Add auditing in IPV callback handler.

## Why?

We need an audit trail.

## Notes

I'm not sure how we should handle IPV_SUCCESSFUL_IDENTITY_RESPONSE_RECEIVED.  As I understand it, we're not yet clear on how the handler should process the IpvInfoResponse.  I think James and I agreed that for now, we would just always log it as successful - I'm definitely open to alternative suggestions.

## Related PRs

#1607 <- earlier PR which added auditing in the other IPV handlers