### PR TITLE
AUT-110: Change redirect on successful IPV callback

### DIFF
--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -53,7 +53,7 @@ public class IPVCallbackHandler
     private final AuditService auditService;
     private final AwsSqsClient sqsClient;
     protected final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
-    private static final String REDIRECT_PATH = "auth-code";
+    private static final String REDIRECT_PATH = "ipv-callback";
 
     public IPVCallbackHandler() {
         this(ConfigurationService.getInstance());

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -117,7 +117,7 @@ class IPVCallbackHandlerTest {
     }
 
     @Test
-    void shouldRedirectToLoginUriForSuccessfulResponse()
+    void shouldRedirectToFrontendCallbackForSuccessfulResponse()
             throws URISyntaxException, JsonProcessingException {
         var salt = "Mmc48imEuO5kkVW7NtXVtx5h0mbCTfXsqXdWvbRMzdw=".getBytes();
         var clientRegistry = generateClientRegistry();
@@ -153,7 +153,7 @@ class IPVCallbackHandlerTest {
         var response = makeHandlerRequest(event);
 
         assertThat(response, hasStatus(302));
-        var expectedRedirectURI = new URIBuilder(LOGIN_URL).setPath("auth-code").build();
+        var expectedRedirectURI = new URIBuilder(LOGIN_URL).setPath("ipv-callback").build();
         assertThat(response.getHeaders().get("Location"), equalTo(expectedRedirectURI.toString()));
         var expectedPairwiseSub =
                 ClientSubjectHelper.getSubject(userProfile, clientRegistry, dynamoService);


### PR DESCRIPTION
## What?

- On a successful response received by IPV callback, change the final redirect to the new `/ipv-callback` in the frontend rather than `/auth-code`.

## Why?

The new route in the frontend handles the IPV state logic without needing to pollute the `auth-code` route.

## Related PRs

Please include links to PRs in other repositories relevant to this PR.
Delete this section if not needed.