### PR TITLE
AUT-328 - Remove api key from doc app callback lambda

### DIFF
--- a/ci/terraform/oidc/doc-app-callback.tf
+++ b/ci/terraform/oidc/doc-app-callback.tf
@@ -66,7 +66,7 @@ module "doc-app-callback" {
   cloudwatch_log_retention               = var.cloudwatch_log_retention
   lambda_env_vars_encryption_kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn
   default_tags                           = local.default_tags
-  api_key_required                       = true
+  api_key_required                       = false
 
   keep_lambda_warm             = var.keep_lambdas_warm
   warmer_handler_function_name = "uk.gov.di.lambdawarmer.lambda.LambdaWarmerHandler::handleRequest"


### PR DESCRIPTION
## What?

 - Remove api key from doc app callback lambda

## Why?

- it is not needed as it is the callback lambda