### PR TITLE
AUT-241: Attach subject ids to SQS message

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/BackChannelLogoutMessage.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/BackChannelLogoutMessage.java
@@ -10,11 +10,16 @@ public class BackChannelLogoutMessage {
     @JsonProperty("logout_uri")
     private String logoutUri;
 
+    @JsonProperty("subject_id")
+    private String subjectId;
+
     public BackChannelLogoutMessage(
             @JsonProperty(required = true, value = "client_id") String clientId,
-            @JsonProperty(required = true, value = "logout_uri") String logoutUri) {
+            @JsonProperty(required = true, value = "logout_uri") String logoutUri,
+            @JsonProperty(required = true, value = "subject_id") String subjectId) {
         this.clientId = clientId;
         this.logoutUri = logoutUri;
+        this.subjectId = subjectId;
     }
 
     public String getClientId() {
@@ -23,5 +28,9 @@ public class BackChannelLogoutMessage {
 
     public String getLogoutUri() {
         return logoutUri;
+    }
+
+    public String getSubjectId() {
+        return subjectId;
     }
 }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
@@ -356,7 +356,7 @@ public class LogoutHandler
                     .ifPresent(
                             clientRegistry ->
                                     backChannelLogoutService.sendLogoutMessage(
-                                            clientRegistry, null));
+                                            clientRegistry, session.getEmailAddress()));
 
             clientSessionService.deleteClientSessionFromRedis(clientSessionId);
         }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
@@ -353,7 +353,10 @@ public class LogoutHandler
                     .stream()
                     .findFirst()
                     .flatMap(dynamoClientService::getClient)
-                    .ifPresent(backChannelLogoutService::sendLogoutMessage);
+                    .ifPresent(
+                            clientRegistry ->
+                                    backChannelLogoutService.sendLogoutMessage(
+                                            clientRegistry, null));
 
             clientSessionService.deleteClientSessionFromRedis(clientSessionId);
         }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/BackChannelLogoutService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/BackChannelLogoutService.java
@@ -44,7 +44,7 @@ public class BackChannelLogoutService {
 
         var message =
                 new BackChannelLogoutMessage(
-                        clientRegistry.getClientID(), clientRegistry.getBackChannelLogoutUri());
+                        clientRegistry.getClientID(), clientRegistry.getBackChannelLogoutUri(), "");
 
         try {
             awsSqsClient.send(ObjectMapperFactory.getInstance().writeValueAsString(message));

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/BackChannelLogoutService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/BackChannelLogoutService.java
@@ -6,10 +6,13 @@ import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.oidc.entity.BackChannelLogoutMessage;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
+import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.AwsSqsClient;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.DynamoService;
 
 import static org.apache.logging.log4j.util.Strings.isBlank;
+import static uk.gov.di.authentication.shared.helpers.ClientSubjectHelper.getSubject;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.CLIENT_ID;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachLogFieldToLogs;
 
@@ -17,17 +20,21 @@ public class BackChannelLogoutService {
 
     private static final Logger LOGGER = LogManager.getLogger(BackChannelLogoutService.class);
     private final AwsSqsClient awsSqsClient;
+    private final AuthenticationService authenticationService;
 
     public BackChannelLogoutService(ConfigurationService configurationService) {
         this(
                 new AwsSqsClient(
                         configurationService.getAwsRegion(),
                         configurationService.getBackChannelLogoutQueueUri(),
-                        configurationService.getSqsEndpointUri()));
+                        configurationService.getSqsEndpointUri()),
+                new DynamoService(configurationService));
     }
 
-    public BackChannelLogoutService(AwsSqsClient awsSqsClient) {
+    public BackChannelLogoutService(
+            AwsSqsClient awsSqsClient, AuthenticationService authenticationService) {
         this.awsSqsClient = awsSqsClient;
+        this.authenticationService = authenticationService;
     }
 
     public void sendLogoutMessage(ClientRegistry clientRegistry, String emailAddress) {
@@ -42,9 +49,15 @@ public class BackChannelLogoutService {
 
         LOGGER.info("Sending logout message");
 
+        var user = authenticationService.getUserProfileByEmail(emailAddress);
+
+        var subjectId = getSubject(user, clientRegistry, authenticationService).getValue();
+
         var message =
                 new BackChannelLogoutMessage(
-                        clientRegistry.getClientID(), clientRegistry.getBackChannelLogoutUri(), "");
+                        clientRegistry.getClientID(),
+                        clientRegistry.getBackChannelLogoutUri(),
+                        subjectId);
 
         try {
             awsSqsClient.send(ObjectMapperFactory.getInstance().writeValueAsString(message));

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/BackChannelLogoutService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/BackChannelLogoutService.java
@@ -30,7 +30,7 @@ public class BackChannelLogoutService {
         this.awsSqsClient = awsSqsClient;
     }
 
-    public void sendLogoutMessage(ClientRegistry clientRegistry) {
+    public void sendLogoutMessage(ClientRegistry clientRegistry, String emailAddress) {
 
         if (isBlank(clientRegistry.getClientID())
                 || isBlank(clientRegistry.getBackChannelLogoutUri())) {

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/LogoutHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/LogoutHandlerTest.java
@@ -624,9 +624,12 @@ class LogoutHandlerTest {
     private void verifySessions() {
         verify(sessionService).deleteSessionFromRedis(SESSION_ID);
 
-        verify(backChannelLogoutService).sendLogoutMessage(argThat(withClientId("client-id")));
-        verify(backChannelLogoutService).sendLogoutMessage(argThat(withClientId("client-id-2")));
-        verify(backChannelLogoutService).sendLogoutMessage(argThat(withClientId("client-id-3")));
+        verify(backChannelLogoutService)
+                .sendLogoutMessage(argThat(withClientId("client-id")), null);
+        verify(backChannelLogoutService)
+                .sendLogoutMessage(argThat(withClientId("client-id-2")), null);
+        verify(backChannelLogoutService)
+                .sendLogoutMessage(argThat(withClientId("client-id-3")), null);
 
         verify(clientSessionService).deleteClientSessionFromRedis(CLIENT_SESSION_ID);
         verify(clientSessionService).deleteClientSessionFromRedis("client-session-id-2");

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/LogoutHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/LogoutHandlerTest.java
@@ -54,6 +54,7 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -625,11 +626,11 @@ class LogoutHandlerTest {
         verify(sessionService).deleteSessionFromRedis(SESSION_ID);
 
         verify(backChannelLogoutService)
-                .sendLogoutMessage(argThat(withClientId("client-id")), null);
+                .sendLogoutMessage(argThat(withClientId("client-id")), eq(EMAIL));
         verify(backChannelLogoutService)
-                .sendLogoutMessage(argThat(withClientId("client-id-2")), null);
+                .sendLogoutMessage(argThat(withClientId("client-id-2")), eq(EMAIL));
         verify(backChannelLogoutService)
-                .sendLogoutMessage(argThat(withClientId("client-id-3")), null);
+                .sendLogoutMessage(argThat(withClientId("client-id-3")), eq(EMAIL));
 
         verify(clientSessionService).deleteClientSessionFromRedis(CLIENT_SESSION_ID);
         verify(clientSessionService).deleteClientSessionFromRedis("client-session-id-2");

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/BackChannelLogoutServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/BackChannelLogoutServiceTest.java
@@ -5,7 +5,9 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import uk.gov.di.authentication.oidc.entity.BackChannelLogoutMessage;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
+import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
+import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.AwsSqsClient;
 
 import java.util.stream.Stream;
@@ -16,19 +18,30 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class BackChannelLogoutServiceTest {
 
     private final AwsSqsClient sqs = mock(AwsSqsClient.class);
-    private final BackChannelLogoutService service = new BackChannelLogoutService(sqs);
+    private final AuthenticationService authenticationService = mock(AuthenticationService.class);
+    private final BackChannelLogoutService service =
+            new BackChannelLogoutService(sqs, authenticationService);
 
     @Test
-    void shouldPostBackChannelLogoutMessageToSqs() throws JsonProcessingException {
+    void shouldPostBackChannelLogoutMessageToSqsForPairwiseClients()
+            throws JsonProcessingException {
+        var user = new UserProfile().setPublicSubjectID("public").setSubjectID("subject");
+
+        when(authenticationService.getUserProfileByEmail("test@test.com")).thenReturn(user);
+        when(authenticationService.getOrGenerateSalt(user)).thenReturn("salt".getBytes());
+
         service.sendLogoutMessage(
                 new ClientRegistry()
                         .setClientID("client-id")
+                        .setSubjectType("pairwise")
+                        .setSectorIdentifierUri("https://example.sign-in.service.gov.uk")
                         .setBackChannelLogoutUri("http://localhost:8080/back-channel-logout"),
-                "");
+                "test@test.com");
 
         var captor = ArgumentCaptor.forClass(String.class);
 
@@ -40,6 +53,9 @@ class BackChannelLogoutServiceTest {
 
         assertThat(message.getClientId(), is("client-id"));
         assertThat(message.getLogoutUri(), is("http://localhost:8080/back-channel-logout"));
+        assertThat(
+                message.getSubjectId(),
+                is("1b8920099adc11e966d68335276d1db274e8c79588b2b608f9182ecc3908ee07"));
     }
 
     @Test

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/BackChannelLogoutServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/BackChannelLogoutServiceTest.java
@@ -27,7 +27,8 @@ class BackChannelLogoutServiceTest {
         service.sendLogoutMessage(
                 new ClientRegistry()
                         .setClientID("client-id")
-                        .setBackChannelLogoutUri("http://localhost:8080/back-channel-logout"));
+                        .setBackChannelLogoutUri("http://localhost:8080/back-channel-logout"),
+                "");
 
         var captor = ArgumentCaptor.forClass(String.class);
 
@@ -47,7 +48,8 @@ class BackChannelLogoutServiceTest {
         var noClientId = new ClientRegistry().setBackChannelLogoutUri("http://localhost:8080/");
         var neitherField = new ClientRegistry();
 
-        Stream.of(noLogoutUri, noClientId, neitherField).forEach(service::sendLogoutMessage);
+        Stream.of(noLogoutUri, noClientId, neitherField)
+                .forEach(clientRegistry -> service.sendLogoutMessage(clientRegistry, null));
 
         verify(sqs, never()).send(anyString());
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ClientSubjectHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ClientSubjectHelper.java
@@ -22,7 +22,7 @@ public class ClientSubjectHelper {
             UserProfile userProfile,
             ClientRegistry client,
             AuthenticationService authenticationService) {
-        if (client.getSubjectType().equalsIgnoreCase("public")) {
+        if ("public".equalsIgnoreCase(client.getSubjectType())) {
             return new Subject(userProfile.getPublicSubjectID());
         } else {
             var uri =


### PR DESCRIPTION
RPs will need to know the subject id to invalidate sessions, so we pass them in the message to SQS.

