### PR TITLE
BAU: Remove unqualified function name in policy

### DIFF
--- a/ci/terraform/account-management/api-gateway.tf
+++ b/ci/terraform/account-management/api-gateway.tf
@@ -57,7 +57,6 @@ resource "aws_iam_role_policy" "invocation_policy" {
       "Action": "lambda:InvokeFunction",
       "Effect": "Allow",
       "Resource": [
-          "${aws_lambda_function.authorizer.arn}",
           "${aws_lambda_alias.authorizer_alias.arn}"
         ]
     }


### PR DESCRIPTION
## What?

- Remove the unqualified form from the authorizer invocation policy (we already include the fully qualified form by including the alias ARN).

## Why?

AWS have implemented a policy change that requires policies to use fully qualified function names.
