### PR TITLE
BAU: Refactor creation of Redis/Dynamo in handlers

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandler.java
@@ -45,11 +45,7 @@ public class AuthenticateHandler
     }
 
     public AuthenticateHandler(ConfigurationService configurationService) {
-        this.authenticationService =
-                new DynamoService(
-                        configurationService.getAwsRegion(),
-                        configurationService.getEnvironment(),
-                        configurationService.getDynamoEndpointUri());
+        this.authenticationService = new DynamoService(configurationService);
         this.auditService = new AuditService(configurationService);
     }
 

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthoriseAccessTokenHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthoriseAccessTokenHandler.java
@@ -53,11 +53,7 @@ public class AuthoriseAccessTokenHandler
                 new TokenValidationService(
                         configurationService, new KmsConnectionService(configurationService));
         dynamoService = new DynamoService(configurationService);
-        clientService =
-                new DynamoClientService(
-                        configurationService.getAwsRegion(),
-                        configurationService.getEnvironment(),
-                        configurationService.getDynamoEndpointUri());
+        clientService = new DynamoClientService(configurationService);
     }
 
     public AuthoriseAccessTokenHandler(ConfigurationService configurationService) {
@@ -66,11 +62,7 @@ public class AuthoriseAccessTokenHandler
                 new TokenValidationService(
                         configurationService, new KmsConnectionService(configurationService));
         dynamoService = new DynamoService(configurationService);
-        clientService =
-                new DynamoClientService(
-                        configurationService.getAwsRegion(),
-                        configurationService.getEnvironment(),
-                        configurationService.getDynamoEndpointUri());
+        clientService = new DynamoClientService(configurationService);
     }
 
     @Override

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandler.java
@@ -53,11 +53,7 @@ public class RemoveAccountHandler
     }
 
     public RemoveAccountHandler(ConfigurationService configurationService) {
-        this.authenticationService =
-                new DynamoService(
-                        configurationService.getAwsRegion(),
-                        configurationService.getEnvironment(),
-                        configurationService.getDynamoEndpointUri());
+        this.authenticationService = new DynamoService(configurationService);
         this.sqsClient =
                 new AwsSqsClient(
                         configurationService.getAwsRegion(),

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandler.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandler.java
@@ -45,11 +45,7 @@ public class ClientRegistrationHandler
     }
 
     public ClientRegistrationHandler(ConfigurationService configurationService) {
-        this.clientService =
-                new DynamoClientService(
-                        configurationService.getAwsRegion(),
-                        configurationService.getEnvironment(),
-                        configurationService.getDynamoEndpointUri());
+        this.clientService = new DynamoClientService(configurationService);
         this.validationService = new ClientConfigValidationService();
         this.auditService = new AuditService(configurationService);
     }

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandler.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandler.java
@@ -52,11 +52,7 @@ public class UpdateClientConfigHandler
     }
 
     public UpdateClientConfigHandler(ConfigurationService configurationService) {
-        this.clientService =
-                new DynamoClientService(
-                        configurationService.getAwsRegion(),
-                        configurationService.getEnvironment(),
-                        configurationService.getDynamoEndpointUri());
+        this.clientService = new DynamoClientService(configurationService);
         this.validationService = new ClientConfigValidationService();
         this.auditService = new AuditService(configurationService);
     }

--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/services/DynamoDocAppService.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/services/DynamoDocAppService.java
@@ -18,18 +18,12 @@ public class DynamoDocAppService {
     private final AmazonDynamoDB dynamoDB;
 
     public DynamoDocAppService(ConfigurationService configurationService) {
-        this(
-                configurationService.getAwsRegion(),
-                configurationService.getEnvironment(),
-                configurationService.getDynamoEndpointUri(),
-                configurationService.getAccessTokenExpiry());
-    }
-
-    public DynamoDocAppService(
-            String region, String environment, Optional<String> dynamoEndpoint, long timeToExist) {
-        this.timeToExist = timeToExist;
+        String region = configurationService.getAwsRegion();
+        String environment = configurationService.getEnvironment();
+        this.timeToExist = configurationService.getAccessTokenExpiry();
         dynamoDB =
-                dynamoEndpoint
+                configurationService
+                        .getDynamoEndpointUri()
                         .map(
                                 t ->
                                         AmazonDynamoDBClientBuilder.standard()

--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/services/DynamoDocAppService.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/services/DynamoDocAppService.java
@@ -1,14 +1,14 @@
 package uk.gov.di.authentication.app.services;
 
-import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
-import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperConfig;
 import uk.gov.di.authentication.app.entity.DocAppCredential;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.util.Optional;
+
+import static uk.gov.di.authentication.shared.dynamodb.DynamoClientHelper.createDynamoClient;
+import static uk.gov.di.authentication.shared.dynamodb.DynamoClientHelper.tableConfig;
 
 public class DynamoDocAppService {
 
@@ -18,29 +18,12 @@ public class DynamoDocAppService {
     private final AmazonDynamoDB dynamoDB;
 
     public DynamoDocAppService(ConfigurationService configurationService) {
-        String region = configurationService.getAwsRegion();
-        String environment = configurationService.getEnvironment();
+        var tableName = configurationService.getEnvironment() + "-" + DOC_APP_CREDENTIAL_TABLE;
+
         this.timeToExist = configurationService.getAccessTokenExpiry();
-        dynamoDB =
-                configurationService
-                        .getDynamoEndpointUri()
-                        .map(
-                                t ->
-                                        AmazonDynamoDBClientBuilder.standard()
-                                                .withEndpointConfiguration(
-                                                        new AwsClientBuilder.EndpointConfiguration(
-                                                                t, region)))
-                        .orElse(AmazonDynamoDBClientBuilder.standard().withRegion(region))
-                        .build();
-        DynamoDBMapperConfig docAppConfig =
-                new DynamoDBMapperConfig.Builder()
-                        .withTableNameOverride(
-                                DynamoDBMapperConfig.TableNameOverride.withTableNameReplacement(
-                                        environment + "-" + DOC_APP_CREDENTIAL_TABLE))
-                        .withConsistentReads(DynamoDBMapperConfig.ConsistentReads.CONSISTENT)
-                        .build();
-        this.docAppCredentialMapper = new DynamoDBMapper(dynamoDB, docAppConfig);
-        warmUp(environment + "-" + DOC_APP_CREDENTIAL_TABLE);
+        this.dynamoDB = createDynamoClient(configurationService);
+        this.docAppCredentialMapper = new DynamoDBMapper(dynamoDB, tableConfig(tableName));
+        warmUp(tableName);
     }
 
     public void addDocAppCredential(String subjectID, String credential) {

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
@@ -58,11 +58,7 @@ public class LogoutHandler
     public LogoutHandler(ConfigurationService configurationService) {
         this.configurationService = configurationService;
         this.sessionService = new SessionService(configurationService);
-        this.dynamoClientService =
-                new DynamoClientService(
-                        configurationService.getAwsRegion(),
-                        configurationService.getEnvironment(),
-                        configurationService.getDynamoEndpointUri());
+        this.dynamoClientService = new DynamoClientService(configurationService);
         this.clientSessionService = new ClientSessionService(configurationService);
         this.tokenValidationService =
                 new TokenValidationService(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
@@ -107,7 +107,8 @@ public class TokenHandler
                         configurationService,
                         redisConnectionService,
                         ObjectMapperFactory.getInstance());
-        this.clientSessionService = new ClientSessionService(configurationService);
+        this.clientSessionService =
+                new ClientSessionService(configurationService, redisConnectionService);
         this.tokenValidationService = new TokenValidationService(configurationService, kms);
     }
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
@@ -94,11 +94,7 @@ public class TokenHandler
         this.configurationService = configurationService;
         this.redisConnectionService = new RedisConnectionService(configurationService);
 
-        this.clientService =
-                new DynamoClientService(
-                        configurationService.getAwsRegion(),
-                        configurationService.getEnvironment(),
-                        configurationService.getDynamoEndpointUri());
+        this.clientService = new DynamoClientService(configurationService);
         this.tokenService =
                 new TokenService(configurationService, this.redisConnectionService, kms);
         this.dynamoService = new DynamoService(configurationService);

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/DynamoTestConfiguration.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/DynamoTestConfiguration.java
@@ -1,0 +1,33 @@
+package uk.gov.di.authentication.sharedtest.basetest;
+
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+import java.util.Optional;
+
+public class DynamoTestConfiguration extends ConfigurationService {
+
+    private final String region;
+    private final String environment;
+    private final String dynamoDbUri;
+
+    public DynamoTestConfiguration(String region, String environment, String dynamoDbUri) {
+        this.region = region;
+        this.environment = environment;
+        this.dynamoDbUri = dynamoDbUri;
+    }
+
+    @Override
+    public String getAwsRegion() {
+        return region;
+    }
+
+    @Override
+    public String getEnvironment() {
+        return environment;
+    }
+
+    @Override
+    public Optional<String> getDynamoEndpointUri() {
+        return Optional.of(dynamoDbUri);
+    }
+}

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/ClientStoreExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/ClientStoreExtension.java
@@ -10,10 +10,10 @@ import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import uk.gov.di.authentication.shared.entity.ClientType;
 import uk.gov.di.authentication.shared.services.DynamoClientService;
+import uk.gov.di.authentication.sharedtest.basetest.DynamoTestConfiguration;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 import static com.amazonaws.services.dynamodbv2.model.KeyType.HASH;
 import static com.amazonaws.services.dynamodbv2.model.ProjectionType.ALL;
@@ -96,7 +96,8 @@ public class ClientStoreExtension extends DynamoExtension implements AfterEachCa
     public void beforeAll(ExtensionContext context) throws Exception {
         super.beforeAll(context);
         dynamoClientService =
-                new DynamoClientService(REGION, ENVIRONMENT, Optional.of(DYNAMO_ENDPOINT));
+                new DynamoClientService(
+                        new DynamoTestConfiguration(REGION, ENVIRONMENT, DYNAMO_ENDPOINT));
     }
 
     @Override

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/SPOTStoreExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/SPOTStoreExtension.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import uk.gov.di.authentication.shared.entity.SPOTCredential;
 import uk.gov.di.authentication.shared.services.DynamoSpotService;
+import uk.gov.di.authentication.sharedtest.basetest.DynamoTestConfiguration;
 
 import java.util.Optional;
 
@@ -24,8 +25,16 @@ public class SPOTStoreExtension extends DynamoExtension implements AfterEachCall
     @Override
     public void beforeAll(ExtensionContext context) throws Exception {
         super.beforeAll(context);
-        dynamoService =
-                new DynamoSpotService(REGION, ENVIRONMENT, Optional.of(DYNAMO_ENDPOINT), 300);
+
+        var configuration =
+                new DynamoTestConfiguration(REGION, ENVIRONMENT, DYNAMO_ENDPOINT) {
+                    @Override
+                    public long getAccessTokenExpiry() {
+                        return 300;
+                    }
+                };
+
+        dynamoService = new DynamoSpotService(configuration);
     }
 
     @Override

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/UserStoreExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/UserStoreExtension.java
@@ -13,6 +13,7 @@ import uk.gov.di.authentication.shared.entity.ClientConsent;
 import uk.gov.di.authentication.shared.entity.TermsAndConditions;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.services.DynamoService;
+import uk.gov.di.authentication.sharedtest.basetest.DynamoTestConfiguration;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -101,7 +102,9 @@ public class UserStoreExtension extends DynamoExtension implements AfterEachCall
     @Override
     public void beforeAll(ExtensionContext context) throws Exception {
         super.beforeAll(context);
-        dynamoService = new DynamoService(REGION, ENVIRONMENT, Optional.of(DYNAMO_ENDPOINT));
+        dynamoService =
+                new DynamoService(
+                        new DynamoTestConfiguration(REGION, ENVIRONMENT, DYNAMO_ENDPOINT));
     }
 
     @Override

--- a/shared/src/main/java/uk/gov/di/authentication/shared/dynamodb/DynamoClientHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/dynamodb/DynamoClientHelper.java
@@ -1,0 +1,29 @@
+package uk.gov.di.authentication.shared.dynamodb;
+
+import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperConfig;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperConfig.ConsistentReads;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+import static com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder.standard;
+import static com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperConfig.TableNameOverride.withTableNameReplacement;
+
+public class DynamoClientHelper {
+
+    public static AmazonDynamoDB createDynamoClient(ConfigurationService configurationService) {
+        return configurationService
+                .getDynamoEndpointUri()
+                .map(uri -> new EndpointConfiguration(uri, configurationService.getAwsRegion()))
+                .map(standard()::withEndpointConfiguration)
+                .orElse(standard().withRegion(configurationService.getAwsRegion()))
+                .build();
+    }
+
+    public static DynamoDBMapperConfig tableConfig(String tableName) {
+        return new DynamoDBMapperConfig.Builder()
+                .withTableNameOverride(withTableNameReplacement(tableName))
+                .withConsistentReads(ConsistentReads.CONSISTENT)
+                .build();
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/dynamodb/DynamoDBSchemaHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/dynamodb/DynamoDBSchemaHelper.java
@@ -2,12 +2,13 @@ package uk.gov.di.authentication.shared.dynamodb;
 
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
-import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperConfig;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.Delete;
 import com.amazonaws.services.dynamodbv2.model.Put;
 
 import java.util.Map;
+
+import static uk.gov.di.authentication.shared.dynamodb.DynamoClientHelper.tableConfig;
 
 public class DynamoDBSchemaHelper {
 
@@ -45,14 +46,7 @@ public class DynamoDBSchemaHelper {
     }
 
     public DynamoDBMapper buildConfiguredDynamoDBMapper(Table table) {
-        return new DynamoDBMapper(
-                dynamoDB,
-                new DynamoDBMapperConfig.Builder()
-                        .withConsistentReads(DynamoDBMapperConfig.ConsistentReads.CONSISTENT)
-                        .withTableNameOverride(
-                                DynamoDBMapperConfig.TableNameOverride.withTableNameReplacement(
-                                        getFullyQualifiedTableName(table)))
-                        .build());
+        return new DynamoDBMapper(dynamoDB, tableConfig(getFullyQualifiedTableName(table)));
     }
 
     public Delete buildDelete(Table table, AttributeValue attributeValue) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/lambda/BaseFrontendHandler.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/lambda/BaseFrontendHandler.java
@@ -63,16 +63,8 @@ public abstract class BaseFrontendHandler<T>
         this.configurationService = configurationService;
         this.sessionService = new SessionService(configurationService);
         this.clientSessionService = new ClientSessionService(configurationService);
-        this.clientService =
-                new DynamoClientService(
-                        configurationService.getAwsRegion(),
-                        configurationService.getEnvironment(),
-                        configurationService.getDynamoEndpointUri());
-        this.authenticationService =
-                new DynamoService(
-                        configurationService.getAwsRegion(),
-                        configurationService.getEnvironment(),
-                        configurationService.getDynamoEndpointUri());
+        this.clientService = new DynamoClientService(configurationService);
+        this.authenticationService = new DynamoService(configurationService);
     }
 
     @Override

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoClientService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoClientService.java
@@ -20,16 +20,11 @@ public class DynamoClientService implements ClientService {
     private final AmazonDynamoDB dynamoDB;
 
     public DynamoClientService(ConfigurationService configurationService) {
-        this(
-                configurationService.getAwsRegion(),
-                configurationService.getEnvironment(),
-                configurationService.getDynamoEndpointUri());
-    }
-
-    public DynamoClientService(String region, String environment, Optional<String> dynamoEndpoint) {
-        String tableName = environment + "-" + CLIENT_REGISTRY_TABLE;
+        String region = configurationService.getAwsRegion();
+        String tableName = configurationService.getEnvironment() + "-" + CLIENT_REGISTRY_TABLE;
         dynamoDB =
-                dynamoEndpoint
+                configurationService
+                        .getDynamoEndpointUri()
                         .map(
                                 t ->
                                         AmazonDynamoDBClientBuilder.standard()

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
@@ -1,8 +1,6 @@
 package uk.gov.di.authentication.shared.services;
 
-import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBQueryExpression;
 import com.amazonaws.services.dynamodbv2.datamodeling.QueryResultPage;
@@ -12,6 +10,7 @@ import com.amazonaws.services.dynamodbv2.model.Put;
 import com.amazonaws.services.dynamodbv2.model.TransactWriteItem;
 import com.amazonaws.services.dynamodbv2.model.TransactWriteItemsRequest;
 import com.nimbusds.oauth2.sdk.id.Subject;
+import uk.gov.di.authentication.shared.dynamodb.DynamoClientHelper;
 import uk.gov.di.authentication.shared.dynamodb.DynamoDBSchemaHelper;
 import uk.gov.di.authentication.shared.entity.ClientConsent;
 import uk.gov.di.authentication.shared.entity.TermsAndConditions;
@@ -44,19 +43,7 @@ public class DynamoService implements AuthenticationService {
     private final DynamoDBSchemaHelper dynamoDBSchemaHelper;
 
     public DynamoService(ConfigurationService configurationService) {
-        String region = configurationService.getAwsRegion();
-        dynamoDB =
-                configurationService
-                        .getDynamoEndpointUri()
-                        .map(
-                                t ->
-                                        AmazonDynamoDBClientBuilder.standard()
-                                                .withEndpointConfiguration(
-                                                        new AwsClientBuilder.EndpointConfiguration(
-                                                                t, region)))
-                        .orElse(AmazonDynamoDBClientBuilder.standard().withRegion(region))
-                        .build();
-
+        this.dynamoDB = DynamoClientHelper.createDynamoClient(configurationService);
         this.dynamoDBSchemaHelper =
                 new DynamoDBSchemaHelper(dynamoDB, configurationService.getEnvironment());
         this.userCredentialsMapper =

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
@@ -44,15 +44,10 @@ public class DynamoService implements AuthenticationService {
     private final DynamoDBSchemaHelper dynamoDBSchemaHelper;
 
     public DynamoService(ConfigurationService configurationService) {
-        this(
-                configurationService.getAwsRegion(),
-                configurationService.getEnvironment(),
-                configurationService.getDynamoEndpointUri());
-    }
-
-    public DynamoService(String region, String environment, Optional<String> dynamoEndpoint) {
+        String region = configurationService.getAwsRegion();
         dynamoDB =
-                dynamoEndpoint
+                configurationService
+                        .getDynamoEndpointUri()
                         .map(
                                 t ->
                                         AmazonDynamoDBClientBuilder.standard()
@@ -62,7 +57,8 @@ public class DynamoService implements AuthenticationService {
                         .orElse(AmazonDynamoDBClientBuilder.standard().withRegion(region))
                         .build();
 
-        this.dynamoDBSchemaHelper = new DynamoDBSchemaHelper(dynamoDB, environment);
+        this.dynamoDBSchemaHelper =
+                new DynamoDBSchemaHelper(dynamoDB, configurationService.getEnvironment());
         this.userCredentialsMapper =
                 dynamoDBSchemaHelper.buildConfiguredDynamoDBMapper(USER_CREDENTIALS_TABLE);
         this.userProfileMapper =

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoSpotService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoSpotService.java
@@ -1,13 +1,13 @@
 package uk.gov.di.authentication.shared.services;
 
-import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
-import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperConfig;
+import uk.gov.di.authentication.shared.dynamodb.DynamoClientHelper;
 import uk.gov.di.authentication.shared.entity.SPOTCredential;
 
 import java.util.Optional;
+
+import static uk.gov.di.authentication.shared.dynamodb.DynamoClientHelper.tableConfig;
 
 public class DynamoSpotService {
 
@@ -17,29 +17,13 @@ public class DynamoSpotService {
     private final AmazonDynamoDB dynamoDB;
 
     public DynamoSpotService(ConfigurationService configurationService) {
-        String region = configurationService.getAwsRegion();
-        String environment = configurationService.getEnvironment();
+        var tableName = configurationService.getEnvironment() + "-" + SPOT_CREDENTIAL_TABLE;
+
         this.timeToExist = configurationService.getAccessTokenExpiry();
-        dynamoDB =
-                configurationService
-                        .getDynamoEndpointUri()
-                        .map(
-                                t ->
-                                        AmazonDynamoDBClientBuilder.standard()
-                                                .withEndpointConfiguration(
-                                                        new AwsClientBuilder.EndpointConfiguration(
-                                                                t, region)))
-                        .orElse(AmazonDynamoDBClientBuilder.standard().withRegion(region))
-                        .build();
-        DynamoDBMapperConfig spotResponseConfig =
-                new DynamoDBMapperConfig.Builder()
-                        .withTableNameOverride(
-                                DynamoDBMapperConfig.TableNameOverride.withTableNameReplacement(
-                                        environment + "-" + SPOT_CREDENTIAL_TABLE))
-                        .withConsistentReads(DynamoDBMapperConfig.ConsistentReads.CONSISTENT)
-                        .build();
-        this.spotCredentialMapper = new DynamoDBMapper(dynamoDB, spotResponseConfig);
-        warmUp(environment + "-" + SPOT_CREDENTIAL_TABLE);
+        this.dynamoDB = DynamoClientHelper.createDynamoClient(configurationService);
+        this.spotCredentialMapper = new DynamoDBMapper(dynamoDB, tableConfig(tableName));
+
+        warmUp(tableName);
     }
 
     public void addSpotResponse(String subjectID, String serializedCredential) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoSpotService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoSpotService.java
@@ -17,18 +17,12 @@ public class DynamoSpotService {
     private final AmazonDynamoDB dynamoDB;
 
     public DynamoSpotService(ConfigurationService configurationService) {
-        this(
-                configurationService.getAwsRegion(),
-                configurationService.getEnvironment(),
-                configurationService.getDynamoEndpointUri(),
-                configurationService.getAccessTokenExpiry());
-    }
-
-    public DynamoSpotService(
-            String region, String environment, Optional<String> dynamoEndpoint, long timeToExist) {
-        this.timeToExist = timeToExist;
+        String region = configurationService.getAwsRegion();
+        String environment = configurationService.getEnvironment();
+        this.timeToExist = configurationService.getAccessTokenExpiry();
         dynamoDB =
-                dynamoEndpoint
+                configurationService
+                        .getDynamoEndpointUri()
                         .map(
                                 t ->
                                         AmazonDynamoDBClientBuilder.standard()


### PR DESCRIPTION

# Redis
Don't initialise a new Redis connection for the ClientSessionService. This will have a minor performance benefit as we're not connecting twice.

# Dynamo
- BAU: Create `DynamoTestConfiguration` for test extensions
- BAU: Remove duplicated constructors
- BAU: Create helper to initialise DynamoDB connections and configuration
- BAU: Use helpers in Dynamo-backed services

