### PR TITLE
AUT-326 - Comment out permissions on the SPOT response lambda

### DIFF
--- a/ci/terraform/oidc/spot-response.tf
+++ b/ci/terraform/oidc/spot-response.tf
@@ -7,66 +7,66 @@ module "ipv_spot_response_role" {
 
   policies_to_attach = [
     aws_iam_policy.dynamo_identity_credentials_write_access_policy.arn,
-    aws_iam_policy.spot_response_sqs_read_policy[0].arn,
+    # aws_iam_policy.spot_response_sqs_read_policy[0].arn,
   ]
 
-  depends_on = [
-    aws_iam_policy.spot_response_sqs_read_policy
-  ]
+  # depends_on = [
+  #   aws_iam_policy.spot_response_sqs_read_policy
+  # ]
 }
 
-data "aws_iam_policy_document" "spot_response_policy_document" {
-  count = var.ipv_api_enabled ? 1 : 0
-  statement {
-    sid    = "ReceiveSQS"
-    effect = "Allow"
+# data "aws_iam_policy_document" "spot_response_policy_document" {
+#   count = var.ipv_api_enabled ? 1 : 0
+#   statement {
+#     sid    = "ReceiveSQS"
+#     effect = "Allow"
 
-    actions = [
-      "sqs:ReceiveMessage",
-      "sqs:DeleteMessage",
-      "sqs:GetQueueAttributes",
-      "sqs:ChangeMessageVisibility",
-    ]
+#     actions = [
+#       "sqs:ReceiveMessage",
+#       "sqs:DeleteMessage",
+#       "sqs:GetQueueAttributes",
+#       "sqs:ChangeMessageVisibility",
+#     ]
 
-    resources = [
-      aws_ssm_parameter.spot_response_queue_arn.value
-    ]
-  }
-  statement {
-    sid    = "AccessKMS"
-    effect = "Allow"
+#     resources = [
+#       aws_ssm_parameter.spot_response_queue_arn.value
+#     ]
+#   }
+#   statement {
+#     sid    = "AccessKMS"
+#     effect = "Allow"
 
-    actions = [
-      "kms:Decrypt",
-    ]
+#     actions = [
+#       "kms:Decrypt",
+#     ]
 
-    resources = [
-      aws_ssm_parameter.spot_response_queue_kms_arn.value
-    ]
-  }
+#     resources = [
+#       aws_ssm_parameter.spot_response_queue_kms_arn.value
+#     ]
+#   }
 
-  depends_on = [
-    time_sleep.wait_60_seconds
-  ]
-}
+#   depends_on = [
+#     time_sleep.wait_60_seconds
+#   ]
+# }
 
-resource "aws_iam_policy" "spot_response_sqs_read_policy" {
-  count       = var.ipv_api_enabled ? 1 : 0
-  policy      = data.aws_iam_policy_document.spot_response_policy_document[0].json
-  path        = "/${var.environment}/sqs/"
-  name_prefix = "spot-response-sqs-read-policy-policy"
-}
+# resource "aws_iam_policy" "spot_response_sqs_read_policy" {
+#   count       = var.ipv_api_enabled ? 1 : 0
+#   policy      = data.aws_iam_policy_document.spot_response_policy_document[0].json
+#   path        = "/${var.environment}/sqs/"
+#   name_prefix = "spot-response-sqs-read-policy-policy"
+# }
 
-resource "aws_lambda_event_source_mapping" "spot_response_lambda_sqs_mapping" {
-  count            = var.ipv_api_enabled ? 1 : 0
-  event_source_arn = aws_ssm_parameter.spot_response_queue_arn.value
-  function_name    = aws_lambda_function.spot_response_lambda[0].arn
+# resource "aws_lambda_event_source_mapping" "spot_response_lambda_sqs_mapping" {
+#   count            = var.ipv_api_enabled ? 1 : 0
+#   event_source_arn = aws_ssm_parameter.spot_response_queue_arn.value
+#   function_name    = aws_lambda_function.spot_response_lambda[0].arn
 
-  depends_on = [
-    aws_lambda_function.spot_response_lambda,
-    aws_iam_policy.spot_response_sqs_read_policy
-  ]
-}
+#   depends_on = [
+#     aws_lambda_function.spot_response_lambda,
+#     aws_iam_policy.spot_response_sqs_read_policy
+#   ]
+# }
 
 resource "aws_lambda_function" "spot_response_lambda" {
   count = var.ipv_api_enabled ? 1 : 0


### PR DESCRIPTION
## What?

- As we have not yet been granted permissions to the SPOT KMS key or SPOT sqs queue, we are seeing an error when the terraform applies. Comment out the section trying to seek access to these resources until we have been given access, this will at least fix the pipeline.
- We can leave in the section granting SPOT access to our resources.

## Why?

- To fix the staging environment until we have been granted access to the SPOT kms key and SQS queue 