### PR TITLE
AUT-296 - Set docAppSubjectId in client session

### DIFF
--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppAuthorizeHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppAuthorizeHandler.java
@@ -9,7 +9,6 @@ import com.nimbusds.oauth2.sdk.AuthorizationRequest;
 import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.id.State;
-import com.nimbusds.oauth2.sdk.id.Subject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.app.entity.DocAppAuthorisationResponse;
@@ -100,7 +99,7 @@ public class DocAppAuthorizeHandler
                                 var state = new State();
                                 var encryptedJWT =
                                         authorisationService.constructRequestJWT(
-                                                state, new Subject());
+                                                state, clientSession.getDocAppSubjectId());
                                 var authRequestBuilder =
                                         new AuthorizationRequest.Builder(
                                                         new ResponseType(ResponseType.Value.CODE),

--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppAuthorizeHandlerTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppAuthorizeHandlerTest.java
@@ -95,6 +95,7 @@ class DocAppAuthorizeHandlerTest {
                 .thenReturn(DOC_APP_CALLBACK_URI);
         when(configurationService.getDocAppAuthorisationURI())
                 .thenReturn(DOC_APP_AUTHORISATION_URI);
+        when(clientSession.getDocAppSubjectId()).thenReturn(new Subject());
     }
 
     @Test

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppAuthorizeHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppAuthorizeHandlerIntegrationTest.java
@@ -5,6 +5,7 @@ import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.id.State;
+import com.nimbusds.oauth2.sdk.id.Subject;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import com.nimbusds.openid.connect.sdk.Nonce;
 import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
@@ -59,6 +60,7 @@ class DocAppAuthorizeHandlerIntegrationTest extends ApiGatewayHandlerIntegration
 
     @Test
     void shouldReturn200WithValidDocAppAuthRequest() throws IOException {
+        redis.addDocAppSubjectIdToClientSession(new Subject(), CLIENT_SESSION_ID);
         var response =
                 makeRequest(
                         Optional.empty(),

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
@@ -3,6 +3,7 @@ package uk.gov.di.authentication.sharedtest.extensions;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.id.State;
+import com.nimbusds.oauth2.sdk.id.Subject;
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.RedisURI;
 import io.lettuce.core.api.StatefulRedisConnection;
@@ -60,6 +61,19 @@ public class RedisExtension
 
     public String createSession() throws IOException {
         return createSession(IdGenerator.generate());
+    }
+
+    public void addDocAppSubjectIdToClientSession(Subject subject, String clientSessionId)
+            throws JsonProcessingException {
+        ClientSession clientSession =
+                objectMapper.readValue(
+                        redis.getValue(CLIENT_SESSION_PREFIX.concat(clientSessionId)),
+                        ClientSession.class);
+        clientSession.setDocAppSubjectId(subject);
+        redis.saveWithExpiry(
+                CLIENT_SESSION_PREFIX.concat(clientSessionId),
+                objectMapper.writeValueAsString(clientSession),
+                3600);
     }
 
     public void addStateToRedis(State state, String sessionId) throws JsonProcessingException {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ClientSession.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ClientSession.java
@@ -1,6 +1,7 @@
 package uk.gov.di.authentication.shared.entity;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.nimbusds.oauth2.sdk.id.Subject;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -19,6 +20,9 @@ public class ClientSession {
 
     @JsonProperty("effective_vector_of_trust")
     private VectorOfTrust effectiveVectorOfTrust;
+
+    @JsonProperty("doc_app_subject_id")
+    private Subject docAppSubjectId;
 
     public ClientSession(
             @JsonProperty(required = true, value = "auth_request_params")
@@ -54,6 +58,15 @@ public class ClientSession {
 
     public ClientSession setEffectiveVectorOfTrust(VectorOfTrust effectiveVectorOfTrust) {
         this.effectiveVectorOfTrust = effectiveVectorOfTrust;
+        return this;
+    }
+
+    public Subject getDocAppSubjectId() {
+        return docAppSubjectId;
+    }
+
+    public ClientSession setDocAppSubjectId(Subject docAppSubjectId) {
+        this.docAppSubjectId = docAppSubjectId;
         return this;
     }
 }


### PR DESCRIPTION
## What?

- Retrieve this subjectId in the DocAppAuthorizeHandler to send in the secure request to the doc app.
- Set docAppSubjectId in client session

## Why?

- When a user comes from the doc app RP they will not have an account however we will require them to have a subject id. This subject ID will be used to determine what user information to get in the user-info endpoint as well as sending it to the doc checking app.
- This docAppSubjectId will be set in the start lambda once it is confirmed they have come from the doc app RP. We will generate a new salt and store a pairwise identifier here.

