### PR TITLE
AUT-381 - Add IdentityVerificationSupported flag to client registry 

### DIFF
--- a/ci/terraform/shared/build-stub-clients.tfvars
+++ b/ci/terraform/shared/build-stub-clients.tfvars
@@ -7,8 +7,9 @@ stub_rp_clients = [
     logout_urls = [
       "https://di-auth-stub-relying-party-build.london.cloudapps.digital/signed-out",
     ]
-    test_client = "0"
-    client_type = "web"
+    test_client                     = "0"
+    client_type                     = "web"
+    identity_verification_supported = "1"
     scopes = [
       "openid",
       "email",
@@ -23,8 +24,9 @@ stub_rp_clients = [
     logout_urls = [
       "https://di-auth-stub-relying-party-build-s2.london.cloudapps.digital/signed-out",
     ]
-    test_client = "1"
-    client_type = "web"
+    test_client                     = "1"
+    identity_verification_supported = "1"
+    client_type                     = "web"
     scopes = [
       "openid",
       "email",
@@ -39,8 +41,9 @@ stub_rp_clients = [
     logout_urls = [
       "https://di-auth-stub-relying-party-build-app.london.cloudapps.digital/signed-out",
     ]
-    test_client = "1"
-    client_type = "app"
+    test_client                     = "1"
+    identity_verification_supported = "1"
+    client_type                     = "app"
     scopes = [
       "openid",
       "doc-checking-app",

--- a/ci/terraform/shared/integration-stub-clients.tfvars
+++ b/ci/terraform/shared/integration-stub-clients.tfvars
@@ -7,8 +7,9 @@ stub_rp_clients = [
     logout_urls = [
       "https://di-auth-stub-relying-party-integration.london.cloudapps.digital/signed-out",
     ]
-    test_client = "0"
-    client_type = "web"
+    test_client                     = "0"
+    client_type                     = "web"
+    identity_verification_supported = "1"
     scopes = [
       "openid",
       "email",

--- a/ci/terraform/shared/staging-stub-clients.tfvars
+++ b/ci/terraform/shared/staging-stub-clients.tfvars
@@ -7,8 +7,9 @@ stub_rp_clients = [
     logout_urls = [
       "https://di-auth-stub-relying-party-staging.london.cloudapps.digital/signed-out",
     ]
-    test_client = "0"
-    client_type = "web"
+    test_client                     = "0"
+    identity_verification_supported = "1"
+    client_type                     = "web"
     scopes = [
       "openid",
       "email",
@@ -23,8 +24,9 @@ stub_rp_clients = [
     logout_urls = [
       "https://di-auth-stub-relying-party-staging-app.london.cloudapps.digital/signed-out",
     ]
-    test_client = "1"
-    client_type = "app"
+    test_client                     = "1"
+    identity_verification_supported = "1"
+    client_type                     = "app"
     scopes = [
       "openid",
       "doc-checking-app",

--- a/ci/terraform/shared/stub-rp-clients.tf
+++ b/ci/terraform/shared/stub-rp-clients.tf
@@ -80,6 +80,9 @@ resource "aws_dynamodb_table_item" "stub_rp_client" {
     ConsentRequired = {
       N = "1"
     }
+    IdentityVerificationSupported = {
+      N = var.stub_rp_clients[count.index].identity_verification_supported
+    }
     ClientType = {
       S = var.stub_rp_clients[count.index].client_type
     }

--- a/ci/terraform/shared/variables.tf
+++ b/ci/terraform/shared/variables.tf
@@ -89,7 +89,7 @@ variable "logging_endpoint_arns" {
 
 variable "stub_rp_clients" {
   default     = []
-  type        = list(object({ client_name : string, callback_urls : list(string), logout_urls : list(string), test_client : string, scopes : list(string), client_type : string }))
+  type        = list(object({ client_name : string, callback_urls : list(string), logout_urls : list(string), test_client : string, scopes : list(string), client_type : string, identity_verification_supported : string }))
   description = "The details of RP clients to provision in the Client table"
 }
 

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandler.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandler.java
@@ -127,7 +127,8 @@ public class ClientRegistrationHandler
                                         clientRegistrationRequest.getSubjectType(),
                                         !clientRegistrationRequest.isIdentityVerificationRequired(),
                                         clientRegistrationRequest.getClaims(),
-                                        clientRegistrationRequest.getClientType());
+                                        clientRegistrationRequest.getClientType(),
+                                        clientRegistrationRequest.isIdentityVerificationRequired());
 
                                 var clientRegistrationResponse =
                                         new ClientRegistrationResponse(

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandlerTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandlerTest.java
@@ -118,7 +118,8 @@ class ClientRegistrationHandlerTest {
                         SUBJECT_TYPE,
                         true,
                         emptyList(),
-                        ClientType.WEB.getValue());
+                        ClientType.WEB.getValue(),
+                        false);
     }
 
     @Test
@@ -158,7 +159,8 @@ class ClientRegistrationHandlerTest {
                         SUBJECT_TYPE,
                         false,
                         emptyList(),
-                        ClientType.WEB.getValue());
+                        ClientType.WEB.getValue(),
+                        true);
     }
 
     @Test
@@ -190,7 +192,8 @@ class ClientRegistrationHandlerTest {
                         SUBJECT_TYPE,
                         true,
                         emptyList(),
-                        ClientType.WEB.getValue());
+                        ClientType.WEB.getValue(),
+                        false);
     }
 
     @Test

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVAuthorisationHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVAuthorisationHandlerIntegrationTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.authentication.ipv.entity.IPVAuthorisationResponse;
 import uk.gov.di.authentication.ipv.lambda.IPVAuthorisationHandler;
+import uk.gov.di.authentication.shared.entity.ClientType;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
@@ -87,6 +88,8 @@ class IPVAuthorisationHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
                 String.valueOf(ServiceType.MANDATORY),
                 "https://test.com",
                 "pairwise",
+                true,
+                ClientType.WEB,
                 true);
 
         var response =

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/ClientStoreExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/ClientStoreExtension.java
@@ -71,6 +71,38 @@ public class ClientStoreExtension extends DynamoExtension implements AfterEachCa
             String subjectType,
             boolean consentRequired,
             ClientType clientType) {
+        registerClient(
+                clientID,
+                clientName,
+                redirectUris,
+                contacts,
+                scopes,
+                publicKey,
+                postLogoutRedirectUris,
+                backChannelLogoutUri,
+                serviceType,
+                sectorIdentifierUri,
+                subjectType,
+                consentRequired,
+                clientType,
+                false);
+    }
+
+    public void registerClient(
+            String clientID,
+            String clientName,
+            List<String> redirectUris,
+            List<String> contacts,
+            List<String> scopes,
+            String publicKey,
+            List<String> postLogoutRedirectUris,
+            String backChannelLogoutUri,
+            String serviceType,
+            String sectorIdentifierUri,
+            String subjectType,
+            boolean consentRequired,
+            ClientType clientType,
+            boolean identityVerificationSupported) {
         dynamoClientService.addClient(
                 clientID,
                 clientName,
@@ -85,7 +117,8 @@ public class ClientStoreExtension extends DynamoExtension implements AfterEachCa
                 subjectType,
                 consentRequired,
                 Collections.emptyList(),
-                clientType.getValue());
+                clientType.getValue(),
+                identityVerificationSupported);
     }
 
     public boolean clientExists(String clientID) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ClientRegistry.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ClientRegistry.java
@@ -23,10 +23,10 @@ public class ClientRegistry {
     private boolean cookieConsentShared = false;
     private boolean consentRequired = false;
     private boolean testClient = false;
-    private List<String> requestUris = new ArrayList<>();
     private List<String> testClientEmailAllowlist = new ArrayList<>();
     private List<String> claims = new ArrayList<>();
     private String clientType;
+    private boolean identityVerificationSupported = false;
 
     @DynamoDBHashKey(attributeName = "ClientID")
     public String getClientID() {
@@ -180,16 +180,6 @@ public class ClientRegistry {
         return this;
     }
 
-    @DynamoDBAttribute(attributeName = "RequestUris")
-    public List<String> getRequestUris() {
-        return requestUris;
-    }
-
-    public ClientRegistry setRequestUris(List<String> requestUris) {
-        this.requestUris = requestUris;
-        return this;
-    }
-
     @DynamoDBAttribute(attributeName = "Claims")
     public List<String> getClaims() {
         return claims;
@@ -207,6 +197,16 @@ public class ClientRegistry {
 
     public ClientRegistry setClientType(String clientType) {
         this.clientType = clientType;
+        return this;
+    }
+
+    @DynamoDBAttribute(attributeName = "IdentityVerificationSupported")
+    public boolean isIdentityVerificationSupported() {
+        return identityVerificationSupported;
+    }
+
+    public ClientRegistry setIdentityVerificationSupported(boolean identityVerificationSupported) {
+        this.identityVerificationSupported = identityVerificationSupported;
         return this;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ClientService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ClientService.java
@@ -25,7 +25,8 @@ public interface ClientService {
             String subjectType,
             boolean consentRequired,
             List<String> claims,
-            String clientType);
+            String clientType,
+            boolean identityVerificationSupported);
 
     Optional<ClientRegistry> getClient(String clientId);
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoClientService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoClientService.java
@@ -46,7 +46,8 @@ public class DynamoClientService implements ClientService {
             String subjectType,
             boolean consentRequired,
             List<String> claims,
-            String clientType) {
+            String clientType,
+            boolean identityVerificationSupported) {
         var clientRegistry =
                 new ClientRegistry()
                         .setClientID(clientID)
@@ -62,7 +63,8 @@ public class DynamoClientService implements ClientService {
                         .setSubjectType(subjectType)
                         .setConsentRequired(consentRequired)
                         .setClaims(claims)
-                        .setClientType(clientType);
+                        .setClientType(clientType)
+                        .setIdentityVerificationSupported(identityVerificationSupported);
         clientRegistryMapper.save(clientRegistry);
     }
 


### PR DESCRIPTION
## What?

- Add IdentityVerificationSupported flag to client registry 
- Set the IdentityVerificationSupported for the Stubs in Dynamo 
- Remove `RequestUris` from Dynamo
## Why?

- We don't currently have anywhere in Dynamo to tell us whether or not identity is supported by a given RP. This flag will allow us to determine this. 
- This flag will be used in the Start handler to help calculate the `identityRequired` value returned. 
- We will not be using the `RequestUris` but instead be using the `Request` object