### PR TITLE
AUT-52: Add acceptance test user seed data in the pipeline

### DIFF
--- a/ci/tasks/deploy-shared-api.yml
+++ b/ci/tasks/deploy-shared-api.yml
@@ -16,6 +16,7 @@ params:
   DI_TOOLS_SIGNING_PROFILE_VERSION_ARN: ((di-tools-signing-profile-version-arn))
 inputs:
   - name: api-terraform-src
+  - name: test-users-seed-data
 outputs:
   - name: terraform-outputs
 run:
@@ -23,6 +24,12 @@ run:
   args:
     - -euc
     - |
+      if test -f "test-users-seed-data/test-users.vars"; then
+        TEST_USERS=$(cat test-users.vars)
+      else
+        TEST_USERS="[]"
+      fi
+  
       cd "api-terraform-src/ci/terraform/shared"
       terraform init -input=false \
         -backend-config "role_arn=${DEPLOYER_ROLE_ARN}" \
@@ -36,6 +43,7 @@ run:
         -var "environment=${DEPLOY_ENVIRONMENT}" \
         -var 'logging_endpoint_arn=arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod' \
         -var "test_client_email_allowlist=${TEST_CLIENT_EMAIL_ALLOWLIST}" \
+        -var "test_users=${TEST_USERS}" \
         -var "password_pepper=${PASSWORD_PEPPER}" \
         -var "common_state_bucket=${STATE_BUCKET}" \
         -var "di_tools_signing_profile_version_arn=${DI_TOOLS_SIGNING_PROFILE_VERSION_ARN}" \

--- a/ci/terraform/shared/test-user.tf
+++ b/ci/terraform/shared/test-user.tf
@@ -1,0 +1,110 @@
+data "aws_dynamodb_table" "user_credential_table" {
+  name = "${var.environment}-user-credentials"
+}
+
+data "aws_dynamodb_table" "user_profile_table" {
+  name = "${var.environment}-user-profile"
+}
+
+resource "time_static" "create_date" {
+  for_each = { for user in var.test_users : user.username => user }
+
+  triggers = {
+    username = each.value.username
+  }
+}
+
+resource "random_string" "subject_id" {
+  for_each = { for user in var.test_users : user.username => user }
+
+  keepers = {
+    username = each.value.username
+  }
+
+  lower   = true
+  upper   = true
+  special = false
+  number  = true
+  length  = 32
+}
+
+resource "random_string" "public_subject_id" {
+  for_each = { for user in var.test_users : user.username => user }
+
+  keepers = {
+    username = each.value.username
+  }
+
+  lower   = true
+  upper   = true
+  special = false
+  number  = true
+  length  = 32
+}
+
+resource "aws_dynamodb_table_item" "user_credentials" {
+  for_each = { for user in var.test_users : user.username => user }
+
+  table_name = data.aws_dynamodb_table.user_credential_table.name
+  hash_key   = data.aws_dynamodb_table.user_credential_table.hash_key
+  item = jsonencode({
+    "Email" = {
+      "S" = each.value.username
+    },
+    "Updated" = {
+      "S" = formatdate("YYYY-MM-DD'T'hh:mm:ss.000000", time_static.create_date[each.key].rfc3339)
+    },
+    "SubjectID" = {
+      "S" = random_string.subject_id[each.key].result
+    },
+    "Password" = {
+      "S" = each.value.hashed_password
+    },
+    "Created" = {
+      "S" = formatdate("YYYY-MM-DD'T'hh:mm:ss.000000", time_static.create_date[each.key].rfc3339)
+    }
+  })
+}
+
+resource "aws_dynamodb_table_item" "user_profile" {
+  for_each = { for user in var.test_users : user.username => user }
+
+  table_name = data.aws_dynamodb_table.user_profile_table.name
+  hash_key   = data.aws_dynamodb_table.user_profile_table.hash_key
+  item = jsonencode({
+    "Email" = {
+      "S" = each.value.username
+    },
+    "EmailVerified" = {
+      "N" = "1"
+    },
+    "PhoneNumberVerified" = {
+      "N" = "1"
+    },
+    "SubjectID" = {
+      "S" = random_string.subject_id[each.key].result
+    },
+    "PhoneNumber" = {
+      "S" = each.value.phone
+    },
+    "PublicSubjectID" = {
+      "S" = random_string.public_subject_id[each.key].result
+    },
+    "termsAndConditions" = {
+      "M" = {
+        "version" = {
+          "S" = "1.0"
+        },
+        "timestamp" = {
+          "S" = formatdate("YYYY-MM-DD'T'hh:mm:ss.000000", time_static.create_date[each.key].rfc3339)
+        }
+      }
+    },
+    "Updated" = {
+      "S" = formatdate("YYYY-MM-DD'T'hh:mm:ss.000000", time_static.create_date[each.key].rfc3339)
+    },
+    "Created" = {
+      "S" = formatdate("YYYY-MM-DD'T'hh:mm:ss.000000", time_static.create_date[each.key].rfc3339)
+    }
+  })
+}

--- a/ci/terraform/shared/variables.tf
+++ b/ci/terraform/shared/variables.tf
@@ -87,6 +87,12 @@ variable "stub_rp_clients" {
   description = "The details of RP clients to provision in the Client table"
 }
 
+variable "test_users" {
+  default     = []
+  type        = list(object({ username : string, hashed_password : string, phone : string, terms_and_conditions_version : string }))
+  description = "Test users to add in the database"
+}
+
 variable "aws_region" {
   default = "eu-west-2"
 }


### PR DESCRIPTION
## What?

Add acceptance test user seed data in the pipeline.

Provide a means to create test users in the database for the acceptance tests in the build environment only.

Pipeline updates to pass in the data to follow.

## Why?

Some test scenarios are better implemented by having existing test data rather than creating all required users through the application during the test runs.

## Related PRs

https://github.com/alphagov/di-infrastructure/pull/225