### PR TITLE
AUT-364: P0 level of confidence

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
@@ -17,6 +17,8 @@ import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import uk.gov.di.authentication.frontendapi.entity.StartResponse;
 import uk.gov.di.authentication.frontendapi.lambda.StartHandler;
@@ -34,6 +36,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -60,18 +63,30 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         handler = new StartHandler(TEST_CONFIGURATION_SERVICE);
     }
 
+    private static Stream<Arguments> successfulRequests() {
+        return Stream.of(
+                Arguments.of(Map.of(), false, false),
+                Arguments.of(Map.of(), false, true),
+                Arguments.of(Map.of("vtr", "[\"P0.Cl.Cm\"]"), false, false),
+                Arguments.of(Map.of("vtr", "[\"P2.Cl.Cm\"]"), true, false));
+    }
+
     @ParameterizedTest
-    @ValueSource(booleans = {true, false})
-    void shouldReturn200AndStartResponse(boolean isAuthenticated) throws IOException {
+    @MethodSource("successfulRequests")
+    void shouldReturn200AndStartResponse(
+            Map<String, String> customAuthParameters, boolean identityRequired, boolean isAuthenticated) throws IOException {
         String sessionId = redis.createSession(isAuthenticated);
+
         Scope scope = new Scope();
         scope.add(OIDCScopeValue.OPENID);
-        AuthenticationRequest authRequest =
+        var builder =
                 new AuthenticationRequest.Builder(
                                 ResponseType.CODE, scope, new ClientID(CLIENT_ID), REDIRECT_URI)
                         .nonce(new Nonce())
-                        .state(new State())
-                        .build();
+                        .state(new State());
+        customAuthParameters.forEach(builder::customParameter);
+        var authRequest = builder.build();
+
         redis.createClientSession(CLIENT_SESSION_ID, authRequest.toParameters());
 
         registerClient(KeyPairHelper.GENERATE_RSA_KEY_PAIR(), ClientType.WEB);
@@ -87,7 +102,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         StartResponse startResponse =
                 objectMapper.readValue(response.getBody(), StartResponse.class);
 
-        assertThat(startResponse.getUser().isIdentityRequired(), equalTo(false));
+        assertThat(startResponse.getUser().isIdentityRequired(), equalTo(identityRequired));
         assertThat(startResponse.getUser().isConsentRequired(), equalTo(true));
         assertThat(startResponse.getUser().isUpliftRequired(), equalTo(false));
         assertThat(startResponse.getClient().getClientName(), equalTo(TEST_CLIENT_NAME));
@@ -172,7 +187,8 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 "https://test.com",
                 "public",
                 true,
-                clientType);
+                clientType,
+                true);
     }
 
     private SignedJWT createSignedJWT(KeyPair keyPair) throws JOSEException {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
@@ -74,7 +74,10 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     @ParameterizedTest
     @MethodSource("successfulRequests")
     void shouldReturn200AndStartResponse(
-            Map<String, String> customAuthParameters, boolean identityRequired, boolean isAuthenticated) throws IOException {
+            Map<String, String> customAuthParameters,
+            boolean identityRequired,
+            boolean isAuthenticated)
+            throws IOException {
         String sessionId = redis.createSession(isAuthenticated);
 
         Scope scope = new Scope();

--- a/shared/src/main/java/uk/gov/di/authentication/shared/conditions/IdentityHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/conditions/IdentityHelper.java
@@ -8,6 +8,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import static uk.gov.di.authentication.shared.entity.LevelOfConfidence.NONE;
+
 public class IdentityHelper {
 
     private IdentityHelper() {}
@@ -26,6 +28,7 @@ public class IdentityHelper {
         }
         List<String> vtr = authRequest.getCustomParameter("vtr");
         VectorOfTrust vectorOfTrust = VectorOfTrust.parseFromAuthRequestAttribute(vtr);
-        return Objects.nonNull(vectorOfTrust.getLevelOfConfidence());
+        return Objects.nonNull(vectorOfTrust.getLevelOfConfidence())
+                && !(vectorOfTrust.getLevelOfConfidence().equals(NONE));
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/LevelOfConfidence.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/LevelOfConfidence.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public enum LevelOfConfidence {
+    NONE("P0", true),
     LOW_LEVEL("P1", false),
     MEDIUM_LEVEL("P2", true),
     HIGH_LEVEL("P3", false),

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/VectorOfTrust.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/VectorOfTrust.java
@@ -15,6 +15,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static net.minidev.json.parser.JSONParser.DEFAULT_PERMISSIVE_MODE;
+import static uk.gov.di.authentication.shared.entity.LevelOfConfidence.NONE;
 
 public class VectorOfTrust {
 
@@ -48,7 +49,7 @@ public class VectorOfTrust {
     }
 
     public boolean containsLevelOfConfidence() {
-        return levelOfConfidence != null;
+        return levelOfConfidence != null && !levelOfConfidence.equals(NONE);
     }
 
     public static VectorOfTrust parseFromAuthRequestAttribute(List<String> vtr) {

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/LevelOfConfidenceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/LevelOfConfidenceTest.java
@@ -50,15 +50,19 @@ class LevelOfConfidenceTest {
         List<String> allLevelOfConfidenceValues =
                 LevelOfConfidence.getAllSupportedLevelOfConfidenceValues();
 
-        assertThat(allLevelOfConfidenceValues.size(), equalTo(1));
+        assertThat(allLevelOfConfidenceValues.size(), equalTo(2));
+
+        assertThat(allLevelOfConfidenceValues.get(0), equalTo(LevelOfConfidence.NONE.getValue()));
 
         assertThat(
-                allLevelOfConfidenceValues.get(0),
+                allLevelOfConfidenceValues.get(1),
                 equalTo(LevelOfConfidence.MEDIUM_LEVEL.getValue()));
     }
 
     private static Stream<Arguments> supportedLevelOfConfidence() {
-        return Stream.of(Arguments.of("P2", LevelOfConfidence.MEDIUM_LEVEL));
+        return Stream.of(
+                Arguments.of("P0", LevelOfConfidence.NONE),
+                Arguments.of("P2", LevelOfConfidence.MEDIUM_LEVEL));
     }
 
     private static Stream<Arguments> unsupportedLevelOfConfidence() {

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/VectorOfTrustTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/VectorOfTrustTest.java
@@ -183,4 +183,13 @@ class VectorOfTrustTest {
                         Collections.singletonList(jsonArrayOf(vectorString)));
         assertFalse(vectorOfTrust.containsLevelOfConfidence());
     }
+
+    @Test
+    void shouldReturnFalseWhenIdentityLevelOfConfidenceIsP0() {
+        String vectorString = "P0.Cl.Cm";
+        VectorOfTrust vectorOfTrust =
+                VectorOfTrust.parseFromAuthRequestAttribute(
+                        Collections.singletonList(jsonArrayOf(vectorString)));
+        assertFalse(vectorOfTrust.containsLevelOfConfidence());
+    }
 }


### PR DESCRIPTION
## What?

- Update the `LevelOfConfidence` enum to include new value `P0`
- Update `IdentityHelper.identityRequired()` to return `false` if `vtr` contains `P0`
- Update `StartIntegrationTest` to test multiple vtr and ensure that correct value for `identityRequired` is returned
- Update `VectorOfTrust.containsLevelOfConfidence()` to return false if a `LevelOfConfidence` is specified but is `NONE`.

## Why?

We need to allow passing of `P0` but to treat it as if no LoC was passed at all.