### PR TITLE
AUT-384 - Make start honour identity enabled flag

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -117,7 +117,10 @@ public class StartHandler
                                                         .getAuthRequestParams());
                                 var userStartInfo =
                                         startService.buildUserStartInfo(
-                                                userContext, cookieConsent, gaTrackingId);
+                                                userContext,
+                                                cookieConsent,
+                                                gaTrackingId,
+                                                configurationService.isIdentityEnabled());
                                 if (userStartInfo.isDocCheckingAppUser()) {
                                     var docAppSubjectId =
                                             ClientSubjectHelper.calculatePairwiseIdentifier(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
@@ -103,7 +103,10 @@ public class StartService {
     }
 
     public UserStartInfo buildUserStartInfo(
-            UserContext userContext, String cookieConsent, String gaTrackingId) {
+            UserContext userContext,
+            String cookieConsent,
+            String gaTrackingId,
+            boolean identityEnabled) {
         var uplift = false;
         var identityRequired = false;
         var consentRequired = false;
@@ -115,7 +118,8 @@ public class StartService {
             identityRequired =
                     IdentityHelper.identityRequired(
                             userContext.getClientSession().getAuthRequestParams(),
-                            clientRegistry.isIdentityVerificationSupported());
+                            clientRegistry.isIdentityVerificationSupported(),
+                            identityEnabled);
         }
         LOG.info(
                 "Found UserStartInfo for Authenticated: {} ConsentRequired: {} UpliftRequired: {} IdentityRequired: {}. CookieConsent: {}. GATrackingId: {}. DocCheckingAppUser: {}",

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -83,6 +83,7 @@ class StartHandlerTest {
 
     @BeforeEach
     void beforeEach() {
+        when(configurationService.isIdentityEnabled()).thenReturn(true);
         when(context.getAwsRequestId()).thenReturn("aws-session-id");
         when(sessionService.getSessionFromRequestHeaders(any()))
                 .thenReturn(Optional.of(new Session("session-id")));
@@ -116,7 +117,7 @@ class StartHandlerTest {
         when(startService.getGATrackingId(anyMap())).thenReturn(gaTrackingId);
         when(startService.getCookieConsentValue(anyMap(), anyString()))
                 .thenReturn(cookieConsentValue);
-        when(startService.buildUserStartInfo(userContext, cookieConsentValue, gaTrackingId))
+        when(startService.buildUserStartInfo(userContext, cookieConsentValue, gaTrackingId, true))
                 .thenReturn(userStartInfo);
         usingValidClientSession();
         usingValidSession();
@@ -185,7 +186,8 @@ class StartHandlerTest {
                                 REDIRECT_URL));
         when(startService.getGATrackingId(anyMap())).thenReturn(null);
         when(startService.getCookieConsentValue(anyMap(), anyString())).thenReturn(null);
-        when(startService.buildUserStartInfo(userContext, null, null)).thenReturn(userStartInfo);
+        when(startService.buildUserStartInfo(userContext, null, null, true))
+                .thenReturn(userStartInfo);
         usingValidClientSession();
         usingValidSession();
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
@@ -123,7 +123,7 @@ class StartServiceTest {
                         rpSupportsIdentity,
                         isAuthenticated);
         var userStartInfo =
-                startService.buildUserStartInfo(userContext, cookieConsent, gaTrackingId);
+                startService.buildUserStartInfo(userContext, cookieConsent, gaTrackingId, true);
 
         assertThat(userStartInfo.isUpliftRequired(), equalTo(false));
         assertThat(userStartInfo.isIdentityRequired(), equalTo(false));
@@ -136,20 +136,26 @@ class StartServiceTest {
 
     private static Stream<Arguments> userStartIdentityInfo() {
         return Stream.of(
-                Arguments.of(jsonArrayOf("P2.Cl.Cm"), true, true),
-                Arguments.of(jsonArrayOf("Cl.Cm"), false, true),
-                Arguments.of(jsonArrayOf("P2.Cl.Cm"), false, false));
+                Arguments.of(jsonArrayOf("P2.Cl.Cm"), true, true, true),
+                Arguments.of(jsonArrayOf("Cl.Cm"), false, true, true),
+                Arguments.of(jsonArrayOf("P2.Cl.Cm"), false, false, true),
+                Arguments.of(jsonArrayOf("P2.Cl.Cm"), true, true, true),
+                Arguments.of(jsonArrayOf("P2.Cl.Cm"), false, true, false),
+                Arguments.of(jsonArrayOf("P2.Cl.Cm"), false, false, false));
     }
 
     @ParameterizedTest
     @MethodSource("userStartIdentityInfo")
     void shouldCreateUserStartInfoWithCorrectIdentityRequiredValue(
-            String vtr, boolean expectedIdentityRequiredValue, boolean rpSupportsIdentity) {
+            String vtr,
+            boolean expectedIdentityRequiredValue,
+            boolean rpSupportsIdentity,
+            boolean identityEnabled) {
         var userContext =
                 buildUserContext(vtr, false, true, ClientType.WEB, null, rpSupportsIdentity, false);
         var userStartInfo =
                 startService.buildUserStartInfo(
-                        userContext, "some-cookie-consent", "some-ga-tracking-id");
+                        userContext, "some-cookie-consent", "some-ga-tracking-id", identityEnabled);
 
         assertThat(userStartInfo.isUpliftRequired(), equalTo(false));
         assertThat(userStartInfo.isIdentityRequired(), equalTo(expectedIdentityRequiredValue));
@@ -178,7 +184,7 @@ class StartServiceTest {
                         isAuthenticated);
         var userStartInfo =
                 startService.buildUserStartInfo(
-                        userContext, "some-cookie-consent", "some-ga-tracking-id");
+                        userContext, "some-cookie-consent", "some-ga-tracking-id", true);
 
         assertThat(userStartInfo.isUpliftRequired(), equalTo(false));
         assertThat(userStartInfo.isIdentityRequired(), equalTo(false));
@@ -209,7 +215,7 @@ class StartServiceTest {
         userContext.getSession().setCurrentCredentialStrength(credentialTrustLevel);
         var userStartInfo =
                 startService.buildUserStartInfo(
-                        userContext, "some-cookie-consent", "some-ga-tracking-id");
+                        userContext, "some-cookie-consent", "some-ga-tracking-id", true);
 
         assertThat(userStartInfo.isUpliftRequired(), equalTo(expectedUpliftRequiredValue));
         assertThat(userStartInfo.isIdentityRequired(), equalTo(expectedIdentityRequiredValue));

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
@@ -60,7 +60,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @BeforeEach
     void setup() {
-        handler = new StartHandler(TEST_CONFIGURATION_SERVICE);
+        handler = new StartHandler(new TestConfigurationService());
     }
 
     private static Stream<Arguments> successfulRequests() {
@@ -212,5 +212,24 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var signer = new RSASSASigner(keyPair.getPrivate());
         signedJWT.sign(signer);
         return signedJWT;
+    }
+
+    protected static class TestConfigurationService extends IntegrationTestConfigurationService {
+
+        @Override
+        public boolean isIdentityEnabled() {
+            return true;
+        }
+
+        public TestConfigurationService() {
+            super(
+                    auditTopic,
+                    notificationsQueue,
+                    auditSigningKey,
+                    tokenSigner,
+                    ipvPrivateKeyJwtSigner,
+                    spotQueue,
+                    docAppPrivateKeyJwtSigner);
+        }
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/conditions/IdentityHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/conditions/IdentityHelper.java
@@ -16,8 +16,9 @@ public class IdentityHelper {
 
     public static boolean identityRequired(
             Map<String, List<String>> authRequestParams,
-            boolean clientSupportsIdentityVerification) {
-        if (!clientSupportsIdentityVerification) {
+            boolean clientSupportsIdentityVerification,
+            boolean identityEnabled) {
+        if (!clientSupportsIdentityVerification || !identityEnabled) {
             return false;
         }
         AuthenticationRequest authRequest;

--- a/shared/src/test/java/uk/gov/di/authentication/shared/conditions/IdentityHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/conditions/IdentityHelperTest.java
@@ -27,35 +27,42 @@ class IdentityHelperTest {
     void shouldReturnFalseWhenVtrNotPresentInAuthRequest() {
         var authRequest = createAuthRequest();
 
-        assertFalse(IdentityHelper.identityRequired(authRequest.toParameters(), true));
+        assertFalse(IdentityHelper.identityRequired(authRequest.toParameters(), true, true));
     }
 
     @Test
     void shouldReturnFalseWhenNoLevelOfConfidenceIsPresentInAuthRequest() {
         var authRequest = createAuthRequest("Cl.Cm");
 
-        assertFalse(IdentityHelper.identityRequired(authRequest.toParameters(), true));
+        assertFalse(IdentityHelper.identityRequired(authRequest.toParameters(), true, true));
     }
 
     @Test
     void shouldReturnFalseWhenP0LevelOfConfidenceIsPresentInAuthRequest() {
         var authRequest = createAuthRequest("P0.Cl.Cm");
 
-        assertFalse(IdentityHelper.identityRequired(authRequest.toParameters(), true));
+        assertFalse(IdentityHelper.identityRequired(authRequest.toParameters(), true, true));
     }
 
     @Test
     void shouldReturnTrueIfLevelOfConfidenceGreaterThanP0IsPresentInAuthRequest() {
         var authRequest = createAuthRequest("P2.Cl.Cm");
 
-        assertTrue(IdentityHelper.identityRequired(authRequest.toParameters(), true));
+        assertTrue(IdentityHelper.identityRequired(authRequest.toParameters(), true, true));
+    }
+
+    @Test
+    void shouldReturnFalseIfIdentityIsNotEnabled() {
+        var authRequest = createAuthRequest("P2.Cl.Cm");
+
+        assertFalse(IdentityHelper.identityRequired(authRequest.toParameters(), true, false));
     }
 
     @Test
     void shouldReturnFalseWhenRPDoesNotSupportIdentityVerification() {
         var authRequest = createAuthRequest("P2.Cl.Cm");
 
-        assertFalse(IdentityHelper.identityRequired(authRequest.toParameters(), false));
+        assertFalse(IdentityHelper.identityRequired(authRequest.toParameters(), false, true));
     }
 
     private AuthenticationRequest createAuthRequest() {


### PR DESCRIPTION
## What?

 - Make start honour identity enabled flag
- If the IDENTITY_ENABLED config value is set to false, then always make sure that the `identityRequired` property in the StartResponse returns false.


## Why?

- This will allow us to deploy the IPV infra to Production whilst ensuring no IPV journeys can be performed.
