### PR TITLE
AUT-328 - Give callback lambda read permissions to client registry

### DIFF
--- a/ci/terraform/oidc/doc-app-callback.tf
+++ b/ci/terraform/oidc/doc-app-callback.tf
@@ -12,6 +12,7 @@ module "doc_app_callback_role" {
     aws_iam_policy.doc_app_public_signing_key_parameter_policy.arn,
     aws_iam_policy.dynamo_doc_app_write_access_policy.arn,
     aws_iam_policy.dynamo_doc_app_read_access_policy.arn,
+    aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
   ]
 }
 


### PR DESCRIPTION
## What?

 - Give callback lambda permissions to client registry table

## Why?

- Needs to get the client from client registry 