### PR TITLE
AUT-5 - Register the Stubs with the correctly named claims

### DIFF
--- a/ci/terraform/shared/stub-rp-clients.tf
+++ b/ci/terraform/shared/stub-rp-clients.tf
@@ -52,13 +52,13 @@ resource "aws_dynamodb_table_item" "stub_rp_client" {
     Claims = {
       L = [
         {
-          S = "name"
+          S = "https://vocab.account.gov.uk/v1/coreIdentityJWT"
         },
         {
-          S = "birthdate"
+          S = "https://vocab.account.gov.uk/v1/passport"
         },
         {
-          S = "address"
+          S = "https://vocab.account.gov.uk/v1/address"
         },
       ]
     }


### PR DESCRIPTION
## What?

 - Register the Stubs with the correctly named claims

## Why?

- So the Stubs can request claims