### PR TITLE
AUT-345: Use ObjectMapperFactory to create ObjectMappers

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandler.java
@@ -12,6 +12,7 @@ import uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent;
 import uk.gov.di.accountmanagement.entity.AuthenticateRequest;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
+import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.helpers.RequestHeaderHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
@@ -31,7 +32,7 @@ public class AuthenticateHandler
     private static final Logger LOG = LogManager.getLogger(AuthenticateHandler.class);
 
     private final AuthenticationService authenticationService;
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
     private final AuditService auditService;
 
     public AuthenticateHandler(

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/NotificationHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/NotificationHandler.java
@@ -11,6 +11,7 @@ import org.apache.logging.log4j.Logger;
 import uk.gov.di.accountmanagement.entity.NotificationType;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.accountmanagement.services.NotificationService;
+import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.service.notify.NotificationClient;
 import uk.gov.service.notify.NotificationClientException;
@@ -24,7 +25,7 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
 
     private static final Logger LOG = LogManager.getLogger(NotificationHandler.class);
     private final NotificationService notificationService;
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
     private final ConfigurationService configurationService;
 
     public NotificationHandler(

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandler.java
@@ -17,6 +17,7 @@ import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
+import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.helpers.RequestBodyHelper;
 import uk.gov.di.authentication.shared.helpers.RequestHeaderHelper;
@@ -41,7 +42,7 @@ public class RemoveAccountHandler
     private final AuthenticationService authenticationService;
     private final AwsSqsClient sqsClient;
     private final AuditService auditService;
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
 
     public RemoveAccountHandler(
             AuthenticationService authenticationService,

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
@@ -16,6 +16,7 @@ import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
+import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.helpers.RequestHeaderHelper;
 import uk.gov.di.authentication.shared.helpers.ValidationHelper;
@@ -47,7 +48,7 @@ public class SendOtpNotificationHandler
     private final CodeGeneratorService codeGeneratorService;
     private final CodeStorageService codeStorageService;
     private final DynamoService dynamoService;
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
     private final AuditService auditService;
 
     public SendOtpNotificationHandler(

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
@@ -18,6 +18,7 @@ import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
+import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.helpers.RequestBodyHelper;
 import uk.gov.di.authentication.shared.helpers.RequestHeaderHelper;
@@ -39,7 +40,7 @@ import static uk.gov.di.authentication.shared.helpers.WarmerHelper.isWarming;
 public class UpdateEmailHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
     private final DynamoService dynamoService;
     private final AwsSqsClient sqsClient;
     private final CodeStorageService codeStorageService;

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandler.java
@@ -18,6 +18,7 @@ import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.Argon2MatcherHelper;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
+import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.helpers.RequestBodyHelper;
 import uk.gov.di.authentication.shared.helpers.RequestHeaderHelper;
@@ -36,7 +37,7 @@ import static uk.gov.di.authentication.shared.helpers.WarmerHelper.isWarming;
 public class UpdatePasswordHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
     private final DynamoService dynamoService;
     private final AwsSqsClient sqsClient;
     private final AuditService auditService;

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandler.java
@@ -18,6 +18,7 @@ import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
+import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.helpers.RequestBodyHelper;
 import uk.gov.di.authentication.shared.helpers.RequestHeaderHelper;
@@ -37,7 +38,7 @@ import static uk.gov.di.authentication.shared.helpers.WarmerHelper.isWarming;
 public class UpdatePhoneNumberHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
     private final DynamoService dynamoService;
     private final AwsSqsClient sqsClient;
     private final CodeStorageService codeStorageService;

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/NotificationHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/NotificationHandlerTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.accountmanagement.services.NotificationService;
+import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.service.notify.NotificationClientException;
 
@@ -40,7 +41,7 @@ public class NotificationHandlerTest {
     private final NotificationService notificationService = mock(NotificationService.class);
     private final ConfigurationService configService = mock(ConfigurationService.class);
     private NotificationHandler handler;
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
 
     @BeforeEach
     public void setUp() {

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandlerTest.java
@@ -12,6 +12,7 @@ import uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
@@ -34,6 +35,8 @@ class RemoveAccountHandlerTest {
 
     private static final String EMAIL = "joe.bloggs@digital.cabinet-office.gov.uk";
     private static final Subject SUBJECT = new Subject();
+    private static final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
+
     private RemoveAccountHandler handler;
     private final Context context = mock(Context.class);
     private final AwsSqsClient sqsClient = mock(AwsSqsClient.class);
@@ -67,7 +70,7 @@ class RemoveAccountHandlerTest {
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
         verify(authenticationService).removeAccount(eq(EMAIL));
         NotifyRequest notifyRequest = new NotifyRequest(EMAIL, DELETE_ACCOUNT);
-        verify(sqsClient).send(new ObjectMapper().writeValueAsString(notifyRequest));
+        verify(sqsClient).send(objectMapper.writeValueAsString(notifyRequest));
 
         verify(auditService)
                 .submitAuditEvent(

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandlerTest.java
@@ -15,6 +15,7 @@ import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.CodeGeneratorService;
@@ -48,6 +49,8 @@ class SendOtpNotificationHandlerTest {
     private static final String TEST_SIX_DIGIT_CODE = "123456";
     private static final String TEST_PHONE_NUMBER = "07755551084";
     private static final long CODE_EXPIRY_TIME = 900;
+    private static final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
+
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final AwsSqsClient awsSqsClient = mock(AwsSqsClient.class);
     private final CodeGeneratorService codeGeneratorService = mock(CodeGeneratorService.class);
@@ -76,7 +79,6 @@ class SendOtpNotificationHandlerTest {
         String persistentIdValue = "some-persistent-session-id";
         NotifyRequest notifyRequest =
                 new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL, TEST_SIX_DIGIT_CODE);
-        ObjectMapper objectMapper = new ObjectMapper();
         String serialisedRequest = objectMapper.writeValueAsString(notifyRequest);
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
@@ -113,7 +115,7 @@ class SendOtpNotificationHandlerTest {
     void shouldReturn204AndPutMessageOnQueueForAValidPhoneRequest() throws JsonProcessingException {
         NotifyRequest notifyRequest =
                 new NotifyRequest(TEST_PHONE_NUMBER, VERIFY_PHONE_NUMBER, TEST_SIX_DIGIT_CODE);
-        ObjectMapper objectMapper = new ObjectMapper();
+
         String serialisedRequest = objectMapper.writeValueAsString(notifyRequest);
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
@@ -200,7 +202,6 @@ class SendOtpNotificationHandlerTest {
     void shouldReturn500IfMessageCannotBeSentToQueue() throws JsonProcessingException {
         NotifyRequest notifyRequest =
                 new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL, TEST_SIX_DIGIT_CODE);
-        ObjectMapper objectMapper = new ObjectMapper();
         String serialisedRequest = objectMapper.writeValueAsString(notifyRequest);
         Mockito.doThrow(SdkClientException.class).when(awsSqsClient).send(eq(serialisedRequest));
 

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandlerTest.java
@@ -15,6 +15,7 @@ import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.DynamoService;
@@ -48,6 +49,8 @@ class UpdateEmailHandlerTest {
     private static final String INVALID_EMAIL_ADDRESS = "igital.cabinet-office.gov.uk";
     private static final String OTP = "123456";
     private static final Subject SUBJECT = new Subject();
+    private static final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
+
     private final AuditService auditService = mock(AuditService.class);
 
     @BeforeEach
@@ -82,7 +85,7 @@ class UpdateEmailHandlerTest {
         assertThat(result, hasStatus(204));
         verify(dynamoService).updateEmail(EXISTING_EMAIL_ADDRESS, NEW_EMAIL_ADDRESS);
         NotifyRequest notifyRequest = new NotifyRequest(NEW_EMAIL_ADDRESS, EMAIL_UPDATED);
-        verify(sqsClient).send(new ObjectMapper().writeValueAsString(notifyRequest));
+        verify(sqsClient).send(objectMapper.writeValueAsString(notifyRequest));
 
         verify(auditService)
                 .submitAuditEvent(
@@ -119,8 +122,8 @@ class UpdateEmailHandlerTest {
         assertThat(result, hasStatus(400));
         verify(dynamoService, never()).updateEmail(EXISTING_EMAIL_ADDRESS, NEW_EMAIL_ADDRESS);
         NotifyRequest notifyRequest = new NotifyRequest(NEW_EMAIL_ADDRESS, EMAIL_UPDATED);
-        verify(sqsClient, never()).send(new ObjectMapper().writeValueAsString(notifyRequest));
-        String expectedResponse = new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1009);
+        verify(sqsClient, never()).send(objectMapper.writeValueAsString(notifyRequest));
+        String expectedResponse = objectMapper.writeValueAsString(ErrorResponse.ERROR_1009);
         assertThat(result, hasBody(expectedResponse));
     }
 
@@ -161,8 +164,8 @@ class UpdateEmailHandlerTest {
         assertThat(result, hasStatus(400));
         verify(dynamoService, never()).updateEmail(EXISTING_EMAIL_ADDRESS, INVALID_EMAIL_ADDRESS);
         NotifyRequest notifyRequest = new NotifyRequest(INVALID_EMAIL_ADDRESS, EMAIL_UPDATED);
-        verify(sqsClient, never()).send(new ObjectMapper().writeValueAsString(notifyRequest));
-        String expectedResponse = new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1020);
+        verify(sqsClient, never()).send(objectMapper.writeValueAsString(notifyRequest));
+        String expectedResponse = objectMapper.writeValueAsString(ErrorResponse.ERROR_1020);
         assertThat(result, hasBody(expectedResponse));
     }
 
@@ -187,8 +190,8 @@ class UpdateEmailHandlerTest {
         assertThat(result, hasStatus(400));
         verify(dynamoService, never()).updateEmail(EXISTING_EMAIL_ADDRESS, INVALID_EMAIL_ADDRESS);
         NotifyRequest notifyRequest = new NotifyRequest(INVALID_EMAIL_ADDRESS, EMAIL_UPDATED);
-        verify(sqsClient, never()).send(new ObjectMapper().writeValueAsString(notifyRequest));
-        String expectedResponse = new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1004);
+        verify(sqsClient, never()).send(objectMapper.writeValueAsString(notifyRequest));
+        String expectedResponse = objectMapper.writeValueAsString(ErrorResponse.ERROR_1004);
         assertThat(result, hasBody(expectedResponse));
     }
 

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandlerTest.java
@@ -16,6 +16,7 @@ import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.Argon2EncoderHelper;
+import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.DynamoService;
@@ -46,6 +47,7 @@ class UpdatePasswordHandlerTest {
     private static final String NEW_PASSWORD = "password2";
     private static final String CURRENT_PASSWORD = "password1";
     private static final Subject SUBJECT = new Subject();
+    private static final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
 
     @BeforeEach
     public void setUp() {
@@ -80,7 +82,7 @@ class UpdatePasswordHandlerTest {
         verify(dynamoService).updatePassword(EXISTING_EMAIL_ADDRESS, NEW_PASSWORD);
         NotifyRequest notifyRequest =
                 new NotifyRequest(EXISTING_EMAIL_ADDRESS, NotificationType.PASSWORD_UPDATED);
-        verify(sqsClient).send(new ObjectMapper().writeValueAsString(notifyRequest));
+        verify(sqsClient).send(objectMapper.writeValueAsString(notifyRequest));
 
         verify(auditService)
                 .submitAuditEvent(
@@ -143,7 +145,7 @@ class UpdatePasswordHandlerTest {
         verify(dynamoService, never()).updatePassword(EXISTING_EMAIL_ADDRESS, NEW_PASSWORD);
         NotifyRequest notifyRequest =
                 new NotifyRequest(EXISTING_EMAIL_ADDRESS, NotificationType.PASSWORD_UPDATED);
-        verify(sqsClient, never()).send(new ObjectMapper().writeValueAsString(notifyRequest));
+        verify(sqsClient, never()).send(objectMapper.writeValueAsString(notifyRequest));
 
         verify(auditService, never())
                 .submitAuditEvent(

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandlerTest.java
@@ -14,6 +14,7 @@ import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.DynamoService;
@@ -48,6 +49,8 @@ class UpdatePhoneNumberHandlerTest {
     private static final String INVALID_PHONE_NUMBER = "12345";
     private static final String OTP = "123456";
     private static final Subject SUBJECT = new Subject();
+    private static final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
+
     private final AuditService auditService = mock(AuditService.class);
 
     @BeforeEach
@@ -86,7 +89,7 @@ class UpdatePhoneNumberHandlerTest {
         assertThat(result, hasStatus(204));
         verify(dynamoService).updatePhoneNumber(EMAIL_ADDRESS, NEW_PHONE_NUMBER);
         NotifyRequest notifyRequest = new NotifyRequest(EMAIL_ADDRESS, PHONE_NUMBER_UPDATED);
-        verify(sqsClient).send(new ObjectMapper().writeValueAsString(notifyRequest));
+        verify(sqsClient).send(objectMapper.writeValueAsString(notifyRequest));
 
         verify(auditService)
                 .submitAuditEvent(
@@ -140,8 +143,8 @@ class UpdatePhoneNumberHandlerTest {
         assertThat(result, hasStatus(400));
         verify(dynamoService, times(0)).updatePhoneNumber(EMAIL_ADDRESS, INVALID_PHONE_NUMBER);
         NotifyRequest notifyRequest = new NotifyRequest(INVALID_PHONE_NUMBER, PHONE_NUMBER_UPDATED);
-        verify(sqsClient, times(0)).send(new ObjectMapper().writeValueAsString(notifyRequest));
-        String expectedResponse = new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1020);
+        verify(sqsClient, times(0)).send(objectMapper.writeValueAsString(notifyRequest));
+        String expectedResponse = objectMapper.writeValueAsString(ErrorResponse.ERROR_1020);
         assertThat(result, hasBody(expectedResponse));
         verifyNoInteractions(auditService);
     }

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/SendOtpNotificationIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/SendOtpNotificationIntegrationTest.java
@@ -1,7 +1,6 @@
 package uk.gov.di.accountmanagement.api;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.i18n.phonenumbers.PhoneNumberUtil;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
@@ -73,8 +72,7 @@ class SendOtpNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTes
                         Collections.emptyMap());
 
         assertThat(response, hasStatus(HttpStatus.SC_BAD_REQUEST));
-        assertThat(
-                response, hasBody(new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1009)));
+        assertThat(response, hasBody(objectMapper.writeValueAsString(ErrorResponse.ERROR_1009)));
 
         NotificationAssertionHelper.assertNoNotificationsReceived(notificationsQueue);
 
@@ -137,8 +135,7 @@ class SendOtpNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTes
                         Collections.emptyMap());
 
         assertThat(response, hasStatus(HttpStatus.SC_BAD_REQUEST));
-        assertThat(
-                response, hasBody(new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1012)));
+        assertThat(response, hasBody(objectMapper.writeValueAsString(ErrorResponse.ERROR_1012)));
 
         NotificationAssertionHelper.assertNoNotificationsReceived(notificationsQueue);
 

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdateEmailIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdateEmailIntegrationTest.java
@@ -1,6 +1,5 @@
 package uk.gov.di.accountmanagement.api;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
@@ -79,8 +78,7 @@ class UpdateEmailIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Map.of("principalId", publicSubjectID));
 
         assertThat(response, hasStatus(HttpStatus.SC_BAD_REQUEST));
-        assertThat(
-                response, hasBody(new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1020)));
+        assertThat(response, hasBody(objectMapper.writeValueAsString(ErrorResponse.ERROR_1020)));
 
         assertNoNotificationsReceived(notificationsQueue);
 
@@ -127,8 +125,7 @@ class UpdateEmailIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Map.of("principalId", publicSubjectID));
 
         assertThat(response, hasStatus(HttpStatus.SC_BAD_REQUEST));
-        assertThat(
-                response, hasBody(new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1009)));
+        assertThat(response, hasBody(objectMapper.writeValueAsString(ErrorResponse.ERROR_1009)));
 
         assertNoNotificationsReceived(notificationsQueue);
 

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdatePasswordIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdatePasswordIntegrationTest.java
@@ -1,6 +1,5 @@
 package uk.gov.di.accountmanagement.api;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
@@ -74,8 +73,7 @@ public class UpdatePasswordIntegrationTest extends ApiGatewayHandlerIntegrationT
                         Map.of("principalId", publicSubjectID));
 
         assertThat(response, hasStatus(HttpStatus.SC_BAD_REQUEST));
-        assertThat(
-                response, hasBody(new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1024)));
+        assertThat(response, hasBody(objectMapper.writeValueAsString(ErrorResponse.ERROR_1024)));
 
         assertNoNotificationsReceived(notificationsQueue);
 

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdatePhoneNumberIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdatePhoneNumberIntegrationTest.java
@@ -1,6 +1,5 @@
 package uk.gov.di.accountmanagement.api;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.i18n.phonenumbers.PhoneNumberUtil;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import org.apache.http.HttpStatus;
@@ -110,8 +109,7 @@ class UpdatePhoneNumberIntegrationTest extends ApiGatewayHandlerIntegrationTest 
                         Map.of("principalId", publicSubjectID));
 
         assertThat(response, hasStatus(HttpStatus.SC_BAD_REQUEST));
-        assertThat(
-                response, hasBody(new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1020)));
+        assertThat(response, hasBody(objectMapper.writeValueAsString(ErrorResponse.ERROR_1020)));
 
         assertNoNotificationsReceived(notificationsQueue);
 

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandler.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandler.java
@@ -14,6 +14,7 @@ import uk.gov.di.authentication.clientregistry.entity.ClientRegistrationRequest;
 import uk.gov.di.authentication.clientregistry.entity.ClientRegistrationResponse;
 import uk.gov.di.authentication.clientregistry.services.ClientConfigValidationService;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
+import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -30,7 +31,7 @@ public class ClientRegistrationHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     private final ClientService clientService;
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
     private final ClientConfigValidationService validationService;
     private final AuditService auditService;
     private static final Logger LOG = LogManager.getLogger(ClientRegistrationHandler.class);

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandler.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandler.java
@@ -15,6 +15,7 @@ import uk.gov.di.authentication.clientregistry.services.ClientConfigValidationSe
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.UpdateClientConfigRequest;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
+import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -35,7 +36,7 @@ public class UpdateClientConfigHandler
     private final ClientService clientService;
     private final ClientConfigValidationService validationService;
     private final AuditService auditService;
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
     private static final Logger LOG = LogManager.getLogger(UpdateClientConfigHandler.class);
 
     public UpdateClientConfigHandler(

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandlerTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandlerTest.java
@@ -18,6 +18,7 @@ import uk.gov.di.authentication.clientregistry.entity.ClientRegistrationResponse
 import uk.gov.di.authentication.clientregistry.services.ClientConfigValidationService;
 import uk.gov.di.authentication.shared.entity.ClientType;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
+import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
@@ -61,7 +62,7 @@ class ClientRegistrationHandlerTest {
     private final ClientConfigValidationService configValidationService =
             mock(ClientConfigValidationService.class);
     private final AuditService auditService = mock(AuditService.class);
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
     private ClientRegistrationHandler handler;
 
     @BeforeEach

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandlerTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandlerTest.java
@@ -15,6 +15,7 @@ import uk.gov.di.authentication.clientregistry.services.ClientConfigValidationSe
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientType;
 import uk.gov.di.authentication.shared.entity.UpdateClientConfigRequest;
+import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
@@ -50,6 +51,8 @@ class UpdateClientConfigHandlerTest {
     private static final String CLIENT_NAME = "client-name-one";
     private static final List<String> SCOPES = singletonList("openid");
     private static final String SERVICE_TYPE = String.valueOf(MANDATORY);
+    private static final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
+
     private final Context context = mock(Context.class);
     private final ClientService clientService = mock(ClientService.class);
     private final ClientConfigValidationService clientValidationService =
@@ -90,7 +93,7 @@ class UpdateClientConfigHandlerTest {
 
         assertThat(result, hasStatus(200));
         ClientRegistrationResponse clientRegistrationResponse =
-                new ObjectMapper().readValue(result.getBody(), ClientRegistrationResponse.class);
+                objectMapper.readValue(result.getBody(), ClientRegistrationResponse.class);
         assertThat(clientRegistrationResponse.getClientId(), equalTo(CLIENT_ID));
         assertThat(clientRegistrationResponse.getClientName(), equalTo(CLIENT_NAME));
         assertThat(clientRegistrationResponse.getSubjectType(), equalTo("Public"));

--- a/delivery-receipts-api/src/main/java/uk/gov/di/authentication/deliveryreceiptsapi/lambda/NotifyCallbackHandler.java
+++ b/delivery-receipts-api/src/main/java/uk/gov/di/authentication/deliveryreceiptsapi/lambda/NotifyCallbackHandler.java
@@ -11,6 +11,7 @@ import com.google.i18n.phonenumbers.PhoneNumberUtil;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.deliveryreceiptsapi.entity.NotifyDeliveryReceipt;
+import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
@@ -28,6 +29,8 @@ public class NotifyCallbackHandler
     private static final String AUTHORIZATION_HEADER = "Authorization";
     private final ConfigurationService configurationService;
     private final CloudwatchMetricsService cloudwatchMetricsService;
+    private final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
+
     private static final Logger LOG = LogManager.getLogger(NotifyCallbackHandler.class);
 
     public NotifyCallbackHandler(
@@ -53,8 +56,7 @@ public class NotifyCallbackHandler
         validateBearerToken(input.getHeaders());
         NotifyDeliveryReceipt deliveryReceipt;
         try {
-            deliveryReceipt =
-                    new ObjectMapper().readValue(input.getBody(), NotifyDeliveryReceipt.class);
+            deliveryReceipt = objectMapper.readValue(input.getBody(), NotifyDeliveryReceipt.class);
             if (deliveryReceipt.getNotificationType().equals("sms")) {
                 var countryCode = getCountryCodeFromNumber(deliveryReceipt.getTo());
                 var deliveryStatus = getDeliveryStatus(deliveryReceipt.getStatus());

--- a/delivery-receipts-api/src/test/java/uk/gov/di/authentication/deliveryreceiptsapi/lambda/NotifyCallbackHandlerTest.java
+++ b/delivery-receipts-api/src/test/java/uk/gov/di/authentication/deliveryreceiptsapi/lambda/NotifyCallbackHandlerTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.authentication.deliveryreceiptsapi.entity.NotifyDeliveryReceipt;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
+import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
@@ -40,7 +41,7 @@ class NotifyCallbackHandlerTest {
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final CloudwatchMetricsService cloudwatchMetricsService =
             mock(CloudwatchMetricsService.class);
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
 
     @BeforeEach
     void setup() {

--- a/delivery-receipts-integration-tests/src/test/java/uk/gov/di/deliveryreceipts/NotifyCallbackHandlerIntegrationTest.java
+++ b/delivery-receipts-integration-tests/src/test/java/uk/gov/di/deliveryreceipts/NotifyCallbackHandlerIntegrationTest.java
@@ -12,6 +12,7 @@ import uk.gov.di.authentication.deliveryreceiptsapi.entity.DeliveryMetricStatus;
 import uk.gov.di.authentication.deliveryreceiptsapi.entity.NotifyDeliveryReceipt;
 import uk.gov.di.authentication.deliveryreceiptsapi.lambda.NotifyCallbackHandler;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
+import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.sharedtest.extensions.CloudwatchMetricsExtension;
 import uk.gov.di.authentication.sharedtest.extensions.ParameterStoreExtension;
@@ -28,6 +29,8 @@ import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyRespon
 public class NotifyCallbackHandlerIntegrationTest {
 
     private static final String BEARER_TOKEN = "notify-test-@bearer-token";
+    private static final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
+
     private final Context context = mock(Context.class);
     private NotifyCallbackHandler handler;
 
@@ -76,7 +79,7 @@ public class NotifyCallbackHandlerIntegrationTest {
                                 .withRequestId(UUID.randomUUID().toString()));
 
         try {
-            request.withBody(new ObjectMapper().writeValueAsString(body));
+            request.withBody(objectMapper.writeValueAsString(body));
         } catch (JsonProcessingException e) {
             throw new RuntimeException("Could not serialise test body", e);
         }

--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/services/DocAppAuthorisationService.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/services/DocAppAuthorisationService.java
@@ -30,6 +30,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
+import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.KmsConnectionService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
@@ -49,6 +50,8 @@ public class DocAppAuthorisationService {
     private final KmsConnectionService kmsConnectionService;
     public static final String STATE_STORAGE_PREFIX = "state:";
     private static final JWSAlgorithm SIGNING_ALGORITHM = JWSAlgorithm.ES256;
+
+    private final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
 
     public DocAppAuthorisationService(
             ConfigurationService configurationService,
@@ -98,7 +101,7 @@ public class DocAppAuthorisationService {
         try {
             redisConnectionService.saveWithExpiry(
                     STATE_STORAGE_PREFIX + sessionId,
-                    new ObjectMapper().writeValueAsString(state),
+                    objectMapper.writeValueAsString(state),
                     configurationService.getSessionExpiry());
         } catch (JsonProcessingException e) {
             LOG.error("Unable to save state to Redis");
@@ -116,7 +119,7 @@ public class DocAppAuthorisationService {
         }
         State storedState;
         try {
-            storedState = new ObjectMapper().readValue(value.get(), State.class);
+            storedState = objectMapper.readValue(value.get(), State.class);
         } catch (JsonProcessingException e) {
             LOG.info("Error when deserializing state from redis");
             return false;

--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppAuthorizeHandlerTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppAuthorizeHandlerTest.java
@@ -32,6 +32,7 @@ import uk.gov.di.authentication.app.services.DocAppAuthorisationService;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.Session;
+import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
@@ -73,6 +74,7 @@ class DocAppAuthorizeHandlerTest {
     private static final String SESSION_ID = "a-session-id";
     private static final String PERSISTENT_SESSION_ID = "a-persistent-session-id";
     private static final Subject DOC_APP_SUBJECT_ID = new Subject();
+    private static final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
 
     private final Context context = mock(Context.class);
     private final SessionService sessionService = mock(SessionService.class);
@@ -115,8 +117,7 @@ class DocAppAuthorizeHandlerTest {
         var response = makeHandlerRequest();
 
         assertThat(response, hasStatus(200));
-        var body =
-                new ObjectMapper().readValue(response.getBody(), DocAppAuthorisationResponse.class);
+        var body = objectMapper.readValue(response.getBody(), DocAppAuthorisationResponse.class);
         assertThat(body.getRedirectUri(), startsWith(DOC_APP_AUTHORISATION_URI.toString()));
         assertThat(
                 splitQuery(body.getRedirectUri()).get("request"),

--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/services/DocAppAuthorisationServiceTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/services/DocAppAuthorisationServiceTest.java
@@ -22,6 +22,7 @@ import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.KmsConnectionService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
@@ -60,6 +61,8 @@ class DocAppAuthorisationServiceTest {
             URI.create("http://localhost/oidc/doc-app/callback");
     private static final URI DOC_APP_AUTHORISATION_URI =
             URI.create("http://localhost/doc-app/authorize");
+    private static final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
+
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final RedisConnectionService redisConnectionService =
             mock(RedisConnectionService.class);
@@ -73,7 +76,7 @@ class DocAppAuthorisationServiceTest {
     void setUp() throws JsonProcessingException {
         when(configurationService.getSessionExpiry()).thenReturn(SESSION_EXPIRY);
         when(redisConnectionService.getValue(STATE_STORAGE_PREFIX + SESSION_ID))
-                .thenReturn(new ObjectMapper().writeValueAsString(STATE));
+                .thenReturn(objectMapper.writeValueAsString(STATE));
         when(configurationService.getDocAppAuthorisationClientId()).thenReturn(DOC_APP_CLIENT_ID);
         when(configurationService.getDocAppAuthorisationCallbackURI())
                 .thenReturn(DOC_APP_CALLBACK_URI);
@@ -158,7 +161,7 @@ class DocAppAuthorisationServiceTest {
             throws JsonProcessingException {
         State differentState = new State();
         when(redisConnectionService.getValue(STATE_STORAGE_PREFIX + SESSION_ID))
-                .thenReturn(new ObjectMapper().writeValueAsString(STATE));
+                .thenReturn(objectMapper.writeValueAsString(STATE));
         Map<String, String> responseHeaders = new HashMap<>();
         responseHeaders.put("state", differentState.getValue());
         responseHeaders.put("code", AUTH_CODE.getValue());
@@ -180,7 +183,7 @@ class DocAppAuthorisationServiceTest {
         verify(redisConnectionService)
                 .saveWithExpiry(
                         STATE_STORAGE_PREFIX + sessionId,
-                        new ObjectMapper().writeValueAsString(STATE),
+                        objectMapper.writeValueAsString(STATE),
                         SESSION_EXPIRY);
     }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandler.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.entity.NotifyRequest;
+import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.NotificationService;
 import uk.gov.service.notify.NotificationClient;
@@ -33,7 +34,7 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
     private static final Logger LOG = LogManager.getLogger(NotificationHandler.class);
 
     private final NotificationService notificationService;
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
     private final AmazonS3 s3Client;
     private final ConfigurationService configurationService;
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
@@ -14,6 +14,7 @@ import uk.gov.di.authentication.frontendapi.entity.CheckUserExistsResponse;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
+import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
@@ -55,7 +56,7 @@ class CheckUserExistsHandlerTest {
     private final ClientService clientService = mock(ClientService.class);
 
     private CheckUserExistsHandler handler;
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private static final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
 
     private final Session session = new Session(IdGenerator.generate());
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
@@ -30,6 +30,7 @@ import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.VectorOfTrust;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
+import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
@@ -74,6 +75,8 @@ class LoginHandlerTest {
             new UserCredentials().setEmail(EMAIL).setPassword(PASSWORD);
     private static final String PHONE_NUMBER = "01234567890";
     private static final ClientID CLIENT_ID = new ClientID();
+    private static final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
+
     private LoginHandler handler;
     private final Context context = mock(Context.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
@@ -148,8 +151,7 @@ class LoginHandlerTest {
 
         assertThat(result, hasStatus(200));
 
-        LoginResponse response =
-                new ObjectMapper().readValue(result.getBody(), LoginResponse.class);
+        LoginResponse response = objectMapper.readValue(result.getBody(), LoginResponse.class);
         assertThat(
                 response.getRedactedPhoneNumber(),
                 equalTo(RedactPhoneNumberHelper.redactPhoneNumber(PHONE_NUMBER)));
@@ -195,8 +197,7 @@ class LoginHandlerTest {
 
         assertThat(result, hasStatus(200));
 
-        LoginResponse response =
-                new ObjectMapper().readValue(result.getBody(), LoginResponse.class);
+        LoginResponse response = objectMapper.readValue(result.getBody(), LoginResponse.class);
         assertThat(
                 response.getRedactedPhoneNumber(),
                 equalTo(RedactPhoneNumberHelper.redactPhoneNumber(PHONE_NUMBER)));
@@ -240,8 +241,7 @@ class LoginHandlerTest {
 
         assertThat(result, hasStatus(200));
 
-        LoginResponse response =
-                new ObjectMapper().readValue(result.getBody(), LoginResponse.class);
+        LoginResponse response = objectMapper.readValue(result.getBody(), LoginResponse.class);
         assertThat(response.getLatestTermsAndConditionsAccepted(), equalTo(true));
         assertThat(
                 response.getRedactedPhoneNumber(),
@@ -268,8 +268,7 @@ class LoginHandlerTest {
 
         assertThat(result, hasStatus(200));
 
-        LoginResponse response =
-                new ObjectMapper().readValue(result.getBody(), LoginResponse.class);
+        LoginResponse response = objectMapper.readValue(result.getBody(), LoginResponse.class);
         assertThat(
                 response.getRedactedPhoneNumber(),
                 equalTo(RedactPhoneNumberHelper.redactPhoneNumber(PHONE_NUMBER)));
@@ -352,8 +351,7 @@ class LoginHandlerTest {
 
         assertThat(result2, hasStatus(200));
 
-        LoginResponse response =
-                new ObjectMapper().readValue(result2.getBody(), LoginResponse.class);
+        LoginResponse response = objectMapper.readValue(result2.getBody(), LoginResponse.class);
     }
 
     @Test

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
@@ -22,6 +22,7 @@ import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.NotifyRequest;
 import uk.gov.di.authentication.shared.entity.Session;
+import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
@@ -80,7 +81,7 @@ public class MfaHandlerTest {
     private final ClientService clientService = mock(ClientService.class);
     private final ClientSession clientSession = mock(ClientSession.class);
     private final AwsSqsClient sqsClient = mock(AwsSqsClient.class);
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
     private final Session session = new Session("a-session-id").setEmailAddress(TEST_EMAIL_ADDRESS);
     private final ClientRegistry testClientRegistry =
             new ClientRegistry()
@@ -139,7 +140,7 @@ public class MfaHandlerTest {
 
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
-        verify(sqsClient).send(new ObjectMapper().writeValueAsString(notifyRequest));
+        verify(sqsClient).send(objectMapper.writeValueAsString(notifyRequest));
         verify(codeStorageService).saveOtpCode(TEST_EMAIL_ADDRESS, CODE, CODE_EXPIRY_TIME, MFA_SMS);
         assertThat(result, hasStatus(204));
 
@@ -171,7 +172,7 @@ public class MfaHandlerTest {
 
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
-        verify(sqsClient).send(new ObjectMapper().writeValueAsString(notifyRequest));
+        verify(sqsClient).send(objectMapper.writeValueAsString(notifyRequest));
         verify(codeStorageService).saveOtpCode(TEST_EMAIL_ADDRESS, CODE, CODE_EXPIRY_TIME, MFA_SMS);
         assertThat(result, hasStatus(204));
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandlerTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import uk.gov.di.authentication.shared.entity.NotifyRequest;
+import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.NotificationService;
 import uk.gov.service.notify.NotificationClientException;
@@ -47,7 +48,7 @@ public class NotificationHandlerTest {
     private final ConfigurationService configService = mock(ConfigurationService.class);
     private final AmazonS3 s3Client = mock(AmazonS3.class);
     private NotificationHandler handler;
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
 
     @BeforeEach
     void setUp() {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandlerTest.java
@@ -15,6 +15,7 @@ import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.helpers.Argon2EncoderHelper;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
+import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
@@ -58,6 +59,8 @@ class ResetPasswordHandlerTest {
     private static final String SUBJECT = "some-subject";
     private static final String EMAIL = "joe.bloggs@digital.cabinet-office.gov.uk";
     private static final String PERSISTENT_ID = "some-persistent-id-value";
+    private static final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
+
     private ResetPasswordHandler handler;
     private final Session session = new Session(IdGenerator.generate()).setEmailAddress(EMAIL);
 
@@ -94,7 +97,7 @@ class ResetPasswordHandlerTest {
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(204));
-        verify(sqsClient, times(1)).send(new ObjectMapper().writeValueAsString(notifyRequest));
+        verify(sqsClient, times(1)).send(objectMapper.writeValueAsString(notifyRequest));
         verify(authenticationService, times(1)).updatePassword(EMAIL, NEW_PASSWORD);
         verify(codeStorageService, times(1)).deleteSubjectWithPasswordResetCode(CODE);
 
@@ -129,7 +132,7 @@ class ResetPasswordHandlerTest {
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(204));
-        verify(sqsClient, times(1)).send(new ObjectMapper().writeValueAsString(notifyRequest));
+        verify(sqsClient, times(1)).send(objectMapper.writeValueAsString(notifyRequest));
         verify(authenticationService, times(1)).updatePassword(EMAIL, NEW_PASSWORD);
 
         verify(auditService)
@@ -164,7 +167,7 @@ class ResetPasswordHandlerTest {
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(204));
-        verify(sqsClient, times(1)).send(new ObjectMapper().writeValueAsString(notifyRequest));
+        verify(sqsClient, times(1)).send(objectMapper.writeValueAsString(notifyRequest));
         verify(authenticationService, times(1)).updatePassword(EMAIL, NEW_PASSWORD);
         verify(codeStorageService, times(1)).deleteSubjectWithPasswordResetCode(CODE);
 
@@ -226,7 +229,7 @@ class ResetPasswordHandlerTest {
 
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1024));
-        verify(sqsClient, never()).send(new ObjectMapper().writeValueAsString(notifyRequest));
+        verify(sqsClient, never()).send(objectMapper.writeValueAsString(notifyRequest));
         verify(authenticationService, never()).updatePassword(EMAIL, NEW_PASSWORD);
         verify(codeStorageService, never()).deleteSubjectWithPasswordResetCode(CODE);
         verifyNoInteractions(auditService);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
@@ -19,6 +19,7 @@ import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.NotifyRequest;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
+import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
@@ -66,6 +67,8 @@ class ResetPasswordRequestHandlerTest {
             "https://localhost:8080/frontend?reset-password?code=123456.54353464565";
     private static final long CODE_EXPIRY_TIME = 900;
     private static final long BLOCKED_EMAIL_DURATION = 799;
+    private static final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
+
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final AwsSqsClient awsSqsClient = mock(AwsSqsClient.class);
     private final SessionService sessionService = mock(SessionService.class);
@@ -126,7 +129,6 @@ class ResetPasswordRequestHandlerTest {
                 .thenReturn(TEST_RESET_PASSWORD_LINK);
         NotifyRequest notifyRequest =
                 new NotifyRequest(TEST_EMAIL_ADDRESS, RESET_PASSWORD, TEST_RESET_PASSWORD_LINK);
-        ObjectMapper objectMapper = new ObjectMapper();
         String serialisedRequest = objectMapper.writeValueAsString(notifyRequest);
 
         usingValidSession();
@@ -169,7 +171,6 @@ class ResetPasswordRequestHandlerTest {
         NotifyRequest notifyRequest =
                 new NotifyRequest(
                         TEST_EMAIL_ADDRESS, RESET_PASSWORD_WITH_CODE, TEST_SIX_DIGIT_CODE);
-        ObjectMapper objectMapper = new ObjectMapper();
         String serialisedRequest = objectMapper.writeValueAsString(notifyRequest);
 
         usingValidSession();
@@ -239,7 +240,6 @@ class ResetPasswordRequestHandlerTest {
                 .thenReturn(TEST_RESET_PASSWORD_LINK);
         NotifyRequest notifyRequest =
                 new NotifyRequest(TEST_EMAIL_ADDRESS, RESET_PASSWORD, TEST_RESET_PASSWORD_LINK);
-        ObjectMapper objectMapper = new ObjectMapper();
         String serialisedRequest = objectMapper.writeValueAsString(notifyRequest);
         Mockito.doThrow(SdkClientException.class).when(awsSqsClient).send(eq(serialisedRequest));
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
@@ -25,6 +25,7 @@ import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.NotifyRequest;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
+import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.AwsSqsClient;
 import uk.gov.di.authentication.shared.services.ClientService;
@@ -95,7 +96,7 @@ class SendNotificationHandlerTest {
                                     "jb2@digital.cabinet-office.gov.uk"));
 
     private final Context context = mock(Context.class);
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
 
     private final Session session =
             new Session(IdGenerator.generate()).setEmailAddress(TEST_EMAIL_ADDRESS);
@@ -173,7 +174,6 @@ class SendNotificationHandlerTest {
         when(configurationService.isTestClientsEnabled()).thenReturn(true);
         NotifyRequest notifyRequest =
                 new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL, TEST_SIX_DIGIT_CODE);
-        ObjectMapper objectMapper = new ObjectMapper();
         String serialisedRequest = objectMapper.writeValueAsString(notifyRequest);
 
         usingValidSession();

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandlerTest.java
@@ -27,6 +27,7 @@ import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.TermsAndConditions;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
+import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
@@ -72,6 +73,7 @@ class SignUpHandlerTest {
     private static final String CLIENT_SESSION_ID = "a-client-session-id";
     private static final ClientID CLIENT_ID = new ClientID();
     private static final URI REDIRECT_URI = URI.create("test-uri");
+    private static final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
 
     private SignUpHandler handler;
 
@@ -144,7 +146,7 @@ class SignUpHandlerTest {
         assertThat(result, hasStatus(200));
 
         SignUpResponse signUpResponse =
-                new ObjectMapper().readValue(result.getBody(), SignUpResponse.class);
+                objectMapper.readValue(result.getBody(), SignUpResponse.class);
 
         assertThat(signUpResponse.isConsentRequired(), equalTo(consentRequired));
         verify(authenticationService)

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -28,6 +28,7 @@ import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.VectorOfTrust;
+import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
@@ -66,6 +67,7 @@ class StartHandlerTest {
     public static final String SESSION_ID = "some-session-id";
     public static final String PERSISTENT_ID = "some-persistent-id-value";
     public static final URI REDIRECT_URL = URI.create("https://localhost/redirect");
+    private static final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
 
     private StartHandler handler;
     private final Context context = mock(Context.class);
@@ -130,8 +132,7 @@ class StartHandlerTest {
 
         assertThat(result, hasStatus(200));
 
-        StartResponse response =
-                new ObjectMapper().readValue(result.getBody(), StartResponse.class);
+        StartResponse response = objectMapper.readValue(result.getBody(), StartResponse.class);
 
         assertThat(
                 response.getClient().getClientName(),
@@ -199,7 +200,7 @@ class StartHandlerTest {
 
         assertThat(result, hasStatus(200));
 
-        var response = new ObjectMapper().readValue(result.getBody(), StartResponse.class);
+        var response = objectMapper.readValue(result.getBody(), StartResponse.class);
 
         assertThat(response.getClient().getClientName(), equalTo(TEST_CLIENT_NAME));
         assertThat(response.getClient().getScopes(), equalTo(scope.toStringList()));
@@ -238,7 +239,7 @@ class StartHandlerTest {
 
         assertThat(result, hasStatus(400));
 
-        String expectedResponse = new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1018);
+        String expectedResponse = objectMapper.writeValueAsString(ErrorResponse.ERROR_1018);
         assertThat(result, hasBody(expectedResponse));
 
         verifyNoInteractions(auditService);
@@ -258,7 +259,7 @@ class StartHandlerTest {
 
         assertThat(result, hasStatus(400));
 
-        String expectedResponse = new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1000);
+        String expectedResponse = objectMapper.writeValueAsString(ErrorResponse.ERROR_1000);
         assertThat(result, hasBody(expectedResponse));
 
         verifyNoInteractions(auditService);
@@ -284,7 +285,7 @@ class StartHandlerTest {
 
         assertThat(result, hasStatus(400));
 
-        String expectedResponse = new ObjectMapper().writeValueAsString(ErrorResponse.ERROR_1038);
+        String expectedResponse = objectMapper.writeValueAsString(ErrorResponse.ERROR_1038);
         assertThat(result, hasBody(expectedResponse));
 
         verifyNoInteractions(auditService);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
@@ -1,6 +1,5 @@
 package uk.gov.di.authentication.api;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.id.ClientID;
@@ -62,7 +61,7 @@ public class AuthCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(response, hasStatus(200));
 
         AuthCodeResponse authCodeResponse =
-                new ObjectMapper().readValue(response.getBody(), AuthCodeResponse.class);
+                objectMapper.readValue(response.getBody(), AuthCodeResponse.class);
 
         assertThat(
                 authCodeResponse.getLocation(),

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientRegistrationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientRegistrationIntegrationTest.java
@@ -1,7 +1,6 @@
 package uk.gov.di.authentication.api;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -30,7 +29,6 @@ import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyRespon
 
 public class ClientRegistrationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
     private static final String VALID_PUBLIC_CERT =
             "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxt91w8GsMDdklOpS8ZXAsIM1ztQZd5QT/bRCQahZJeS1a6Os4hbuKwzHlz52zfTNp7BL4RB/KOcRIPhOQLgqeyM+bVngRa1EIfTkugJHS2/gu2Xv0aelwvXj8FZgAPRPD+ps2wiV4tUehrFIsRyHZM3yOp9g6qapCcxF7l0E1PlVkKPcPNmxn2oFiqnP6ZThGbE+N2avdXHcySIqt/v6Hbmk8cDHzSExazW7j/XvA+xnp0nQ5m2GisCZul5If5edCTXD0tKzx/I/gtEG4gkv9kENWOt4grP8/0zjNAl2ac6kpRny3tY5RkKBKCOB1VHwq2lUTSNKs32O1BsA5ByyYQIDAQAB";
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppAuthorizeHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppAuthorizeHandlerIntegrationTest.java
@@ -1,6 +1,5 @@
 package uk.gov.di.authentication.api;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.id.ClientID;
@@ -73,8 +72,7 @@ class DocAppAuthorizeHandlerIntegrationTest extends ApiGatewayHandlerIntegration
 
         assertThat(response, hasStatus(200));
 
-        var body =
-                new ObjectMapper().readValue(response.getBody(), DocAppAuthorisationResponse.class);
+        var body = objectMapper.readValue(response.getBody(), DocAppAuthorisationResponse.class);
 
         assertThat(
                 body.getRedirectUri(),

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVAuthorisationHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVAuthorisationHandlerIntegrationTest.java
@@ -1,6 +1,5 @@
 package uk.gov.di.authentication.api;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.id.ClientID;
@@ -99,7 +98,7 @@ class IPVAuthorisationHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
 
         assertThat(response, hasStatus(200));
 
-        var body = new ObjectMapper().readValue(response.getBody(), IPVAuthorisationResponse.class);
+        var body = objectMapper.readValue(response.getBody(), IPVAuthorisationResponse.class);
 
         assertThat(
                 body.getRedirectUri(),

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
@@ -1,6 +1,5 @@
 package uk.gov.di.authentication.api;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.id.ClientID;
@@ -105,7 +104,7 @@ public class LoginIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(response, hasStatus(200));
 
         LoginResponse loginResponse =
-                new ObjectMapper().readValue(response.getBody(), LoginResponse.class);
+                objectMapper.readValue(response.getBody(), LoginResponse.class);
 
         assertThat(loginResponse.isMfaRequired(), equalTo(level != LOW_LEVEL));
         assertThat(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/SignupIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/SignupIntegrationTest.java
@@ -1,6 +1,5 @@
 package uk.gov.di.authentication.api;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.id.ClientID;
@@ -99,7 +98,7 @@ public class SignupIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         assertThat(response, hasStatus(200));
         SignUpResponse signUpResponse =
-                new ObjectMapper().readValue(response.getBody(), SignUpResponse.class);
+                objectMapper.readValue(response.getBody(), SignUpResponse.class);
         assertThat(signUpResponse.isConsentRequired(), equalTo(consentRequired));
 
         assertTrue(userStore.userExists("joe.bloggs+5@digital.cabinet-office.gov.uk"));

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
@@ -1,6 +1,5 @@
 package uk.gov.di.authentication.api;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
@@ -53,8 +52,6 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     private static final URI REDIRECT_URI = URI.create("http://localhost/redirect");
     public static final String CLIENT_SESSION_ID = "a-client-session-id";
     public static final String TEST_CLIENT_NAME = "test-client-name";
-
-    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @BeforeEach
     void setup() {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
@@ -2,7 +2,6 @@ package uk.gov.di.authentication.api;
 
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jwt.JWTClaimsSet;
@@ -276,7 +275,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 new RefreshTokenStore(List.of(refreshToken.getValue()), internalSubject.getValue());
         redis.addToRedis(
                 REFRESH_TOKEN_PREFIX + CLIENT_ID + "." + publicSubject.getValue(),
-                new ObjectMapper().writeValueAsString(tokenStore),
+                objectMapper.writeValueAsString(tokenStore),
                 900L);
         PrivateKey privateKey = keyPair.getPrivate();
         JWTAuthenticationClaimsSet claimsSet =

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
@@ -1,7 +1,6 @@
 package uk.gov.di.authentication.api;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.id.Subject;
@@ -79,7 +78,7 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var accessToken = new BearerAccessToken(signedJWT.serialize());
         var accessTokenStore =
                 new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
-        var accessTokenStoreString = new ObjectMapper().writeValueAsString(accessTokenStore);
+        var accessTokenStoreString = objectMapper.writeValueAsString(accessTokenStore);
         redis.addToRedis(
                 ACCESS_TOKEN_PREFIX + CLIENT_ID + "." + PUBLIC_SUBJECT,
                 accessTokenStoreString,
@@ -155,7 +154,7 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
         redis.addToRedis(
                 ACCESS_TOKEN_PREFIX + CLIENT_ID + "." + PUBLIC_SUBJECT,
-                new ObjectMapper().writeValueAsString(accessTokenStore),
+                objectMapper.writeValueAsString(accessTokenStore),
                 300L);
         var signedCredential = SignedCredentialHelper.generateCredential();
         setUpDynamo(signedCredential.serialize());

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandler.java
@@ -11,6 +11,7 @@ import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.ipv.domain.IPVAuditableEvent;
 import uk.gov.di.authentication.ipv.entity.SPOTResponse;
 import uk.gov.di.authentication.ipv.entity.SPOTStatus;
+import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoSpotService;
@@ -19,7 +20,7 @@ import java.util.NoSuchElementException;
 
 public class SPOTResponseHandler implements RequestHandler<SQSEvent, Object> {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
     private final DynamoSpotService dynamoSpotService;
     private final AuditService auditService;
 

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationService.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationService.java
@@ -31,6 +31,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
+import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.KmsConnectionService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
@@ -51,6 +52,7 @@ public class IPVAuthorisationService {
     private final KmsConnectionService kmsConnectionService;
     public static final String STATE_STORAGE_PREFIX = "state:";
     private static final JWSAlgorithm SIGNING_ALGORITHM = JWSAlgorithm.ES256;
+    private static final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
 
     public IPVAuthorisationService(
             ConfigurationService configurationService,
@@ -100,7 +102,7 @@ public class IPVAuthorisationService {
         try {
             redisConnectionService.saveWithExpiry(
                     STATE_STORAGE_PREFIX + sessionId,
-                    new ObjectMapper().writeValueAsString(state),
+                    objectMapper.writeValueAsString(state),
                     configurationService.getSessionExpiry());
         } catch (JsonProcessingException e) {
             LOG.error("Unable to save state to Redis");
@@ -118,7 +120,7 @@ public class IPVAuthorisationService {
         }
         State storedState;
         try {
-            storedState = new ObjectMapper().readValue(value.get(), State.class);
+            storedState = objectMapper.readValue(value.get(), State.class);
         } catch (JsonProcessingException e) {
             LOG.info("Error when deserializing state from redis");
             return false;

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandlerTest.java
@@ -4,7 +4,6 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.jose.EncryptionMethod;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWEAlgorithm;
@@ -42,6 +41,7 @@ import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
+import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
@@ -160,7 +160,9 @@ public class IPVAuthorisationHandlerTest {
         var response = makeHandlerRequest();
 
         assertThat(response, hasStatus(200));
-        var body = new ObjectMapper().readValue(response.getBody(), IPVAuthorisationResponse.class);
+        var body =
+                ObjectMapperFactory.getInstance()
+                        .readValue(response.getBody(), IPVAuthorisationResponse.class);
         assertThat(body.getRedirectUri(), startsWith(IPV_AUTHORISATION_URI.toString()));
         assertThat(
                 splitQuery(body.getRedirectUri()).get("request"),

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -4,7 +4,6 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.AccessTokenResponse;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import com.nimbusds.oauth2.sdk.ErrorObject;
@@ -38,6 +37,7 @@ import uk.gov.di.authentication.shared.entity.LevelOfConfidence;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
+import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AwsSqsClient;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
@@ -161,7 +161,7 @@ class IPVCallbackHandlerTest {
                 ClientSubjectHelper.getSubject(userProfile, clientRegistry, dynamoService);
         verify(awsSqsClient)
                 .send(
-                        new ObjectMapper()
+                        ObjectMapperFactory.getInstance()
                                 .writeValueAsString(
                                         new SPOTRequest(
                                                 SPOTClaims.builder()

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationServiceTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationServiceTest.java
@@ -25,6 +25,7 @@ import com.nimbusds.openid.connect.sdk.Nonce;
 import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.KmsConnectionService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
@@ -61,6 +62,8 @@ class IPVAuthorisationServiceTest {
     private static final String IPV_CLIENT_ID = "ipv-client-id";
     private static final URI IPV_CALLBACK_URI = URI.create("http://localhost/oidc/ipv/callback");
     private static final URI IPV_AUTHORISATION_URI = URI.create("http://localhost/ipv/authorize");
+    private static final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
+
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final RedisConnectionService redisConnectionService =
             mock(RedisConnectionService.class);
@@ -74,7 +77,7 @@ class IPVAuthorisationServiceTest {
     void setUp() throws JsonProcessingException {
         when(configurationService.getSessionExpiry()).thenReturn(SESSION_EXPIRY);
         when(redisConnectionService.getValue(STATE_STORAGE_PREFIX + SESSION_ID))
-                .thenReturn(new ObjectMapper().writeValueAsString(STATE));
+                .thenReturn(objectMapper.writeValueAsString(STATE));
         when(configurationService.getIPVAuthorisationClientId()).thenReturn(IPV_CLIENT_ID);
         when(configurationService.getIPVAuthorisationCallbackURI()).thenReturn(IPV_CALLBACK_URI);
         when(configurationService.getIPVAuthorisationURI()).thenReturn(IPV_AUTHORISATION_URI);
@@ -157,7 +160,7 @@ class IPVAuthorisationServiceTest {
             throws JsonProcessingException {
         State differentState = new State();
         when(redisConnectionService.getValue(STATE_STORAGE_PREFIX + SESSION_ID))
-                .thenReturn(new ObjectMapper().writeValueAsString(STATE));
+                .thenReturn(objectMapper.writeValueAsString(STATE));
         Map<String, String> responseHeaders = new HashMap<>();
         responseHeaders.put("state", differentState.getValue());
         responseHeaders.put("code", AUTH_CODE.getValue());
@@ -179,7 +182,7 @@ class IPVAuthorisationServiceTest {
         verify(redisConnectionService)
                 .saveWithExpiry(
                         STATE_STORAGE_PREFIX + sessionId,
-                        new ObjectMapper().writeValueAsString(STATE),
+                        objectMapper.writeValueAsString(STATE),
                         SESSION_EXPIRY);
     }
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
@@ -67,6 +67,8 @@ public class TokenHandler
     private final ClientSessionService clientSessionService;
     private final TokenValidationService tokenValidationService;
     private final RedisConnectionService redisConnectionService;
+    private final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
+
     private static final String TOKEN_PATH = "token";
     private static final String REFRESH_TOKEN_PREFIX = "REFRESH_TOKEN:";
 
@@ -333,7 +335,7 @@ public class TokenHandler
                 Optional.ofNullable(redisConnectionService.getValue(redisKey));
         RefreshTokenStore tokenStore;
         try {
-            tokenStore = new ObjectMapper().readValue(refreshToken.get(), RefreshTokenStore.class);
+            tokenStore = objectMapper.readValue(refreshToken.get(), RefreshTokenStore.class);
         } catch (JsonProcessingException | NoSuchElementException | IllegalArgumentException e) {
             LOG.warn("Refresh token not found with given key");
             return generateApiGatewayProxyResponse(
@@ -355,10 +357,8 @@ public class TokenHandler
             try {
                 redisConnectionService.saveWithExpiry(
                         redisKey,
-                        new ObjectMapper()
-                                .writeValueAsString(
-                                        tokenStore.removeRefreshToken(
-                                                currentRefreshToken.getValue())),
+                        objectMapper.writeValueAsString(
+                                tokenStore.removeRefreshToken(currentRefreshToken.getValue())),
                         configurationService.getSessionExpiry());
             } catch (JsonProcessingException e) {
                 LOG.error("Unable to serialize refresh token store when updating");

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AccessTokenService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AccessTokenService.java
@@ -18,6 +18,7 @@ import uk.gov.di.authentication.shared.entity.ValidClaims;
 import uk.gov.di.authentication.shared.entity.ValidScopes;
 import uk.gov.di.authentication.shared.exceptions.AccessTokenException;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
+import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.services.DynamoClientService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
 import uk.gov.di.authentication.shared.services.TokenValidationService;
@@ -37,6 +38,7 @@ public class AccessTokenService {
     private final RedisConnectionService redisConnectionService;
     private final DynamoClientService clientService;
     private final TokenValidationService tokenValidationService;
+    private final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
     private static final String ACCESS_TOKEN_PREFIX = "ACCESS_TOKEN:";
     private static final String INVALID_ACCESS_TOKEN = "Invalid Access Token";
 
@@ -141,8 +143,7 @@ public class AccessTokenService {
         String result =
                 redisConnectionService.getValue(ACCESS_TOKEN_PREFIX + clientId + "." + subjectId);
         try {
-            return Optional.ofNullable(
-                    new ObjectMapper().readValue(result, AccessTokenStore.class));
+            return Optional.ofNullable(objectMapper.readValue(result, AccessTokenStore.class));
         } catch (JsonProcessingException | IllegalArgumentException e) {
             LOG.error("Error getting AccessToken from Redis", e);
             return Optional.empty();

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -34,6 +34,7 @@ import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.VectorOfTrust;
 import uk.gov.di.authentication.shared.exceptions.ClientNotFoundException;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
+import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthorisationCodeService;
@@ -81,6 +82,8 @@ class AuthCodeHandlerTest {
     private static final String EMAIL = "joe.bloggs@digital.cabinet-office.gov.uk";
     private static final URI REDIRECT_URI = URI.create("http://localhost/redirect");
     private static final ClientID CLIENT_ID = new ClientID();
+    private static final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
+
     private final AuthorizationService authorizationService = mock(AuthorizationService.class);
     private final AuthorisationCodeService authorisationCodeService =
             mock(AuthorisationCodeService.class);
@@ -176,7 +179,7 @@ class AuthCodeHandlerTest {
 
         assertThat(response, hasStatus(200));
         AuthCodeResponse authCodeResponse =
-                new ObjectMapper().readValue(response.getBody(), AuthCodeResponse.class);
+                objectMapper.readValue(response.getBody(), AuthCodeResponse.class);
         assertThat(authCodeResponse.getLocation(), equalTo(authSuccessResponse.toURI().toString()));
         assertThat(session.getCurrentCredentialStrength(), equalTo(finalLevel));
         verify(sessionService).save(session.setAuthenticated(true));
@@ -246,7 +249,7 @@ class AuthCodeHandlerTest {
 
         assertThat(response, hasStatus(200));
         AuthCodeResponse authCodeResponse =
-                new ObjectMapper().readValue(response.getBody(), AuthCodeResponse.class);
+                objectMapper.readValue(response.getBody(), AuthCodeResponse.class);
         assertThat(
                 authCodeResponse.getLocation(),
                 equalTo(
@@ -274,7 +277,7 @@ class AuthCodeHandlerTest {
 
         assertThat(response, hasStatus(200));
         AuthCodeResponse authCodeResponse =
-                new ObjectMapper().readValue(response.getBody(), AuthCodeResponse.class);
+                objectMapper.readValue(response.getBody(), AuthCodeResponse.class);
         assertThat(
                 authCodeResponse.getLocation(),
                 equalTo(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
@@ -44,6 +44,7 @@ import uk.gov.di.authentication.shared.entity.RefreshTokenStore;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.ValidScopes;
 import uk.gov.di.authentication.shared.entity.VectorOfTrust;
+import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.services.AuthorisationCodeService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
@@ -101,6 +102,8 @@ public class TokenHandlerTest {
     public static final String CLIENT_SESSION_ID = "a-client-session-id";
     private static final Nonce NONCE = new Nonce();
     private static final String REFRESH_TOKEN_PREFIX = "REFRESH_TOKEN:";
+    private static final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
+
     private final BearerAccessToken accessToken = new BearerAccessToken();
     private final RefreshToken refreshToken = new RefreshToken();
     private final Context context = mock(Context.class);
@@ -235,7 +238,7 @@ public class TokenHandlerTest {
                 new RefreshTokenStore(
                         singletonList(refreshToken.getValue()), INTERNAL_SUBJECT.getValue());
         String redisKey = REFRESH_TOKEN_PREFIX + CLIENT_ID + "." + PUBLIC_SUBJECT.getValue();
-        String tokenStoreString = new ObjectMapper().writeValueAsString(tokenStore);
+        String tokenStoreString = ObjectMapperFactory.getInstance().writeValueAsString(tokenStore);
         when(redisConnectionService.getValue(redisKey)).thenReturn(tokenStoreString);
         when(tokenService.generateRefreshTokenResponse(
                         eq(CLIENT_ID),
@@ -282,7 +285,7 @@ public class TokenHandlerTest {
                         List.of(refreshToken.getValue(), refreshToken2.getValue()),
                         INTERNAL_SUBJECT.getValue());
         String redisKey = REFRESH_TOKEN_PREFIX + CLIENT_ID + "." + PUBLIC_SUBJECT.getValue();
-        String tokenStoreString = new ObjectMapper().writeValueAsString(tokenStore);
+        String tokenStoreString = objectMapper.writeValueAsString(tokenStore);
         when(redisConnectionService.getValue(redisKey)).thenReturn(tokenStoreString);
         when(tokenService.generateRefreshTokenResponse(
                         eq(CLIENT_ID),
@@ -298,11 +301,9 @@ public class TokenHandlerTest {
         assertTrue(result.getBody().contains(accessToken.getValue()));
 
         String updatedTokenstore =
-                new ObjectMapper()
-                        .writeValueAsString(
-                                new RefreshTokenStore(
-                                        List.of(refreshToken2.getValue()),
-                                        INTERNAL_SUBJECT.getValue()));
+                objectMapper.writeValueAsString(
+                        new RefreshTokenStore(
+                                List.of(refreshToken2.getValue()), INTERNAL_SUBJECT.getValue()));
         verify(redisConnectionService, times(1)).saveWithExpiry(redisKey, updatedTokenstore, 1234L);
     }
 

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TrustMarkHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TrustMarkHandlerTest.java
@@ -4,12 +4,12 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.oidc.entity.TrustMarkResponse;
 import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.LevelOfConfidence;
+import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.util.List;
@@ -17,7 +17,8 @@ import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 class TrustMarkHandlerTest {
@@ -51,7 +52,8 @@ class TrustMarkHandlerTest {
         assertThat(result, hasStatus(200));
 
         TrustMarkResponse response =
-                new ObjectMapper().readValue(result.getBody(), TrustMarkResponse.class);
+                ObjectMapperFactory.getInstance()
+                        .readValue(result.getBody(), TrustMarkResponse.class);
 
         assertEquals(response.getIdp(), trustMarkResponse.getIdp());
         assertEquals(response.getTrustMark(), trustMarkResponse.getTrustMark());

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AccessTokenServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AccessTokenServiceTest.java
@@ -26,6 +26,7 @@ import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ValidClaims;
 import uk.gov.di.authentication.shared.exceptions.AccessTokenException;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
+import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.services.DynamoClientService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
 import uk.gov.di.authentication.shared.services.TokenValidationService;
@@ -67,6 +68,8 @@ class AccessTokenServiceTest {
     private static final String BASE_URL = "https://example.com";
     private static final String KEY_ID = "14342354354353";
     private static final String ACCESS_TOKEN_PREFIX = "ACCESS_TOKEN:";
+    private static final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
+
     private final ClaimsSetRequest claimsSetRequest =
             new ClaimsSetRequest().add(ValidClaims.ADDRESS).add(ValidClaims.BIRTHDATE);
     private final OIDCClaimsRequest oidcValidClaimsRequest =
@@ -112,11 +115,9 @@ class AccessTokenServiceTest {
                 .thenReturn(Optional.of(generateClientRegistry(SCOPES)));
         when(redisConnectionService.getValue(ACCESS_TOKEN_PREFIX + CLIENT_ID + "." + SUBJECT))
                 .thenReturn(
-                        new ObjectMapper()
-                                .writeValueAsString(
-                                        new AccessTokenStore(
-                                                accessToken.getValue(),
-                                                INTERNAL_SUBJECT.getValue())));
+                        objectMapper.writeValueAsString(
+                                new AccessTokenStore(
+                                        accessToken.getValue(), INTERNAL_SUBJECT.getValue())));
 
         var accessTokenInfo =
                 validationService.parse(accessToken.toAuthorizationHeader(), identityEndpoint);
@@ -215,11 +216,9 @@ class AccessTokenServiceTest {
                 .thenReturn(Optional.of(generateClientRegistry(SCOPES)));
         when(redisConnectionService.getValue(ACCESS_TOKEN_PREFIX + CLIENT_ID + "." + SUBJECT))
                 .thenReturn(
-                        new ObjectMapper()
-                                .writeValueAsString(
-                                        new AccessTokenStore(
-                                                accessToken.getValue(),
-                                                INTERNAL_SUBJECT.getValue())));
+                        objectMapper.writeValueAsString(
+                                new AccessTokenStore(
+                                        accessToken.getValue(), INTERNAL_SUBJECT.getValue())));
 
         var accessTokenException =
                 assertThrows(
@@ -267,11 +266,10 @@ class AccessTokenServiceTest {
                 .thenReturn(Optional.of(generateClientRegistry(SCOPES)));
         when(redisConnectionService.getValue(ACCESS_TOKEN_PREFIX + CLIENT_ID + "." + SUBJECT))
                 .thenReturn(
-                        new ObjectMapper()
-                                .writeValueAsString(
-                                        new AccessTokenStore(
-                                                createSignedAccessToken(null, false).getValue(),
-                                                INTERNAL_SUBJECT.getValue())));
+                        objectMapper.writeValueAsString(
+                                new AccessTokenStore(
+                                        createSignedAccessToken(null, false).getValue(),
+                                        INTERNAL_SUBJECT.getValue())));
 
         var accessTokenException =
                 assertThrows(

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/matchers/APIGatewayProxyResponseEventMatcher.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/matchers/APIGatewayProxyResponseEventMatcher.java
@@ -1,10 +1,10 @@
 package uk.gov.di.authentication.sharedtest.matchers;
 
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
+import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 
 import java.net.URI;
 import java.util.function.Function;
@@ -69,7 +69,8 @@ public class APIGatewayProxyResponseEventMatcher<T, M extends Matcher>
 
     public static APIGatewayProxyResponseEventMatcher<String, Matcher<String>> hasJsonBody(
             Object body) {
-        var expectedValue = unchecked(new ObjectMapper()::writeValueAsString).apply(body);
+        var expectedValue =
+                unchecked(ObjectMapperFactory.getInstance()::writeValueAsString).apply(body);
 
         return new APIGatewayProxyResponseEventMatcher<>(
                 "body", APIGatewayProxyResponseEvent::getBody, equalTo(expectedValue));

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ApiGatewayResponseHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ApiGatewayResponseHelper.java
@@ -29,11 +29,11 @@ public class ApiGatewayResponseHelper {
     private static final String X_FRAME_OPTIONS_HEADER_VALUE = "DENY";
 
     private static final Logger LOG = LogManager.getLogger(ApiGatewayResponseHelper.class);
+    private static final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
 
     public static <T> APIGatewayProxyResponseEvent generateApiGatewayProxyResponse(
             int statusCode, T body) throws JsonProcessingException {
-        return generateApiGatewayProxyResponse(
-                statusCode, new ObjectMapper().writeValueAsString(body));
+        return generateApiGatewayProxyResponse(statusCode, objectMapper.writeValueAsString(body));
     }
 
     public static <T> APIGatewayProxyResponseEvent generateApiGatewayProxyErrorResponse(
@@ -47,7 +47,7 @@ public class ApiGatewayResponseHelper {
 
         try {
             return generateApiGatewayProxyResponse(
-                    statusCode, new ObjectMapper().writeValueAsString(errorResponse));
+                    statusCode, objectMapper.writeValueAsString(errorResponse));
         } catch (JsonProcessingException e) {
             LOG.warn("Unable to generateApiGatewayProxyErrorResponse: " + e);
             return generateApiGatewayProxyResponse(500, "Internal server error");

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
@@ -45,6 +45,7 @@ import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.RefreshTokenStore;
 import uk.gov.di.authentication.shared.entity.ValidScopes;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
+import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.sharedtest.helper.TokenGeneratorHelper;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
@@ -110,6 +111,8 @@ public class TokenServiceTest {
     private static final String REFRESH_TOKEN_PREFIX = "REFRESH_TOKEN:";
     private static final String ACCESS_TOKEN_PREFIX = "ACCESS_TOKEN:";
 
+    private static final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
+
     @RegisterExtension
     public final CaptureLoggingExtension logging = new CaptureLoggingExtension(TokenService.class);
 
@@ -168,9 +171,7 @@ public class TokenServiceTest {
                         INTERNAL_SUBJECT.getValue());
         verify(redisConnectionService)
                 .saveWithExpiry(
-                        refreshTokenKey,
-                        new ObjectMapper().writeValueAsString(refreshTokenStore),
-                        300L);
+                        refreshTokenKey, objectMapper.writeValueAsString(refreshTokenStore), 300L);
     }
 
     @Test
@@ -227,9 +228,7 @@ public class TokenServiceTest {
                         INTERNAL_SUBJECT.getValue());
         verify(redisConnectionService)
                 .saveWithExpiry(
-                        refreshTokenKey,
-                        new ObjectMapper().writeValueAsString(refreshTokenStore),
-                        300L);
+                        refreshTokenKey, objectMapper.writeValueAsString(refreshTokenStore), 300L);
     }
 
     @Test
@@ -530,9 +529,7 @@ public class TokenServiceTest {
                         INTERNAL_SUBJECT.getValue());
         verify(redisConnectionService)
                 .saveWithExpiry(
-                        accessTokenKey,
-                        new ObjectMapper().writeValueAsString(accessTokenStore),
-                        300L);
+                        accessTokenKey, objectMapper.writeValueAsString(accessTokenStore), 300L);
 
         var header = (JWSHeader) tokenResponse.getOIDCTokens().getIDToken().getHeader();
 


### PR DESCRIPTION
## What?

- In all places that a `new ObjectMapper()` at class level, use `ObjectMapperFactory.getInstance()`
- Where `new ObjectMapper()` appears in code use a class level instance (created as above)
- Use static instance variables in test classes to stop re-initialisation

## Why?

Initialising the Jackson `ObjectMapper` class can be an expensive operation, we need to ensure this is only done once, preferably during the lambda cold-start. Also, the `ObjectMapperFactory` ensures only one instance exists and that it has a standard set of modules attached.
