### PR TITLE
AUT-292: Remove redundant parameters on IPV auth call

### DIFF
--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandler.java
@@ -116,10 +116,6 @@ public class IPVAuthorisationHandler extends BaseFrontendHandler<IPVAuthorisatio
             var authRequestBuilder =
                     new AuthorizationRequest.Builder(
                                     new ResponseType(ResponseType.Value.CODE), clientID)
-                            .scope(authRequest.getScope())
-                            .customParameter("nonce", nonce.getValue())
-                            .state(state)
-                            .redirectionURI(configurationService.getIPVAuthorisationCallbackURI())
                             .endpointURI(configurationService.getIPVAuthorisationURI())
                             .requestObject(encryptedJWT);
 


### PR DESCRIPTION
## What?

- Remove `scope`, `redirect_uri`, `state` and `nonce` parameters from the IPV authorisation redirect

## Why?

These are all included in the JAR so do not need to be passed as a `GET` parameter..
