### PR TITLE
AUT-307 - Create new scope for the doc-checking-app

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/CustomScopeValue.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/CustomScopeValue.java
@@ -15,6 +15,10 @@ public class CustomScopeValue extends Scope.Value {
             new CustomScopeValue(
                     "govuk-account", Requirement.OPTIONAL, new String[] {"read"}, true);
 
+    public static final CustomScopeValue DOC_CHECKING_APP =
+            new CustomScopeValue(
+                    "doc-checking-app", Requirement.OPTIONAL, new String[] {"read"}, true);
+
     private final String[] claims;
 
     private boolean privateScope = true;

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ValidScopes.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ValidScopes.java
@@ -22,7 +22,10 @@ public class ValidScopes {
                     OIDCScopeValue.OFFLINE_ACCESS);
 
     private static final List<CustomScopeValue> allowedCustomScopes =
-            List.of(CustomScopeValue.ACCOUNT_MANAGEMENT, CustomScopeValue.GOVUK_ACCOUNT);
+            List.of(
+                    CustomScopeValue.ACCOUNT_MANAGEMENT,
+                    CustomScopeValue.GOVUK_ACCOUNT,
+                    CustomScopeValue.DOC_CHECKING_APP);
 
     private ValidScopes() {}
 

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/ValidScopesTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/ValidScopesTest.java
@@ -1,6 +1,5 @@
 package uk.gov.di.authentication.shared.entity;
 
-import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import org.junit.jupiter.api.Test;
 
@@ -10,15 +9,16 @@ import java.util.Set;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class ValidScopesTest {
 
     @Test
     void shouldReturnCorrectClaimsForOpenidScope() {
         assertThat(ValidScopes.getClaimsForListOfScopes(List.of("openid")), contains("sub"));
-        assertEquals(ValidScopes.getClaimsForListOfScopes(List.of("openid")).size(), 1);
+        assertThat(ValidScopes.getClaimsForListOfScopes(List.of("openid")).size(), equalTo(1));
     }
 
     @Test
@@ -26,12 +26,13 @@ class ValidScopesTest {
         assertThat(
                 ValidScopes.getClaimsForListOfScopes(List.of("email")),
                 containsInAnyOrder("email", "email_verified"));
-        assertEquals(ValidScopes.getClaimsForListOfScopes(List.of("email")).size(), 2);
+        assertThat(ValidScopes.getClaimsForListOfScopes(List.of("email")).size(), equalTo(2));
     }
 
     @Test
     void shouldNotReturnAnyClaimsForOfflineAccessScope() {
-        assertEquals(ValidScopes.getClaimsForListOfScopes(List.of("offline_access")).size(), 0);
+        assertThat(
+                ValidScopes.getClaimsForListOfScopes(List.of("offline_access")).size(), equalTo(0));
     }
 
     @Test
@@ -39,7 +40,7 @@ class ValidScopesTest {
         assertThat(
                 ValidScopes.getClaimsForListOfScopes(List.of("phone")),
                 containsInAnyOrder("phone_number", "phone_number_verified"));
-        assertEquals(ValidScopes.getClaimsForListOfScopes(List.of("phone")).size(), 2);
+        assertThat(ValidScopes.getClaimsForListOfScopes(List.of("phone")).size(), equalTo(2));
     }
 
     @Test
@@ -47,7 +48,27 @@ class ValidScopesTest {
         assertThat(
                 ValidScopes.getClaimsForListOfScopes(List.of("am")),
                 containsInAnyOrder("read", "write"));
-        assertEquals(ValidScopes.getClaimsForListOfScopes(List.of("am")).size(), 2);
+
+        assertThat(ValidScopes.getClaimsForListOfScopes(List.of("am")).size(), equalTo(2));
+    }
+
+    @Test
+    void shouldReturnCorrectClaimsForDocCheckingAppScope() {
+        assertThat(
+                ValidScopes.getClaimsForListOfScopes(List.of("doc-checking-app")),
+                containsInAnyOrder("read"));
+        assertThat(
+                ValidScopes.getClaimsForListOfScopes(List.of("doc-checking-app")).size(),
+                equalTo(1));
+    }
+
+    @Test
+    void shouldReturnCorrectClaimsForGovUkAccountScope() {
+        assertThat(
+                ValidScopes.getClaimsForListOfScopes(List.of("govuk-account")),
+                containsInAnyOrder("read"));
+        assertThat(
+                ValidScopes.getClaimsForListOfScopes(List.of("govuk-account")).size(), equalTo(1));
     }
 
     @Test
@@ -55,7 +76,8 @@ class ValidScopesTest {
         assertThat(
                 ValidScopes.getClaimsForListOfScopes(List.of("openid", "am")),
                 containsInAnyOrder("sub", "read", "write"));
-        assertEquals(ValidScopes.getClaimsForListOfScopes(List.of("openid", "am")).size(), 3);
+        assertThat(
+                ValidScopes.getClaimsForListOfScopes(List.of("openid", "am")).size(), equalTo(3));
     }
 
     @Test
@@ -71,28 +93,36 @@ class ValidScopesTest {
                         "phone_number_verified",
                         "read",
                         "write"));
-        assertEquals(
+
+        assertThat(
                 ValidScopes.getClaimsForListOfScopes(
                                 List.of("openid", "email", "phone", "am", "offline_access"))
                         .size(),
-                7);
+                equalTo(7));
     }
 
     @Test
     void shouldReturnAllValidScopesInCorrectOrder() {
         assertThat(
                 ValidScopes.getAllValidScopes(),
-                contains("openid", "email", "phone", "offline_access", "am", "govuk-account"));
+                contains(
+                        "openid",
+                        "email",
+                        "phone",
+                        "offline_access",
+                        "am",
+                        "govuk-account",
+                        "doc-checking-app"));
     }
 
     @Test
     void shouldReturnCorrectNumberOfValidScopes() {
-        assertEquals(ValidScopes.getAllValidScopes().size(), 6);
+        assertThat(ValidScopes.getAllValidScopes().size(), equalTo(7));
     }
 
     @Test
     void shouldNotReturnPrivateScopesWhenPublicRequested() {
-        assertEquals(ValidScopes.getPublicValidScopes().size(), 4);
+        assertThat(ValidScopes.getPublicValidScopes().size(), equalTo(4));
         assertThat(
                 ValidScopes.getPublicValidScopes(),
                 contains("openid", "email", "phone", "offline_access"));
@@ -101,13 +131,15 @@ class ValidScopesTest {
 
     @Test
     void shouldReturnOIDCScopesForWellKnown() {
-        Scope scope = ValidScopes.getScopesForWellKnownHandler();
-        assertEquals(scope.toStringList(), List.of("openid", "email", "phone", "offline_access"));
+        var scope = ValidScopes.getScopesForWellKnownHandler();
+        assertThat(
+                scope.toStringList(),
+                equalTo(List.of("openid", "email", "phone", "offline_access")));
     }
 
     @Test
     void shouldReturnScopesForListOfValidClaims() {
-        Set<String> claims =
+        var claims =
                 Set.of(
                         "sub",
                         "email",
@@ -117,15 +149,15 @@ class ValidScopesTest {
                         "read",
                         "write");
 
-        assertEquals(ValidScopes.getScopesForListOfClaims(claims).size(), 5);
+        assertThat(ValidScopes.getScopesForListOfClaims(claims).size(), equalTo(6));
     }
 
     @Test
     void shouldNotReturnEmailScopesWhenAllEmailsClaimsAreNotGiven() {
-        Set<String> claims =
+        var claims =
                 Set.of("sub", "email", "phone_number", "phone_number_verified", "read", "write");
 
-        assertEquals(ValidScopes.getScopesForListOfClaims(claims).size(), 4);
+        assertThat(ValidScopes.getScopesForListOfClaims(claims).size(), equalTo(5));
         assertFalse(
                 ValidScopes.getScopesForListOfClaims(claims)
                         .contains(OIDCScopeValue.EMAIL.getValue()));


### PR DESCRIPTION
## What?

- Create new doc-checking-app scope which will be used by the doc-checking-app RP.


## Why?

- This scope will be used in the auth request and will be set in the access token. The userinfo will then use the scope in the access token to return the right user credential.
