### PR TITLE
AUT-273: Update sector id rules (for pairwise identifiers)

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
@@ -78,7 +78,7 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
     void shouldRedirectToLoginWhenSuccessfullyProcessedIpvResponse() throws IOException {
         var sessionId = "some-session-id";
         var clientSessionId = "some-client-session-id";
-        var sectorId = "https://test.com";
+        var sectorId = "test.com";
         var scope = new Scope(OIDCScopeValue.OPENID);
         var authRequestBuilder =
                 new AuthenticationRequest.Builder(
@@ -123,7 +123,7 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                                 salt,
                                 sectorId,
                                 calculatePairwiseIdentifier(
-                                        INTERNAL_SUBJECT.getValue(), "https://test.com", salt),
+                                        INTERNAL_SUBJECT.getValue(), "test.com", salt),
                                 new LogIds(sessionId))));
     }
 

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -120,7 +120,7 @@ class IPVCallbackHandlerTest {
     void shouldRedirectToFrontendCallbackForSuccessfulResponse()
             throws URISyntaxException, JsonProcessingException {
         var salt = "Mmc48imEuO5kkVW7NtXVtx5h0mbCTfXsqXdWvbRMzdw=".getBytes();
-        var sectorId = "https://test.com";
+        var sectorId = "test.com";
         var clientRegistry = generateClientRegistry();
         var userProfile = generateUserProfile();
         var credential = SignedCredentialHelper.generateCredential().serialize();

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/BackChannelLogoutServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/BackChannelLogoutServiceTest.java
@@ -57,7 +57,7 @@ class BackChannelLogoutServiceTest {
         assertThat(message.getLogoutUri(), is("http://localhost:8080/back-channel-logout"));
         assertThat(
                 message.getSubjectId(),
-                is("1b8920099adc11e966d68335276d1db274e8c79588b2b608f9182ecc3908ee07"));
+                is("b46381e6de5f4405ff162a3aa91223f0a3c32fbbce839802a88e25e670d9083b"));
     }
 
     @Test


### PR DESCRIPTION
## What?

Update sector id rules (for pairwise identifiers).

## Why?

Create the sector id according to the spec:

https://openid.net/specs/openid-connect-core-1_0.html#PairwiseAlg

"If the Client has not provided a value for sector_identifier_uri in [Dynamic Client Registration](https://openid.net/specs/openid-connect-core-1_0.html#OpenID.Registration) [OpenID.Registration], the Sector Identifier used for pairwise identifier calculation is the host component of the registered redirect_uri. If there are multiple hostnames in the registered redirect_uris, the Client MUST register a sector_identifier_uri.

When a sector_identifier_uri is provided, the host component of that URL is used as the Sector Identifier for the pairwise identifier calculation. The value of the sector_identifier_uri MUST be a URL using the https scheme that points to a JSON file containing an array of redirect_uri values. The values of the registered redirect_uris MUST be included in the elements of the array."
