### PR TITLE
AUT-326 - Grant read access to SPOT sqs queues

### DIFF
--- a/ci/terraform/oidc/spot-response.tf
+++ b/ci/terraform/oidc/spot-response.tf
@@ -16,11 +16,6 @@ data "aws_iam_policy_document" "spot_response_policy_document" {
     sid    = "ReceiveSQS"
     effect = "Allow"
 
-    principals {
-      type        = "AWS"
-      identifiers = [module.ipv_spot_response_role.arn]
-    }
-
     actions = [
       "sqs:ReceiveMessage",
       "sqs:DeleteMessage",
@@ -30,6 +25,18 @@ data "aws_iam_policy_document" "spot_response_policy_document" {
 
     resources = [
       aws_ssm_parameter.spot_response_queue_arn.value
+    ]
+  }
+  statement {
+    sid    = "AccessKMS"
+    effect = "Allow"
+
+    actions = [
+      "kms:GenerateDataKey",
+    ]
+
+    resources = [
+      aws_ssm_parameter.spot_response_queue_kms_arn.value
     ]
   }
 

--- a/ci/terraform/oidc/spot-response.tf
+++ b/ci/terraform/oidc/spot-response.tf
@@ -6,7 +6,7 @@ module "ipv_spot_response_role" {
 
   policies_to_attach = [
     aws_iam_policy.dynamo_identity_credentials_write_access_policy.arn,
-    aws_iam_policy.spot_response_sqs_read_policy.arn,
+    aws_iam_policy.spot_response_sqs_read_policy[0].arn,
   ]
 }
 

--- a/ci/terraform/oidc/spot-response.tf
+++ b/ci/terraform/oidc/spot-response.tf
@@ -6,6 +6,53 @@ module "ipv_spot_response_role" {
 
   policies_to_attach = [
     aws_iam_policy.dynamo_identity_credentials_write_access_policy.arn,
+    aws_iam_policy.spot_response_sqs_read_policy.arn,
+  ]
+}
+
+data "aws_iam_policy_document" "spot_response_policy_document" {
+  count = var.ipv_api_enabled ? 1 : 0
+  statement {
+    sid    = "ReceiveSQS"
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = [module.ipv_spot_response_role.arn]
+    }
+
+    actions = [
+      "sqs:ReceiveMessage",
+      "sqs:DeleteMessage",
+      "sqs:GetQueueAttributes",
+      "sqs:ChangeMessageVisibility",
+    ]
+
+    resources = [
+      aws_ssm_parameter.spot_response_queue_arn.value
+    ]
+  }
+
+  depends_on = [
+    time_sleep.wait_60_seconds
+  ]
+}
+
+resource "aws_iam_policy" "spot_response_sqs_read_policy" {
+  count       = var.ipv_api_enabled ? 1 : 0
+  policy      = data.aws_iam_policy_document.spot_response_policy_document[0].json
+  path        = "/${var.environment}/sqs/"
+  name_prefix = "spot-response-sqs-read-policy-policy"
+}
+
+resource "aws_lambda_event_source_mapping" "spot_response_lambda_sqs_mapping" {
+  count            = var.ipv_api_enabled ? 1 : 0
+  event_source_arn = aws_ssm_parameter.spot_response_queue_arn.value
+  function_name    = aws_lambda_function.spot_response_lambda[0].arn
+
+  depends_on = [
+    aws_lambda_function.spot_response_lambda,
+    aws_iam_policy.spot_response_sqs_read_policy
   ]
 }
 

--- a/ci/terraform/oidc/spot-sqs.tf
+++ b/ci/terraform/oidc/spot-sqs.tf
@@ -45,9 +45,21 @@ data "aws_iam_policy_document" "spot_request_queue_policy_document" {
       "sqs:ChangeMessageVisibility",
       "sqs:GetQueueAttributes",
     ]
+  }
+  statement {
+    sid    = "AllowSpotAccountToReceive"
+    effect = "Allow"
 
-    resources = [
-      aws_sqs_queue.spot_request_queue[0].arn
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${aws_ssm_parameter.spot_account_number.value}:root"]
+    }
+
+    actions = [
+      "sqs:ReceiveMessage",
+      "sqs:ChangeMessageVisibility",
+      "sqs:DeleteMessage",
+      "sqs:GetQueueAttributes",
     ]
   }
 }
@@ -94,48 +106,6 @@ resource "aws_sqs_queue_policy" "spot_request_dlq_queue_policy" {
 
   queue_url = aws_sqs_queue.spot_request_dead_letter_queue[0].id
   policy    = data.aws_iam_policy_document.spot_request_dlq_queue_policy_document[0].json
-}
-
-data "aws_iam_policy_document" "spot_request_queue_policy_document" {
-  count = var.ipv_api_enabled ? 1 : 0
-  statement {
-    sid    = "AllowSpotAccountToReceive"
-    effect = "Allow"
-
-    principals {
-      type        = "AWS"
-      identifiers = ["arn:aws:iam::${aws_ssm_parameter.spot_account_number.value}:root"]
-    }
-
-    actions = [
-      "sqs:ReceiveMessage",
-      "sqs:ChangeMessageVisibility",
-      "sqs:DeleteMessage",
-      "sqs:GetQueueAttributes",
-    ]
-  }
-  statement {
-    sid    = "AllowUsToDoAnything"
-    effect = "Allow"
-
-    principals {
-      type        = "AWS"
-      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
-    }
-    actions = [
-      "sqs:*",
-    ]
-  }
-}
-
-resource "aws_sqs_queue_policy" "spot_request_read_queue_policy" {
-  count = var.ipv_api_enabled ? 1 : 0
-  depends_on = [
-    data.aws_iam_policy_document.spot_request_queue_policy_document,
-  ]
-
-  queue_url = aws_sqs_queue.spot_request_queue[0].id
-  policy    = data.aws_iam_policy_document.spot_request_queue_policy_document[0].json
 }
 
 data "aws_iam_policy_document" "spot_request_kms_key_policy" {


### PR DESCRIPTION
## What?

- Grant read access to the SPOT request queue to the SPOT AWS account
- Grant the ipv_spot_response_role permissions to read from SPOT response SQS queue
- Create a new KMS key for the SPOT request queue as AWS managed keys cannot be shared across account. Give SPOT kms:GenerateDataKey to the key.  

## Why?

- As we are reading from queues cross account we need to set up the correct permissions so the lambdas can each read from those SQS queues. 
