### PR TITLE
AUT-233 - Add claims to ClientRegistry

### DIFF
--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/entity/ClientRegistrationRequest.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/entity/ClientRegistrationRequest.java
@@ -42,6 +42,9 @@ public class ClientRegistrationRequest {
     @JsonProperty("identity_verification_required")
     private boolean identityVerificationRequired;
 
+    @JsonProperty("claims")
+    private List<String> claims = new ArrayList<>();
+
     public ClientRegistrationRequest(
             @JsonProperty(required = true, value = "client_name") String clientName,
             @JsonProperty(required = true, value = "redirect_uris") List<String> redirectUris,
@@ -55,7 +58,8 @@ public class ClientRegistrationRequest {
                     String sectorIdentifierUri,
             @JsonProperty(required = true, value = "subject_type") String subjectType,
             @JsonProperty(value = "identity_verification_required")
-                    boolean identityVerificationRequired) {
+                    boolean identityVerificationRequired,
+            @JsonProperty(value = "claims") List<String> claims) {
         this.clientName = clientName;
         this.redirectUris = redirectUris;
         this.contacts = contacts;
@@ -72,6 +76,9 @@ public class ClientRegistrationRequest {
         this.sectorIdentifierUri = sectorIdentifierUri;
         this.subjectType = subjectType;
         this.identityVerificationRequired = identityVerificationRequired;
+        if (Objects.nonNull(claims)) {
+            this.claims = claims;
+        }
     }
 
     public String getClientName() {
@@ -116,5 +123,9 @@ public class ClientRegistrationRequest {
 
     public boolean isIdentityVerificationRequired() {
         return identityVerificationRequired;
+    }
+
+    public List<String> getClaims() {
+        return claims;
     }
 }

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/entity/ClientRegistrationResponse.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/entity/ClientRegistrationResponse.java
@@ -39,6 +39,9 @@ public class ClientRegistrationResponse {
     @JsonProperty("service_type")
     private final String serviceType;
 
+    @JsonProperty("claims")
+    private final List<String> claims;
+
     public ClientRegistrationResponse(
             @JsonProperty(required = true, value = "client_name") String clientName,
             @JsonProperty(required = true, value = "client_id") String clientId,
@@ -48,7 +51,8 @@ public class ClientRegistrationResponse {
             @JsonProperty(value = "post_logout_redirect_uris") List<String> postLogoutRedirectUris,
             @JsonProperty(value = "back_channel_logout_uri") String backChannelLogoutUri,
             @JsonProperty(required = true, value = "service_type") String serviceType,
-            @JsonProperty(required = true, value = "subject_type") String subjectType) {
+            @JsonProperty(required = true, value = "subject_type") String subjectType,
+            @JsonProperty(value = "claims") List<String> claims) {
         this.clientName = clientName;
         this.clientId = clientId;
         this.redirectUris = redirectUris;
@@ -58,6 +62,7 @@ public class ClientRegistrationResponse {
         this.backChannelLogoutUri = backChannelLogoutUri;
         this.serviceType = serviceType;
         this.subjectType = subjectType;
+        this.claims = claims;
     }
 
     public String getClientName() {
@@ -102,5 +107,9 @@ public class ClientRegistrationResponse {
 
     public String getServiceType() {
         return serviceType;
+    }
+
+    public List<String> getClaims() {
+        return claims;
     }
 }

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandler.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandler.java
@@ -124,10 +124,10 @@ public class ClientRegistrationHandler
                                         sanitiseUrl(
                                                 clientRegistrationRequest.getSectorIdentifierUri()),
                                         clientRegistrationRequest.getSubjectType(),
-                                        !clientRegistrationRequest
-                                                .isIdentityVerificationRequired());
+                                        !clientRegistrationRequest.isIdentityVerificationRequired(),
+                                        clientRegistrationRequest.getClaims());
 
-                                ClientRegistrationResponse clientRegistrationResponse =
+                                var clientRegistrationResponse =
                                         new ClientRegistrationResponse(
                                                 clientRegistrationRequest.getClientName(),
                                                 clientID,
@@ -138,7 +138,8 @@ public class ClientRegistrationHandler
                                                         .getPostLogoutRedirectUris(),
                                                 clientRegistrationRequest.getBackChannelLogoutUri(),
                                                 clientRegistrationRequest.getServiceType(),
-                                                clientRegistrationRequest.getSubjectType());
+                                                clientRegistrationRequest.getSubjectType(),
+                                                clientRegistrationRequest.getClaims());
                                 LOG.info("Generating successful Client registration response");
                                 return generateApiGatewayProxyResponse(
                                         200, clientRegistrationResponse);

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandler.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandler.java
@@ -140,7 +140,8 @@ public class UpdateClientConfigHandler
                                                 clientRegistry.getPostLogoutRedirectUrls(),
                                                 clientRegistry.getBackChannelLogoutUri(),
                                                 clientRegistry.getServiceType(),
-                                                clientRegistry.getSubjectType());
+                                                clientRegistry.getSubjectType(),
+                                                clientRegistry.getClaims());
                                 LOG.info("Client updated");
                                 return generateApiGatewayProxyResponse(
                                         200, clientRegistrationResponse);

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandlerTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandlerTest.java
@@ -22,6 +22,7 @@ import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 import java.util.List;
 import java.util.Optional;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -111,7 +112,8 @@ class ClientRegistrationHandlerTest {
                         serviceType,
                         sectorIdentifierUri,
                         subjectType,
-                        true);
+                        true,
+                        emptyList());
     }
 
     @Test
@@ -156,7 +158,8 @@ class ClientRegistrationHandlerTest {
                         serviceType,
                         sectorIdentifierUri,
                         subjectType,
-                        false);
+                        false,
+                        emptyList());
     }
 
     @Test
@@ -195,7 +198,8 @@ class ClientRegistrationHandlerTest {
                         serviceType,
                         sectorIdentifierUri,
                         subjectType,
-                        true);
+                        true,
+                        emptyList());
     }
 
     @Test

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/ClientStoreExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/ClientStoreExtension.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import uk.gov.di.authentication.shared.services.DynamoClientService;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -51,7 +52,8 @@ public class ClientStoreExtension extends DynamoExtension implements AfterEachCa
                 serviceType,
                 sectorIdentifierUri,
                 subjectType,
-                consentRequired);
+                consentRequired,
+                Collections.emptyList());
     }
 
     public boolean clientExists(String clientID) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ClientRegistry.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ClientRegistry.java
@@ -24,6 +24,7 @@ public class ClientRegistry {
     private boolean consentRequired = false;
     private boolean testClient = false;
     private List<String> testClientEmailAllowlist = new ArrayList<>();
+    private List<String> claims = new ArrayList<>();
 
     @DynamoDBHashKey(attributeName = "ClientID")
     public String getClientID() {
@@ -174,6 +175,16 @@ public class ClientRegistry {
 
     public ClientRegistry setConsentRequired(boolean consentRequired) {
         this.consentRequired = consentRequired;
+        return this;
+    }
+
+    @DynamoDBAttribute(attributeName = "Claims")
+    public List<String> getClaims() {
+        return claims;
+    }
+
+    public ClientRegistry setClaims(List<String> claims) {
+        this.claims = claims;
         return this;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/UpdateClientConfigRequest.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/UpdateClientConfigRequest.java
@@ -30,6 +30,9 @@ public class UpdateClientConfigRequest {
     @JsonProperty("service_type")
     private String serviceType;
 
+    @JsonProperty("claims")
+    private List<String> claims;
+
     public UpdateClientConfigRequest() {}
 
     public String getClientId() {
@@ -62,6 +65,10 @@ public class UpdateClientConfigRequest {
 
     public String getServiceType() {
         return serviceType;
+    }
+
+    public List<String> getClaims() {
+        return claims;
     }
 
     public UpdateClientConfigRequest setClientId(String clientId) {
@@ -102,6 +109,11 @@ public class UpdateClientConfigRequest {
 
     public UpdateClientConfigRequest setServiceType(String serviceType) {
         this.serviceType = serviceType;
+        return this;
+    }
+
+    public UpdateClientConfigRequest setClaims(List<String> claims) {
+        this.claims = claims;
         return this;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ClientService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ClientService.java
@@ -23,7 +23,8 @@ public interface ClientService {
             String serviceType,
             String sectorIdentifierUri,
             String subjectType,
-            boolean consentRequired);
+            boolean consentRequired,
+            List<String> claims);
 
     Optional<ClientRegistry> getClient(String clientId);
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoClientService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoClientService.java
@@ -68,7 +68,8 @@ public class DynamoClientService implements ClientService {
             String serviceType,
             String sectorIdentifierUri,
             String subjectType,
-            boolean consentRequired) {
+            boolean consentRequired,
+            List<String> claims) {
         ClientRegistry clientRegistry =
                 new ClientRegistry()
                         .setClientID(clientID)
@@ -82,7 +83,8 @@ public class DynamoClientService implements ClientService {
                         .setServiceType(serviceType)
                         .setSectorIdentifierUri(sectorIdentifierUri)
                         .setSubjectType(subjectType)
-                        .setConsentRequired(consentRequired);
+                        .setConsentRequired(consentRequired)
+                        .setClaims(claims);
         clientRegistryMapper.save(clientRegistry);
     }
 


### PR DESCRIPTION
## What?

- Add claims to ClientRegistry
- Make the backchannel uri optional when validating it 

## Why?

- So RPs are only issued claims that they have registered to receive.
