### PR TITLE
AUT-343 - Add log_ids to SPOT request

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/testsupport/helpers/SpotQueueAssertionHelper.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/testsupport/helpers/SpotQueueAssertionHelper.java
@@ -53,6 +53,24 @@ public class SpotQueueAssertionHelper {
                                 .getLogIds()
                                 .getSessionId()));
 
+        assertThat(
+                expectedSpotRequest.getLogIds().getClientId(),
+                equalTo(
+                        actualRequests.stream()
+                                .findFirst()
+                                .orElseThrow()
+                                .getLogIds()
+                                .getClientId()));
+
+        assertThat(
+                expectedSpotRequest.getLogIds().getPersistentSessionId(),
+                equalTo(
+                        actualRequests.stream()
+                                .findFirst()
+                                .orElseThrow()
+                                .getLogIds()
+                                .getPersistentSessionId()));
+
         expectedRequests.forEach(
                 spotRequest ->
                         assertThat(

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/LogIds.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/LogIds.java
@@ -7,13 +7,37 @@ public class LogIds {
     @JsonProperty(value = "session_id")
     private String sessionId;
 
-    public LogIds(String sessionId) {
+    @JsonProperty(value = "persistent_session_id")
+    private String persistentSessionId;
+
+    @JsonProperty(value = "request_id")
+    private String requestId;
+
+    @JsonProperty(value = "client_id")
+    private String clientId;
+
+    public LogIds(String sessionId, String persistentSessionId, String requestId, String clientId) {
         this.sessionId = sessionId;
+        this.persistentSessionId = persistentSessionId;
+        this.requestId = requestId;
+        this.clientId = clientId;
     }
 
     public LogIds() {}
 
     public String getSessionId() {
         return sessionId;
+    }
+
+    public String getPersistentSessionId() {
+        return persistentSessionId;
+    }
+
+    public String getRequestId() {
+        return requestId;
+    }
+
+    public String getClientId() {
+        return clientId;
     }
 }


### PR DESCRIPTION
## What?

 - Add log_ids to SPOT request

## Why?

- As per RFC 0013 - https://github.com/alphagov/digital-identity-architecture/blob/main/rfc/0013-spot-request-response-structures.md, we require additional log ids in the SPOT request.
