### PR TITLE
AUT-322 - Fix logout bug

### DIFF
--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
@@ -104,8 +104,10 @@ public class DocAppCallbackHandler
                                                         sessionCookiesIds.getSessionId())
                                                 .orElseThrow();
                                 var clientSession =
-                                        clientSessionService.getClientSession(
-                                                sessionCookiesIds.getClientSessionId());
+                                        clientSessionService
+                                                .getClientSession(
+                                                        sessionCookiesIds.getClientSessionId())
+                                                .orElse(null);
                                 if (Objects.isNull(clientSession)) {
                                     LOG.error("ClientSession not found");
                                     throw new RuntimeException();

--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
@@ -328,7 +328,8 @@ class DocAppCallbackHandlerTest {
     }
 
     private void usingValidClientSession() {
-        when(clientSessionService.getClientSession(CLIENT_SESSION_ID)).thenReturn(clientSession);
+        when(clientSessionService.getClientSession(CLIENT_SESSION_ID))
+                .thenReturn(Optional.of(clientSession));
         clientSession.setDocAppSubjectId(PAIRWISE_SUBJECT_ID);
     }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandlerTest.java
@@ -257,7 +257,8 @@ class SignUpHandlerTest {
     }
 
     private void usingValidClientSession() {
-        when(clientSessionService.getClientSession(CLIENT_SESSION_ID)).thenReturn(clientSession);
+        when(clientSessionService.getClientSession(CLIENT_SESSION_ID))
+                .thenReturn(Optional.of(clientSession));
     }
 
     private ClientRegistry generateClientRegistry(boolean consentRequired) {

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -125,8 +125,10 @@ public class IPVCallbackHandler
                                                         sessionCookiesIds.getSessionId())
                                                 .orElseThrow();
                                 var clientSession =
-                                        clientSessionService.getClientSession(
-                                                sessionCookiesIds.getClientSessionId());
+                                        clientSessionService
+                                                .getClientSession(
+                                                        sessionCookiesIds.getClientSessionId())
+                                                .orElse(null);
                                 if (Objects.isNull(clientSession)) {
                                     LOG.error("ClientSession not found");
                                     throw new RuntimeException();

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -408,7 +408,8 @@ class IPVCallbackHandlerTest {
     }
 
     private void usingValidClientSession() {
-        when(clientSessionService.getClientSession(CLIENT_SESSION_ID)).thenReturn(clientSession);
+        when(clientSessionService.getClientSession(CLIENT_SESSION_ID))
+                .thenReturn(Optional.of(clientSession));
     }
 
     private UserProfile generateUserProfile() {

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
@@ -80,6 +80,14 @@ public class RedisExtension
         redis.saveWithExpiry("state:" + sessionId, objectMapper.writeValueAsString(state), 3600);
     }
 
+    public void addClientSessionIdToSession(String clientSessionId, String sessionId)
+            throws JsonProcessingException {
+        Session session = objectMapper.readValue(redis.getValue(sessionId), Session.class);
+        session.addClientSession(clientSessionId);
+        redis.saveWithExpiry(
+                session.getSessionId(), objectMapper.writeValueAsString(session), 3600);
+    }
+
     public void addAuthRequestToSession(
             String clientSessionId, String sessionId, Map<String, List<String>> authRequest)
             throws JsonProcessingException {


### PR DESCRIPTION
- Since October we have seen errors in ours log from the LogoutHandler quoting `Error getting client session from Redis`.
- If a users existing session is still valid and they hit /authorize again, it will create a new session, copy everything over from the old session (including client sessions) and delete the old session. The new session has a 60 minute expiry and is rolling, so every time the session is saved it was reset to 60 minute expiry. However the client sessions which have been copied over from a previous session will not be rolling and will expire before the existing session does. We save these client session with a expiry time in Redis, so once they have expired they will not exist in Redis. The session however still has a list of all client sessions ID stored whether they are expired or not.
- The errors occur when a client session has expired and the client session id is present in the session. The users then clicks logout and it tries to delete the client session but as it doesn't exist it just throws an exception. This also means that the session is never deleted from Redis as it throws before that point.
- Change this behaviour to stop throwing an exception if the client session is not present in Redis and continue deleting the remaining client sessions which are before finally deleting the session.