### PR TITLE
AUT-300 - Update StartLambda to cater for Doc checking app users

### DIFF
--- a/ci/terraform/oidc/start.tf
+++ b/ci/terraform/oidc/start.tf
@@ -25,6 +25,7 @@ module "start" {
     EVENTS_SNS_TOPIC_ARN     = aws_sns_topic.events.arn
     AUDIT_SIGNING_KEY_ALIAS  = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT      = var.use_localstack ? var.localstack_endpoint : null
+    DOC_APP_DOMAIN           = var.doc_app_domain
     REDIS_KEY                = local.redis_key
     ENVIRONMENT              = var.environment
     DYNAMO_ENDPOINT          = var.use_localstack ? var.lambda_dynamo_endpoint : null

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -302,3 +302,8 @@ variable "doc_app_api_enabled" {
   type    = bool
   default = false
 }
+
+variable "doc_app_domain" {
+  type    = string
+  default = "undefined"
+}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/UserStartInfo.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/UserStartInfo.java
@@ -22,19 +22,24 @@ public class UserStartInfo {
     @JsonProperty("gaCrossDomainTrackingId")
     private String gaCrossDomainTrackingId;
 
+    @JsonProperty("docCheckingAppUser")
+    private boolean docCheckingAppUser;
+
     public UserStartInfo(
             @JsonProperty(required = true, value = "consentRequired") boolean consentRequired,
             @JsonProperty(required = true, value = "upliftRequired") boolean upliftRequired,
             @JsonProperty(required = true, value = "identityRequired") boolean identityRequired,
             @JsonProperty(required = true, value = "authenticated") boolean authenticated,
             @JsonProperty(value = "cookieConsent") String cookieConsent,
-            @JsonProperty(value = "gaCrossDomainTrackingId") String gaCrossDomainTrackingId) {
+            @JsonProperty(value = "gaCrossDomainTrackingId") String gaCrossDomainTrackingId,
+            @JsonProperty(value = "docCheckingAppUser") boolean docCheckingAppUser) {
         this.consentRequired = consentRequired;
         this.upliftRequired = upliftRequired;
         this.identityRequired = identityRequired;
         this.authenticated = authenticated;
         this.cookieConsent = cookieConsent;
         this.gaCrossDomainTrackingId = gaCrossDomainTrackingId;
+        this.docCheckingAppUser = docCheckingAppUser;
     }
 
     public boolean isConsentRequired() {
@@ -59,5 +64,9 @@ public class UserStartInfo {
 
     public String getGaCrossDomainTrackingId() {
         return gaCrossDomainTrackingId;
+    }
+
+    public boolean isDocCheckingAppUser() {
+        return docCheckingAppUser;
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -258,6 +258,7 @@ class StartHandlerTest {
     }
 
     private UserStartInfo getUserStartInfo(String cookieConsent, String gaCrossDomainTrackingId) {
-        return new UserStartInfo(true, false, false, true, cookieConsent, gaCrossDomainTrackingId);
+        return new UserStartInfo(
+                true, false, false, true, cookieConsent, gaCrossDomainTrackingId, false);
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -23,12 +23,15 @@ import uk.gov.di.authentication.frontendapi.entity.UserStartInfo;
 import uk.gov.di.authentication.frontendapi.services.StartService;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
+import uk.gov.di.authentication.shared.entity.CustomScopeValue;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.VectorOfTrust;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
@@ -40,6 +43,8 @@ import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -70,6 +75,7 @@ class StartHandlerTest {
     private final StartService startService = mock(StartService.class);
     private final UserContext userContext = mock(UserContext.class);
     private final ClientRegistry clientRegistry = mock(ClientRegistry.class);
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final Session session = new Session(SESSION_ID);
     private final ClientSession clientSession = getClientSession();
 
@@ -82,7 +88,12 @@ class StartHandlerTest {
         when(userContext.getClientSession()).thenReturn(clientSession);
         when(clientRegistry.getClientID()).thenReturn(TEST_CLIENT_ID);
         handler =
-                new StartHandler(clientSessionService, sessionService, auditService, startService);
+                new StartHandler(
+                        clientSessionService,
+                        sessionService,
+                        auditService,
+                        startService,
+                        configurationService);
     }
 
     private static Stream<Arguments> cookieConsentGaTrackingIdValues() {
@@ -142,6 +153,68 @@ class StartHandlerTest {
                 response.getUser().isUpliftRequired(), equalTo(userStartInfo.isUpliftRequired()));
         assertThat(response.getUser().getCookieConsent(), equalTo(cookieConsentValue));
         assertThat(response.getUser().getGaCrossDomainTrackingId(), equalTo(gaTrackingId));
+
+        verify(auditService)
+                .submitAuditEvent(
+                        FrontendAuditableEvent.START_INFO_FOUND,
+                        "aws-session-id",
+                        SESSION_ID,
+                        TEST_CLIENT_ID,
+                        auditService.UNKNOWN,
+                        auditService.UNKNOWN,
+                        "123.123.123.123",
+                        PERSISTENT_ID,
+                        AuditService.UNKNOWN);
+    }
+
+    @Test
+    void shouldReturn200WhenDocCheckingAppUserIsPresent()
+            throws JsonProcessingException, ParseException {
+        when(configurationService.getDocAppDomain()).thenReturn("https://doc-app");
+        var userStartInfo = new UserStartInfo(false, false, false, false, null, null, true);
+        when(startService.buildUserContext(session, clientSession)).thenReturn(userContext);
+        var scope = new Scope(OIDCScopeValue.OPENID, CustomScopeValue.DOC_CHECKING_APP);
+        when(startService.buildClientStartInfo(userContext))
+                .thenReturn(
+                        new ClientStartInfo(
+                                TEST_CLIENT_NAME,
+                                scope.toStringList(),
+                                "MANDATORY",
+                                false,
+                                REDIRECT_URL));
+        when(startService.getGATrackingId(anyMap())).thenReturn(null);
+        when(startService.getCookieConsentValue(anyMap(), anyString())).thenReturn(null);
+        when(startService.buildUserStartInfo(userContext, null, null)).thenReturn(userStartInfo);
+        usingValidClientSession();
+        usingValidSession();
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, PERSISTENT_ID);
+        headers.put(CLIENT_SESSION_ID_HEADER, CLIENT_SESSION_ID);
+        headers.put(SESSION_ID_HEADER, SESSION_ID);
+        var event = new APIGatewayProxyRequestEvent();
+        event.setHeaders(headers);
+        event.setRequestContext(contextWithSourceIp("123.123.123.123"));
+        var result = handler.handleRequest(event, context);
+
+        assertThat(result, hasStatus(200));
+
+        var response = new ObjectMapper().readValue(result.getBody(), StartResponse.class);
+
+        assertThat(response.getClient().getClientName(), equalTo(TEST_CLIENT_NAME));
+        assertThat(response.getClient().getScopes(), equalTo(scope.toStringList()));
+        assertThat(
+                response.getClient().getServiceType(), equalTo(ServiceType.MANDATORY.toString()));
+        assertThat(response.getClient().getRedirectUri(), equalTo(REDIRECT_URL));
+        assertFalse(response.getClient().getCookieConsentShared());
+        assertTrue(response.getUser().isDocCheckingAppUser());
+        assertFalse(response.getUser().isIdentityRequired());
+        assertFalse(response.getUser().isUpliftRequired());
+        assertFalse(response.getUser().isAuthenticated());
+        assertFalse(response.getUser().isConsentRequired());
+        assertThat(response.getUser().getCookieConsent(), equalTo(null));
+        assertThat(response.getUser().getGaCrossDomainTrackingId(), equalTo(null));
+        verify(clientSessionService).saveClientSession(anyString(), any());
 
         verify(auditService)
                 .submitAuditEvent(

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -41,6 +41,7 @@ test {
     environment "OIDC_API_BASE_URL", "http://localhost"
     environment "DEFAULT_LOGOUT_URI", "http://localhost:3000/signed-out"
     environment "DOMAIN_NAME", "localhost"
+    environment "DOC_APP_DOMAIN", "https://doc-app"
     environment "DYNAMO_ENDPOINT", "http://localhost:8000"
     environment "ENVIRONMENT", "local"
     environment "LOCALSTACK_ENDPOINT", "http://localhost:45678"

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
@@ -1,6 +1,13 @@
 package uk.gov.di.authentication.api;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.AuthorizationRequest;
 import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.id.ClientID;
@@ -12,6 +19,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.frontendapi.entity.StartResponse;
 import uk.gov.di.authentication.frontendapi.lambda.StartHandler;
+import uk.gov.di.authentication.shared.entity.ClientType;
+import uk.gov.di.authentication.shared.entity.CustomScopeValue;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.helper.KeyPairHelper;
@@ -28,6 +37,9 @@ import java.util.Optional;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.START_INFO_FOUND;
 import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceived;
 import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertNoAuditEventsReceived;
@@ -62,7 +74,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         redis.createClientSession(CLIENT_SESSION_ID, authRequest.toParameters());
         redis.createSession(sessionId);
 
-        registerClient(KeyPairHelper.GENERATE_RSA_KEY_PAIR());
+        registerClient(KeyPairHelper.GENERATE_RSA_KEY_PAIR(), ClientType.WEB);
 
         Map<String, String> headers = new HashMap<>();
         headers.put("Session-Id", sessionId);
@@ -99,7 +111,49 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertNoAuditEventsReceived(auditTopic);
     }
 
-    private void registerClient(KeyPair keyPair) {
+    @Test
+    void shouldReturn200WhenUserIsADocCheckignAppUser() throws IOException, JOSEException {
+        KeyPair keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        var sessionId = redis.createSession();
+        var scope = new Scope();
+        scope.add(OIDCScopeValue.OPENID);
+        scope.add(CustomScopeValue.DOC_CHECKING_APP);
+        var authRequest =
+                new AuthorizationRequest.Builder(ResponseType.CODE, new ClientID(CLIENT_ID))
+                        .requestObject(createSignedJWT(keyPair))
+                        .build();
+        redis.createClientSession(CLIENT_SESSION_ID, authRequest.toParameters());
+        redis.createSession(sessionId);
+
+        registerClient(keyPair, ClientType.APP);
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Session-Id", sessionId);
+        headers.put("Client-Session-Id", CLIENT_SESSION_ID);
+        headers.put("X-API-Key", FRONTEND_API_KEY);
+
+        var response = makeRequest(Optional.empty(), headers, Map.of());
+        assertThat(response, hasStatus(200));
+
+        var startResponse = objectMapper.readValue(response.getBody(), StartResponse.class);
+
+        assertFalse(startResponse.getUser().isIdentityRequired());
+        assertFalse(startResponse.getUser().isConsentRequired());
+        assertFalse(startResponse.getUser().isUpliftRequired());
+        assertNull(startResponse.getUser().getCookieConsent());
+        assertNull(startResponse.getUser().getGaCrossDomainTrackingId());
+        assertTrue(startResponse.getUser().isDocCheckingAppUser());
+
+        assertThat(startResponse.getClient().getClientName(), equalTo(TEST_CLIENT_NAME));
+        assertThat(startResponse.getClient().getServiceType(), equalTo("MANDATORY"));
+        assertFalse(startResponse.getClient().getCookieConsentShared());
+        assertThat(startResponse.getClient().getScopes(), equalTo(scope.toStringList()));
+        assertThat(startResponse.getClient().getRedirectUri(), equalTo(REDIRECT_URI));
+
+        assertEventTypesReceived(auditTopic, List.of(START_INFO_FOUND));
+    }
+
+    private void registerClient(KeyPair keyPair, ClientType clientType) {
         clientStore.registerClient(
                 CLIENT_ID,
                 TEST_CLIENT_NAME,
@@ -112,6 +166,27 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 String.valueOf(ServiceType.MANDATORY),
                 "https://test.com",
                 "public",
-                true);
+                true,
+                clientType);
+    }
+
+    private SignedJWT createSignedJWT(KeyPair keyPair) throws JOSEException {
+        var jwtClaimsSet =
+                new JWTClaimsSet.Builder()
+                        .audience("http://localhost")
+                        .claim("redirect_uri", REDIRECT_URI.toString())
+                        .claim("response_type", ResponseType.CODE.toString())
+                        .claim(
+                                "scope",
+                                new Scope(OIDCScopeValue.OPENID, CustomScopeValue.DOC_CHECKING_APP)
+                                        .toString())
+                        .claim("client_id", CLIENT_ID)
+                        .issuer(CLIENT_ID)
+                        .build();
+        var jwsHeader = new JWSHeader(JWSAlgorithm.RS256);
+        var signedJWT = new SignedJWT(jwsHeader, jwtClaimsSet);
+        var signer = new RSASSASigner(keyPair.getPrivate());
+        signedJWT.sign(signer);
+        return signedJWT;
     }
 }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/ClientStoreExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/ClientStoreExtension.java
@@ -41,6 +41,36 @@ public class ClientStoreExtension extends DynamoExtension implements AfterEachCa
             String sectorIdentifierUri,
             String subjectType,
             boolean consentRequired) {
+        registerClient(
+                clientID,
+                clientName,
+                redirectUris,
+                contacts,
+                scopes,
+                publicKey,
+                postLogoutRedirectUris,
+                backChannelLogoutUri,
+                serviceType,
+                sectorIdentifierUri,
+                subjectType,
+                consentRequired,
+                ClientType.WEB);
+    }
+
+    public void registerClient(
+            String clientID,
+            String clientName,
+            List<String> redirectUris,
+            List<String> contacts,
+            List<String> scopes,
+            String publicKey,
+            List<String> postLogoutRedirectUris,
+            String backChannelLogoutUri,
+            String serviceType,
+            String sectorIdentifierUri,
+            String subjectType,
+            boolean consentRequired,
+            ClientType clientType) {
         dynamoClientService.addClient(
                 clientID,
                 clientName,
@@ -55,7 +85,7 @@ public class ClientStoreExtension extends DynamoExtension implements AfterEachCa
                 subjectType,
                 consentRequired,
                 Collections.emptyList(),
-                ClientType.WEB.getValue());
+                clientType.getValue());
     }
 
     public boolean clientExists(String clientID) {

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
@@ -202,6 +202,15 @@ public class RedisExtension
                 300);
     }
 
+    public ClientSession getClientSession(String clientSessionId) {
+        try {
+            var result = redis.getValue(CLIENT_SESSION_PREFIX.concat(clientSessionId));
+            return objectMapper.readValue(result, ClientSession.class);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     @Override
     public void afterAll(ExtensionContext context) throws Exception {
         redis.close();

--- a/shared/src/main/java/uk/gov/di/authentication/shared/conditions/DocAppUserHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/conditions/DocAppUserHelper.java
@@ -1,0 +1,34 @@
+package uk.gov.di.authentication.shared.conditions;
+
+import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.oauth2.sdk.Scope;
+import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+import uk.gov.di.authentication.shared.entity.ClientType;
+import uk.gov.di.authentication.shared.entity.CustomScopeValue;
+import uk.gov.di.authentication.shared.state.UserContext;
+
+public class DocAppUserHelper {
+
+    private DocAppUserHelper() {}
+
+    public static boolean isDocCheckingAppUser(UserContext context) {
+        var authRequestParams = context.getClientSession().getAuthRequestParams();
+        if (Boolean.FALSE.equals(authRequestParams.containsKey("request"))) {
+            return false;
+        }
+        try {
+            var authRequest = AuthenticationRequest.parse(authRequestParams);
+            var requestObject = authRequest.getRequestObject();
+            var claimScope = (String) requestObject.getJWTClaimsSet().getClaim("scope");
+            var scope = Scope.parse(claimScope);
+            if (Boolean.FALSE.equals(scope.contains(CustomScopeValue.DOC_CHECKING_APP))) {
+                return false;
+            }
+            return context.getClient()
+                    .filter(t -> t.getClientType().equals(ClientType.APP.getValue()))
+                    .isPresent();
+        } catch (ParseException | java.text.ParseException e) {
+            throw new RuntimeException();
+        }
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/conditions/UpliftHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/conditions/UpliftHelper.java
@@ -2,11 +2,16 @@ package uk.gov.di.authentication.shared.conditions;
 
 import uk.gov.di.authentication.shared.state.UserContext;
 
+import java.util.Objects;
+
 public class UpliftHelper {
 
     private UpliftHelper() {}
 
     public static boolean upliftRequired(UserContext context) {
+        if (Objects.isNull(context.getSession().getCurrentCredentialStrength())) {
+            return false;
+        }
         return (context.getSession()
                         .getCurrentCredentialStrength()
                         .compareTo(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/SaltHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/SaltHelper.java
@@ -1,0 +1,17 @@
+package uk.gov.di.authentication.shared.helpers;
+
+import java.security.SecureRandom;
+
+public class SaltHelper {
+
+    private static final int SALT_BYTES = 32;
+    private static final SecureRandom secureRandom = new SecureRandom();
+
+    private SaltHelper() {}
+
+    public static byte[] generateNewSalt() {
+        byte[] salt = new byte[SALT_BYTES];
+        secureRandom.nextBytes(salt);
+        return salt;
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
@@ -20,8 +20,8 @@ import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.Argon2EncoderHelper;
 import uk.gov.di.authentication.shared.helpers.Argon2MatcherHelper;
 import uk.gov.di.authentication.shared.helpers.PhoneNumberHelper;
+import uk.gov.di.authentication.shared.helpers.SaltHelper;
 
-import java.security.SecureRandom;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Arrays;
@@ -38,14 +38,10 @@ import static uk.gov.di.authentication.shared.dynamodb.DynamoDBSchemaHelper.Tabl
 
 public class DynamoService implements AuthenticationService {
 
-    private static final int SALT_BYTES = 32;
-
     private final DynamoDBMapper userCredentialsMapper;
     private final DynamoDBMapper userProfileMapper;
     private final AmazonDynamoDB dynamoDB;
     private final DynamoDBSchemaHelper dynamoDBSchemaHelper;
-
-    private final SecureRandom secureRandom = new SecureRandom();
 
     public DynamoService(ConfigurationService configurationService) {
         this(
@@ -284,7 +280,7 @@ public class DynamoService implements AuthenticationService {
     @Override
     public byte[] getOrGenerateSalt(UserProfile userProfile) {
         if (userProfile.getSalt() == null || userProfile.getSalt().array().length == 0) {
-            byte[] salt = generateNewSalt();
+            byte[] salt = SaltHelper.generateNewSalt();
             userProfile.setSalt(salt);
             userProfileMapper.save(
                     getUserProfileFromSubject(userProfile.getSubjectID())
@@ -378,11 +374,5 @@ public class DynamoService implements AuthenticationService {
 
     private void warmUp(String tableName) {
         dynamoDB.describeTable(tableName);
-    }
-
-    private byte[] generateNewSalt() {
-        byte[] salt = new byte[SALT_BYTES];
-        secureRandom.nextBytes(salt);
-        return salt;
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/conditions/DocAppUserHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/conditions/DocAppUserHelperTest.java
@@ -1,0 +1,145 @@
+package uk.gov.di.authentication.shared.conditions;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.AuthorizationRequest;
+import com.nimbusds.oauth2.sdk.ResponseType;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.id.State;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import uk.gov.di.authentication.shared.entity.ClientRegistry;
+import uk.gov.di.authentication.shared.entity.ClientSession;
+import uk.gov.di.authentication.shared.entity.ClientType;
+import uk.gov.di.authentication.shared.entity.Session;
+import uk.gov.di.authentication.shared.entity.VectorOfTrust;
+import uk.gov.di.authentication.shared.state.UserContext;
+
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DocAppUserHelperTest {
+
+    private static final ClientID CLIENT_ID = new ClientID("client-id");
+    private static final String CLIENT_NAME = "test-client";
+    private static final Session SESSION = new Session("a-session-id");
+    private static final String AUDIENCE = "oidc-audience";
+    private static final String VALID_SCOPE = "openid doc-checking-app";
+    private static final State STATE = new State();
+    private static final String REDIRECT_URI = "https://localhost:8080";
+
+    private static Stream<ClientType> clientTypes() {
+        return Stream.of(ClientType.WEB, ClientType.APP);
+    }
+
+    @ParameterizedTest
+    @MethodSource("clientTypes")
+    void shouldReturnFalseIfAuthRequestDoesNotContainRequestObject(ClientType clientType) {
+        var userContext = buildUserContext(clientType, null);
+
+        assertFalse(DocAppUserHelper.isDocCheckingAppUser(userContext));
+    }
+
+    @ParameterizedTest
+    @MethodSource("clientTypes")
+    void shouldReturnFalseIfRequestObjectDoesNotContainDocAppScope(ClientType clientType)
+            throws NoSuchAlgorithmException, JOSEException {
+        var jwtClaimsSet =
+                new JWTClaimsSet.Builder()
+                        .audience(AUDIENCE)
+                        .claim("redirect_uri", REDIRECT_URI)
+                        .claim("response_type", ResponseType.CODE.toString())
+                        .claim("scope", "openid")
+                        .claim("client_id", CLIENT_ID.getValue())
+                        .claim("state", STATE)
+                        .issuer(CLIENT_ID.getValue())
+                        .build();
+        var signedJWT = generateSignedJWT(jwtClaimsSet);
+        var userContext = buildUserContext(clientType, signedJWT);
+
+        assertFalse(DocAppUserHelper.isDocCheckingAppUser(userContext));
+    }
+
+    @Test
+    void shouldReturnFalseIfClientIsNotAppClient() throws NoSuchAlgorithmException, JOSEException {
+        var jwtClaimsSet =
+                new JWTClaimsSet.Builder()
+                        .audience(AUDIENCE)
+                        .claim("redirect_uri", REDIRECT_URI)
+                        .claim("response_type", ResponseType.CODE.toString())
+                        .claim("scope", VALID_SCOPE)
+                        .claim("client_id", CLIENT_ID.getValue())
+                        .claim("state", STATE)
+                        .issuer(CLIENT_ID.getValue())
+                        .build();
+        var signedJWT = generateSignedJWT(jwtClaimsSet);
+        var userContext = buildUserContext(ClientType.WEB, signedJWT);
+
+        assertFalse(DocAppUserHelper.isDocCheckingAppUser(userContext));
+    }
+
+    @Test
+    void shouldReturnTrueIfClientIsDocCheckingAppUser()
+            throws NoSuchAlgorithmException, JOSEException {
+        var jwtClaimsSet =
+                new JWTClaimsSet.Builder()
+                        .audience(AUDIENCE)
+                        .claim("redirect_uri", REDIRECT_URI)
+                        .claim("response_type", ResponseType.CODE.toString())
+                        .claim("scope", VALID_SCOPE)
+                        .claim("client_id", CLIENT_ID.getValue())
+                        .claim("state", STATE)
+                        .issuer(CLIENT_ID.getValue())
+                        .build();
+        var signedJWT = generateSignedJWT(jwtClaimsSet);
+        var userContext = buildUserContext(ClientType.APP, signedJWT);
+
+        assertTrue(DocAppUserHelper.isDocCheckingAppUser(userContext));
+    }
+
+    private UserContext buildUserContext(ClientType clientType, SignedJWT requestObject) {
+        var authRequestBuilder =
+                new AuthorizationRequest.Builder(
+                        new ResponseType(ResponseType.Value.CODE), CLIENT_ID);
+        if (Objects.nonNull(requestObject)) {
+            authRequestBuilder.requestObject(requestObject);
+        }
+        var clientSession =
+                new ClientSession(
+                        authRequestBuilder.build().toParameters(),
+                        LocalDateTime.now(),
+                        VectorOfTrust.getDefaults());
+        var clientRegistry =
+                new ClientRegistry()
+                        .setClientID(CLIENT_ID.getValue())
+                        .setClientName(CLIENT_NAME)
+                        .setConsentRequired(false)
+                        .setCookieConsentShared(false)
+                        .setClientType(clientType.getValue());
+        return UserContext.builder(SESSION)
+                .withClientSession(clientSession)
+                .withClient(clientRegistry)
+                .build();
+    }
+
+    private SignedJWT generateSignedJWT(JWTClaimsSet jwtClaimsSet)
+            throws NoSuchAlgorithmException, JOSEException {
+        var keyPair = KeyPairGenerator.getInstance("RSA").generateKeyPair();
+        var jwsHeader = new JWSHeader(JWSAlgorithm.RS256);
+        var signedJWT = new SignedJWT(jwsHeader, jwtClaimsSet);
+        var signer = new RSASSASigner(keyPair.getPrivate());
+        signedJWT.sign(signer);
+        return signedJWT;
+    }
+}


### PR DESCRIPTION
## What?

- Create a helper to determine whether it is a doc checking app user. This is determined by whether a request object was present in the auth request, that the doc checking app scope is present and if the client has `app` as their `ClientType`
- If it is a doc checking app user, then we need to build the ClientStartInfo using the claims in request object as `redirect_uri` and `scope` will not be present as the usual auth request query parameter.
- Return a new property in the UserStartInfo called `docCheckingAppUser` this will be a boolean and will be used by the frontend to direct the user to the correct location.
- When the user is a docCheckingAppUser then set the `docAppSubjectId` in the client session using a new salt and the sector identifier which is the doc checking app domain. This will be a pairwise identifier and be used instead the SubjectID which is usually in the user profile. 

## Why?

- When the user is a docAppCheckingAppUser we need to let the frontend know this so they can redirect the user to the correct location. 
- The user will not have an entry in the UserProfile so we need to set a temp SubjectID in the client session which can be used later on in the journey. 
