### PR TITLE
AUT-307 - Set ClientType to `web` for Stub clients

### DIFF
--- a/ci/terraform/shared/stub-rp-clients.tf
+++ b/ci/terraform/shared/stub-rp-clients.tf
@@ -88,6 +88,9 @@ resource "aws_dynamodb_table_item" "stub_rp_client" {
     ConsentRequired = {
       N = "1"
     }
+    ClientType = {
+      S = "web"
+    }
     TestClient = {
       N = var.stub_rp_clients[count.index].test_client
     }


### PR DESCRIPTION
## What?

- Set ClientType to `web` for Stub clients

## Why?

- A new field has been added to the ClientRegistry to support app clients. Explicitly set the Stub RP ClientType to `web`, although at some point we will want a Stub RP with an `app` ClientType