### PR TITLE
BAU - Allow RPs to update sector ID URI

### DIFF
--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/entity/ClientRegistrationResponse.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/entity/ClientRegistrationResponse.java
@@ -45,6 +45,9 @@ public class ClientRegistrationResponse {
     @JsonProperty(value = "claims")
     private List<String> claims;
 
+    @JsonProperty("sector_identifier_uri")
+    private String sectorIdentifierUri;
+
     public ClientRegistrationResponse(
             String clientName,
             String clientId,
@@ -56,7 +59,8 @@ public class ClientRegistrationResponse {
             String serviceType,
             String subjectType,
             List<String> claims,
-            List<String> requestUris) {
+            List<String> requestUris,
+            String sectorIdentifierUri) {
         this.clientName = clientName;
         this.clientId = clientId;
         this.redirectUris = redirectUris;
@@ -68,6 +72,7 @@ public class ClientRegistrationResponse {
         this.subjectType = subjectType;
         this.claims = claims;
         this.requestUris = requestUris;
+        this.sectorIdentifierUri = sectorIdentifierUri;
     }
 
     public ClientRegistrationResponse() {}
@@ -133,5 +138,9 @@ public class ClientRegistrationResponse {
 
     public List<String> getRequestUris() {
         return requestUris;
+    }
+
+    public String getSectorIdentifierUri() {
+        return sectorIdentifierUri;
     }
 }

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandler.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandler.java
@@ -141,7 +141,8 @@ public class ClientRegistrationHandler
                                                 clientRegistrationRequest.getServiceType(),
                                                 clientRegistrationRequest.getSubjectType(),
                                                 clientRegistrationRequest.getClaims(),
-                                                clientRegistrationRequest.getRequestUris());
+                                                clientRegistrationRequest.getRequestUris(),
+                                                clientRegistrationRequest.getSectorIdentifierUri());
                                 LOG.info("Generating successful Client registration response");
                                 return generateApiGatewayProxyResponse(
                                         200, clientRegistrationResponse);

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandler.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandler.java
@@ -142,7 +142,8 @@ public class UpdateClientConfigHandler
                                                 clientRegistry.getServiceType(),
                                                 clientRegistry.getSubjectType(),
                                                 clientRegistry.getClaims(),
-                                                clientRegistry.getRequestUris());
+                                                clientRegistry.getRequestUris(),
+                                                clientRegistry.getSectorIdentifierUri());
                                 LOG.info("Client updated");
                                 return generateApiGatewayProxyResponse(
                                         200, clientRegistrationResponse);

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationServiceTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationServiceTest.java
@@ -221,7 +221,8 @@ class ClientConfigValidationServiceTest {
                                 VALID_PUBLIC_CERT,
                                 singletonList("openid"),
                                 singletonList("http://localhost/post-redirect-logout"),
-                                String.valueOf(MANDATORY)));
+                                String.valueOf(MANDATORY),
+                                "http://localhost/sector-id"));
         assertThat(errorResponse, equalTo(Optional.empty()));
     }
 
@@ -241,7 +242,8 @@ class ClientConfigValidationServiceTest {
                                 VALID_PUBLIC_CERT,
                                 singletonList("openid"),
                                 singletonList("invalid-logout-uri"),
-                                String.valueOf(MANDATORY)));
+                                String.valueOf(MANDATORY),
+                                null));
         assertThat(errorResponse, equalTo(Optional.of(INVALID_POST_LOGOUT_URI)));
     }
 
@@ -254,7 +256,8 @@ class ClientConfigValidationServiceTest {
                                 VALID_PUBLIC_CERT,
                                 singletonList("openid"),
                                 singletonList("http://localhost/post-redirect-logout"),
-                                String.valueOf(MANDATORY)));
+                                String.valueOf(MANDATORY),
+                                null));
         assertThat(errorResponse, equalTo(Optional.of(RegistrationError.INVALID_REDIRECT_URI)));
     }
 
@@ -267,7 +270,8 @@ class ClientConfigValidationServiceTest {
                                 "invalid-public-cert",
                                 singletonList("openid"),
                                 singletonList("http://localhost/post-redirect-logout"),
-                                String.valueOf(MANDATORY)));
+                                String.valueOf(MANDATORY),
+                                null));
         assertThat(errorResponse, equalTo(Optional.of(INVALID_PUBLIC_KEY)));
     }
 
@@ -280,7 +284,8 @@ class ClientConfigValidationServiceTest {
                                 VALID_PUBLIC_CERT,
                                 List.of("openid", "email", "fax"),
                                 singletonList("http://localhost/post-redirect-logout"),
-                                String.valueOf(MANDATORY)));
+                                String.valueOf(MANDATORY),
+                                null));
         assertThat(errorResponse, equalTo(Optional.of(INVALID_SCOPE)));
     }
 
@@ -316,13 +321,15 @@ class ClientConfigValidationServiceTest {
             String publicCert,
             List<String> scopes,
             List<String> postLogoutUris,
-            String serviceType) {
+            String serviceType,
+            String sectorURI) {
         UpdateClientConfigRequest configRequest = new UpdateClientConfigRequest();
         configRequest.setScopes(scopes);
         configRequest.setRedirectUris(redirectUri);
         configRequest.setPublicKey(publicCert);
         configRequest.setPostLogoutRedirectUris(postLogoutUris);
         configRequest.setServiceType(serviceType);
+        configRequest.setSectorIdentifierUri(sectorURI);
         return configRequest;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/UpdateClientConfigRequest.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/UpdateClientConfigRequest.java
@@ -36,6 +36,9 @@ public class UpdateClientConfigRequest {
     @JsonProperty("claims")
     private List<String> claims;
 
+    @JsonProperty("sector_identifier_uri")
+    private String sectorIdentifierUri;
+
     public UpdateClientConfigRequest() {}
 
     public String getClientId() {
@@ -76,6 +79,10 @@ public class UpdateClientConfigRequest {
 
     public List<String> getClaims() {
         return claims;
+    }
+
+    public String getSectorIdentifierUri() {
+        return sectorIdentifierUri;
     }
 
     public UpdateClientConfigRequest setClientId(String clientId) {
@@ -127,5 +134,9 @@ public class UpdateClientConfigRequest {
     public UpdateClientConfigRequest setClaims(List<String> claims) {
         this.claims = claims;
         return this;
+    }
+
+    public void setSectorIdentifierUri(String sectorIdentifierUri) {
+        this.sectorIdentifierUri = sectorIdentifierUri;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoClientService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoClientService.java
@@ -103,6 +103,8 @@ public class DynamoClientService implements ClientService {
         Optional.ofNullable(updateRequest.getPublicKey()).ifPresent(clientRegistry::setPublicKey);
         Optional.ofNullable(updateRequest.getServiceType())
                 .ifPresent(clientRegistry::setServiceType);
+        Optional.ofNullable(updateRequest.getSectorIdentifierUri())
+                .ifPresent(clientRegistry::setSectorIdentifierUri);
         clientRegistryMapper.save(clientRegistry);
         return clientRegistry;
     }


### PR DESCRIPTION
## What?

- Allow RPs to update sector ID uri via the update endpoint
- Validate the sector ID URI in both register and update endpoints

## Why?

- So RPs can update sector ID in the immediate future until the way to register/update changes 