### PR TITLE
BAU: configure spot request queue for ipv callback

### DIFF
--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -40,7 +40,7 @@ module "ipv-callback" {
     OIDC_API_BASE_URL              = local.api_base_url
     REDIS_KEY                      = local.redis_key
     SPOT_ENABLED                   = tostring(var.spot_enabled)
-    SPOT_QUEUE_URL                 = var.spot_queue_url
+    SPOT_QUEUE_URL                 = aws_sqs_queue.spot_request_queue[0].id
   }
   handler_function_name = "uk.gov.di.authentication.ipv.lambda.IPVCallbackHandler::handleRequest"
 


### PR DESCRIPTION
## What?

Configure spot request queue for ipv callback

## Why?

The request queue is currently undefined so ipv callback is failing.

