### PR TITLE
AUT-335: Add `Resource` field to queue policy statement & increase visibility timeout

### DIFF
--- a/ci/terraform/oidc/spot-sqs.tf
+++ b/ci/terraform/oidc/spot-sqs.tf
@@ -23,7 +23,8 @@ resource "aws_sqs_queue" "spot_request_dead_letter_queue" {
   kms_master_key_id                 = var.use_localstack ? null : aws_kms_key.spot_request_sqs_key.id
   kms_data_key_reuse_period_seconds = var.use_localstack ? null : 300
 
-  message_retention_seconds = 3600 * 6
+  message_retention_seconds  = 3600 * 6
+  visibility_timeout_seconds = 60
 
   tags = local.default_tags
 }
@@ -45,6 +46,10 @@ data "aws_iam_policy_document" "spot_request_queue_policy_document" {
       "sqs:ChangeMessageVisibility",
       "sqs:GetQueueAttributes",
     ]
+
+    resources = [
+      aws_sqs_queue.spot_request_queue[0].arn
+    ]
   }
   statement {
     sid    = "AllowSpotAccountToReceive"
@@ -60,6 +65,10 @@ data "aws_iam_policy_document" "spot_request_queue_policy_document" {
       "sqs:ChangeMessageVisibility",
       "sqs:DeleteMessage",
       "sqs:GetQueueAttributes",
+    ]
+
+    resources = [
+      aws_sqs_queue.spot_request_queue[0].arn
     ]
   }
 }


### PR DESCRIPTION
## What?

- Add the resource to queue access policy
- Increase visibility timeout to 60 seconds

## Why?

SPOT were unable to connect to our queue, this resolves it.
