### PR TITLE
AUT-241: Grant logout read-access to user profile

### DIFF
--- a/ci/terraform/oidc/logout.tf
+++ b/ci/terraform/oidc/logout.tf
@@ -5,6 +5,7 @@ module "oidc_logout_role" {
   vpc_arn     = local.authentication_vpc_arn
 
   policies_to_attach = [
+    aws_iam_policy.dynamo_user_read_access_policy.arn,
     aws_iam_policy.oidc_default_id_token_public_key_kms_policy.arn,
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,


### PR DESCRIPTION
The logout lambda needs this to get the user salt.
