### PR TITLE
AUT-295 - Use on feature flag for supporting request objects

### DIFF
--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -22,17 +22,17 @@ module "authorize" {
   environment     = var.environment
 
   handler_environment_variables = {
-    DOMAIN_NAME                    = module.dns.service_domain_name
-    EVENTS_SNS_TOPIC_ARN           = aws_sns_topic.events.arn
-    AUDIT_SIGNING_KEY_ALIAS        = local.audit_signing_key_alias_name
-    LOGIN_URI                      = module.dns.frontend_url
-    LOCALSTACK_ENDPOINT            = var.use_localstack ? var.localstack_endpoint : null
-    REDIS_KEY                      = local.redis_key
-    ENVIRONMENT                    = var.environment
-    DYNAMO_ENDPOINT                = var.use_localstack ? var.lambda_dynamo_endpoint : null
-    TERMS_CONDITIONS_VERSION       = var.terms_and_conditions
-    HEADERS_CASE_INSENSITIVE       = var.use_localstack ? "true" : "false"
-    REQUEST_OBJECT_PARAM_SUPPORTED = var.request_object_param_supported
+    DOMAIN_NAME              = module.dns.service_domain_name
+    DOC_APP_API_ENABLED      = var.doc_app_api_enabled
+    EVENTS_SNS_TOPIC_ARN     = aws_sns_topic.events.arn
+    AUDIT_SIGNING_KEY_ALIAS  = local.audit_signing_key_alias_name
+    LOGIN_URI                = module.dns.frontend_url
+    LOCALSTACK_ENDPOINT      = var.use_localstack ? var.localstack_endpoint : null
+    REDIS_KEY                = local.redis_key
+    ENVIRONMENT              = var.environment
+    DYNAMO_ENDPOINT          = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    TERMS_CONDITIONS_VERSION = var.terms_and_conditions
+    HEADERS_CASE_INSENSITIVE = var.use_localstack ? "true" : "false"
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.AuthorisationHandler::handleRequest"
   rest_api_id           = aws_api_gateway_rest_api.di_authentication_api.id

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -258,11 +258,6 @@ variable "endpoint_memory_size" {
   type    = number
 }
 
-variable "request_object_param_supported" {
-  default = false
-  type    = bool
-}
-
 variable "spot_enabled" {
   default = false
   type    = bool

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -53,7 +53,7 @@ test {
     environment "STUB_RELYING_PARTY_REDIRECT_URI", "https://di-auth-stub-relying-party-build.london.cloudapps.digital/"
     environment "TERMS_CONDITIONS_VERSION", "1.0"
     environment "HEADERS_CASE_INSENSITIVE", "true"
-    environment "REQUEST_OBJECT_PARAM_SUPPORTED", "true"
+    environment "DOC_APP_API_ENABLED", "true"
     environment "IDENTITY_ENABLED", "false"
     environment "SPOT_ENABLED", "true"
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -151,7 +151,7 @@ public class AuthorisationHandler
                             }
                             Optional<AuthRequestError> authRequestError;
                             if (authRequest.getRequestObject() != null
-                                    && configurationService.isRequestObjectParamSupported()) {
+                                    && configurationService.isDocAppApiEnabled()) {
                                 authRequestError =
                                         requestObjectService.validateRequestObject(authRequest);
                             } else {

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -434,7 +434,7 @@ class AuthorisationHandlerTest {
     @ParameterizedTest
     @MethodSource("expectedErrorObjects")
     void shouldReturnErrorWhenRequestObjectIsInvalid(ErrorObject errorObject) {
-        when(configService.isRequestObjectParamSupported()).thenReturn(true);
+        when(configService.isDocAppApiEnabled()).thenReturn(true);
         when(requestObjectService.validateRequestObject(any(AuthenticationRequest.class)))
                 .thenReturn(
                         Optional.of(
@@ -478,7 +478,7 @@ class AuthorisationHandlerTest {
 
     @Test
     void shouldRedirectToLoginWhenRequestObjectIsValid() {
-        when(configService.isRequestObjectParamSupported()).thenReturn(true);
+        when(configService.isDocAppApiEnabled()).thenReturn(true);
         when(requestObjectService.validateRequestObject(any(AuthenticationRequest.class)))
                 .thenReturn(Optional.empty());
         when(clientSessionService.generateClientSession(any(ClientSession.class)))

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -75,6 +75,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return URI.create(System.getenv().getOrDefault("DOC_APP_AUTHORISATION_URI", ""));
     }
 
+    public boolean isDocAppApiEnabled() {
+        return System.getenv().getOrDefault("DOC_APP_API_ENABLED", "false").equals("true");
+    }
+
     public URI getDocAppBackendURI() {
         return URI.create(System.getenv().getOrDefault("DOC_APP_BACKEND_URI", ""));
     }
@@ -262,12 +266,6 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
 
     public String getResetPasswordRoute() {
         return System.getenv().getOrDefault("RESET_PASSWORD_ROUTE", "");
-    }
-
-    public boolean isRequestObjectParamSupported() {
-        return System.getenv()
-                .getOrDefault("REQUEST_OBJECT_PARAM_SUPPORTED", "false")
-                .equals("true");
     }
 
     public String getSessionCookieAttributes() {


### PR DESCRIPTION
## What?

 - Use on feature flag for supporting request objects

## Why?

- Instead of managing 2 feature flags for the doc app journey, use a single feature flag to make it easier and clearer to manage.