### PR TITLE
AUT-345: Add XRay Segment annotations

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/InstrumentationHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/InstrumentationHelper.java
@@ -33,6 +33,18 @@ public class InstrumentationHelper {
         }
     }
 
+    public static void startSegment(String name) {
+        if (tracingEnabled) {
+            AWSXRay.beginSegment(name);
+        }
+    }
+
+    public static void endSegment() {
+        if (tracingEnabled) {
+            AWSXRay.endSegment();
+        }
+    }
+
     public static void addAnnotation(String key, String value) {
         if (tracingEnabled) {
             AWSXRay.getCurrentSegment().putAnnotation(key, value);


### PR DESCRIPTION
## What?

- Re-add the lines to associate annotations to the segment
- Add a main segment at the beginning of the `TokenHandler` lambda `handleRequest` method

## Why?

A previous attempt to add the annotations failed as it seems you cannot add annotations to a Lambda facade segment, so we now explicitly create a segment for the lambda.
