### PR TITLE
BAU - Change endpoint of the data endpoint for the doc app

### DIFF
--- a/ci/terraform/oidc/build-overrides.tfvars
+++ b/ci/terraform/oidc/build-overrides.tfvars
@@ -1,5 +1,5 @@
 doc_app_api_enabled                = true
-doc_app_cri_data_endpoint          = "user-identity"
+doc_app_cri_data_endpoint          = "credentials/issue"
 doc_app_backend_uri                = "https://build-doc-app-cri-stub.london.cloudapps.digital"
 doc_app_domain                     = "https://build-doc-app-cri-stub.london.cloudapps.digital"
 doc_app_authorisation_client_id    = "authOrchestrator"


### PR DESCRIPTION
## What?

- Change endpoint of the data endpoint for the doc app

## Why?

- The Stub CRI uses /credentials/issue instead of user-identity