### PR TITLE
AUT-262 - Support JWT-Secured Auth Requests to IPV

### DIFF
--- a/ci/terraform/oidc/ipv-authorize.tf
+++ b/ci/terraform/oidc/ipv-authorize.tf
@@ -10,6 +10,7 @@ module "ipv_authorize_role" {
     aws_iam_policy.dynamo_user_read_access_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
+    aws_iam_policy.ipv_token_auth_kms_policy.arn,
   ]
 }
 

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -81,13 +81,14 @@ public class IPVCallbackHandler
     }
 
     public IPVCallbackHandler(ConfigurationService configurationService) {
+        var kmsConnectionService = new KmsConnectionService(configurationService);
         this.configurationService = configurationService;
         this.ipvAuthorisationService =
                 new IPVAuthorisationService(
-                        configurationService, new RedisConnectionService(configurationService));
-        this.ipvTokenService =
-                new IPVTokenService(
-                        configurationService, new KmsConnectionService(configurationService));
+                        configurationService,
+                        new RedisConnectionService(configurationService),
+                        kmsConnectionService);
+        this.ipvTokenService = new IPVTokenService(configurationService, kmsConnectionService);
         this.sessionService = new SessionService(configurationService);
         this.dynamoService = new DynamoService(configurationService);
         this.clientSessionService = new ClientSessionService(configurationService);

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationService.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationService.java
@@ -1,16 +1,37 @@
 package uk.gov.di.authentication.ipv.services;
 
+import com.amazonaws.services.kms.model.SignRequest;
+import com.amazonaws.services.kms.model.SigningAlgorithmSpec;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.impl.ECDSA;
+import com.nimbusds.jose.util.Base64URL;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
+import com.nimbusds.oauth2.sdk.ResponseType;
+import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.id.State;
+import com.nimbusds.oauth2.sdk.id.Subject;
+import com.nimbusds.openid.connect.sdk.Nonce;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.KmsConnectionService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
 
+import java.nio.ByteBuffer;
+import java.text.ParseException;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 public class IPVAuthorisationService {
@@ -18,13 +39,17 @@ public class IPVAuthorisationService {
     private static final Logger LOG = LogManager.getLogger(IPVAuthorisationService.class);
     private final ConfigurationService configurationService;
     private final RedisConnectionService redisConnectionService;
+    private final KmsConnectionService kmsConnectionService;
     public static final String STATE_STORAGE_PREFIX = "state:";
+    private static final JWSAlgorithm SIGNING_ALGORITHM = JWSAlgorithm.ES256;
 
     public IPVAuthorisationService(
             ConfigurationService configurationService,
-            RedisConnectionService redisConnectionService) {
+            RedisConnectionService redisConnectionService,
+            KmsConnectionService kmsConnectionService) {
         this.configurationService = configurationService;
         this.redisConnectionService = redisConnectionService;
+        this.kmsConnectionService = kmsConnectionService;
     }
 
     public Optional<ErrorObject> validateResponse(Map<String, String> headers, String sessionId) {
@@ -95,5 +120,53 @@ public class IPVAuthorisationService {
                 storedState.getValue(),
                 responseState.equals(storedState.getValue()));
         return responseState.equals(storedState.getValue());
+    }
+
+    public SignedJWT constructRequestJWT(
+            State state, Nonce nonce, Scope scope, Subject subject, String claims) {
+        var jwsHeader = new JWSHeader(SIGNING_ALGORITHM);
+        var jwtID = IdGenerator.generate();
+        var expiryDate =
+                Date.from(LocalDateTime.now().plusMinutes(3).atZone(ZoneId.of("UTC")).toInstant());
+        var claimsBuilder =
+                new JWTClaimsSet.Builder()
+                        .issuer(configurationService.getIPVAuthorisationClientId())
+                        .audience(configurationService.getIPVAuthorisationURI().toString())
+                        .expirationTime(expiryDate)
+                        .subject(subject.getValue())
+                        .issueTime(
+                                Date.from(LocalDateTime.now().atZone(ZoneId.of("UTC")).toInstant()))
+                        .jwtID(jwtID)
+                        .claim("state", state.getValue())
+                        .claim("nonce", nonce.getValue())
+                        .claim(
+                                "redirect_uri",
+                                configurationService.getIPVAuthorisationCallbackURI().toString())
+                        .claim("client_id", configurationService.getIPVAuthorisationClientId())
+                        .claim("response_type", ResponseType.CODE.toString())
+                        .claim("scope", scope.toString());
+        if (Objects.nonNull(claims)) {
+            claimsBuilder.claim("claims", claims);
+        }
+        var encodedHeader = jwsHeader.toBase64URL();
+        var encodedClaims = Base64URL.encode(claimsBuilder.build().toString());
+        var message = encodedHeader + "." + encodedClaims;
+        var signRequest = new SignRequest();
+        signRequest.setMessage(ByteBuffer.wrap(message.getBytes()));
+        signRequest.setKeyId(configurationService.getIPVTokenSigningKeyAlias());
+        signRequest.setSigningAlgorithm(SigningAlgorithmSpec.ECDSA_SHA_256.toString());
+        try {
+            var signResult = kmsConnectionService.sign(signRequest);
+            LOG.info("Token has been signed successfully");
+            var signature =
+                    Base64URL.encode(
+                                    ECDSA.transcodeSignatureToConcat(
+                                            signResult.getSignature().array(),
+                                            ECDSA.getSignatureByteArrayLength(SIGNING_ALGORITHM)))
+                            .toString();
+            return SignedJWT.parse(message + "." + signature);
+        } catch (ParseException | JOSEException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandlerTest.java
@@ -5,10 +5,19 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.id.State;
+import com.nimbusds.oauth2.sdk.id.Subject;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import com.nimbusds.openid.connect.sdk.Nonce;
 import com.nimbusds.openid.connect.sdk.OIDCClaimsRequest;
@@ -20,8 +29,10 @@ import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.ipv.domain.IPVAuditableEvent;
 import uk.gov.di.authentication.ipv.entity.IPVAuthorisationResponse;
 import uk.gov.di.authentication.ipv.services.IPVAuthorisationService;
+import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.Session;
+import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
@@ -30,15 +41,20 @@ import uk.gov.di.authentication.shared.services.ClientSessionService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SessionService;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URLDecoder;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 
 import static java.lang.String.format;
+import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.startsWith;
@@ -53,17 +69,6 @@ import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyRespon
 
 public class IPVAuthorisationHandlerTest {
 
-    private static final String SESSION_ID = "a-session-id";
-    private static final String PERSISTENT_SESSION_ID = "a-persistent-session-id";
-    private static final String TEST_CLIENT_ID = "test-client-id";
-    private static final String IPV_CLIENT_ID = "ipv-client-id";
-
-    private static final URI REDIRECT_URI = URI.create("http://localhost/oidc/redirect");
-    private static final URI IPV_CALLBACK_URI = URI.create("http://localhost/oidc/ipv/callback");
-    private static final URI IPV_AUTHORISATION_URI = URI.create("http://localhost/ipv/authorize");
-
-    private static final String TEST_EMAIL_ADDRESS = "test@test.com";
-
     private final Context context = mock(Context.class);
     private final ConfigurationService configService = mock(ConfigurationService.class);
     private final SessionService sessionService = mock(SessionService.class);
@@ -72,7 +77,29 @@ public class IPVAuthorisationHandlerTest {
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
     private final ClientService clientService = mock(ClientService.class);
     private final AuditService auditService = mock(AuditService.class);
-    private IPVAuthorisationService authorisationService = mock(IPVAuthorisationService.class);
+
+    private static final String CLIENT_SESSION_ID = "client-session-v1";
+    private static final String SESSION_ID = "a-session-id";
+    private static final String PERSISTENT_SESSION_ID = "a-persistent-session-id";
+    private static final String CLIENT_ID = "test-client-id";
+    private static final String IPV_CLIENT_ID = "ipv-client-id";
+    private static final String PHONE_NUMBER = "01234567890";
+    private static final Date CREATED_DATE_TIME =
+            Date.from(LocalDateTime.now().atZone(ZoneId.of("UTC")).toInstant().minusSeconds(30));
+    private static final Date UPDATED_DATE_TIME =
+            Date.from(LocalDateTime.now().atZone(ZoneId.of("UTC")).toInstant());
+    private static final String LEGACY_SUBJECT_ID = new Subject("legacy-subject-id-1").getValue();
+    private static final String PUBLIC_SUBJECT_ID = new Subject("public-subject-id-2").getValue();
+    private static final String SUBJECT_ID = new Subject("subject-id-3").getValue();
+    private static final ByteBuffer SALT =
+            ByteBuffer.wrap("a-test-salt".getBytes(StandardCharsets.UTF_8));
+    private static final URI REDIRECT_URI = URI.create("http://localhost/oidc/redirect");
+    private static final URI IPV_CALLBACK_URI = URI.create("http://localhost/oidc/ipv/callback");
+    private static final URI IPV_AUTHORISATION_URI = URI.create("http://localhost/ipv/authorize");
+    private static final String EMAIL_ADDRESS = "test@test.com";
+
+    private final IPVAuthorisationService authorisationService =
+            mock(IPVAuthorisationService.class);
     private final ClaimsSetRequest.Entry nameEntry =
             new ClaimsSetRequest.Entry("name").withClaimRequirement(ClaimRequirement.ESSENTIAL);
     private final ClaimsSetRequest.Entry birthDateEntry =
@@ -83,10 +110,11 @@ public class IPVAuthorisationHandlerTest {
 
     private IPVAuthorisationHandler handler;
 
-    final Session session = new Session(SESSION_ID);
+    private final Session session = new Session(SESSION_ID).setEmailAddress(EMAIL_ADDRESS);
 
     @BeforeEach
     void setup() {
+        var userProfile = generateUserProfile();
         handler =
                 new IPVAuthorisationHandler(
                         configService,
@@ -100,53 +128,56 @@ public class IPVAuthorisationHandlerTest {
         when(configService.getIPVAuthorisationCallbackURI()).thenReturn(IPV_CALLBACK_URI);
         when(configService.getIPVAuthorisationURI()).thenReturn(IPV_AUTHORISATION_URI);
         when(configService.getSessionExpiry()).thenReturn(3600L);
+        when(clientService.getClient(CLIENT_ID)).thenReturn(Optional.of(generateClientRegistry()));
+        when(authenticationService.getUserProfileFromEmail(EMAIL_ADDRESS))
+                .thenReturn(Optional.of(userProfile));
+        when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(SALT.array());
     }
 
     @Test
-    void shouldReturn200AndRedirectURIWithClaims()
-            throws JsonProcessingException, UnsupportedEncodingException {
-
+    void shouldReturn200AndRedirectURIWithClaims() throws JsonProcessingException, JOSEException {
+        var signedJWT = createSignedJWT();
+        when(authorisationService.constructRequestJWT(
+                        any(State.class),
+                        any(Nonce.class),
+                        any(Scope.class),
+                        any(Subject.class),
+                        any()))
+                .thenReturn(signedJWT);
         usingValidSession();
-        usingValidClientSession(TEST_CLIENT_ID);
+        usingValidClientSession();
 
-        Map<String, String> headers = new HashMap<>();
-        headers.put(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, PERSISTENT_SESSION_ID);
-        headers.put("Session-Id", session.getSessionId());
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        event.setHeaders(headers);
-        event.setBody(format("{ \"email\": \"%s\"}", TEST_EMAIL_ADDRESS));
-        event.setRequestContext(contextWithSourceIp("123.123.123.123"));
-
-        APIGatewayProxyResponseEvent response = makeHandlerRequest(event);
+        var response = makeHandlerRequest();
 
         assertThat(response, hasStatus(200));
-
-        IPVAuthorisationResponse body =
-                new ObjectMapper().readValue(response.getBody(), IPVAuthorisationResponse.class);
-
+        var body = new ObjectMapper().readValue(response.getBody(), IPVAuthorisationResponse.class);
         assertThat(body.getRedirectUri(), startsWith(IPV_AUTHORISATION_URI.toString()));
         assertThat(
-                splitQuery(body.getRedirectUri()).get("claims"),
-                equalTo(claimsSetRequest.toJSONString()));
+                splitQuery(body.getRedirectUri()).get("request"), equalTo(signedJWT.serialize()));
         verify(authorisationService).storeState(eq(session.getSessionId()), any(State.class));
-
         verify(auditService)
                 .submitAuditEvent(
                         IPVAuditableEvent.IPV_AUTHORISATION_REQUESTED,
                         context.getAwsRequestId(),
                         SESSION_ID,
+                        CLIENT_ID,
                         AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        TEST_EMAIL_ADDRESS,
+                        EMAIL_ADDRESS,
                         "123.123.123.123",
                         AuditService.UNKNOWN,
                         PERSISTENT_SESSION_ID);
     }
 
-    private APIGatewayProxyResponseEvent makeHandlerRequest(APIGatewayProxyRequestEvent event) {
-        var response = handler.handleRequest(event, context);
-
-        return response;
+    private APIGatewayProxyResponseEvent makeHandlerRequest() {
+        Map<String, String> headers = new HashMap<>();
+        headers.put(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, PERSISTENT_SESSION_ID);
+        headers.put("Session-Id", session.getSessionId());
+        headers.put("Client-Session-Id", CLIENT_SESSION_ID);
+        var event = new APIGatewayProxyRequestEvent();
+        event.setHeaders(headers);
+        event.setBody(format("{ \"email\": \"%s\"}", EMAIL_ADDRESS));
+        event.setRequestContext(contextWithSourceIp("123.123.123.123"));
+        return handler.handleRequest(event, context);
     }
 
     private void usingValidSession() {
@@ -154,21 +185,21 @@ public class IPVAuthorisationHandlerTest {
                 .thenReturn(Optional.of(session));
     }
 
-    private void usingValidClientSession(String clientId) {
+    private void usingValidClientSession() {
         when(clientSessionService.getClientSessionFromRequestHeaders(anyMap()))
                 .thenReturn(Optional.of(clientSession));
         when(clientSession.getAuthRequestParams())
-                .thenReturn(withAuthenticationRequest(clientId).toParameters());
+                .thenReturn(withAuthenticationRequest().toParameters());
     }
 
-    private AuthenticationRequest withAuthenticationRequest(String clientId) {
+    private AuthenticationRequest withAuthenticationRequest() {
         Scope scope = new Scope();
         scope.add(OIDCScopeValue.OPENID);
         var oidcClaimsRequest = new OIDCClaimsRequest().withUserInfoClaimsRequest(claimsSetRequest);
         return new AuthenticationRequest.Builder(
                         new ResponseType(ResponseType.Value.CODE),
                         scope,
-                        new ClientID(clientId),
+                        new ClientID(CLIENT_ID),
                         REDIRECT_URI)
                 .state(new State())
                 .nonce(new Nonce())
@@ -176,8 +207,7 @@ public class IPVAuthorisationHandlerTest {
                 .build();
     }
 
-    public static Map<String, String> splitQuery(String stringUrl)
-            throws UnsupportedEncodingException {
+    public static Map<String, String> splitQuery(String stringUrl) {
         URI uri = URI.create(stringUrl);
         Map<String, String> query_pairs = new LinkedHashMap<>();
         String query = uri.getQuery();
@@ -185,9 +215,55 @@ public class IPVAuthorisationHandlerTest {
         for (String pair : pairs) {
             int idx = pair.indexOf("=");
             query_pairs.put(
-                    URLDecoder.decode(pair.substring(0, idx), "UTF-8"),
-                    URLDecoder.decode(pair.substring(idx + 1), "UTF-8"));
+                    URLDecoder.decode(pair.substring(0, idx), StandardCharsets.UTF_8),
+                    URLDecoder.decode(pair.substring(idx + 1), StandardCharsets.UTF_8));
         }
         return query_pairs;
+    }
+
+    private ClientRegistry generateClientRegistry() {
+        return new ClientRegistry()
+                .setRedirectUrls(singletonList(REDIRECT_URI.toString()))
+                .setClientID(CLIENT_ID)
+                .setContacts(singletonList("joe.bloggs@digital.cabinet-office.gov.uk"))
+                .setPublicKey(null)
+                .setSectorIdentifierUri("http://sector-identifier")
+                .setScopes(singletonList("openid"))
+                .setCookieConsentShared(true)
+                .setSubjectType("pairwise");
+    }
+
+    private UserProfile generateUserProfile() {
+        return new UserProfile()
+                .setEmail(EMAIL_ADDRESS)
+                .setEmailVerified(true)
+                .setPhoneNumber(PHONE_NUMBER)
+                .setPhoneNumberVerified(true)
+                .setPublicSubjectID(PUBLIC_SUBJECT_ID)
+                .setSubjectID(SUBJECT_ID)
+                .setLegacySubjectID(LEGACY_SUBJECT_ID)
+                .setSalt(SALT)
+                .setCreated(CREATED_DATE_TIME.toString())
+                .setUpdated(UPDATED_DATE_TIME.toString());
+    }
+
+    private SignedJWT createSignedJWT() throws JOSEException {
+        var ecSigningKey =
+                new ECKeyGenerator(Curve.P_256)
+                        .keyID("key-id")
+                        .algorithm(JWSAlgorithm.ES256)
+                        .generate();
+        var ecdsaSigner = new ECDSASigner(ecSigningKey);
+        var jwtClaimsSet =
+                new JWTClaimsSet.Builder()
+                        .claim("redirect_uri", REDIRECT_URI)
+                        .claim("response_type", ResponseType.CODE.toString())
+                        .claim("client_id", CLIENT_ID)
+                        .issuer(CLIENT_ID)
+                        .build();
+        var jwsHeader = new JWSHeader(JWSAlgorithm.ES256);
+        var signedJWT = new SignedJWT(jwsHeader, jwtClaimsSet);
+        signedJWT.sign(ecdsaSigner);
+        return signedJWT;
     }
 }

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationServiceTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationServiceTest.java
@@ -1,23 +1,44 @@
 package uk.gov.di.authentication.ipv.services;
 
+import com.amazonaws.services.kms.model.SignRequest;
+import com.amazonaws.services.kms.model.SignResult;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.crypto.impl.ECDSA;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
+import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.id.State;
+import com.nimbusds.oauth2.sdk.id.Subject;
+import com.nimbusds.openid.connect.sdk.Nonce;
+import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.KmsConnectionService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
 
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.text.ParseException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
+import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -29,17 +50,26 @@ class IPVAuthorisationServiceTest {
     private static final State STATE = new State();
     private static final String SESSION_ID = "session-id";
     private static final Long SESSION_EXPIRY = 3600L;
+    private static final String KEY_ID = "14342354354353";
+    private static final String IPV_CLIENT_ID = "ipv-client-id";
+    private static final URI IPV_CALLBACK_URI = URI.create("http://localhost/oidc/ipv/callback");
+    private static final URI IPV_AUTHORISATION_URI = URI.create("http://localhost/ipv/authorize");
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final RedisConnectionService redisConnectionService =
             mock(RedisConnectionService.class);
-    private final IPVAuthorisationService IPVAuthorisationService =
-            new IPVAuthorisationService(configurationService, redisConnectionService);
+    private final KmsConnectionService kmsConnectionService = mock(KmsConnectionService.class);
+    private final IPVAuthorisationService authorisationService =
+            new IPVAuthorisationService(
+                    configurationService, redisConnectionService, kmsConnectionService);
 
     @BeforeEach
     void setUp() throws JsonProcessingException {
         when(configurationService.getSessionExpiry()).thenReturn(SESSION_EXPIRY);
         when(redisConnectionService.getValue(STATE_STORAGE_PREFIX + SESSION_ID))
                 .thenReturn(new ObjectMapper().writeValueAsString(STATE));
+        when(configurationService.getIPVAuthorisationClientId()).thenReturn(IPV_CLIENT_ID);
+        when(configurationService.getIPVAuthorisationCallbackURI()).thenReturn(IPV_CALLBACK_URI);
+        when(configurationService.getIPVAuthorisationURI()).thenReturn(IPV_AUTHORISATION_URI);
     }
 
     @Test
@@ -49,7 +79,7 @@ class IPVAuthorisationServiceTest {
         responseHeaders.put("state", STATE.getValue());
 
         assertThat(
-                IPVAuthorisationService.validateResponse(responseHeaders, SESSION_ID),
+                authorisationService.validateResponse(responseHeaders, SESSION_ID),
                 equalTo(Optional.empty()));
     }
 
@@ -64,14 +94,14 @@ class IPVAuthorisationServiceTest {
         responseHeaders.put("error", errorObject.toString());
 
         assertThat(
-                IPVAuthorisationService.validateResponse(responseHeaders, SESSION_ID),
+                authorisationService.validateResponse(responseHeaders, SESSION_ID),
                 equalTo(Optional.of(new ErrorObject(errorObject.getCode()))));
     }
 
     @Test
     void shouldReturnErrorObjectWhenResponseContainsNoQueryParams() {
         assertThat(
-                IPVAuthorisationService.validateResponse(Collections.emptyMap(), SESSION_ID),
+                authorisationService.validateResponse(Collections.emptyMap(), SESSION_ID),
                 equalTo(
                         Optional.of(
                                 new ErrorObject(
@@ -85,7 +115,7 @@ class IPVAuthorisationServiceTest {
         responseHeaders.put("code", AUTH_CODE.getValue());
 
         assertThat(
-                IPVAuthorisationService.validateResponse(responseHeaders, SESSION_ID),
+                authorisationService.validateResponse(responseHeaders, SESSION_ID),
                 equalTo(
                         Optional.of(
                                 new ErrorObject(
@@ -99,7 +129,7 @@ class IPVAuthorisationServiceTest {
         responseHeaders.put("state", STATE.getValue());
 
         assertThat(
-                IPVAuthorisationService.validateResponse(responseHeaders, SESSION_ID),
+                authorisationService.validateResponse(responseHeaders, SESSION_ID),
                 equalTo(
                         Optional.of(
                                 new ErrorObject(
@@ -118,7 +148,7 @@ class IPVAuthorisationServiceTest {
         responseHeaders.put("code", AUTH_CODE.getValue());
 
         assertThat(
-                IPVAuthorisationService.validateResponse(responseHeaders, SESSION_ID),
+                authorisationService.validateResponse(responseHeaders, SESSION_ID),
                 equalTo(
                         Optional.of(
                                 new ErrorObject(
@@ -129,12 +159,56 @@ class IPVAuthorisationServiceTest {
     @Test
     void shouldSaveStateToRedis() throws JsonProcessingException {
         var sessionId = "session-id";
-        IPVAuthorisationService.storeState(sessionId, STATE);
+        authorisationService.storeState(sessionId, STATE);
 
         verify(redisConnectionService)
                 .saveWithExpiry(
                         STATE_STORAGE_PREFIX + sessionId,
                         new ObjectMapper().writeValueAsString(STATE),
                         SESSION_EXPIRY);
+    }
+
+    @Test
+    void shouldConstructASignedRequestJWT() throws JOSEException, ParseException {
+        var ecSigningKey =
+                new ECKeyGenerator(Curve.P_256)
+                        .keyID(KEY_ID)
+                        .algorithm(JWSAlgorithm.ES256)
+                        .generate();
+        var ecdsaSigner = new ECDSASigner(ecSigningKey);
+        var jwtClaimsSet = new JWTClaimsSet.Builder().build();
+        var jwsHeader = new JWSHeader(JWSAlgorithm.ES256);
+        var signedJWT = new SignedJWT(jwsHeader, jwtClaimsSet);
+        signedJWT.sign(ecdsaSigner);
+        var signResult = new SignResult();
+        byte[] signatureToDER = ECDSA.transcodeSignatureToDER(signedJWT.getSignature().decode());
+        signResult.setSignature(ByteBuffer.wrap(signatureToDER));
+        signResult.setKeyId(KEY_ID);
+        signResult.setSigningAlgorithm(JWSAlgorithm.ES256.getName());
+        when(kmsConnectionService.sign(any(SignRequest.class))).thenReturn(signResult);
+        var state = new State();
+        var nonce = new Nonce();
+        var scope = new Scope(OIDCScopeValue.OPENID);
+        var pairwise = new Subject("pairwise-identifier");
+        var claims = "{\"name\":{\"essential\":true}}";
+
+        var signedJWTResponse =
+                authorisationService.constructRequestJWT(state, nonce, scope, pairwise, claims);
+
+        assertThat(
+                signedJWTResponse.getJWTClaimsSet().getClaim("client_id"), equalTo(IPV_CLIENT_ID));
+        assertThat(
+                signedJWTResponse.getJWTClaimsSet().getClaim("state"), equalTo(state.getValue()));
+        assertThat(
+                signedJWTResponse.getJWTClaimsSet().getClaim("nonce"), equalTo(nonce.getValue()));
+        assertThat(signedJWTResponse.getJWTClaimsSet().getSubject(), equalTo(pairwise.getValue()));
+        assertThat(
+                signedJWTResponse.getJWTClaimsSet().getClaim("scope"), equalTo(scope.toString()));
+        assertThat(signedJWTResponse.getJWTClaimsSet().getIssuer(), equalTo(IPV_CLIENT_ID));
+        assertThat(
+                signedJWTResponse.getJWTClaimsSet().getAudience(),
+                equalTo(singletonList(IPV_AUTHORISATION_URI.toString())));
+        assertThat(signedJWTResponse.getJWTClaimsSet().getClaim("response_type"), equalTo("code"));
+        assertThat(signedJWTResponse.getJWTClaimsSet().getClaim("claims"), equalTo(claims));
     }
 }


### PR DESCRIPTION
## What?

- Going forward, we will be making our authorize requests to IPV using the JWT-Secured Authorization Request https://www.rfc-editor.org/rfc/rfc9101.html
 - Give IPV authorize lambda permissions to the IPV token signing key and create a signed JWT which will contain the required claims required by IPV.
 - Add the request parameter to the current auth request, alongside the existing params. This will be ignored until IPV start parsing it etc, at that point we will be able to remove the other parameters.
- Set the expiry time of the JWT at 3 mins for now. This is subject to change

## Why?

- Requests may include PII so need to be secure. This JWT will also be encrypted but that will be in another PR. 