### PR TITLE
BAU - Use unique names for aws_cloudwatch_log_subscription_filter resources

### DIFF
--- a/ci/terraform/account-management/sqs.tf
+++ b/ci/terraform/account-management/sqs.tf
@@ -212,7 +212,7 @@ resource "aws_cloudwatch_log_group" "sqs_lambda_log_group" {
 resource "aws_cloudwatch_log_subscription_filter" "sqs_lambda_log_subscription" {
   count = length(var.logging_endpoint_arns)
 
-  name            = "${aws_lambda_function.email_sqs_lambda.function_name}-log-subscription"
+  name            = "${aws_lambda_function.email_sqs_lambda.function_name}-log-subscription-${count.index}"
   log_group_name  = aws_cloudwatch_log_group.sqs_lambda_log_group[0].name
   filter_pattern  = ""
   destination_arn = var.logging_endpoint_arns[count.index]

--- a/ci/terraform/audit-processors/counter_fraud.tf
+++ b/ci/terraform/audit-processors/counter_fraud.tf
@@ -108,7 +108,7 @@ resource "aws_cloudwatch_log_group" "fraud_realtime_logging_lambda_log_group" {
 
 resource "aws_cloudwatch_log_subscription_filter" "fraud_realtime_logging_log_subscription" {
   count           = length(var.logging_endpoint_arns)
-  name            = "${aws_lambda_function.fraud_realtime_logging_lambda.function_name}-log-subscription"
+  name            = "${aws_lambda_function.fraud_realtime_logging_lambda.function_name}-log-subscription-${count.index}"
   log_group_name  = aws_cloudwatch_log_group.fraud_realtime_logging_lambda_log_group[0].name
   filter_pattern  = ""
   destination_arn = var.logging_endpoint_arns[count.index]

--- a/ci/terraform/audit-processors/performance_analysis.tf
+++ b/ci/terraform/audit-processors/performance_analysis.tf
@@ -108,7 +108,7 @@ resource "aws_cloudwatch_log_group" "performance_analysis_logging_lambda_log_gro
 
 resource "aws_cloudwatch_log_subscription_filter" "performance_analysis_logging_log_subscription" {
   count           = length(var.logging_endpoint_arns)
-  name            = "${aws_lambda_function.performance_analysis_logging_lambda.function_name}-log-subscription"
+  name            = "${aws_lambda_function.performance_analysis_logging_lambda.function_name}-log-subscription-${count.index}"
   log_group_name  = aws_cloudwatch_log_group.performance_analysis_logging_lambda_log_group[0].name
   filter_pattern  = ""
   destination_arn = var.logging_endpoint_arns[count.index]

--- a/ci/terraform/audit-processors/storage.tf
+++ b/ci/terraform/audit-processors/storage.tf
@@ -196,7 +196,7 @@ resource "aws_cloudwatch_log_group" "lambda_log_group" {
 
 resource "aws_cloudwatch_log_subscription_filter" "log_subscription" {
   count           = length(var.logging_endpoint_arns)
-  name            = "${aws_lambda_function.audit_processor_lambda.function_name}-log-subscription"
+  name            = "${aws_lambda_function.audit_processor_lambda.function_name}-log-subscription-${count.index}"
   log_group_name  = aws_cloudwatch_log_group.lambda_log_group[0].name
   filter_pattern  = ""
   destination_arn = var.logging_endpoint_arns[count.index]

--- a/ci/terraform/delivery-receipts/api-gateway.tf
+++ b/ci/terraform/delivery-receipts/api-gateway.tf
@@ -34,7 +34,7 @@ resource "aws_cloudwatch_log_group" "delivery_receipts_api_stage_execution_logs"
 
 resource "aws_cloudwatch_log_subscription_filter" "delivery_receipts_api_execution_log_subscription" {
   count           = length(var.logging_endpoint_arns)
-  name            = "${var.environment}-delivery-receipts-api-execution-log-subscription"
+  name            = "${var.environment}-delivery-receipts-api-execution-log-subscription-${count.index}"
   log_group_name  = aws_cloudwatch_log_group.delivery_receipts_api_stage_execution_logs[0].name
   filter_pattern  = ""
   destination_arn = var.logging_endpoint_arns[count.index]
@@ -50,7 +50,7 @@ resource "aws_cloudwatch_log_group" "delivery_receipts_stage_access_logs" {
 
 resource "aws_cloudwatch_log_subscription_filter" "delivery_receipts_api_access_log_subscription" {
   count           = length(var.logging_endpoint_arns)
-  name            = "${var.environment}-delivery-receipts-api-access-logs-subscription"
+  name            = "${var.environment}-delivery-receipts-api-access-logs-subscription-${count.index}"
   log_group_name  = aws_cloudwatch_log_group.delivery_receipts_stage_access_logs[0].name
   filter_pattern  = ""
   destination_arn = var.logging_endpoint_arns[count.index]

--- a/ci/terraform/modules/endpoint-module/lambda.tf
+++ b/ci/terraform/modules/endpoint-module/lambda.tf
@@ -48,7 +48,7 @@ resource "aws_cloudwatch_log_group" "lambda_log_group" {
 
 resource "aws_cloudwatch_log_subscription_filter" "log_subscription" {
   count           = length(var.logging_endpoint_arns)
-  name            = "${var.endpoint_name}-log-subscription"
+  name            = "${var.endpoint_name}-log-subscription-${count.index}"
   log_group_name  = aws_cloudwatch_log_group.lambda_log_group[0].name
   filter_pattern  = ""
   destination_arn = var.logging_endpoint_arns[count.index]

--- a/ci/terraform/oidc/api-gateway-frontend.tf
+++ b/ci/terraform/oidc/api-gateway-frontend.tf
@@ -90,7 +90,7 @@ resource "aws_cloudwatch_log_group" "frontend_api_stage_execution_logs" {
 
 resource "aws_cloudwatch_log_subscription_filter" "frontend_api_execution_log_subscription" {
   count           = length(var.logging_endpoint_arns)
-  name            = "${var.environment}-frontend-api-execution-log-subscription"
+  name            = "${var.environment}-frontend-api-execution-log-subscription-${count.index}"
   log_group_name  = aws_cloudwatch_log_group.frontend_api_stage_execution_logs[0].name
   filter_pattern  = ""
   destination_arn = var.logging_endpoint_arns[count.index]
@@ -106,7 +106,7 @@ resource "aws_cloudwatch_log_group" "frontend_stage_access_logs" {
 
 resource "aws_cloudwatch_log_subscription_filter" "frontend_api_access_log_subscription" {
   count           = length(var.logging_endpoint_arns)
-  name            = "${var.environment}-frontend-api-access-logs-subscription"
+  name            = "${var.environment}-frontend-api-access-logs-subscription-${count.index}"
   log_group_name  = aws_cloudwatch_log_group.frontend_stage_access_logs[0].name
   filter_pattern  = ""
   destination_arn = var.logging_endpoint_arns[count.index]
@@ -122,7 +122,7 @@ resource "aws_cloudwatch_log_group" "frontend_waf_logs" {
 
 resource "aws_cloudwatch_log_subscription_filter" "frontend_api_waf_log_subscription" {
   count           = length(var.logging_endpoint_arns)
-  name            = "${var.environment}-frontend-api-waf-logs-subscription"
+  name            = "${var.environment}-frontend-api-waf-logs-subscription-${count.index}"
   log_group_name  = aws_cloudwatch_log_group.frontend_waf_logs[0].name
   filter_pattern  = ""
   destination_arn = var.logging_endpoint_arns[count.index]

--- a/ci/terraform/oidc/api-gateway.tf
+++ b/ci/terraform/oidc/api-gateway.tf
@@ -159,7 +159,7 @@ resource "aws_cloudwatch_log_group" "oidc_stage_execution_logs" {
 
 resource "aws_cloudwatch_log_subscription_filter" "oidc_api_execution_log_subscription" {
   count           = length(var.logging_endpoint_arns)
-  name            = "${var.environment}-oidc-api-execution-log-subscription"
+  name            = "${var.environment}-oidc-api-execution-log-subscription-${count.index}"
   log_group_name  = aws_cloudwatch_log_group.oidc_stage_execution_logs[0].name
   filter_pattern  = ""
   destination_arn = var.logging_endpoint_arns[count.index]
@@ -175,7 +175,7 @@ resource "aws_cloudwatch_log_group" "oidc_stage_access_logs" {
 
 resource "aws_cloudwatch_log_subscription_filter" "oidc_access_log_subscription" {
   count           = length(var.logging_endpoint_arns)
-  name            = "${var.environment}-oidc-api-access-logs-subscription"
+  name            = "${var.environment}-oidc-api-access-logs-subscription-${count.index}"
   log_group_name  = aws_cloudwatch_log_group.oidc_stage_access_logs[0].name
   filter_pattern  = ""
   destination_arn = var.logging_endpoint_arns[count.index]
@@ -191,7 +191,7 @@ resource "aws_cloudwatch_log_group" "oidc_waf_logs" {
 
 resource "aws_cloudwatch_log_subscription_filter" "oidc_waf_log_subscription" {
   count           = length(var.logging_endpoint_arns)
-  name            = "${var.environment}-oidc-api-waf-logs-subscription"
+  name            = "${var.environment}-oidc-api-waf-logs-subscription-${count.index}"
   log_group_name  = aws_cloudwatch_log_group.oidc_waf_logs[0].name
   filter_pattern  = ""
   destination_arn = var.logging_endpoint_arns[count.index]

--- a/ci/terraform/oidc/backchannel-logout-request.tf
+++ b/ci/terraform/oidc/backchannel-logout-request.tf
@@ -52,7 +52,7 @@ resource "aws_cloudwatch_log_group" "backchannel_logout_request_lambda_log_group
 
 resource "aws_cloudwatch_log_subscription_filter" "backchannel_logout_request_lambda_log_subscription" {
   count           = length(var.logging_endpoint_arns)
-  name            = "${aws_lambda_function.backchannel_logout_request_lambda.function_name}-log-subscription"
+  name            = "${aws_lambda_function.backchannel_logout_request_lambda.function_name}-log-subscription-${count.index}"
   log_group_name  = aws_cloudwatch_log_group.backchannel_logout_request_lambda_log_group[0].name
   filter_pattern  = ""
   destination_arn = var.logging_endpoint_arns[count.index]

--- a/ci/terraform/oidc/spot-response.tf
+++ b/ci/terraform/oidc/spot-response.tf
@@ -59,7 +59,7 @@ resource "aws_cloudwatch_log_group" "spot_response_lambda_log_group" {
 
 resource "aws_cloudwatch_log_subscription_filter" "spot_response_lambda_log_subscription" {
   count           = var.ipv_api_enabled ? length(var.logging_endpoint_arns) : 0
-  name            = "${aws_lambda_function.spot_response_lambda[0].function_name}-log-subscription"
+  name            = "${aws_lambda_function.spot_response_lambda[0].function_name}-log-subscription-${count.index}"
   log_group_name  = aws_cloudwatch_log_group.spot_response_lambda_log_group[0].name
   filter_pattern  = ""
   destination_arn = var.logging_endpoint_arns[count.index]

--- a/ci/terraform/oidc/sqs.tf
+++ b/ci/terraform/oidc/sqs.tf
@@ -201,7 +201,7 @@ resource "aws_cloudwatch_log_group" "sqs_lambda_log_group" {
 
 resource "aws_cloudwatch_log_subscription_filter" "sqs_lambda_log_subscription" {
   count           = length(var.logging_endpoint_arns)
-  name            = "${aws_lambda_function.email_sqs_lambda.function_name}-log-subscription"
+  name            = "${aws_lambda_function.email_sqs_lambda.function_name}-log-subscription-${count.index}"
   log_group_name  = aws_cloudwatch_log_group.sqs_lambda_log_group[0].name
   filter_pattern  = ""
   destination_arn = var.logging_endpoint_arns[count.index]

--- a/ci/terraform/shared/sns-alerts.tf
+++ b/ci/terraform/shared/sns-alerts.tf
@@ -113,7 +113,7 @@ resource "aws_cloudwatch_log_group" "sns_log_group" {
 
 resource "aws_cloudwatch_log_subscription_filter" "log_subscription" {
   count           = length(var.logging_endpoint_arns)
-  name            = "${aws_sns_topic.slack_events.name}-log-subscription"
+  name            = "${aws_sns_topic.slack_events.name}-log-subscription-${count.index}"
   log_group_name  = aws_cloudwatch_log_group.sns_log_group[0].name
   filter_pattern  = ""
   destination_arn = var.logging_endpoint_arns[count.index]


### PR DESCRIPTION
## What?

- Use unique names for aws_cloudwatch_log_subscription_filter resources

## Why?

- Now that there are multiple logging arns, we are creating multiple aws_cloudwatch_log_subscription_filter resources. Therefore these resources need to have a unique name otherwise we will see an error like ` Error creating Cloudwatch log subscription filter: OperationAbortedException: A conflicting operation is currently in progress against this resource. Please try again.`