### PR TITLE
Revert "BAU: Stop using TieredCompilation, it slowed down our lambdas"

### DIFF
--- a/ci/terraform/account-management/authorizer-warmer.tf
+++ b/ci/terraform/account-management/authorizer-warmer.tf
@@ -62,6 +62,7 @@ resource "aws_lambda_function" "warmer_function" {
       LAMBDA_QUALIFIER       = aws_lambda_alias.authorizer_alias.name
       LAMBDA_TYPE            = "AUTHORIZER"
       LAMBDA_MIN_CONCURRENCY = var.lambda_min_concurrency
+      JAVA_TOOL_OPTIONS      = "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
     }
   }
   kms_key_arn = data.terraform_remote_state.shared.outputs.lambda_env_vars_encryption_kms_key_arn

--- a/ci/terraform/account-management/authorizer.tf
+++ b/ci/terraform/account-management/authorizer.tf
@@ -35,6 +35,7 @@ resource "aws_lambda_function" "authorizer" {
     variables = {
       TOKEN_SIGNING_KEY_ALIAS = data.aws_kms_key.id_token_public_key.key_id
       ENVIRONMENT             = var.environment
+      JAVA_TOOL_OPTIONS       = "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
     }
   }
   kms_key_arn = data.terraform_remote_state.shared.outputs.lambda_env_vars_encryption_kms_key_arn

--- a/ci/terraform/account-management/sqs.tf
+++ b/ci/terraform/account-management/sqs.tf
@@ -184,6 +184,7 @@ resource "aws_lambda_function" "email_sqs_lambda" {
       CONTACT_US_LINK_ROUTE = var.contact_us_link_route
       NOTIFY_API_KEY        = var.notify_api_key
       NOTIFY_URL            = var.notify_url
+      JAVA_TOOL_OPTIONS     = "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
     })
   }
   kms_key_arn = data.terraform_remote_state.shared.outputs.lambda_env_vars_encryption_kms_key_arn

--- a/ci/terraform/modules/endpoint-module/lambda.tf
+++ b/ci/terraform/modules/endpoint-module/lambda.tf
@@ -22,7 +22,8 @@ resource "aws_lambda_function" "endpoint_lambda" {
   }
   environment {
     variables = merge(var.handler_environment_variables, {
-      WARMER_DELAY = var.warmer_delay_millis
+      WARMER_DELAY      = var.warmer_delay_millis
+      JAVA_TOOL_OPTIONS = "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
     })
   }
   kms_key_arn = var.lambda_env_vars_encryption_kms_key_arn

--- a/ci/terraform/modules/endpoint-module/warmer.tf
+++ b/ci/terraform/modules/endpoint-module/warmer.tf
@@ -145,8 +145,9 @@ resource "aws_lambda_function" "warmer_function" {
 
   environment {
     variables = merge(var.warmer_handler_environment_variables, {
-      LAMBDA_ARN       = aws_lambda_function.endpoint_lambda.arn
-      LAMBDA_QUALIFIER = aws_lambda_alias.endpoint_lambda.name
+      LAMBDA_ARN        = aws_lambda_function.endpoint_lambda.arn
+      LAMBDA_QUALIFIER  = aws_lambda_alias.endpoint_lambda.name
+      JAVA_TOOL_OPTIONS = "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
     })
   }
   kms_key_arn = var.lambda_env_vars_encryption_kms_key_arn

--- a/ci/terraform/oidc/sqs.tf
+++ b/ci/terraform/oidc/sqs.tf
@@ -177,6 +177,7 @@ resource "aws_lambda_function" "email_sqs_lambda" {
       NOTIFY_URL                = var.notify_url
       NOTIFY_TEST_PHONE_NUMBER  = var.notify_test_phone_number
       SMOKETEST_SMS_BUCKET_NAME = local.sms_bucket_name
+      JAVA_TOOL_OPTIONS         = "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
     })
   }
   kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn


### PR DESCRIPTION
## What

Revert alphagov/di-authentication-api#1734

## Why

We now believe that this wasn't to blame for the slow down as we have identified other sources of latency.
