### PR TITLE
AUT-298: Add Dynamo read role to doc app callback

### DIFF
--- a/ci/terraform/oidc/doc-app-callback.tf
+++ b/ci/terraform/oidc/doc-app-callback.tf
@@ -11,6 +11,7 @@ module "doc_app_callback_role" {
     aws_iam_policy.doc_app_auth_kms_policy.arn,
     aws_iam_policy.doc_app_public_signing_key_parameter_policy.arn,
     aws_iam_policy.dynamo_doc_app_write_access_policy.arn,
+    aws_iam_policy.dynamo_doc_app_read_access_policy.arn,
   ]
 }
 


### PR DESCRIPTION
## What?

- Add Dynamo read role to doc app callback

## Why?

This is required by the "warm up" routine.