### PR TITLE
AUT-241: Log at warn rather than error about missing fields

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/BackChannelLogoutService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/BackChannelLogoutService.java
@@ -34,7 +34,7 @@ public class BackChannelLogoutService {
 
         if (isBlank(clientRegistry.getClientID())
                 || isBlank(clientRegistry.getBackChannelLogoutUri())) {
-            LOGGER.error("Client missing required fields");
+            LOGGER.warn("Client missing required fields");
             return;
         }
 


### PR DESCRIPTION
It is currently _only_ logging errors because no-one has the backchannel URI set up yet
