### PR TITLE
AUT-33 - Prefix pairwise identifiers with urn:uuid:

### DIFF
--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/BackChannelLogoutServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/BackChannelLogoutServiceTest.java
@@ -1,6 +1,5 @@
 package uk.gov.di.authentication.oidc.services;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import uk.gov.di.authentication.oidc.entity.BackChannelLogoutMessage;
@@ -28,8 +27,7 @@ class BackChannelLogoutServiceTest {
             new BackChannelLogoutService(sqs, authenticationService);
 
     @Test
-    void shouldPostBackChannelLogoutMessageToSqsForPairwiseClients()
-            throws JsonProcessingException {
+    void shouldPostBackChannelLogoutMessageToSqsForPairwiseClients() {
         var user = new UserProfile().setPublicSubjectID("public").setSubjectID("subject");
 
         when(authenticationService.getUserProfileByEmailMaybe("test@test.com"))
@@ -54,7 +52,7 @@ class BackChannelLogoutServiceTest {
         assertThat(message.getLogoutUri(), is("http://localhost:8080/back-channel-logout"));
         assertThat(
                 message.getSubjectId(),
-                is("b46381e6de5f4405ff162a3aa91223f0a3c32fbbce839802a88e25e670d9083b"));
+                is("urn:uuid:b46381e6de5f4405ff162a3aa91223f0a3c32fbbce839802a88e25e670d9083b"));
     }
 
     @Test

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ClientSubjectHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ClientSubjectHelper.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 public class ClientSubjectHelper {
 
     private static final Logger LOG = LogManager.getLogger(ClientSubjectHelper.class);
+    private static final String PAIRWISE_PREFIX = "urn:uuid:";
 
     public static Subject getSubject(
             UserProfile userProfile,
@@ -99,7 +100,7 @@ public class ClientSubjectHelper {
                 sb.append(Integer.toString((aByte & 0xff) + 0x100, 16).substring(1));
             }
 
-            return sb.toString();
+            return PAIRWISE_PREFIX + sb;
         } catch (NoSuchAlgorithmException e) {
             LOG.error("Failed to hash", e);
             throw new RuntimeException(e);

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ClientSubjectHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ClientSubjectHelperTest.java
@@ -106,6 +106,38 @@ class ClientSubjectHelperTest {
     }
 
     @Test
+    void shouldReturnSubjectIDAsURIWhenClientTypeIsPairwise() {
+        stubAuthenticationService();
+        var keyPair = generateRsaKeyPair();
+        var userProfile = generateUserProfile();
+
+        var clientRegistry1 =
+                generateClientRegistryPairwise(
+                        keyPair, "test-client-id-1", "pairwise", "https://test.com");
+
+        var subject =
+                ClientSubjectHelper.getSubject(userProfile, clientRegistry1, authenticationService);
+
+        assertTrue(subject.getValue().startsWith("urn:uuid:"));
+    }
+
+    @Test
+    void shouldNotReturnSubjectIDAsURIWhenClientTypeIsPublic() {
+        stubAuthenticationService();
+        var keyPair = generateRsaKeyPair();
+        var userProfile = generateUserProfile();
+
+        var clientRegistry1 =
+                generateClientRegistryPairwise(
+                        keyPair, "test-client-id-1", "public", "https://test.com");
+
+        var subject =
+                ClientSubjectHelper.getSubject(userProfile, clientRegistry1, authenticationService);
+
+        assertFalse(subject.getValue().startsWith("urn:uuid:"));
+    }
+
+    @Test
     void shouldGetHostAsSectorIdentierWhenDefinedByClient() {
         KeyPair keyPair = generateRsaKeyPair();
         ClientRegistry clientRegistry1 =
@@ -258,15 +290,15 @@ class ClientSubjectHelperTest {
     }
 
     private ClientRegistry generateClientRegistryPairwise(
-            KeyPair keyPair, String clientID, String subectType, String sector) {
+            KeyPair keyPair, String clientID, String subjectType, String sector) {
         return generateClientRegistryPairwise(
-                keyPair, clientID, subectType, sector, singletonList(REDIRECT_URI));
+                keyPair, clientID, subjectType, sector, singletonList(REDIRECT_URI));
     }
 
     private ClientRegistry generateClientRegistryPairwise(
             KeyPair keyPair,
             String clientID,
-            String subectType,
+            String subjectType,
             String sector,
             List<String> redirectUrls) {
         return new ClientRegistry()
@@ -278,7 +310,7 @@ class ClientSubjectHelperTest {
                 .setPublicKey(
                         Base64.getMimeEncoder().encodeToString(keyPair.getPublic().getEncoded()))
                 .setSectorIdentifierUri(sector)
-                .setSubjectType(subectType);
+                .setSubjectType(subjectType);
     }
 
     private UserProfile generateUserProfile() {


### PR DESCRIPTION
## What?

- At the point of generating a pairwise identifier, they should be prefixed with `urn:uuid:`.

## Why?

- Verifiable Credentials require identifiers to be URIs, which in this case is the pairwise identifier. Keep things consistent and make pairwises identifiers all have the same prefix.
- See RFC-0014 for more info - https://github.com/alphagov/digital-identity-architecture/blob/main/rfc/0014-identity-ipv-core-oauth-profile.md