### PR TITLE
AUT-331: Allow multiple test OTP destinations

### DIFF
--- a/ci/tasks/deploy-oidc-api.yml
+++ b/ci/tasks/deploy-oidc-api.yml
@@ -10,7 +10,7 @@ params:
   DEPLOYER_ROLE_ARN: ((deployer-role-arn-non-prod))
   DEPLOY_ENVIRONMENT: build
   NOTIFY_API_KEY: ((build-notify-api-key))
-  NOTIFY_PHONE_NUMBER: ((test-notify-phone-number))
+  NOTIFY_DESTINATIONS: ((test-notify-phone-number))
   DNS_DEPLOYER_ROLE_ARN: ((deployer-role-arn-production))
   DNS_STATE_BUCKET: ((dns-state-bucket))
   DNS_STATE_KEY: ((dns-state-key))
@@ -64,7 +64,7 @@ run:
         -var "test_client_verify_email_otp=${TEST_CLIENT_VERIFY_EMAIL_OTP}" \
         -var "test_client_verify_phone_number_otp=${TEST_CLIENT_VERIFY_PHONE_NUMBER_OTP}" \
         -var "test_clients_enabled=${TEST_CLIENTS_ENABLED}" \
-        -var "notify_test_phone_number=${NOTIFY_PHONE_NUMBER}" \
+        -var "notify_test_destinations=${NOTIFY_DESTINATIONS}" \
         -var "spot_account_number=${SPOT_ACCOUNT_NUMBER}" \
         -var "spot_response_queue_arn=${SPOT_RESPONSE_QUEUE_ARN}" \
         -var "spot_response_queue_kms_arn=${SPOT_RESPONSE_QUEUE_KMS_ARN}" \

--- a/ci/terraform/oidc/sqs.tf
+++ b/ci/terraform/oidc/sqs.tf
@@ -175,7 +175,7 @@ resource "aws_lambda_function" "email_sqs_lambda" {
       CONTACT_US_LINK_ROUTE     = var.contact_us_link_route
       NOTIFY_API_KEY            = var.notify_api_key
       NOTIFY_URL                = var.notify_url
-      NOTIFY_TEST_PHONE_NUMBER  = var.notify_test_phone_number
+      NOTIFY_TEST_DESTINATIONS  = var.notify_test_destinations
       SMOKETEST_SMS_BUCKET_NAME = local.sms_bucket_name
       JAVA_TOOL_OPTIONS         = "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
     })

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -50,7 +50,7 @@ variable "notify_url" {
   default = null
 }
 
-variable "notify_test_phone_number" {
+variable "notify_test_destinations" {
   type    = string
   default = null
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandler.java
@@ -180,17 +180,13 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
     }
 
     private void writeTestClientOtpToS3(String otp, String destination) {
-        Boolean isNotifyTestNumber =
-                configurationService
-                        .getNotifyTestPhoneNumber()
-                        .map(t -> t.equals(destination))
-                        .orElse(false);
-        if (isNotifyTestNumber) {
-            LOG.info("Notify Test Number used in request. Writing to S3 bucket");
-            String key = configurationService.getNotifyTestPhoneNumber().get();
+        Boolean isNotifyDestination =
+                configurationService.getNotifyTestDestinations().contains(destination);
+        if (isNotifyDestination) {
+            LOG.info("Notify Test Destination used in request. Writing to S3 bucket");
             String bucketName = configurationService.getSmoketestBucketName();
             try {
-                s3Client.putObject(bucketName, key, otp);
+                s3Client.putObject(bucketName, destination, otp);
             } catch (Exception e) {
                 LOG.error("Exception thrown when writing to S3 bucket");
             }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandlerTest.java
@@ -16,8 +16,8 @@ import uk.gov.di.authentication.shared.services.NotificationService;
 import uk.gov.service.notify.NotificationClientException;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -52,7 +52,7 @@ public class NotificationHandlerTest {
 
     @BeforeEach
     void setUp() {
-        when(configService.getNotifyTestPhoneNumber()).thenReturn(Optional.of(NOTIFY_PHONE_NUMBER));
+        when(configService.getNotifyTestDestinations()).thenReturn(List.of(NOTIFY_PHONE_NUMBER));
         when(configService.getSmoketestBucketName()).thenReturn(BUCKET_NAME);
         when(configService.getFrontendBaseUrl()).thenReturn(FRONTEND_BASE_URL);
         when(configService.getContactUsLinkRoute()).thenReturn(CONTACT_US_LINK_ROUTE);

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -21,11 +21,14 @@ import java.security.NoSuchAlgorithmException;
 import java.security.interfaces.ECPublicKey;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.X509EncodedKeySpec;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static java.text.MessageFormat.format;
+import static java.util.Objects.isNull;
 
 public class ConfigurationService implements BaseLambdaConfiguration, AuditPublisherConfiguration {
 
@@ -247,8 +250,11 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return getSsmClient().getParameter(request).getParameter().getValue();
     }
 
-    public Optional<String> getNotifyTestPhoneNumber() {
-        return Optional.ofNullable(System.getenv("NOTIFY_TEST_PHONE_NUMBER"));
+    public List<String> getNotifyTestDestinations() {
+        var destinations = System.getenv("NOTIFY_TEST_PHONE_NUMBER");
+        return isNull(destinations)
+                ? List.of()
+                : Arrays.stream(destinations.split(",")).collect(Collectors.toList());
     }
 
     public Optional<String> getOidcApiBaseURL() {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -251,8 +251,8 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
     }
 
     public List<String> getNotifyTestDestinations() {
-        var destinations = System.getenv("NOTIFY_TEST_PHONE_NUMBER");
-        return isNull(destinations)
+        var destinations = System.getenv("NOTIFY_TEST_DESTINATIONS");
+        return isNull(destinations) || destinations.isBlank()
                 ? List.of()
                 : Arrays.stream(destinations.split(",")).collect(Collectors.toList());
     }


### PR DESCRIPTION
## What?

- Allow the use of multiple phone/numbers that get written to S3
- Rename `ConfigurationService.getNotifyTestPhoneNumber()` to `getNotifyTestDestinations()` to reflect that it may contain multiple values and may also be an e-mail address
- Rename `NOTIFY_TEST_PHONE_NUMBER` variable to be `NOTIFY_TEST_DESTINATIONS` to reflect that it may be plural and could also hold email addresses.
- Rename associated Terraform variables
- Change parsing of environment variable to handle the empty string

## Why?

To support end-to-end automated testing
