### PR TITLE
AUT-5 - Return identity credentials in /user-info

### DIFF
--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -31,6 +31,7 @@ module "userinfo" {
     DYNAMO_ENDPOINT         = var.use_localstack ? var.lambda_dynamo_endpoint : null
     TOKEN_SIGNING_KEY_ALIAS = local.id_token_signing_key_alias_name
     IDENTITY_ENABLED        = var.ipv_api_enabled
+    IPV_DOMAIN              = var.ipv_domain
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.UserInfoHandler::handleRequest"
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -171,7 +171,7 @@ class StartHandlerTest {
     @Test
     void shouldReturn200WhenDocCheckingAppUserIsPresent()
             throws JsonProcessingException, ParseException {
-        when(configurationService.getDocAppDomain()).thenReturn("https://doc-app");
+        when(configurationService.getDocAppDomain()).thenReturn(URI.create("https://doc-app"));
         var userStartInfo = new UserStartInfo(false, false, false, false, null, null, true);
         when(startService.buildUserContext(session, clientSession)).thenReturn(userContext);
         var scope = new Scope(OIDCScopeValue.OPENID, CustomScopeValue.DOC_CHECKING_APP);

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/SPOTStatus.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/SPOTStatus.java
@@ -1,10 +1,6 @@
 package uk.gov.di.authentication.ipv.entity;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 public enum SPOTStatus {
-    @JsonProperty("Accepted")
     ACCEPTED,
-    @JsonProperty("Rejected")
     REJECTED;
 }

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandlerTest.java
@@ -33,7 +33,7 @@ class SPOTResponseHandlerTest {
     @Test
     void shouldWriteToDynamoForSuccesssfulSPOTResponse() {
         String json =
-                "{\"sub\":\"some-pairwise-identifier\",\"status\":\"Accepted\","
+                "{\"sub\":\"some-pairwise-identifier\",\"status\":\"ACCEPTED\","
                         + "\"claims\":{\"http://something/v1/verifiableIdentityJWT\":\"random-searalized-credential\"}}";
 
         handler.handleRequest(generateSQSEvent(json), context);
@@ -76,7 +76,7 @@ class SPOTResponseHandlerTest {
     @Test
     void shouldNotWriteToDynamoWhenSPOTResponseStatusIsNotOK() {
         String json =
-                "{\"sub\":\"some-pairwise-identifier\",\"status\":\"Rejected\","
+                "{\"sub\":\"some-pairwise-identifier\",\"status\":\"REJECTED\","
                         + "\"claims\":{\"http://something/v1/verifiableIdentityJWT\":\"random-searalized-credential\"}}";
 
         handler.handleRequest(generateSQSEvent(json), context);
@@ -99,7 +99,7 @@ class SPOTResponseHandlerTest {
     @Test
     void shouldNotWriteToDynamoWhenStatusIsOKButNoCredentialIsPresent() {
         String json =
-                "{\"sub\":\"some-pairwise-identifier\",\"status\":\"Accepted\"," + "\"claims\":{}}";
+                "{\"sub\":\"some-pairwise-identifier\",\"status\":\"ACCEPTED\"," + "\"claims\":{}}";
 
         handler.handleRequest(generateSQSEvent(json), context);
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandler.java
@@ -97,7 +97,8 @@ public class UserInfoHandler
                                 userInfo =
                                         userInfoService.populateUserInfo(
                                                 accessTokenInfo,
-                                                configurationService.isIdentityEnabled());
+                                                configurationService.isIdentityEnabled(),
+                                                configurationService.getIPVDomain());
                             } catch (AccessTokenException e) {
                                 LOG.warn(
                                         "AccessTokenException. Sending back UserInfoErrorResponse");

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandlerTest.java
@@ -34,6 +34,7 @@ public class UserInfoHandlerTest {
 
     private static final String EMAIL_ADDRESS = "joe.bloggs@digital.cabinet-office.gov.uk";
     private static final String PHONE_NUMBER = "01234567890";
+    private static final String IPV_DOMAIN = "https://ipv-domain";
     private static final Subject SUBJECT = new Subject();
     private final Context context = mock(Context.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
@@ -47,6 +48,7 @@ public class UserInfoHandlerTest {
     @BeforeEach
     void setUp() {
         handler = new UserInfoHandler(configurationService, userInfoService, accessTokenService);
+        when(configurationService.getIPVDomain()).thenReturn(IPV_DOMAIN);
     }
 
     @Test
@@ -60,7 +62,8 @@ public class UserInfoHandlerTest {
         userInfo.setEmailAddress(EMAIL_ADDRESS);
         when(accessTokenService.parse(accessToken.toAuthorizationHeader(), false))
                 .thenReturn(accessTokenInfo);
-        when(userInfoService.populateUserInfo(accessTokenInfo, false)).thenReturn(userInfo);
+        when(userInfoService.populateUserInfo(accessTokenInfo, false, IPV_DOMAIN))
+                .thenReturn(userInfo);
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setHeaders(Map.of("Authorization", accessToken.toAuthorizationHeader()));

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
@@ -21,7 +21,9 @@ import uk.gov.di.authentication.shared.entity.AccessTokenStore;
 import uk.gov.di.authentication.shared.entity.IdentityCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.ValidClaims;
+import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
+import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.DynamoIdentityService;
 import uk.gov.di.authentication.sharedtest.helper.SignedCredentialHelper;
@@ -62,6 +64,7 @@ class UserInfoServiceTest {
     private static final String PHONE_NUMBER = "01234567891";
     private static final String BASE_URL = "https://example.com";
     private static final String KEY_ID = "14342354354353";
+    private static final String IPV_DOMAIN = "https://ipv-domain";
     private final ClaimsSetRequest claimsSetRequest =
             new ClaimsSetRequest().add(ValidClaims.CORE_IDENTITY_JWT.getValue());
     private final OIDCClaimsRequest oidcValidClaimsRequest =
@@ -101,7 +104,7 @@ class UserInfoServiceTest {
         var accessTokenInfo =
                 new AccessTokenInfo(accessTokenStore, SUBJECT.getValue(), SCOPES, null);
 
-        var userInfo = userInfoService.populateUserInfo(accessTokenInfo, false);
+        var userInfo = userInfoService.populateUserInfo(accessTokenInfo, false, IPV_DOMAIN);
         assertThat(userInfo.getEmailAddress(), equalTo(EMAIL));
         assertThat(userInfo.getEmailVerified(), equalTo(true));
         assertThat(userInfo.getPhoneNumber(), equalTo(PHONE_NUMBER));
@@ -124,7 +127,7 @@ class UserInfoServiceTest {
         var accessTokenInfo =
                 new AccessTokenInfo(accessTokenStore, SUBJECT.getValue(), scopes, null);
 
-        var userInfo = userInfoService.populateUserInfo(accessTokenInfo, false);
+        var userInfo = userInfoService.populateUserInfo(accessTokenInfo, false, IPV_DOMAIN);
         assertThat(userInfo.getEmailAddress(), equalTo(EMAIL));
         assertThat(userInfo.getEmailVerified(), equalTo(true));
         assertNull(userInfo.getPhoneNumber());
@@ -146,7 +149,7 @@ class UserInfoServiceTest {
         var accessTokenInfo =
                 new AccessTokenInfo(accessTokenStore, SUBJECT.getValue(), SCOPES, null);
 
-        var userInfo = userInfoService.populateUserInfo(accessTokenInfo, true);
+        var userInfo = userInfoService.populateUserInfo(accessTokenInfo, true, IPV_DOMAIN);
         assertThat(userInfo.getEmailAddress(), equalTo(EMAIL));
         assertThat(userInfo.getEmailVerified(), equalTo(true));
         assertThat(userInfo.getPhoneNumber(), equalTo(PHONE_NUMBER));
@@ -159,10 +162,16 @@ class UserInfoServiceTest {
     @Test
     void shouldPopulateIdentityClaimsWhenClaimsArePresentAndIdentityIsEnabled()
             throws JOSEException {
+        var userProfile = generateUserprofile();
+        var ipvSubject =
+                ClientSubjectHelper.calculatePairwiseIdentifier(
+                        SUBJECT.getValue(), "ipv-domain", userProfile.getSalt().array());
         accessToken = createSignedAccessToken(oidcValidClaimsRequest);
         when(authenticationService.getUserProfileFromSubject(INTERNAL_SUBJECT.getValue()))
-                .thenReturn(generateUserprofile());
-        when(spotService.getIdentityCredentials(SUBJECT.getValue()))
+                .thenReturn(userProfile);
+        when(authenticationService.getOrGenerateSalt(userProfile))
+                .thenReturn(userProfile.getSalt().array());
+        when(spotService.getIdentityCredentials(ipvSubject))
                 .thenReturn(Optional.of(identityCredentials));
 
         var accessTokenStore =
@@ -176,7 +185,7 @@ class UserInfoServiceTest {
                                 .map(ClaimsSetRequest.Entry::getClaimName)
                                 .collect(Collectors.toList()));
 
-        var userInfo = userInfoService.populateUserInfo(accessTokenInfo, true);
+        var userInfo = userInfoService.populateUserInfo(accessTokenInfo, true, IPV_DOMAIN);
         assertThat(userInfo.getEmailAddress(), equalTo(EMAIL));
         assertThat(userInfo.getEmailVerified(), equalTo(true));
         assertThat(userInfo.getPhoneNumber(), equalTo(PHONE_NUMBER));
@@ -214,6 +223,7 @@ class UserInfoServiceTest {
                 .setEmailVerified(true)
                 .setPhoneNumber(PHONE_NUMBER)
                 .setPhoneNumberVerified(true)
+                .setSalt(SaltHelper.generateNewSalt())
                 .setSubjectID(SUBJECT.toString())
                 .setCreated(LocalDateTime.now().toString())
                 .setUpdated(LocalDateTime.now().toString());

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ClientSubjectHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ClientSubjectHelper.java
@@ -79,6 +79,11 @@ public class ClientSubjectHelper {
         }
     }
 
+    public static String calculatePairwiseIdentifier(String subjectID, URI uri, byte[] salt) {
+        var host = returnHost(uri.toString());
+        return calculatePairwiseIdentifier(subjectID, host, salt);
+    }
+
     public static String calculatePairwiseIdentifier(
             String subjectID, String sectorHost, byte[] salt) {
         try {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -147,8 +147,8 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return docAppCredentialSigningPublicKey;
     }
 
-    public String getDocAppDomain() {
-        return System.getenv("DOC_APP_DOMAIN");
+    public URI getDocAppDomain() {
+        return URI.create(System.getenv("DOC_APP_DOMAIN"));
     }
 
     public String getDomainName() {


### PR DESCRIPTION
## What?

- Retrieve identity credentials using pairwise identifier
- Generate the doc app pairwise identifier correctly
- Put the SPOTStatus in uppercase

## Why?

- We save identity information in the identity credentials table using the pairwise identifier as the key. This pairwise identifier is generated using the IPV domain as the sector URI and NOT the RP sector URI
- The doc app domain will need to be parsed to a host before generating a pairwise identifier. Add an overloaded method to the ClientSubjectHelper to cater for this
- SPOT will be returning the status in uppercase so lets be explicit 