### PR TITLE
AUT-345: Send application metrics asynchronously

### DIFF
--- a/delivery-receipts-integration-tests/src/test/java/uk/gov/di/deliveryreceipts/NotifyCallbackHandlerIntegrationTest.java
+++ b/delivery-receipts-integration-tests/src/test/java/uk/gov/di/deliveryreceipts/NotifyCallbackHandlerIntegrationTest.java
@@ -20,7 +20,9 @@ import uk.gov.di.authentication.sharedtest.extensions.ParameterStoreExtension;
 import java.util.Date;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.mock;
@@ -64,9 +66,13 @@ public class NotifyCallbackHandlerIntegrationTest {
                                 1),
                         Map.of("Authorization", "Bearer " + BEARER_TOKEN));
 
-        assertThat(
-                cloudwatchMetrics.getLastValue(DeliveryMetricStatus.SMS_DELIVERED.toString()),
-                is(1.0));
+        await().atMost(5, TimeUnit.SECONDS)
+                .untilAsserted(
+                        () ->
+                                assertThat(
+                                        cloudwatchMetrics.getLastValue(
+                                                DeliveryMetricStatus.SMS_DELIVERED.toString()),
+                                        is(1.0)));
         assertThat(response, hasStatus(204));
     }
 

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/CloudwatchMetricsExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/CloudwatchMetricsExtension.java
@@ -49,8 +49,15 @@ public class CloudwatchMetricsExtension extends BaseAwsResourceExtension
                         .endTime(Instant.now())
                         .build();
 
-        var results = cloudWatch.getMetricData(request).metricDataResults().get(0).values();
+        var response = cloudWatch.getMetricData(request);
+        if (response.metricDataResults().size() == 0) {
+            return 0.0;
+        }
 
+        var results = response.metricDataResults().get(0).values();
+        if (results.size() == 0) {
+            return 0.0;
+        }
         return results.get(results.size() - 1);
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsService.java
@@ -3,7 +3,7 @@ package uk.gov.di.authentication.shared.services;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
+import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient;
 import software.amazon.awssdk.services.cloudwatch.model.Dimension;
 import software.amazon.awssdk.services.cloudwatch.model.MetricDatum;
 import software.amazon.awssdk.services.cloudwatch.model.PutMetricDataRequest;
@@ -17,21 +17,22 @@ public class CloudwatchMetricsService {
 
     private static final Logger LOG = LogManager.getLogger(CloudwatchMetricsService.class);
 
-    private final CloudWatchClient cloudwatch;
+    private final CloudWatchAsyncClient cloudwatch;
 
     public CloudwatchMetricsService(ConfigurationService configurationService) {
-        var client =
-                CloudWatchClient.builder().region(Region.of(configurationService.getAwsRegion()));
+        var clientBuilder =
+                CloudWatchAsyncClient.builder()
+                        .region(Region.of(configurationService.getAwsRegion()));
 
         configurationService
                 .getLocalstackEndpointUri()
                 .map(URI::create)
-                .ifPresent(client::endpointOverride);
+                .ifPresent(clientBuilder::endpointOverride);
 
-        this.cloudwatch = client.build();
+        this.cloudwatch = clientBuilder.build();
     }
 
-    public CloudwatchMetricsService(CloudWatchClient cloudwatch) {
+    public CloudwatchMetricsService(CloudWatchAsyncClient cloudwatch) {
         this.cloudwatch = cloudwatch;
     }
 

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsServiceTest.java
@@ -3,7 +3,7 @@ package uk.gov.di.authentication.shared.services;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.ArgumentMatcher;
-import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
+import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient;
 import software.amazon.awssdk.services.cloudwatch.model.MetricDatum;
 import software.amazon.awssdk.services.cloudwatch.model.PutMetricDataRequest;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
@@ -29,7 +29,7 @@ class CloudwatchMetricsServiceTest {
 
     @Test
     void shouldPublishMetricValueWithDimensions() {
-        var cloudwatch = mock(CloudWatchClient.class);
+        var cloudwatch = mock(CloudWatchAsyncClient.class);
 
         var metrics = new CloudwatchMetricsService(cloudwatch);
 
@@ -41,7 +41,7 @@ class CloudwatchMetricsServiceTest {
 
     @Test
     void shouldIncrementCounter() {
-        var cloudwatch = mock(CloudWatchClient.class);
+        var cloudwatch = mock(CloudWatchAsyncClient.class);
 
         var metrics = new CloudwatchMetricsService(cloudwatch);
 
@@ -53,7 +53,7 @@ class CloudwatchMetricsServiceTest {
 
     @Test
     void shouldLogErrorAndContinueIfProblemPublishingMetric() {
-        var cloudwatch = mock(CloudWatchClient.class);
+        var cloudwatch = mock(CloudWatchAsyncClient.class);
 
         var metrics = new CloudwatchMetricsService(cloudwatch);
 


### PR DESCRIPTION
## What?

- In the `CloudwatchMetricsService` swap the `CloudWatchClient` for a `CloudWatchAsyncClient` so that metrics get sent asynchronously.

## Why?

Xray shows that sending of metrics, in `auth-code` takes anything from ~100ms to 7 seconds. This is a "fire and forget" operation, we don't wait for the results.
