### PR TITLE
AUT-352 - Enable doc app lambdas in build

### DIFF
--- a/ci/terraform/oidc/build-overrides.tfvars
+++ b/ci/terraform/oidc/build-overrides.tfvars
@@ -1,3 +1,5 @@
+doc_app_api_enabled = true
+
 blocked_email_duration = 30
 
 logging_endpoint_arns = [


### PR DESCRIPTION
## What?

- Enable doc app lambdas in build

## Why?

- We want to be able to test the doc app journey in the build environment using our stubs. Therefore set the doc_app_api_enabled to allow this to happen.