### PR TITLE
AUT-268: Migrate logging subscription (1)

### DIFF
--- a/ci/tasks/deploy-acct-mgmt-api.yml
+++ b/ci/tasks/deploy-acct-mgmt-api.yml
@@ -38,6 +38,7 @@ run:
         -var "environment=${DEPLOY_ENVIRONMENT}" \
         -var "notify_api_key=${NOTIFY_API_KEY}" \
         -var 'logging_endpoint_arn=arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod' \
+        -var 'logging_endpoint_arns=["arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"]' \
         -var "lambda_zip_file=$(ls -1 ../../../../api-release/*.zip)" \
         -var "lambda_warmer_zip_file=$(ls -1 ../../../../lambda-warmer-release/*.zip)" \
         -var "common_state_bucket=${STATE_BUCKET}" \

--- a/ci/tasks/deploy-audit-processors.yml
+++ b/ci/tasks/deploy-audit-processors.yml
@@ -36,6 +36,7 @@ run:
         -var "environment=${DEPLOY_ENVIRONMENT}" \
         -var "shared_state_bucket=${STATE_BUCKET}" \
         -var 'logging_endpoint_arn=arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod' \
+        -var 'logging_endpoint_arns=["arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"]' \
         -var "audit_storage_expiry_days=${AUDIT_STORE_EXPIRY_DAYS}" \
         -var-file "${DEPLOY_ENVIRONMENT}-overrides.tfvars" \
 

--- a/ci/tasks/deploy-delivery-receipts-api.yml
+++ b/ci/tasks/deploy-delivery-receipts-api.yml
@@ -32,6 +32,7 @@ run:
         -var "deployer_role_arn=${DEPLOYER_ROLE_ARN}" \
         -var "environment=${DEPLOY_ENVIRONMENT}" \
         -var 'logging_endpoint_arn=arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod' \
+        -var 'logging_endpoint_arns=["arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"]' \
         -var "lambda_zip_file=$(ls -1 ../../../../delivery-receipts-api-release/*.zip)" \
         -var "common_state_bucket=${STATE_BUCKET}" \
         -var-file "${DEPLOY_ENVIRONMENT}-overrides.tfvars" \

--- a/ci/tasks/deploy-oidc-api.yml
+++ b/ci/tasks/deploy-oidc-api.yml
@@ -51,6 +51,7 @@ run:
         -var "notify_api_key=${NOTIFY_API_KEY}" \
         -var "environment=${DEPLOY_ENVIRONMENT}" \
         -var 'logging_endpoint_arn=arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod' \
+        -var 'logging_endpoint_arns=["arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"]' \
         -var "dns_state_bucket=${DNS_STATE_BUCKET}" \
         -var "dns_state_key=${DNS_STATE_KEY}" \
         -var "dns_state_role=${DNS_DEPLOYER_ROLE_ARN}" \

--- a/ci/tasks/deploy-shared-api.yml
+++ b/ci/tasks/deploy-shared-api.yml
@@ -42,6 +42,7 @@ run:
         -var "deployer_role_arn=${DEPLOYER_ROLE_ARN}" \
         -var "environment=${DEPLOY_ENVIRONMENT}" \
         -var 'logging_endpoint_arn=arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod' \
+        -var 'logging_endpoint_arns=["arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"]' \
         -var "test_client_email_allowlist=${TEST_CLIENT_EMAIL_ALLOWLIST}" \
         -var "test_users=${TEST_USERS}" \
         -var "password_pepper=${PASSWORD_PEPPER}" \

--- a/ci/terraform/account-management/variables.tf
+++ b/ci/terraform/account-management/variables.tf
@@ -95,6 +95,12 @@ variable "logging_endpoint_arn" {
   description = "Amazon Resource Name (ARN) for the endpoint to ship logs to"
 }
 
+variable "logging_endpoint_arns" {
+  type        = list(string)
+  default     = []
+  description = "Amazon Resource Name (ARN) for the CSLS endpoints to ship logs to"
+}
+
 variable "external_redis_host" {
   type    = string
   default = "redis"

--- a/ci/terraform/audit-processors/variables.tf
+++ b/ci/terraform/audit-processors/variables.tf
@@ -49,6 +49,12 @@ variable "logging_endpoint_arn" {
   description = "Amazon Resource Name (ARN) for the endpoint to ship logs to"
 }
 
+variable "logging_endpoint_arns" {
+  type        = list(string)
+  default     = []
+  description = "Amazon Resource Name (ARN) for the CSLS endpoints to ship logs to"
+}
+
 variable "audit_storage_expiry_days" {
   type        = number
   description = "How long before files in the audit store are expired (default: 7 years)"

--- a/ci/terraform/delivery-receipts/variables.tf
+++ b/ci/terraform/delivery-receipts/variables.tf
@@ -66,6 +66,12 @@ variable "logging_endpoint_arn" {
   description = "Amazon Resource Name (ARN) for the endpoint to ship logs to"
 }
 
+variable "logging_endpoint_arns" {
+  type        = list(string)
+  default     = []
+  description = "Amazon Resource Name (ARN) for the CSLS endpoints to ship logs to"
+}
+
 variable "aws_region" {
   default = "eu-west-2"
 }

--- a/ci/terraform/modules/endpoint-module/variables.tf
+++ b/ci/terraform/modules/endpoint-module/variables.tf
@@ -106,6 +106,12 @@ variable "logging_endpoint_arn" {
   description = "Amazon Resource Name (ARN) for the endpoint to ship logs to"
 }
 
+variable "logging_endpoint_arns" {
+  type        = list(string)
+  default     = []
+  description = "Amazon Resource Name (ARN) for the CSLS endpoints to ship logs to"
+}
+
 variable "use_localstack" {
   type = bool
 }

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -125,6 +125,12 @@ variable "logging_endpoint_arn" {
   description = "Amazon Resource Name (ARN) for the endpoint to ship logs to"
 }
 
+variable "logging_endpoint_arns" {
+  type        = list(string)
+  default     = []
+  description = "Amazon Resource Name (ARN) for the CSLS endpoints to ship logs to"
+}
+
 variable "stub_rp_clients" {
   default     = []
   type        = list(object({ client_name : string, callback_urls : list(string), logout_urls : list(string) }))


### PR DESCRIPTION
This sets up a new variable, `logging_endpoint_arns`, that will allow us to specify multiple logging endpoint subscriptions.

This PR doesn't use the variable yet, but does use the existing ARN in configuration.

The following PR will remove both `logging_endpoint_arn` and `logging_endpoint_enabled` (as an empty list is equivalent to no logging).
