### PR TITLE
AUT-328 - Parse the scope claim in the token handler from a request object

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
@@ -46,6 +46,7 @@ import java.util.Optional;
 
 import static java.lang.String.format;
 import static uk.gov.di.authentication.shared.conditions.DocAppUserHelper.getRequestObjectClaim;
+import static uk.gov.di.authentication.shared.conditions.DocAppUserHelper.getRequestObjectScopeClaim;
 import static uk.gov.di.authentication.shared.conditions.DocAppUserHelper.isDocCheckingAppUserWithSubjectId;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.authentication.shared.helpers.ConstructUriHelper.buildURI;
@@ -284,10 +285,7 @@ public class TokenHandler
                             final OIDCClaimsRequest finalClaimsRequest = claimsRequest;
                             OIDCTokenResponse tokenResponse;
                             if (isDocCheckingAppUserWithSubjectId(clientSession)) {
-                                Scope scope =
-                                        new Scope(
-                                                getRequestObjectClaim(
-                                                        authRequest, "scope", String.class));
+                                Scope scope = new Scope(getRequestObjectScopeClaim(authRequest));
                                 tokenResponse =
                                         segmentedFunctionCall(
                                                 "generateTokenResponse",

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
@@ -416,7 +416,7 @@ public class TokenHandlerTest {
         when(tokenService.generateTokenResponse(
                         DOC_APP_CLIENT_ID.getValue(),
                         DOC_APP_USER_PUBLIC_SUBJECT,
-                        new Scope(DOC_CHECKING_APP),
+                        new Scope(OIDCScopeValue.OPENID, DOC_CHECKING_APP),
                         Map.of(),
                         DOC_APP_USER_PUBLIC_SUBJECT,
                         vtr.retrieveVectorOfTrustForToken(),
@@ -557,12 +557,13 @@ public class TokenHandlerTest {
 
     private static AuthorizationRequest generateRequestObjectAuthRequest() throws JOSEException {
         var keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        Scope scope = new Scope(DOC_CHECKING_APP, OIDCScopeValue.OPENID);
         var jwtClaimsSet =
                 new JWTClaimsSet.Builder()
                         .audience(AUDIENCE)
-                        .claim("redirect_uri", REDIRECT_URI.toString())
+                        .claim("redirect_uri", REDIRECT_URI)
                         .claim("response_type", ResponseType.CODE.toString())
-                        .claim("scope", DOC_CHECKING_APP.toString())
+                        .claim("scope", scope.toString())
                         .claim("client_id", DOC_APP_CLIENT_ID.getValue())
                         .claim("state", STATE.getValue())
                         .issuer(CLIENT_ID)

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RequestObjectServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RequestObjectServiceTest.java
@@ -24,7 +24,9 @@ import java.net.URI;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
 import java.util.Base64;
+import java.util.List;
 import java.util.Optional;
 
 import static java.util.Collections.singletonList;
@@ -66,12 +68,16 @@ class RequestObjectServiceTest {
 
     @Test
     void shouldSuccessfullyProcessRequestUriPayload() throws JOSEException {
+        List<String> scopes = new ArrayList<>();
+        scopes.add("openid");
+        scopes.add("doc-checking-app");
+        var scope = Scope.parse(scopes);
         var jwtClaimsSet =
                 new JWTClaimsSet.Builder()
                         .audience(AUDIENCE)
                         .claim("redirect_uri", REDIRECT_URI)
                         .claim("response_type", ResponseType.CODE.toString())
-                        .claim("scope", SCOPE)
+                        .claim("scope", scope.toString())
                         .claim("state", new State())
                         .claim("client_id", CLIENT_ID.getValue())
                         .issuer(CLIENT_ID.getValue())
@@ -446,6 +452,7 @@ class RequestObjectServiceTest {
     }
 
     private AuthenticationRequest generateAuthRequest(SignedJWT signedJWT, Scope scope) {
+
         AuthenticationRequest.Builder builder =
                 new AuthenticationRequest.Builder(
                                 ResponseType.CODE, scope, CLIENT_ID, URI.create(REDIRECT_URI))

--- a/shared/src/main/java/uk/gov/di/authentication/shared/conditions/DocAppUserHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/conditions/DocAppUserHelper.java
@@ -71,4 +71,25 @@ public class DocAppUserHelper {
                     format("Unable to read claim from RequestObject: %s", claim), e);
         }
     }
+
+    public static Scope getRequestObjectScopeClaim(AuthenticationRequest authenticationRequest) {
+        try {
+            if (authenticationRequest.getRequestObject() != null
+                    && authenticationRequest.getRequestObject().getJWTClaimsSet() != null
+                    && authenticationRequest.getRequestObject().getJWTClaimsSet().getClaim("scope")
+                            != null) {
+                return Scope.parse(
+                        authenticationRequest
+                                .getRequestObject()
+                                .getJWTClaimsSet()
+                                .getClaim("scope")
+                                .toString());
+            } else {
+                LOG.info("Claim is missing from RequestObject: {}", "scope");
+                throw new RuntimeException("Scope is missing from RequestObject");
+            }
+        } catch (java.text.ParseException e) {
+            throw new RuntimeException("Unable to read scope claim from RequestObject");
+        }
+    }
 }


### PR DESCRIPTION
## What?

- Parse the scope claim in the token handler from a request object

## Why?

- We need to parse the scopes in the request object as a scope so it will be entered into the access token as an array.

