### PR TITLE
AUT-326 - Store SPOT config in SSM

### DIFF
--- a/ci/tasks/deploy-oidc-api.yml
+++ b/ci/tasks/deploy-oidc-api.yml
@@ -17,6 +17,9 @@ params:
   STATE_BUCKET: digital-identity-dev-tfstate
   TEST_CLIENT_VERIFY_EMAIL_OTP: ((test-client-verify-email-otp))
   TEST_CLIENT_VERIFY_PHONE_NUMBER_OTP: ((test-client-verify-phone-number-otp))
+  SPOT_ACCOUNT_NUMBER: ((staging-spot-account-number))
+  SPOT_RESPONSE_QUEUE_ARN: ((staging-spot-response_queue_arn))
+  SPOT_RESPONSE_QUEUE_KMS_ARN: ((staging-spot-response_queue_kms_arn))
   TEST_CLIENTS_ENABLED: false
 inputs:
   - name: api-terraform-src
@@ -62,6 +65,9 @@ run:
         -var "test_client_verify_phone_number_otp=${TEST_CLIENT_VERIFY_PHONE_NUMBER_OTP}" \
         -var "test_clients_enabled=${TEST_CLIENTS_ENABLED}" \
         -var "notify_test_phone_number=${NOTIFY_PHONE_NUMBER}" \
+        -var "spot_account_number=${SPOT_ACCOUNT_NUMBER}" \
+        -var "spot_response_queue_arn=${SPOT_RESPONSE_QUEUE_ARN}" \
+        -var "spot_response_queue_kms_arn=${SPOT_RESPONSE_QUEUE_KMS_ARN}" \
         -var-file "${DEPLOY_ENVIRONMENT}-overrides.tfvars" \
 
       terraform output --json > ../../../../terraform-outputs/${DEPLOY_ENVIRONMENT}-terraform-outputs.json

--- a/ci/terraform/oidc/ssm.tf
+++ b/ci/terraform/oidc/ssm.tf
@@ -140,3 +140,22 @@ resource "aws_iam_policy" "doc_app_public_signing_key_parameter_policy" {
   name_prefix = "doc-app-public-signing-key-parameter-store-policy"
 }
 
+## SPOT  
+
+resource "aws_ssm_parameter" "spot_account_number" {
+  name  = "${var.environment}-spot-account-number"
+  type  = "String"
+  value = var.spot_account_number
+}
+
+resource "aws_ssm_parameter" "spot_response_queue_arn" {
+  name  = "${var.environment}-spot-response-queue-arn"
+  type  = "String"
+  value = var.spot_response_queue_arn
+}
+
+resource "aws_ssm_parameter" "spot_response_queue_kms_arn" {
+  name  = "${var.environment}-spot-response-queue-kms-arn"
+  type  = "String"
+  value = var.spot_response_queue_kms_arn
+}

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -329,3 +329,21 @@ variable "doc_app_cri_public_signing_key" {
   default     = "undefined"
   description = "The PEM encoded public key used to sign VCs from the Doc App CRI"
 }
+
+variable "spot_account_number" {
+  type        = string
+  default     = "undefined"
+  description = "The AWS account number for SPOT"
+}
+
+variable "spot_response_queue_arn" {
+  type        = string
+  default     = "undefined"
+  description = "The ARN for the SPOT response queue"
+}
+
+variable "spot_response_queue_kms_arn" {
+  type        = string
+  default     = "undefined"
+  description = "The ARN for the KMS key used by the SPOT response queue"
+}


### PR DESCRIPTION
## What?

- Read in SPOT config via concourse into terraform variables and store them variables in parameter store. 


## Why?

- This makes it easier if we were to move away from concourse.
- The values in parameter store will then be used to give permission to the require terraform resources.
