### PR TITLE
AUT-326 - Ensure module is created after spot_response_sqs_read_policy

### DIFF
--- a/ci/terraform/oidc/spot-response.tf
+++ b/ci/terraform/oidc/spot-response.tf
@@ -9,6 +9,10 @@ module "ipv_spot_response_role" {
     aws_iam_policy.dynamo_identity_credentials_write_access_policy.arn,
     aws_iam_policy.spot_response_sqs_read_policy[0].arn,
   ]
+
+  depends_on = [
+    aws_iam_policy.spot_response_sqs_read_policy
+  ]
 }
 
 data "aws_iam_policy_document" "spot_response_policy_document" {


### PR DESCRIPTION
## What?

- Ensure module is created after spot_response_sqs_read_policy

## Why?

- Make sure the spot_response_sqs_read_policy is created before creating the ipv_spot_response_role