### PR TITLE
AUT-303 - Create Dynamo table to store the Doc App Credential

### DIFF
--- a/ci/terraform/shared/dynamodb.tf
+++ b/ci/terraform/shared/dynamodb.tf
@@ -166,3 +166,37 @@ resource "aws_dynamodb_table" "spot_credential_table" {
 
   tags = local.default_tags
 }
+
+resource "aws_dynamodb_table" "doc_app_credential_table" {
+  count        = var.doc_app_api_enabled ? 1 : 0
+  name         = "${var.environment}-doc-app-credential"
+  billing_mode = var.provision_dynamo ? "PROVISIONED" : "PAY_PER_REQUEST"
+  hash_key     = "SubjectID"
+
+  read_capacity  = var.provision_dynamo ? var.dynamo_default_read_capacity : null
+  write_capacity = var.provision_dynamo ? var.dynamo_default_write_capacity : null
+
+  attribute {
+    name = "SubjectID"
+    type = "S"
+  }
+
+  point_in_time_recovery {
+    enabled = !var.use_localstack
+  }
+
+  server_side_encryption {
+    enabled = !var.use_localstack
+  }
+
+  lifecycle {
+    prevent_destroy = false
+  }
+
+  ttl {
+    attribute_name = "TimeToExist"
+    enabled        = true
+  }
+
+  tags = local.default_tags
+}

--- a/ci/terraform/shared/variables.tf
+++ b/ci/terraform/shared/variables.tf
@@ -111,6 +111,11 @@ variable "provision_dynamo" {
   default = false
 }
 
+variable "doc_app_api_enabled" {
+  type    = bool
+  default = false
+}
+
 variable "ipv_api_enabled" {
   default = false
 }

--- a/doc-checking-app-api/build.gradle
+++ b/doc-checking-app-api/build.gradle
@@ -7,7 +7,8 @@ group "uk.gov.di.authentication.ipvapi"
 version "unspecified"
 
 dependencies {
-    compileOnly configurations.lambda
+    compileOnly configurations.lambda,
+            configurations.dynamodb
 
     implementation configurations.jackson,
             configurations.nimbus,

--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/entity/DocAppCredential.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/entity/DocAppCredential.java
@@ -1,0 +1,43 @@
+package uk.gov.di.authentication.app.entity;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBAttribute;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
+
+public class DocAppCredential {
+
+    private String subjectID;
+    private String credential;
+    private long timeToExist;
+
+    public DocAppCredential() {}
+
+    @DynamoDBHashKey(attributeName = "SubjectID")
+    public String getSubjectID() {
+        return subjectID;
+    }
+
+    public DocAppCredential setSubjectID(String subjectID) {
+        this.subjectID = subjectID;
+        return this;
+    }
+
+    @DynamoDBAttribute(attributeName = "Credential")
+    public String getCredential() {
+        return credential;
+    }
+
+    public DocAppCredential setCredential(String credential) {
+        this.credential = credential;
+        return this;
+    }
+
+    @DynamoDBAttribute(attributeName = "TimeToExist")
+    public long getTimeToExist() {
+        return timeToExist;
+    }
+
+    public DocAppCredential setTimeToExist(long timeToExist) {
+        this.timeToExist = timeToExist;
+        return this;
+    }
+}

--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/services/DynamoDocAppService.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/services/DynamoDocAppService.java
@@ -1,0 +1,74 @@
+package uk.gov.di.authentication.app.services;
+
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperConfig;
+import uk.gov.di.authentication.app.entity.DocAppCredential;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+import java.util.Optional;
+
+public class DynamoDocAppService {
+
+    private static final String DOC_APP_CREDENTIAL_TABLE = "doc-app-credential";
+    private final DynamoDBMapper docAppCredentialMapper;
+    private final long timeToExist;
+    private final AmazonDynamoDB dynamoDB;
+
+    public DynamoDocAppService(ConfigurationService configurationService) {
+        this(
+                configurationService.getAwsRegion(),
+                configurationService.getEnvironment(),
+                configurationService.getDynamoEndpointUri(),
+                configurationService.getAccessTokenExpiry());
+    }
+
+    public DynamoDocAppService(
+            String region, String environment, Optional<String> dynamoEndpoint, long timeToExist) {
+        this.timeToExist = timeToExist;
+        dynamoDB =
+                dynamoEndpoint
+                        .map(
+                                t ->
+                                        AmazonDynamoDBClientBuilder.standard()
+                                                .withEndpointConfiguration(
+                                                        new AwsClientBuilder.EndpointConfiguration(
+                                                                t, region)))
+                        .orElse(AmazonDynamoDBClientBuilder.standard().withRegion(region))
+                        .build();
+        DynamoDBMapperConfig docAppConfig =
+                new DynamoDBMapperConfig.Builder()
+                        .withTableNameOverride(
+                                DynamoDBMapperConfig.TableNameOverride.withTableNameReplacement(
+                                        environment + "-" + DOC_APP_CREDENTIAL_TABLE))
+                        .withConsistentReads(DynamoDBMapperConfig.ConsistentReads.CONSISTENT)
+                        .build();
+        this.docAppCredentialMapper = new DynamoDBMapper(dynamoDB, docAppConfig);
+        warmUp(environment + "-" + DOC_APP_CREDENTIAL_TABLE);
+    }
+
+    public void addDocAppCredential(String subjectID, String credential) {
+        var docAppCredential =
+                new DocAppCredential()
+                        .setSubjectID(subjectID)
+                        .setCredential(credential)
+                        .setTimeToExist(timeToExist);
+
+        docAppCredentialMapper.save(docAppCredential);
+    }
+
+    public Optional<DocAppCredential> getDocAppCredential(String subjectID) {
+        return Optional.ofNullable(docAppCredentialMapper.load(DocAppCredential.class, subjectID));
+    }
+
+    public void deleteDocAppCredential(String subjectID) {
+        docAppCredentialMapper.delete(
+                docAppCredentialMapper.load(DocAppCredential.class, subjectID));
+    }
+
+    private void warmUp(String tableName) {
+        dynamoDB.describeTable(tableName);
+    }
+}


### PR DESCRIPTION
## What?

- Create a new table to store this credential where the Subject will be the key. Add a time to exist on it which we will set for the same time as the validity as the access token issued to the RP.
- Add a feature flag to for the doc-checking-app-api and default it to false. The dynamo table will only be created when this has been switched to true.


## Why?

- When we receive a credential in the DocAppCallbackHandler, we need to store this temporarily in dynamo. This is because we will only return it to the RP when we have received a valid access token via the OIDC flow.
