### PR TITLE
AUT-345: Send backchannel logout to SQS async

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
@@ -164,7 +164,7 @@ public class LogoutHandler
         Map<String, String> queryStringParameters = input.getQueryStringParameters();
         if (queryStringParameters == null || queryStringParameters.isEmpty()) {
             LOG.info("Deleting session and returning default logout as no input parameters");
-            destroySessions(session);
+            segmentedFunctionCall("destroySessions", () -> destroySessions(session));
             return generateDefaultLogoutResponse(
                     state, input, context, Optional.empty(), Optional.of(session.getSessionId()));
         }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/BackChannelLogoutService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/BackChannelLogoutService.java
@@ -1,11 +1,9 @@
 package uk.gov.di.authentication.oidc.services;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.oidc.entity.BackChannelLogoutMessage;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
-import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.AwsSqsClient;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -64,10 +62,6 @@ public class BackChannelLogoutService {
                         clientRegistry.getBackChannelLogoutUri(),
                         subjectId);
 
-        try {
-            awsSqsClient.send(ObjectMapperFactory.getInstance().writeValueAsString(message));
-        } catch (JsonProcessingException e) {
-            LOGGER.error("Unable to serialise back channel logout message: " + message);
-        }
+        awsSqsClient.sendAsync(message);
     }
 }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/BackChannelLogoutServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/BackChannelLogoutServiceTest.java
@@ -6,7 +6,6 @@ import org.mockito.ArgumentCaptor;
 import uk.gov.di.authentication.oidc.entity.BackChannelLogoutMessage;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.UserProfile;
-import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.AwsSqsClient;
 
@@ -45,13 +44,11 @@ class BackChannelLogoutServiceTest {
                         .setBackChannelLogoutUri("http://localhost:8080/back-channel-logout"),
                 "test@test.com");
 
-        var captor = ArgumentCaptor.forClass(String.class);
+        var captor = ArgumentCaptor.forClass(BackChannelLogoutMessage.class);
 
-        verify(sqs).send(captor.capture());
+        verify(sqs).sendAsync(captor.capture());
 
-        var message =
-                ObjectMapperFactory.getInstance()
-                        .readValue(captor.getValue(), BackChannelLogoutMessage.class);
+        var message = captor.getValue();
 
         assertThat(message.getClientId(), is("client-id"));
         assertThat(message.getLogoutUri(), is("http://localhost:8080/back-channel-logout"));


### PR DESCRIPTION
## What?

- Use a completable future to send the backchannel logout event to the SQS queue.
- Add missing `segmentedFunctionCall()` on alternate path through `LogoutHandler`

## Why?

Xray shows 200-300ms latency when talking to SQS. As we don't need to wait for a result, lets try sending it asynchronously and see how that affects overall latency.
