### PR TITLE
AUT-335: Fix IPV Callback permissions and max message size

### DIFF
--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -12,6 +12,7 @@ module "ipv_callback_role" {
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
     aws_iam_policy.ipv_token_auth_kms_policy.arn,
+    aws_iam_policy.spot_queue_encryption_policy.arn,
   ]
 }
 


### PR DESCRIPTION
## What?

- Give permissions to IPV Callback to encrypt data for the queue
- Increase max message size on SPOT request queue

## Why?

IPV callback handler is failing