### PR TITLE
BAU - Set nbf claims in token requests to IPV and DocApp CRI

### DIFF
--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/services/DocAppCriService.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/services/DocAppCriService.java
@@ -67,7 +67,7 @@ public class DocAppCriService {
                         new ClientID(configurationService.getDocAppAuthorisationClientId()),
                         singletonList(new Audience(tokenURI)),
                         NowHelper.nowPlus(PRIVATE_KEY_JWT_EXPIRY, ChronoUnit.MINUTES),
-                        null,
+                        NowHelper.now(),
                         NowHelper.now(),
                         new JWTID());
         return new TokenRequest(

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVTokenService.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVTokenService.java
@@ -62,7 +62,7 @@ public class IPVTokenService {
                         new ClientID(configurationService.getIPVAuthorisationClientId()),
                         singletonList(new Audience(ipvTokenURI)),
                         NowHelper.nowPlus(PRIVATE_KEY_JWT_EXPIRY, ChronoUnit.MINUTES),
-                        null,
+                        NowHelper.now(),
                         NowHelper.now(),
                         new JWTID());
         return new TokenRequest(


### PR DESCRIPTION
## What?

- Set nbf claims in token requests to IPV and DocApp CRI

## Why?

- We should specify the NBF in the token request as it outlines the time where the token cannot be processed before.