### PR TITLE
AUT-321 - Add extra validation for the request object in authorize

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -19,6 +19,7 @@ import uk.gov.di.authentication.oidc.lambda.AuthorisationHandler;
 import uk.gov.di.authentication.shared.entity.ClientConsent;
 import uk.gov.di.authentication.shared.entity.ClientType;
 import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
+import uk.gov.di.authentication.shared.entity.CustomScopeValue;
 import uk.gov.di.authentication.shared.entity.ResponseHeaders;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.shared.entity.ValidScopes;
@@ -492,7 +493,11 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @Test
     void shouldCallAuthorizeWithRequestObject() throws JOSEException {
-        registerClient(CLIENT_ID, "test-client", singletonList("openid"), ClientType.APP);
+        registerClient(
+                CLIENT_ID,
+                "test-client",
+                List.of(OPENID.getValue(), CustomScopeValue.DOC_CHECKING_APP.getValue()),
+                ClientType.APP);
         var signedJWT = createSignedJWT();
         var queryStringParameters =
                 new HashMap<>(
@@ -595,7 +600,10 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         .audience("http://localhost/authorize")
                         .claim("redirect_uri", RP_REDIRECT_URI)
                         .claim("response_type", ResponseType.CODE.toString())
-                        .claim("scope", new Scope(OIDCScopeValue.OPENID).toString())
+                        .claim(
+                                "scope",
+                                new Scope(OIDCScopeValue.OPENID, CustomScopeValue.DOC_CHECKING_APP)
+                                        .toString())
                         .claim("client_id", CLIENT_ID)
                         .claim("state", new State())
                         .issuer(CLIENT_ID)

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -10,6 +10,7 @@ import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.Scope;
+import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.openid.connect.sdk.Nonce;
 import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import org.junit.jupiter.api.BeforeEach;
@@ -593,6 +594,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         .claim("response_type", ResponseType.CODE.toString())
                         .claim("scope", new Scope(OIDCScopeValue.OPENID).toString())
                         .claim("client_id", CLIENT_ID)
+                        .claim("state", new State())
                         .issuer(CLIENT_ID)
                         .build();
         var jwsHeader = new JWSHeader(JWSAlgorithm.RS256);

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/RequestObjectService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/RequestObjectService.java
@@ -4,6 +4,7 @@ import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSVerifier;
 import com.nimbusds.jose.crypto.RSASSAVerifier;
 import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.Scope;
@@ -132,6 +133,15 @@ public class RequestObjectService {
                             client)) {
                 LOG.warn("Invalid scopes in request JWT");
                 return Optional.of(new AuthRequestError(OAuth2Error.INVALID_SCOPE, redirectURI));
+            }
+            if (Objects.isNull(jwtClaimsSet.getClaim("state"))) {
+                LOG.warn("State is missing from authRequest");
+                return Optional.of(
+                        new AuthRequestError(
+                                new ErrorObject(
+                                        OAuth2Error.INVALID_REQUEST_CODE,
+                                        "Request is missing state parameter"),
+                                redirectURI));
             }
         } catch (ParseException e) {
             throw new RuntimeException(e);

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/RequestObjectService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/RequestObjectService.java
@@ -14,6 +14,7 @@ import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.oidc.entity.AuthRequestError;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientType;
+import uk.gov.di.authentication.shared.entity.CustomScopeValue;
 import uk.gov.di.authentication.shared.entity.ValidScopes;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoClientService;
@@ -89,7 +90,8 @@ public class RequestObjectService {
                 return Optional.of(
                         new AuthRequestError(OAuth2Error.UNSUPPORTED_RESPONSE_TYPE, redirectURI));
             }
-            if (requestContainsInvalidScopes(authRequest.getScope().toStringList(), client)) {
+            if (requestContainsInvalidScopes(
+                    authRequest.getScope().toStringList(), client, false)) {
                 LOG.warn(
                         "Invalid scopes in authRequest. Scopes in request: {}",
                         authRequest.getScope().toStringList());
@@ -136,7 +138,8 @@ public class RequestObjectService {
             if (Objects.isNull(jwtClaimsSet.getClaim("scope"))
                     || requestContainsInvalidScopes(
                             Scope.parse(jwtClaimsSet.getClaim("scope").toString()).toStringList(),
-                            client)) {
+                            client,
+                            true)) {
                 LOG.warn("Invalid scopes in request JWT");
                 return Optional.of(new AuthRequestError(OAuth2Error.INVALID_SCOPE, redirectURI));
             }
@@ -157,7 +160,10 @@ public class RequestObjectService {
     }
 
     private boolean requestContainsInvalidScopes(
-            List<String> scopes, ClientRegistry clientRegistry) {
+            List<String> scopes, ClientRegistry clientRegistry, boolean requestObject) {
+        if (requestObject && !scopes.contains(CustomScopeValue.DOC_CHECKING_APP.getValue())) {
+            return true;
+        }
         for (String scope : scopes) {
             if (ValidScopes.getAllValidScopes().stream().noneMatch(t -> t.equals(scope))) {
                 return true;

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/RequestObjectService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/RequestObjectService.java
@@ -13,6 +13,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.oidc.entity.AuthRequestError;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
+import uk.gov.di.authentication.shared.entity.ClientType;
 import uk.gov.di.authentication.shared.entity.ValidScopes;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoClientService;
@@ -77,6 +78,11 @@ public class RequestObjectService {
                 throw new RuntimeException("Invalid Redirect URI in request JWT");
             }
             var redirectURI = URI.create((String) jwtClaimsSet.getClaim("redirect_uri"));
+            if (Boolean.FALSE.equals(client.getClientType().equals(ClientType.APP.getValue()))) {
+                LOG.warn("ClientType of client is not 'app'");
+                return Optional.of(
+                        new AuthRequestError(OAuth2Error.UNAUTHORIZED_CLIENT, redirectURI));
+            }
             if (!authRequest.getResponseType().toString().equals(ResponseType.CODE.toString())) {
                 LOG.warn(
                         "Unsupported responseType included in request. Expected responseType of code");


### PR DESCRIPTION
## What?

- Validate that the request object contains the custom `doc-checking-app` scope 
- Validate the request object contains the state claim 
- Validate that the client who sent the request_object has a client type of `app` 

## Why?

- We need to ensure the state param is present when an RP uses the request object as we will need to return it in the auth response. This will allow the RP to validate that the state param sent back in the response is the same as the request and will prevent against Cross-site request forgery attacks.
- Only clients with a ClientType of `app` can use request objects.
- We now have a doc-checking-app custom scope which be used by the app RP. We expect this to be in the request object JWT so we should validate for this