### PR TITLE
AUT-345: GSON vs Jackson experiment

### DIFF
--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -25,6 +25,8 @@ dependencies {
             "com.amazonaws:aws-java-sdk-lambda:1.12.209",
             "com.google.protobuf:protobuf-java:3.20.1"
 
+    implementation "com.google.code.gson:gson:2.9.0"
+
     testImplementation configurations.tests,
             configurations.lambda_tests,
             project(":shared-test")

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
@@ -2,6 +2,7 @@ package uk.gov.di.authentication.shared.entity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.annotations.Expose;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -15,30 +16,39 @@ public class Session {
     }
 
     @JsonProperty("session_id")
+    @Expose
     private String sessionId;
 
     @JsonProperty("client_sessions")
+    @Expose
     private List<String> clientSessions;
 
     @JsonProperty("email_address")
+    @Expose
     private String emailAddress;
 
     @JsonProperty("retry_count")
+    @Expose
     private int retryCount;
 
     @JsonProperty("password_reset_count")
+    @Expose
     private int passwordResetCount;
 
     @JsonProperty("code_request_count")
+    @Expose
     private int codeRequestCount;
 
     @JsonProperty("current_credential_strength")
+    @Expose
     private CredentialTrustLevel currentCredentialStrength;
 
     @JsonProperty("is_new_account")
+    @Expose
     private AccountState isNewAccount;
 
     @JsonProperty("authenticated")
+    @Expose
     private boolean authenticated;
 
     public Session(String sessionId) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/SerializationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/SerializationService.java
@@ -1,0 +1,41 @@
+package uk.gov.di.authentication.shared.services;
+
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import static java.util.Objects.isNull;
+
+public class SerializationService {
+
+    private static SerializationService INSTANCE;
+    private static Logger LOG = LogManager.getLogger(SerializationService.class);
+
+    private final Gson gson;
+
+    public SerializationService() {
+        gson =
+                new GsonBuilder()
+                        .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+                        .serializeNulls()
+                        .excludeFieldsWithoutExposeAnnotation()
+                        .create();
+    }
+
+    public <T> T deserialize(String jsonString, Class<T> clazz) {
+        return gson.fromJson(jsonString, clazz);
+    }
+
+    public <T> String serialize(T object, Class<T> clazz) {
+        return gson.toJson(object, clazz);
+    }
+
+    public static SerializationService getInstance() {
+        if (isNull(INSTANCE)) {
+            INSTANCE = new SerializationService();
+        }
+        return INSTANCE;
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/SessionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/SessionService.java
@@ -22,6 +22,8 @@ public class SessionService {
     private static final Logger LOG = LogManager.getLogger(SessionService.class);
 
     private static final ObjectMapper OBJECT_MAPPER = ObjectMapperFactory.getInstance();
+    private static final SerializationService SERIALIZATION_SERVICE =
+            SerializationService.getInstance();
 
     private final ConfigurationService configurationService;
     private final RedisConnectionService redisConnectionService;
@@ -116,7 +118,7 @@ public class SessionService {
                         segmentedFunctionCall(
                                 "Deserialise session",
                                 () ->
-                                        OBJECT_MAPPER.readValue(
+                                        SERIALIZATION_SERVICE.deserialize(
                                                 redisConnectionService.getValue(sessionId),
                                                 Session.class)));
             } else {


### PR DESCRIPTION
## What?

- Use GSON to deserialise the `Session` object fetched from Redis. 

## Why?

This is an experiment to allow us to compare XRay traces with the Jackson version to compare performance.