### PR TITLE
AUT-356: Add validator to `SerializationService` and use in `AuthenticateHandler`

### DIFF
--- a/account-management-api/build.gradle
+++ b/account-management-api/build.gradle
@@ -16,7 +16,8 @@ dependencies {
 
     implementation configurations.nimbus,
             configurations.govuk_notify,
-            configurations.jackson
+            configurations.jackson,
+            configurations.gson
 
     implementation project(":shared")
 

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/AuthenticateRequest.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/AuthenticateRequest.java
@@ -1,15 +1,17 @@
 package uk.gov.di.accountmanagement.entity;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.annotations.Expose;
+import jakarta.validation.constraints.NotNull;
 
 public class AuthenticateRequest {
 
-    private String email;
-    private String password;
+    @Expose @NotNull private String email;
 
-    public AuthenticateRequest(
-            @JsonProperty(required = true, value = "email") String email,
-            @JsonProperty(required = true, value = "password") String password) {
+    @Expose @NotNull private String password;
+
+    public AuthenticateRequest() {}
+
+    public AuthenticateRequest(String email, String password) {
         this.email = email;
         this.password = password;
     }

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandler.java
@@ -18,6 +18,7 @@ import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
+import uk.gov.di.authentication.shared.services.SerializationService;
 
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.SESSION_ID_HEADER;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
@@ -32,7 +33,7 @@ public class AuthenticateHandler
     private static final Logger LOG = LogManager.getLogger(AuthenticateHandler.class);
 
     private final AuthenticationService authenticationService;
-    private final Json objectMapper = Json.jackson();
+    private final Json objectMapper = SerializationService.getInstance();
     private final AuditService auditService;
 
     public AuthenticateHandler(

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ ext {
         aws_sdk_v2_version: "2.17.195",
         aws_lambda_core_version: "1.2.1",
         aws_lambda_events_version: "3.11.0",
+        gson: "2.9.0",
         nimbusds_oauth_version: "9.35",
         nimbusds_jwt_version: "9.22",
         protobuf_version: "3.20.1",
@@ -71,6 +72,7 @@ subprojects {
         dynamodb
         glassfish
         govuk_notify
+        gson
         hamcrest
         jackson
         lambda
@@ -107,6 +109,8 @@ subprojects {
                 "jakarta.activation:jakarta.activation-api:2.1.0"
 
         govuk_notify "uk.gov.service.notify:notifications-java-client:3.17.3-RELEASE"
+
+        gson "com.google.code.gson:gson:${dependencyVersions.gson}"
 
         hamcrest "org.hamcrest:hamcrest:2.2"
 

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -22,10 +22,9 @@ dependencies {
             configurations.ssm,
             configurations.xray,
             configurations.cloudwatch,
+            configurations.gson,
             "com.amazonaws:aws-java-sdk-lambda:1.12.224",
             "com.google.protobuf:protobuf-java:3.20.1"
-
-    implementation "com.google.code.gson:gson:2.9.0"
 
     testImplementation configurations.tests,
             configurations.lambda_tests,


### PR DESCRIPTION
## What?

- Add the Jakarta bean validator to the `SerializationService.readValue()` method
- Add a GSON dependency configuration to the root `build.gradle`
- Update the shared `build.gradle` to use the new configuration
- Use GSON to deserialise and validate the request body in the `AuthenticateHandler`

## Why?

We need to support validation of required attributes in JSON, add the bean validator to the `SerializationService`. We need to prove this works, as intended, on a relatively simple handler and measure any latency hit so adding it to the AuthenticateHandler is ideal.