### PR TITLE
BAU - Calculate whether consent is required using vot value in TokenHandler

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
@@ -253,6 +253,12 @@ public class TokenHandler
                                     && Objects.nonNull(authRequest.getOIDCClaims())) {
                                 claimsRequest = authRequest.getOIDCClaims();
                             }
+                            var isConsentRequired =
+                                    client.isConsentRequired()
+                                            && !clientSession
+                                                    .getEffectiveVectorOfTrust()
+                                                    .containsLevelOfConfidence();
+
                             var tokenResponse =
                                     tokenService.generateTokenResponse(
                                             clientID,
@@ -262,7 +268,7 @@ public class TokenHandler
                                             publicSubject,
                                             vot,
                                             userProfile.getClientConsent(),
-                                            client.isConsentRequired(),
+                                            isConsentRequired,
                                             claimsRequest);
 
                             clientSessionService.saveClientSession(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/VectorOfTrust.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/VectorOfTrust.java
@@ -47,6 +47,10 @@ public class VectorOfTrust {
         return levelOfConfidence;
     }
 
+    public boolean containsLevelOfConfidence() {
+        return levelOfConfidence != null;
+    }
+
     public static VectorOfTrust parseFromAuthRequestAttribute(List<String> vtr) {
         if (Objects.isNull(vtr) || vtr.isEmpty()) {
             LOG.info(

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/VectorOfTrustTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/VectorOfTrustTest.java
@@ -7,8 +7,10 @@ import java.util.Collections;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.LOW_LEVEL;
 import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.MEDIUM_LEVEL;
 import static uk.gov.di.authentication.sharedtest.helper.JsonArrayHelper.jsonArrayOf;
@@ -162,5 +164,23 @@ class VectorOfTrustTest {
                 VectorOfTrust.parseFromAuthRequestAttribute(
                         Collections.singletonList(jsonArrayOf(vectorString)));
         assertThat(vectorOfTrust.retrieveVectorOfTrustForToken(), equalTo(vectorString));
+    }
+
+    @Test
+    void shouldReturnTrueWhenIdentityLevelOfConfidenceIsPresent() {
+        String vectorString = "P2.Cl.Cm";
+        VectorOfTrust vectorOfTrust =
+                VectorOfTrust.parseFromAuthRequestAttribute(
+                        Collections.singletonList(jsonArrayOf(vectorString)));
+        assertTrue(vectorOfTrust.containsLevelOfConfidence());
+    }
+
+    @Test
+    void shouldReturnFalseWhenIdentityLevelOfConfidenceIsNotPresent() {
+        String vectorString = "Cl.Cm";
+        VectorOfTrust vectorOfTrust =
+                VectorOfTrust.parseFromAuthRequestAttribute(
+                        Collections.singletonList(jsonArrayOf(vectorString)));
+        assertFalse(vectorOfTrust.containsLevelOfConfidence());
     }
 }


### PR DESCRIPTION
## What?

- Only require consent if there is no level of confidence value in the vot and consent required is true in the client registry

## Why?

- There are some cases where consent is set to true in client registry but as the user is on an identity journey, then they will not be asked for consent. This means that this could cause a null pointer when working out the scopes for the token.