### PR TITLE
AUT-383: Do not update authenticated flag or save session in auth-code for doc app jo…

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -232,12 +232,11 @@ public class AuthCodeHandler
                                                 authenticationRequest.getClientID().getValue()));
 
                                 if (!docCheckingUser) {
-                                    LOG.info(
-                                            "isDocCheckingAppUserWithSubjectId => authenticated = false");
+                                    sessionService.save(
+                                            session.setAuthenticated(true).setNewAccount(EXISTING));
+                                } else {
+                                    LOG.info("Session not saved for DocCheckingAppUser");
                                 }
-                                sessionService.save(
-                                        session.setAuthenticated(!docCheckingUser)
-                                                .setNewAccount(EXISTING));
 
                                 auditService.submitAuditEvent(
                                         OidcAuditableEvent.AUTH_CODE_ISSUED,

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -70,6 +70,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -202,7 +203,7 @@ class AuthCodeHandlerTest {
         assertThat(session.getCurrentCredentialStrength(), equalTo(finalLevel));
         assertThat(session.isAuthenticated(), not(equalTo(docAppJourney)));
 
-        verify(sessionService).save(session);
+        verify(sessionService, times(docAppJourney ? 0 : 1)).save(session);
 
         verify(auditService)
                 .submitAuditEvent(


### PR DESCRIPTION
## What?

Do not update authenticated flag or save session in auth-code for doc app journey.

## Why?

Setting the authenticated flag causes an SSO issue for a logged in user.  They are asked to login again after going through the doc app journey then navigating to another service.  (This is not actually a scenario anyone would ever do but is still considered worth fixing).

## Related PRs

#1893 