### PR TITLE
AUT-330: Add custom instrumentation to TokenHandler and TokenService

### DIFF
--- a/account-management-api/build.gradle
+++ b/account-management-api/build.gradle
@@ -16,8 +16,9 @@ dependencies {
 
     implementation configurations.nimbus,
             configurations.govuk_notify,
-            configurations.jackson,
-            project(":shared")
+            configurations.jackson
+
+    implementation project(":shared"), noXray
 
     runtimeOnly configurations.logging_runtime
 

--- a/account-management-integration-tests/build.gradle
+++ b/account-management-integration-tests/build.gradle
@@ -19,8 +19,9 @@ dependencies {
             "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${dependencyVersions.jackson_version}",
             "com.google.protobuf:protobuf-java:${dependencyVersions.protobuf_version}",
             project(":account-management-api"),
-            project(":shared"),
             project(":shared-test")
+    implementation project(":shared"), noXray
+
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${dependencyVersions.junit}"
 }
 

--- a/audit-processors/build.gradle
+++ b/audit-processors/build.gradle
@@ -19,10 +19,11 @@ dependencies {
             configurations.s3,
             configurations.dynamodb
 
-    implementation project(":shared"),
-            "com.google.protobuf:protobuf-java:${dependencyVersions.protobuf_version}",
+    implementation "com.google.protobuf:protobuf-java:${dependencyVersions.protobuf_version}",
             "com.google.protobuf:protobuf-java-util:${dependencyVersions.protobuf_version}",
             "com.google.code.gson:gson:2.9.0"
+
+    implementation project(":shared"), noXray
 
     runtimeOnly configurations.logging_runtime
 

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,15 @@ ext {
         AWS_ACCESS_KEY_ID: "mock-access-key",
         AWS_SECRET_ACCESS_KEY: "mock-secret-key",
     ] : [:]
+
+    noXray = {
+        exclude group: "com.amazonaws", module: "aws-xray-recorder-sdk-bom"
+        exclude group: "com.amazonaws", module: "aws-xray-recorder-sdk-core"
+        exclude group: "com.amazonaws", module: "aws-xray-recorder-sdk-aws-sdk-core"
+        exclude group: "com.amazonaws", module: "aws-xray-recorder-sdk-aws-sdk-instrumentor"
+        exclude group: "com.amazonaws", module: "aws-xray-recorder-sdk-aws-sdk-v2"
+        exclude group: "com.amazonaws", module: "aws-xray-recorder-sdk-aws-sdk-v2-instrumentor"
+    }
 }
 
 repositories {

--- a/ci/terraform/oidc/token.tf
+++ b/ci/terraform/oidc/token.tf
@@ -61,7 +61,7 @@ module "token" {
     TOKEN_SIGNING_KEY_ALIAS  = local.id_token_signing_key_alias_name
     LOCALSTACK_ENDPOINT      = var.use_localstack ? var.localstack_endpoint : null
     HEADERS_CASE_INSENSITIVE = var.use_localstack ? "true" : "false"
-
+    TRACING_ENABLED          = "true"
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.TokenHandler::handleRequest"
 

--- a/client-registry-api/build.gradle
+++ b/client-registry-api/build.gradle
@@ -14,8 +14,9 @@ dependencies {
             configurations.dynamodb
 
     implementation configurations.nimbus,
-            'commons-validator:commons-validator:1.7',
-            project(":shared")
+            'commons-validator:commons-validator:1.7'
+
+    implementation project(":shared"), noXray
 
     runtimeOnly configurations.logging_runtime
 

--- a/delivery-receipts-api/build.gradle
+++ b/delivery-receipts-api/build.gradle
@@ -11,8 +11,9 @@ dependencies {
             configurations.lambda,
             configurations.jackson,
             configurations.libphonenumber,
-            configurations.cloudwatch,
-            project(":shared")
+            configurations.cloudwatch
+
+    implementation project(":shared"), noXray
 
     runtimeOnly configurations.logging_runtime
 

--- a/delivery-receipts-integration-tests/build.gradle
+++ b/delivery-receipts-integration-tests/build.gradle
@@ -13,8 +13,10 @@ dependencies {
             configurations.lambda,
             configurations.lettuce,
             project(":delivery-receipts-api"),
-            project(":shared"),
             project(":shared-test")
+
+    implementation project(":shared"), noXray
+
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${dependencyVersions.junit}"
 }
 

--- a/doc-checking-app-api/build.gradle
+++ b/doc-checking-app-api/build.gradle
@@ -13,8 +13,10 @@ dependencies {
 
     implementation configurations.jackson,
             configurations.nimbus,
-            configurations.bouncycastle,
-            project(":shared")
+            configurations.bouncycastle
+
+    implementation project(":shared"), noXray
+
     runtimeOnly configurations.logging_runtime
 
     testImplementation configurations.tests,

--- a/frontend-api/build.gradle
+++ b/frontend-api/build.gradle
@@ -19,8 +19,9 @@ dependencies {
             configurations.jackson,
             configurations.nimbus,
             configurations.cloudwatch,
-            configurations.bouncycastle,
-            project(":shared")
+            configurations.bouncycastle
+
+    implementation project(":shared"), noXray
 
     runtimeOnly configurations.logging_runtime
 

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -18,21 +18,14 @@ dependencies {
             configurations.lambda,
             "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${dependencyVersions.jackson_version}",
             "com.google.protobuf:protobuf-java:${dependencyVersions.protobuf_version}",
-            project(":client-registry-api"),
-            project(":frontend-api"),
-            project(":ipv-api"),
-            project(":doc-checking-app-api"),
-            project(":shared"),
             project(":shared-test")
 
-    implementation(project(":oidc-api")) {
-        exclude group: "com.amazonaws", module: "aws-xray-recorder-sdk-bom"
-        exclude group: "com.amazonaws", module: "aws-xray-recorder-sdk-core"
-        exclude group: "com.amazonaws", module: "aws-xray-recorder-sdk-aws-sdk-core"
-        exclude group: "com.amazonaws", module: "aws-xray-recorder-sdk-aws-sdk-instrumentor"
-        exclude group: "com.amazonaws", module: "aws-xray-recorder-sdk-aws-sdk-v2"
-        exclude group: "com.amazonaws", module: "aws-xray-recorder-sdk-aws-sdk-v2-instrumentor"
-    }
+    implementation project(":shared"), noXray
+    implementation project(":oidc-api"), noXray
+    implementation project(":frontend-api"), noXray
+    implementation project(":client-registry-api"), noXray
+    implementation project(":ipv-api"), noXray
+    implementation project(":doc-checking-app-api"), noXray
 
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${dependencyVersions.junit}"
 }

--- a/ipv-api/build.gradle
+++ b/ipv-api/build.gradle
@@ -14,8 +14,10 @@ dependencies {
             configurations.dynamodb
 
     implementation configurations.jackson,
-            configurations.nimbus,
-            project(":shared")
+            configurations.nimbus
+
+    implementation project(":shared"), noXray
+
     runtimeOnly configurations.logging_runtime
 
     testImplementation configurations.tests,

--- a/oidc-api/build.gradle
+++ b/oidc-api/build.gradle
@@ -18,7 +18,6 @@ dependencies {
             configurations.nimbus,
             configurations.bouncycastle,
             configurations.cloudwatch,
-            configurations.xray,
             project(":shared"),
             project(":client-registry-api")
 

--- a/shared-test/build.gradle
+++ b/shared-test/build.gradle
@@ -19,8 +19,9 @@ dependencies {
             "org.eclipse.jetty:jetty-server:11.0.9",
             "com.amazonaws:aws-java-sdk-lambda:1.12.205",
             "com.google.protobuf:protobuf-java:3.20.1",
-            "com.google.code.gson:gson:2.9.0",
-            project(":shared")
+            "com.google.code.gson:gson:2.9.0"
+
+    implementation project(":shared"), noXray
 }
 
 test {

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -20,6 +20,7 @@ dependencies {
             configurations.sns,
             configurations.sqs,
             configurations.ssm,
+            configurations.xray,
             configurations.cloudwatch,
             "com.amazonaws:aws-java-sdk-lambda:1.12.205",
             "com.google.protobuf:protobuf-java:3.20.1"

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/InstrumentationHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/InstrumentationHelper.java
@@ -1,0 +1,31 @@
+package uk.gov.di.authentication.shared.helpers;
+
+import com.amazonaws.xray.AWSXRay;
+
+import java.util.Optional;
+import java.util.concurrent.Callable;
+
+public class InstrumentationHelper {
+    private static final boolean tracingEnabled =
+            Boolean.parseBoolean(System.getenv().getOrDefault("TRACING_ENABLED", "false"));
+
+    public static <T> T segmentedFunctionCall(String segmentName, Callable<T> callable) {
+        if (tracingEnabled) {
+            var segment = Optional.of(AWSXRay.beginSubsegment(segmentName));
+            try {
+                return callable.call();
+            } catch (Exception e) {
+                segment.ifPresent(s -> s.addException(e));
+                throw new RuntimeException(e);
+            } finally {
+                AWSXRay.endSegment();
+            }
+        } else {
+            try {
+                return callable.call();
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
@@ -70,6 +70,7 @@ import java.util.stream.Collectors;
 
 import static uk.gov.di.authentication.shared.helpers.ConstructUriHelper.buildURI;
 import static uk.gov.di.authentication.shared.helpers.HashHelper.hashSha256String;
+import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
 
 public class TokenService {
 
@@ -109,17 +110,39 @@ public class TokenService {
             scopesForToken = authRequestScopes.toStringList();
         }
         AccessToken accessToken =
-                generateAndStoreAccessToken(
-                        clientID, internalSubject, scopesForToken, publicSubject, claimsRequest);
+                segmentedFunctionCall(
+                        "generateAndStoreAccessToken",
+                        () ->
+                                generateAndStoreAccessToken(
+                                        clientID,
+                                        internalSubject,
+                                        scopesForToken,
+                                        publicSubject,
+                                        claimsRequest));
         AccessTokenHash accessTokenHash =
-                AccessTokenHash.compute(accessToken, TOKEN_ALGORITHM, null);
+                segmentedFunctionCall(
+                        "AccessTokenHash.compute",
+                        () -> AccessTokenHash.compute(accessToken, TOKEN_ALGORITHM, null));
         SignedJWT idToken =
-                generateIDToken(
-                        clientID, publicSubject, additionalTokenClaims, accessTokenHash, vot);
+                segmentedFunctionCall(
+                        "generateIDToken",
+                        () ->
+                                generateIDToken(
+                                        clientID,
+                                        publicSubject,
+                                        additionalTokenClaims,
+                                        accessTokenHash,
+                                        vot));
         if (scopesForToken.contains(OIDCScopeValue.OFFLINE_ACCESS.getValue())) {
             RefreshToken refreshToken =
-                    generateAndStoreRefreshToken(
-                            clientID, internalSubject, scopesForToken, publicSubject);
+                    segmentedFunctionCall(
+                            "generateAndStoreRefreshToken",
+                            () ->
+                                    generateAndStoreRefreshToken(
+                                            clientID,
+                                            internalSubject,
+                                            scopesForToken,
+                                            publicSubject));
             return new OIDCTokenResponse(new OIDCTokens(idToken, accessToken, refreshToken));
         } else {
             return new OIDCTokenResponse(new OIDCTokens(idToken, accessToken, null));


### PR DESCRIPTION
## What?

- Add a new helper to execute a funtion in custom subsegment
- Wrap certain cryptographic operations in the helper so that its execution times are recorded in sub segment (if tracing enabled)
- Add excludes to Gradle sub-modules that use the `shared` module so that XRay is not pulled into modules that don't need it
- Enable tracing on token endpoint
- Wrap additional operations in `TokenHandler` with custom subsegments

## Why?

Traces resulting from previous pull-request show that there is bottleneck in any AWS related service calls, we suspect that one of the calls we have wrapped in a custom segment is causing the issue. This PR should help us focus on where the issue might lie.

## Related PRs

#1744 
#1745 
