### PR TITLE
AUT-307 - Deploy doc app lambdas to staging

### DIFF
--- a/ci/terraform/oidc/staging-overrides.tfvars
+++ b/ci/terraform/oidc/staging-overrides.tfvars
@@ -1,3 +1,4 @@
+doc_app_api_enabled                = true
 ipv_api_enabled                    = true
 ipv_authorisation_client_id        = "authOrchestrator"
 ipv_authorisation_uri              = "https://staging-di-ipv-core-front.london.cloudapps.digital/oauth2/authorize"

--- a/ci/terraform/shared/dynamodb.tf
+++ b/ci/terraform/shared/dynamodb.tf
@@ -168,7 +168,6 @@ resource "aws_dynamodb_table" "spot_credential_table" {
 }
 
 resource "aws_dynamodb_table" "doc_app_credential_table" {
-  count        = var.doc_app_api_enabled ? 1 : 0
   name         = "${var.environment}-doc-app-credential"
   billing_mode = var.provision_dynamo ? "PROVISIONED" : "PAY_PER_REQUEST"
   hash_key     = "SubjectID"

--- a/ci/terraform/shared/variables.tf
+++ b/ci/terraform/shared/variables.tf
@@ -117,11 +117,6 @@ variable "provision_dynamo" {
   default = false
 }
 
-variable "doc_app_api_enabled" {
-  type    = bool
-  default = false
-}
-
 variable "ipv_api_enabled" {
   default = false
 }


### PR DESCRIPTION
## What?

- Start deploying the doc app lambdas to the staging environment only
- Remove the condition on the dynamo tables so that they are built in every environment. This is similar to what we done for the SPOT tables.

## Why?

- So we know the lambdas are deployed to an environment successfully 
- Staging is the environment where we will be testing the doc checking app integration 