### PR TITLE
AUT-262 - Tidy up unused encryption key variables

### DIFF
--- a/ci/terraform/oidc/ipv-authorize.tf
+++ b/ci/terraform/oidc/ipv-authorize.tf
@@ -35,7 +35,6 @@ module "ipv-authorize" {
     IPV_AUTHORISATION_CALLBACK_URI = var.ipv_authorisation_callback_uri
     IPV_AUTHORISATION_CLIENT_ID    = var.ipv_authorisation_client_id
     IPV_TOKEN_SIGNING_KEY_ALIAS    = local.ipv_token_auth_key_alias_name
-    IPV_AUTH_ENCRYPTION_KEY_ALIAS  = local.ipv_token_auth_key_alias_name
   }
   handler_function_name = "uk.gov.di.authentication.ipv.lambda.IPVAuthorisationHandler::handleRequest"
 

--- a/ci/terraform/oidc/kms-policies.tf
+++ b/ci/terraform/oidc/kms-policies.tf
@@ -60,27 +60,3 @@ resource "aws_iam_policy" "ipv_token_auth_kms_policy" {
 
   policy = data.aws_iam_policy_document.ipv_token_auth_kms_policy_document.json
 }
-
-### IPV encryption key access
-
-data "aws_iam_policy_document" "ipv_auth_encryption_kms_policy_document" {
-  statement {
-    sid    = "AllowAccessToIPVKmsEncryptionKey"
-    effect = "Allow"
-
-    actions = [
-      "kms:GetPublicKey",
-    ]
-    resources = [
-      local.ipv_auth_encryption_key_arn
-    ]
-  }
-}
-
-resource "aws_iam_policy" "ipv_auth_encryption_kms_policy" {
-  name_prefix = "kms-ipv-auth-encryption-policy"
-  path        = "/${var.environment}/ipv-token/"
-  description = "IAM policy for managing IPV authentication encryption KMS key access"
-
-  policy = data.aws_iam_policy_document.ipv_auth_encryption_kms_policy_document.json
-}

--- a/ci/terraform/oidc/shared.tf
+++ b/ci/terraform/oidc/shared.tf
@@ -26,8 +26,6 @@ locals {
   id_token_signing_key_arn                    = data.terraform_remote_state.shared.outputs.id_token_signing_key_arn
   ipv_token_auth_key_alias_name               = data.terraform_remote_state.shared.outputs.ipv_token_auth_signing_key_alias_name
   ipv_token_auth_signing_key_arn              = data.terraform_remote_state.shared.outputs.ipv_token_auth_signing_key_arn
-  ipv_auth_encryption_key_alias_name          = data.terraform_remote_state.shared.outputs.ipv_auth_encryption_key_alias_name
-  ipv_auth_encryption_key_arn                 = data.terraform_remote_state.shared.outputs.ipv_auth_encryption_key_arn
   audit_signing_key_alias_name                = data.terraform_remote_state.shared.outputs.audit_signing_key_alias_name
   audit_signing_key_arn                       = data.terraform_remote_state.shared.outputs.audit_signing_key_arn
   sms_bucket_name                             = data.terraform_remote_state.shared.outputs.sms_bucket_name

--- a/ci/terraform/shared/outputs.tf
+++ b/ci/terraform/shared/outputs.tf
@@ -80,14 +80,6 @@ output "ipv_token_auth_signing_key_arn" {
   value = aws_kms_key.ipv_token_auth_signing_key.arn
 }
 
-output "ipv_auth_encryption_key_alias_name" {
-  value = aws_kms_alias.ipv_auth_encryption_key_alias.name
-}
-
-output "ipv_auth_encryption_key_arn" {
-  value = aws_kms_key.ipv_auth_encryption_key.arn
-}
-
 output "audit_signing_key_alias_name" {
   value = aws_kms_alias.audit_payload_signing_key_alias.name
 }

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationService.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationService.java
@@ -134,6 +134,7 @@ public class IPVAuthorisationService {
 
     public EncryptedJWT constructRequestJWT(
             State state, Nonce nonce, Scope scope, Subject subject, String claims) {
+        LOG.info("Generating request JWT");
         var jwsHeader = new JWSHeader(SIGNING_ALGORITHM);
         var jwtID = IdGenerator.generate();
         var expiryDate =
@@ -166,8 +167,9 @@ public class IPVAuthorisationService {
         signRequest.setKeyId(configurationService.getIPVTokenSigningKeyAlias());
         signRequest.setSigningAlgorithm(SigningAlgorithmSpec.ECDSA_SHA_256.toString());
         try {
+            LOG.info("Signing request JWT");
             var signResult = kmsConnectionService.sign(signRequest);
-            LOG.info("Token has been signed successfully");
+            LOG.info("Request JWT has been signed successfully");
             var signature =
                     Base64URL.encode(
                                     ECDSA.transcodeSignatureToConcat(
@@ -175,14 +177,18 @@ public class IPVAuthorisationService {
                                             ECDSA.getSignatureByteArrayLength(SIGNING_ALGORITHM)))
                             .toString();
             var signedJWT = SignedJWT.parse(message + "." + signature);
-            return encryptJWT(signedJWT);
+            var encryptedJWT = encryptJWT(signedJWT);
+            LOG.info("Encrypted request JWT has been generated");
+            return encryptedJWT;
         } catch (ParseException | JOSEException e) {
+            LOG.error("Error when generating SignedJWT", e);
             throw new RuntimeException(e);
         }
     }
 
     private EncryptedJWT encryptJWT(SignedJWT signedJWT) {
         try {
+            LOG.info("Encrypting SignedJWT");
             var publicEncryptionKey = getPublicKey();
             var jweObject =
                     new JWEObject(
@@ -192,16 +198,20 @@ public class IPVAuthorisationService {
                                     .build(),
                             new Payload(signedJWT));
             jweObject.encrypt(new RSAEncrypter(publicEncryptionKey));
-
+            LOG.info("SignedJWT has been successfully encrypted");
             return EncryptedJWT.parse(jweObject.serialize());
-        } catch (JOSEException | ParseException e) {
+        } catch (JOSEException e) {
             LOG.error("Error when encrypting SignedJWT", e);
+            throw new RuntimeException(e);
+        } catch (ParseException e) {
+            LOG.error("Error when parsing JWE object to EncryptedJWT", e);
             throw new RuntimeException(e);
         }
     }
 
     private RSAPublicKey getPublicKey() {
         try {
+            LOG.info("Getting IPV Auth Encryption Public Key");
             var ipvAuthEncryptionPublicKey = configurationService.getIPVAuthEncryptionPublicKey();
             return new RSAKey.Builder(
                             (RSAKey) JWK.parseFromPEMEncodedObjects(ipvAuthEncryptionPublicKey))

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationService.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationService.java
@@ -1,6 +1,5 @@
 package uk.gov.di.authentication.ipv.services;
 
-import com.amazonaws.services.kms.model.GetPublicKeyRequest;
 import com.amazonaws.services.kms.model.SignRequest;
 import com.amazonaws.services.kms.model.SigningAlgorithmSpec;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -184,8 +183,6 @@ public class IPVAuthorisationService {
 
     private EncryptedJWT encryptJWT(SignedJWT signedJWT) {
         try {
-            var getPublicKeyRequest = new GetPublicKeyRequest();
-            getPublicKeyRequest.setKeyId(configurationService.getIPVAuthEncryptionKeyAlias());
             var publicEncryptionKey = getPublicKey();
             var jweObject =
                     new JWEObject(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -135,10 +135,6 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return System.getenv("IPV_TOKEN_SIGNING_KEY_ALIAS");
     }
 
-    public String getIPVAuthEncryptionKeyAlias() {
-        return System.getenv("IPV_AUTH_ENCRYPTION_KEY_ALIAS");
-    }
-
     public String getIPVAuthEncryptionPublicKey() {
         var paramName = format("{0}-ipv-public-encryption-key", getEnvironment());
         try {


### PR DESCRIPTION
## What?

- Tidy up unused encryption key variables
- Add additional logging

## Why?

- Some of these values around the encryption key are longer required as we will be reading the public key via SSM instead.
