### PR TITLE
BAU - Log exception thrown by user-identity endpoint

### DIFF
--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVTokenService.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVTokenService.java
@@ -103,7 +103,7 @@ public class IPVTokenService {
                 return userIdentityUserInfo;
             }
         } catch (IOException | ParseException e) {
-            LOG.error("Error when attempting to call IPV user-identity endpoint");
+            LOG.error("Error when attempting to call IPV user-identity endpoint", e);
             throw new RuntimeException();
         }
     }


### PR DESCRIPTION
## What?

 - Log exception thrown by user-identity endpoint

## Why?

- We are getting an exception whilst trying to call the IPV user-identity endpoint. Log the exception.