### PR TITLE
AUT-285 - Remove the kms encryption key

### DIFF
--- a/ci/terraform/shared/kms.tf
+++ b/ci/terraform/shared/kms.tf
@@ -302,22 +302,6 @@ resource "aws_kms_alias" "ipv_token_auth_signing_key_alias" {
   target_key_id = aws_kms_key.ipv_token_auth_signing_key.key_id
 }
 
-# IPV Authentication encryption KMS key
-
-resource "aws_kms_key" "ipv_auth_encryption_key" {
-  description              = "KMS encryption key for secure JWT authentication request"
-  deletion_window_in_days  = 30
-  key_usage                = "ENCRYPT_DECRYPT"
-  customer_master_key_spec = "RSA_2048"
-
-  tags = local.default_tags
-}
-
-resource "aws_kms_alias" "ipv_auth_encryption_key_alias" {
-  name          = "alias/${var.environment}-ipv-auth-encryption-kms-key-alias"
-  target_key_id = aws_kms_key.ipv_auth_encryption_key.key_id
-}
-
 # Doc Checking App Authentication Signing KMS key
 
 resource "aws_kms_key" "doc_app_auth_signing_key" {


### PR DESCRIPTION
## What?

- Remove the kms encryption key

## Why?

- It is not used
- We will be encrypting the secure jar using a public encryption key supplied to us by IPV. This will be kept in parameter store and therefore this key is redundant.
