### PR TITLE
BAU - Retrieve identity credentials using subject in access token

### DIFF
--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -31,7 +31,6 @@ module "userinfo" {
     DYNAMO_ENDPOINT         = var.use_localstack ? var.lambda_dynamo_endpoint : null
     TOKEN_SIGNING_KEY_ALIAS = local.id_token_signing_key_alias_name
     IDENTITY_ENABLED        = var.ipv_api_enabled
-    IPV_DOMAIN              = var.ipv_domain
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.UserInfoHandler::handleRequest"
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
@@ -19,7 +19,6 @@ import uk.gov.di.authentication.shared.entity.ClientType;
 import uk.gov.di.authentication.shared.entity.CustomScopeValue;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.shared.entity.ValidClaims;
-import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.helper.KeyPairHelper;
@@ -50,7 +49,6 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     private static final String FORMATTED_PHONE_NUMBER = "+441234567890";
     private static final String TEST_PASSWORD = "password-1";
     private static final String CLIENT_ID = "client-id-one";
-    private static final String IPV_DOMAIN = "https://ipv-domain";
     private static final String APP_CLIENT_ID = "app-client-id-one";
     private static final String ACCESS_TOKEN_PREFIX = "ACCESS_TOKEN:";
     private static final Subject PUBLIC_SUBJECT = new Subject();
@@ -239,14 +237,10 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     }
 
     private void setUpDynamo(String coreIdentityJWT) {
-        userStore.signUp(TEST_EMAIL_ADDRESS, TEST_PASSWORD, INTERNAL_SUBJECT);
-        var salt = userStore.addSalt(TEST_EMAIL_ADDRESS);
         if (Objects.nonNull(coreIdentityJWT)) {
-            var pairwiseIdentifier =
-                    ClientSubjectHelper.calculatePairwiseIdentifier(
-                            INTERNAL_SUBJECT.getValue(), "ipv-domain", salt);
-            identityStore.addCoreIdentityJWT(pairwiseIdentifier, coreIdentityJWT);
+            identityStore.addCoreIdentityJWT(PUBLIC_SUBJECT.getValue(), coreIdentityJWT);
         }
+        userStore.signUp(TEST_EMAIL_ADDRESS, TEST_PASSWORD, INTERNAL_SUBJECT);
         userStore.addPhoneNumber(TEST_EMAIL_ADDRESS, TEST_PHONE_NUMBER);
         userStore.setPhoneNumberVerified(TEST_EMAIL_ADDRESS, true);
         KeyPair keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
@@ -295,11 +289,6 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         @Override
         public boolean isIdentityEnabled() {
             return true;
-        }
-
-        @Override
-        public String getIPVDomain() {
-            return IPV_DOMAIN;
         }
     }
 }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/AccessTokenInfo.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/AccessTokenInfo.java
@@ -7,17 +7,17 @@ import java.util.List;
 public class AccessTokenInfo {
 
     private final AccessTokenStore accessTokenStore;
-    private final String publicSubject;
+    private final String subject;
     private final List<String> scopes;
     private final List<String> identityClaims;
 
     public AccessTokenInfo(
             AccessTokenStore accessTokenStore,
-            String publicSubject,
+            String subject,
             List<String> scopes,
             List<String> identityClaims) {
         this.accessTokenStore = accessTokenStore;
-        this.publicSubject = publicSubject;
+        this.subject = subject;
         this.scopes = scopes;
         this.identityClaims = identityClaims;
     }
@@ -26,8 +26,8 @@ public class AccessTokenInfo {
         return accessTokenStore;
     }
 
-    public String getPublicSubject() {
-        return publicSubject;
+    public String getSubject() {
+        return subject;
     }
 
     public List<String> getScopes() {

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
@@ -304,7 +304,7 @@ public class TokenHandler
                                 UserProfile userProfile =
                                         dynamoService.getUserProfileByEmail(
                                                 authCodeExchangeData.getEmail());
-                                Subject publicSubject =
+                                Subject subject =
                                         ClientSubjectHelper.getSubject(
                                                 userProfile, client, dynamoService);
                                 tokenResponse =
@@ -317,7 +317,7 @@ public class TokenHandler
                                                                         userProfile.getSubjectID()),
                                                                 authRequest.getScope(),
                                                                 additionalTokenClaims,
-                                                                publicSubject,
+                                                                subject,
                                                                 vot,
                                                                 userProfile.getClientConsent(),
                                                                 isConsentRequired,
@@ -348,12 +348,12 @@ public class TokenHandler
             return generateApiGatewayProxyResponse(
                     400, OAuth2Error.INVALID_GRANT.toJSONObject().toJSONString());
         }
-        Subject publicSubject;
+        Subject subject;
         List<String> scopes;
         String jti;
         try {
             SignedJWT signedJwt = SignedJWT.parse(currentRefreshToken.getValue());
-            publicSubject = new Subject(signedJwt.getJWTClaimsSet().getSubject());
+            subject = new Subject(signedJwt.getJWTClaimsSet().getSubject());
             scopes = (List<String>) signedJwt.getJWTClaimsSet().getClaim("scope");
             jti = signedJwt.getJWTClaimsSet().getJWTID();
         } catch (java.text.ParseException e) {
@@ -397,10 +397,7 @@ public class TokenHandler
 
         OIDCTokenResponse tokenResponse =
                 tokenService.generateRefreshTokenResponse(
-                        clientId,
-                        new Subject(tokenStore.getInternalSubjectId()),
-                        scopes,
-                        publicSubject);
+                        clientId, new Subject(tokenStore.getInternalSubjectId()), scopes, subject);
         LOG.info("Generating successful RefreshToken response");
         return generateApiGatewayProxyResponse(200, tokenResponse.toJSONObject().toJSONString());
     }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandler.java
@@ -105,8 +105,7 @@ public class UserInfoHandler
                                 userInfo =
                                         userInfoService.populateUserInfo(
                                                 accessTokenInfo,
-                                                configurationService.isIdentityEnabled(),
-                                                configurationService.getIPVDomain());
+                                                configurationService.isIdentityEnabled());
                             } catch (AccessTokenException e) {
                                 LOG.warn(
                                         "AccessTokenException. Sending back UserInfoErrorResponse");

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/UserInfoService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/UserInfoService.java
@@ -34,7 +34,7 @@ public class UserInfoService {
 
     public UserInfo populateUserInfo(AccessTokenInfo accessTokenInfo, boolean identityEnabled) {
         LOG.info("Populating UserInfo");
-        var userInfo = new UserInfo(new Subject(accessTokenInfo.getPublicSubject()));
+        var userInfo = new UserInfo(new Subject(accessTokenInfo.getSubject()));
         if (accessTokenInfo.getScopes().contains(CustomScopeValue.DOC_CHECKING_APP.getValue())) {
             return populateDocAppUserInfo(accessTokenInfo, userInfo);
         }
@@ -63,9 +63,7 @@ public class UserInfoService {
     private UserInfo populateIdentityInfo(AccessTokenInfo accessTokenInfo, UserInfo userInfo) {
         LOG.info("Populating IdentityInfo");
         var identityCredentials =
-                identityService
-                        .getIdentityCredentials(accessTokenInfo.getPublicSubject())
-                        .orElse(null);
+                identityService.getIdentityCredentials(accessTokenInfo.getSubject()).orElse(null);
         if (Objects.isNull(identityCredentials)) {
             LOG.info("No identity credentials present");
             return userInfo;
@@ -85,7 +83,7 @@ public class UserInfoService {
 
     private UserInfo populateDocAppUserInfo(AccessTokenInfo accessTokenInfo, UserInfo userInfo) {
         return dynamoDocAppService
-                .getDocAppCredential(accessTokenInfo.getPublicSubject())
+                .getDocAppCredential(accessTokenInfo.getSubject())
                 .map(
                         docAppCredential -> {
                             userInfo.setClaim(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandlerTest.java
@@ -34,7 +34,6 @@ public class UserInfoHandlerTest {
 
     private static final String EMAIL_ADDRESS = "joe.bloggs@digital.cabinet-office.gov.uk";
     private static final String PHONE_NUMBER = "01234567890";
-    private static final String IPV_DOMAIN = "https://ipv-domain";
     private static final Subject SUBJECT = new Subject();
     private final Context context = mock(Context.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
@@ -48,7 +47,6 @@ public class UserInfoHandlerTest {
     @BeforeEach
     void setUp() {
         handler = new UserInfoHandler(configurationService, userInfoService, accessTokenService);
-        when(configurationService.getIPVDomain()).thenReturn(IPV_DOMAIN);
     }
 
     @Test
@@ -62,8 +60,7 @@ public class UserInfoHandlerTest {
         userInfo.setEmailAddress(EMAIL_ADDRESS);
         when(accessTokenService.parse(accessToken.toAuthorizationHeader(), false))
                 .thenReturn(accessTokenInfo);
-        when(userInfoService.populateUserInfo(accessTokenInfo, false, IPV_DOMAIN))
-                .thenReturn(userInfo);
+        when(userInfoService.populateUserInfo(accessTokenInfo, false)).thenReturn(userInfo);
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setHeaders(Map.of("Authorization", accessToken.toAuthorizationHeader()));

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AccessTokenServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AccessTokenServiceTest.java
@@ -130,7 +130,7 @@ class AccessTokenServiceTest {
         assertThat(
                 accessTokenInfo.getAccessTokenStore().getInternalSubjectId(),
                 equalTo(INTERNAL_SUBJECT.getValue()));
-        assertThat(accessTokenInfo.getPublicSubject(), equalTo(SUBJECT.getValue()));
+        assertThat(accessTokenInfo.getSubject(), equalTo(SUBJECT.getValue()));
         assertThat(accessTokenInfo.getScopes(), equalTo(SCOPES));
         assertThat(accessTokenInfo.getIdentityClaims(), equalTo(expectedIdentityClaims));
     }


### PR DESCRIPTION
## What?

- Identity credentials will be saved using a pairwise identifier generated with the RP sector identifier. This is and should be the same pairwise identifier that we have set in the access token, therefore we can just use that to retrieve the identity credentials. 
- We have a variable in a number of places called `publicSubject`. This is misleading as it can sometimes be either a publicSubject or pairwiseSubject identifier depending on the client. Calling it subject is more generic and appropriate

## Why?

- Otherwise we will not be able to retrieve identity credentials 
- To make it clear what the subject is and isn't