### PR TITLE
AUT-363: Make the client_id parameter optional in the Token service

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
@@ -162,12 +162,6 @@ public class TokenService {
 
     public Optional<ErrorObject> validateTokenRequestParams(String tokenRequestBody) {
         Map<String, String> requestBody = RequestBodyHelper.parseRequestBody(tokenRequestBody);
-        if (!requestBody.containsKey("client_id")) {
-            return Optional.of(
-                    new ErrorObject(
-                            OAuth2Error.INVALID_REQUEST_CODE,
-                            "Request is missing client_id parameter"));
-        }
         if (!requestBody.containsKey("grant_type")) {
             return Optional.of(
                     new ErrorObject(
@@ -225,6 +219,21 @@ public class TokenService {
             return Optional.of(OAuth2Error.INVALID_CLIENT);
         }
         return Optional.empty();
+    }
+
+    public Optional<String> getClientIDFromPrivateKeyJWT(String requestString) {
+        PrivateKeyJWT privateKeyJWT;
+        try {
+            privateKeyJWT = PrivateKeyJWT.parse(requestString);
+        } catch (ParseException e) {
+            LOG.warn("Could not parse Private Key JWT");
+            return Optional.empty();
+        }
+        if (Objects.isNull(privateKeyJWT.getClientID())) {
+            LOG.warn("Invalid ClientID in PrivateKeyJWT");
+            return Optional.empty();
+        }
+        return Optional.of(privateKeyJWT.getClientID().toString());
     }
 
     private List<String> calculateScopesForToken(


### PR DESCRIPTION
## What?

Make the client_id parameter optional in the Token service.

- If client_id not supplied then retrieve it from the private key JWT.
- If client_id is supplied then validate that the client id matches the value in the private key JWT.

## Why?

Our clients are 'authenticated' so according to the spec client_id is an optional parameter:

https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.3