### PR TITLE
AUT-5 - Return coreIdentityJWT claim in userinfo

### DIFF
--- a/ci/terraform/oidc/dynamo-policies.tf
+++ b/ci/terraform/oidc/dynamo-policies.tf
@@ -10,10 +10,6 @@ data "aws_dynamodb_table" "client_registry_table" {
   name = "${var.environment}-client-registry"
 }
 
-data "aws_dynamodb_table" "spot_credential_table" {
-  name = "${var.environment}-spot-credential"
-}
-
 data "aws_dynamodb_table" "identity_credentials_table" {
   name = "${var.environment}-identity-credentials"
 }

--- a/ci/terraform/shared/dynamodb.tf
+++ b/ci/terraform/shared/dynamodb.tf
@@ -134,39 +134,6 @@ resource "aws_dynamodb_table" "client_registry_table" {
   tags = local.default_tags
 }
 
-resource "aws_dynamodb_table" "spot_credential_table" {
-  name         = "${var.environment}-spot-credential"
-  billing_mode = var.provision_dynamo ? "PROVISIONED" : "PAY_PER_REQUEST"
-  hash_key     = "SubjectID"
-
-  read_capacity  = var.provision_dynamo ? var.dynamo_default_read_capacity : null
-  write_capacity = var.provision_dynamo ? var.dynamo_default_write_capacity : null
-
-  attribute {
-    name = "SubjectID"
-    type = "S"
-  }
-
-  point_in_time_recovery {
-    enabled = !var.use_localstack
-  }
-
-  server_side_encryption {
-    enabled = !var.use_localstack
-  }
-
-  lifecycle {
-    prevent_destroy = false
-  }
-
-  ttl {
-    attribute_name = "TimeToExist"
-    enabled        = true
-  }
-
-  tags = local.default_tags
-}
-
 resource "aws_dynamodb_table" "identity_credentials_table" {
   name         = "${var.environment}-identity-credentials"
   billing_mode = var.provision_dynamo ? "PROVISIONED" : "PAY_PER_REQUEST"

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
@@ -184,7 +184,9 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(userInfoResponse.getPhoneNumber(), equalTo(FORMATTED_PHONE_NUMBER));
         assertThat(userInfoResponse.getPhoneNumberVerified(), equalTo(true));
         assertThat(userInfoResponse.getSubject(), equalTo(PUBLIC_SUBJECT));
-        assertThat(userInfoResponse.getClaim("identity"), equalTo(signedCredential.serialize()));
+        assertThat(
+                userInfoResponse.getClaim(ValidClaims.CORE_IDENTITY_JWT.getValue()),
+                equalTo(signedCredential.serialize()));
         assertThat(userInfoResponse.toJWTClaimsSet().getClaims().size(), equalTo(6));
 
         assertNoAuditEventsReceived(auditTopic);
@@ -234,9 +236,9 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertNoAuditEventsReceived(auditTopic);
     }
 
-    private void setUpDynamo(String serializedCredential) {
-        if (Objects.nonNull(serializedCredential)) {
-            identityStore.addCredential(PUBLIC_SUBJECT.getValue(), serializedCredential);
+    private void setUpDynamo(String coreIdentityJWT) {
+        if (Objects.nonNull(coreIdentityJWT)) {
+            identityStore.addCoreIdentityJWT(PUBLIC_SUBJECT.getValue(), coreIdentityJWT);
         }
         userStore.signUp(TEST_EMAIL_ADDRESS, TEST_PASSWORD, INTERNAL_SUBJECT);
         userStore.addPhoneNumber(TEST_EMAIL_ADDRESS, TEST_PHONE_NUMBER);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/SpotResponseIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/SpotResponseIntegrationTest.java
@@ -50,7 +50,7 @@ public class SpotResponseIntegrationTest extends HandlerIntegrationTest<SQSEvent
                 identityStore
                         .getIdentityCredentials(pairwiseIdentifier.getValue())
                         .get()
-                        .getSerializedCredential(),
+                        .getCoreIdentityJWT(),
                 equalTo(signedCredential));
     }
 

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandler.java
@@ -64,7 +64,7 @@ public class SPOTResponseHandler implements RequestHandler<SQSEvent, Object> {
                     return null;
                 }
 
-                dynamoIdentityService.addIdentityCredential(
+                dynamoIdentityService.addCoreIdentityJWT(
                         spotResponse.getSub(),
                         spotResponse.getClaims().values().stream()
                                 .map(Object::toString)

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandlerTest.java
@@ -39,7 +39,7 @@ class SPOTResponseHandlerTest {
         handler.handleRequest(generateSQSEvent(json), context);
 
         verify(dynamoIdentityService)
-                .addIdentityCredential("some-pairwise-identifier", "random-searalized-credential");
+                .addCoreIdentityJWT("some-pairwise-identifier", "random-searalized-credential");
 
         verify(auditService)
                 .submitAuditEvent(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
@@ -52,8 +52,6 @@ class UserInfoServiceTest {
 
     private static final Subject INTERNAL_SUBJECT = new Subject("internal-subject");
     private static final Subject SUBJECT = new Subject("some-subject");
-    private static final String ADDRESS_CLAIM = "some-address";
-    private static final String PASSPORT_NUMBER_CLAIM = "123456789";
     private static final List<String> SCOPES =
             List.of(
                     OIDCScopeValue.OPENID.getValue(),
@@ -62,22 +60,17 @@ class UserInfoServiceTest {
     private static final String CLIENT_ID = "client-id";
     private static final String EMAIL = "joe.bloggs@digital.cabinet-office.gov.uk";
     private static final String PHONE_NUMBER = "01234567891";
-    private static final String BASE_URL = "http://example.com";
+    private static final String BASE_URL = "https://example.com";
     private static final String KEY_ID = "14342354354353";
     private final ClaimsSetRequest claimsSetRequest =
-            new ClaimsSetRequest()
-                    .add(ValidClaims.ADDRESS.getValue())
-                    .add(ValidClaims.PASSPORT.getValue());
+            new ClaimsSetRequest().add(ValidClaims.CORE_IDENTITY_JWT.getValue());
     private final OIDCClaimsRequest oidcValidClaimsRequest =
             new OIDCClaimsRequest().withUserInfoClaimsRequest(claimsSetRequest);
-    private final String serializedCredential =
-            SignedCredentialHelper.generateCredential().serialize();
+    private final String coreIdentityJWT = SignedCredentialHelper.generateCredential().serialize();
     private final IdentityCredentials identityCredentials =
             new IdentityCredentials()
                     .setSubjectID(SUBJECT.getValue())
-                    .setSerializedCredential(serializedCredential)
-                    .setAddress(ADDRESS_CLAIM)
-                    .setPassportNumber(PASSPORT_NUMBER_CLAIM);
+                    .setCoreIdentityJWT(coreIdentityJWT);
     private AccessToken accessToken;
 
     @RegisterExtension
@@ -113,9 +106,9 @@ class UserInfoServiceTest {
         assertThat(userInfo.getEmailVerified(), equalTo(true));
         assertThat(userInfo.getPhoneNumber(), equalTo(PHONE_NUMBER));
         assertThat(userInfo.getPhoneNumberVerified(), equalTo(true));
-        assertNull(userInfo.getClaim("address"));
-        assertNull(userInfo.getClaim("passport-number"));
-        assertNull(userInfo.getClaim("identity"));
+        assertNull(userInfo.getClaim(ValidClaims.CORE_IDENTITY_JWT.getValue()));
+        assertNull(userInfo.getClaim(ValidClaims.ADDRESS.getValue()));
+        assertNull(userInfo.getClaim(ValidClaims.PASSPORT.getValue()));
     }
 
     @Test
@@ -136,9 +129,9 @@ class UserInfoServiceTest {
         assertThat(userInfo.getEmailVerified(), equalTo(true));
         assertNull(userInfo.getPhoneNumber());
         assertNull(userInfo.getPhoneNumberVerified());
-        assertNull(userInfo.getClaim("address"));
-        assertNull(userInfo.getClaim("passport-number"));
-        assertNull(userInfo.getClaim("identity"));
+        assertNull(userInfo.getClaim(ValidClaims.ADDRESS.getValue()));
+        assertNull(userInfo.getClaim(ValidClaims.PASSPORT.getValue()));
+        assertNull(userInfo.getClaim(ValidClaims.CORE_IDENTITY_JWT.getValue()));
     }
 
     @Test
@@ -158,9 +151,9 @@ class UserInfoServiceTest {
         assertThat(userInfo.getEmailVerified(), equalTo(true));
         assertThat(userInfo.getPhoneNumber(), equalTo(PHONE_NUMBER));
         assertThat(userInfo.getPhoneNumberVerified(), equalTo(true));
-        assertNull(userInfo.getClaim("address"));
-        assertNull(userInfo.getClaim("passport-number"));
-        assertNull(userInfo.getClaim("identity"));
+        assertNull(userInfo.getClaim(ValidClaims.ADDRESS.getValue()));
+        assertNull(userInfo.getClaim(ValidClaims.PASSPORT.getValue()));
+        assertNull(userInfo.getClaim(ValidClaims.CORE_IDENTITY_JWT.getValue()));
     }
 
     @Test
@@ -188,9 +181,9 @@ class UserInfoServiceTest {
         assertThat(userInfo.getEmailVerified(), equalTo(true));
         assertThat(userInfo.getPhoneNumber(), equalTo(PHONE_NUMBER));
         assertThat(userInfo.getPhoneNumberVerified(), equalTo(true));
-        assertThat(userInfo.getClaim("address"), equalTo(ADDRESS_CLAIM));
-        assertThat(userInfo.getClaim("passport-number"), equalTo(PASSPORT_NUMBER_CLAIM));
-        assertThat(userInfo.getClaim("identity"), equalTo(serializedCredential));
+        assertThat(
+                userInfo.getClaim(ValidClaims.CORE_IDENTITY_JWT.getValue()),
+                equalTo(coreIdentityJWT));
     }
 
     private AccessToken createSignedAccessToken(OIDCClaimsRequest identityClaims)

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/IdentityStoreExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/IdentityStoreExtension.java
@@ -49,8 +49,8 @@ public class IdentityStoreExtension extends DynamoExtension implements AfterEach
         }
     }
 
-    public void addCredential(String subjectID, String serializedCredential) {
-        dynamoService.addIdentityCredential(subjectID, serializedCredential);
+    public void addCoreIdentityJWT(String subjectID, String coreIdentityJWT) {
+        dynamoService.addCoreIdentityJWT(subjectID, coreIdentityJWT);
     }
 
     public Optional<IdentityCredentials> getIdentityCredentials(String subjectID) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/IdentityCredentials.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/IdentityCredentials.java
@@ -6,9 +6,7 @@ import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
 public class IdentityCredentials {
 
     private String subjectID;
-    private String serializedCredential;
-    private String address;
-    private String passportNumber;
+    private String coreIdentityJWT;
     private long timeToExist;
 
     public IdentityCredentials() {}
@@ -23,13 +21,13 @@ public class IdentityCredentials {
         return this;
     }
 
-    @DynamoDBAttribute(attributeName = "SerializedCredential")
-    public String getSerializedCredential() {
-        return serializedCredential;
+    @DynamoDBAttribute(attributeName = "CoreIdentityJWT")
+    public String getCoreIdentityJWT() {
+        return coreIdentityJWT;
     }
 
-    public IdentityCredentials setSerializedCredential(String serializedCredential) {
-        this.serializedCredential = serializedCredential;
+    public IdentityCredentials setCoreIdentityJWT(String coreIdentityJWT) {
+        this.coreIdentityJWT = coreIdentityJWT;
         return this;
     }
 
@@ -40,26 +38,6 @@ public class IdentityCredentials {
 
     public IdentityCredentials setTimeToExist(long timeToExist) {
         this.timeToExist = timeToExist;
-        return this;
-    }
-
-    @DynamoDBAttribute(attributeName = "Address")
-    public String getAddress() {
-        return address;
-    }
-
-    public IdentityCredentials setAddress(String address) {
-        this.address = address;
-        return this;
-    }
-
-    @DynamoDBAttribute(attributeName = "PassportNumber")
-    public String getPassportNumber() {
-        return passportNumber;
-    }
-
-    public IdentityCredentials setPassportNumber(String passportNumber) {
-        this.passportNumber = passportNumber;
         return this;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoIdentityService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoIdentityService.java
@@ -26,11 +26,11 @@ public class DynamoIdentityService {
         warmUp(tableName);
     }
 
-    public void addIdentityCredential(String subjectID, String serializedCredential) {
+    public void addCoreIdentityJWT(String subjectID, String coreIdentityJWT) {
         var identityCredentials =
                 new IdentityCredentials()
                         .setSubjectID(subjectID)
-                        .setSerializedCredential(serializedCredential)
+                        .setCoreIdentityJWT(coreIdentityJWT)
                         .setTimeToExist(timeToExist);
 
         identityCredentialsMapper.save(identityCredentials);


### PR DESCRIPTION
## What?

- Return the coreIdentityJWT claim in `/userinfo` if the coreIdentityJWT claim is present in the access token and in the identity credentials table. 
- Remove the other claims from the Identity credentials table. 
- Delete the spot credential table 

## Why?

- So RPS can retrieve the coreIdentityJWT claim with the correct claim name 'https://vocab.account.gov.uk/v1/coreIdentityJWT'
- These are not being returned from IPV yet so we can add additional claims in once the format is known
- The spot credential table has been replaced by the identity credentials table