### PR TITLE
AUT-253: Add back channel logout support to wellknown endpoint

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/WellknownHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/WellknownHandler.java
@@ -107,6 +107,7 @@ public class WellknownHandler
                                                 "https://auth-tech-docs.london.cloudapps.digital/"));
                                 providerMetadata.setEndSessionEndpointURI(
                                         buildURI(baseUrl, "/logout"));
+                                providerMetadata.setSupportsBackChannelLogout(true);
                                 providerMetadata.setCustomParameter(
                                         "trustmarks", buildURI(baseUrl, "/trustmark").toString());
                                 providerMetadata.setCustomParameter(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/WellknownHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/WellknownHandlerTest.java
@@ -50,6 +50,9 @@ class WellknownHandlerTest {
                 OIDCProviderMetadata.parse(result.getBody()).getRegistrationEndpointURI(),
                 equalTo(expectedRegistrationURI));
         assertThat(
+                OIDCProviderMetadata.parse(result.getBody()).supportsBackChannelLogout(),
+                equalTo(true));
+        assertThat(
                 OIDCProviderMetadata.parse(result.getBody())
                         .getCustomParameters()
                         .get("trustmarks"),


### PR DESCRIPTION
## What?

Add back channel logout support to wellknown endpoint.

## Why?

The provider metadata needs to reflect that back channel logout is supported.