### PR TITLE
AUT-262 - Add key-id to authorize

### DIFF
--- a/ci/terraform/oidc/ipv-authorize.tf
+++ b/ci/terraform/oidc/ipv-authorize.tf
@@ -33,6 +33,7 @@ module "ipv-authorize" {
     IPV_AUTHORISATION_URI          = var.ipv_authorisation_uri
     IPV_AUTHORISATION_CALLBACK_URI = var.ipv_authorisation_callback_uri
     IPV_AUTHORISATION_CLIENT_ID    = var.ipv_authorisation_client_id
+    IPV_TOKEN_SIGNING_KEY_ALIAS    = local.ipv_token_auth_key_alias_name
   }
   handler_function_name = "uk.gov.di.authentication.ipv.lambda.IPVAuthorisationHandler::handleRequest"
 


### PR DESCRIPTION
## What?

- Add key-id to authorize

## Why?

- Otherwise the key id will be null and it will throw an AWSKMSException
