### PR TITLE
AUT-268: Ensure subscriptions are destroyed before creation

### DIFF
--- a/ci/terraform/account-management/api-gateway.tf
+++ b/ci/terraform/account-management/api-gateway.tf
@@ -72,6 +72,10 @@ resource "aws_cloudwatch_log_subscription_filter" "authorizer_log_subscription" 
   log_group_name  = aws_cloudwatch_log_group.lambda_log_group[0].name
   filter_pattern  = ""
   destination_arn = var.logging_endpoint_arns[count.index]
+
+  lifecycle {
+    create_before_destroy = false
+  }
 }
 
 resource "aws_iam_role" "invocation_role" {
@@ -163,6 +167,10 @@ resource "aws_cloudwatch_log_subscription_filter" "account_management_execution_
   log_group_name  = aws_cloudwatch_log_group.account_management_stage_execution_logs[0].name
   filter_pattern  = ""
   destination_arn = var.logging_endpoint_arns[count.index]
+
+  lifecycle {
+    create_before_destroy = false
+  }
 }
 
 resource "aws_cloudwatch_log_group" "account_management_access_logs" {
@@ -179,6 +187,10 @@ resource "aws_cloudwatch_log_subscription_filter" "account_management_access_log
   log_group_name  = aws_cloudwatch_log_group.account_management_access_logs[0].name
   filter_pattern  = ""
   destination_arn = var.logging_endpoint_arns[count.index]
+
+  lifecycle {
+    create_before_destroy = false
+  }
 }
 
 resource "aws_cloudwatch_log_group" "account_management_waf_logs" {
@@ -195,6 +207,10 @@ resource "aws_cloudwatch_log_subscription_filter" "account_management_waf_log_su
   log_group_name  = aws_cloudwatch_log_group.account_management_waf_logs[0].name
   filter_pattern  = ""
   destination_arn = var.logging_endpoint_arns[count.index]
+
+  lifecycle {
+    create_before_destroy = false
+  }
 }
 
 resource "aws_api_gateway_stage" "stage" {

--- a/ci/terraform/account-management/sqs.tf
+++ b/ci/terraform/account-management/sqs.tf
@@ -216,6 +216,10 @@ resource "aws_cloudwatch_log_subscription_filter" "sqs_lambda_log_subscription" 
   log_group_name  = aws_cloudwatch_log_group.sqs_lambda_log_group[0].name
   filter_pattern  = ""
   destination_arn = var.logging_endpoint_arns[count.index]
+
+  lifecycle {
+    create_before_destroy = false
+  }
 }
 
 resource "aws_lambda_alias" "sqs_lambda_active" {

--- a/ci/terraform/audit-processors/counter_fraud.tf
+++ b/ci/terraform/audit-processors/counter_fraud.tf
@@ -112,6 +112,10 @@ resource "aws_cloudwatch_log_subscription_filter" "fraud_realtime_logging_log_su
   log_group_name  = aws_cloudwatch_log_group.fraud_realtime_logging_lambda_log_group[0].name
   filter_pattern  = ""
   destination_arn = var.logging_endpoint_arns[count.index]
+
+  lifecycle {
+    create_before_destroy = false
+  }
 }
 
 resource "aws_lambda_alias" "fraud_realtime_logging_lambda_active" {

--- a/ci/terraform/audit-processors/performance_analysis.tf
+++ b/ci/terraform/audit-processors/performance_analysis.tf
@@ -112,6 +112,10 @@ resource "aws_cloudwatch_log_subscription_filter" "performance_analysis_logging_
   log_group_name  = aws_cloudwatch_log_group.performance_analysis_logging_lambda_log_group[0].name
   filter_pattern  = ""
   destination_arn = var.logging_endpoint_arns[count.index]
+
+  lifecycle {
+    create_before_destroy = false
+  }
 }
 
 resource "aws_lambda_alias" "performance_analysis_logging_lambda_active" {

--- a/ci/terraform/audit-processors/storage.tf
+++ b/ci/terraform/audit-processors/storage.tf
@@ -200,6 +200,10 @@ resource "aws_cloudwatch_log_subscription_filter" "log_subscription" {
   log_group_name  = aws_cloudwatch_log_group.lambda_log_group[0].name
   filter_pattern  = ""
   destination_arn = var.logging_endpoint_arns[count.index]
+
+  lifecycle {
+    create_before_destroy = false
+  }
 }
 
 resource "aws_lambda_alias" "active_processor" {

--- a/ci/terraform/delivery-receipts/api-gateway.tf
+++ b/ci/terraform/delivery-receipts/api-gateway.tf
@@ -38,6 +38,10 @@ resource "aws_cloudwatch_log_subscription_filter" "delivery_receipts_api_executi
   log_group_name  = aws_cloudwatch_log_group.delivery_receipts_api_stage_execution_logs[0].name
   filter_pattern  = ""
   destination_arn = var.logging_endpoint_arns[count.index]
+
+  lifecycle {
+    create_before_destroy = false
+  }
 }
 
 resource "aws_cloudwatch_log_group" "delivery_receipts_stage_access_logs" {
@@ -54,6 +58,10 @@ resource "aws_cloudwatch_log_subscription_filter" "delivery_receipts_api_access_
   log_group_name  = aws_cloudwatch_log_group.delivery_receipts_stage_access_logs[0].name
   filter_pattern  = ""
   destination_arn = var.logging_endpoint_arns[count.index]
+
+  lifecycle {
+    create_before_destroy = false
+  }
 }
 
 resource "aws_api_gateway_stage" "endpoint_delivery_receipts_stage" {

--- a/ci/terraform/modules/endpoint-module/lambda.tf
+++ b/ci/terraform/modules/endpoint-module/lambda.tf
@@ -52,6 +52,10 @@ resource "aws_cloudwatch_log_subscription_filter" "log_subscription" {
   log_group_name  = aws_cloudwatch_log_group.lambda_log_group[0].name
   filter_pattern  = ""
   destination_arn = var.logging_endpoint_arns[count.index]
+
+  lifecycle {
+    create_before_destroy = false
+  }
 }
 
 resource "aws_lambda_alias" "endpoint_lambda" {

--- a/ci/terraform/oidc/api-gateway-frontend.tf
+++ b/ci/terraform/oidc/api-gateway-frontend.tf
@@ -94,6 +94,10 @@ resource "aws_cloudwatch_log_subscription_filter" "frontend_api_execution_log_su
   log_group_name  = aws_cloudwatch_log_group.frontend_api_stage_execution_logs[0].name
   filter_pattern  = ""
   destination_arn = var.logging_endpoint_arns[count.index]
+
+  lifecycle {
+    create_before_destroy = false
+  }
 }
 
 resource "aws_cloudwatch_log_group" "frontend_stage_access_logs" {
@@ -110,6 +114,10 @@ resource "aws_cloudwatch_log_subscription_filter" "frontend_api_access_log_subsc
   log_group_name  = aws_cloudwatch_log_group.frontend_stage_access_logs[0].name
   filter_pattern  = ""
   destination_arn = var.logging_endpoint_arns[count.index]
+
+  lifecycle {
+    create_before_destroy = false
+  }
 }
 
 resource "aws_cloudwatch_log_group" "frontend_waf_logs" {
@@ -126,6 +134,10 @@ resource "aws_cloudwatch_log_subscription_filter" "frontend_api_waf_log_subscrip
   log_group_name  = aws_cloudwatch_log_group.frontend_waf_logs[0].name
   filter_pattern  = ""
   destination_arn = var.logging_endpoint_arns[count.index]
+
+  lifecycle {
+    create_before_destroy = false
+  }
 }
 
 resource "aws_api_gateway_stage" "endpoint_frontend_stage" {

--- a/ci/terraform/oidc/api-gateway.tf
+++ b/ci/terraform/oidc/api-gateway.tf
@@ -163,6 +163,10 @@ resource "aws_cloudwatch_log_subscription_filter" "oidc_api_execution_log_subscr
   log_group_name  = aws_cloudwatch_log_group.oidc_stage_execution_logs[0].name
   filter_pattern  = ""
   destination_arn = var.logging_endpoint_arns[count.index]
+
+  lifecycle {
+    create_before_destroy = false
+  }
 }
 
 resource "aws_cloudwatch_log_group" "oidc_stage_access_logs" {
@@ -179,6 +183,10 @@ resource "aws_cloudwatch_log_subscription_filter" "oidc_access_log_subscription"
   log_group_name  = aws_cloudwatch_log_group.oidc_stage_access_logs[0].name
   filter_pattern  = ""
   destination_arn = var.logging_endpoint_arns[count.index]
+
+  lifecycle {
+    create_before_destroy = false
+  }
 }
 
 resource "aws_cloudwatch_log_group" "oidc_waf_logs" {
@@ -195,6 +203,10 @@ resource "aws_cloudwatch_log_subscription_filter" "oidc_waf_log_subscription" {
   log_group_name  = aws_cloudwatch_log_group.oidc_waf_logs[0].name
   filter_pattern  = ""
   destination_arn = var.logging_endpoint_arns[count.index]
+
+  lifecycle {
+    create_before_destroy = false
+  }
 }
 
 resource "aws_api_gateway_stage" "endpoint_stage" {

--- a/ci/terraform/oidc/backchannel-logout-request.tf
+++ b/ci/terraform/oidc/backchannel-logout-request.tf
@@ -56,6 +56,10 @@ resource "aws_cloudwatch_log_subscription_filter" "backchannel_logout_request_la
   log_group_name  = aws_cloudwatch_log_group.backchannel_logout_request_lambda_log_group[0].name
   filter_pattern  = ""
   destination_arn = var.logging_endpoint_arns[count.index]
+
+  lifecycle {
+    create_before_destroy = false
+  }
 }
 
 resource "aws_lambda_alias" "backchannel_logout_request_lambda_active" {

--- a/ci/terraform/oidc/spot-response.tf
+++ b/ci/terraform/oidc/spot-response.tf
@@ -63,6 +63,10 @@ resource "aws_cloudwatch_log_subscription_filter" "spot_response_lambda_log_subs
   log_group_name  = aws_cloudwatch_log_group.spot_response_lambda_log_group[0].name
   filter_pattern  = ""
   destination_arn = var.logging_endpoint_arns[count.index]
+
+  lifecycle {
+    create_before_destroy = false
+  }
 }
 
 resource "aws_lambda_alias" "spot_response_lambda_active" {

--- a/ci/terraform/oidc/sqs.tf
+++ b/ci/terraform/oidc/sqs.tf
@@ -205,6 +205,10 @@ resource "aws_cloudwatch_log_subscription_filter" "sqs_lambda_log_subscription" 
   log_group_name  = aws_cloudwatch_log_group.sqs_lambda_log_group[0].name
   filter_pattern  = ""
   destination_arn = var.logging_endpoint_arns[count.index]
+
+  lifecycle {
+    create_before_destroy = false
+  }
 }
 
 resource "aws_lambda_alias" "sqs_lambda_active" {

--- a/ci/terraform/shared/sns-alerts.tf
+++ b/ci/terraform/shared/sns-alerts.tf
@@ -117,5 +117,9 @@ resource "aws_cloudwatch_log_subscription_filter" "log_subscription" {
   log_group_name  = aws_cloudwatch_log_group.sns_log_group[0].name
   filter_pattern  = ""
   destination_arn = var.logging_endpoint_arns[count.index]
+
+  lifecycle {
+    create_before_destroy = false
+  }
 }
 


### PR DESCRIPTION
## What?

- Explicitly set the `create_before_destroy` to `false` for all `aws_cloudwatch_log_subscription_filter` resources.

## Why?

This shouldn't be necessary, as the default should be `false`, however, Terraform state indicates this is not the case. As such, we recently experience problems with renaming filters.

## Related PRs

#1708 