### PR TITLE
AUT-320: grant user-info access to the doc-app-credential table

### DIFF
--- a/ci/terraform/oidc/dynamo-policies.tf
+++ b/ci/terraform/oidc/dynamo-policies.tf
@@ -53,8 +53,10 @@ data "aws_iam_policy_document" "dynamo_user_read_policy_document" {
     resources = [
       data.aws_dynamodb_table.user_credentials_table.arn,
       data.aws_dynamodb_table.user_profile_table.arn,
+      data.aws_dynamodb_table.doc_app_cri_credential_table.arn,
       "${data.aws_dynamodb_table.user_profile_table.arn}/index/*",
       "${data.aws_dynamodb_table.user_credentials_table.arn}/index/*",
+      "${data.aws_dynamodb_table.doc_app_cri_credential_table.arn}/index/*",
     ]
   }
 }


### PR DESCRIPTION
## What?

Grant user-info access to the doc-app-credential table.

## Why?

Even though the path is not currently being called the warmer is trying to access the table resulting in an error:

build-userinfo-lambda is not authorized to perform: dynamodb:DescribeTable on resource: :table/build-doc-app-credential 

## Related PRs

#1739 