### PR TITLE
AUT-397 - Update Pairwise prefix to make them VC compliant

### DIFF
--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/BackChannelLogoutServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/BackChannelLogoutServiceTest.java
@@ -52,7 +52,8 @@ class BackChannelLogoutServiceTest {
         assertThat(message.getLogoutUri(), is("http://localhost:8080/back-channel-logout"));
         assertThat(
                 message.getSubjectId(),
-                is("urn:uuid:b46381e6de5f4405ff162a3aa91223f0a3c32fbbce839802a88e25e670d9083b"));
+                is(
+                        "urn:fdc:gov.uk:2022:b46381e6de5f4405ff162a3aa91223f0a3c32fbbce839802a88e25e670d9083b"));
     }
 
     @Test

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/BackChannelLogoutServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/BackChannelLogoutServiceTest.java
@@ -52,8 +52,7 @@ class BackChannelLogoutServiceTest {
         assertThat(message.getLogoutUri(), is("http://localhost:8080/back-channel-logout"));
         assertThat(
                 message.getSubjectId(),
-                is(
-                        "urn:fdc:gov.uk:2022:b46381e6de5f4405ff162a3aa91223f0a3c32fbbce839802a88e25e670d9083b"));
+                is("urn:fdc:gov.uk:2022:tGOB5t5fRAX_Fio6qRIj8KPDL7vOg5gCqI4l5nDZCDs"));
     }
 
     @Test

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ClientSubjectHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ClientSubjectHelper.java
@@ -16,7 +16,7 @@ import java.util.stream.Collectors;
 public class ClientSubjectHelper {
 
     private static final Logger LOG = LogManager.getLogger(ClientSubjectHelper.class);
-    private static final String PAIRWISE_PREFIX = "urn:uuid:";
+    private static final String PAIRWISE_PREFIX = "urn:fdc:gov.uk:2022:";
 
     public static Subject getSubject(
             UserProfile userProfile,

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ClientSubjectHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ClientSubjectHelper.java
@@ -3,6 +3,7 @@ package uk.gov.di.authentication.shared.helpers;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.jose4j.base64url.Base64Url;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
@@ -95,10 +96,7 @@ public class ClientSubjectHelper {
 
             byte[] bytes = md.digest(salt);
 
-            var sb = new StringBuilder();
-            for (byte aByte : bytes) {
-                sb.append(Integer.toString((aByte & 0xff) + 0x100, 16).substring(1));
-            }
+            var sb = Base64Url.encode(bytes);
 
             return PAIRWISE_PREFIX + sb;
         } catch (NoSuchAlgorithmException e) {

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ClientSubjectHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ClientSubjectHelperTest.java
@@ -118,7 +118,7 @@ class ClientSubjectHelperTest {
         var subject =
                 ClientSubjectHelper.getSubject(userProfile, clientRegistry1, authenticationService);
 
-        assertTrue(subject.getValue().startsWith("urn:uuid:"));
+        assertTrue(subject.getValue().startsWith("urn:fdc:gov.uk:2022:"));
     }
 
     @Test
@@ -134,7 +134,7 @@ class ClientSubjectHelperTest {
         var subject =
                 ClientSubjectHelper.getSubject(userProfile, clientRegistry1, authenticationService);
 
-        assertFalse(subject.getValue().startsWith("urn:uuid:"));
+        assertFalse(subject.getValue().startsWith("urn:fdc:gov.uk:2022:"));
     }
 
     @Test


### PR DESCRIPTION
## What?

- Make our pairwise identifiers VC compliant by implementing them as a URN as per RFC4198. This would prefix all identifiers with 'urn:fdc:gov.uk:2022:', where 2022 is the DateId and would remain fixed.
- Use base64 url encoding to generate the subject resourceId

## Why?

- We previously had a prefix of 'urn:uuid:' however our identifiers were not a valid UUID and did not comply the UUID spec.
- The VC data model instructs that subject identifiers MUST be URIs. We want to make sure we are compliant with the VC spec as much as possible otherwise it could cause issues for our VCs being compatible across other trust frameworks.
- We were currently using Base16 to generate this identifier. Switching to Base64 URL encoding allows us to use a lib rather than have to write our own as well as reducing any side affects if clients choose to interpret these URNs as URLs