### PR TITLE
AUT-295 - Add new Stub and make config dynamic

### DIFF
--- a/ci/terraform/shared/build-stub-clients.tfvars
+++ b/ci/terraform/shared/build-stub-clients.tfvars
@@ -2,13 +2,18 @@ stub_rp_clients = [
   {
     client_name = "di-auth-stub-relying-party-build"
     callback_urls = [
-      "http://localhost:8081/oidc/authorization-code/callback",
       "https://di-auth-stub-relying-party-build.london.cloudapps.digital/oidc/authorization-code/callback",
     ]
     logout_urls = [
       "https://di-auth-stub-relying-party-build.london.cloudapps.digital/signed-out",
     ]
     test_client = "0"
+    client_type = "web"
+    scopes = [
+      "openid",
+      "email",
+      "phone",
+    ]
   },
   {
     client_name = "di-auth-stub-relying-party-build-s2"
@@ -19,5 +24,11 @@ stub_rp_clients = [
       "https://di-auth-stub-relying-party-build-s2.london.cloudapps.digital/signed-out",
     ]
     test_client = "1"
+    client_type = "web"
+    scopes = [
+      "openid",
+      "email",
+      "phone",
+    ]
   },
 ]

--- a/ci/terraform/shared/integration-stub-clients.tfvars
+++ b/ci/terraform/shared/integration-stub-clients.tfvars
@@ -8,5 +8,11 @@ stub_rp_clients = [
       "https://di-auth-stub-relying-party-integration.london.cloudapps.digital/signed-out",
     ]
     test_client = "0"
+    client_type = "web"
+    scopes = [
+      "openid",
+      "email",
+      "phone",
+    ]
   },
 ]

--- a/ci/terraform/shared/staging-stub-clients.tfvars
+++ b/ci/terraform/shared/staging-stub-clients.tfvars
@@ -8,5 +8,26 @@ stub_rp_clients = [
       "https://di-auth-stub-relying-party-staging.london.cloudapps.digital/signed-out",
     ]
     test_client = "0"
+    client_type = "web"
+    scopes = [
+      "openid",
+      "email",
+      "phone",
+    ]
+  },
+  {
+    client_name = "di-auth-stub-relying-party-staging-app"
+    callback_urls = [
+      "https://di-auth-stub-relying-party-staging-app.london.cloudapps.digital/oidc/authorization-code/callback",
+    ]
+    logout_urls = [
+      "https://di-auth-stub-relying-party-staging-app.london.cloudapps.digital/signed-out",
+    ]
+    test_client = "1"
+    client_type = "app"
+    scopes = [
+      "openid",
+      "doc-checking-app",
+    ]
   },
 ]

--- a/ci/terraform/shared/stub-rp-clients.tf
+++ b/ci/terraform/shared/stub-rp-clients.tf
@@ -45,17 +45,9 @@ resource "aws_dynamodb_table_item" "stub_rp_client" {
       }]
     }
     Scopes = {
-      L = [
-        {
-          S = "openid"
-        },
-        {
-          S = "phone"
-        },
-        {
-          S = "email"
-        },
-      ]
+      L = [for scope in var.stub_rp_clients[count.index].scopes : {
+        S = scope
+      }]
     },
     Claims = {
       L = [
@@ -89,7 +81,7 @@ resource "aws_dynamodb_table_item" "stub_rp_client" {
       N = "1"
     }
     ClientType = {
-      S = "web"
+      S = var.stub_rp_clients[count.index].client_type
     }
     TestClient = {
       N = var.stub_rp_clients[count.index].test_client


### PR DESCRIPTION
## What?

- Remove the localhost redirect URI for Stub build 1 as it is not used and avoids us having to add a sector identifier
- Make ClientType dynamic so it is not hardcoded the same for each stub
- Make scope dynamic so they are not hardcoded the same for each stub
- Add a new Stub config in for Staging to replicate the Doc Checking App RP. This will include the doc-checking-app scope and also the `app` ClientType

## Why?

- So we can configure it on a Stub by Stub basis 
- So we can test out the journey from a Doc Checking App Stub