### PR TITLE
AUT_328 - Give doc app callback lambda permission to egress

### DIFF
--- a/ci/terraform/oidc/doc-app-callback.tf
+++ b/ci/terraform/oidc/doc-app-callback.tf
@@ -55,7 +55,6 @@ module "doc-app-callback" {
 
   authentication_vpc_arn = local.authentication_vpc_arn
   security_group_ids = [
-    local.authentication_security_group_id,
     local.authentication_oidc_redis_security_group_id,
     local.authentication_egress_security_group_id,
   ]


### PR DESCRIPTION
## What?

 - Remove the `authentication_security_group_id` as this restricts permissions for this lambda to egress. This is giving this lambda the same permissions as the ipv callback lambda

## Why?

- It needs to egress to call the token endpoint
