### PR TITLE
BAU - Give SPOT response lambda describe permissions

### DIFF
--- a/ci/terraform/oidc/spot-response.tf
+++ b/ci/terraform/oidc/spot-response.tf
@@ -7,6 +7,7 @@ module "ipv_spot_response_role" {
 
   policies_to_attach = [
     aws_iam_policy.dynamo_identity_credentials_write_access_policy.arn,
+    aws_iam_policy.dynamo_identity_credentials_read_access_policy.arn,
     aws_iam_policy.spot_response_sqs_read_policy[0].arn,
   ]
 


### PR DESCRIPTION
## What?

 - Give SPOT response lambda describe permissions

## Why?

- Describe table permissions are required for the warmer. At the moment this is causing lots of errors in the logs.
