### PR TITLE
AUT-350: Add context logging to IPV journey

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/LogLineHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/LogLineHelper.java
@@ -8,6 +8,8 @@ import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName
 
 public class LogLineHelper {
 
+    public static final String UNKNOWN = "unknown";
+
     public enum LogFieldName {
         SESSION_ID("sessionId", true),
         CLIENT_SESSION_ID("clientSessionId", true),


### PR DESCRIPTION
## What?

Add context logging to IPV journey.

BaseFrontendHandler already adds session id and client session id if it is used so these are not needed for IPVAuthorisationHandler.

ipv-capacity is called by an RP when no user context is available so there is no benefit in adding the logging.

Log ids are not currently available in the SPOTResponse but will be added at a later date.

## Why?

Monitor end-to-end journey for diagnostics.

