### PR TITLE
AUT-385 - Re-enable IPV in Staging and Integration

### DIFF
--- a/ci/terraform/oidc/integration-overrides.tfvars
+++ b/ci/terraform/oidc/integration-overrides.tfvars
@@ -1,5 +1,5 @@
-ipv_api_enabled                = false
-ipv_capacity_allowed           = false
+ipv_api_enabled                = true
+ipv_capacity_allowed           = true
 ipv_authorisation_client_id    = "authOrchestrator"
 ipv_authorisation_uri          = "https://identity.integration.account.gov.uk/oauth2/authorize"
 ipv_authorisation_callback_uri = "https://oidc.integration.account.gov.uk/ipv-callback"

--- a/ci/terraform/oidc/staging-overrides.tfvars
+++ b/ci/terraform/oidc/staging-overrides.tfvars
@@ -1,6 +1,6 @@
 doc_app_api_enabled                = true
-ipv_capacity_allowed               = false
-ipv_api_enabled                    = false
+ipv_capacity_allowed               = true
+ipv_api_enabled                    = true
 doc_app_authorisation_client_id    = "authOrchestratorDocApp"
 doc_app_authorisation_callback_uri = "https://oidc.staging.account.gov.uk/doc-checking-app-callback"
 ipv_authorisation_client_id        = "authOrchestrator"


### PR DESCRIPTION
## What?

- Re-enable IPV in Staging and Integration

## Why?

- We have removed the feature flag for IPV so we should now be able to re-enable IPV in Staging and Integration.
