### PR TITLE
AUT-340: Validate VTM returned by IPV

### DIFF
--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -312,6 +312,7 @@ public class IPVCallbackHandler
 
         if (!trustmark.equals(userIdentityUserInfo.getClaim(VTM.getValue()))) {
             LOG.info("IPV trustmark is invalid.");
+            return false;
         }
         return true;
     }


### PR DESCRIPTION
## What?

- If the VTM returned by IPV is not the one we sent, then fail validation and do not send to SPOT

## Why?

We currently only log if this validation fails, we need to ensure that SPOT is not invoked if this validation fails.