### PR TITLE
AUT-241: Back-channel logout support in API (1)

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
@@ -11,6 +11,7 @@ import org.apache.http.client.utils.URIBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.oidc.domain.OidcAuditableEvent;
+import uk.gov.di.authentication.oidc.services.BackChannelLogoutService;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ResponseHeaders;
 import uk.gov.di.authentication.shared.entity.Session;
@@ -48,6 +49,7 @@ public class LogoutHandler
     private final ClientSessionService clientSessionService;
     private final TokenValidationService tokenValidationService;
     private final AuditService auditService;
+    private final BackChannelLogoutService backChannelLogoutService;
 
     public LogoutHandler() {
         this(ConfigurationService.getInstance());
@@ -66,6 +68,7 @@ public class LogoutHandler
                 new TokenValidationService(
                         configurationService, new KmsConnectionService(configurationService));
         this.auditService = new AuditService(configurationService);
+        this.backChannelLogoutService = new BackChannelLogoutService();
     }
 
     public LogoutHandler(
@@ -74,13 +77,15 @@ public class LogoutHandler
             DynamoClientService dynamoClientService,
             ClientSessionService clientSessionService,
             TokenValidationService tokenValidationService,
-            AuditService auditService) {
+            AuditService auditService,
+            BackChannelLogoutService backChannelLogoutService) {
         this.configurationService = configurationService;
         this.sessionService = sessionService;
         this.dynamoClientService = dynamoClientService;
         this.clientSessionService = clientSessionService;
         this.tokenValidationService = tokenValidationService;
         this.auditService = auditService;
+        this.backChannelLogoutService = backChannelLogoutService;
     }
 
     @Override

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
@@ -346,7 +346,15 @@ public class LogoutHandler
 
     private void destroySessions(Session session) {
         for (String clientSessionId : session.getClientSessions()) {
-            LOG.info("Deleting ClientSession");
+            clientSessionService
+                    .getClientSession(clientSessionId)
+                    .getAuthRequestParams()
+                    .get("client_id")
+                    .stream()
+                    .findFirst()
+                    .flatMap(dynamoClientService::getClient)
+                    .ifPresent(backChannelLogoutService::sendLogoutMessage);
+
             clientSessionService.deleteClientSessionFromRedis(clientSessionId);
         }
         LOG.info("Deleting Session");

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/BackChannelLogoutService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/BackChannelLogoutService.java
@@ -1,3 +1,7 @@
 package uk.gov.di.authentication.oidc.services;
 
-public class BackChannelLogoutService {}
+import uk.gov.di.authentication.shared.entity.ClientRegistry;
+
+public class BackChannelLogoutService {
+    public void sendLogoutMessage(ClientRegistry clientRegistry) {}
+}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/BackChannelLogoutService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/BackChannelLogoutService.java
@@ -1,0 +1,3 @@
+package uk.gov.di.authentication.oidc.services;
+
+public class BackChannelLogoutService {}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/BackChannelLogoutService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/BackChannelLogoutService.java
@@ -1,7 +1,19 @@
 package uk.gov.di.authentication.oidc.services;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.CLIENT_ID;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachLogFieldToLogs;
+
 public class BackChannelLogoutService {
-    public void sendLogoutMessage(ClientRegistry clientRegistry) {}
+
+    private static final Logger LOGGER = LogManager.getLogger(BackChannelLogoutService.class);
+
+    public void sendLogoutMessage(ClientRegistry clientRegistry) {
+        attachLogFieldToLogs(CLIENT_ID, clientRegistry.getClientID());
+
+        LOGGER.info("Sending logout message");
+    }
 }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/LogoutHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/LogoutHandlerTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.authentication.oidc.domain.OidcAuditableEvent;
+import uk.gov.di.authentication.oidc.services.BackChannelLogoutService;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.ResponseHeaders;
@@ -69,6 +70,8 @@ class LogoutHandlerTest {
     private final AuditService auditService = mock(AuditService.class);
     private final TokenValidationService tokenValidationService =
             mock(TokenValidationService.class);
+    private final BackChannelLogoutService backChannelLogoutService =
+            mock(BackChannelLogoutService.class);
 
     private static final State STATE = new State();
     private static final String COOKIE = "Cookie";
@@ -109,7 +112,8 @@ class LogoutHandlerTest {
                         dynamoClientService,
                         clientSessionService,
                         tokenValidationService,
-                        auditService);
+                        auditService,
+                        backChannelLogoutService);
         when(configurationService.getDefaultLogoutURI()).thenReturn(DEFAULT_LOGOUT_URI);
         ECKey ecSigningKey =
                 new ECKeyGenerator(Curve.P_256).algorithm(JWSAlgorithm.ES256).generate();


### PR DESCRIPTION
## What?

This PR creates a new component, `BackChannelLogoutService`, which currently does nothing except log.

During logout flows, the client id for every live client session is pulled from the session, used to get the client configuration from the configuration store, and then dispatched to the new component.

Future PRs will add functionality to the new service.
