### PR TITLE
AUT-262 - Set a default value for the IPV encryption cert

### DIFF
--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -262,5 +262,6 @@ variable "spot_queue_url" {
 }
 
 variable "ipv_auth_public_encryption_key" {
-  type = string
+  type    = string
+  default = "undefined"
 }


### PR DESCRIPTION
- Otherwise terraform doesn't like it

## What?

Please include a summary of the change.

## Why?

Please include reason for the change and any other relevant context.

## Related PRs

Please include links to PRs in other repositories relevant to this PR.
Delete this section if not needed.