### PR TITLE
AUT-298: PEM certs and integration tests

### DIFF
--- a/doc-checking-app-api/build.gradle
+++ b/doc-checking-app-api/build.gradle
@@ -12,6 +12,7 @@ dependencies {
 
     implementation configurations.jackson,
             configurations.nimbus,
+            configurations.bouncycastle,
             project(":shared")
     runtimeOnly configurations.logging_runtime
 

--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/services/DocAppCriService.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/services/DocAppCriService.java
@@ -9,7 +9,6 @@ import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jose.JWSVerifier;
 import com.nimbusds.jose.crypto.ECDSAVerifier;
 import com.nimbusds.jose.crypto.impl.ECDSA;
-import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jose.util.Base64URL;
 import com.nimbusds.jwt.JWT;
 import com.nimbusds.jwt.SignedJWT;
@@ -131,8 +130,7 @@ public class DocAppCriService {
             JWT jwt = response.getContentAsJWT();
             if (jwt instanceof SignedJWT) {
                 var signed = (SignedJWT) jwt;
-                var signingPublicKey =
-                        ECKey.parse(configurationService.getDocAppCredentialSigningPublicKey());
+                var signingPublicKey = configurationService.getDocAppCredentialSigningPublicKey();
                 JWSVerifier verifier = new ECDSAVerifier(signingPublicKey);
 
                 return signed.verify(verifier);
@@ -143,9 +141,6 @@ public class DocAppCriService {
         } catch (JOSEException e) {
             throw new UnsuccesfulCredentialResponseException(
                     "Error verifying CRI response signature", e);
-        } catch (java.text.ParseException e) {
-            throw new UnsuccesfulCredentialResponseException(
-                    "Error parsing signing public key from config", e);
         }
     }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppCallbackHandlerIntegrationTest.java
@@ -35,6 +35,7 @@ import uk.gov.di.authentication.sharedtest.extensions.TokenSigningExtension;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.security.interfaces.ECPublicKey;
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
@@ -60,7 +61,7 @@ class DocAppCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
             privateKey = new ECKeyGenerator(Curve.P_256).keyID("my-key-id").generate();
             publicKey = privateKey.toPublicJWK();
         } catch (JOSEException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 
@@ -213,8 +214,12 @@ class DocAppCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
         }
 
         @Override
-        public String getDocAppCredentialSigningPublicKey() {
-            return signingPublicKey.toString();
+        public ECPublicKey getDocAppCredentialSigningPublicKey() {
+            try {
+                return publicKey.toECPublicKey();
+            } catch (JOSEException e) {
+                throw new RuntimeException(e);
+            }
         }
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppCallbackHandlerIntegrationTest.java
@@ -17,6 +17,7 @@ import org.apache.http.client.utils.URIBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.di.authentication.app.exception.UnsuccesfulCredentialResponseException;
 import uk.gov.di.authentication.app.lambda.DocAppCallbackHandler;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.ClientType;
@@ -45,14 +46,20 @@ import java.util.Optional;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.startsWith;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static uk.gov.di.authentication.app.domain.DocAppAuditableEvent.DOC_APP_AUTHORISATION_RESPONSE_RECEIVED;
 import static uk.gov.di.authentication.app.domain.DocAppAuditableEvent.DOC_APP_SUCCESSFUL_CREDENTIAL_RESPONSE_RECEIVED;
 import static uk.gov.di.authentication.app.domain.DocAppAuditableEvent.DOC_APP_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED;
+import static uk.gov.di.authentication.app.domain.DocAppAuditableEvent.DOC_APP_UNSUCCESSFUL_CREDENTIAL_RESPONSE_RECEIVED;
 import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 class DocAppCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
+    public static final String SESSION_ID = "some-session-id";
+    public static final String CLIENT_SESSION_ID = "some-client-session-id";
+    public static final Scope SCOPE = new Scope(OIDCScopeValue.OPENID);
+    public static final State STATE = new State();
     private static ECKey privateKey;
     private static ECKey publicKey;
 
@@ -65,8 +72,7 @@ class DocAppCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
         }
     }
 
-    @RegisterExtension
-    public static final CriStubExtension criStub = new CriStubExtension(privateKey);
+    @RegisterExtension public static final CriStubExtension criStub = new CriStubExtension();
 
     @RegisterExtension
     protected static final DocumentAppCredentialStoreExtension credentialExtension =
@@ -89,7 +95,7 @@ class DocAppCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
 
     @BeforeEach
     void setup() throws JOSEException {
-        criStub.init();
+        criStub.init(privateKey);
         handler = new DocAppCallbackHandler(configurationService);
         clientStore.registerClient(
                 CLIENT_ID,
@@ -109,34 +115,14 @@ class DocAppCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
 
     @Test
     void shouldRedirectToLoginWhenSuccessfullyProcessedIpvResponse() throws IOException {
-        var sessionId = "some-session-id";
-        var clientSessionId = "some-client-session-id";
-        var scope = new Scope(OIDCScopeValue.OPENID);
-        var state = new State();
-        var authRequestBuilder =
-                new AuthenticationRequest.Builder(
-                                ResponseType.CODE,
-                                scope,
-                                new ClientID(CLIENT_ID),
-                                URI.create(REDIRECT_URI))
-                        .state(state)
-                        .nonce(new Nonce());
-        redis.createSession(sessionId);
-        var clientSession =
-                new ClientSession(
-                        authRequestBuilder.build().toParameters(),
-                        LocalDateTime.now(),
-                        VectorOfTrust.getDefaults());
-        clientSession.setDocAppSubjectId(new Subject());
-        redis.createClientSession(clientSessionId, clientSession);
-        redis.addStateToRedis(state, sessionId);
+        setupSession();
 
         var response =
                 makeRequest(
                         Optional.empty(),
                         constructHeaders(
-                                Optional.of(buildSessionCookie(sessionId, clientSessionId))),
-                        constructQueryStringParameters(state));
+                                Optional.of(buildSessionCookie(SESSION_ID, CLIENT_SESSION_ID))),
+                        constructQueryStringParameters(STATE));
 
         assertThat(response, hasStatus(302));
         assertThat(
@@ -149,6 +135,98 @@ class DocAppCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
                         DOC_APP_AUTHORISATION_RESPONSE_RECEIVED,
                         DOC_APP_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
                         DOC_APP_SUCCESSFUL_CREDENTIAL_RESPONSE_RECEIVED));
+    }
+
+    @Test
+    void shouldThrowIfInvalidResponseReceivedFromCriProtectedEndpoint() throws IOException {
+        setupSession();
+
+        criStub.register("/protected-resource", 200, "application/jwt", "invalid-response");
+
+        assertThrows(
+                UnsuccesfulCredentialResponseException.class,
+                () ->
+                        makeRequest(
+                                Optional.empty(),
+                                constructHeaders(
+                                        Optional.of(
+                                                buildSessionCookie(SESSION_ID, CLIENT_SESSION_ID))),
+                                constructQueryStringParameters(STATE)));
+        assertEventTypesReceived(
+                auditTopic,
+                List.of(
+                        DOC_APP_AUTHORISATION_RESPONSE_RECEIVED,
+                        DOC_APP_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
+                        DOC_APP_UNSUCCESSFUL_CREDENTIAL_RESPONSE_RECEIVED));
+    }
+
+    @Test
+    void shouldThrowIfErrorReceivedFromCriProtectedEndpoint() throws IOException {
+        setupSession();
+
+        criStub.register("/protected-resource", 400, "application/jwt", "error");
+
+        assertThrows(
+                UnsuccesfulCredentialResponseException.class,
+                () ->
+                        makeRequest(
+                                Optional.empty(),
+                                constructHeaders(
+                                        Optional.of(
+                                                buildSessionCookie(SESSION_ID, CLIENT_SESSION_ID))),
+                                constructQueryStringParameters(STATE)));
+
+        assertEventTypesReceived(
+                auditTopic,
+                List.of(
+                        DOC_APP_AUTHORISATION_RESPONSE_RECEIVED,
+                        DOC_APP_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
+                        DOC_APP_UNSUCCESSFUL_CREDENTIAL_RESPONSE_RECEIVED));
+    }
+
+    @Test
+    void shouldThrowIfErrorBadlySignedCriResponseReceived() throws IOException, JOSEException {
+        setupSession();
+        var badPrivateKey = new ECKeyGenerator(Curve.P_256).keyID("bad-key-id").generate();
+
+        criStub.init(badPrivateKey);
+
+        assertThrows(
+                UnsuccesfulCredentialResponseException.class,
+                () ->
+                        makeRequest(
+                                Optional.empty(),
+                                constructHeaders(
+                                        Optional.of(
+                                                buildSessionCookie(SESSION_ID, CLIENT_SESSION_ID))),
+                                constructQueryStringParameters(STATE)));
+
+        assertEventTypesReceived(
+                auditTopic,
+                List.of(
+                        DOC_APP_AUTHORISATION_RESPONSE_RECEIVED,
+                        DOC_APP_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
+                        DOC_APP_UNSUCCESSFUL_CREDENTIAL_RESPONSE_RECEIVED));
+    }
+
+    private void setupSession() throws IOException {
+        var authRequestBuilder =
+                new AuthenticationRequest.Builder(
+                                ResponseType.CODE,
+                                SCOPE,
+                                new ClientID(CLIENT_ID),
+                                URI.create(REDIRECT_URI))
+                        .state(STATE)
+                        .nonce(new Nonce());
+        redis.createSession(SESSION_ID);
+        var clientSession =
+                new ClientSession(
+                        authRequestBuilder.build().toParameters(),
+                        LocalDateTime.now(),
+                        VectorOfTrust.getDefaults());
+        clientSession.setDocAppSubjectId(new Subject());
+        redis.createClientSession(CLIENT_SESSION_ID, clientSession);
+        redis.addStateToRedis(STATE, SESSION_ID);
     }
 
     private Map<String, String> constructQueryStringParameters(State state) {

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/CriStubExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/CriStubExtension.java
@@ -14,7 +14,6 @@ import static java.lang.String.format;
 
 public class CriStubExtension extends HttpStubExtension {
 
-    private final ECKey signingKey;
     private final String credential =
             "{"
                     + "  \"sub\": \"urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6\","
@@ -35,17 +34,15 @@ public class CriStubExtension extends HttpStubExtension {
                     + "  }"
                     + "}";
 
-    public CriStubExtension(int port, ECKey signingKey) {
+    public CriStubExtension(int port) {
         super(port);
-        this.signingKey = signingKey;
     }
 
-    public CriStubExtension(ECKey signingKey) {
+    public CriStubExtension() {
         super();
-        this.signingKey = signingKey;
     }
 
-    public void init() throws JOSEException {
+    public void init(ECKey signingKey) throws JOSEException {
         register(
                 "/token",
                 200,
@@ -59,10 +56,10 @@ public class CriStubExtension extends HttpStubExtension {
                                 + "}",
                         getHttpPort()));
 
-        register("/protected-resource", 200, "application/jwt", signedResponse());
+        register("/protected-resource", 200, "application/jwt", signedResponse(signingKey));
     }
 
-    private String signedResponse() throws JOSEException {
+    private String signedResponse(ECKey signingKey) throws JOSEException {
         JWSSigner signer = new ECDSASigner(signingKey);
         JWSObject jwsObject =
                 new JWSObject(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/configuration/BaseLambdaConfiguration.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/configuration/BaseLambdaConfiguration.java
@@ -9,7 +9,7 @@ public interface BaseLambdaConfiguration {
     }
 
     default String getEnvironment() {
-        return System.getenv("ENVIRONMENT");
+        return System.getenv().getOrDefault("ENVIRONMENT", "test");
     }
 
     default Optional<String> getLocalstackEndpointUri() {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -8,10 +8,19 @@ import com.amazonaws.services.simplesystemsmanagement.model.GetParametersRequest
 import com.amazonaws.services.simplesystemsmanagement.model.ParameterNotFoundException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.util.io.pem.PemReader;
 import uk.gov.di.authentication.shared.configuration.AuditPublisherConfiguration;
 import uk.gov.di.authentication.shared.configuration.BaseLambdaConfiguration;
 
+import java.io.IOException;
+import java.io.StringReader;
 import java.net.URI;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.ECPublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.X509EncodedKeySpec;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -33,6 +42,14 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
     private AWSSimpleSystemsManagement ssmClient;
     private Map<String, String> ssmRedisParameters;
     private Optional<String> passwordPepper;
+
+    private ECPublicKey docAppCredentialSigningPublicKey;
+
+    public ConfigurationService() {}
+
+    ConfigurationService(AWSSimpleSystemsManagement ssmClient) {
+        this.ssmClient = ssmClient;
+    }
 
     // Please keep the method names in alphabetical order so we can find stuff more easily.
     public long getAccessTokenExpiry() {
@@ -110,15 +127,24 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         }
     }
 
-    public String getDocAppCredentialSigningPublicKey() {
-        var paramName = format("{0}-doc-app-public-signing-key", getEnvironment());
-        try {
-            var request = new GetParameterRequest().withWithDecryption(true).withName(paramName);
-            return getSsmClient().getParameter(request).getParameter().getValue();
-        } catch (ParameterNotFoundException e) {
-            LOG.error("No parameter exists with name: {}", paramName);
-            throw new RuntimeException(e);
+    public ECPublicKey getDocAppCredentialSigningPublicKey() {
+        if (docAppCredentialSigningPublicKey == null) {
+            var paramName = format("{0}-doc-app-public-signing-key", getEnvironment());
+            try {
+                var request =
+                        new GetParameterRequest().withWithDecryption(true).withName(paramName);
+                docAppCredentialSigningPublicKey =
+                        createECPublicKeyFromPEM(
+                                getSsmClient().getParameter(request).getParameter().getValue());
+            } catch (ParameterNotFoundException e) {
+                LOG.error("No parameter exists with name: {}", paramName);
+                throw new RuntimeException(e);
+            } catch (IOException | NoSuchAlgorithmException | InvalidKeySpecException e) {
+                LOG.error("Error creating public key from parameter: {}", paramName);
+                throw new RuntimeException(e);
+            }
         }
+        return docAppCredentialSigningPublicKey;
     }
 
     public String getDocAppDomain() {
@@ -386,6 +412,18 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
 
     private String getRedisKey() {
         return System.getenv("REDIS_KEY");
+    }
+
+    private ECPublicKey createECPublicKeyFromPEM(String pem)
+            throws IOException, NoSuchAlgorithmException, InvalidKeySpecException {
+        try (var configReader = new StringReader(pem)) {
+            PemReader reader = new PemReader(configReader);
+            var keySpec = new X509EncodedKeySpec(reader.readPemObject().getContent());
+
+            return (ECPublicKey)
+                    KeyFactory.getInstance("EC", new BouncyCastleProvider())
+                            .generatePublic(keySpec);
+        }
     }
 
     public String getBackChannelLogoutQueueUri() {

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/ConfigurationServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/ConfigurationServiceTest.java
@@ -1,8 +1,28 @@
 package uk.gov.di.authentication.shared.services;
 
+import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement;
+import com.amazonaws.services.simplesystemsmanagement.model.GetParameterRequest;
+import com.amazonaws.services.simplesystemsmanagement.model.GetParameterResult;
+import com.amazonaws.services.simplesystemsmanagement.model.Parameter;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.util.io.pem.PemObject;
+import org.bouncycastle.util.io.pem.PemWriter;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.io.StringWriter;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class ConfigurationServiceTest {
 
@@ -16,5 +36,66 @@ class ConfigurationServiceTest {
     void getSessionCookieAttributesShouldEqualDefaultWhenEnvVarUnset() {
         ConfigurationService configurationService = new ConfigurationService();
         assertEquals("Secure; HttpOnly;", configurationService.getSessionCookieAttributes());
+    }
+
+    @Test
+    void getDocAppCredentialSigningPublicKeyShouldGetECPublicKeyObjectFromParameterStorePEM()
+            throws JOSEException {
+        var privateKey = new ECKeyGenerator(Curve.P_256).keyID("my-key-id").generate();
+        var publicKey = privateKey.toPublicJWK();
+        var pem = publicKeyToPem(publicKey);
+        var ssmClient = mock(AWSSimpleSystemsManagement.class);
+        var request =
+                new GetParameterRequest()
+                        .withWithDecryption(true)
+                        .withName("test-doc-app-public-signing-key");
+        when(ssmClient.getParameter(eq(request)))
+                .thenReturn(
+                        new GetParameterResult()
+                                .withParameter(
+                                        new Parameter()
+                                                .withName("test-doc-app-public-signing-key")
+                                                .withValue(pem)));
+
+        ConfigurationService configurationService = new ConfigurationService(ssmClient);
+
+        var result = configurationService.getDocAppCredentialSigningPublicKey();
+
+        assertThat(result, equalTo(publicKey.toECPublicKey(new BouncyCastleProvider())));
+    }
+
+    @Test
+    void getDocAppCredentialSigningPublicKeyShouldThrowParameterStorePEMIsNull()
+            throws JOSEException {
+        var ssmClient = mock(AWSSimpleSystemsManagement.class);
+        var request =
+                new GetParameterRequest()
+                        .withWithDecryption(true)
+                        .withName("test-doc-app-public-signing-key");
+        when(ssmClient.getParameter(eq(request)))
+                .thenReturn(
+                        new GetParameterResult()
+                                .withParameter(
+                                        new Parameter()
+                                                .withName("test-doc-app-public-signing-key")
+                                                .withValue("not-a-pem-public-key")));
+
+        ConfigurationService configurationService = new ConfigurationService(ssmClient);
+
+        assertThrows(
+                RuntimeException.class,
+                () -> configurationService.getDocAppCredentialSigningPublicKey());
+    }
+
+    private String publicKeyToPem(ECKey publicKey) {
+        var writer = new StringWriter();
+        try (var pemWriter = new PemWriter(writer)) {
+            pemWriter.writeObject(
+                    new PemObject("PUBLIC KEY", publicKey.toPublicKey().getEncoded()));
+
+        } catch (IOException | JOSEException e) {
+            throw new RuntimeException(e);
+        }
+        return writer.toString();
     }
 }


### PR DESCRIPTION
## What?

- Update `ConfigurationService` to return an `ECPublicKey` object parsing the parameter store value as a PEM.
- Cache the converted certificate for subsequent calls
- Add integration tests to test for invalid CRI responses.

## Why?

We will be storing the public key, initially, in parameter store in PEM format. Updating the configuration service allows us to swap in implementations if we decide to read direct from KMS at a later date.

The integration tests, previously, only tested the happy path, added extra test for unhappy path.

## Related PRs

#1723 