### PR TITLE
AUT-272: Pass identity claims to SPOT for P2

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.authentication.ipv.entity.LogIds;
-import uk.gov.di.authentication.ipv.entity.SPOTClaims;
 import uk.gov.di.authentication.ipv.entity.SPOTRequest;
 import uk.gov.di.authentication.ipv.lambda.IPVCallbackHandler;
 import uk.gov.di.authentication.shared.entity.LevelOfConfidence;
@@ -44,6 +43,8 @@ import static uk.gov.di.authentication.ipv.domain.IPVAuditableEvent.IPV_AUTHORIS
 import static uk.gov.di.authentication.ipv.domain.IPVAuditableEvent.IPV_SPOT_REQUESTED;
 import static uk.gov.di.authentication.ipv.domain.IPVAuditableEvent.IPV_SUCCESSFUL_IDENTITY_RESPONSE_RECEIVED;
 import static uk.gov.di.authentication.ipv.domain.IPVAuditableEvent.IPV_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED;
+import static uk.gov.di.authentication.shared.entity.IdentityClaims.VOT;
+import static uk.gov.di.authentication.shared.entity.IdentityClaims.VTM;
 import static uk.gov.di.authentication.shared.helpers.ClientSubjectHelper.calculatePairwiseIdentifier;
 import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
@@ -118,7 +119,11 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                 spotQueue,
                 List.of(
                         new SPOTRequest(
-                                new SPOTClaims(LevelOfConfidence.MEDIUM_LEVEL.getValue(), null),
+                                Map.of(
+                                        VOT.getValue(),
+                                        LevelOfConfidence.MEDIUM_LEVEL.getValue(),
+                                        VTM.getValue(),
+                                        "/trustmark"),
                                 INTERNAL_SUBJECT.getValue(),
                                 salt,
                                 sectorId,

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
@@ -72,6 +72,7 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static uk.gov.di.authentication.shared.entity.IdentityClaims.VOT;
 import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertNoAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
@@ -126,7 +127,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         .getOIDCTokens()
                         .getIDToken()
                         .getJWTClaimsSet()
-                        .getClaim("vot"),
+                        .getClaim(VOT.getValue()),
                 equalTo(expectedVotClaim));
 
         assertNoAuditEventsReceived(auditTopic);

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/IPVUserIndentityResponse.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/IPVUserIndentityResponse.java
@@ -1,0 +1,5 @@
+package uk.gov.di.authentication.ipv.entity;
+
+import java.util.HashMap;
+
+public class IPVUserIndentityResponse extends HashMap<String, Object> {}

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/SPOTClaims.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/SPOTClaims.java
@@ -1,27 +1,55 @@
 package uk.gov.di.authentication.ipv.entity;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static uk.gov.di.authentication.shared.entity.IdentityClaims.SUB;
+import static uk.gov.di.authentication.shared.entity.IdentityClaims.VOT;
+import static uk.gov.di.authentication.shared.entity.IdentityClaims.VTM;
 
 public class SPOTClaims {
 
-    @JsonProperty(value = "vot")
-    private String vot;
+    private SPOTClaims() {}
 
-    @JsonProperty(value = "vtm")
-    private String vtm;
-
-    public SPOTClaims(String vot, String vtm) {
-        this.vot = vot;
-        this.vtm = vtm;
+    public static SPOTClaimsBuilder builder() {
+        return new SPOTClaimsBuilder();
     }
 
-    public SPOTClaims() {}
+    public static class SPOTClaimsBuilder {
+        Map<String, Object> spotClaims = new HashMap<>();
 
-    public String getVot() {
-        return vot;
-    }
+        public SPOTClaimsBuilder withClaims(HashMap<String, Object> claims) {
+            claims.entrySet().stream()
+                    .filter(SPOTClaimsBuilder::isAddableClaim)
+                    .forEach(c -> spotClaims.put(c.getKey(), c.getValue()));
+            return this;
+        }
 
-    public String getVtm() {
-        return vtm;
+        private static boolean isAddableClaim(Map.Entry claim) {
+            return !claim.getKey().equals(SUB.getValue()) && !claim.getKey().equals(VTM.getValue());
+        }
+
+        public SPOTClaimsBuilder withVot(Object vot) {
+            return withClaim(VOT.getValue(), vot);
+        }
+
+        public SPOTClaimsBuilder withVtm(Object vtm) {
+            return withClaim(VTM.getValue(), vtm);
+        }
+
+        public SPOTClaimsBuilder withClaim(String claimName, Object claimValue) {
+            spotClaims.put(claimName, claimValue);
+            return this;
+        }
+
+        public SPOTClaimsBuilder withClaimArray(String claimName, Object claimValues) {
+            spotClaims.put(claimName, claimValues);
+            return this;
+        }
+
+        public Map<String, Object> build() {
+            return Collections.unmodifiableMap(spotClaims);
+        }
     }
 }

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/SPOTRequest.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/SPOTRequest.java
@@ -2,10 +2,12 @@ package uk.gov.di.authentication.ipv.entity;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Map;
+
 public class SPOTRequest {
 
     @JsonProperty(value = "in_claims")
-    private SPOTClaims spotClaims;
+    private Map<String, Object> spotClaims;
 
     @JsonProperty(value = "in_local_account_id")
     private String localAccountId;
@@ -23,7 +25,7 @@ public class SPOTRequest {
     private LogIds logIds;
 
     public SPOTRequest(
-            SPOTClaims spotClaims,
+            Map<String, Object> spotClaims,
             String localAccountId,
             byte[] salt,
             String rpSectorId,
@@ -39,7 +41,7 @@ public class SPOTRequest {
 
     public SPOTRequest() {}
 
-    public SPOTClaims getSpotClaims() {
+    public Map<String, Object> getSpotClaims() {
         return spotClaims;
     }
 

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/entity/SPOTRequestTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/entity/SPOTRequestTest.java
@@ -1,0 +1,65 @@
+package uk.gov.di.authentication.ipv.entity;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
+
+import java.util.Base64;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class SPOTRequestTest {
+
+    @Test
+    void shouldReadSPOTRequestFromJson() throws JsonProcessingException {
+
+        String saltString =
+                Base64.getEncoder()
+                        .encodeToString("Mmc48imEuO5kkVW7NtXVtx5h0mbCTfXsqXdWvbRMzdw=".getBytes());
+        String spotRequestJson = buildSpotRequestJson("P2", "/trustmark", saltString);
+
+        ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
+        SPOTRequest spotRequest = objectMapper.readValue(spotRequestJson, SPOTRequest.class);
+
+        assertNotNull(spotRequest);
+        assertEquals(4, spotRequest.getSpotClaims().size());
+        assertEquals(
+                List.of("<JWT-encoded VC 1>", "<JWT-encoded VC 2>"),
+                spotRequest.getSpotClaims().get("https://vocab.account.gov.uk/v1/credentialJWT"));
+        assertEquals("P2", spotRequest.getSpotClaims().get("vot"));
+        assertEquals("/trustmark", spotRequest.getSpotClaims().get("vtm"));
+        assertEquals(saltString, Base64.getEncoder().encodeToString(spotRequest.getSalt()));
+        assertEquals("<id>", spotRequest.getLocalAccountId());
+        assertEquals("<subject identifier>", spotRequest.getSub());
+        assertEquals("<id>", spotRequest.getLogIds().getSessionId());
+        assertEquals("<sector id>", spotRequest.getRpSectorId());
+    }
+
+    private String buildSpotRequestJson(String vot, String vtm, String saltString) {
+        return "{\"in_claims\": {"
+                + "     \"https://vocab.account.gov.uk/v1/credentialJWT\": ["
+                + "         \"<JWT-encoded VC 1>\", "
+                + "         \"<JWT-encoded VC 2>\" "
+                + "     ],"
+                + "     \"vot\": \""
+                + vot
+                + "\","
+                + "     \"vtm\": \""
+                + vtm
+                + "\", "
+                + "     \"http://something/v1/IdentityCredential\": \"<JSON>\""
+                + "},"
+                + "\"in_local_account_id\": \"<id>\","
+                + "\"in_salt\": \""
+                + saltString
+                + "\","
+                + "\"in_rp_sector_id\": \"<sector id>\","
+                + "\"out_sub\": \"<subject identifier>\","
+                + "\"log_ids\": {"
+                + "     \"session_id\": \"<id>\" "
+                + "} }";
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/IdentityClaims.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/IdentityClaims.java
@@ -1,0 +1,17 @@
+package uk.gov.di.authentication.shared.entity;
+
+public enum IdentityClaims {
+    VOT("vot"),
+    VTM("vtm"),
+    SUB("sub");
+
+    private String value;
+
+    IdentityClaims(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}


### PR DESCRIPTION
## What?

Pass identity claims to SPOT for P2.

Retrieving the IPV core user identity outputs:

https://github.com/alphagov/digital-identity-architecture/blob/main/rfc/0014-identity-ipv-core-oauth-profile.md

Passing to SPOT:

https://github.com/alphagov/digital-identity-architecture/blob/main/rfc/0013-spot-request-response-structures.md

## Why?

Claims need to be signed by SPOT before being returned to the RP.
