### PR TITLE
AUT-5 - Support correct IPV claims

### DIFF
--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationService.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationService.java
@@ -169,7 +169,7 @@ public class ClientConfigValidationService {
 
     private boolean areClaimsValid(List<String> claims) {
         for (String claim : claims) {
-            if (ValidClaims.getAllowedClaimNames().stream().noneMatch(t -> t.equals(claim))) {
+            if (ValidClaims.getAllValidClaims().stream().noneMatch(t -> t.equals(claim))) {
                 return false;
             }
         }

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationServiceTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationServiceTest.java
@@ -42,7 +42,7 @@ class ClientConfigValidationServiceTest {
                 Arguments.of(
                         singletonList("http://localhost/post-redirect-logout"),
                         "http://back-channel.com",
-                        List.of(ValidClaims.ADDRESS),
+                        List.of(ValidClaims.ADDRESS.getValue()),
                         String.valueOf(MANDATORY),
                         ClientType.WEB.getValue()),
                 Arguments.of(
@@ -51,9 +51,9 @@ class ClientConfigValidationServiceTest {
                                 "http://localhost/post-redirect-logout-v2"),
                         "http://back-channel.com",
                         List.of(
-                                ValidClaims.CORE_IDENTITY_JWT,
-                                ValidClaims.ADDRESS,
-                                ValidClaims.PASSPORT),
+                                ValidClaims.CORE_IDENTITY_JWT.getValue(),
+                                ValidClaims.ADDRESS.getValue(),
+                                ValidClaims.PASSPORT.getValue()),
                         String.valueOf(OPTIONAL),
                         ClientType.APP.getValue()));
     }

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationServiceTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationServiceTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.authentication.clientregistry.entity.ClientRegistrationRequest;
 import uk.gov.di.authentication.shared.entity.ClientType;
 import uk.gov.di.authentication.shared.entity.UpdateClientConfigRequest;
+import uk.gov.di.authentication.shared.entity.ValidClaims;
 
 import java.util.List;
 import java.util.Optional;
@@ -41,7 +42,7 @@ class ClientConfigValidationServiceTest {
                 Arguments.of(
                         singletonList("http://localhost/post-redirect-logout"),
                         "http://back-channel.com",
-                        List.of("address"),
+                        List.of(ValidClaims.ADDRESS),
                         String.valueOf(MANDATORY),
                         ClientType.WEB.getValue()),
                 Arguments.of(
@@ -49,7 +50,10 @@ class ClientConfigValidationServiceTest {
                                 "http://localhost/post-redirect-logout",
                                 "http://localhost/post-redirect-logout-v2"),
                         "http://back-channel.com",
-                        List.of("address", "birthdate", "name"),
+                        List.of(
+                                ValidClaims.CORE_IDENTITY_JWT,
+                                ValidClaims.ADDRESS,
+                                ValidClaims.PASSPORT),
                         String.valueOf(OPTIONAL),
                         ClientType.APP.getValue()));
     }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientRegistrationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientRegistrationIntegrationTest.java
@@ -44,7 +44,7 @@ public class ClientRegistrationIntegrationTest extends ApiGatewayHandlerIntegrat
                 Arguments.of(
                         singletonList("http://localhost/post-redirect-logout"),
                         "http://back-channel.com",
-                        List.of(ValidClaims.ADDRESS),
+                        List.of(ValidClaims.ADDRESS.getValue()),
                         String.valueOf(MANDATORY)),
                 Arguments.of(
                         List.of(
@@ -52,9 +52,9 @@ public class ClientRegistrationIntegrationTest extends ApiGatewayHandlerIntegrat
                                 "http://localhost/post-redirect-logout-v2"),
                         "http://back-channel.com",
                         List.of(
-                                ValidClaims.CORE_IDENTITY_JWT,
-                                ValidClaims.PASSPORT,
-                                ValidClaims.ADDRESS),
+                                ValidClaims.CORE_IDENTITY_JWT.getValue(),
+                                ValidClaims.PASSPORT.getValue(),
+                                ValidClaims.ADDRESS.getValue()),
                         String.valueOf(OPTIONAL)));
     }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientRegistrationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientRegistrationIntegrationTest.java
@@ -9,6 +9,7 @@ import uk.gov.di.authentication.clientregistry.entity.ClientRegistrationRequest;
 import uk.gov.di.authentication.clientregistry.entity.ClientRegistrationResponse;
 import uk.gov.di.authentication.clientregistry.lambda.ClientRegistrationHandler;
 import uk.gov.di.authentication.shared.entity.ClientType;
+import uk.gov.di.authentication.shared.entity.ValidClaims;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 
 import java.util.List;
@@ -43,14 +44,17 @@ public class ClientRegistrationIntegrationTest extends ApiGatewayHandlerIntegrat
                 Arguments.of(
                         singletonList("http://localhost/post-redirect-logout"),
                         "http://back-channel.com",
-                        List.of("address"),
+                        List.of(ValidClaims.ADDRESS),
                         String.valueOf(MANDATORY)),
                 Arguments.of(
                         List.of(
                                 "http://localhost/post-redirect-logout",
                                 "http://localhost/post-redirect-logout-v2"),
                         "http://back-channel.com",
-                        List.of("address", "birthdate", "name"),
+                        List.of(
+                                ValidClaims.CORE_IDENTITY_JWT,
+                                ValidClaims.PASSPORT,
+                                ValidClaims.ADDRESS),
                         String.valueOf(OPTIONAL)));
     }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
@@ -137,9 +137,9 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         handler = new UserInfoHandler(configurationService);
         var claimsSetRequest =
                 new ClaimsSetRequest()
-                        .add(ValidClaims.CORE_IDENTITY_JWT)
-                        .add(ValidClaims.ADDRESS)
-                        .add(ValidClaims.PASSPORT);
+                        .add(ValidClaims.CORE_IDENTITY_JWT.getValue())
+                        .add(ValidClaims.ADDRESS.getValue())
+                        .add(ValidClaims.PASSPORT.getValue());
         var oidcValidClaimsRequest =
                 new OIDCClaimsRequest().withUserInfoClaimsRequest(claimsSetRequest);
         var claimsSet =

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
@@ -136,7 +136,10 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var configurationService = new UserInfoIntegrationTest.UserInfoConfigurationService();
         handler = new UserInfoHandler(configurationService);
         var claimsSetRequest =
-                new ClaimsSetRequest().add(ValidClaims.NAME).add(ValidClaims.BIRTHDATE);
+                new ClaimsSetRequest()
+                        .add(ValidClaims.CORE_IDENTITY_JWT)
+                        .add(ValidClaims.ADDRESS)
+                        .add(ValidClaims.PASSPORT);
         var oidcValidClaimsRequest =
                 new OIDCClaimsRequest().withUserInfoClaimsRequest(claimsSetRequest);
         var claimsSet =

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AccessTokenService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AccessTokenService.java
@@ -169,7 +169,7 @@ public class AccessTokenService {
                 JSONArrayUtils.parse(claimsSet.getClaim("claims").toString()).stream()
                         .map(Objects::toString)
                         .collect(Collectors.toList());
-        if (!ValidClaims.getAllowedClaimNames().containsAll(identityClaims)) {
+        if (!ValidClaims.getAllValidClaims().containsAll(identityClaims)) {
             LOG.warn("Invalid set of Identity claims present in access token: {}", identityClaims);
             throw new AccessTokenException("Invalid Identity claims", OAuth2Error.INVALID_REQUEST);
         }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthorizationService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthorizationService.java
@@ -197,7 +197,7 @@ public class AuthorizationService {
                         .map(ClaimsSetRequest.Entry::getClaimName)
                         .collect(Collectors.toList());
         for (String claim : claimNames) {
-            if (ValidClaims.getAllowedClaimNames().stream().noneMatch(t -> t.equals(claim))) {
+            if (ValidClaims.getAllValidClaims().stream().noneMatch(t -> t.equals(claim))) {
                 return false;
             }
         }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/UserInfoService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/UserInfoService.java
@@ -75,7 +75,7 @@ public class UserInfoService {
         }
         var passportNumber =
                 accessTokenInfo.getIdentityClaims().stream()
-                        .filter(t -> t.equals(ValidClaims.PASSPORT_NUMBER))
+                        .filter(t -> t.equals(ValidClaims.PASSPORT))
                         .findFirst()
                         .orElse(null);
         if (Objects.nonNull(passportNumber)

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/UserInfoService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/UserInfoService.java
@@ -67,7 +67,7 @@ public class UserInfoService {
         }
         var address =
                 accessTokenInfo.getIdentityClaims().stream()
-                        .filter(t -> t.equals(ValidClaims.ADDRESS))
+                        .filter(t -> t.equals(ValidClaims.ADDRESS.getValue()))
                         .findFirst()
                         .orElse(null);
         if (Objects.nonNull(address) && Objects.nonNull(spotCredential.get().getAddress())) {
@@ -75,7 +75,7 @@ public class UserInfoService {
         }
         var passportNumber =
                 accessTokenInfo.getIdentityClaims().stream()
-                        .filter(t -> t.equals(ValidClaims.PASSPORT))
+                        .filter(t -> t.equals(ValidClaims.PASSPORT.getValue()))
                         .findFirst()
                         .orElse(null);
         if (Objects.nonNull(passportNumber)

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AccessTokenServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AccessTokenServiceTest.java
@@ -72,9 +72,9 @@ class AccessTokenServiceTest {
 
     private final ClaimsSetRequest claimsSetRequest =
             new ClaimsSetRequest()
-                    .add(ValidClaims.ADDRESS)
-                    .add(ValidClaims.PASSPORT)
-                    .add(ValidClaims.CORE_IDENTITY_JWT);
+                    .add(ValidClaims.ADDRESS.getValue())
+                    .add(ValidClaims.PASSPORT.getValue())
+                    .add(ValidClaims.CORE_IDENTITY_JWT.getValue());
     private final OIDCClaimsRequest oidcValidClaimsRequest =
             new OIDCClaimsRequest().withUserInfoClaimsRequest(claimsSetRequest);
     private AccessToken accessToken = createSignedAccessToken(null, false);
@@ -210,7 +210,8 @@ class AccessTokenServiceTest {
 
     @Test
     void shouldThrowExceptionWhenIdentityClaimsAreInvalid() throws JsonProcessingException {
-        var claimsSetRequest = new ClaimsSetRequest().add("email").add(ValidClaims.ADDRESS);
+        var claimsSetRequest =
+                new ClaimsSetRequest().add("email").add(ValidClaims.ADDRESS.getValue());
         var invalidClaimsRequest =
                 new OIDCClaimsRequest().withUserInfoClaimsRequest(claimsSetRequest);
         accessToken = createSignedAccessToken(invalidClaimsRequest, false);

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AccessTokenServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AccessTokenServiceTest.java
@@ -71,7 +71,10 @@ class AccessTokenServiceTest {
     private static final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
 
     private final ClaimsSetRequest claimsSetRequest =
-            new ClaimsSetRequest().add(ValidClaims.ADDRESS).add(ValidClaims.BIRTHDATE);
+            new ClaimsSetRequest()
+                    .add(ValidClaims.ADDRESS)
+                    .add(ValidClaims.PASSPORT)
+                    .add(ValidClaims.CORE_IDENTITY_JWT);
     private final OIDCClaimsRequest oidcValidClaimsRequest =
             new OIDCClaimsRequest().withUserInfoClaimsRequest(claimsSetRequest);
     private AccessToken accessToken = createSignedAccessToken(null, false);
@@ -207,7 +210,7 @@ class AccessTokenServiceTest {
 
     @Test
     void shouldThrowExceptionWhenIdentityClaimsAreInvalid() throws JsonProcessingException {
-        var claimsSetRequest = new ClaimsSetRequest().add("email").add(ValidClaims.BIRTHDATE);
+        var claimsSetRequest = new ClaimsSetRequest().add("email").add(ValidClaims.ADDRESS);
         var invalidClaimsRequest =
                 new OIDCClaimsRequest().withUserInfoClaimsRequest(claimsSetRequest);
         accessToken = createSignedAccessToken(invalidClaimsRequest, false);

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AuthorizationServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AuthorizationServiceTest.java
@@ -22,13 +22,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.CustomScopeValue;
+import uk.gov.di.authentication.shared.entity.ValidClaims;
 import uk.gov.di.authentication.shared.exceptions.ClientNotFoundException;
 import uk.gov.di.authentication.shared.helpers.CookieHelper;
 import uk.gov.di.authentication.shared.services.DynamoClientService;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -108,7 +108,7 @@ class AuthorizationServiceTest {
     }
 
     @Test
-    void shouldGenerateSuccessfulAuthResponse() throws URISyntaxException {
+    void shouldGenerateSuccessfulAuthResponse() {
         AuthorizationCode authCode = new AuthorizationCode();
         Scope scope = new Scope();
         scope.add(OIDCScopeValue.OPENID);
@@ -199,10 +199,11 @@ class AuthorizationServiceTest {
                         .setRedirectUrls(singletonList(REDIRECT_URI.toString()))
                         .setClientID(CLIENT_ID.toString())
                         .setScopes(scope.toStringList())
-                        .setClaims(List.of("name", "birthdate"));
+                        .setClaims(List.of(ValidClaims.ADDRESS, ValidClaims.CORE_IDENTITY_JWT));
         when(dynamoClientService.getClient(CLIENT_ID.toString()))
                 .thenReturn(Optional.of(clientRegistry));
-        var claimsSetRequest = new ClaimsSetRequest().add("name").add("birthdate");
+        var claimsSetRequest =
+                new ClaimsSetRequest().add(ValidClaims.ADDRESS).add(ValidClaims.CORE_IDENTITY_JWT);
         var oidcClaimsRequest = new OIDCClaimsRequest().withUserInfoClaimsRequest(claimsSetRequest);
         var authRequest =
                 generateAuthRequest(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AuthorizationServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AuthorizationServiceTest.java
@@ -199,11 +199,16 @@ class AuthorizationServiceTest {
                         .setRedirectUrls(singletonList(REDIRECT_URI.toString()))
                         .setClientID(CLIENT_ID.toString())
                         .setScopes(scope.toStringList())
-                        .setClaims(List.of(ValidClaims.ADDRESS, ValidClaims.CORE_IDENTITY_JWT));
+                        .setClaims(
+                                List.of(
+                                        ValidClaims.ADDRESS.getValue(),
+                                        ValidClaims.CORE_IDENTITY_JWT.getValue()));
         when(dynamoClientService.getClient(CLIENT_ID.toString()))
                 .thenReturn(Optional.of(clientRegistry));
         var claimsSetRequest =
-                new ClaimsSetRequest().add(ValidClaims.ADDRESS).add(ValidClaims.CORE_IDENTITY_JWT);
+                new ClaimsSetRequest()
+                        .add(ValidClaims.ADDRESS.getValue())
+                        .add(ValidClaims.CORE_IDENTITY_JWT.getValue());
         var oidcClaimsRequest = new OIDCClaimsRequest().withUserInfoClaimsRequest(claimsSetRequest);
         var authRequest =
                 generateAuthRequest(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
@@ -65,7 +65,7 @@ class UserInfoServiceTest {
     private static final String BASE_URL = "http://example.com";
     private static final String KEY_ID = "14342354354353";
     private final ClaimsSetRequest claimsSetRequest =
-            new ClaimsSetRequest().add(ValidClaims.ADDRESS).add(ValidClaims.PASSPORT_NUMBER);
+            new ClaimsSetRequest().add(ValidClaims.ADDRESS).add(ValidClaims.PASSPORT);
     private final OIDCClaimsRequest oidcValidClaimsRequest =
             new OIDCClaimsRequest().withUserInfoClaimsRequest(claimsSetRequest);
     private final String serializedCredential =

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
@@ -65,7 +65,9 @@ class UserInfoServiceTest {
     private static final String BASE_URL = "http://example.com";
     private static final String KEY_ID = "14342354354353";
     private final ClaimsSetRequest claimsSetRequest =
-            new ClaimsSetRequest().add(ValidClaims.ADDRESS).add(ValidClaims.PASSPORT);
+            new ClaimsSetRequest()
+                    .add(ValidClaims.ADDRESS.getValue())
+                    .add(ValidClaims.PASSPORT.getValue());
     private final OIDCClaimsRequest oidcValidClaimsRequest =
             new OIDCClaimsRequest().withUserInfoClaimsRequest(claimsSetRequest);
     private final String serializedCredential =

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ValidClaims.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ValidClaims.java
@@ -8,18 +8,13 @@ import java.util.stream.Collectors;
 
 public class ValidClaims {
 
-    public static final String NAME = "name";
-    public static final String ADDRESS = "address";
-    public static final String PASSPORT_NUMBER = "passport-number";
-    public static final String BIRTHDATE = "birthdate";
+    public static final String ADDRESS = "https://vocab.account.gov.uk/v1/address";
+    public static final String PASSPORT = "https://vocab.account.gov.uk/v1/passport";
+    public static final String CORE_IDENTITY_JWT =
+            "https://vocab.account.gov.uk/v1/coreIdentityJWT";
 
     protected static final Collection<ClaimsSetRequest.Entry> allowedClaims =
-            new ClaimsSetRequest()
-                    .add(NAME)
-                    .add(BIRTHDATE)
-                    .add(ADDRESS)
-                    .add(PASSPORT_NUMBER)
-                    .getEntries();
+            new ClaimsSetRequest().add(CORE_IDENTITY_JWT).add(ADDRESS).add(PASSPORT).getEntries();
 
     private ValidClaims() {}
 
@@ -27,5 +22,9 @@ public class ValidClaims {
         return allowedClaims.stream()
                 .map(ClaimsSetRequest.Entry::getClaimName)
                 .collect(Collectors.toSet());
+    }
+
+    public static boolean isValidClaim(String claim) {
+        return allowedClaims.stream().anyMatch(t -> t.getClaimName().equals(claim));
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ValidClaims.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ValidClaims.java
@@ -1,30 +1,33 @@
 package uk.gov.di.authentication.shared.entity;
 
-import com.nimbusds.openid.connect.sdk.claims.ClaimsSetRequest;
-
-import java.util.Collection;
+import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class ValidClaims {
+public enum ValidClaims {
+    ADDRESS("https://vocab.account.gov.uk/v1/address"),
+    PASSPORT("https://vocab.account.gov.uk/v1/passport"),
+    CORE_IDENTITY_JWT("https://vocab.account.gov.uk/v1/coreIdentityJWT");
 
-    public static final String ADDRESS = "https://vocab.account.gov.uk/v1/address";
-    public static final String PASSPORT = "https://vocab.account.gov.uk/v1/passport";
-    public static final String CORE_IDENTITY_JWT =
-            "https://vocab.account.gov.uk/v1/coreIdentityJWT";
+    private final String value;
 
-    protected static final Collection<ClaimsSetRequest.Entry> allowedClaims =
-            new ClaimsSetRequest().add(CORE_IDENTITY_JWT).add(ADDRESS).add(PASSPORT).getEntries();
+    ValidClaims(String value) {
+        this.value = value;
+    }
 
-    private ValidClaims() {}
+    public String getValue() {
+        return value;
+    }
 
-    public static Set<String> getAllowedClaimNames() {
-        return allowedClaims.stream()
-                .map(ClaimsSetRequest.Entry::getClaimName)
+    public static Set<String> getAllValidClaims() {
+        return Arrays.stream(ValidClaims.values())
+                .map(ValidClaims::getValue)
                 .collect(Collectors.toSet());
     }
 
     public static boolean isValidClaim(String claim) {
-        return allowedClaims.stream().anyMatch(t -> t.getClaimName().equals(claim));
+        return Arrays.stream(ValidClaims.values())
+                .map(ValidClaims::getValue)
+                .anyMatch(t -> t.equals(claim));
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/ValidClaimsTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/ValidClaimsTest.java
@@ -28,13 +28,13 @@ class ValidClaimsTest {
 
     @Test
     void shouldReturnCorrectNumberOfClaimsSupported() {
-        assertThat(ValidClaims.getAllowedClaimNames().size(), equalTo(3));
+        assertThat(ValidClaims.getAllValidClaims().size(), equalTo(3));
     }
 
     @ParameterizedTest
     @MethodSource("supportedClaims")
     void shouldReturnNamesOfSupportedClaims(String supportedClaim) {
-        assertTrue(ValidClaims.getAllowedClaimNames().contains(supportedClaim));
+        assertTrue(ValidClaims.getAllValidClaims().contains(supportedClaim));
     }
 
     @ParameterizedTest

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/ValidClaimsTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/ValidClaimsTest.java
@@ -8,22 +8,44 @@ import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ValidClaimsTest {
 
-    static Stream<String> suppportedClaims() {
-        return Stream.of("name", "birthdate", "address", "passport-number");
+    static Stream<String> supportedClaims() {
+        return Stream.of(
+                "https://vocab.account.gov.uk/v1/address",
+                "https://vocab.account.gov.uk/v1/passport",
+                "https://vocab.account.gov.uk/v1/coreIdentityJWT");
+    }
+
+    static Stream<String> unsupportedClaims() {
+        return Stream.of(
+                "https://vocab.account.gov.uk/v1/name",
+                "https://vocab.account.gov.uk/v1/birthdate");
     }
 
     @Test
     void shouldReturnCorrectNumberOfClaimsSupported() {
-        assertThat(ValidClaims.getAllowedClaimNames().size(), equalTo(4));
+        assertThat(ValidClaims.getAllowedClaimNames().size(), equalTo(3));
     }
 
     @ParameterizedTest
-    @MethodSource("suppportedClaims")
+    @MethodSource("supportedClaims")
     void shouldReturnNamesOfSupportedClaims(String supportedClaim) {
         assertTrue(ValidClaims.getAllowedClaimNames().contains(supportedClaim));
+    }
+
+    @ParameterizedTest
+    @MethodSource("supportedClaims")
+    void shouldReturnTrueForSupportedClaims(String claimName) {
+        assertTrue(ValidClaims.isValidClaim(claimName));
+    }
+
+    @ParameterizedTest
+    @MethodSource("unsupportedClaims")
+    void shouldReturnFalseForUnsupportedClaims(String claimName) {
+        assertFalse(ValidClaims.isValidClaim(claimName));
     }
 }


### PR DESCRIPTION
## What?

- Support correct identity claims
- Convert ValidClaims to an enum

## Why?

- Update ValidClaims to reflect the claims that we will expect from an RP. These claims will then be passed onto IPV.
- An enum is more appropriate for defining the list of valid claims