### PR TITLE
AUT-343 - Add additional auditing to the SpotResponseHandler

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/SpotResponseIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/SpotResponseIntegrationTest.java
@@ -13,6 +13,7 @@ import uk.gov.di.authentication.ipv.lambda.SPOTResponseHandler;
 import uk.gov.di.authentication.sharedtest.basetest.HandlerIntegrationTest;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
@@ -22,6 +23,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static uk.gov.di.authentication.ipv.domain.IPVAuditableEvent.SPOT_SUCCESSFUL_RESPONSE_RECEIVED;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceived;
 
 public class SpotResponseIntegrationTest extends HandlerIntegrationTest<SQSEvent, Object> {
 
@@ -52,6 +55,8 @@ public class SpotResponseIntegrationTest extends HandlerIntegrationTest<SQSEvent
                         .get()
                         .getSerializedCredential(),
                 equalTo(signedCredential));
+
+        assertEventTypesReceived(auditTopic, List.of(SPOT_SUCCESSFUL_RESPONSE_RECEIVED));
     }
 
     private <T> SQSEvent createSqsEvent(T... request) {

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/domain/IPVAuditableEvent.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/domain/IPVAuditableEvent.java
@@ -10,7 +10,8 @@ public enum IPVAuditableEvent implements AuditableEvent {
     IPV_SUCCESSFUL_IDENTITY_RESPONSE_RECEIVED,
     IPV_CAPACITY_REQUESTED,
     IPV_SPOT_REQUESTED,
-    SPOT_RESPONSE_RECEIVED;
+    SPOT_SUCCESSFUL_RESPONSE_RECEIVED,
+    SPOT_UNSUCCESSFUL_RESPONSE_RECEIVED;
 
     public AuditableEvent parseFromName(String name) {
         return valueOf(name);

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandlerTest.java
@@ -43,7 +43,7 @@ class SPOTResponseHandlerTest {
 
         verify(auditService)
                 .submitAuditEvent(
-                        IPVAuditableEvent.SPOT_RESPONSE_RECEIVED,
+                        IPVAuditableEvent.SPOT_SUCCESSFUL_RESPONSE_RECEIVED,
                         REQUEST_ID,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
@@ -62,7 +62,7 @@ class SPOTResponseHandlerTest {
 
         verify(auditService)
                 .submitAuditEvent(
-                        IPVAuditableEvent.SPOT_RESPONSE_RECEIVED,
+                        IPVAuditableEvent.SPOT_UNSUCCESSFUL_RESPONSE_RECEIVED,
                         REQUEST_ID,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
@@ -85,7 +85,7 @@ class SPOTResponseHandlerTest {
 
         verify(auditService)
                 .submitAuditEvent(
-                        IPVAuditableEvent.SPOT_RESPONSE_RECEIVED,
+                        IPVAuditableEvent.SPOT_UNSUCCESSFUL_RESPONSE_RECEIVED,
                         REQUEST_ID,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
@@ -107,7 +107,7 @@ class SPOTResponseHandlerTest {
 
         verify(auditService)
                 .submitAuditEvent(
-                        IPVAuditableEvent.SPOT_RESPONSE_RECEIVED,
+                        IPVAuditableEvent.SPOT_SUCCESSFUL_RESPONSE_RECEIVED,
                         REQUEST_ID,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,


### PR DESCRIPTION
## What?

 - Add additional auditing to the SpotResponseHandler

## Why?

- To differentiate between the successful and unsuccessful SPOT responses 