### PR TITLE
AUT-384 - Move IPV capacity lambda to OIDC api

### DIFF
--- a/ci/terraform/oidc/api-gateway-frontend.tf
+++ b/ci/terraform/oidc/api-gateway-frontend.tf
@@ -58,8 +58,6 @@ resource "aws_api_gateway_deployment" "frontend_deployment" {
       module.reset-password-request.method_trigger_value,
       var.ipv_api_enabled ? module.ipv-authorize[0].integration_trigger_value : null,
       var.ipv_api_enabled ? module.ipv-authorize[0].method_trigger_value : null,
-      var.ipv_api_enabled ? module.ipv-capacity[0].integration_trigger_value : null,
-      var.ipv_api_enabled ? module.ipv-capacity[0].method_trigger_value : null,
       var.doc_app_api_enabled ? module.doc-app-authorize[0].integration_trigger_value : null,
       var.doc_app_api_enabled ? module.doc-app-authorize[0].method_trigger_value : null,
     ]))

--- a/ci/terraform/oidc/api-gateway.tf
+++ b/ci/terraform/oidc/api-gateway.tf
@@ -129,6 +129,8 @@ resource "aws_api_gateway_deployment" "deployment" {
       module.userinfo.method_trigger_value,
       var.ipv_api_enabled ? module.ipv-callback[0].integration_trigger_value : null,
       var.ipv_api_enabled ? module.ipv-callback[0].method_trigger_value : null,
+      var.ipv_api_enabled ? module.ipv-capacity[0].integration_trigger_value : null,
+      var.ipv_api_enabled ? module.ipv-capacity[0].method_trigger_value : null,
       var.doc_app_api_enabled ? module.doc-app-callback[0].integration_trigger_value : null,
       var.doc_app_api_enabled ? module.doc-app-callback[0].method_trigger_value : null,
     ]))

--- a/ci/terraform/oidc/ipv-capacity.tf
+++ b/ci/terraform/oidc/ipv-capacity.tf
@@ -34,9 +34,9 @@ module "ipv-capacity" {
   handler_function_name = "uk.gov.di.authentication.ipv.lambda.IPVCapacityHandler::handleRequest"
 
   create_endpoint  = true
-  rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
-  root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
-  execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
+  rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
+  root_resource_id = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
+  execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
   memory_size      = var.endpoint_memory_size
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
@@ -69,7 +69,7 @@ module "ipv-capacity" {
   use_localstack = var.use_localstack
 
   depends_on = [
-    aws_api_gateway_rest_api.di_authentication_frontend_api,
+    aws_api_gateway_rest_api.di_authentication_api,
     aws_api_gateway_resource.connect_resource,
     aws_api_gateway_resource.wellknown_resource,
   ]


### PR DESCRIPTION

## What?

 - Move IPV capacity lambda to OIDC api

## Why?

- This lambda will be requested by RPs. Therefore the API needs to be publicly available to them.