### PR TITLE
AUT-268: Migrate CSLS subscription (2)

### DIFF
--- a/ci/terraform/account-management/api-gateway.tf
+++ b/ci/terraform/account-management/api-gateway.tf
@@ -67,11 +67,11 @@ EOF
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "authorizer_log_subscription" {
-  count           = var.logging_endpoint_enabled ? 1 : 0
+  count           = length(var.logging_endpoint_arns)
   name            = "authorizer-log-subscription"
   log_group_name  = aws_cloudwatch_log_group.lambda_log_group[0].name
   filter_pattern  = ""
-  destination_arn = var.logging_endpoint_arn
+  destination_arn = var.logging_endpoint_arns[count.index]
 }
 
 resource "aws_iam_role" "invocation_role" {
@@ -158,11 +158,11 @@ resource "aws_cloudwatch_log_group" "account_management_stage_execution_logs" {
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "account_management_execution_log_subscription" {
-  count           = var.logging_endpoint_enabled ? 1 : 0
+  count           = length(var.logging_endpoint_arns)
   name            = "${var.environment}-oidc-api-execution-log-subscription"
   log_group_name  = aws_cloudwatch_log_group.account_management_stage_execution_logs[0].name
   filter_pattern  = ""
-  destination_arn = var.logging_endpoint_arn
+  destination_arn = var.logging_endpoint_arns[count.index]
 }
 
 resource "aws_cloudwatch_log_group" "account_management_access_logs" {
@@ -174,11 +174,11 @@ resource "aws_cloudwatch_log_group" "account_management_access_logs" {
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "account_management_access_log_subscription" {
-  count           = var.logging_endpoint_enabled ? 1 : 0
+  count           = length(var.logging_endpoint_arns)
   name            = "${var.environment}-account-management_-api-access-logs-subscription"
   log_group_name  = aws_cloudwatch_log_group.account_management_access_logs[0].name
   filter_pattern  = ""
-  destination_arn = var.logging_endpoint_arn
+  destination_arn = var.logging_endpoint_arns[count.index]
 }
 
 resource "aws_cloudwatch_log_group" "account_management_waf_logs" {
@@ -190,11 +190,11 @@ resource "aws_cloudwatch_log_group" "account_management_waf_logs" {
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "account_management_waf_log_subscription" {
-  count           = var.logging_endpoint_enabled ? 1 : 0
+  count           = length(var.logging_endpoint_arns)
   name            = "${var.environment}-account-management-api-waf-logs-subscription"
   log_group_name  = aws_cloudwatch_log_group.account_management_waf_logs[0].name
   filter_pattern  = ""
-  destination_arn = var.logging_endpoint_arn
+  destination_arn = var.logging_endpoint_arns[count.index]
 }
 
 resource "aws_api_gateway_stage" "stage" {

--- a/ci/terraform/account-management/authenticate.tf
+++ b/ci/terraform/account-management/authenticate.tf
@@ -46,8 +46,7 @@ module "authenticate" {
   subnet_id                              = local.private_subnet_ids
   environment                            = var.environment
   lambda_role_arn                        = module.account_management_api_authenticate_role.arn
-  logging_endpoint_enabled               = var.logging_endpoint_enabled
-  logging_endpoint_arn                   = var.logging_endpoint_arn
+  logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention
   lambda_env_vars_encryption_kms_key_arn = data.terraform_remote_state.shared.outputs.lambda_env_vars_encryption_kms_key_arn

--- a/ci/terraform/account-management/remove-account.tf
+++ b/ci/terraform/account-management/remove-account.tf
@@ -50,8 +50,7 @@ module "delete_account" {
   lambda_role_arn                        = module.account_management_api_remove_account_role.arn
   use_localstack                         = var.use_localstack
   default_tags                           = local.default_tags
-  logging_endpoint_enabled               = var.logging_endpoint_enabled
-  logging_endpoint_arn                   = var.logging_endpoint_arn
+  logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention
   lambda_env_vars_encryption_kms_key_arn = data.terraform_remote_state.shared.outputs.lambda_env_vars_encryption_kms_key_arn

--- a/ci/terraform/account-management/sandpit.tfvars
+++ b/ci/terraform/account-management/sandpit.tfvars
@@ -8,3 +8,4 @@ dns_state_key       = null
 dns_state_role      = null
 
 logging_endpoint_enabled = false
+logging_endpoint_arns    = []

--- a/ci/terraform/account-management/send_otp_notification.tf
+++ b/ci/terraform/account-management/send_otp_notification.tf
@@ -49,8 +49,7 @@ module "send_otp_notification" {
   ]
   subnet_id                              = local.private_subnet_ids
   lambda_role_arn                        = module.account_management_api_send_notification_role.arn
-  logging_endpoint_enabled               = var.logging_endpoint_enabled
-  logging_endpoint_arn                   = var.logging_endpoint_arn
+  logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention
   lambda_env_vars_encryption_kms_key_arn = data.terraform_remote_state.shared.outputs.lambda_env_vars_encryption_kms_key_arn

--- a/ci/terraform/account-management/sqs.tf
+++ b/ci/terraform/account-management/sqs.tf
@@ -210,12 +210,12 @@ resource "aws_cloudwatch_log_group" "sqs_lambda_log_group" {
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "sqs_lambda_log_subscription" {
-  count = var.logging_endpoint_enabled ? 1 : 0
+  count = length(var.logging_endpoint_arns)
 
   name            = "${aws_lambda_function.email_sqs_lambda.function_name}-log-subscription"
   log_group_name  = aws_cloudwatch_log_group.sqs_lambda_log_group[0].name
   filter_pattern  = ""
-  destination_arn = var.logging_endpoint_arn
+  destination_arn = var.logging_endpoint_arns[count.index]
 }
 
 resource "aws_lambda_alias" "sqs_lambda_active" {

--- a/ci/terraform/account-management/update-email.tf
+++ b/ci/terraform/account-management/update-email.tf
@@ -53,8 +53,7 @@ module "update_email" {
   lambda_role_arn                        = module.account_management_api_update_email_role.arn
   use_localstack                         = var.use_localstack
   default_tags                           = local.default_tags
-  logging_endpoint_enabled               = var.logging_endpoint_enabled
-  logging_endpoint_arn                   = var.logging_endpoint_arn
+  logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention
   lambda_env_vars_encryption_kms_key_arn = data.terraform_remote_state.shared.outputs.lambda_env_vars_encryption_kms_key_arn

--- a/ci/terraform/account-management/update-password.tf
+++ b/ci/terraform/account-management/update-password.tf
@@ -50,8 +50,7 @@ module "update_password" {
   lambda_role_arn                        = module.account_management_api_update_password_role.arn
   use_localstack                         = var.use_localstack
   default_tags                           = local.default_tags
-  logging_endpoint_enabled               = var.logging_endpoint_enabled
-  logging_endpoint_arn                   = var.logging_endpoint_arn
+  logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention
   lambda_env_vars_encryption_kms_key_arn = data.terraform_remote_state.shared.outputs.lambda_env_vars_encryption_kms_key_arn

--- a/ci/terraform/account-management/update-phone-number.tf
+++ b/ci/terraform/account-management/update-phone-number.tf
@@ -52,8 +52,7 @@ module "update_phone_number" {
   lambda_role_arn                        = module.account_management_api_update_phone_number_role.arn
   use_localstack                         = var.use_localstack
   default_tags                           = local.default_tags
-  logging_endpoint_enabled               = var.logging_endpoint_enabled
-  logging_endpoint_arn                   = var.logging_endpoint_arn
+  logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention
   lambda_env_vars_encryption_kms_key_arn = data.terraform_remote_state.shared.outputs.lambda_env_vars_encryption_kms_key_arn

--- a/ci/terraform/audit-processors/counter_fraud.tf
+++ b/ci/terraform/audit-processors/counter_fraud.tf
@@ -107,11 +107,11 @@ resource "aws_cloudwatch_log_group" "fraud_realtime_logging_lambda_log_group" {
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "fraud_realtime_logging_log_subscription" {
-  count           = var.logging_endpoint_enabled ? 1 : 0
+  count           = length(var.logging_endpoint_arns)
   name            = "${aws_lambda_function.fraud_realtime_logging_lambda.function_name}-log-subscription"
   log_group_name  = aws_cloudwatch_log_group.fraud_realtime_logging_lambda_log_group[0].name
   filter_pattern  = ""
-  destination_arn = var.logging_endpoint_arn
+  destination_arn = var.logging_endpoint_arns[count.index]
 }
 
 resource "aws_lambda_alias" "fraud_realtime_logging_lambda_active" {

--- a/ci/terraform/audit-processors/performance_analysis.tf
+++ b/ci/terraform/audit-processors/performance_analysis.tf
@@ -107,11 +107,11 @@ resource "aws_cloudwatch_log_group" "performance_analysis_logging_lambda_log_gro
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "performance_analysis_logging_log_subscription" {
-  count           = var.logging_endpoint_enabled ? 1 : 0
+  count           = length(var.logging_endpoint_arns)
   name            = "${aws_lambda_function.performance_analysis_logging_lambda.function_name}-log-subscription"
   log_group_name  = aws_cloudwatch_log_group.performance_analysis_logging_lambda_log_group[0].name
   filter_pattern  = ""
-  destination_arn = var.logging_endpoint_arn
+  destination_arn = var.logging_endpoint_arns[count.index]
 }
 
 resource "aws_lambda_alias" "performance_analysis_logging_lambda_active" {

--- a/ci/terraform/audit-processors/sandpit.tfvars
+++ b/ci/terraform/audit-processors/sandpit.tfvars
@@ -2,3 +2,4 @@ environment         = "sandpit"
 shared_state_bucket = "digital-identity-dev-tfstate"
 
 logging_endpoint_enabled = false
+logging_endpoint_arns    = []

--- a/ci/terraform/audit-processors/shared.tf
+++ b/ci/terraform/audit-processors/shared.tf
@@ -21,8 +21,7 @@ locals {
   lambda_iam_role_name                   = data.terraform_remote_state.shared.outputs.lambda_iam_role_name
   audit_signing_key_alias_name           = data.terraform_remote_state.shared.outputs.audit_signing_key_alias_name
   audit_signing_key_arn                  = data.terraform_remote_state.shared.outputs.audit_signing_key_arn
-  logging_endpoint_enabled               = var.logging_endpoint_enabled
-  logging_endpoint_arn                   = var.logging_endpoint_arn
+  logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = 5
   authentication_vpc_arn                 = data.terraform_remote_state.shared.outputs.authentication_vpc_arn

--- a/ci/terraform/audit-processors/storage.tf
+++ b/ci/terraform/audit-processors/storage.tf
@@ -195,11 +195,11 @@ resource "aws_cloudwatch_log_group" "lambda_log_group" {
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "log_subscription" {
-  count           = var.logging_endpoint_enabled ? 1 : 0
+  count           = length(var.logging_endpoint_arns)
   name            = "${aws_lambda_function.audit_processor_lambda.function_name}-log-subscription"
   log_group_name  = aws_cloudwatch_log_group.lambda_log_group[0].name
   filter_pattern  = ""
-  destination_arn = var.logging_endpoint_arn
+  destination_arn = var.logging_endpoint_arns[count.index]
 }
 
 resource "aws_lambda_alias" "active_processor" {

--- a/ci/terraform/delivery-receipts/api-gateway.tf
+++ b/ci/terraform/delivery-receipts/api-gateway.tf
@@ -33,11 +33,11 @@ resource "aws_cloudwatch_log_group" "delivery_receipts_api_stage_execution_logs"
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "delivery_receipts_api_execution_log_subscription" {
-  count           = var.logging_endpoint_enabled ? 1 : 0
+  count           = length(var.logging_endpoint_arns)
   name            = "${var.environment}-delivery-receipts-api-execution-log-subscription"
   log_group_name  = aws_cloudwatch_log_group.delivery_receipts_api_stage_execution_logs[0].name
   filter_pattern  = ""
-  destination_arn = var.logging_endpoint_arn
+  destination_arn = var.logging_endpoint_arns[count.index]
 }
 
 resource "aws_cloudwatch_log_group" "delivery_receipts_stage_access_logs" {
@@ -49,11 +49,11 @@ resource "aws_cloudwatch_log_group" "delivery_receipts_stage_access_logs" {
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "delivery_receipts_api_access_log_subscription" {
-  count           = var.logging_endpoint_enabled ? 1 : 0
+  count           = length(var.logging_endpoint_arns)
   name            = "${var.environment}-delivery-receipts-api-access-logs-subscription"
   log_group_name  = aws_cloudwatch_log_group.delivery_receipts_stage_access_logs[0].name
   filter_pattern  = ""
-  destination_arn = var.logging_endpoint_arn
+  destination_arn = var.logging_endpoint_arns[count.index]
 }
 
 resource "aws_api_gateway_stage" "endpoint_delivery_receipts_stage" {

--- a/ci/terraform/delivery-receipts/notify-callback.tf
+++ b/ci/terraform/delivery-receipts/notify-callback.tf
@@ -42,8 +42,7 @@ module "notify_callback" {
   ]
   subnet_id                              = local.private_subnet_ids
   lambda_role_arn                        = module.delivery_receipts_api_notify_callback_role.arn
-  logging_endpoint_enabled               = var.logging_endpoint_enabled
-  logging_endpoint_arn                   = var.logging_endpoint_arn
+  logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention
   lambda_env_vars_encryption_kms_key_arn = data.terraform_remote_state.shared.outputs.lambda_env_vars_encryption_kms_key_arn

--- a/ci/terraform/delivery-receipts/sandpit.tfvars
+++ b/ci/terraform/delivery-receipts/sandpit.tfvars
@@ -2,3 +2,4 @@ environment         = "sandpit"
 common_state_bucket = "digital-identity-dev-tfstate"
 
 logging_endpoint_enabled = false
+logging_endpoint_arns    = []

--- a/ci/terraform/modules/endpoint-module/lambda.tf
+++ b/ci/terraform/modules/endpoint-module/lambda.tf
@@ -47,11 +47,11 @@ resource "aws_cloudwatch_log_group" "lambda_log_group" {
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "log_subscription" {
-  count           = var.logging_endpoint_enabled ? 1 : 0
+  count           = length(var.logging_endpoint_arns)
   name            = "${var.endpoint_name}-log-subscription"
   log_group_name  = aws_cloudwatch_log_group.lambda_log_group[0].name
   filter_pattern  = ""
-  destination_arn = var.logging_endpoint_arn
+  destination_arn = var.logging_endpoint_arns[count.index]
 }
 
 resource "aws_lambda_alias" "endpoint_lambda" {

--- a/ci/terraform/oidc/api-gateway-frontend.tf
+++ b/ci/terraform/oidc/api-gateway-frontend.tf
@@ -89,11 +89,11 @@ resource "aws_cloudwatch_log_group" "frontend_api_stage_execution_logs" {
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "frontend_api_execution_log_subscription" {
-  count           = var.logging_endpoint_enabled ? 1 : 0
+  count           = length(var.logging_endpoint_arns)
   name            = "${var.environment}-frontend-api-execution-log-subscription"
   log_group_name  = aws_cloudwatch_log_group.frontend_api_stage_execution_logs[0].name
   filter_pattern  = ""
-  destination_arn = var.logging_endpoint_arn
+  destination_arn = var.logging_endpoint_arns[count.index]
 }
 
 resource "aws_cloudwatch_log_group" "frontend_stage_access_logs" {
@@ -105,11 +105,11 @@ resource "aws_cloudwatch_log_group" "frontend_stage_access_logs" {
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "frontend_api_access_log_subscription" {
-  count           = var.logging_endpoint_enabled ? 1 : 0
+  count           = length(var.logging_endpoint_arns)
   name            = "${var.environment}-frontend-api-access-logs-subscription"
   log_group_name  = aws_cloudwatch_log_group.frontend_stage_access_logs[0].name
   filter_pattern  = ""
-  destination_arn = var.logging_endpoint_arn
+  destination_arn = var.logging_endpoint_arns[count.index]
 }
 
 resource "aws_cloudwatch_log_group" "frontend_waf_logs" {
@@ -121,11 +121,11 @@ resource "aws_cloudwatch_log_group" "frontend_waf_logs" {
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "frontend_api_waf_log_subscription" {
-  count           = var.logging_endpoint_enabled ? 1 : 0
+  count           = length(var.logging_endpoint_arns)
   name            = "${var.environment}-frontend-api-waf-logs-subscription"
   log_group_name  = aws_cloudwatch_log_group.frontend_waf_logs[0].name
   filter_pattern  = ""
-  destination_arn = var.logging_endpoint_arn
+  destination_arn = var.logging_endpoint_arns[count.index]
 }
 
 resource "aws_api_gateway_stage" "endpoint_frontend_stage" {

--- a/ci/terraform/oidc/api-gateway.tf
+++ b/ci/terraform/oidc/api-gateway.tf
@@ -158,11 +158,11 @@ resource "aws_cloudwatch_log_group" "oidc_stage_execution_logs" {
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "oidc_api_execution_log_subscription" {
-  count           = var.logging_endpoint_enabled ? 1 : 0
+  count           = length(var.logging_endpoint_arns)
   name            = "${var.environment}-oidc-api-execution-log-subscription"
   log_group_name  = aws_cloudwatch_log_group.oidc_stage_execution_logs[0].name
   filter_pattern  = ""
-  destination_arn = var.logging_endpoint_arn
+  destination_arn = var.logging_endpoint_arns[count.index]
 }
 
 resource "aws_cloudwatch_log_group" "oidc_stage_access_logs" {
@@ -174,11 +174,11 @@ resource "aws_cloudwatch_log_group" "oidc_stage_access_logs" {
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "oidc_access_log_subscription" {
-  count           = var.logging_endpoint_enabled ? 1 : 0
+  count           = length(var.logging_endpoint_arns)
   name            = "${var.environment}-oidc-api-access-logs-subscription"
   log_group_name  = aws_cloudwatch_log_group.oidc_stage_access_logs[0].name
   filter_pattern  = ""
-  destination_arn = var.logging_endpoint_arn
+  destination_arn = var.logging_endpoint_arns[count.index]
 }
 
 resource "aws_cloudwatch_log_group" "oidc_waf_logs" {
@@ -190,11 +190,11 @@ resource "aws_cloudwatch_log_group" "oidc_waf_logs" {
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "oidc_waf_log_subscription" {
-  count           = var.logging_endpoint_enabled ? 1 : 0
+  count           = length(var.logging_endpoint_arns)
   name            = "${var.environment}-oidc-api-waf-logs-subscription"
   log_group_name  = aws_cloudwatch_log_group.oidc_waf_logs[0].name
   filter_pattern  = ""
-  destination_arn = var.logging_endpoint_arn
+  destination_arn = var.logging_endpoint_arns[count.index]
 }
 
 resource "aws_api_gateway_stage" "endpoint_stage" {

--- a/ci/terraform/oidc/auth-code.tf
+++ b/ci/terraform/oidc/auth-code.tf
@@ -52,8 +52,7 @@ module "auth-code" {
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.oidc_auth_code_role.arn
   environment                            = var.environment
-  logging_endpoint_enabled               = var.logging_endpoint_enabled
-  logging_endpoint_arn                   = var.logging_endpoint_arn
+  logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention
   lambda_env_vars_encryption_kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn

--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -54,8 +54,7 @@ module "authorize" {
   ]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.oidc_authorize_role.arn
-  logging_endpoint_enabled               = var.logging_endpoint_enabled
-  logging_endpoint_arn                   = var.logging_endpoint_arn
+  logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention
   lambda_env_vars_encryption_kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn

--- a/ci/terraform/oidc/backchannel-logout-request.tf
+++ b/ci/terraform/oidc/backchannel-logout-request.tf
@@ -51,11 +51,11 @@ resource "aws_cloudwatch_log_group" "backchannel_logout_request_lambda_log_group
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "backchannel_logout_request_lambda_log_subscription" {
-  count           = var.logging_endpoint_enabled ? 1 : 0
+  count           = length(var.logging_endpoint_arns)
   name            = "${aws_lambda_function.backchannel_logout_request_lambda.function_name}-log-subscription"
   log_group_name  = aws_cloudwatch_log_group.backchannel_logout_request_lambda_log_group[0].name
   filter_pattern  = ""
-  destination_arn = var.logging_endpoint_arn
+  destination_arn = var.logging_endpoint_arns[count.index]
 }
 
 resource "aws_lambda_alias" "backchannel_logout_request_lambda_active" {

--- a/ci/terraform/oidc/doc-app-authorize.tf
+++ b/ci/terraform/oidc/doc-app-authorize.tf
@@ -54,8 +54,7 @@ module "doc-app-authorize" {
   ]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.doc_app_authorize_role.arn
-  logging_endpoint_enabled               = var.logging_endpoint_enabled
-  logging_endpoint_arn                   = var.logging_endpoint_arn
+  logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention
   lambda_env_vars_encryption_kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn

--- a/ci/terraform/oidc/ipv-authorize.tf
+++ b/ci/terraform/oidc/ipv-authorize.tf
@@ -60,8 +60,7 @@ module "ipv-authorize" {
   ]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.ipv_authorize_role.arn
-  logging_endpoint_enabled               = var.logging_endpoint_enabled
-  logging_endpoint_arn                   = var.logging_endpoint_arn
+  logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention
   lambda_env_vars_encryption_kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn

--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -63,8 +63,7 @@ module "ipv-callback" {
   ]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.ipv_callback_role.arn
-  logging_endpoint_enabled               = var.logging_endpoint_enabled
-  logging_endpoint_arn                   = var.logging_endpoint_arn
+  logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention
   lambda_env_vars_encryption_kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn

--- a/ci/terraform/oidc/ipv-capacity.tf
+++ b/ci/terraform/oidc/ipv-capacity.tf
@@ -53,8 +53,7 @@ module "ipv-capacity" {
   ]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.ipv_capacity_role.arn
-  logging_endpoint_enabled               = var.logging_endpoint_enabled
-  logging_endpoint_arn                   = var.logging_endpoint_arn
+  logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention
   lambda_env_vars_encryption_kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn

--- a/ci/terraform/oidc/jwks.tf
+++ b/ci/terraform/oidc/jwks.tf
@@ -42,8 +42,7 @@ module "jwks" {
   security_group_ids                     = [local.authentication_security_group_id]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.oidc_jwks_role.arn
-  logging_endpoint_enabled               = var.logging_endpoint_enabled
-  logging_endpoint_arn                   = var.logging_endpoint_arn
+  logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention
   lambda_env_vars_encryption_kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn

--- a/ci/terraform/oidc/login.tf
+++ b/ci/terraform/oidc/login.tf
@@ -55,8 +55,7 @@ module "login" {
   ]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.frontend_api_login_role.arn
-  logging_endpoint_enabled               = var.logging_endpoint_enabled
-  logging_endpoint_arn                   = var.logging_endpoint_arn
+  logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention
   lambda_env_vars_encryption_kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn

--- a/ci/terraform/oidc/logout.tf
+++ b/ci/terraform/oidc/logout.tf
@@ -55,8 +55,7 @@ module "logout" {
   ]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.oidc_logout_role.arn
-  logging_endpoint_enabled               = var.logging_endpoint_enabled
-  logging_endpoint_arn                   = var.logging_endpoint_arn
+  logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention
   lambda_env_vars_encryption_kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn

--- a/ci/terraform/oidc/mfa.tf
+++ b/ci/terraform/oidc/mfa.tf
@@ -53,8 +53,7 @@ module "mfa" {
   ]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.frontend_api_mfa_role.arn
-  logging_endpoint_enabled               = var.logging_endpoint_enabled
-  logging_endpoint_arn                   = var.logging_endpoint_arn
+  logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention
   lambda_env_vars_encryption_kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn

--- a/ci/terraform/oidc/register.tf
+++ b/ci/terraform/oidc/register.tf
@@ -47,8 +47,7 @@ module "register" {
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.client_registry_role.arn
   environment                            = var.environment
-  logging_endpoint_enabled               = var.logging_endpoint_enabled
-  logging_endpoint_arn                   = var.logging_endpoint_arn
+  logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention
   lambda_env_vars_encryption_kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn

--- a/ci/terraform/oidc/reset-password-request.tf
+++ b/ci/terraform/oidc/reset-password-request.tf
@@ -55,8 +55,7 @@ module "reset-password-request" {
   ]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.frontend_api_reset_password_request_role.arn
-  logging_endpoint_enabled               = var.logging_endpoint_enabled
-  logging_endpoint_arn                   = var.logging_endpoint_arn
+  logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention
   lambda_env_vars_encryption_kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn

--- a/ci/terraform/oidc/reset_password.tf
+++ b/ci/terraform/oidc/reset_password.tf
@@ -54,8 +54,7 @@ module "reset_password" {
   ]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.frontend_api_reset_password_role.arn
-  logging_endpoint_enabled               = var.logging_endpoint_enabled
-  logging_endpoint_arn                   = var.logging_endpoint_arn
+  logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention
   lambda_env_vars_encryption_kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn

--- a/ci/terraform/oidc/sandpit.tfvars
+++ b/ci/terraform/oidc/sandpit.tfvars
@@ -13,5 +13,6 @@ ipv_authorisation_callback_uri      = ""
 ipv_authorisation_uri               = ""
 ipv_authorisation_client_id         = ""
 logging_endpoint_enabled            = false
+logging_endpoint_arns               = []
 
 enable_api_gateway_execution_request_tracing = true

--- a/ci/terraform/oidc/send_notification.tf
+++ b/ci/terraform/oidc/send_notification.tf
@@ -52,8 +52,7 @@ module "send_notification" {
   ]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.frontend_api_send_notification_role.arn
-  logging_endpoint_enabled               = var.logging_endpoint_enabled
-  logging_endpoint_arn                   = var.logging_endpoint_arn
+  logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention
   lambda_env_vars_encryption_kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn

--- a/ci/terraform/oidc/signup.tf
+++ b/ci/terraform/oidc/signup.tf
@@ -52,8 +52,7 @@ module "signup" {
   ]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.frontend_api_signup_role.arn
-  logging_endpoint_enabled               = var.logging_endpoint_enabled
-  logging_endpoint_arn                   = var.logging_endpoint_arn
+  logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention
   lambda_env_vars_encryption_kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn

--- a/ci/terraform/oidc/spot-response.tf
+++ b/ci/terraform/oidc/spot-response.tf
@@ -58,11 +58,11 @@ resource "aws_cloudwatch_log_group" "spot_response_lambda_log_group" {
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "spot_response_lambda_log_subscription" {
-  count           = var.logging_endpoint_enabled && var.ipv_api_enabled ? 1 : 0
+  count           = var.ipv_api_enabled ? length(var.logging_endpoint_arns) : 0
   name            = "${aws_lambda_function.spot_response_lambda[0].function_name}-log-subscription"
   log_group_name  = aws_cloudwatch_log_group.spot_response_lambda_log_group[0].name
   filter_pattern  = ""
-  destination_arn = var.logging_endpoint_arn
+  destination_arn = var.logging_endpoint_arns[count.index]
 }
 
 resource "aws_lambda_alias" "spot_response_lambda_active" {

--- a/ci/terraform/oidc/sqs.tf
+++ b/ci/terraform/oidc/sqs.tf
@@ -200,11 +200,11 @@ resource "aws_cloudwatch_log_group" "sqs_lambda_log_group" {
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "sqs_lambda_log_subscription" {
-  count           = var.logging_endpoint_enabled ? 1 : 0
+  count           = length(var.logging_endpoint_arns)
   name            = "${aws_lambda_function.email_sqs_lambda.function_name}-log-subscription"
   log_group_name  = aws_cloudwatch_log_group.sqs_lambda_log_group[0].name
   filter_pattern  = ""
-  destination_arn = var.logging_endpoint_arn
+  destination_arn = var.logging_endpoint_arns[count.index]
 }
 
 resource "aws_lambda_alias" "sqs_lambda_active" {

--- a/ci/terraform/oidc/start.tf
+++ b/ci/terraform/oidc/start.tf
@@ -51,8 +51,7 @@ module "start" {
   ]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.frontend_api_start_role.arn
-  logging_endpoint_enabled               = var.logging_endpoint_enabled
-  logging_endpoint_arn                   = var.logging_endpoint_arn
+  logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention
   lambda_env_vars_encryption_kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn

--- a/ci/terraform/oidc/token.tf
+++ b/ci/terraform/oidc/token.tf
@@ -79,8 +79,7 @@ module "token" {
   ]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.oidc_token_role.arn
-  logging_endpoint_enabled               = var.logging_endpoint_enabled
-  logging_endpoint_arn                   = var.logging_endpoint_arn
+  logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention
   lambda_env_vars_encryption_kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn

--- a/ci/terraform/oidc/trustmarks.tf
+++ b/ci/terraform/oidc/trustmarks.tf
@@ -41,8 +41,7 @@ module "trustmarks" {
   security_group_ids                     = [local.authentication_security_group_id]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.oidc_trustmarks_role.arn
-  logging_endpoint_enabled               = var.logging_endpoint_enabled
-  logging_endpoint_arn                   = var.logging_endpoint_arn
+  logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention
   lambda_env_vars_encryption_kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn

--- a/ci/terraform/oidc/update.tf
+++ b/ci/terraform/oidc/update.tf
@@ -51,8 +51,7 @@ module "update" {
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.client_update_role.arn
   environment                            = var.environment
-  logging_endpoint_enabled               = var.logging_endpoint_enabled
-  logging_endpoint_arn                   = var.logging_endpoint_arn
+  logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention
   lambda_env_vars_encryption_kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn

--- a/ci/terraform/oidc/update_profile.tf
+++ b/ci/terraform/oidc/update_profile.tf
@@ -53,8 +53,7 @@ module "update_profile" {
   ]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.frontend_api_update_profile_role.arn
-  logging_endpoint_enabled               = var.logging_endpoint_enabled
-  logging_endpoint_arn                   = var.logging_endpoint_arn
+  logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention
   lambda_env_vars_encryption_kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn

--- a/ci/terraform/oidc/userexists.tf
+++ b/ci/terraform/oidc/userexists.tf
@@ -52,8 +52,7 @@ module "userexists" {
   ]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.frontend_api_user_exists_role.arn
-  logging_endpoint_enabled               = var.logging_endpoint_enabled
-  logging_endpoint_arn                   = var.logging_endpoint_arn
+  logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention
   lambda_env_vars_encryption_kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -53,8 +53,7 @@ module "userinfo" {
   ]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.oidc_userinfo_role.arn
-  logging_endpoint_enabled               = var.logging_endpoint_enabled
-  logging_endpoint_arn                   = var.logging_endpoint_arn
+  logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention
   lambda_env_vars_encryption_kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn

--- a/ci/terraform/oidc/verify_code.tf
+++ b/ci/terraform/oidc/verify_code.tf
@@ -57,8 +57,7 @@ module "verify_code" {
   ]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.frontend_api_verify_code_role.arn
-  logging_endpoint_enabled               = var.logging_endpoint_enabled
-  logging_endpoint_arn                   = var.logging_endpoint_arn
+  logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention
   lambda_env_vars_encryption_kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn

--- a/ci/terraform/oidc/wellknown.tf
+++ b/ci/terraform/oidc/wellknown.tf
@@ -37,8 +37,7 @@ module "openid_configuration_discovery" {
   security_group_ids                     = [local.authentication_security_group_id]
   subnet_id                              = local.authentication_subnet_ids
   lambda_role_arn                        = module.openid_configuration_role.arn
-  logging_endpoint_enabled               = var.logging_endpoint_enabled
-  logging_endpoint_arn                   = var.logging_endpoint_arn
+  logging_endpoint_arns                  = var.logging_endpoint_arns
   cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
   cloudwatch_log_retention               = var.cloudwatch_log_retention
   lambda_env_vars_encryption_kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn

--- a/ci/terraform/shared/sns-alerts.tf
+++ b/ci/terraform/shared/sns-alerts.tf
@@ -112,10 +112,10 @@ resource "aws_cloudwatch_log_group" "sns_log_group" {
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "log_subscription" {
-  count           = var.logging_endpoint_enabled ? 1 : 0
+  count           = length(var.logging_endpoint_arns)
   name            = "${aws_sns_topic.slack_events.name}-log-subscription"
   log_group_name  = aws_cloudwatch_log_group.sns_log_group[0].name
   filter_pattern  = ""
-  destination_arn = var.logging_endpoint_arn
+  destination_arn = var.logging_endpoint_arns[count.index]
 }
 

--- a/ci/terraform/shared/variables.tf
+++ b/ci/terraform/shared/variables.tf
@@ -81,6 +81,12 @@ variable "logging_endpoint_arn" {
   description = "Amazon Resource Name (ARN) for the endpoint to ship logs to"
 }
 
+variable "logging_endpoint_arns" {
+  type        = list(string)
+  default     = []
+  description = "Amazon Resource Name (ARN) for the CSLS endpoints to ship logs to"
+}
+
 variable "stub_rp_clients" {
   default     = []
   type        = list(object({ client_name : string, callback_urls : list(string), logout_urls : list(string), test_client : string }))


### PR DESCRIPTION
This PR uses the new `logging_endpoint_arns` variable rather than the two previous variables.

We keep the old variables around and will remove them in a later PR
