### PR TITLE
AUT-241: Don't send message if user does not exist

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/BackChannelLogoutService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/BackChannelLogoutService.java
@@ -49,9 +49,14 @@ public class BackChannelLogoutService {
 
         LOGGER.info("Sending logout message");
 
-        var user = authenticationService.getUserProfileByEmail(emailAddress);
+        var user = authenticationService.getUserProfileByEmailMaybe(emailAddress);
 
-        var subjectId = getSubject(user, clientRegistry, authenticationService).getValue();
+        if (user.isEmpty()) {
+            LOGGER.warn("User does not exist");
+            return;
+        }
+
+        var subjectId = getSubject(user.get(), clientRegistry, authenticationService).getValue();
 
         var message =
                 new BackChannelLogoutMessage(


### PR DESCRIPTION
## What?

If the user profile does not exist, then do not send the message.

## Why?

We redirect to logout after we delete the account, which was breaking a build journey.
