### PR TITLE
AUT-296 -  Add terraform for the doc app authorize lambda

### DIFF
--- a/ci/tasks/deploy-oidc-api.yml
+++ b/ci/tasks/deploy-oidc-api.yml
@@ -24,6 +24,7 @@ inputs:
   - name: frontend-api-release
   - name: client-registry-api-release
   - name: ipv-api-release
+  - name: doc-checking-app-api-release
   - name: lambda-warmer-release
   - name: shared-terraform-outputs
 outputs:
@@ -46,6 +47,7 @@ run:
         -var "frontend_api_lambda_zip_file=$(ls -1 ../../../../frontend-api-release/*.zip)" \
         -var "client_registry_api_lambda_zip_file=$(ls -1 ../../../../client-registry-api-release/*.zip)" \
         -var "ipv_api_lambda_zip_file=$(ls -1 ../../../../ipv-api-release/*.zip)" \
+        -var "doc_checking_app_api_lambda_zip_file=$(ls -1 ../../../../doc-checking-app-api-release/*.zip)" \
         -var "lambda_warmer_zip_file=$(ls -1 ../../../../lambda-warmer-release/*.zip)" \
         -var "deployer_role_arn=${DEPLOYER_ROLE_ARN}" \
         -var "notify_api_key=${NOTIFY_API_KEY}" \

--- a/ci/terraform/oidc/doc-app-authorize.tf
+++ b/ci/terraform/oidc/doc-app-authorize.tf
@@ -1,0 +1,79 @@
+module "doc_app_authorize_role" {
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "doc-app-authorize-role"
+  vpc_arn     = local.authentication_vpc_arn
+
+  policies_to_attach = [
+    aws_iam_policy.redis_parameter_policy.arn,
+    aws_iam_policy.doc_app_auth_kms_policy.arn,
+    aws_iam_policy.doc_app_public_encryption_key_parameter_policy.arn,
+  ]
+}
+
+module "doc-app-authorize" {
+  count  = var.doc_app_api_enabled ? 1 : 0
+  source = "../modules/endpoint-module"
+
+  endpoint_name   = "doc-checking-app-authorize"
+  path_part       = "doc-checking-app-authorize"
+  endpoint_method = "POST"
+  environment     = var.environment
+
+  handler_environment_variables = {
+    ENVIRONMENT                        = var.environment
+    EVENTS_SNS_TOPIC_ARN               = aws_sns_topic.events.arn
+    AUDIT_SIGNING_KEY_ALIAS            = local.audit_signing_key_alias_name
+    LOCALSTACK_ENDPOINT                = var.use_localstack ? var.localstack_endpoint : null
+    REDIS_KEY                          = local.redis_key
+    DYNAMO_ENDPOINT                    = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    DOC_APP_AUTHORISATION_URI          = var.doc_app_authorisation_uri
+    DOC_APP_AUTHORISATION_CALLBACK_URI = var.doc_app_authorisation_callback_uri
+    DOC_APP_AUTHORISATION_CLIENT_ID    = var.doc_app_authorisation_client_id
+    DOC_APP_TOKEN_SIGNING_KEY_ALIAS    = local.doc_app_auth_key_alias_name
+  }
+  handler_function_name = "uk.gov.di.authentication.app.lambda.DocAppAuthorizeHandler::handleRequest"
+
+  create_endpoint  = true
+  rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
+  root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
+  execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
+  memory_size      = var.endpoint_memory_size
+
+  source_bucket                  = aws_s3_bucket.source_bucket.bucket
+  lambda_zip_file                = aws_s3_bucket_object.doc_checking_app_api_release_zip.key
+  lambda_zip_file_version        = aws_s3_bucket_object.doc_checking_app_api_release_zip.version_id
+  warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
+  warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+  code_signing_config_arn        = local.lambda_code_signing_configuration_arn
+
+  authentication_vpc_arn = local.authentication_vpc_arn
+  security_group_ids = [
+    local.authentication_security_group_id,
+    local.authentication_oidc_redis_security_group_id,
+  ]
+  subnet_id                              = local.authentication_subnet_ids
+  lambda_role_arn                        = module.doc_app_authorize_role.arn
+  logging_endpoint_enabled               = var.logging_endpoint_enabled
+  logging_endpoint_arn                   = var.logging_endpoint_arn
+  cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  cloudwatch_log_retention               = var.cloudwatch_log_retention
+  lambda_env_vars_encryption_kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn
+  default_tags                           = local.default_tags
+  api_key_required                       = true
+
+  keep_lambda_warm             = var.keep_lambdas_warm
+  warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
+  warmer_security_group_ids    = [local.authentication_security_group_id]
+  warmer_handler_environment_variables = {
+    LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
+  }
+
+  use_localstack = var.use_localstack
+
+  depends_on = [
+    aws_api_gateway_rest_api.di_authentication_frontend_api,
+    aws_api_gateway_resource.connect_resource,
+    aws_api_gateway_resource.wellknown_resource,
+  ]
+}

--- a/ci/terraform/oidc/kms-policies.tf
+++ b/ci/terraform/oidc/kms-policies.tf
@@ -60,3 +60,28 @@ resource "aws_iam_policy" "ipv_token_auth_kms_policy" {
 
   policy = data.aws_iam_policy_document.ipv_token_auth_kms_policy_document.json
 }
+
+### Doc App signing key access
+
+data "aws_iam_policy_document" "doc_app_auth_kms_policy_document" {
+  statement {
+    sid    = "AllowAccessToKmsSigningKey"
+    effect = "Allow"
+
+    actions = [
+      "kms:Sign",
+      "kms:GetPublicKey",
+    ]
+    resources = [
+      local.doc_app_auth_signing_key_arn
+    ]
+  }
+}
+
+resource "aws_iam_policy" "doc_app_auth_kms_policy" {
+  name_prefix = "kms-doc-app-auth-policy"
+  path        = "/${var.environment}/doc-app/"
+  description = "IAM policy for managing Doc app authentication KMS key access"
+
+  policy = data.aws_iam_policy_document.doc_app_auth_kms_policy_document.json
+}

--- a/ci/terraform/oidc/s3-objects.tf
+++ b/ci/terraform/oidc/s3-objects.tf
@@ -50,3 +50,12 @@ resource "aws_s3_bucket_object" "ipv_api_release_zip" {
   source                 = var.ipv_api_lambda_zip_file
   source_hash            = filemd5(var.ipv_api_lambda_zip_file)
 }
+
+resource "aws_s3_bucket_object" "doc_checking_app_api_release_zip" {
+  bucket = aws_s3_bucket.source_bucket.bucket
+  key    = "doc-checking-app-api-release.zip"
+
+  server_side_encryption = "AES256"
+  source                 = var.doc_checking_app_api_lambda_zip_file
+  source_hash            = filemd5(var.doc_checking_app_api_lambda_zip_file)
+}

--- a/ci/terraform/oidc/shared.tf
+++ b/ci/terraform/oidc/shared.tf
@@ -26,6 +26,8 @@ locals {
   id_token_signing_key_arn                    = data.terraform_remote_state.shared.outputs.id_token_signing_key_arn
   ipv_token_auth_key_alias_name               = data.terraform_remote_state.shared.outputs.ipv_token_auth_signing_key_alias_name
   ipv_token_auth_signing_key_arn              = data.terraform_remote_state.shared.outputs.ipv_token_auth_signing_key_arn
+  doc_app_auth_key_alias_name                 = data.terraform_remote_state.shared.outputs.doc_app_auth_signing_key_alias_name
+  doc_app_auth_signing_key_arn                = data.terraform_remote_state.shared.outputs.doc_app_auth_signing_key_arn
   audit_signing_key_alias_name                = data.terraform_remote_state.shared.outputs.audit_signing_key_alias_name
   audit_signing_key_arn                       = data.terraform_remote_state.shared.outputs.audit_signing_key_arn
   sms_bucket_name                             = data.terraform_remote_state.shared.outputs.sms_bucket_name

--- a/ci/terraform/oidc/ssm.tf
+++ b/ci/terraform/oidc/ssm.tf
@@ -59,3 +59,31 @@ resource "aws_iam_policy" "ipv_public_encryption_key_parameter_policy" {
   name_prefix = "ipv-public-encryption-key-parameter-store-policy"
 }
 
+resource "aws_ssm_parameter" "doc_app_public_encryption_key" {
+  name  = "${var.environment}-doc-app-public-encryption-key"
+  type  = "String"
+  value = var.doc_app_auth_public_encryption_key
+}
+
+data "aws_iam_policy_document" "doc_app_public_encryption_key_parameter_policy_document" {
+  statement {
+    sid    = "AllowGetParameters"
+    effect = "Allow"
+
+    actions = [
+      "ssm:GetParameter",
+      "ssm:GetParameters",
+    ]
+
+    resources = [
+      aws_ssm_parameter.doc_app_public_encryption_key.arn
+    ]
+  }
+}
+
+resource "aws_iam_policy" "doc_app_public_encryption_key_parameter_policy" {
+  policy      = data.aws_iam_policy_document.doc_app_public_encryption_key_parameter_policy_document.json
+  path        = "/${var.environment}/lambda-parameters/"
+  name_prefix = "doc-app-public-encryption-key-parameter-store-policy"
+}
+

--- a/ci/terraform/oidc/staging-overrides.tfvars
+++ b/ci/terraform/oidc/staging-overrides.tfvars
@@ -1,10 +1,21 @@
-ipv_api_enabled                = true
-ipv_authorisation_client_id    = "authOrchestrator"
-ipv_authorisation_uri          = "https://staging-di-ipv-core-front.london.cloudapps.digital/oauth2/authorize"
-ipv_authorisation_callback_uri = "https://oidc.staging.account.gov.uk/ipv-callback"
-ipv_backend_uri                = "https://18zwbqzm0k.execute-api.eu-west-2.amazonaws.com/staging"
-ipv_domain                     = "https://ipv.account.gov.uk"
-ipv_auth_public_encryption_key = <<-EOT
+ipv_api_enabled                    = true
+ipv_authorisation_client_id        = "authOrchestrator"
+ipv_authorisation_uri              = "https://staging-di-ipv-core-front.london.cloudapps.digital/oauth2/authorize"
+ipv_authorisation_callback_uri     = "https://oidc.staging.account.gov.uk/ipv-callback"
+ipv_backend_uri                    = "https://18zwbqzm0k.execute-api.eu-west-2.amazonaws.com/staging"
+ipv_domain                         = "https://ipv.account.gov.uk"
+ipv_auth_public_encryption_key     = <<-EOT
+-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAudZq3RAtd6me99lfWd8N
+AfOIo5rfkt0uCOMtTqHlYVLbjIBeLRvSg1Aq55mSFKbdJ+DE4wFN9PyGZVpH266C
+2DVSOVI0ETfmPP2rVyG9FXwJqGsWYEn7XMqznFPlxi9IjeqOjhybLlaZKdm6VCpO
+KEoQViR4Cm73eax1KDztlmOncypB1o8WIEte3SvFK97Ar3KTJgaS1PsmgXttx6AP
+Q3D0/fQcE0Hp/swIgPsO9gYxhEdv3M+dxO07OJ+/X396bg+uZ7/J84hTz/uIXASy
+bJ5G58qyvEL0h3BMEBayDN1cT3/Q7NU3jkaa1ODynLjkvXEtlccgsrAa2he7OQUY
+ZQIDAQAB
+-----END PUBLIC KEY-----
+EOT
+doc_app_auth_public_encryption_key = <<-EOT
 -----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAudZq3RAtd6me99lfWd8N
 AfOIo5rfkt0uCOMtTqHlYVLbjIBeLRvSg1Aq55mSFKbdJ+DE4wFN9PyGZVpH266C

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -22,6 +22,12 @@ variable "ipv_api_lambda_zip_file" {
   type        = string
 }
 
+variable "doc_checking_app_api_lambda_zip_file" {
+  default     = "../../../doc-checking-app-api/build/distributions/doc-checking-app-api.zip"
+  description = "Location of the doc checking app API Lambda ZIP file"
+  type        = string
+}
+
 variable "lambda_warmer_zip_file" {
   default     = "../../../lambda-warmer/build/distributions/lambda-warmer.zip"
   description = "Location of the Lambda Warmer ZIP file"
@@ -275,4 +281,24 @@ variable "ipv_auth_public_encryption_key" {
 variable "doc_app_auth_public_encryption_key" {
   type    = string
   default = "undefined"
+}
+
+variable "doc_app_authorisation_uri" {
+  type    = string
+  default = "undefined"
+}
+
+variable "doc_app_authorisation_callback_uri" {
+  type    = string
+  default = "undefined"
+}
+
+variable "doc_app_authorisation_client_id" {
+  type    = string
+  default = "undefined"
+}
+
+variable "doc_app_api_enabled" {
+  type    = bool
+  default = false
 }

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -271,3 +271,8 @@ variable "ipv_auth_public_encryption_key" {
   type    = string
   default = "undefined"
 }
+
+variable "doc_app_auth_public_encryption_key" {
+  type    = string
+  default = "undefined"
+}

--- a/ci/terraform/shared/kms.tf
+++ b/ci/terraform/shared/kms.tf
@@ -317,3 +317,19 @@ resource "aws_kms_alias" "ipv_auth_encryption_key_alias" {
   name          = "alias/${var.environment}-ipv-auth-encryption-kms-key-alias"
   target_key_id = aws_kms_key.ipv_auth_encryption_key.key_id
 }
+
+# Doc Checking App Authentication Signing KMS key
+
+resource "aws_kms_key" "doc_app_auth_signing_key" {
+  description              = "KMS signing key for authentication to the Doc Checking App"
+  deletion_window_in_days  = 30
+  key_usage                = "SIGN_VERIFY"
+  customer_master_key_spec = "ECC_NIST_P256"
+
+  tags = local.default_tags
+}
+
+resource "aws_kms_alias" "doc_app_auth_signing_key_alias" {
+  name          = "alias/${var.environment}-doc-app-auth-kms-key-alias"
+  target_key_id = aws_kms_key.doc_app_auth_signing_key.key_id
+}

--- a/ci/terraform/shared/outputs.tf
+++ b/ci/terraform/shared/outputs.tf
@@ -80,6 +80,14 @@ output "ipv_token_auth_signing_key_arn" {
   value = aws_kms_key.ipv_token_auth_signing_key.arn
 }
 
+output "doc_app_auth_signing_key_alias_name" {
+  value = aws_kms_alias.doc_app_auth_signing_key_alias.name
+}
+
+output "doc_app_auth_signing_key_arn" {
+  value = aws_kms_key.doc_app_auth_signing_key.arn
+}
+
 output "audit_signing_key_alias_name" {
   value = aws_kms_alias.audit_payload_signing_key_alias.name
 }


### PR DESCRIPTION
## What?

- Create signing key for doc checking app integration
- Store doc app encryption public key in parameter store
-  Add terraform for the doc app authorize lambda
- Set doc_checking_app_api_lambda_zip_file in deploy-oidc-api.yml

## Why?

 - Signing key will be used to sign secure JWT in auth requests and signing private key JWT for requests to the token endpoint
 - This is a placeholder public key and will be replaced with the public key which corresponds to the doc apps private encryption key. 
 - So the lambda can be created in AWS