### PR TITLE
AUT-382: Start handler authenticated always false for doc app journey

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
@@ -131,7 +131,7 @@ public class StartService {
                 consentRequired,
                 uplift,
                 identityRequired,
-                userContext.getSession().isAuthenticated(),
+                docCheckingAppUser ? false : userContext.getSession().isAuthenticated(),
                 cookieConsent,
                 gaTrackingId,
                 docCheckingAppUser);

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
@@ -53,7 +53,11 @@ public class RedisExtension
     }
 
     public String createSession(String sessionId) throws IOException {
-        Session session = new Session(sessionId);
+        return createSession(sessionId, false);
+    }
+
+    private String createSession(String sessionId, boolean isAuthenticated) throws IOException {
+        Session session = new Session(sessionId).setAuthenticated(isAuthenticated);
         redis.saveWithExpiry(
                 session.getSessionId(), objectMapper.writeValueAsString(session), 3600);
         return session.getSessionId();
@@ -61,6 +65,10 @@ public class RedisExtension
 
     public String createSession() throws IOException {
         return createSession(IdGenerator.generate());
+    }
+
+    public String createSession(boolean isAuthenticated) throws IOException {
+        return createSession(IdGenerator.generate(), isAuthenticated);
     }
 
     public void addDocAppSubjectIdToClientSession(Subject subject, String clientSessionId)


### PR DESCRIPTION
## What?

Start handler authenticated should always be false for the doc app journey.

## Why?

Fixes an SSO issue where a logged in user tries to run a doc app journey.  The assumption is that authentication is always required for the doc app, therefore the session cannot already be authenticated.