### PR TITLE
AUT-320: Update oidc flow for the doc app

### DIFF
--- a/oidc-api/build.gradle
+++ b/oidc-api/build.gradle
@@ -19,7 +19,8 @@ dependencies {
             configurations.bouncycastle,
             configurations.cloudwatch,
             project(":shared"),
-            project(":client-registry-api")
+            project(":client-registry-api"),
+            project(":doc-checking-app-api")
 
     testImplementation configurations.tests,
             configurations.lambda_tests,

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/exceptions/UserInfoException.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/exceptions/UserInfoException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.authentication.oidc.exceptions;
+
+public class UserInfoException extends RuntimeException {
+    public UserInfoException(String message) {
+        super(message);
+    }
+}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandler.java
@@ -8,6 +8,7 @@ import com.nimbusds.openid.connect.sdk.UserInfoErrorResponse;
 import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.app.services.DynamoDocAppService;
 import uk.gov.di.authentication.oidc.entity.AccessTokenInfo;
 import uk.gov.di.authentication.oidc.services.AccessTokenService;
 import uk.gov.di.authentication.oidc.services.UserInfoService;
@@ -53,7 +54,8 @@ public class UserInfoHandler
         this.userInfoService =
                 new UserInfoService(
                         new DynamoService(configurationService),
-                        new DynamoSpotService(configurationService));
+                        new DynamoSpotService(configurationService),
+                        new DynamoDocAppService(configurationService));
         this.accessTokenService =
                 new AccessTokenService(
                         new RedisConnectionService(configurationService),

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthorizationService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthorizationService.java
@@ -12,7 +12,6 @@ import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import com.nimbusds.openid.connect.sdk.AuthenticationSuccessResponse;
 import com.nimbusds.openid.connect.sdk.OIDCClaimsRequest;
 import com.nimbusds.openid.connect.sdk.claims.ClaimsSetRequest;
-import org.apache.http.client.utils.URIBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.oidc.entity.AuthRequestError;
@@ -26,7 +25,6 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoClientService;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -60,17 +58,17 @@ public class AuthorizationService {
     }
 
     public AuthenticationSuccessResponse generateSuccessfulAuthResponse(
-            AuthenticationRequest authRequest, AuthorizationCode authorizationCode)
-            throws URISyntaxException {
-
-        URIBuilder redirectUri = new URIBuilder(authRequest.getRedirectionURI());
+            AuthenticationRequest authRequest,
+            AuthorizationCode authorizationCode,
+            URI redirectUri,
+            State state) {
 
         return new AuthenticationSuccessResponse(
-                redirectUri.build(),
+                redirectUri,
                 authorizationCode,
                 null,
                 null,
-                authRequest.getState(),
+                state,
                 null,
                 authRequest.getResponseMode());
     }
@@ -162,13 +160,13 @@ public class AuthorizationService {
     }
 
     public AuthenticationErrorResponse generateAuthenticationErrorResponse(
-            AuthenticationRequest authRequest, ErrorObject errorObject) {
+            AuthenticationRequest authRequest,
+            ErrorObject errorObject,
+            URI redirectUri,
+            State state) {
 
         return generateAuthenticationErrorResponse(
-                authRequest.getRedirectionURI(),
-                authRequest.getState(),
-                authRequest.getResponseMode(),
-                errorObject);
+                redirectUri, state, authRequest.getResponseMode(), errorObject);
     }
 
     public AuthenticationErrorResponse generateAuthenticationErrorResponse(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/helper/RequestObjectTestHelper.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/helper/RequestObjectTestHelper.java
@@ -1,0 +1,22 @@
+package uk.gov.di.authentication.oidc.helper;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+
+import java.security.KeyPair;
+
+public class RequestObjectTestHelper {
+
+    public static SignedJWT generateSignedJWT(JWTClaimsSet jwtClaimsSet, KeyPair keyPair)
+            throws JOSEException {
+        var jwsHeader = new JWSHeader(JWSAlgorithm.RS256);
+        var signedJWT = new SignedJWT(jwsHeader, jwtClaimsSet);
+        var signer = new RSASSASigner(keyPair.getPrivate());
+        signedJWT.sign(signer);
+        return signedJWT;
+    }
+}

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AuthorizationServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AuthorizationServiceTest.java
@@ -117,7 +117,8 @@ class AuthorizationServiceTest {
                 generateAuthRequest(REDIRECT_URI.toString(), responseType, scope);
 
         AuthenticationSuccessResponse authSuccessResponse =
-                authorizationService.generateSuccessfulAuthResponse(authRequest, authCode);
+                authorizationService.generateSuccessfulAuthResponse(
+                        authRequest, authCode, REDIRECT_URI, STATE);
         assertThat(authSuccessResponse.getState(), equalTo(STATE));
         assertThat(authSuccessResponse.getAuthorizationCode(), equalTo(authCode));
         assertThat(authSuccessResponse.getRedirectionURI(), equalTo(REDIRECT_URI));

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RequestObjectServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RequestObjectServiceTest.java
@@ -1,9 +1,6 @@
 package uk.gov.di.authentication.oidc.services;
 
 import com.nimbusds.jose.JOSEException;
-import com.nimbusds.jose.JWSAlgorithm;
-import com.nimbusds.jose.JWSHeader;
-import com.nimbusds.jose.crypto.RSASSASigner;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
@@ -37,6 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.oidc.helper.RequestObjectTestHelper.generateSignedJWT;
 
 class RequestObjectServiceTest {
 
@@ -78,7 +76,7 @@ class RequestObjectServiceTest {
                         .claim("client_id", CLIENT_ID.getValue())
                         .issuer(CLIENT_ID.getValue())
                         .build();
-        var signedJWT = generateSignedJWT(jwtClaimsSet);
+        var signedJWT = generateSignedJWT(jwtClaimsSet, keyPair);
 
         var requestObjectError = service.validateRequestObject(generateAuthRequest(signedJWT));
 
@@ -96,7 +94,7 @@ class RequestObjectServiceTest {
                         .claim("client_id", CLIENT_ID.getValue())
                         .issuer(CLIENT_ID.getValue())
                         .build();
-        var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet));
+        var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet, keyPair));
         assertThrows(
                 RuntimeException.class,
                 () -> service.validateRequestObject(authRequest),
@@ -115,7 +113,7 @@ class RequestObjectServiceTest {
                         .claim("client_id", CLIENT_ID.getValue())
                         .issuer(CLIENT_ID.getValue())
                         .build();
-        var signedJWT = generateSignedJWT(jwtClaimsSet);
+        var signedJWT = generateSignedJWT(jwtClaimsSet, keyPair);
 
         assertThrows(
                 RuntimeException.class,
@@ -143,7 +141,7 @@ class RequestObjectServiceTest {
                         .claim("client_id", CLIENT_ID.getValue())
                         .issuer(CLIENT_ID.getValue())
                         .build();
-        var signedJWT = generateSignedJWT(jwtClaimsSet);
+        var signedJWT = generateSignedJWT(jwtClaimsSet, keyPair);
 
         var requestObjectError = service.validateRequestObject(generateAuthRequest(signedJWT));
 
@@ -165,7 +163,7 @@ class RequestObjectServiceTest {
                         .issuer(CLIENT_ID.getValue())
                         .claim("client_id", CLIENT_ID.getValue())
                         .build();
-        var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet));
+        var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet, keyPair));
         var requestObjectError = service.validateRequestObject(authRequest);
 
         assertTrue(requestObjectError.isPresent());
@@ -186,7 +184,7 @@ class RequestObjectServiceTest {
                         .issuer(CLIENT_ID.getValue())
                         .claim("client_id", "invalid-client-id")
                         .build();
-        var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet));
+        var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet, keyPair));
         var requestObjectError = service.validateRequestObject(authRequest);
 
         assertTrue(requestObjectError.isPresent());
@@ -207,7 +205,7 @@ class RequestObjectServiceTest {
                         .claim("client_id", CLIENT_ID.getValue())
                         .issuer(CLIENT_ID.getValue())
                         .build();
-        var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet));
+        var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet, keyPair));
         var requestObjectError = service.validateRequestObject(authRequest);
 
         assertTrue(requestObjectError.isPresent());
@@ -226,7 +224,7 @@ class RequestObjectServiceTest {
                         .claim("client_id", CLIENT_ID.getValue())
                         .issuer(CLIENT_ID.getValue())
                         .build();
-        var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet));
+        var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet, keyPair));
         var requestObjectError = service.validateRequestObject(authRequest);
 
         assertTrue(requestObjectError.isPresent());
@@ -252,7 +250,7 @@ class RequestObjectServiceTest {
                         .claim("client_id", CLIENT_ID.getValue())
                         .issuer(CLIENT_ID.getValue())
                         .build();
-        var signedJWT = generateSignedJWT(jwtClaimsSet);
+        var signedJWT = generateSignedJWT(jwtClaimsSet, keyPair);
 
         var requestObjectError = service.validateRequestObject(generateAuthRequest(signedJWT));
 
@@ -273,7 +271,7 @@ class RequestObjectServiceTest {
                         .claim("client_id", CLIENT_ID.getValue())
                         .issuer(CLIENT_ID.getValue())
                         .build();
-        var signedJWT = generateSignedJWT(jwtClaimsSet);
+        var signedJWT = generateSignedJWT(jwtClaimsSet, keyPair);
 
         var requestObjectError =
                 service.validateRequestObject(
@@ -296,7 +294,7 @@ class RequestObjectServiceTest {
                         .claim("client_id", CLIENT_ID.getValue())
                         .issuer(CLIENT_ID.getValue())
                         .build();
-        var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet));
+        var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet, keyPair));
         var requestObjectError = service.validateRequestObject(authRequest);
 
         assertTrue(requestObjectError.isPresent());
@@ -316,7 +314,7 @@ class RequestObjectServiceTest {
                         .issuer(CLIENT_ID.getValue())
                         .build();
 
-        var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet));
+        var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet, keyPair));
         var requestObjectError = service.validateRequestObject(authRequest);
 
         assertTrue(requestObjectError.isPresent());
@@ -335,7 +333,7 @@ class RequestObjectServiceTest {
                         .claim("client_id", CLIENT_ID.getValue())
                         .issuer("invalid-client")
                         .build();
-        var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet));
+        var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet, keyPair));
         var requestObjectError = service.validateRequestObject(authRequest);
 
         assertTrue(requestObjectError.isPresent());
@@ -357,8 +355,8 @@ class RequestObjectServiceTest {
                         .claim("request", "some-random-request-value")
                         .issuer(CLIENT_ID.getValue())
                         .build();
-        generateSignedJWT(jwtClaimsSet);
-        var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet));
+        generateSignedJWT(jwtClaimsSet, keyPair);
+        var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet, keyPair));
         var requestObjectError = service.validateRequestObject(authRequest);
 
         assertTrue(requestObjectError.isPresent());
@@ -378,7 +376,7 @@ class RequestObjectServiceTest {
                         .claim("request_uri", URI.create("https://localhost/request_uri"))
                         .issuer(CLIENT_ID.getValue())
                         .build();
-        var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet));
+        var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet, keyPair));
         var requestObjectError = service.validateRequestObject(authRequest);
 
         assertTrue(requestObjectError.isPresent());
@@ -417,7 +415,7 @@ class RequestObjectServiceTest {
                         .claim("client_id", CLIENT_ID.getValue())
                         .issuer(CLIENT_ID.getValue())
                         .build();
-        var signedJWT = generateSignedJWT(jwtClaimsSet);
+        var signedJWT = generateSignedJWT(jwtClaimsSet, keyPair);
 
         var requestObjectError = service.validateRequestObject(generateAuthRequest(signedJWT));
 
@@ -427,19 +425,6 @@ class RequestObjectServiceTest {
                 requestObjectError.get().getErrorObject().getDescription(),
                 equalTo("Request is missing state parameter"));
         assertThat(requestObjectError.get().getRedirectURI().toString(), equalTo(REDIRECT_URI));
-    }
-
-    private SignedJWT generateSignedJWT(JWTClaimsSet jwtClaimsSet) throws JOSEException {
-        return generateSignedJWT(jwtClaimsSet, keyPair);
-    }
-
-    private SignedJWT generateSignedJWT(JWTClaimsSet jwtClaimsSet, KeyPair keyPair)
-            throws JOSEException {
-        var jwsHeader = new JWSHeader(JWSAlgorithm.RS256);
-        var signedJWT = new SignedJWT(jwsHeader, jwtClaimsSet);
-        var signer = new RSASSASigner(keyPair.getPrivate());
-        signedJWT.sign(signer);
-        return signedJWT;
     }
 
     private ClientRegistry generateClientRegistry(String clientType, Scope scope) {

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.di.authentication.app.services.DynamoDocAppService;
 import uk.gov.di.authentication.oidc.entity.AccessTokenInfo;
 import uk.gov.di.authentication.shared.entity.AccessTokenStore;
 import uk.gov.di.authentication.shared.entity.SPOTCredential;
@@ -47,6 +48,8 @@ class UserInfoServiceTest {
     private UserInfoService userInfoService;
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
     private final DynamoSpotService spotService = mock(DynamoSpotService.class);
+    private final DynamoDocAppService dynamoDocAppService = mock(DynamoDocAppService.class);
+
     private static final Subject INTERNAL_SUBJECT = new Subject("internal-subject");
     private static final Subject SUBJECT = new Subject("some-subject");
     private static final String ADDRESS_CLAIM = "some-address";
@@ -88,7 +91,8 @@ class UserInfoServiceTest {
 
     @BeforeEach
     void setUp() {
-        userInfoService = new UserInfoService(authenticationService, spotService);
+        userInfoService =
+                new UserInfoService(authenticationService, spotService, dynamoDocAppService);
     }
 
     @Test

--- a/shared-test/build.gradle
+++ b/shared-test/build.gradle
@@ -22,6 +22,7 @@ dependencies {
             "com.google.code.gson:gson:2.9.0"
 
     implementation project(":shared"), noXray
+    implementation project(":doc-checking-app-api")
 }
 
 test {

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
@@ -10,6 +10,7 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.sharedtest.extensions.AuditSnsTopicExtension;
 import uk.gov.di.authentication.sharedtest.extensions.ClientStoreExtension;
 import uk.gov.di.authentication.sharedtest.extensions.CloudwatchMetricsExtension;
+import uk.gov.di.authentication.sharedtest.extensions.DocumentAppCredentialStoreExtension;
 import uk.gov.di.authentication.sharedtest.extensions.KmsKeyExtension;
 import uk.gov.di.authentication.sharedtest.extensions.ParameterStoreExtension;
 import uk.gov.di.authentication.sharedtest.extensions.RedisExtension;
@@ -121,6 +122,10 @@ public abstract class HandlerIntegrationTest<Q, S> {
 
     @RegisterExtension
     protected static final SPOTStoreExtension spotStore = new SPOTStoreExtension();
+
+    @RegisterExtension
+    protected static final DocumentAppCredentialStoreExtension documentAppCredentialStore =
+            new DocumentAppCredentialStoreExtension();
 
     protected Map<String, String> constructHeaders(Optional<HttpCookie> cookie) {
         final Map<String, String> headers = new HashMap<>();

--- a/shared/src/main/java/uk/gov/di/authentication/shared/conditions/DocAppUserHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/conditions/DocAppUserHelper.java
@@ -3,32 +3,72 @@ package uk.gov.di.authentication.shared.conditions;
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.ClientType;
 import uk.gov.di.authentication.shared.entity.CustomScopeValue;
+import uk.gov.di.authentication.shared.exceptions.RequestObjectException;
 import uk.gov.di.authentication.shared.state.UserContext;
 
+import java.util.List;
+import java.util.Map;
+
+import static java.lang.String.format;
+
 public class DocAppUserHelper {
+
+    private static final Logger LOG = LogManager.getLogger(DocAppUserHelper.class);
 
     private DocAppUserHelper() {}
 
     public static boolean isDocCheckingAppUser(UserContext context) {
         var authRequestParams = context.getClientSession().getAuthRequestParams();
-        if (Boolean.FALSE.equals(authRequestParams.containsKey("request"))) {
+        if (!authRequestParams.containsKey("request")) {
             return false;
         }
-        try {
-            var authRequest = AuthenticationRequest.parse(authRequestParams);
-            var requestObject = authRequest.getRequestObject();
-            var claimScope = (String) requestObject.getJWTClaimsSet().getClaim("scope");
-            var scope = Scope.parse(claimScope);
-            if (Boolean.FALSE.equals(scope.contains(CustomScopeValue.DOC_CHECKING_APP))) {
-                return false;
-            }
+        if (!hasDocCheckingScope(authRequestParams)) {
+            return false;
+        } else {
             return context.getClient()
                     .filter(t -> t.getClientType().equals(ClientType.APP.getValue()))
                     .isPresent();
-        } catch (ParseException | java.text.ParseException e) {
-            throw new RuntimeException();
+        }
+    }
+
+    public static boolean isDocCheckingAppUserWithSubjectId(ClientSession clientSession) {
+        return clientSession.getDocAppSubjectId() != null
+                && hasDocCheckingScope(clientSession.getAuthRequestParams());
+    }
+
+    private static boolean hasDocCheckingScope(Map<String, List<String>> authRequestParams) {
+        try {
+            var scopeClaim =
+                    getRequestObjectClaim(
+                            AuthenticationRequest.parse(authRequestParams), "scope", String.class);
+            return (scopeClaim != null
+                    && Scope.parse(scopeClaim).contains(CustomScopeValue.DOC_CHECKING_APP));
+        } catch (ParseException e) {
+            throw new RequestObjectException("Unable to read claim from RequestObject: scope", e);
+        }
+    }
+
+    public static <T> T getRequestObjectClaim(
+            AuthenticationRequest authenticationRequest, String claim, Class<T> claimType) {
+        try {
+            if (authenticationRequest.getRequestObject() != null
+                    && authenticationRequest.getRequestObject().getJWTClaimsSet() != null
+                    && authenticationRequest.getRequestObject().getJWTClaimsSet().getClaim(claim)
+                            != null) {
+                return claimType.cast(
+                        authenticationRequest.getRequestObject().getJWTClaimsSet().getClaim(claim));
+            } else {
+                LOG.info("Claim is missing from RequestObject: {}", claim);
+                return null;
+            }
+        } catch (java.text.ParseException e) {
+            throw new RequestObjectException(
+                    format("Unable to read claim from RequestObject: %s", claim), e);
         }
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/RequestObjectException.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/RequestObjectException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.authentication.shared.exceptions;
+
+public class RequestObjectException extends RuntimeException {
+    public RequestObjectException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
@@ -159,7 +159,8 @@ public class TokenServiceTest {
                                         claimsForListOfScopes,
                                         LocalDateTime.now(ZoneId.of("UTC")).toString())),
                         false,
-                        null);
+                        null,
+                        false);
 
         assertSuccessfullTokenResponse(tokenResponse);
 
@@ -203,7 +204,8 @@ public class TokenServiceTest {
                                         claimsForListOfScopes,
                                         LocalDateTime.now(ZoneId.of("UTC")).toString())),
                         false,
-                        oidcClaimsRequest);
+                        oidcClaimsRequest,
+                        false);
 
         assertSuccessfullTokenResponse(tokenResponse);
 
@@ -256,7 +258,8 @@ public class TokenServiceTest {
                                         claimsForListOfScopes,
                                         LocalDateTime.now(ZoneId.of("UTC")).toString())),
                         false,
-                        null);
+                        null,
+                        false);
 
         assertSuccessfullTokenResponse(tokenResponse);
 


### PR DESCRIPTION
## What?

Update oidc flow for the doc app.

Doc app 'authorisations' use a request object instead of parameters, containing a custom 'doc-checking-app' scope and a subject id.  This PR makes changes to the oidc flow to:

1. Check when it is being called by the app.
2. Use the information in the request object where required rather than the normal auth parameters.
3. Not rely on the user-profile as this won't exist for an app user.
4. Return a  temporary credential from the database for a doc app user in user-info rather than the standard attributes.

Changes have been made to the auth-code, token and user-info endpoints, with some supporting helper methods

## Why?

A doc app checking user bypasses the authentication frontend journey but is still authenticated in the background. 
