### PR TITLE
AUT-384: Add `IDENTITY_ENABLED` to `StartHandler`

### DIFF
--- a/ci/terraform/oidc/start.tf
+++ b/ci/terraform/oidc/start.tf
@@ -30,6 +30,7 @@ module "start" {
     ENVIRONMENT              = var.environment
     DYNAMO_ENDPOINT          = var.use_localstack ? var.lambda_dynamo_endpoint : null
     HEADERS_CASE_INSENSITIVE = var.use_localstack ? "true" : "false"
+    IDENTITY_ENABLED         = var.ipv_api_enabled
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.StartHandler::handleRequest"
 


### PR DESCRIPTION
## What?

- Add the `IDENTITY_ENABLED` environment variable to the `StartHandler` lambda as this is now the feature flag for identity

## Why?

IPV journeys not currently working in staging or integration

## Related PRs

#1896 
