### PR TITLE
AUT-385 - Check whether identity is enabled in IPV callback and authorize lambdas

### DIFF
--- a/ci/terraform/oidc/ipv-authorize.tf
+++ b/ci/terraform/oidc/ipv-authorize.tf
@@ -32,6 +32,7 @@ module "ipv-authorize" {
     LOCALSTACK_ENDPOINT            = var.use_localstack ? var.localstack_endpoint : null
     REDIS_KEY                      = local.redis_key
     DYNAMO_ENDPOINT                = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    IDENTITY_ENABLED               = var.ipv_api_enabled
     IPV_AUTHORISATION_URI          = var.ipv_authorisation_uri
     IPV_AUTHORISATION_CALLBACK_URI = var.ipv_authorisation_callback_uri
     IPV_AUTHORISATION_CLIENT_ID    = var.ipv_authorisation_client_id

--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -30,6 +30,7 @@ module "ipv-callback" {
     DYNAMO_ENDPOINT                = var.use_localstack ? var.lambda_dynamo_endpoint : null
     EVENTS_SNS_TOPIC_ARN           = aws_sns_topic.events.arn
     ENVIRONMENT                    = var.environment
+    IDENTITY_ENABLED               = var.ipv_api_enabled
     IPV_TOKEN_SIGNING_KEY_ALIAS    = local.ipv_token_auth_key_alias_name
     IPV_AUTHORISATION_CLIENT_ID    = var.ipv_authorisation_client_id
     IPV_AUTHORISATION_CALLBACK_URI = var.ipv_authorisation_callback_uri

--- a/ci/terraform/oidc/production-overrides.tfvars
+++ b/ci/terraform/oidc/production-overrides.tfvars
@@ -12,3 +12,5 @@ cloudwatch_log_retention    = 5
 lambda_min_concurrency      = 50
 client_registry_api_enabled = false
 ipv_api_enabled             = false
+ipv_capacity_allowed        = false
+spot_enabled                = false

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVAuthorisationHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVAuthorisationHandlerIntegrationTest.java
@@ -196,5 +196,10 @@ class IPVAuthorisationHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
         public String getIPVSector() {
             return IPV_SECTOR;
         }
+
+        @Override
+        public boolean isIdentityEnabled() {
+            return true;
+        }
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
@@ -226,5 +226,10 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
         public URI getIPVAuthorisationCallbackURI() {
             return URI.create("http://localhost/redirect");
         }
+
+        @Override
+        public boolean isIdentityEnabled() {
+            return true;
+        }
     }
 }

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandler.java
@@ -94,6 +94,10 @@ public class IPVAuthorisationHandler extends BaseFrontendHandler<IPVAuthorisatio
             IPVAuthorisationRequest request,
             UserContext userContext) {
         try {
+            if (!configurationService.isIdentityEnabled()) {
+                LOG.error("Identity is not enabled");
+                throw new RuntimeException("Identity is not enabled");
+            }
             var persistentId =
                     PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders());
             attachLogFieldToLogs(PERSISTENT_SESSION_ID, persistentId);

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -124,6 +124,10 @@ public class IPVCallbackHandler
                 .orElseGet(
                         () -> {
                             LOG.info("Request received to IPVCallbackHandler");
+                            if (!configurationService.isIdentityEnabled()) {
+                                LOG.error("Identity is not enabled");
+                                throw new RuntimeException("Identity is not enabled");
+                            }
                             try {
                                 var sessionCookiesIds =
                                         CookieHelper.parseSessionCookie(input.getHeaders())

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandlerTest.java
@@ -67,6 +67,7 @@ import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.startsWith;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
@@ -141,6 +142,22 @@ public class IPVAuthorisationHandlerTest {
                 .thenReturn(Optional.of(userProfile));
         when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(SALT.array());
         when(configService.getIPVSector()).thenReturn(IPV_SECTOR);
+        when(configService.isIdentityEnabled()).thenReturn(true);
+    }
+
+    @Test
+    void shouldThrowWhenIdentityIsNotEnabled() {
+        usingValidSession();
+        usingValidClientSession();
+        when(configService.isIdentityEnabled()).thenReturn(false);
+
+        var exception =
+                assertThrows(
+                        RuntimeException.class,
+                        this::makeHandlerRequest,
+                        "Expected to throw exception");
+
+        assertThat(exception.getMessage(), equalTo("Identity is not enabled"));
     }
 
     @Test

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -127,8 +127,23 @@ class IPVCallbackHandlerTest {
         when(configService.isSpotEnabled()).thenReturn(true);
         when(configService.getIPVBackendURI()).thenReturn(IPV_URI);
         when(configService.getIPVSector()).thenReturn(OIDC_BASE_URL + "/trustmark");
-
+        when(configService.isIdentityEnabled()).thenReturn(true);
         when(context.getAwsRequestId()).thenReturn(REQUEST_ID);
+    }
+
+    @Test
+    void shouldThrowWhenIdentityIsNotEnabled() {
+        when(configService.isIdentityEnabled()).thenReturn(false);
+        usingValidSession();
+        usingValidClientSession();
+
+        var exception =
+                assertThrows(
+                        RuntimeException.class,
+                        () -> makeHandlerRequest(getApiGatewayProxyRequestEvent("P2")),
+                        "Expected to throw exception");
+
+        assertThat(exception.getMessage(), equalTo("Identity is not enabled"));
     }
 
     @Test


### PR DESCRIPTION
## What?

- To ensure that Identity journey cannot be carried out in production, add a check on the IPVCallback and IPVAuthorize lambdas to see if identity is enabled and throw and exception if it is not.

## Why?

- We currently have an ipv_enabled flag on the terraform which determines whether or not we deploy IPV infra. We want to start deploying IPV infra to production so we are in a position to share our config with other teams, however the Identity code is not yet ready to be used in production.
