### PR TITLE
AUT-352 - Move IPV capacity parameter to OIDC module 

### DIFF
--- a/ci/terraform/oidc/integration-overrides.tfvars
+++ b/ci/terraform/oidc/integration-overrides.tfvars
@@ -1,4 +1,5 @@
 ipv_api_enabled                = true
+ipv_capacity_allowed           = true
 ipv_authorisation_client_id    = "authOrchestrator"
 ipv_authorisation_uri          = "https://integration-di-ipv-core-front.london.cloudapps.digital/oauth2/authorize"
 ipv_authorisation_callback_uri = "https://oidc.integration.account.gov.uk/ipv-callback"

--- a/ci/terraform/oidc/shared.tf
+++ b/ci/terraform/oidc/shared.tf
@@ -37,6 +37,5 @@ locals {
   lambda_parameter_encryption_alias_id        = data.terraform_remote_state.shared.outputs.lambda_parameter_encryption_alias_id
   redis_ssm_parameter_policy                  = data.terraform_remote_state.shared.outputs.redis_ssm_parameter_policy
   pepper_ssm_parameter_policy                 = data.terraform_remote_state.shared.outputs.pepper_ssm_parameter_policy
-  ipv_capacity_ssm_parameter_policy           = data.terraform_remote_state.shared.outputs.ipv_capacity_ssm_parameter_policy
   lambda_code_signing_configuration_arn       = data.terraform_remote_state.shared.outputs.lambda_code_signing_configuration_arn
 }

--- a/ci/terraform/oidc/ssm.tf
+++ b/ci/terraform/oidc/ssm.tf
@@ -20,16 +20,37 @@ resource "aws_iam_policy" "pepper_parameter_policy" {
   name_prefix = "pepper-parameter-store-policy"
 }
 
+## IPV capacity parameter
 
-data "aws_iam_policy" "ipv_capacity_parameter_policy" {
-  arn = local.ipv_capacity_ssm_parameter_policy
+resource "aws_ssm_parameter" "ipv-capacity" {
+  name  = "${var.environment}-ipv-capacity"
+  type  = "String"
+  value = var.ipv_capacity_allowed ? "1" : "0"
+}
+
+data "aws_iam_policy_document" "ipv_capacity_parameter_policy_document" {
+  statement {
+    sid    = "AllowGetParameters"
+    effect = "Allow"
+
+    actions = [
+      "ssm:GetParameter",
+      "ssm:GetParameters",
+    ]
+
+    resources = [
+      aws_ssm_parameter.ipv-capacity.arn
+    ]
+  }
 }
 
 resource "aws_iam_policy" "ipv_capacity_parameter_policy" {
-  policy      = data.aws_iam_policy.ipv_capacity_parameter_policy.policy
+  policy      = data.aws_iam_policy_document.ipv_capacity_parameter_policy_document.json
   path        = "/${var.environment}/lambda-parameters/"
   name_prefix = "ipv-capacity-parameter-store-policy"
 }
+
+## IPV public encryption key parameter
 
 resource "aws_ssm_parameter" "ipv_public_encryption_key" {
   name  = "${var.environment}-ipv-public-encryption-key"
@@ -59,6 +80,8 @@ resource "aws_iam_policy" "ipv_public_encryption_key_parameter_policy" {
   name_prefix = "ipv-public-encryption-key-parameter-store-policy"
 }
 
+## Doc app public encryption key parameter
+
 resource "aws_ssm_parameter" "doc_app_public_encryption_key" {
   name  = "${var.environment}-doc-app-public-encryption-key"
   type  = "String"
@@ -86,6 +109,8 @@ resource "aws_iam_policy" "doc_app_public_encryption_key_parameter_policy" {
   path        = "/${var.environment}/lambda-parameters/"
   name_prefix = "doc-app-public-encryption-key-parameter-store-policy"
 }
+
+## Doc app public signing key parameter
 
 resource "aws_ssm_parameter" "doc_app_public_signing_key" {
   name  = "${var.environment}-doc-app-public-signing-key"

--- a/ci/terraform/oidc/staging-overrides.tfvars
+++ b/ci/terraform/oidc/staging-overrides.tfvars
@@ -1,4 +1,5 @@
 doc_app_api_enabled                = true
+ipv_capacity_allowed               = true
 ipv_api_enabled                    = true
 ipv_authorisation_client_id        = "authOrchestrator"
 ipv_authorisation_uri              = "https://staging-di-ipv-core-front.london.cloudapps.digital/oauth2/authorize"

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -228,6 +228,10 @@ variable "ipv_api_enabled" {
   default = false
 }
 
+variable "ipv_capacity_allowed" {
+  default = false
+}
+
 variable "ipv_authorisation_uri" {
   type    = string
   default = "undefined"

--- a/ci/terraform/shared/outputs.tf
+++ b/ci/terraform/shared/outputs.tf
@@ -142,10 +142,6 @@ output "pepper_ssm_parameter_policy" {
   value = aws_iam_policy.pepper_parameter_policy.arn
 }
 
-output "ipv_capacity_ssm_parameter_policy" {
-  value = aws_iam_policy.ipv_capacity_parameter_policy.arn
-}
-
 output "lambda_code_signing_configuration_arn" {
   value = aws_lambda_code_signing_config.code_signing_config.arn
 }

--- a/ci/terraform/shared/ssm.tf
+++ b/ci/terraform/shared/ssm.tf
@@ -182,30 +182,3 @@ resource "aws_iam_role_policy_attachment" "lambda_iam_role_pepper_parameters" {
   policy_arn = aws_iam_policy.pepper_parameter_policy.arn
   role       = aws_iam_role.lambda_iam_role.name
 }
-
-data "aws_iam_policy_document" "ipv_capacity_parameter_policy_document" {
-  statement {
-    sid    = "AllowGetParameters"
-    effect = "Allow"
-
-    actions = [
-      "ssm:GetParameter",
-      "ssm:GetParameters",
-    ]
-
-    resources = [
-      aws_ssm_parameter.ipv-capacity.arn
-    ]
-  }
-}
-
-resource "aws_iam_policy" "ipv_capacity_parameter_policy" {
-  policy      = data.aws_iam_policy_document.ipv_capacity_parameter_policy_document.json
-  path        = "/${var.environment}/lambda-parameters/"
-  name_prefix = "ipv-capacity-parameter-store-policy"
-}
-
-resource "aws_iam_role_policy_attachment" "lambda_iam_role_ipv_capacity_parameters" {
-  policy_arn = aws_iam_policy.ipv_capacity_parameter_policy.arn
-  role       = aws_iam_role.lambda_iam_role.name
-}


### PR DESCRIPTION
## What?

- Move IPV capacity parameter to OIDC module
- Set IPV capacity to true for Integration and Staging environment

## Why?

- The IPV capacity parameter is only ever used in the OIDC terraform module. Moving this parameter here makes it easier to configure the variables alongside the other IPV terraform variables.
 - Otherwise we will not be able to test out the IPV journey