### PR TITLE
AUT-296 - Audit the Doc App authorize handler

### DIFF
--- a/ci/terraform/oidc/doc-app-authorize.tf
+++ b/ci/terraform/oidc/doc-app-authorize.tf
@@ -5,6 +5,8 @@ module "doc_app_authorize_role" {
   vpc_arn     = local.authentication_vpc_arn
 
   policies_to_attach = [
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
     aws_iam_policy.doc_app_auth_kms_policy.arn,
     aws_iam_policy.doc_app_public_encryption_key_parameter_policy.arn,

--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/domain/DocAppAuditableEvent.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/domain/DocAppAuditableEvent.java
@@ -1,0 +1,12 @@
+package uk.gov.di.authentication.app.domain;
+
+import uk.gov.di.authentication.shared.domain.AuditableEvent;
+
+public enum DocAppAuditableEvent implements AuditableEvent {
+    DOC_APP_AUTHORISATION_REQUESTED;
+
+    @Override
+    public AuditableEvent parseFromName(String name) {
+        return valueOf(name);
+    }
+}

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppAuthorizeHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppAuthorizeHandlerIntegrationTest.java
@@ -22,11 +22,14 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.startsWith;
+import static uk.gov.di.authentication.app.domain.DocAppAuditableEvent.DOC_APP_AUTHORISATION_REQUESTED;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceived;
 import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertNoAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
@@ -76,6 +79,7 @@ class DocAppAuthorizeHandlerIntegrationTest extends ApiGatewayHandlerIntegration
         assertThat(
                 body.getRedirectUri(),
                 startsWith(configurationService.getDocAppAuthorisationURI().toString()));
+        assertEventTypesReceived(auditTopic, List.of(DOC_APP_AUTHORISATION_REQUESTED));
     }
 
     @Test


### PR DESCRIPTION
## What?

- Add an audit event to the doc app authorize handler 
- Give the lambda the correct permissions to submit an audit event

## Why?

- So we have a full audit trail