### PR TITLE
AUT-245 - Use IPV sector identifier for IPV auth Subject ID

### DIFF
--- a/ci/terraform/oidc/ipv-authorize.tf
+++ b/ci/terraform/oidc/ipv-authorize.tf
@@ -35,6 +35,7 @@ module "ipv-authorize" {
     IPV_AUTHORISATION_CALLBACK_URI = var.ipv_authorisation_callback_uri
     IPV_AUTHORISATION_CLIENT_ID    = var.ipv_authorisation_client_id
     IPV_TOKEN_SIGNING_KEY_ALIAS    = local.ipv_token_auth_key_alias_name
+    IPV_DOMAIN                     = var.ipv_domain
   }
   handler_function_name = "uk.gov.di.authentication.ipv.lambda.IPVAuthorisationHandler::handleRequest"
 

--- a/ci/terraform/oidc/staging-overrides.tfvars
+++ b/ci/terraform/oidc/staging-overrides.tfvars
@@ -3,6 +3,7 @@ ipv_authorisation_client_id    = "authOrchestrator"
 ipv_authorisation_uri          = "https://staging-di-ipv-core-front.london.cloudapps.digital/oauth2/authorize"
 ipv_authorisation_callback_uri = "https://oidc.staging.account.gov.uk/ipv-callback"
 ipv_backend_uri                = "https://18zwbqzm0k.execute-api.eu-west-2.amazonaws.com/staging"
+ipv_domain                     = "https://ipv.account.gov.uk"
 ipv_auth_public_encryption_key = <<-EOT
 -----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAudZq3RAtd6me99lfWd8N

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -241,6 +241,11 @@ variable "ipv_backend_uri" {
   default = "undefined"
 }
 
+variable "ipv_domain" {
+  type    = string
+  default = "undefined"
+}
+
 variable "endpoint_memory_size" {
   default = 4096
   type    = number

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVAuthorisationHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVAuthorisationHandlerIntegrationTest.java
@@ -47,6 +47,7 @@ class IPVAuthorisationHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
     private static final ClientID CLIENT_ID = new ClientID("test-client");
 
     private static final URI REDIRECT_URI = URI.create("http://localhost/redirect");
+    private static final String IPV_DOMAIN = "https://ipv/redirect";
 
     private static final String TEST_EMAIL_ADDRESS = "test@emailtest.com";
     private static final String IPV_CLIENT_ID = "ipv-client-id";
@@ -187,6 +188,11 @@ class IPVAuthorisationHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
         @Override
         public String getIPVAuthEncryptionPublicKey() {
             return publicKey;
+        }
+
+        @Override
+        public String getIPVDomain() {
+            return IPV_DOMAIN;
         }
     }
 }

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandler.java
@@ -95,9 +95,9 @@ public class IPVAuthorisationHandler extends BaseFrontendHandler<IPVAuthorisatio
                     AuthenticationRequest.parse(
                             userContext.getClientSession().getAuthRequestParams());
             var pairwiseSubject =
-                    ClientSubjectHelper.getSubject(
+                    ClientSubjectHelper.getSubjectWithSectorIdentifier(
                             userContext.getUserProfile().orElseThrow(),
-                            userContext.getClient().orElseThrow(),
+                            configurationService.getIPVDomain(),
                             authenticationService);
             var clientID = new ClientID(configurationService.getIPVAuthorisationClientId());
             var state = new State();

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandlerTest.java
@@ -106,6 +106,7 @@ public class IPVAuthorisationHandlerTest {
     private static final URI IPV_CALLBACK_URI = URI.create("http://localhost/oidc/ipv/callback");
     private static final URI IPV_AUTHORISATION_URI = URI.create("http://localhost/ipv/authorize");
     private static final String EMAIL_ADDRESS = "test@test.com";
+    private static final String IPV_DOMAIN = "https://ipv.account.gov.uk";
 
     private final IPVAuthorisationService authorisationService =
             mock(IPVAuthorisationService.class);
@@ -141,6 +142,7 @@ public class IPVAuthorisationHandlerTest {
         when(authenticationService.getUserProfileFromEmail(EMAIL_ADDRESS))
                 .thenReturn(Optional.of(userProfile));
         when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(SALT.array());
+        when(configService.getIPVDomain()).thenReturn(IPV_DOMAIN);
     }
 
     @Test

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ClientSubjectHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ClientSubjectHelper.java
@@ -32,6 +32,17 @@ public class ClientSubjectHelper {
         }
     }
 
+    public static Subject getSubjectWithSectorIdentifier(
+            UserProfile userProfile,
+            String sectorIdentifierURI,
+            AuthenticationService authenticationService) {
+        return new Subject(
+                calculatePairwiseIdentifier(
+                        userProfile.getSubjectID(),
+                        returnHost(sectorIdentifierURI),
+                        authenticationService.getOrGenerateSalt(userProfile)));
+    }
+
     public static String getSectorIdentifierForClient(ClientRegistry client) {
         if (!hasValidClientConfig(client)) {
             String message =
@@ -68,11 +79,12 @@ public class ClientSubjectHelper {
         }
     }
 
-    public static String calculatePairwiseIdentifier(String subjectID, String sector, byte[] salt) {
+    public static String calculatePairwiseIdentifier(
+            String subjectID, String sectorHost, byte[] salt) {
         try {
             var md = MessageDigest.getInstance("SHA-256");
 
-            md.update(sector.getBytes(StandardCharsets.UTF_8));
+            md.update(sectorHost.getBytes(StandardCharsets.UTF_8));
             md.update(subjectID.getBytes(StandardCharsets.UTF_8));
 
             byte[] bytes = md.digest(salt);

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -146,6 +146,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         }
     }
 
+    public String getIPVDomain() {
+        return System.getenv("IPV_DOMAIN");
+    }
+
     public Optional<String> getInvokedLambdaEndpoint() {
         return Optional.ofNullable(System.getenv("INVOKED_LAMBDA_ENDPOINT"));
     }


### PR DESCRIPTION
## What?

- Use a placeholder IPV domain as the sector identifier. This will need to be updated with the real value when it is known.
- Create a new method in the ClientSubjectHelper which can take in the Sector Identifier in directly so it can calculate the pairwise subject

## Why?

- Because we need to be using the IPV sector identifier instead of the RP's