### PR TITLE
AUT-345: Remove parenthesis from segment names

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/RedisConnectionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/RedisConnectionService.java
@@ -60,28 +60,28 @@ public class RedisConnectionService implements AutoCloseable {
 
     public void saveWithExpiry(final String key, final String value, final long expiry) {
         segmentedFunctionCall(
-                "Redis: saveWithExpiry()",
+                "Redis: saveWithExpiry",
                 () -> executeCommand(commands -> commands.setex(key, expiry, value)));
     }
 
     public boolean keyExists(final String key) {
         return segmentedFunctionCall(
-                "Redis: keyExists()", () -> executeCommand(commands -> commands.exists(key) == 1));
+                "Redis: keyExists", () -> executeCommand(commands -> commands.exists(key) == 1));
     }
 
     public String getValue(final String key) {
         return segmentedFunctionCall(
-                "Redis: getValue()", () -> executeCommand(commands -> commands.get(key)));
+                "Redis: getValue", () -> executeCommand(commands -> commands.get(key)));
     }
 
     public long deleteValue(final String key) {
         return segmentedFunctionCall(
-                "Redis: deleteValue()", () -> executeCommand(commands -> commands.del(key)));
+                "Redis: deleteValue", () -> executeCommand(commands -> commands.del(key)));
     }
 
     public String popValue(final String key) {
         return segmentedFunctionCall(
-                "Redis: popValue()",
+                "Redis: popValue",
                 () ->
                         executeCommand(
                                 commands -> {
@@ -95,7 +95,7 @@ public class RedisConnectionService implements AutoCloseable {
 
     private void warmUp() {
         segmentedFunctionCall(
-                "Redis: warmUp()", () -> executeCommand(RedisServerCommands::clientGetname));
+                "Redis: warmUp", () -> executeCommand(RedisServerCommands::clientGetname));
     }
 
     @Override


### PR DESCRIPTION
## What?

- Remove the use of parenthesis in segment names in `RedisConnectionService`

## Why?

Parenthesis are not valid for segment names and, as such, the segments are not appearing:

> name – The logical name of the service that handled the request, up to 200 characters. For example, your application's name or domain name. Names can contain Unicode letters, numbers, and whitespace, and the following symbols: _, ., :, /, %, &, #, =, +, \, -, @

## Related PRs

#1786 