### PR TITLE
AUT-352 - Check ipv flag in authorize

### DIFF
--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -9,6 +9,7 @@ module "oidc_authorize_role" {
     aws_iam_policy.dynamo_user_read_access_policy.arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
+    aws_iam_policy.ipv_capacity_parameter_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
   ]
 }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/IPVCapacityService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/IPVCapacityService.java
@@ -1,0 +1,16 @@
+package uk.gov.di.authentication.oidc.services;
+
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+public class IPVCapacityService {
+
+    private final ConfigurationService configurationService;
+
+    public IPVCapacityService(ConfigurationService configurationService) {
+        this.configurationService = configurationService;
+    }
+
+    public boolean isIPVCapacityAvailable() {
+        return configurationService.getIPVCapacity().map(c -> c.equals("1")).orElse(false);
+    }
+}

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
@@ -230,5 +230,10 @@ public abstract class HandlerIntegrationTest<Q, S> {
         public String getSpotQueueUri() {
             return spotQueue.getQueueUrl();
         }
+
+        @Override
+        public Optional<String> getIPVCapacity() {
+            return Optional.of("1");
+        }
     }
 }


### PR DESCRIPTION
## What?

- For any RP which has a level of confidence in the auth request, we need to check the ipv capacity param in parameter store to ensure that identity is available before redirecting them to the frontend. If the flag is false then we need to redirect the user back to the RP with a temporarily_unavailable.
- Give authorize lambda permissions to read the ipv capacity param in parameter store

## Why?

- So that we don't send a user on who requires identity when identity is not available. 