### PR TITLE
AUT-262 - Read IPV encryption public key from parameter store

### DIFF
--- a/ci/terraform/oidc/ipv-authorize.tf
+++ b/ci/terraform/oidc/ipv-authorize.tf
@@ -11,7 +11,7 @@ module "ipv_authorize_role" {
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
     aws_iam_policy.ipv_token_auth_kms_policy.arn,
-    aws_iam_policy.ipv_auth_encryption_kms_policy.arn,
+    aws_iam_policy.ipv_public_encryption_key_parameter_policy.arn,
   ]
 }
 

--- a/ci/terraform/oidc/ssm.tf
+++ b/ci/terraform/oidc/ssm.tf
@@ -31,3 +31,31 @@ resource "aws_iam_policy" "ipv_capacity_parameter_policy" {
   name_prefix = "ipv-capacity-parameter-store-policy"
 }
 
+resource "aws_ssm_parameter" "ipv_public_encryption_key" {
+  name  = "${var.environment}-ipv-public-encryption-key"
+  type  = "String"
+  value = var.ipv_auth_public_encryption_key
+}
+
+data "aws_iam_policy_document" "ipv_public_encryption_key_parameter_policy_document" {
+  statement {
+    sid    = "AllowGetParameters"
+    effect = "Allow"
+
+    actions = [
+      "ssm:GetParameter",
+      "ssm:GetParameters",
+    ]
+
+    resources = [
+      aws_ssm_parameter.ipv_public_encryption_key.arn
+    ]
+  }
+}
+
+resource "aws_iam_policy" "ipv_public_encryption_key_parameter_policy" {
+  policy      = data.aws_iam_policy_document.ipv_public_encryption_key_parameter_policy_document.json
+  path        = "/${var.environment}/lambda-parameters/"
+  name_prefix = "ipv-public-encryption-key-parameter-store-policy"
+}
+

--- a/ci/terraform/oidc/staging-overrides.tfvars
+++ b/ci/terraform/oidc/staging-overrides.tfvars
@@ -3,3 +3,14 @@ ipv_authorisation_client_id    = "authOrchestrator"
 ipv_authorisation_uri          = "https://staging-di-ipv-core-front.london.cloudapps.digital/oauth2/authorize"
 ipv_authorisation_callback_uri = "https://oidc.staging.account.gov.uk/ipv-callback"
 ipv_backend_uri                = "https://18zwbqzm0k.execute-api.eu-west-2.amazonaws.com/staging"
+ipv_auth_public_encryption_key = <<-EOT
+-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAudZq3RAtd6me99lfWd8N
+AfOIo5rfkt0uCOMtTqHlYVLbjIBeLRvSg1Aq55mSFKbdJ+DE4wFN9PyGZVpH266C
+2DVSOVI0ETfmPP2rVyG9FXwJqGsWYEn7XMqznFPlxi9IjeqOjhybLlaZKdm6VCpO
+KEoQViR4Cm73eax1KDztlmOncypB1o8WIEte3SvFK97Ar3KTJgaS1PsmgXttx6AP
+Q3D0/fQcE0Hp/swIgPsO9gYxhEdv3M+dxO07OJ+/X396bg+uZ7/J84hTz/uIXASy
+bJ5G58qyvEL0h3BMEBayDN1cT3/Q7NU3jkaa1ODynLjkvXEtlccgsrAa2he7OQUY
+ZQIDAQAB
+-----END PUBLIC KEY-----
+EOT

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -260,3 +260,7 @@ variable "spot_queue_url" {
   default = "undefined"
   type    = string
 }
+
+variable "ipv_auth_public_encryption_key" {
+  type = string
+}

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVAuthorisationHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVAuthorisationHandlerIntegrationTest.java
@@ -22,6 +22,10 @@ import uk.gov.di.authentication.sharedtest.extensions.IPVStubExtension;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -46,6 +50,11 @@ class IPVAuthorisationHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
 
     private static final String TEST_EMAIL_ADDRESS = "test@emailtest.com";
     private static final String IPV_CLIENT_ID = "ipv-client-id";
+    private final KeyPair keyPair = generateRsaKeyPair();
+    private final String publicKey =
+            "-----BEGIN PUBLIC KEY-----\n"
+                    + Base64.getMimeEncoder().encodeToString(keyPair.getPublic().getEncoded())
+                    + "\n-----END PUBLIC KEY-----\n";
 
     @RegisterExtension public static final IPVStubExtension ipvStub = new IPVStubExtension();
 
@@ -126,6 +135,17 @@ class IPVAuthorisationHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
                 .build();
     }
 
+    private KeyPair generateRsaKeyPair() {
+        KeyPairGenerator kpg;
+        try {
+            kpg = KeyPairGenerator.getInstance("RSA");
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+        kpg.initialize(2048);
+        return kpg.generateKeyPair();
+    }
+
     private class IPVTestConfigurationService extends IntegrationTestConfigurationService {
 
         private final IPVStubExtension ipvStubExtension;
@@ -165,8 +185,8 @@ class IPVAuthorisationHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
         }
 
         @Override
-        public String getIPVAuthEncryptionKeyAlias() {
-            return ipvEncryptionKey.getKeyAlias();
+        public String getIPVAuthEncryptionPublicKey() {
+            return publicKey;
         }
     }
 }

--- a/ipv-api/build.gradle
+++ b/ipv-api/build.gradle
@@ -11,7 +11,6 @@ dependencies {
             configurations.sqs,
             configurations.ssm,
             configurations.sns,
-            configurations.bouncycastle,
             configurations.dynamodb
 
     implementation configurations.jackson,

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -139,6 +139,17 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return System.getenv("IPV_AUTH_ENCRYPTION_KEY_ALIAS");
     }
 
+    public String getIPVAuthEncryptionPublicKey() {
+        var paramName = format("{0}-ipv-auth-encryption-public-key", getEnvironment());
+        try {
+            var request = new GetParameterRequest().withWithDecryption(true).withName(paramName);
+            return getSsmClient().getParameter(request).getParameter().getValue();
+        } catch (ParameterNotFoundException e) {
+            LOG.error("No parameter exists with name: {}", paramName);
+            throw new RuntimeException(e);
+        }
+    }
+
     public Optional<String> getInvokedLambdaEndpoint() {
         return Optional.ofNullable(System.getenv("INVOKED_LAMBDA_ENDPOINT"));
     }


### PR DESCRIPTION
## What?

- Read IPV encryption public key from parameter store and add the encryption cert for staging to the overrides. This is OK as it is a public certificate. 
- Create a parameter in parameter store where we can store this certificate and read it in from Config. This will replace reading it from KMS.
- Remove bouncycastle dependency from IPV as it is no longer required now that we are not using KMS to read the public key


## Why?

- IPV will own the encryption key and then share with us the public part so we can encrypt requests on the authorize endpoint.
