### PR TITLE
AUT-330: Add XRay tracing to API gateway

### DIFF
--- a/ci/terraform/oidc/api-gateway.tf
+++ b/ci/terraform/oidc/api-gateway.tf
@@ -216,6 +216,8 @@ resource "aws_api_gateway_stage" "endpoint_stage" {
   rest_api_id   = aws_api_gateway_rest_api.di_authentication_api.id
   stage_name    = var.environment
 
+  xray_tracing_enabled = true
+
   dynamic "access_log_settings" {
     for_each = var.use_localstack ? [] : aws_cloudwatch_log_group.oidc_stage_access_logs
     iterator = log_group


### PR DESCRIPTION
## What?

- Enable XRay tracing on the OIDC API gateway stage. 

## Why?

This will help tie requests together end-to-end and measure any latency through the gateway
