### PR TITLE
AUT-76: Terraform read-only metrics roles

### DIFF
--- a/ci/tasks/deploy-shared-api.yml
+++ b/ci/tasks/deploy-shared-api.yml
@@ -14,6 +14,7 @@ params:
   STATE_BUCKET: digital-identity-dev-tfstate
   TEST_CLIENT_EMAIL_ALLOWLIST: ((test-client-email-allowlist))
   DI_TOOLS_SIGNING_PROFILE_VERSION_ARN: ((di-tools-signing-profile-version-arn))
+  DI_TOOLS_ACCOUNT_NUMBER: ((di-tools-account-id-non-prod))
 inputs:
   - name: api-terraform-src
   - name: test-users-seed-data
@@ -48,6 +49,7 @@ run:
         -var "password_pepper=${PASSWORD_PEPPER}" \
         -var "common_state_bucket=${STATE_BUCKET}" \
         -var "di_tools_signing_profile_version_arn=${DI_TOOLS_SIGNING_PROFILE_VERSION_ARN}" \
+        -var "tools_account_id=${DI_TOOLS_ACCOUNT_NUMBER}" \
         -var-file ${DEPLOY_ENVIRONMENT}-stub-clients.tfvars \
         -var-file ${DEPLOY_ENVIRONMENT}-sizing.tfvars \
 

--- a/ci/terraform/shared/grafana-read-only-role.tf
+++ b/ci/terraform/shared/grafana-read-only-role.tf
@@ -1,0 +1,79 @@
+data "aws_iam_policy_document" "tools_account_assume_role_policy" {
+  version = "2012-10-17"
+
+  statement {
+    effect = "Allow"
+    principals {
+      identifiers = [
+        "arn:aws:iam::${var.tools_account_id}:root"
+      ]
+      type = "AWS"
+    }
+
+    actions = [
+      "sts:AssumeRole"
+    ]
+  }
+}
+
+resource "aws_iam_role" "grafana_metrics_read_only_role" {
+  count = contains(["integration", "production"], var.environment) ? 1 : 0
+  name  = "grafana-metrics-read-only"
+
+  assume_role_policy = data.aws_iam_policy_document.tools_account_assume_role_policy.json
+
+  tags = local.default_tags
+}
+
+data "aws_iam_policy_document" "metrics_access_policy_document" {
+
+  version = "2012-10-17"
+
+  statement {
+    sid    = "AllowReadingMetricsFromCloudWatch"
+    effect = "Allow"
+    actions = [
+      "cloudwatch:DescribeAlarmsForMetric",
+      "cloudwatch:DescribeAlarmHistory",
+      "cloudwatch:DescribeAlarms",
+      "cloudwatch:ListMetrics",
+      "cloudwatch:GetMetricStatistics",
+      "cloudwatch:GetMetricData"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "AllowReadingTagsInstancesRegionsFromEC2"
+    effect = "Allow"
+    actions = [
+      "ec2:DescribeTags",
+      "ec2:DescribeInstances",
+      "ec2:DescribeRegions"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "AllowReadingResourcesForTags"
+    effect = "Allow"
+    actions = [
+      "tag:GetResources"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "metrics_access_policy" {
+  count = contains(["integration", "production"], var.environment) ? 1 : 0
+
+  name        = "grafana-metrics-read-only-policy"
+  description = "IAM policy for read-only access to Cloudwatch metrics"
+
+  policy = data.aws_iam_policy_document.metrics_access_policy_document.json
+}
+
+resource "aws_iam_role_policy_attachment" "metrics_access" {
+  role       = aws_iam_role.grafana_metrics_read_only_role.name
+  policy_arn = aws_iam_policy.metrics_access_policy.arn
+}

--- a/ci/terraform/shared/variables.tf
+++ b/ci/terraform/shared/variables.tf
@@ -148,3 +148,8 @@ variable "common_state_bucket" {
 variable "di_tools_signing_profile_version_arn" {
   description = "The AWS Signer profile version to use from the `di-tools-prod` account"
 }
+
+variable "tools_account_id" {
+  description = "AWS Account for the corresponding tools account to this environment"
+  type        = string
+}


### PR DESCRIPTION
We only create this role in integration and production (happy to discuss why)
