### PR TITLE
AUT-326 - Only add spot_response_sqs_read_policy if ipv is enabled

### DIFF
--- a/ci/terraform/oidc/spot-response.tf
+++ b/ci/terraform/oidc/spot-response.tf
@@ -4,10 +4,10 @@ module "ipv_spot_response_role" {
   role_name   = "ipv-spot-response-role"
   vpc_arn     = local.authentication_vpc_arn
 
-  policies_to_attach = [
+  policies_to_attach = compact([
     aws_iam_policy.dynamo_identity_credentials_write_access_policy.arn,
-    aws_iam_policy.spot_response_sqs_read_policy[0].arn,
-  ]
+    var.ipv_api_enabled ? aws_iam_policy.spot_response_sqs_read_policy[0].arn : "",
+  ])
 }
 
 data "aws_iam_policy_document" "spot_response_policy_document" {

--- a/ci/terraform/oidc/spot-response.tf
+++ b/ci/terraform/oidc/spot-response.tf
@@ -32,7 +32,7 @@ data "aws_iam_policy_document" "spot_response_policy_document" {
     effect = "Allow"
 
     actions = [
-      "kms:GenerateDataKey",
+      "kms:Decrypt",
     ]
 
     resources = [

--- a/ci/terraform/oidc/spot-sqs.tf
+++ b/ci/terraform/oidc/spot-sqs.tf
@@ -125,7 +125,7 @@ data "aws_iam_policy_document" "spot_request_kms_key_policy" {
   statement {
     sid = "Give SPOT permissions to SQS KMS key"
     actions = [
-      "kms:GenerateDataKey",
+      "kms:Decrypt",
     ]
     effect = "Allow"
     principals {


### PR DESCRIPTION
## What?

 - Only add spot_response_sqs_read_policy if ipv is enabled
 - Set right permissions to KMS key

## Why?

- IPV isn't enabled in all environments so the spot_response_sqs_read_policy will not always be present
- We need to give SPOT permissions to decrypt our key and we need to give the SPOT response lambda permissions to decrypt the SPOT kms key