### PR TITLE
AUT-343 - Change SPOT Response status

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/SpotResponseIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/SpotResponseIntegrationTest.java
@@ -41,7 +41,7 @@ public class SpotResponseIntegrationTest extends HandlerIntegrationTest<SQSEvent
                                         "https://vocab.sign-in.service.gov.uk/v1/verifiableIdentityJWT",
                                         signedCredential),
                                 pairwiseIdentifier.getValue(),
-                                SPOTStatus.OK)),
+                                SPOTStatus.ACCEPTED)),
                 mock(Context.class));
 
         assertTrue(spotStore.getSpotCredential(pairwiseIdentifier.getValue()).isPresent());

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/SPOTStatus.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/SPOTStatus.java
@@ -1,6 +1,10 @@
 package uk.gov.di.authentication.ipv.entity;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public enum SPOTStatus {
-    OK,
-    OTHER
+    @JsonProperty("Accepted")
+    ACCEPTED,
+    @JsonProperty("Rejected")
+    REJECTED;
 }

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandler.java
@@ -55,9 +55,9 @@ public class SPOTResponseHandler implements RequestHandler<SQSEvent, Object> {
         for (SQSMessage msg : event.getRecords()) {
             try {
                 var spotResponse = objectMapper.readValue(msg.getBody(), SPOTResponse.class);
-                if (spotResponse.getStatus() != SPOTStatus.OK) {
+                if (spotResponse.getStatus() != SPOTStatus.ACCEPTED) {
                     LOG.warn(
-                            "SPOTResponse Status is not OK. Actual Status: {}",
+                            "SPOTResponse Status is not Accepted. Actual Status: {}",
                             spotResponse.getStatus());
                     return null;
                 }

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandlerTest.java
@@ -33,7 +33,7 @@ class SPOTResponseHandlerTest {
     @Test
     void shouldWriteToDynamoForSuccesssfulSPOTResponse() {
         String json =
-                "{\"sub\":\"some-pairwise-identifier\",\"status\":\"OK\","
+                "{\"sub\":\"some-pairwise-identifier\",\"status\":\"Accepted\","
                         + "\"claims\":{\"http://something/v1/verifiableIdentityJWT\":\"random-searalized-credential\"}}";
 
         handler.handleRequest(generateSQSEvent(json), context);
@@ -76,7 +76,7 @@ class SPOTResponseHandlerTest {
     @Test
     void shouldNotWriteToDynamoWhenSPOTResponseStatusIsNotOK() {
         String json =
-                "{\"sub\":\"some-pairwise-identifier\",\"status\":\"OTHER\","
+                "{\"sub\":\"some-pairwise-identifier\",\"status\":\"Rejected\","
                         + "\"claims\":{\"http://something/v1/verifiableIdentityJWT\":\"random-searalized-credential\"}}";
 
         handler.handleRequest(generateSQSEvent(json), context);
@@ -98,7 +98,8 @@ class SPOTResponseHandlerTest {
 
     @Test
     void shouldNotWriteToDynamoWhenStatusIsOKButNoCredentialIsPresent() {
-        String json = "{\"sub\":\"some-pairwise-identifier\",\"status\":\"OK\"," + "\"claims\":{}}";
+        String json =
+                "{\"sub\":\"some-pairwise-identifier\",\"status\":\"Accepted\"," + "\"claims\":{}}";
 
         handler.handleRequest(generateSQSEvent(json), context);
 


### PR DESCRIPTION
## What?

- Change SPOT Response status

## Why?

- The status on the SPOT Response can either be Accepted or Rejected. Change the enum to reflect this. This can be seen in RFC 0013 - https://github.com/alphagov/digital-identity-architecture/blob/main/rfc/0013-spot-request-response-structures.md