### PR TITLE
AUT-267 - Ensure the Identity p values are not included in the VOT claim

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/VectorOfTrust.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/VectorOfTrust.java
@@ -73,11 +73,7 @@ public class VectorOfTrust {
     }
 
     public String retrieveVectorOfTrustForToken() {
-        if (Objects.isNull(levelOfConfidence)) {
-            return credentialTrustLevel.getValue();
-        } else {
-            return levelOfConfidence.getValue() + "." + credentialTrustLevel.getValue();
-        }
+        return credentialTrustLevel.getValue();
     }
 
     private static VectorOfTrust parseVtrSet(JSONArray vtrJsonArray) {

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/VectorOfTrustTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/VectorOfTrustTest.java
@@ -146,18 +146,17 @@ class VectorOfTrustTest {
     }
 
     @Test
-    void shouldReturnCorrectlyFormattedVectorOfTrustForTokenWhenIdentityValuesArePresent() {
+    void shouldNotIncludeIdentityValuesInTokenWhenTheyArePresent() {
         String vectorString = "P2.Cl.Cm";
 
         VectorOfTrust vectorOfTrust =
                 VectorOfTrust.parseFromAuthRequestAttribute(
                         Collections.singletonList(jsonArrayOf(vectorString)));
-        assertThat(vectorOfTrust.retrieveVectorOfTrustForToken(), equalTo(vectorString));
+        assertThat(vectorOfTrust.retrieveVectorOfTrustForToken(), equalTo("Cl.Cm"));
     }
 
     @Test
-    void
-            shouldReturnCorrectlyFormattedVectorOfTrustForTokenWhenOnlyCredentialTrustLevelIsPresent() {
+    void shouldReturnCorrectCredentialTrustLevelInToken() {
         String vectorString = "Cl.Cm";
         VectorOfTrust vectorOfTrust =
                 VectorOfTrust.parseFromAuthRequestAttribute(


### PR DESCRIPTION
## What?

 - Ensure the Identity p values are not included in the VOT claim

## Why?

- In the ID token there is a VOT claim which claims the vector of trust level. We must not return the identity values in this token as RPs discover the level of confidence only by inspecting the VC that comes from the single point of trust (SPOT)