### PR TITLE
AUT-262 - Use the correct parameter name in config service

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -140,7 +140,7 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
     }
 
     public String getIPVAuthEncryptionPublicKey() {
-        var paramName = format("{0}-ipv-auth-encryption-public-key", getEnvironment());
+        var paramName = format("{0}-ipv-public-encryption-key", getEnvironment());
         try {
             var request = new GetParameterRequest().withWithDecryption(true).withName(paramName);
             return getSsmClient().getParameter(request).getParameter().getValue();


### PR DESCRIPTION
## What?

 - Use the correct parameter name in config service

## Why?

- Because the param it is trying to get does not exist. 

`
 name  = "${var.environment}-ipv-public-encryption-key"
`