### PR TITLE
AUT-295 - Support client type in ClientRegistry

### DIFF
--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/entity/ClientRegistrationRequest.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/entity/ClientRegistrationRequest.java
@@ -1,6 +1,7 @@
 package uk.gov.di.authentication.clientregistry.entity;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.di.authentication.shared.entity.ClientType;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 
 import java.util.ArrayList;
@@ -45,6 +46,9 @@ public class ClientRegistrationRequest {
     @JsonProperty("claims")
     private List<String> claims = new ArrayList<>();
 
+    @JsonProperty("client_type")
+    private String clientType;
+
     public ClientRegistrationRequest(
             @JsonProperty(required = true, value = "client_name") String clientName,
             @JsonProperty(required = true, value = "redirect_uris") List<String> redirectUris,
@@ -59,7 +63,8 @@ public class ClientRegistrationRequest {
             @JsonProperty(required = true, value = "subject_type") String subjectType,
             @JsonProperty(value = "identity_verification_required")
                     boolean identityVerificationRequired,
-            @JsonProperty(value = "claims") List<String> claims) {
+            @JsonProperty(value = "claims") List<String> claims,
+            @JsonProperty(value = "client_type") String clientType) {
         this.clientName = clientName;
         this.redirectUris = redirectUris;
         this.contacts = contacts;
@@ -79,6 +84,10 @@ public class ClientRegistrationRequest {
         if (Objects.nonNull(claims)) {
             this.claims = claims;
         }
+        if (Objects.isNull(clientType)) {
+            clientType = ClientType.WEB.getValue();
+        }
+        this.clientType = clientType;
     }
 
     public String getClientName() {
@@ -127,5 +136,9 @@ public class ClientRegistrationRequest {
 
     public List<String> getClaims() {
         return claims;
+    }
+
+    public String getClientType() {
+        return clientType;
     }
 }

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/entity/ClientRegistrationResponse.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/entity/ClientRegistrationResponse.java
@@ -45,6 +45,9 @@ public class ClientRegistrationResponse {
     @JsonProperty("sector_identifier_uri")
     private String sectorIdentifierUri;
 
+    @JsonProperty("client_type")
+    private String clientType;
+
     public ClientRegistrationResponse(
             String clientName,
             String clientId,
@@ -56,7 +59,8 @@ public class ClientRegistrationResponse {
             String serviceType,
             String subjectType,
             List<String> claims,
-            String sectorIdentifierUri) {
+            String sectorIdentifierUri,
+            String clientType) {
         this.clientName = clientName;
         this.clientId = clientId;
         this.redirectUris = redirectUris;
@@ -68,6 +72,7 @@ public class ClientRegistrationResponse {
         this.subjectType = subjectType;
         this.claims = claims;
         this.sectorIdentifierUri = sectorIdentifierUri;
+        this.clientType = clientType;
     }
 
     public ClientRegistrationResponse() {}
@@ -128,5 +133,9 @@ public class ClientRegistrationResponse {
 
     public String getSectorIdentifierUri() {
         return sectorIdentifierUri;
+    }
+
+    public String getClientType() {
+        return clientType;
     }
 }

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandler.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandler.java
@@ -6,7 +6,6 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
 import org.apache.commons.validator.routines.UrlValidator;
 import org.apache.logging.log4j.LogManager;
@@ -19,8 +18,6 @@ import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoClientService;
-
-import java.util.Optional;
 
 import static uk.gov.di.authentication.clientregistry.domain.ClientRegistryAuditableEvent.REGISTER_CLIENT_REQUEST_ERROR;
 import static uk.gov.di.authentication.clientregistry.domain.ClientRegistryAuditableEvent.REGISTER_CLIENT_REQUEST_RECEIVED;
@@ -81,10 +78,10 @@ public class ClientRegistrationHandler
 
                             try {
                                 LOG.info("Client registration request received");
-                                ClientRegistrationRequest clientRegistrationRequest =
+                                var clientRegistrationRequest =
                                         objectMapper.readValue(
                                                 input.getBody(), ClientRegistrationRequest.class);
-                                Optional<ErrorObject> errorResponse =
+                                var errorResponse =
                                         validationService.validateClientRegistrationConfig(
                                                 clientRegistrationRequest);
                                 if (errorResponse.isPresent()) {
@@ -125,7 +122,8 @@ public class ClientRegistrationHandler
                                                 clientRegistrationRequest.getSectorIdentifierUri()),
                                         clientRegistrationRequest.getSubjectType(),
                                         !clientRegistrationRequest.isIdentityVerificationRequired(),
-                                        clientRegistrationRequest.getClaims());
+                                        clientRegistrationRequest.getClaims(),
+                                        clientRegistrationRequest.getClientType());
 
                                 var clientRegistrationResponse =
                                         new ClientRegistrationResponse(
@@ -140,7 +138,8 @@ public class ClientRegistrationHandler
                                                 clientRegistrationRequest.getServiceType(),
                                                 clientRegistrationRequest.getSubjectType(),
                                                 clientRegistrationRequest.getClaims(),
-                                                clientRegistrationRequest.getSectorIdentifierUri());
+                                                clientRegistrationRequest.getSectorIdentifierUri(),
+                                                clientRegistrationRequest.getClientType());
                                 LOG.info("Generating successful Client registration response");
                                 return generateApiGatewayProxyResponse(
                                         200, clientRegistrationResponse);

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandler.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandler.java
@@ -142,7 +142,8 @@ public class UpdateClientConfigHandler
                                                 clientRegistry.getServiceType(),
                                                 clientRegistry.getSubjectType(),
                                                 clientRegistry.getClaims(),
-                                                clientRegistry.getSectorIdentifierUri());
+                                                clientRegistry.getSectorIdentifierUri(),
+                                                clientRegistry.getClientType());
                                 LOG.info("Client updated");
                                 return generateApiGatewayProxyResponse(
                                         200, clientRegistrationResponse);

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationService.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationService.java
@@ -4,6 +4,7 @@ import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.client.RegistrationError;
 import com.nimbusds.openid.connect.sdk.SubjectType;
 import uk.gov.di.authentication.clientregistry.entity.ClientRegistrationRequest;
+import uk.gov.di.authentication.shared.entity.ClientType;
 import uk.gov.di.authentication.shared.entity.UpdateClientConfigRequest;
 import uk.gov.di.authentication.shared.entity.ValidClaims;
 import uk.gov.di.authentication.shared.entity.ValidScopes;
@@ -12,6 +13,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.security.KeyFactory;
 import java.security.spec.X509EncodedKeySpec;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
 import java.util.Optional;
@@ -36,6 +38,8 @@ public class ClientConfigValidationService {
             new ErrorObject("invalid_client_metadata", "Insufficient Claim");
     public static final ErrorObject INVALID_SECTOR_IDENTIFIER_URI =
             new ErrorObject("invalid_client_metadata", "Invalid Sector Identifier URI");
+    public static final ErrorObject INVALID_CLIENT_TYPE =
+            new ErrorObject("invalid_client_metadata", "Invalid Client Type");
 
     public Optional<ErrorObject> validateClientRegistrationConfig(
             ClientRegistrationRequest registrationRequest) {
@@ -74,6 +78,10 @@ public class ClientConfigValidationService {
                 .orElse(true)) {
             return Optional.of(INVALID_CLAIM);
         }
+        if (Arrays.stream(ClientType.values())
+                .noneMatch(t -> t.getValue().equals(registrationRequest.getClientType()))) {
+            return Optional.of(INVALID_CLIENT_TYPE);
+        }
         return Optional.empty();
     }
 
@@ -108,6 +116,11 @@ public class ClientConfigValidationService {
                 .map(t -> areUrisValid(singletonList(t)))
                 .orElse(true)) {
             return Optional.of(INVALID_SECTOR_IDENTIFIER_URI);
+        }
+        if (!Optional.ofNullable(updateRequest.getClientType())
+                .map(c -> Arrays.stream(ClientType.values()).anyMatch(t -> t.getValue().equals(c)))
+                .orElse(true)) {
+            return Optional.of(INVALID_CLIENT_TYPE);
         }
         return Optional.empty();
     }

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandlerTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandlerTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.authentication.clientregistry.entity.ClientRegistrationResponse;
 import uk.gov.di.authentication.clientregistry.services.ClientConfigValidationService;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
+import uk.gov.di.authentication.shared.entity.ClientType;
 import uk.gov.di.authentication.shared.entity.UpdateClientConfigRequest;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ClientService;
@@ -96,6 +97,7 @@ class UpdateClientConfigHandlerTest {
         assertThat(clientRegistrationResponse.getTokenAuthMethod(), equalTo("private_key_jwt"));
         assertThat(clientRegistrationResponse.getScopes(), equalTo(SCOPES));
         assertThat(clientRegistrationResponse.getServiceType(), equalTo(SERVICE_TYPE));
+        assertThat(clientRegistrationResponse.getClientType(), equalTo(ClientType.WEB.getValue()));
     }
 
     @Test
@@ -219,6 +221,7 @@ class UpdateClientConfigHandlerTest {
         clientRegistry.setContacts(singletonList("contant-name"));
         clientRegistry.setPostLogoutRedirectUrls(singletonList("localhost/logout"));
         clientRegistry.setServiceType(SERVICE_TYPE);
+        clientRegistry.setClientType(ClientType.WEB.getValue());
         return clientRegistry;
     }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientRegistrationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientRegistrationIntegrationTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.authentication.clientregistry.entity.ClientRegistrationRequest;
 import uk.gov.di.authentication.clientregistry.entity.ClientRegistrationResponse;
 import uk.gov.di.authentication.clientregistry.lambda.ClientRegistrationHandler;
+import uk.gov.di.authentication.shared.entity.ClientType;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 
 import java.util.List;
@@ -76,7 +77,8 @@ public class ClientRegistrationIntegrationTest extends ApiGatewayHandlerIntegrat
                         "https://test.com",
                         "public",
                         false,
-                        claims);
+                        claims,
+                        ClientType.WEB.getValue());
 
         var response = makeRequest(Optional.of(clientRequest), Map.of(), Map.of());
 
@@ -87,6 +89,7 @@ public class ClientRegistrationIntegrationTest extends ApiGatewayHandlerIntegrat
         assertTrue(clientStore.clientExists(clientResponse.getClientId()));
         assertThat(clientResponse.getClaims(), equalTo(claims));
         assertThat(clientResponse.getBackChannelLogoutUri(), equalTo(backChannelLogoutUri));
+        assertThat(clientResponse.getClientType(), equalTo(ClientType.WEB.getValue()));
 
         assertEventTypesReceived(auditTopic, List.of(REGISTER_CLIENT_REQUEST_RECEIVED));
     }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/ClientStoreExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/ClientStoreExtension.java
@@ -8,6 +8,7 @@ import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
 import com.amazonaws.services.dynamodbv2.model.Projection;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import uk.gov.di.authentication.shared.entity.ClientType;
 import uk.gov.di.authentication.shared.services.DynamoClientService;
 
 import java.util.Collections;
@@ -53,7 +54,8 @@ public class ClientStoreExtension extends DynamoExtension implements AfterEachCa
                 sectorIdentifierUri,
                 subjectType,
                 consentRequired,
-                Collections.emptyList());
+                Collections.emptyList(),
+                ClientType.WEB.getValue());
     }
 
     public boolean clientExists(String clientID) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ClientRegistry.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ClientRegistry.java
@@ -26,6 +26,7 @@ public class ClientRegistry {
     private List<String> requestUris = new ArrayList<>();
     private List<String> testClientEmailAllowlist = new ArrayList<>();
     private List<String> claims = new ArrayList<>();
+    private String clientType;
 
     @DynamoDBHashKey(attributeName = "ClientID")
     public String getClientID() {
@@ -196,6 +197,16 @@ public class ClientRegistry {
 
     public ClientRegistry setClaims(List<String> claims) {
         this.claims = claims;
+        return this;
+    }
+
+    @DynamoDBAttribute(attributeName = "ClientType")
+    public String getClientType() {
+        return clientType;
+    }
+
+    public ClientRegistry setClientType(String clientType) {
+        this.clientType = clientType;
         return this;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ClientType.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ClientType.java
@@ -1,0 +1,16 @@
+package uk.gov.di.authentication.shared.entity;
+
+public enum ClientType {
+    APP("app"),
+    WEB("web");
+
+    private String value;
+
+    ClientType(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/UpdateClientConfigRequest.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/UpdateClientConfigRequest.java
@@ -36,6 +36,9 @@ public class UpdateClientConfigRequest {
     @JsonProperty("sector_identifier_uri")
     private String sectorIdentifierUri;
 
+    @JsonProperty("client_type")
+    private String clientType;
+
     public UpdateClientConfigRequest() {}
 
     public String getClientId() {
@@ -76,6 +79,10 @@ public class UpdateClientConfigRequest {
 
     public String getSectorIdentifierUri() {
         return sectorIdentifierUri;
+    }
+
+    public String getClientType() {
+        return clientType;
     }
 
     public UpdateClientConfigRequest setClientId(String clientId) {
@@ -121,6 +128,11 @@ public class UpdateClientConfigRequest {
 
     public UpdateClientConfigRequest setClaims(List<String> claims) {
         this.claims = claims;
+        return this;
+    }
+
+    public UpdateClientConfigRequest setClientType(String clientType) {
+        this.clientType = clientType;
         return this;
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ClientService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ClientService.java
@@ -24,7 +24,8 @@ public interface ClientService {
             String sectorIdentifierUri,
             String subjectType,
             boolean consentRequired,
-            List<String> claims);
+            List<String> claims,
+            String clientType);
 
     Optional<ClientRegistry> getClient(String clientId);
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoClientService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoClientService.java
@@ -69,8 +69,9 @@ public class DynamoClientService implements ClientService {
             String sectorIdentifierUri,
             String subjectType,
             boolean consentRequired,
-            List<String> claims) {
-        ClientRegistry clientRegistry =
+            List<String> claims,
+            String clientType) {
+        var clientRegistry =
                 new ClientRegistry()
                         .setClientID(clientID)
                         .setClientName(clientName)
@@ -84,7 +85,8 @@ public class DynamoClientService implements ClientService {
                         .setSectorIdentifierUri(sectorIdentifierUri)
                         .setSubjectType(subjectType)
                         .setConsentRequired(consentRequired)
-                        .setClaims(claims);
+                        .setClaims(claims)
+                        .setClientType(clientType);
         clientRegistryMapper.save(clientRegistry);
     }
 


### PR DESCRIPTION
## What?

- Add clientType field in the client registry.
- If it is not present in the registration request then it will default to `web`

## Why?

 This can either be `app` or `web`. For the majority of clients we expect it to be `web`. This is to support the app journey flow.
