### PR TITLE
BAU: Use Clock instead of LocalDateTime

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthoriseAccessTokenHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthoriseAccessTokenHandler.java
@@ -13,14 +13,13 @@ import org.apache.logging.log4j.Logger;
 import uk.gov.di.accountmanagement.entity.AuthPolicy;
 import uk.gov.di.accountmanagement.entity.TokenAuthorizerContext;
 import uk.gov.di.authentication.shared.entity.CustomScopeValue;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoClientService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.KmsConnectionService;
 import uk.gov.di.authentication.shared.services.TokenValidationService;
 
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.Date;
 import java.util.List;
 
@@ -95,9 +94,7 @@ public class AuthoriseAccessTokenHandler
                 SignedJWT signedAccessToken = SignedJWT.parse(accessToken.getValue());
                 JWTClaimsSet claimsSet = signedAccessToken.getJWTClaimsSet();
 
-                LocalDateTime localDateTime = LocalDateTime.now();
-                Date currentDateTime =
-                        Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
+                Date currentDateTime = NowHelper.now();
                 if (DateUtils.isBefore(claimsSet.getExpirationTime(), currentDateTime, 0)) {
                     LOG.warn(
                             "Access Token expires at: {}. CurrentDateTime is: {}",

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/AuthoriseAccessTokenHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/AuthoriseAccessTokenHandlerTest.java
@@ -22,6 +22,7 @@ import uk.gov.di.authentication.sharedtest.helper.TokenGeneratorHelper;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.List;
 
@@ -192,7 +193,7 @@ class AuthoriseAccessTokenHandlerTest {
     }
 
     private SignedJWT createSignedExpiredAccessToken(List<String> scopes) throws JOSEException {
-        LocalDateTime localDateTime = LocalDateTime.now().minusMinutes(2);
+        LocalDateTime localDateTime = LocalDateTime.now().minus(2, ChronoUnit.MINUTES);
         Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
         ECKey ecJWK = new ECKeyGenerator(Curve.P_256).keyID(KEY_ID).generate();
         JWSSigner signer = new ECDSASigner(ecJWK);

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/AuthoriseAccessTokenHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/AuthoriseAccessTokenHandlerTest.java
@@ -14,14 +14,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.accountmanagement.entity.AuthPolicy;
 import uk.gov.di.accountmanagement.entity.TokenAuthorizerContext;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoClientService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.TokenValidationService;
 import uk.gov.di.authentication.sharedtest.helper.TokenGeneratorHelper;
 
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.List;
@@ -193,8 +192,7 @@ class AuthoriseAccessTokenHandlerTest {
     }
 
     private SignedJWT createSignedExpiredAccessToken(List<String> scopes) throws JOSEException {
-        LocalDateTime localDateTime = LocalDateTime.now().minus(2, ChronoUnit.MINUTES);
-        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
+        Date expiryDate = NowHelper.nowMinus(2, ChronoUnit.MINUTES);
         ECKey ecJWK = new ECKeyGenerator(Curve.P_256).keyID(KEY_ID).generate();
         JWSSigner signer = new ECDSASigner(ecJWK);
         return TokenGeneratorHelper.generateSignedToken(

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/AuthoriseAccessTokenIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/AuthoriseAccessTokenIntegrationTest.java
@@ -52,8 +52,7 @@ class AuthoriseAccessTokenIntegrationTest
     @BeforeEach
     void setup() {
         handler = new AuthoriseAccessTokenHandler(TEST_CONFIGURATION_SERVICE);
-        var localDateTime = LocalDateTime.now().plus(5, ChronoUnit.MINUTES);
-        validDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
+        validDate = NowHelper.nowPlus(5, ChronoUnit.MINUTES);
     }
 
     @Test

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/AuthoriseAccessTokenIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/AuthoriseAccessTokenIntegrationTest.java
@@ -18,6 +18,7 @@ import uk.gov.di.authentication.sharedtest.helper.KeyPairHelper;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
 import java.util.Base64;
 import java.util.Date;
 import java.util.List;
@@ -50,7 +51,7 @@ class AuthoriseAccessTokenIntegrationTest
     @BeforeEach
     void setup() {
         handler = new AuthoriseAccessTokenHandler(TEST_CONFIGURATION_SERVICE);
-        var localDateTime = LocalDateTime.now().plusMinutes(5);
+        var localDateTime = LocalDateTime.now().plus(5, ChronoUnit.MINUTES);
         validDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
     }
 
@@ -73,7 +74,7 @@ class AuthoriseAccessTokenIntegrationTest
     @Test
     void shouldThrowExceptionWhenAccessTokenHasExpired() {
         var publicSubject = setUpUserProfileAndGetPublicSubjectId();
-        var localDateTime = LocalDateTime.now().minusMinutes(1);
+        var localDateTime = LocalDateTime.now().minus(1, ChronoUnit.MINUTES);
         var expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
         var scopes =
                 asList(

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/AuthoriseAccessTokenIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/AuthoriseAccessTokenIntegrationTest.java
@@ -17,8 +17,6 @@ import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.sharedtest.basetest.HandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.helper.KeyPairHelper;
 
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.Base64;
 import java.util.Date;
@@ -74,8 +72,7 @@ class AuthoriseAccessTokenIntegrationTest
     @Test
     void shouldThrowExceptionWhenAccessTokenHasExpired() {
         var publicSubject = setUpUserProfileAndGetPublicSubjectId();
-        var localDateTime = LocalDateTime.now().minus(1, ChronoUnit.MINUTES);
-        var expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
+        var expiryDate = NowHelper.nowMinus(1, ChronoUnit.MINUTES);
         var scopes =
                 asList(
                         OIDCScopeValue.OPENID.getValue(),

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/AuthoriseAccessTokenIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/AuthoriseAccessTokenIntegrationTest.java
@@ -13,6 +13,7 @@ import uk.gov.di.accountmanagement.entity.TokenAuthorizerContext;
 import uk.gov.di.accountmanagement.lambda.AuthoriseAccessTokenHandler;
 import uk.gov.di.authentication.shared.entity.CustomScopeValue;
 import uk.gov.di.authentication.shared.entity.ServiceType;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.sharedtest.basetest.HandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.helper.KeyPairHelper;
 
@@ -162,8 +163,7 @@ class AuthoriseAccessTokenIntegrationTest
                         .claim("scope", scopes)
                         .issuer("issuer-id")
                         .expirationTime(expiryDate)
-                        .issueTime(
-                                Date.from(LocalDateTime.now().atZone(ZoneId.of("UTC")).toInstant()))
+                        .issueTime(NowHelper.now())
                         .claim("client_id", clientId)
                         .subject(publicSubject)
                         .jwtID(UUID.randomUUID().toString())

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/ResetPasswordService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/ResetPasswordService.java
@@ -4,6 +4,7 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
 import java.util.Date;
 
 import static uk.gov.di.authentication.shared.helpers.ConstructUriHelper.buildURI;
@@ -19,7 +20,7 @@ public class ResetPasswordService {
     public String buildResetPasswordLink(
             String code, String sessionID, String persistentSessionId) {
         LocalDateTime localDateTime =
-                LocalDateTime.now().plusSeconds(configurationService.getCodeExpiry());
+                LocalDateTime.now().plus(configurationService.getCodeExpiry(), ChronoUnit.SECONDS);
         Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
         return buildURI(
                         configurationService.getFrontendBaseUrl(),

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/ResetPasswordService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/ResetPasswordService.java
@@ -1,9 +1,8 @@
 package uk.gov.di.authentication.frontendapi.services;
 
+import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
 
@@ -19,9 +18,8 @@ public class ResetPasswordService {
 
     public String buildResetPasswordLink(
             String code, String sessionID, String persistentSessionId) {
-        LocalDateTime localDateTime =
-                LocalDateTime.now().plus(configurationService.getCodeExpiry(), ChronoUnit.SECONDS);
-        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
+        Date expiryDate =
+                NowHelper.nowPlus(configurationService.getCodeExpiry(), ChronoUnit.SECONDS);
         return buildURI(
                         configurationService.getFrontendBaseUrl(),
                         configurationService.getResetPasswordRoute()

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
@@ -17,12 +17,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.oidc.lambda.LogoutHandler;
 import uk.gov.di.authentication.shared.entity.ServiceType;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 
 import java.io.IOException;
 import java.net.URI;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.List;
@@ -136,8 +135,7 @@ public class LogoutIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     private SignedJWT setupClientAndSession(String sessionId, String clientSessionId)
             throws ParseException, IOException {
         Nonce nonce = new Nonce();
-        LocalDateTime localDateTime = LocalDateTime.now().plus(10, ChronoUnit.MINUTES);
-        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
+        Date expiryDate = NowHelper.nowPlus(10, ChronoUnit.MINUTES);
         IDTokenClaimsSet idTokenClaims =
                 new IDTokenClaimsSet(
                         new Issuer(BASE_URL),

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -135,7 +136,7 @@ public class LogoutIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     private SignedJWT setupClientAndSession(String sessionId, String clientSessionId)
             throws ParseException, IOException {
         Nonce nonce = new Nonce();
-        LocalDateTime localDateTime = LocalDateTime.now().plusMinutes(10);
+        LocalDateTime localDateTime = LocalDateTime.now().plus(10, ChronoUnit.MINUTES);
         Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
         IDTokenClaimsSet idTokenClaims =
                 new IDTokenClaimsSet(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
@@ -281,12 +281,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         JWTAuthenticationClaimsSet claimsSet =
                 new JWTAuthenticationClaimsSet(
                         new ClientID(CLIENT_ID), new Audience(ROOT_RESOURCE_URL + TOKEN_ENDPOINT));
-        var expiryDate =
-                Date.from(
-                        LocalDateTime.now()
-                                .plus(5, ChronoUnit.MINUTES)
-                                .atZone(ZoneId.of("UTC"))
-                                .toInstant());
+        var expiryDate = NowHelper.nowPlus(5, ChronoUnit.MINUTES);
         claimsSet.getExpirationTime().setTime(expiryDate.getTime());
         var privateKeyJWT =
                 new PrivateKeyJWT(
@@ -319,8 +314,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     }
 
     private SignedJWT generateSignedRefreshToken(Scope scope, Subject publicSubject) {
-        LocalDateTime localDateTime = LocalDateTime.now().plus(60, ChronoUnit.MINUTES);
-        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
+        Date expiryDate = NowHelper.nowPlus(60, ChronoUnit.MINUTES);
         JWTClaimsSet claimsSet =
                 new JWTClaimsSet.Builder()
                         .claim("scope", scope.toStringList())
@@ -387,8 +381,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             Optional<OIDCClaimsRequest> oidcClaimsRequest)
             throws JOSEException, JsonProcessingException {
         PrivateKey privateKey = keyPair.getPrivate();
-        LocalDateTime localDateTime = LocalDateTime.now().plus(5, ChronoUnit.MINUTES);
-        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
+        Date expiryDate = NowHelper.nowPlus(5, ChronoUnit.MINUTES);
         JWTAuthenticationClaimsSet claimsSet =
                 new JWTAuthenticationClaimsSet(
                         new ClientID(CLIENT_ID), new Audience(ROOT_RESOURCE_URL + TOKEN_ENDPOINT));

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
@@ -52,6 +52,7 @@ import java.security.PrivateKey;
 import java.security.interfaces.RSAPrivateKey;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.Date;
@@ -280,7 +281,11 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 new JWTAuthenticationClaimsSet(
                         new ClientID(CLIENT_ID), new Audience(ROOT_RESOURCE_URL + TOKEN_ENDPOINT));
         var expiryDate =
-                Date.from(LocalDateTime.now().plusMinutes(5).atZone(ZoneId.of("UTC")).toInstant());
+                Date.from(
+                        LocalDateTime.now()
+                                .plus(5, ChronoUnit.MINUTES)
+                                .atZone(ZoneId.of("UTC"))
+                                .toInstant());
         claimsSet.getExpirationTime().setTime(expiryDate.getTime());
         var privateKeyJWT =
                 new PrivateKeyJWT(
@@ -313,7 +318,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     }
 
     private SignedJWT generateSignedRefreshToken(Scope scope, Subject publicSubject) {
-        LocalDateTime localDateTime = LocalDateTime.now().plusMinutes(60);
+        LocalDateTime localDateTime = LocalDateTime.now().plus(60, ChronoUnit.MINUTES);
         Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
         JWTClaimsSet claimsSet =
                 new JWTClaimsSet.Builder()
@@ -382,7 +387,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             Optional<OIDCClaimsRequest> oidcClaimsRequest)
             throws JOSEException, JsonProcessingException {
         PrivateKey privateKey = keyPair.getPrivate();
-        LocalDateTime localDateTime = LocalDateTime.now().plusMinutes(5);
+        LocalDateTime localDateTime = LocalDateTime.now().plus(5, ChronoUnit.MINUTES);
         Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
         JWTAuthenticationClaimsSet claimsSet =
                 new JWTAuthenticationClaimsSet(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
@@ -42,6 +42,7 @@ import uk.gov.di.authentication.shared.entity.RefreshTokenStore;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.shared.entity.ValidScopes;
 import uk.gov.di.authentication.shared.entity.VectorOfTrust;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.helper.JsonArrayHelper;
 import uk.gov.di.authentication.sharedtest.helper.KeyPairHelper;
@@ -325,8 +326,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         .claim("scope", scope.toStringList())
                         .issuer("issuer-id")
                         .expirationTime(expiryDate)
-                        .issueTime(
-                                Date.from(LocalDateTime.now().atZone(ZoneId.of("UTC")).toInstant()))
+                        .issueTime(NowHelper.now())
                         .claim("client_id", CLIENT_ID)
                         .subject(publicSubject.getValue())
                         .jwtID(UUID.randomUUID().toString())

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
@@ -17,6 +17,7 @@ import uk.gov.di.authentication.oidc.lambda.UserInfoHandler;
 import uk.gov.di.authentication.shared.entity.AccessTokenStore;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.shared.entity.ValidClaims;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.helper.KeyPairHelper;
 import uk.gov.di.authentication.sharedtest.helper.SignedCredentialHelper;
@@ -76,8 +77,7 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         .claim("scope", SCOPES)
                         .issuer("issuer-id")
                         .expirationTime(EXPIRY_DATE)
-                        .issueTime(
-                                Date.from(LocalDateTime.now().atZone(ZoneId.of("UTC")).toInstant()))
+                        .issueTime(NowHelper.now())
                         .claim("client_id", "client-id-one")
                         .subject(PUBLIC_SUBJECT.getValue())
                         .jwtID(UUID.randomUUID().toString())
@@ -143,8 +143,7 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         .claim("scope", SCOPES)
                         .issuer("issuer-id")
                         .expirationTime(EXPIRY_DATE)
-                        .issueTime(
-                                Date.from(LocalDateTime.now().atZone(ZoneId.of("UTC")).toInstant()))
+                        .issueTime(NowHelper.now())
                         .claim("client_id", "client-id-one")
                         .subject(PUBLIC_SUBJECT.getValue())
                         .jwtID(UUID.randomUUID().toString())

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
@@ -24,6 +24,7 @@ import uk.gov.di.authentication.sharedtest.helper.SignedCredentialHelper;
 import java.security.KeyPair;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
 import java.util.Base64;
 import java.util.Date;
 import java.util.List;
@@ -56,7 +57,11 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                     OIDCScopeValue.EMAIL.getValue(),
                     OIDCScopeValue.PHONE.getValue());
     private static final Date EXPIRY_DATE =
-            Date.from(LocalDateTime.now().plusMinutes(10).atZone(ZoneId.of("UTC")).toInstant());
+            Date.from(
+                    LocalDateTime.now()
+                            .plus(10, ChronoUnit.MINUTES)
+                            .atZone(ZoneId.of("UTC"))
+                            .toInstant());
 
     @BeforeEach
     void setup() {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
@@ -23,8 +23,6 @@ import uk.gov.di.authentication.sharedtest.helper.KeyPairHelper;
 import uk.gov.di.authentication.sharedtest.helper.SignedCredentialHelper;
 
 import java.security.KeyPair;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.Base64;
 import java.util.Date;
@@ -57,12 +55,7 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                     OIDCScopeValue.OPENID.getValue(),
                     OIDCScopeValue.EMAIL.getValue(),
                     OIDCScopeValue.PHONE.getValue());
-    private static final Date EXPIRY_DATE =
-            Date.from(
-                    LocalDateTime.now()
-                            .plus(10, ChronoUnit.MINUTES)
-                            .atZone(ZoneId.of("UTC"))
-                            .toInstant());
+    private static final Date EXPIRY_DATE = NowHelper.nowPlus(10, ChronoUnit.MINUTES);
 
     @BeforeEach
     void setup() {

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationService.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationService.java
@@ -39,6 +39,7 @@ import java.security.interfaces.RSAPublicKey;
 import java.text.ParseException;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.Map;
 import java.util.Objects;
@@ -138,7 +139,11 @@ public class IPVAuthorisationService {
         var jwsHeader = new JWSHeader(SIGNING_ALGORITHM);
         var jwtID = IdGenerator.generate();
         var expiryDate =
-                Date.from(LocalDateTime.now().plusMinutes(3).atZone(ZoneId.of("UTC")).toInstant());
+                Date.from(
+                        LocalDateTime.now()
+                                .plus(3, ChronoUnit.MINUTES)
+                                .atZone(ZoneId.of("UTC"))
+                                .toInstant());
         var claimsBuilder =
                 new JWTClaimsSet.Builder()
                         .issuer(configurationService.getIPVAuthorisationClientId())

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationService.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationService.java
@@ -30,6 +30,7 @@ import com.nimbusds.openid.connect.sdk.Nonce;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.KmsConnectionService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
@@ -150,8 +151,7 @@ public class IPVAuthorisationService {
                         .audience(configurationService.getIPVAuthorisationURI().toString())
                         .expirationTime(expiryDate)
                         .subject(subject.getValue())
-                        .issueTime(
-                                Date.from(LocalDateTime.now().atZone(ZoneId.of("UTC")).toInstant()))
+                        .issueTime(NowHelper.now())
                         .jwtID(jwtID)
                         .claim("state", state.getValue())
                         .claim("nonce", nonce.getValue())

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationService.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationService.java
@@ -38,10 +38,7 @@ import uk.gov.di.authentication.shared.services.RedisConnectionService;
 import java.nio.ByteBuffer;
 import java.security.interfaces.RSAPublicKey;
 import java.text.ParseException;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
-import java.util.Date;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -139,12 +136,7 @@ public class IPVAuthorisationService {
         LOG.info("Generating request JWT");
         var jwsHeader = new JWSHeader(SIGNING_ALGORITHM);
         var jwtID = IdGenerator.generate();
-        var expiryDate =
-                Date.from(
-                        LocalDateTime.now()
-                                .plus(3, ChronoUnit.MINUTES)
-                                .atZone(ZoneId.of("UTC"))
-                                .toInstant());
+        var expiryDate = NowHelper.nowPlus(3, ChronoUnit.MINUTES);
         var claimsBuilder =
                 new JWTClaimsSet.Builder()
                         .issuer(configurationService.getIPVAuthorisationClientId())

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVTokenService.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVTokenService.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.Map;
 
@@ -58,7 +59,7 @@ public class IPVTokenService {
                         configurationService.getIPVAuthorisationCallbackURI());
         var ipvBackendURI = configurationService.getIPVBackendURI();
         var ipvTokenURI = ConstructUriHelper.buildURI(ipvBackendURI.toString(), "token");
-        var expiryDate = LocalDateTime.now().plusMinutes(PRIVATE_KEY_JWT_EXPIRY);
+        var expiryDate = LocalDateTime.now().plus(PRIVATE_KEY_JWT_EXPIRY, ChronoUnit.MINUTES);
         var claimsSet =
                 new JWTAuthenticationClaimsSet(
                         new ClientID(configurationService.getIPVAuthorisationClientId()),

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVTokenService.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVTokenService.java
@@ -30,10 +30,7 @@ import uk.gov.di.authentication.shared.services.KmsConnectionService;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
-import java.util.Date;
 import java.util.Map;
 
 import static java.util.Collections.singletonList;
@@ -60,12 +57,11 @@ public class IPVTokenService {
                         configurationService.getIPVAuthorisationCallbackURI());
         var ipvBackendURI = configurationService.getIPVBackendURI();
         var ipvTokenURI = ConstructUriHelper.buildURI(ipvBackendURI.toString(), "token");
-        var expiryDate = LocalDateTime.now().plus(PRIVATE_KEY_JWT_EXPIRY, ChronoUnit.MINUTES);
         var claimsSet =
                 new JWTAuthenticationClaimsSet(
                         new ClientID(configurationService.getIPVAuthorisationClientId()),
                         singletonList(new Audience(ipvTokenURI)),
-                        Date.from(expiryDate.atZone(ZoneId.of("UTC")).toInstant()),
+                        NowHelper.nowPlus(PRIVATE_KEY_JWT_EXPIRY, ChronoUnit.MINUTES),
                         null,
                         NowHelper.now(),
                         new JWTID());

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVTokenService.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVTokenService.java
@@ -24,6 +24,7 @@ import com.nimbusds.openid.connect.sdk.UserInfoRequest;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.helpers.ConstructUriHelper;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.KmsConnectionService;
 
@@ -66,7 +67,7 @@ public class IPVTokenService {
                         singletonList(new Audience(ipvTokenURI)),
                         Date.from(expiryDate.atZone(ZoneId.of("UTC")).toInstant()),
                         null,
-                        Date.from(LocalDateTime.now().atZone(ZoneId.of("UTC")).toInstant()),
+                        NowHelper.now(),
                         new JWTID());
         return new TokenRequest(
                 ipvTokenURI,

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandlerTest.java
@@ -41,6 +41,7 @@ import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
@@ -100,8 +101,7 @@ public class IPVAuthorisationHandlerTest {
                             .atZone(ZoneId.of("UTC"))
                             .toInstant()
                             .minus(30, ChronoUnit.SECONDS));
-    private static final Date UPDATED_DATE_TIME =
-            Date.from(LocalDateTime.now().atZone(ZoneId.of("UTC")).toInstant());
+    private static final Date UPDATED_DATE_TIME = NowHelper.now();
     private static final String LEGACY_SUBJECT_ID = new Subject("legacy-subject-id-1").getValue();
     private static final String PUBLIC_SUBJECT_ID = new Subject("public-subject-id-2").getValue();
     private static final String SUBJECT_ID = new Subject("subject-id-3").getValue();

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandlerTest.java
@@ -56,6 +56,7 @@ import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -94,7 +95,11 @@ public class IPVAuthorisationHandlerTest {
     private static final String IPV_CLIENT_ID = "ipv-client-id";
     private static final String PHONE_NUMBER = "01234567890";
     private static final Date CREATED_DATE_TIME =
-            Date.from(LocalDateTime.now().atZone(ZoneId.of("UTC")).toInstant().minusSeconds(30));
+            Date.from(
+                    LocalDateTime.now()
+                            .atZone(ZoneId.of("UTC"))
+                            .toInstant()
+                            .minus(30, ChronoUnit.SECONDS));
     private static final Date UPDATED_DATE_TIME =
             Date.from(LocalDateTime.now().atZone(ZoneId.of("UTC")).toInstant());
     private static final String LEGACY_SUBJECT_ID = new Subject("legacy-subject-id-1").getValue();

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandlerTest.java
@@ -55,8 +55,6 @@ import java.net.URLDecoder;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.HashMap;
@@ -95,12 +93,7 @@ public class IPVAuthorisationHandlerTest {
     private static final String CLIENT_ID = "test-client-id";
     private static final String IPV_CLIENT_ID = "ipv-client-id";
     private static final String PHONE_NUMBER = "01234567890";
-    private static final Date CREATED_DATE_TIME =
-            Date.from(
-                    LocalDateTime.now()
-                            .atZone(ZoneId.of("UTC"))
-                            .toInstant()
-                            .minus(30, ChronoUnit.SECONDS));
+    private static final Date CREATED_DATE_TIME = NowHelper.nowMinus(30, ChronoUnit.SECONDS);
     private static final Date UPDATED_DATE_TIME = NowHelper.now();
     private static final String LEGACY_SUBJECT_ID = new Subject("legacy-subject-id-1").getValue();
     private static final String PUBLIC_SUBJECT_ID = new Subject("public-subject-id-2").getValue();

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVTokenServiceTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVTokenServiceTest.java
@@ -26,10 +26,7 @@ import uk.gov.di.authentication.shared.services.KmsConnectionService;
 
 import java.net.URI;
 import java.nio.ByteBuffer;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
-import java.util.Date;
 
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -91,11 +88,7 @@ class IPVTokenServiceTest {
                 new JWTAuthenticationClaimsSet(
                         new ClientID(CLIENT_ID),
                         singletonList(new Audience(buildURI(IPV_URI.toString(), "token"))),
-                        Date.from(
-                                LocalDateTime.now()
-                                        .plus(5, ChronoUnit.MINUTES)
-                                        .atZone(ZoneId.of("UTC"))
-                                        .toInstant()),
+                        NowHelper.nowPlus(5, ChronoUnit.MINUTES),
                         null,
                         NowHelper.now(),
                         new JWTID());

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVTokenServiceTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVTokenServiceTest.java
@@ -27,6 +27,7 @@ import java.net.URI;
 import java.nio.ByteBuffer;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
 import java.util.Date;
 
 import static java.util.Collections.singletonList;
@@ -91,7 +92,7 @@ class IPVTokenServiceTest {
                         singletonList(new Audience(buildURI(IPV_URI.toString(), "token"))),
                         Date.from(
                                 LocalDateTime.now()
-                                        .plusMinutes(5)
+                                        .plus(5, ChronoUnit.MINUTES)
                                         .atZone(ZoneId.of("UTC"))
                                         .toInstant()),
                         null,

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVTokenServiceTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVTokenServiceTest.java
@@ -20,6 +20,7 @@ import com.nimbusds.oauth2.sdk.id.JWTID;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.KmsConnectionService;
 
@@ -96,7 +97,7 @@ class IPVTokenServiceTest {
                                         .atZone(ZoneId.of("UTC"))
                                         .toInstant()),
                         null,
-                        Date.from(LocalDateTime.now().atZone(ZoneId.of("UTC")).toInstant()),
+                        NowHelper.now(),
                         new JWTID());
         var ecdsaSigner = new ECDSASigner(ecSigningKey);
         var jwsHeader =

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AccessTokenService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AccessTokenService.java
@@ -17,14 +17,12 @@ import uk.gov.di.authentication.shared.entity.AccessTokenStore;
 import uk.gov.di.authentication.shared.entity.ValidClaims;
 import uk.gov.di.authentication.shared.entity.ValidScopes;
 import uk.gov.di.authentication.shared.exceptions.AccessTokenException;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.services.DynamoClientService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
 import uk.gov.di.authentication.shared.services.TokenValidationService;
 
 import java.text.ParseException;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -65,8 +63,7 @@ public class AccessTokenService {
         try {
             signedJWT = SignedJWT.parse(accessToken.getValue());
 
-            var localDateTime = LocalDateTime.now();
-            var currentDateTime = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
+            var currentDateTime = NowHelper.now();
             if (DateUtils.isBefore(
                     signedJWT.getJWTClaimsSet().getExpirationTime(), currentDateTime, 0)) {
                 LOG.warn(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AccessTokenServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AccessTokenServiceTest.java
@@ -25,16 +25,14 @@ import uk.gov.di.authentication.shared.entity.AccessTokenStore;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ValidClaims;
 import uk.gov.di.authentication.shared.exceptions.AccessTokenException;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.services.DynamoClientService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
 import uk.gov.di.authentication.shared.services.TokenValidationService;
 import uk.gov.di.authentication.sharedtest.helper.TokenGeneratorHelper;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
-import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -311,11 +309,12 @@ class AccessTokenServiceTest {
 
     private AccessToken createSignedAccessToken(OIDCClaimsRequest identityClaims, boolean expired) {
         try {
-            var localDateTime = LocalDateTime.now().plus(3, ChronoUnit.MINUTES);
-            if (expired) {
-                localDateTime = LocalDateTime.now().minus(2, ChronoUnit.MINUTES);
-            }
-            var expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
+
+            var expiryDate =
+                    expired
+                            ? NowHelper.nowMinus(2, ChronoUnit.MINUTES)
+                            : NowHelper.nowPlus(3, ChronoUnit.MINUTES);
+
             var ecSigningKey =
                     new ECKeyGenerator(Curve.P_256)
                             .keyID(KEY_ID)

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AccessTokenServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AccessTokenServiceTest.java
@@ -33,6 +33,7 @@ import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
@@ -310,9 +311,9 @@ class AccessTokenServiceTest {
 
     private AccessToken createSignedAccessToken(OIDCClaimsRequest identityClaims, boolean expired) {
         try {
-            var localDateTime = LocalDateTime.now().plusMinutes(3);
+            var localDateTime = LocalDateTime.now().plus(3, ChronoUnit.MINUTES);
             if (expired) {
-                localDateTime = LocalDateTime.now().minusMinutes(2);
+                localDateTime = LocalDateTime.now().minus(2, ChronoUnit.MINUTES);
             }
             var expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
             var ecSigningKey =

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
@@ -189,7 +189,7 @@ class UserInfoServiceTest {
 
     private AccessToken createSignedAccessToken(OIDCClaimsRequest identityClaims)
             throws JOSEException {
-        var localDateTime = LocalDateTime.now().plusMinutes(3);
+        var localDateTime = LocalDateTime.now().plus(3, ChronoUnit.MINUTES);
         var expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
         var ecSigningKey =
                 new ECKeyGenerator(Curve.P_256)

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
@@ -20,6 +20,7 @@ import uk.gov.di.authentication.shared.entity.AccessTokenStore;
 import uk.gov.di.authentication.shared.entity.SPOTCredential;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.ValidClaims;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.DynamoSpotService;
 import uk.gov.di.authentication.sharedtest.helper.SignedCredentialHelper;
@@ -27,8 +28,7 @@ import uk.gov.di.authentication.sharedtest.helper.TokenGeneratorHelper;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
 import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.util.Date;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -189,8 +189,7 @@ class UserInfoServiceTest {
 
     private AccessToken createSignedAccessToken(OIDCClaimsRequest identityClaims)
             throws JOSEException {
-        var localDateTime = LocalDateTime.now().plus(3, ChronoUnit.MINUTES);
-        var expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
+        var expiryDate = NowHelper.nowPlus(3, ChronoUnit.MINUTES);
         var ecSigningKey =
                 new ECKeyGenerator(Curve.P_256)
                         .keyID(KEY_ID)

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/TokenGeneratorHelper.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/TokenGeneratorHelper.java
@@ -18,6 +18,7 @@ import com.nimbusds.oauth2.sdk.id.Subject;
 import com.nimbusds.openid.connect.sdk.OIDCClaimsRequest;
 import com.nimbusds.openid.connect.sdk.claims.ClaimsSetRequest;
 import com.nimbusds.openid.connect.sdk.claims.IDTokenClaimsSet;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -117,8 +118,7 @@ public class TokenGeneratorHelper {
                         .claim("scope", scopes)
                         .issuer(issuerUrl)
                         .expirationTime(expiryDate)
-                        .issueTime(
-                                Date.from(LocalDateTime.now().atZone(ZoneId.of("UTC")).toInstant()))
+                        .issueTime(NowHelper.now())
                         .claim("client_id", clientId)
                         .subject(subject.getValue())
                         .jwtID(UUID.randomUUID().toString());

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/TokenGeneratorHelper.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/TokenGeneratorHelper.java
@@ -20,8 +20,6 @@ import com.nimbusds.openid.connect.sdk.claims.ClaimsSetRequest;
 import com.nimbusds.openid.connect.sdk.claims.IDTokenClaimsSet;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.List;
@@ -37,8 +35,7 @@ public class TokenGeneratorHelper {
 
     public static SignedJWT generateIDToken(
             String clientId, Subject subject, String issuerUrl, JWK signingKey) {
-        LocalDateTime localDateTime = LocalDateTime.now().plus(2, ChronoUnit.MINUTES);
-        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
+        Date expiryDate = NowHelper.nowPlus(2, ChronoUnit.MINUTES);
         return generateIDToken(clientId, subject, issuerUrl, signingKey, expiryDate);
     }
 
@@ -83,8 +80,7 @@ public class TokenGeneratorHelper {
             Subject subject,
             String keyId) {
 
-        LocalDateTime localDateTime = LocalDateTime.now().plus(2, ChronoUnit.MINUTES);
-        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
+        Date expiryDate = NowHelper.nowPlus(2, ChronoUnit.MINUTES);
 
         return generateSignedToken(
                 clientId, issuerUrl, scopes, signer, subject, keyId, expiryDate, null);

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/TokenGeneratorHelper.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/TokenGeneratorHelper.java
@@ -21,6 +21,7 @@ import com.nimbusds.openid.connect.sdk.claims.IDTokenClaimsSet;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
@@ -35,7 +36,7 @@ public class TokenGeneratorHelper {
 
     public static SignedJWT generateIDToken(
             String clientId, Subject subject, String issuerUrl, JWK signingKey) {
-        LocalDateTime localDateTime = LocalDateTime.now().plusMinutes(2);
+        LocalDateTime localDateTime = LocalDateTime.now().plus(2, ChronoUnit.MINUTES);
         Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
         return generateIDToken(clientId, subject, issuerUrl, signingKey, expiryDate);
     }
@@ -81,7 +82,7 @@ public class TokenGeneratorHelper {
             Subject subject,
             String keyId) {
 
-        LocalDateTime localDateTime = LocalDateTime.now().plusMinutes(2);
+        LocalDateTime localDateTime = LocalDateTime.now().plus(2, ChronoUnit.MINUTES);
         Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
 
         return generateSignedToken(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/NowHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/NowHelper.java
@@ -14,4 +14,9 @@ public class NowHelper {
         return Date.from(
                 LocalDateTime.now().plus(amount, unit).atZone(ZoneId.of("UTC")).toInstant());
     }
+
+    public static Date nowMinus(long amount, ChronoUnit unit) {
+        return Date.from(
+                LocalDateTime.now().minus(amount, unit).atZone(ZoneId.of("UTC")).toInstant());
+    }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/NowHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/NowHelper.java
@@ -1,0 +1,12 @@
+package uk.gov.di.authentication.shared.helpers;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+
+public class NowHelper {
+
+    public static Date now() {
+        return Date.from(LocalDateTime.now().atZone(ZoneId.of("UTC")).toInstant());
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/NowHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/NowHelper.java
@@ -9,4 +9,9 @@ public class NowHelper {
     public static Date now() {
         return Date.from(LocalDateTime.now().atZone(ZoneId.of("UTC")).toInstant());
     }
+
+    public static Date nowPlus(long amount, ChronoUnit unit) {
+        return Date.from(
+                LocalDateTime.now().plus(amount, unit).atZone(ZoneId.of("UTC")).toInstant());
+    }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/NowHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/NowHelper.java
@@ -1,22 +1,20 @@
 package uk.gov.di.authentication.shared.helpers;
 
-import java.time.LocalDateTime;
-import java.time.ZoneId;
+import java.time.Clock;
+import java.time.temporal.ChronoUnit;
 import java.util.Date;
 
 public class NowHelper {
 
     public static Date now() {
-        return Date.from(LocalDateTime.now().atZone(ZoneId.of("UTC")).toInstant());
+        return Date.from(Clock.systemUTC().instant());
     }
 
     public static Date nowPlus(long amount, ChronoUnit unit) {
-        return Date.from(
-                LocalDateTime.now().plus(amount, unit).atZone(ZoneId.of("UTC")).toInstant());
+        return Date.from(Clock.systemUTC().instant().plus(amount, unit));
     }
 
     public static Date nowMinus(long amount, ChronoUnit unit) {
-        return Date.from(
-                LocalDateTime.now().minus(amount, unit).atZone(ZoneId.of("UTC")).toInstant());
+        return Date.from(Clock.systemUTC().instant().minus(amount, unit));
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
@@ -55,8 +55,6 @@ import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.X509EncodedKeySpec;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.Base64;
 import java.util.Collections;
@@ -252,9 +250,7 @@ public class TokenService {
 
         LOG.info("Generating IdToken");
         URI trustMarkUri = buildURI(configService.getOidcApiBaseURL().get(), "/trustmark");
-        LocalDateTime localDateTime =
-                LocalDateTime.now().plus(configService.getIDTokenExpiry(), ChronoUnit.SECONDS);
-        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
+        Date expiryDate = NowHelper.nowPlus(configService.getIDTokenExpiry(), ChronoUnit.SECONDS);
         IDTokenClaimsSet idTokenClaims =
                 new IDTokenClaimsSet(
                         new Issuer(configService.getOidcApiBaseURL().get()),
@@ -282,9 +278,8 @@ public class TokenService {
             OIDCClaimsRequest claimsRequest) {
 
         LOG.info("Generating AccessToken");
-        LocalDateTime localDateTime =
-                LocalDateTime.now().plus(configService.getAccessTokenExpiry(), ChronoUnit.SECONDS);
-        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
+        Date expiryDate =
+                NowHelper.nowPlus(configService.getAccessTokenExpiry(), ChronoUnit.SECONDS);
         var jwtID = UUID.randomUUID().toString();
 
         LOG.info("AccessToken being created with JWTID: {}", jwtID);
@@ -328,9 +323,7 @@ public class TokenService {
     private RefreshToken generateAndStoreRefreshToken(
             String clientId, Subject internalSubject, List<String> scopes, Subject publicSubject) {
         LOG.info("Generating RefreshToken");
-        LocalDateTime localDateTime =
-                LocalDateTime.now().plus(configService.getSessionExpiry(), ChronoUnit.SECONDS);
-        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
+        Date expiryDate = NowHelper.nowPlus(configService.getSessionExpiry(), ChronoUnit.SECONDS);
         JWTClaimsSet claimsSet =
                 new JWTClaimsSet.Builder()
                         .claim("scope", scopes)

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
@@ -56,6 +56,7 @@ import java.security.spec.InvalidKeySpecException;
 import java.security.spec.X509EncodedKeySpec;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.Date;
@@ -251,7 +252,7 @@ public class TokenService {
         LOG.info("Generating IdToken");
         URI trustMarkUri = buildURI(configService.getOidcApiBaseURL().get(), "/trustmark");
         LocalDateTime localDateTime =
-                LocalDateTime.now().plusSeconds(configService.getIDTokenExpiry());
+                LocalDateTime.now().plus(configService.getIDTokenExpiry(), ChronoUnit.SECONDS);
         Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
         IDTokenClaimsSet idTokenClaims =
                 new IDTokenClaimsSet(
@@ -281,7 +282,7 @@ public class TokenService {
 
         LOG.info("Generating AccessToken");
         LocalDateTime localDateTime =
-                LocalDateTime.now().plusSeconds(configService.getAccessTokenExpiry());
+                LocalDateTime.now().plus(configService.getAccessTokenExpiry(), ChronoUnit.SECONDS);
         Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
         var jwtID = UUID.randomUUID().toString();
 
@@ -328,7 +329,7 @@ public class TokenService {
             String clientId, Subject internalSubject, List<String> scopes, Subject publicSubject) {
         LOG.info("Generating RefreshToken");
         LocalDateTime localDateTime =
-                LocalDateTime.now().plusSeconds(configService.getSessionExpiry());
+                LocalDateTime.now().plus(configService.getSessionExpiry(), ChronoUnit.SECONDS);
         Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
         JWTClaimsSet claimsSet =
                 new JWTClaimsSet.Builder()

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
@@ -45,6 +45,7 @@ import uk.gov.di.authentication.shared.entity.AccessTokenStore;
 import uk.gov.di.authentication.shared.entity.ClientConsent;
 import uk.gov.di.authentication.shared.entity.RefreshTokenStore;
 import uk.gov.di.authentication.shared.entity.ValidScopes;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.helpers.RequestBodyHelper;
 
 import java.net.URI;
@@ -293,8 +294,7 @@ public class TokenService {
                         .claim("scope", scopes)
                         .issuer(configService.getOidcApiBaseURL().get())
                         .expirationTime(expiryDate)
-                        .issueTime(
-                                Date.from(LocalDateTime.now().atZone(ZoneId.of("UTC")).toInstant()))
+                        .issueTime(NowHelper.now())
                         .claim("client_id", clientId)
                         .subject(publicSubject.getValue())
                         .jwtID(jwtID);
@@ -336,8 +336,7 @@ public class TokenService {
                         .claim("scope", scopes)
                         .issuer(configService.getOidcApiBaseURL().get())
                         .expirationTime(expiryDate)
-                        .issueTime(
-                                Date.from(LocalDateTime.now().atZone(ZoneId.of("UTC")).toInstant()))
+                        .issueTime(NowHelper.now())
                         .claim("client_id", clientId)
                         .subject(publicSubject.getValue())
                         .jwtID(UUID.randomUUID().toString())
@@ -415,8 +414,7 @@ public class TokenService {
     private boolean hasPrivateKeyJwtExpired(SignedJWT signedJWT) {
         try {
             JWTClaimsSet claimsSet = signedJWT.getJWTClaimsSet();
-            LocalDateTime localDateTime = LocalDateTime.now();
-            Date currentDateTime = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
+            Date currentDateTime = NowHelper.now();
             if (DateUtils.isBefore(claimsSet.getExpirationTime(), currentDateTime, 30)) {
                 return true;
             }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/UserCredentialsTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/UserCredentialsTest.java
@@ -3,6 +3,7 @@ package uk.gov.di.authentication.shared.entity;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -25,8 +26,7 @@ class UserCredentialsTest {
                             .atZone(ZoneId.of("UTC"))
                             .toInstant()
                             .minus(30, ChronoUnit.SECONDS));
-    private static final Date UPDATED_DATE_TIME =
-            Date.from(LocalDateTime.now().atZone(ZoneId.of("UTC")).toInstant());
+    private static final Date UPDATED_DATE_TIME = NowHelper.now();
 
     @Test
     void shouldCreateUserCredentials() {

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/UserCredentialsTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/UserCredentialsTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.Map;
 
@@ -19,7 +20,11 @@ class UserCredentialsTest {
     private static final String MIGRATED_PASSWORD = "oldpassword";
     private static final String SUBJECT_ID = new Subject("subject-id-3").getValue();
     private static final Date CREATED_DATE_TIME =
-            Date.from(LocalDateTime.now().atZone(ZoneId.of("UTC")).toInstant().minusSeconds(30));
+            Date.from(
+                    LocalDateTime.now()
+                            .atZone(ZoneId.of("UTC"))
+                            .toInstant()
+                            .minus(30, ChronoUnit.SECONDS));
     private static final Date UPDATED_DATE_TIME =
             Date.from(LocalDateTime.now().atZone(ZoneId.of("UTC")).toInstant());
 

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/UserCredentialsTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/UserCredentialsTest.java
@@ -5,8 +5,6 @@ import com.nimbusds.oauth2.sdk.id.Subject;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.Map;
@@ -20,12 +18,7 @@ class UserCredentialsTest {
     private static final String PASSWORD = "password123";
     private static final String MIGRATED_PASSWORD = "oldpassword";
     private static final String SUBJECT_ID = new Subject("subject-id-3").getValue();
-    private static final Date CREATED_DATE_TIME =
-            Date.from(
-                    LocalDateTime.now()
-                            .atZone(ZoneId.of("UTC"))
-                            .toInstant()
-                            .minus(30, ChronoUnit.SECONDS));
+    private static final Date CREATED_DATE_TIME = NowHelper.nowMinus(30, ChronoUnit.SECONDS);
     private static final Date UPDATED_DATE_TIME = NowHelper.now();
 
     @Test

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/UserProfileTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/UserProfileTest.java
@@ -5,6 +5,7 @@ import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -30,8 +31,7 @@ class UserProfileTest {
                             .atZone(ZoneId.of("UTC"))
                             .toInstant()
                             .minus(30, ChronoUnit.SECONDS));
-    private static final Date UPDATED_DATE_TIME =
-            Date.from(LocalDateTime.now().atZone(ZoneId.of("UTC")).toInstant());
+    private static final Date UPDATED_DATE_TIME = NowHelper.now();
     private static final String LEGACY_SUBJECT_ID = new Subject("legacy-subject-id-1").getValue();
     private static final String PUBLIC_SUBJECT_ID = new Subject("public-subject-id-2").getValue();
     private static final String SUBJECT_ID = new Subject("subject-id-3").getValue();

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/UserProfileTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/UserProfileTest.java
@@ -10,6 +10,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -24,7 +25,11 @@ class UserProfileTest {
     private static final String PHONE_NUMBER = "01234567890";
     private static final String CLIENT_ID = "client-id";
     private static final Date CREATED_DATE_TIME =
-            Date.from(LocalDateTime.now().atZone(ZoneId.of("UTC")).toInstant().minusSeconds(30));
+            Date.from(
+                    LocalDateTime.now()
+                            .atZone(ZoneId.of("UTC"))
+                            .toInstant()
+                            .minus(30, ChronoUnit.SECONDS));
     private static final Date UPDATED_DATE_TIME =
             Date.from(LocalDateTime.now().atZone(ZoneId.of("UTC")).toInstant());
     private static final String LEGACY_SUBJECT_ID = new Subject("legacy-subject-id-1").getValue();

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/UserProfileTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/UserProfileTest.java
@@ -9,8 +9,6 @@ import uk.gov.di.authentication.shared.helpers.NowHelper;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.List;
@@ -25,12 +23,7 @@ class UserProfileTest {
     private static final String EMAIL = "user.one@test.com";
     private static final String PHONE_NUMBER = "01234567890";
     private static final String CLIENT_ID = "client-id";
-    private static final Date CREATED_DATE_TIME =
-            Date.from(
-                    LocalDateTime.now()
-                            .atZone(ZoneId.of("UTC"))
-                            .toInstant()
-                            .minus(30, ChronoUnit.SECONDS));
+    private static final Date CREATED_DATE_TIME = NowHelper.nowMinus(30, ChronoUnit.SECONDS);
     private static final Date UPDATED_DATE_TIME = NowHelper.now();
     private static final String LEGACY_SUBJECT_ID = new Subject("legacy-subject-id-1").getValue();
     private static final String PUBLIC_SUBJECT_ID = new Subject("public-subject-id-2").getValue();

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
@@ -44,6 +44,7 @@ import uk.gov.di.authentication.shared.entity.ClientConsent;
 import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.RefreshTokenStore;
 import uk.gov.di.authentication.shared.entity.ValidScopes;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.sharedtest.helper.TokenGeneratorHelper;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
@@ -55,6 +56,7 @@ import java.security.interfaces.RSAPrivateKey;
 import java.text.ParseException;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.Date;
@@ -266,8 +268,7 @@ public class TokenServiceTest {
     void shouldSuccessfullyValidatePrivateKeyJWT() throws JOSEException {
         KeyPair keyPair = generateRsaKeyPair();
         String publicKey = Base64.getMimeEncoder().encodeToString(keyPair.getPublic().getEncoded());
-        LocalDateTime localDateTime = LocalDateTime.now().plus(5, ChronoUnit.MINUTES);
-        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
+        Date expiryDate = NowHelper.nowPlus(5, ChronoUnit.MINUTES);
         String requestParams = generateSerialisedPrivateKeyJWT(keyPair, expiryDate.getTime());
         assertThat(
                 tokenService.validatePrivateKeyJWT(requestParams, publicKey, TOKEN_URI, CLIENT_ID),
@@ -278,8 +279,12 @@ public class TokenServiceTest {
     void shouldFailToValidatePrivateKeyJWTIfExpired() throws JOSEException {
         KeyPair keyPair = generateRsaKeyPair();
         String publicKey = Base64.getMimeEncoder().encodeToString(keyPair.getPublic().getEncoded());
-        LocalDateTime localDateTime = LocalDateTime.now().minus(2, ChronoUnit.MINUTES);
-        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
+        Date expiryDate =
+                Date.from(
+                        LocalDateTime.now()
+                                .minus(2, ChronoUnit.MINUTES)
+                                .atZone(ZoneId.of("UTC"))
+                                .toInstant());
         String requestParams = generateSerialisedPrivateKeyJWT(keyPair, expiryDate.getTime());
         assertThat(
                 tokenService.validatePrivateKeyJWT(requestParams, publicKey, TOKEN_URI, CLIENT_ID),
@@ -290,8 +295,7 @@ public class TokenServiceTest {
     void shouldFailToValidatePrivateKeyJWTIfInvalidClientId() throws JOSEException {
         KeyPair keyPair = generateRsaKeyPair();
         String publicKey = Base64.getMimeEncoder().encodeToString(keyPair.getPublic().getEncoded());
-        LocalDateTime localDateTime = LocalDateTime.now().plus(5, ChronoUnit.MINUTES);
-        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
+        Date expiryDate = NowHelper.nowPlus(5, ChronoUnit.MINUTES);
         String requestParams = generateSerialisedPrivateKeyJWT(keyPair, expiryDate.getTime());
         assertThat(
                 tokenService.validatePrivateKeyJWT(
@@ -305,8 +309,7 @@ public class TokenServiceTest {
         KeyPair keyPairTwo = generateRsaKeyPair();
         String publicKey =
                 Base64.getMimeEncoder().encodeToString(keyPairTwo.getPublic().getEncoded());
-        LocalDateTime localDateTime = LocalDateTime.now().plus(5, ChronoUnit.MINUTES);
-        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
+        Date expiryDate = NowHelper.nowPlus(5, ChronoUnit.MINUTES);
         String requestParams = generateSerialisedPrivateKeyJWT(keyPair, expiryDate.getTime());
         assertThat(
                 tokenService.validatePrivateKeyJWT(requestParams, publicKey, TOKEN_URI, CLIENT_ID),
@@ -482,8 +485,7 @@ public class TokenServiceTest {
     }
 
     private SignedJWT createSignedIdToken(ECKey ecSigningKey) {
-        LocalDateTime localDateTime = LocalDateTime.now().plus(2, ChronoUnit.MINUTES);
-        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
+        Date expiryDate = NowHelper.nowPlus(2, ChronoUnit.MINUTES);
         return TokenGeneratorHelper.generateIDToken(
                 CLIENT_ID, PUBLIC_SUBJECT, BASE_URL, ecSigningKey, expiryDate);
     }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
@@ -266,7 +266,7 @@ public class TokenServiceTest {
     void shouldSuccessfullyValidatePrivateKeyJWT() throws JOSEException {
         KeyPair keyPair = generateRsaKeyPair();
         String publicKey = Base64.getMimeEncoder().encodeToString(keyPair.getPublic().getEncoded());
-        LocalDateTime localDateTime = LocalDateTime.now().plusMinutes(5);
+        LocalDateTime localDateTime = LocalDateTime.now().plus(5, ChronoUnit.MINUTES);
         Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
         String requestParams = generateSerialisedPrivateKeyJWT(keyPair, expiryDate.getTime());
         assertThat(
@@ -278,7 +278,7 @@ public class TokenServiceTest {
     void shouldFailToValidatePrivateKeyJWTIfExpired() throws JOSEException {
         KeyPair keyPair = generateRsaKeyPair();
         String publicKey = Base64.getMimeEncoder().encodeToString(keyPair.getPublic().getEncoded());
-        LocalDateTime localDateTime = LocalDateTime.now().minusMinutes(2);
+        LocalDateTime localDateTime = LocalDateTime.now().minus(2, ChronoUnit.MINUTES);
         Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
         String requestParams = generateSerialisedPrivateKeyJWT(keyPair, expiryDate.getTime());
         assertThat(
@@ -290,7 +290,7 @@ public class TokenServiceTest {
     void shouldFailToValidatePrivateKeyJWTIfInvalidClientId() throws JOSEException {
         KeyPair keyPair = generateRsaKeyPair();
         String publicKey = Base64.getMimeEncoder().encodeToString(keyPair.getPublic().getEncoded());
-        LocalDateTime localDateTime = LocalDateTime.now().plusMinutes(5);
+        LocalDateTime localDateTime = LocalDateTime.now().plus(5, ChronoUnit.MINUTES);
         Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
         String requestParams = generateSerialisedPrivateKeyJWT(keyPair, expiryDate.getTime());
         assertThat(
@@ -305,7 +305,7 @@ public class TokenServiceTest {
         KeyPair keyPairTwo = generateRsaKeyPair();
         String publicKey =
                 Base64.getMimeEncoder().encodeToString(keyPairTwo.getPublic().getEncoded());
-        LocalDateTime localDateTime = LocalDateTime.now().plusMinutes(5);
+        LocalDateTime localDateTime = LocalDateTime.now().plus(5, ChronoUnit.MINUTES);
         Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
         String requestParams = generateSerialisedPrivateKeyJWT(keyPair, expiryDate.getTime());
         assertThat(
@@ -482,7 +482,7 @@ public class TokenServiceTest {
     }
 
     private SignedJWT createSignedIdToken(ECKey ecSigningKey) {
-        LocalDateTime localDateTime = LocalDateTime.now().plusMinutes(2);
+        LocalDateTime localDateTime = LocalDateTime.now().plus(2, ChronoUnit.MINUTES);
         Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
         return TokenGeneratorHelper.generateIDToken(
                 CLIENT_ID, PUBLIC_SUBJECT, BASE_URL, ecSigningKey, expiryDate);

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
@@ -279,12 +279,7 @@ public class TokenServiceTest {
     void shouldFailToValidatePrivateKeyJWTIfExpired() throws JOSEException {
         KeyPair keyPair = generateRsaKeyPair();
         String publicKey = Base64.getMimeEncoder().encodeToString(keyPair.getPublic().getEncoded());
-        Date expiryDate =
-                Date.from(
-                        LocalDateTime.now()
-                                .minus(2, ChronoUnit.MINUTES)
-                                .atZone(ZoneId.of("UTC"))
-                                .toInstant());
+        Date expiryDate = NowHelper.nowMinus(2, ChronoUnit.MINUTES);
         String requestParams = generateSerialisedPrivateKeyJWT(keyPair, expiryDate.getTime());
         assertThat(
                 tokenService.validatePrivateKeyJWT(requestParams, publicKey, TOKEN_URI, CLIENT_ID),

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenValidationServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenValidationServiceTest.java
@@ -21,8 +21,6 @@ import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.sharedtest.helper.TokenGeneratorHelper;
 
 import java.nio.ByteBuffer;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.Base64;
 import java.util.Date;
@@ -80,12 +78,7 @@ class TokenValidationServiceTest {
 
     @Test
     void shouldNotFailSignatureValidationIfIdTokenHasExpired() {
-        Date expiryDate =
-                Date.from(
-                        LocalDateTime.now()
-                                .minus(2, ChronoUnit.MINUTES)
-                                .atZone(ZoneId.systemDefault())
-                                .toInstant());
+        Date expiryDate = NowHelper.nowMinus(2, ChronoUnit.MINUTES);
         SignedJWT signedIdToken = createSignedIdToken(expiryDate);
         assertTrue(tokenValidationService.isTokenSignatureValid(signedIdToken.serialize()));
     }
@@ -110,8 +103,7 @@ class TokenValidationServiceTest {
 
     @Test
     void shouldFailToValidateRefreshTokenIfExpired() {
-        LocalDateTime localDateTime = LocalDateTime.now().minus(2, ChronoUnit.MINUTES);
-        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
+        Date expiryDate = NowHelper.nowMinus(2, ChronoUnit.MINUTES);
 
         SignedJWT signedAccessToken = createSignedRefreshTokenWithExpiry(signer, expiryDate);
         assertFalse(

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenValidationServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenValidationServiceTest.java
@@ -17,6 +17,7 @@ import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.oauth2.sdk.token.RefreshToken;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.sharedtest.helper.TokenGeneratorHelper;
 
 import java.nio.ByteBuffer;
@@ -72,16 +73,19 @@ class TokenValidationServiceTest {
 
     @Test
     void shouldSuccessfullyValidateIDToken() {
-        LocalDateTime localDateTime = LocalDateTime.now().plus(2, ChronoUnit.MINUTES);
-        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
+        Date expiryDate = NowHelper.nowPlus(2, ChronoUnit.MINUTES);
         SignedJWT signedIdToken = createSignedIdToken(expiryDate);
         assertTrue(tokenValidationService.isTokenSignatureValid(signedIdToken.serialize()));
     }
 
     @Test
     void shouldNotFailSignatureValidationIfIdTokenHasExpired() {
-        LocalDateTime localDateTime = LocalDateTime.now().minus(2, ChronoUnit.MINUTES);
-        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant());
+        Date expiryDate =
+                Date.from(
+                        LocalDateTime.now()
+                                .minus(2, ChronoUnit.MINUTES)
+                                .atZone(ZoneId.systemDefault())
+                                .toInstant());
         SignedJWT signedIdToken = createSignedIdToken(expiryDate);
         assertTrue(tokenValidationService.isTokenSignatureValid(signedIdToken.serialize()));
     }
@@ -96,8 +100,7 @@ class TokenValidationServiceTest {
 
     @Test
     void shouldSuccessfullyValidateRefreshToken() {
-        LocalDateTime localDateTime = LocalDateTime.now().plus(2, ChronoUnit.MINUTES);
-        Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
+        Date expiryDate = NowHelper.nowPlus(2, ChronoUnit.MINUTES);
 
         SignedJWT signedAccessToken = createSignedRefreshTokenWithExpiry(signer, expiryDate);
         assertTrue(

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenValidationServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenValidationServiceTest.java
@@ -22,6 +22,7 @@ import uk.gov.di.authentication.sharedtest.helper.TokenGeneratorHelper;
 import java.nio.ByteBuffer;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
 import java.util.Base64;
 import java.util.Date;
 import java.util.List;
@@ -71,7 +72,7 @@ class TokenValidationServiceTest {
 
     @Test
     void shouldSuccessfullyValidateIDToken() {
-        LocalDateTime localDateTime = LocalDateTime.now().plusMinutes(2);
+        LocalDateTime localDateTime = LocalDateTime.now().plus(2, ChronoUnit.MINUTES);
         Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
         SignedJWT signedIdToken = createSignedIdToken(expiryDate);
         assertTrue(tokenValidationService.isTokenSignatureValid(signedIdToken.serialize()));
@@ -79,7 +80,7 @@ class TokenValidationServiceTest {
 
     @Test
     void shouldNotFailSignatureValidationIfIdTokenHasExpired() {
-        LocalDateTime localDateTime = LocalDateTime.now().minusMinutes(2);
+        LocalDateTime localDateTime = LocalDateTime.now().minus(2, ChronoUnit.MINUTES);
         Date expiryDate = Date.from(localDateTime.atZone(ZoneId.systemDefault()).toInstant());
         SignedJWT signedIdToken = createSignedIdToken(expiryDate);
         assertTrue(tokenValidationService.isTokenSignatureValid(signedIdToken.serialize()));
@@ -95,7 +96,7 @@ class TokenValidationServiceTest {
 
     @Test
     void shouldSuccessfullyValidateRefreshToken() {
-        LocalDateTime localDateTime = LocalDateTime.now().plusMinutes(2);
+        LocalDateTime localDateTime = LocalDateTime.now().plus(2, ChronoUnit.MINUTES);
         Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
 
         SignedJWT signedAccessToken = createSignedRefreshTokenWithExpiry(signer, expiryDate);
@@ -106,7 +107,7 @@ class TokenValidationServiceTest {
 
     @Test
     void shouldFailToValidateRefreshTokenIfExpired() {
-        LocalDateTime localDateTime = LocalDateTime.now().minusMinutes(2);
+        LocalDateTime localDateTime = LocalDateTime.now().minus(2, ChronoUnit.MINUTES);
         Date expiryDate = Date.from(localDateTime.atZone(ZoneId.of("UTC")).toInstant());
 
         SignedJWT signedAccessToken = createSignedRefreshTokenWithExpiry(signer, expiryDate);


### PR DESCRIPTION
Move to using `Clock` instead of `LocalDateTime` to avoid timezone issues. The OIDC spec mandates UTC and we should never use any localisation
