### PR TITLE
AUT-345: Tidy up use of `noXray` directive in Gradle

### DIFF
--- a/account-management-api/build.gradle
+++ b/account-management-api/build.gradle
@@ -18,7 +18,7 @@ dependencies {
             configurations.govuk_notify,
             configurations.jackson
 
-    implementation project(":shared"), noXray
+    implementation project(":shared")
 
     runtimeOnly configurations.logging_runtime
 

--- a/account-management-integration-tests/build.gradle
+++ b/account-management-integration-tests/build.gradle
@@ -17,10 +17,11 @@ dependencies {
             configurations.lettuce,
             configurations.libphonenumber,
             "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${dependencyVersions.jackson_version}",
-            "com.google.protobuf:protobuf-java:${dependencyVersions.protobuf_version}",
-            project(":account-management-api"),
-            project(":shared-test")
-    implementation project(":shared"), noXray
+            "com.google.protobuf:protobuf-java:${dependencyVersions.protobuf_version}"
+    testImplementation project(":shared"), noXray
+    testImplementation project(":account-management-api"), noXray
+    testImplementation project(":shared-test"), noXray
+
 
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${dependencyVersions.junit}"
 }

--- a/audit-processors/build.gradle
+++ b/audit-processors/build.gradle
@@ -23,7 +23,7 @@ dependencies {
             "com.google.protobuf:protobuf-java-util:${dependencyVersions.protobuf_version}",
             "com.google.code.gson:gson:2.9.0"
 
-    implementation project(":shared"), noXray
+    implementation project(":shared")
 
     runtimeOnly configurations.logging_runtime
 

--- a/client-registry-api/build.gradle
+++ b/client-registry-api/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     implementation configurations.nimbus,
             'commons-validator:commons-validator:1.7'
 
-    implementation project(":shared"), noXray
+    implementation project(":shared")
 
     runtimeOnly configurations.logging_runtime
 

--- a/delivery-receipts-api/build.gradle
+++ b/delivery-receipts-api/build.gradle
@@ -13,7 +13,7 @@ dependencies {
             configurations.libphonenumber,
             configurations.cloudwatch
 
-    implementation project(":shared"), noXray
+    implementation project(":shared")
 
     runtimeOnly configurations.logging_runtime
 

--- a/delivery-receipts-integration-tests/build.gradle
+++ b/delivery-receipts-integration-tests/build.gradle
@@ -11,11 +11,11 @@ dependencies {
             configurations.glassfish,
             configurations.tests,
             configurations.lambda,
-            configurations.lettuce,
-            project(":delivery-receipts-api"),
-            project(":shared-test")
+            configurations.lettuce
 
     implementation project(":shared"), noXray
+    testImplementation project(":delivery-receipts-api"), noXray
+    testImplementation project(":shared-test"), noXray
 
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${dependencyVersions.junit}"
 }

--- a/doc-checking-app-api/build.gradle
+++ b/doc-checking-app-api/build.gradle
@@ -15,7 +15,7 @@ dependencies {
             configurations.nimbus,
             configurations.bouncycastle
 
-    implementation project(":shared"), noXray
+    implementation project(":shared")
 
     runtimeOnly configurations.logging_runtime
 

--- a/frontend-api/build.gradle
+++ b/frontend-api/build.gradle
@@ -21,7 +21,7 @@ dependencies {
             configurations.cloudwatch,
             configurations.bouncycastle
 
-    implementation project(":shared"), noXray
+    implementation project(":shared")
 
     runtimeOnly configurations.logging_runtime
 

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -17,10 +17,10 @@ dependencies {
             configurations.lettuce,
             configurations.lambda,
             "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${dependencyVersions.jackson_version}",
-            "com.google.protobuf:protobuf-java:${dependencyVersions.protobuf_version}",
-            project(":shared-test")
+            "com.google.protobuf:protobuf-java:${dependencyVersions.protobuf_version}"
 
     implementation project(":shared"), noXray
+    implementation project(":shared-test"), noXray
     implementation project(":oidc-api"), noXray
     implementation project(":frontend-api"), noXray
     implementation project(":client-registry-api"), noXray

--- a/ipv-api/build.gradle
+++ b/ipv-api/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     implementation configurations.jackson,
             configurations.nimbus
 
-    implementation project(":shared"), noXray
+    implementation project(":shared")
 
     runtimeOnly configurations.logging_runtime
 

--- a/shared-test/build.gradle
+++ b/shared-test/build.gradle
@@ -21,7 +21,7 @@ dependencies {
             "com.google.protobuf:protobuf-java:3.20.1",
             "com.google.code.gson:gson:2.9.0"
 
-    implementation project(":shared"), noXray
+    implementation project(":shared")
     implementation project(":doc-checking-app-api")
 }
 


### PR DESCRIPTION
## What?

- Remove `noXray` from all projects except the integration tests

## Why?

This was added to all Gradle modules, but we only need to exclude from integration tests (as it causes failures).
