### PR TITLE
AUT-76: Don't attach the policy if the role doesn't exist

### DIFF
--- a/ci/terraform/shared/grafana-read-only-role.tf
+++ b/ci/terraform/shared/grafana-read-only-role.tf
@@ -74,6 +74,7 @@ resource "aws_iam_policy" "metrics_access_policy" {
 }
 
 resource "aws_iam_role_policy_attachment" "metrics_access" {
-  role       = aws_iam_role.grafana_metrics_read_only_role.name
-  policy_arn = aws_iam_policy.metrics_access_policy.arn
+  count      = contains(["integration", "production"], var.environment) ? 1 : 0
+  role       = aws_iam_role.grafana_metrics_read_only_role[0].name
+  policy_arn = aws_iam_policy.metrics_access_policy[0].arn
 }


### PR DESCRIPTION
The build is currently broken because we depend on things that don't exist
