### PR TITLE
AUT-190 - Support request object auth request parameter

### DIFF
--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -51,7 +51,7 @@ test {
     environment "STUB_RELYING_PARTY_REDIRECT_URI", "https://di-auth-stub-relying-party-build.london.cloudapps.digital/"
     environment "TERMS_CONDITIONS_VERSION", "1.0"
     environment "HEADERS_CASE_INSENSITIVE", "true"
-    environment "REQUEST_URI_PARAM_SUPPORTED", "true"
+    environment "REQUEST_OBJECT_PARAM_SUPPORTED", "true"
     environment "IDENTITY_ENABLED", "false"
     environment "SPOT_ENABLED", "true"
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/AuthRequestError.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/AuthRequestError.java
@@ -2,13 +2,15 @@ package uk.gov.di.authentication.oidc.entity;
 
 import com.nimbusds.oauth2.sdk.ErrorObject;
 
-public class RequestObjectError {
+import java.net.URI;
+
+public class AuthRequestError {
 
     private ErrorObject errorObject;
 
-    private String redirectURI;
+    private URI redirectURI;
 
-    public RequestObjectError(ErrorObject errorObject, String redirectURI) {
+    public AuthRequestError(ErrorObject errorObject, URI redirectURI) {
         this.errorObject = errorObject;
         this.redirectURI = redirectURI;
     }
@@ -17,7 +19,7 @@ public class RequestObjectError {
         return errorObject;
     }
 
-    public String getRedirectURI() {
+    public URI getRedirectURI() {
         return redirectURI;
     }
 }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/RequestObjectError.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/RequestObjectError.java
@@ -1,0 +1,23 @@
+package uk.gov.di.authentication.oidc.entity;
+
+import com.nimbusds.oauth2.sdk.ErrorObject;
+
+public class RequestObjectError {
+
+    private ErrorObject errorObject;
+
+    private String redirectURI;
+
+    public RequestObjectError(ErrorObject errorObject, String redirectURI) {
+        this.errorObject = errorObject;
+        this.redirectURI = redirectURI;
+    }
+
+    public ErrorObject getErrorObject() {
+        return errorObject;
+    }
+
+    public String getRedirectURI() {
+        return redirectURI;
+    }
+}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -143,8 +143,8 @@ public class AuthorisationHandler
                                         "No query string parameters are present in the Authentication request",
                                         e);
                             }
-
-                            var error = authorizationService.validateAuthRequest(authRequest);
+                            Optional<ErrorObject> error =
+                                    authorizationService.validateAuthRequest(authRequest);
 
                             return error.map(
                                             e ->

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/RequestObjectService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/RequestObjectService.java
@@ -1,0 +1,155 @@
+package uk.gov.di.authentication.oidc.services;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSVerifier;
+import com.nimbusds.jose.crypto.RSASSAVerifier;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.OAuth2Error;
+import com.nimbusds.oauth2.sdk.ResponseType;
+import com.nimbusds.oauth2.sdk.Scope;
+import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.oidc.entity.RequestObjectError;
+import uk.gov.di.authentication.shared.entity.ClientRegistry;
+import uk.gov.di.authentication.shared.entity.ValidScopes;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.DynamoClientService;
+
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.X509EncodedKeySpec;
+import java.text.ParseException;
+import java.util.Base64;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.lang.String.format;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.CLIENT_ID;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachLogFieldToLogs;
+
+public class RequestObjectService {
+
+    private static final Logger LOG = LogManager.getLogger(RequestObjectService.class);
+
+    private final DynamoClientService dynamoClientService;
+    private final ConfigurationService configurationService;
+
+    public RequestObjectService(
+            DynamoClientService dynamoClientService, ConfigurationService configurationService) {
+        this.dynamoClientService = dynamoClientService;
+        this.configurationService = configurationService;
+    }
+
+    public Optional<RequestObjectError> validateRequestObject(AuthenticationRequest authRequest) {
+        var clientId = authRequest.getClientID().toString();
+
+        attachLogFieldToLogs(CLIENT_ID, clientId);
+
+        var client = dynamoClientService.getClient(clientId).orElse(null);
+        try {
+
+            if (Objects.isNull(client)) {
+                var errorMsg = format("No client found with ClientID: %s", clientId);
+                LOG.warn(errorMsg);
+                throw new RuntimeException(errorMsg);
+            }
+            var signedJWT = (SignedJWT) authRequest.getRequestObject();
+            var signatureValid = isSignatureValid(signedJWT, client.getPublicKey());
+            if (!signatureValid) {
+                LOG.error("Invalid Signature on request JWT");
+                throw new RuntimeException();
+            }
+            var jwtClaimsSet = signedJWT.getJWTClaimsSet();
+            if (client.getRedirectUrls().stream()
+                    .filter(Objects::nonNull)
+                    .noneMatch(s -> s.equals(jwtClaimsSet.getClaim("redirect_uri")))) {
+                throw new RuntimeException("Invalid Redirect URI in request JWT");
+            }
+            var redirectURI = (String) jwtClaimsSet.getClaim("redirect_uri");
+            if (!authRequest.getResponseType().toString().equals(ResponseType.CODE.toString())) {
+                LOG.warn(
+                        "Unsupported responseType included in request. Expected responseType of code");
+                return Optional.of(
+                        new RequestObjectError(OAuth2Error.UNSUPPORTED_RESPONSE_TYPE, redirectURI));
+            }
+            if (requestContainsInvalidScopes(authRequest.getScope().toStringList(), client)) {
+                LOG.warn(
+                        "Invalid scopes in authRequest. Scopes in request: {}",
+                        authRequest.getScope().toStringList());
+                return Optional.of(new RequestObjectError(OAuth2Error.INVALID_SCOPE, redirectURI));
+            }
+            if (Objects.isNull(jwtClaimsSet.getClaim("client_id"))
+                    || !jwtClaimsSet
+                            .getClaim("client_id")
+                            .toString()
+                            .equals(authRequest.getClientID().getValue())) {
+                return Optional.of(
+                        new RequestObjectError(OAuth2Error.UNAUTHORIZED_CLIENT, redirectURI));
+            }
+            if (Objects.nonNull(jwtClaimsSet.getClaim("request"))
+                    || Objects.nonNull(jwtClaimsSet.getClaim("request_uri"))) {
+                LOG.warn("request or request_uri claim should not be incldued in request JWT");
+                return Optional.of(
+                        new RequestObjectError(OAuth2Error.INVALID_REQUEST, redirectURI));
+            }
+            if (Objects.isNull(jwtClaimsSet.getAudience())
+                    || !jwtClaimsSet
+                            .getAudience()
+                            .contains(configurationService.getOidcApiBaseURL().orElseThrow())) {
+                LOG.warn("Invalid or missing audience");
+                return Optional.of(new RequestObjectError(OAuth2Error.ACCESS_DENIED, redirectURI));
+            }
+            if (Objects.isNull(jwtClaimsSet.getIssuer())
+                    || !jwtClaimsSet.getIssuer().equals(client.getClientID())) {
+                LOG.warn("Invalid or missing issuer");
+                return Optional.of(
+                        new RequestObjectError(OAuth2Error.UNAUTHORIZED_CLIENT, redirectURI));
+            }
+            if (!ResponseType.CODE.toString().equals(jwtClaimsSet.getClaim("response_type"))) {
+                LOG.warn(
+                        "Unsupported responseType included in request JWT. Expected responseType of code");
+                return Optional.of(
+                        new RequestObjectError(OAuth2Error.UNSUPPORTED_RESPONSE_TYPE, redirectURI));
+            }
+            if (Objects.isNull(jwtClaimsSet.getClaim("scope"))
+                    || requestContainsInvalidScopes(
+                            Scope.parse(jwtClaimsSet.getClaim("scope").toString()).toStringList(),
+                            client)) {
+                LOG.warn("Invalid scopes in request JWT");
+                return Optional.of(new RequestObjectError(OAuth2Error.INVALID_SCOPE, redirectURI));
+            }
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
+        }
+        return Optional.empty();
+    }
+
+    private boolean requestContainsInvalidScopes(
+            List<String> scopes, ClientRegistry clientRegistry) {
+        for (String scope : scopes) {
+            if (ValidScopes.getAllValidScopes().stream().noneMatch(t -> t.equals(scope))) {
+                return true;
+            }
+        }
+        return !clientRegistry.getScopes().containsAll(scopes);
+    }
+
+    public static boolean isSignatureValid(SignedJWT signedJWT, String publicKey) {
+        try {
+            byte[] decodedKey = Base64.getMimeDecoder().decode(publicKey);
+            X509EncodedKeySpec keySpec = new X509EncodedKeySpec(decodedKey);
+            KeyFactory kf = KeyFactory.getInstance("RSA");
+            PublicKey pubKey = kf.generatePublic(keySpec);
+            JWSVerifier verifier = new RSASSAVerifier((RSAPublicKey) pubKey);
+            return signedJWT.verify(verifier);
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException | JOSEException e) {
+            LOG.error("Error when validating JWT signature");
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RequestObjectServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RequestObjectServiceTest.java
@@ -134,7 +134,7 @@ class RequestObjectServiceTest {
         assertThat(
                 requestObjectError.get().getErrorObject(),
                 equalTo(OAuth2Error.UNSUPPORTED_RESPONSE_TYPE));
-        assertThat(requestObjectError.get().getRedirectURI(), equalTo(REDIRECT_URI));
+        assertThat(requestObjectError.get().getRedirectURI().toString(), equalTo(REDIRECT_URI));
     }
 
     @Test
@@ -155,7 +155,7 @@ class RequestObjectServiceTest {
         assertThat(
                 requestObjectError.get().getErrorObject(),
                 equalTo(OAuth2Error.UNAUTHORIZED_CLIENT));
-        assertThat(requestObjectError.get().getRedirectURI(), equalTo(REDIRECT_URI));
+        assertThat(requestObjectError.get().getRedirectURI().toString(), equalTo(REDIRECT_URI));
     }
 
     @Test
@@ -174,7 +174,7 @@ class RequestObjectServiceTest {
 
         assertTrue(requestObjectError.isPresent());
         assertThat(requestObjectError.get().getErrorObject(), equalTo(OAuth2Error.INVALID_SCOPE));
-        assertThat(requestObjectError.get().getRedirectURI(), equalTo(REDIRECT_URI));
+        assertThat(requestObjectError.get().getRedirectURI().toString(), equalTo(REDIRECT_URI));
     }
 
     @Test
@@ -193,7 +193,7 @@ class RequestObjectServiceTest {
 
         assertTrue(requestObjectError.isPresent());
         assertThat(requestObjectError.get().getErrorObject(), equalTo(OAuth2Error.INVALID_SCOPE));
-        assertThat(requestObjectError.get().getRedirectURI(), equalTo(REDIRECT_URI));
+        assertThat(requestObjectError.get().getRedirectURI().toString(), equalTo(REDIRECT_URI));
     }
 
     @Test
@@ -213,7 +213,7 @@ class RequestObjectServiceTest {
 
         assertTrue(requestObjectError.isPresent());
         assertThat(requestObjectError.get().getErrorObject(), equalTo(OAuth2Error.ACCESS_DENIED));
-        assertThat(requestObjectError.get().getRedirectURI(), equalTo(REDIRECT_URI));
+        assertThat(requestObjectError.get().getRedirectURI().toString(), equalTo(REDIRECT_URI));
     }
 
     @Test
@@ -234,7 +234,7 @@ class RequestObjectServiceTest {
         assertThat(
                 requestObjectError.get().getErrorObject(),
                 equalTo(OAuth2Error.UNAUTHORIZED_CLIENT));
-        assertThat(requestObjectError.get().getRedirectURI(), equalTo(REDIRECT_URI));
+        assertThat(requestObjectError.get().getRedirectURI().toString(), equalTo(REDIRECT_URI));
     }
 
     @Test
@@ -255,7 +255,7 @@ class RequestObjectServiceTest {
 
         assertTrue(requestObjectError.isPresent());
         assertThat(requestObjectError.get().getErrorObject(), equalTo(OAuth2Error.INVALID_REQUEST));
-        assertThat(requestObjectError.get().getRedirectURI(), equalTo(REDIRECT_URI));
+        assertThat(requestObjectError.get().getRedirectURI().toString(), equalTo(REDIRECT_URI));
     }
 
     @Test
@@ -275,7 +275,7 @@ class RequestObjectServiceTest {
 
         assertTrue(requestObjectError.isPresent());
         assertThat(requestObjectError.get().getErrorObject(), equalTo(OAuth2Error.INVALID_REQUEST));
-        assertThat(requestObjectError.get().getRedirectURI(), equalTo(REDIRECT_URI));
+        assertThat(requestObjectError.get().getRedirectURI().toString(), equalTo(REDIRECT_URI));
     }
 
     @Test

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RequestObjectServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RequestObjectServiceTest.java
@@ -1,0 +1,339 @@
+package uk.gov.di.authentication.oidc.services;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.OAuth2Error;
+import com.nimbusds.oauth2.sdk.ResponseType;
+import com.nimbusds.oauth2.sdk.Scope;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.id.State;
+import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+import com.nimbusds.openid.connect.sdk.Nonce;
+import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.entity.ClientRegistry;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.DynamoClientService;
+import uk.gov.di.authentication.sharedtest.helper.KeyPairHelper;
+
+import java.net.URI;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Collections.singletonList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RequestObjectServiceTest {
+
+    private static final URI REQUEST_URI = URI.create("https://localhost/request_uri");
+    private static final String REDIRECT_URI = "https://localhost:8080";
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private final DynamoClientService dynamoClientService = mock(DynamoClientService.class);
+    private KeyPair keyPair;
+    private static final String SCOPE = "openid";
+    private static final State STATE = new State();
+    private static final ClientID CLIENT_ID = new ClientID("test-id");
+    private static final String AUDIENCE = "oidc-audience";
+    private RequestObjectService service;
+
+    @BeforeEach
+    void setup() {
+        when(configurationService.getOidcApiBaseURL()).thenReturn(Optional.of(AUDIENCE));
+        keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        service = new RequestObjectService(dynamoClientService, configurationService);
+        ClientRegistry clientRegistry = generateClientRegistry();
+        when(dynamoClientService.getClient(CLIENT_ID.getValue()))
+                .thenReturn(Optional.of(clientRegistry));
+    }
+
+    @Test
+    void shouldSuccessfullyProcessRequestUriPayload() throws JOSEException {
+        var jwtClaimsSet =
+                new JWTClaimsSet.Builder()
+                        .audience(AUDIENCE)
+                        .claim("redirect_uri", REDIRECT_URI)
+                        .claim("response_type", ResponseType.CODE.toString())
+                        .claim("scope", SCOPE)
+                        .claim("client_id", CLIENT_ID.getValue())
+                        .issuer(CLIENT_ID.getValue())
+                        .build();
+        var signedJWT = generateSignedJWT(jwtClaimsSet);
+
+        var requestObjectError = service.validateRequestObject(generateAuthRequest(signedJWT));
+
+        assertThat(requestObjectError, equalTo(Optional.empty()));
+    }
+
+    @Test
+    void shouldThrowWhenRedirectUriIsInvalid() throws JOSEException {
+        var jwtClaimsSet =
+                new JWTClaimsSet.Builder()
+                        .audience(AUDIENCE)
+                        .claim("redirect_uri", "https://invalid-redirect-uri")
+                        .claim("response_type", ResponseType.CODE.toString())
+                        .claim("scope", SCOPE)
+                        .claim("client_id", CLIENT_ID.getValue())
+                        .issuer(CLIENT_ID.getValue())
+                        .build();
+        var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet));
+        assertThrows(
+                RuntimeException.class,
+                () -> service.validateRequestObject(authRequest),
+                "Expected to throw exception");
+    }
+
+    @Test
+    void shouldThrowWhenInvalidClient() throws JOSEException {
+        when(dynamoClientService.getClient(CLIENT_ID.getValue())).thenReturn(Optional.empty());
+        var jwtClaimsSet =
+                new JWTClaimsSet.Builder()
+                        .audience(AUDIENCE)
+                        .claim("redirect_uri", REDIRECT_URI)
+                        .claim("response_type", ResponseType.CODE.toString())
+                        .claim("scope", SCOPE)
+                        .claim("client_id", CLIENT_ID.getValue())
+                        .issuer(CLIENT_ID.getValue())
+                        .build();
+        var signedJWT = generateSignedJWT(jwtClaimsSet);
+
+        assertThrows(
+                RuntimeException.class,
+                () -> service.validateRequestObject(generateAuthRequest(signedJWT)),
+                "Expected to throw exception");
+    }
+
+    @Test
+    void shouldReturnErrorForInvalidResponseType() throws JOSEException {
+        var jwtClaimsSet =
+                new JWTClaimsSet.Builder()
+                        .audience(AUDIENCE)
+                        .claim("redirect_uri", REDIRECT_URI)
+                        .claim("response_type", ResponseType.CODE_IDTOKEN.toString())
+                        .claim("scope", SCOPE)
+                        .issuer(CLIENT_ID.getValue())
+                        .claim("client_id", CLIENT_ID.getValue())
+                        .build();
+        var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet));
+        var requestObjectError = service.validateRequestObject(authRequest);
+
+        assertTrue(requestObjectError.isPresent());
+        assertThat(
+                requestObjectError.get().getErrorObject(),
+                equalTo(OAuth2Error.UNSUPPORTED_RESPONSE_TYPE));
+        assertThat(requestObjectError.get().getRedirectURI(), equalTo(REDIRECT_URI));
+    }
+
+    @Test
+    void shouldReturnErrorWhenClientIDIsInvalid() throws JOSEException {
+        var jwtClaimsSet =
+                new JWTClaimsSet.Builder()
+                        .audience(AUDIENCE)
+                        .claim("redirect_uri", REDIRECT_URI)
+                        .claim("response_type", ResponseType.CODE.toString())
+                        .claim("scope", SCOPE)
+                        .issuer(CLIENT_ID.getValue())
+                        .claim("client_id", "invalid-client-id")
+                        .build();
+        var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet));
+        var requestObjectError = service.validateRequestObject(authRequest);
+
+        assertTrue(requestObjectError.isPresent());
+        assertThat(
+                requestObjectError.get().getErrorObject(),
+                equalTo(OAuth2Error.UNAUTHORIZED_CLIENT));
+        assertThat(requestObjectError.get().getRedirectURI(), equalTo(REDIRECT_URI));
+    }
+
+    @Test
+    void shouldReturnErrorForUnsupportedScope() throws JOSEException {
+        var jwtClaimsSet =
+                new JWTClaimsSet.Builder()
+                        .audience(AUDIENCE)
+                        .claim("redirect_uri", REDIRECT_URI)
+                        .claim("response_type", ResponseType.CODE.toString())
+                        .claim("scope", "openid profile")
+                        .claim("client_id", CLIENT_ID.getValue())
+                        .issuer(CLIENT_ID.getValue())
+                        .build();
+        var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet));
+        var requestObjectError = service.validateRequestObject(authRequest);
+
+        assertTrue(requestObjectError.isPresent());
+        assertThat(requestObjectError.get().getErrorObject(), equalTo(OAuth2Error.INVALID_SCOPE));
+        assertThat(requestObjectError.get().getRedirectURI(), equalTo(REDIRECT_URI));
+    }
+
+    @Test
+    void shouldReturnErrorForUnregisteredScope() throws JOSEException {
+        var jwtClaimsSet =
+                new JWTClaimsSet.Builder()
+                        .audience(AUDIENCE)
+                        .claim("redirect_uri", REDIRECT_URI)
+                        .claim("response_type", ResponseType.CODE.toString())
+                        .claim("scope", "openid email")
+                        .claim("client_id", CLIENT_ID.getValue())
+                        .issuer(CLIENT_ID.getValue())
+                        .build();
+        var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet));
+        var requestObjectError = service.validateRequestObject(authRequest);
+
+        assertTrue(requestObjectError.isPresent());
+        assertThat(requestObjectError.get().getErrorObject(), equalTo(OAuth2Error.INVALID_SCOPE));
+        assertThat(requestObjectError.get().getRedirectURI(), equalTo(REDIRECT_URI));
+    }
+
+    @Test
+    void shouldReturnErrorForInvalidAudience() throws JOSEException {
+        var jwtClaimsSet =
+                new JWTClaimsSet.Builder()
+                        .audience("invalid-audience")
+                        .claim("redirect_uri", REDIRECT_URI)
+                        .claim("response_type", ResponseType.CODE.toString())
+                        .claim("scope", "openid")
+                        .claim("client_id", CLIENT_ID.getValue())
+                        .issuer(CLIENT_ID.getValue())
+                        .build();
+
+        var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet));
+        var requestObjectError = service.validateRequestObject(authRequest);
+
+        assertTrue(requestObjectError.isPresent());
+        assertThat(requestObjectError.get().getErrorObject(), equalTo(OAuth2Error.ACCESS_DENIED));
+        assertThat(requestObjectError.get().getRedirectURI(), equalTo(REDIRECT_URI));
+    }
+
+    @Test
+    void shouldReturnErrorForInvalidIssuer() throws JOSEException {
+        var jwtClaimsSet =
+                new JWTClaimsSet.Builder()
+                        .audience(AUDIENCE)
+                        .claim("redirect_uri", REDIRECT_URI)
+                        .claim("response_type", ResponseType.CODE.toString())
+                        .claim("scope", "openid")
+                        .claim("client_id", CLIENT_ID.getValue())
+                        .issuer("invalid-client")
+                        .build();
+        var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet));
+        var requestObjectError = service.validateRequestObject(authRequest);
+
+        assertTrue(requestObjectError.isPresent());
+        assertThat(
+                requestObjectError.get().getErrorObject(),
+                equalTo(OAuth2Error.UNAUTHORIZED_CLIENT));
+        assertThat(requestObjectError.get().getRedirectURI(), equalTo(REDIRECT_URI));
+    }
+
+    @Test
+    void shouldReturnErrorIfRequestClaimIsPresentJwt() throws JOSEException {
+        var jwtClaimsSet =
+                new JWTClaimsSet.Builder()
+                        .audience(AUDIENCE)
+                        .claim("redirect_uri", REDIRECT_URI)
+                        .claim("response_type", ResponseType.CODE.toString())
+                        .claim("scope", "openid")
+                        .claim("client_id", CLIENT_ID.getValue())
+                        .claim("request", "some-random-request-value")
+                        .issuer(CLIENT_ID.getValue())
+                        .build();
+        generateSignedJWT(jwtClaimsSet);
+        var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet));
+        var requestObjectError = service.validateRequestObject(authRequest);
+
+        assertTrue(requestObjectError.isPresent());
+        assertThat(requestObjectError.get().getErrorObject(), equalTo(OAuth2Error.INVALID_REQUEST));
+        assertThat(requestObjectError.get().getRedirectURI(), equalTo(REDIRECT_URI));
+    }
+
+    @Test
+    void shouldReturnErrorIfRequestUriClaimIsPresentJwt() throws JOSEException {
+        var jwtClaimsSet =
+                new JWTClaimsSet.Builder()
+                        .audience(AUDIENCE)
+                        .claim("redirect_uri", REDIRECT_URI)
+                        .claim("response_type", ResponseType.CODE.toString())
+                        .claim("scope", "openid")
+                        .claim("client_id", CLIENT_ID.getValue())
+                        .claim("request_uri", REQUEST_URI)
+                        .issuer(CLIENT_ID.getValue())
+                        .build();
+        var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet));
+        var requestObjectError = service.validateRequestObject(authRequest);
+
+        assertTrue(requestObjectError.isPresent());
+        assertThat(requestObjectError.get().getErrorObject(), equalTo(OAuth2Error.INVALID_REQUEST));
+        assertThat(requestObjectError.get().getRedirectURI(), equalTo(REDIRECT_URI));
+    }
+
+    @Test
+    void shouldThrowWhenUnableToValidateRequestJwtSignature()
+            throws JOSEException, NoSuchAlgorithmException {
+        var keyPair2 = KeyPairGenerator.getInstance("RSA").generateKeyPair();
+        var jwtClaimsSet =
+                new JWTClaimsSet.Builder()
+                        .audience(AUDIENCE)
+                        .claim("redirect_uri", REDIRECT_URI)
+                        .claim("response_type", ResponseType.CODE.toString())
+                        .claim("scope", SCOPE)
+                        .claim("client_id", CLIENT_ID.getValue())
+                        .issuer(CLIENT_ID.getValue())
+                        .build();
+        var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet, keyPair2));
+        assertThrows(
+                RuntimeException.class,
+                () -> service.validateRequestObject(authRequest),
+                "Expected to throw exception");
+    }
+
+    private SignedJWT generateSignedJWT(JWTClaimsSet jwtClaimsSet) throws JOSEException {
+        return generateSignedJWT(jwtClaimsSet, keyPair);
+    }
+
+    private SignedJWT generateSignedJWT(JWTClaimsSet jwtClaimsSet, KeyPair keyPair)
+            throws JOSEException {
+        var jwsHeader = new JWSHeader(JWSAlgorithm.RS256);
+        var signedJWT = new SignedJWT(jwsHeader, jwtClaimsSet);
+        var signer = new RSASSASigner(keyPair.getPrivate());
+        signedJWT.sign(signer);
+        return signedJWT;
+    }
+
+    private ClientRegistry generateClientRegistry() {
+        return new ClientRegistry()
+                .setClientID(CLIENT_ID.getValue())
+                .setPublicKey(
+                        Base64.getMimeEncoder().encodeToString(keyPair.getPublic().getEncoded()))
+                .setConsentRequired(false)
+                .setClientName("test-client")
+                .setScopes(List.of("openid"))
+                .setRedirectUrls(singletonList(REDIRECT_URI))
+                .setRequestUris(singletonList(REQUEST_URI.toString()))
+                .setSectorIdentifierUri("https://test.com")
+                .setSubjectType("pairwise");
+    }
+
+    private AuthenticationRequest generateAuthRequest(SignedJWT signedJWT) {
+        Scope scope = new Scope();
+        scope.add(OIDCScopeValue.OPENID);
+        AuthenticationRequest.Builder builder =
+                new AuthenticationRequest.Builder(
+                                ResponseType.CODE, scope, CLIENT_ID, URI.create(REDIRECT_URI))
+                        .state(STATE)
+                        .nonce(new Nonce())
+                        .requestObject(signedJWT);
+        return builder.build();
+    }
+}


### PR DESCRIPTION
## What?

-  When the request object is present in the auth request and the request object supported is set to true in config then call the RequestObjectService from authorize to validate the request object.
-  Create an AuthRequestError and return it as an optional from both the AuthorizationService and the RequestObjectService. This will allow us to set the redirect URI in the object when present and ensure that the user is redirected there in a case of an error. The redirect URI is present in the auth request when a request object is not present and is present in the request object when one is present. This allows us to cater for both scenarios.
- When the request object is present but the request object supported is set to false then call the authorization service. This service will then return a request object not supported error.

## Why?

- So we can allow some clients to use the request object param in the auth request. By default this feature flag is set to false.