### PR TITLE
BAU - Give ipv-authorize write access to the user tables

### DIFF
--- a/ci/terraform/oidc/ipv-authorize.tf
+++ b/ci/terraform/oidc/ipv-authorize.tf
@@ -8,6 +8,7 @@ module "ipv_authorize_role" {
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.dynamo_user_read_access_policy.arn,
+    aws_iam_policy.dynamo_user_write_access_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
     aws_iam_policy.ipv_token_auth_kms_policy.arn,


### PR DESCRIPTION
## What?

 - Give ipv-authorize write access to the user tables

## Why?

- The ipv-authorize needs write permissions as if a user does not have a salt, one will be created and then the user-profile table will be updated.