### PR TITLE
AUT-298: Deployment of document app callback

### DIFF
--- a/ci/terraform/oidc/api-gateway.tf
+++ b/ci/terraform/oidc/api-gateway.tf
@@ -129,6 +129,8 @@ resource "aws_api_gateway_deployment" "deployment" {
       module.userinfo.method_trigger_value,
       var.ipv_api_enabled ? module.ipv-callback[0].integration_trigger_value : null,
       var.ipv_api_enabled ? module.ipv-callback[0].method_trigger_value : null,
+      var.doc_app_api_enabled ? module.doc-app-callback[0].integration_trigger_value : null,
+      var.doc_app_api_enabled ? module.doc-app-callback[0].method_trigger_value : null,
     ]))
   }
 

--- a/ci/terraform/oidc/doc-app-callback.tf
+++ b/ci/terraform/oidc/doc-app-callback.tf
@@ -1,0 +1,81 @@
+module "doc_app_callback_role" {
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "doc-app-callback-role"
+  vpc_arn     = local.authentication_vpc_arn
+
+  policies_to_attach = [
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    aws_iam_policy.lambda_sns_policy.arn,
+    aws_iam_policy.redis_parameter_policy.arn,
+    aws_iam_policy.doc_app_auth_kms_policy.arn,
+    aws_iam_policy.doc_app_public_signing_key_parameter_policy.arn,
+    aws_iam_policy.dynamo_doc_app_write_access_policy,
+  ]
+}
+
+module "doc-app-callback" {
+  count  = var.doc_app_api_enabled ? 1 : 0
+  source = "../modules/endpoint-module"
+
+  endpoint_name   = "doc-checking-app-callback"
+  path_part       = "doc-checking-app-callback"
+  endpoint_method = "GET"
+  environment     = var.environment
+
+  handler_environment_variables = {
+    ENVIRONMENT                        = var.environment
+    EVENTS_SNS_TOPIC_ARN               = aws_sns_topic.events.arn
+    AUDIT_SIGNING_KEY_ALIAS            = local.audit_signing_key_alias_name
+    LOCALSTACK_ENDPOINT                = var.use_localstack ? var.localstack_endpoint : null
+    REDIS_KEY                          = local.redis_key
+    DYNAMO_ENDPOINT                    = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    DOC_APP_AUTHORISATION_CALLBACK_URI = var.doc_app_authorisation_callback_uri
+    DOC_APP_AUTHORISATION_CLIENT_ID    = var.doc_app_authorisation_client_id
+    DOC_APP_TOKEN_SIGNING_KEY_ALIAS    = local.doc_app_auth_key_alias_name
+    DOC_APP_BACKEND_URI                = var.doc_app_backend_uri
+    DOC_APP_CRI_DATA_ENDPOINT          = var.doc_app_cri_data_endpoint
+  }
+  handler_function_name = "uk.gov.di.authentication.app.lambda.DocAppCallbackHandler::handleRequest"
+
+  create_endpoint  = true
+  rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
+  root_resource_id = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
+  execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
+  memory_size      = var.endpoint_memory_size
+
+  source_bucket                  = aws_s3_bucket.source_bucket.bucket
+  lambda_zip_file                = aws_s3_bucket_object.doc_checking_app_api_release_zip.key
+  lambda_zip_file_version        = aws_s3_bucket_object.doc_checking_app_api_release_zip.version_id
+  warmer_lambda_zip_file         = aws_s3_bucket_object.warmer_release_zip.key
+  warmer_lambda_zip_file_version = aws_s3_bucket_object.warmer_release_zip.version_id
+  code_signing_config_arn        = local.lambda_code_signing_configuration_arn
+
+  authentication_vpc_arn = local.authentication_vpc_arn
+  security_group_ids = [
+    local.authentication_security_group_id,
+    local.authentication_oidc_redis_security_group_id,
+    local.authentication_egress_security_group_id,
+  ]
+  subnet_id                              = local.authentication_subnet_ids
+  lambda_role_arn                        = module.doc_app_callback_role.arn
+  logging_endpoint_arns                  = var.logging_endpoint_arns
+  cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  cloudwatch_log_retention               = var.cloudwatch_log_retention
+  lambda_env_vars_encryption_kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn
+  default_tags                           = local.default_tags
+  api_key_required                       = true
+
+  keep_lambda_warm             = var.keep_lambdas_warm
+  warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"
+  warmer_security_group_ids    = [local.authentication_security_group_id]
+  warmer_handler_environment_variables = {
+    LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
+  }
+
+  use_localstack = var.use_localstack
+
+  depends_on = [
+    aws_api_gateway_rest_api.di_authentication_api,
+  ]
+}

--- a/ci/terraform/oidc/dynamo-policies.tf
+++ b/ci/terraform/oidc/dynamo-policies.tf
@@ -14,6 +14,10 @@ data "aws_dynamodb_table" "spot_credential_table" {
   name = "${var.environment}-spot-credential"
 }
 
+data "aws_dynamodb_table" "doc_app_cri_credential_table" {
+  name = "${var.environment}-doc-app-credential"
+}
+
 data "aws_iam_policy_document" "dynamo_user_write_policy_document" {
   statement {
     sid    = "AllowAccessToDynamoTables"
@@ -136,6 +140,39 @@ data "aws_iam_policy_document" "dynamo_spot_read_access_policy_document" {
   }
 }
 
+data "aws_iam_policy_document" "dynamo_doc_app_write_access_policy_document" {
+  statement {
+    sid    = "AllowAccessToDynamoTables"
+    effect = "Allow"
+
+    actions = [
+      "dynamodb:UpdateItem",
+      "dynamodb:PutItem",
+    ]
+    resources = [
+      data.aws_dynamodb_table.doc_app_cri_credential_table.arn,
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "dynamo_doc_app_read_access_policy_document" {
+  statement {
+    sid    = "AllowAccessToDynamoTables"
+    effect = "Allow"
+
+    actions = [
+      "dynamodb:BatchGetItem",
+      "dynamodb:DescribeTable",
+      "dynamodb:Get*",
+      "dynamodb:Query",
+      "dynamodb:Scan",
+    ]
+    resources = [
+      data.aws_dynamodb_table.doc_app_cri_credential_table.arn,
+    ]
+  }
+}
+
 resource "aws_iam_policy" "dynamo_client_registry_write_access_policy" {
   name_prefix = "dynamo-client-registry-write-policy"
   path        = "/${var.environment}/oidc-default/"
@@ -190,4 +227,20 @@ resource "aws_iam_policy" "dynamo_spot_delete_access_policy" {
   description = "IAM policy for managing delete permissions to the Dynamo SPOT credential table"
 
   policy = data.aws_iam_policy_document.dynamo_spot_delete_access_policy_document.json
+}
+
+resource "aws_iam_policy" "dynamo_doc_app_write_access_policy" {
+  name_prefix = "dynamo-access-policy"
+  path        = "/${var.environment}/oidc-default/"
+  description = "IAM policy for managing write permissions to the Dynamo Doc App CRI credential table"
+
+  policy = data.aws_iam_policy_document.dynamo_doc_app_write_access_policy_document.json
+}
+
+resource "aws_iam_policy" "dynamo_doc_app_read_access_policy" {
+  name_prefix = "dynamo-access-policy"
+  path        = "/${var.environment}/oidc-default/"
+  description = "IAM policy for managing read permissions to the Dynamo Doc App CRI credential table"
+
+  policy = data.aws_iam_policy_document.dynamo_doc_app_read_access_policy_document.json
 }

--- a/ci/terraform/oidc/ssm.tf
+++ b/ci/terraform/oidc/ssm.tf
@@ -87,3 +87,31 @@ resource "aws_iam_policy" "doc_app_public_encryption_key_parameter_policy" {
   name_prefix = "doc-app-public-encryption-key-parameter-store-policy"
 }
 
+resource "aws_ssm_parameter" "doc_app_public_signing_key" {
+  name  = "${var.environment}-doc-app-public-signing-key"
+  type  = "String"
+  value = var.doc_app_cri_public_signing_key
+}
+
+data "aws_iam_policy_document" "doc_app_public_signing_key_parameter_policy_document" {
+  statement {
+    sid    = "AllowGetParameters"
+    effect = "Allow"
+
+    actions = [
+      "ssm:GetParameter",
+      "ssm:GetParameters",
+    ]
+
+    resources = [
+      aws_ssm_parameter.doc_app_public_signing_key.arn
+    ]
+  }
+}
+
+resource "aws_iam_policy" "doc_app_public_signing_key_parameter_policy" {
+  policy      = data.aws_iam_policy_document.doc_app_public_signing_key_parameter_policy_document.json
+  path        = "/${var.environment}/lambda-parameters/"
+  name_prefix = "doc-app-public-signing-key-parameter-store-policy"
+}
+

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -302,3 +302,21 @@ variable "doc_app_domain" {
   type    = string
   default = "undefined"
 }
+
+variable "doc_app_backend_uri" {
+  type        = string
+  default     = ""
+  description = "The base URL of the Doc App CRI API (to be used with the token endpoint and protected resource)"
+}
+
+variable "doc_app_cri_data_endpoint" {
+  type        = string
+  default     = ""
+  description = "The endpoint path to the protected resource on the Doc App CRI (this is appended to the doc_app_backend_uri variable)"
+}
+
+variable "doc_app_cri_public_signing_key" {
+  type        = string
+  default     = "undefined"
+  description = "The PEM encoded public key used to sign VCs from the Doc App CRI"
+}


### PR DESCRIPTION
## What?

- Add the callback endpoint to the OIDC API
- Add new policies to allow reading/writing of the credential table
- Add new parameter to store PEM of CRI signing certificate

## Why?

We have implemented a callback lambda, lets now publish to an API endpoint.

## Related PRs

#1723 
#1729 