### PR TITLE
AUT-330: Add XRay Instrumentation to OIDC API

### DIFF
--- a/account-management-integration-tests/build.gradle
+++ b/account-management-integration-tests/build.gradle
@@ -18,10 +18,7 @@ dependencies {
             configurations.libphonenumber,
             "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${dependencyVersions.jackson_version}",
             "com.google.protobuf:protobuf-java:${dependencyVersions.protobuf_version}",
-            project(":client-registry-api"),
-            project(":frontend-api"),
             project(":account-management-api"),
-            project(":oidc-api"),
             project(":shared"),
             project(":shared-test")
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${dependencyVersions.junit}"

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ ext {
         junit: "5.8.2",
         jackson_version: "2.13.2",
         glassfish_version: "3.0.4",
+        xray: "2.11.1"
     ]
 
     terraformEnvironment = project.properties["terraformEnvironment"] ?: "localstack"
@@ -75,6 +76,7 @@ subprojects {
         ssm
         tests
         test_runtime
+        xray
     }
 
     configurations.all {
@@ -140,6 +142,12 @@ subprojects {
                 configurations.hamcrest
 
         test_runtime "org.junit.jupiter:junit-jupiter-engine:${dependencyVersions.junit}"
+
+        xray platform("com.amazonaws:aws-xray-recorder-sdk-bom:${dependencyVersions.xray}"),
+                "com.amazonaws:aws-xray-recorder-sdk-core:${dependencyVersions.xray}",
+                "com.amazonaws:aws-xray-recorder-sdk-aws-sdk-core:${dependencyVersions.xray}",
+                "com.amazonaws:aws-xray-recorder-sdk-aws-sdk-v2:${dependencyVersions.xray}",
+                "com.amazonaws:aws-xray-recorder-sdk-aws-sdk-v2-instrumentor:${dependencyVersions.xray}"
     }
 }
 

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -20,11 +20,18 @@ dependencies {
             "com.google.protobuf:protobuf-java:${dependencyVersions.protobuf_version}",
             project(":client-registry-api"),
             project(":frontend-api"),
-            project(":oidc-api"),
             project(":ipv-api"),
             project(":doc-checking-app-api"),
             project(":shared"),
             project(":shared-test")
+
+    implementation(project(":oidc-api")) {
+        exclude group: "com.amazonaws", module: "aws-xray-recorder-sdk-bom"
+        exclude group: "com.amazonaws", module: "aws-xray-recorder-sdk-core"
+        exclude group: "com.amazonaws", module: "aws-xray-recorder-sdk-aws-sdk-core"
+        exclude group: "com.amazonaws", module: "aws-xray-recorder-sdk-aws-sdk-v2"
+        exclude group: "com.amazonaws", module: "aws-xray-recorder-sdk-aws-sdk-v2-instrumentor"
+    }
 
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${dependencyVersions.junit}"
 }

--- a/oidc-api/build.gradle
+++ b/oidc-api/build.gradle
@@ -18,6 +18,7 @@ dependencies {
             configurations.nimbus,
             configurations.bouncycastle,
             configurations.cloudwatch,
+            configurations.xray,
             project(":shared"),
             project(":client-registry-api")
 


### PR DESCRIPTION
## What?

- Add X-Ray SDK dependencies to OIDC API
- Add Gradle `exclude` for X-Ray SDK to `integration-tests` module
- Remove unecessary dependencies from`account-management-integration-tests` which cause X-Ray to be pulled through

## Why?

We wish to inspect which operations are taking the time in the token endpoint.

Excluding the SDK from integration tests prevents requirement to provide extra setup for the tests.
