### PR TITLE
AUT-385 - Swap feature flag in aws_lambda_event_source_mapping to spot_enabled

### DIFF
--- a/ci/terraform/oidc/build-overrides.tfvars
+++ b/ci/terraform/oidc/build-overrides.tfvars
@@ -5,6 +5,7 @@ doc_app_domain                     = "https://build-doc-app-cri-stub.london.clou
 doc_app_authorisation_client_id    = "authOrchestrator"
 doc_app_authorisation_callback_uri = "https://oidc.build.account.gov.uk/doc-checking-app-callback"
 doc_app_authorisation_uri          = "https://build-doc-app-cri-stub.london.cloudapps.digital/authorize"
+spot_enabled                       = false
 doc_app_auth_public_encryption_key = <<-EOT
 -----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvnQV8yrKnVObCMg+ZNLQ

--- a/ci/terraform/oidc/production-overrides.tfvars
+++ b/ci/terraform/oidc/production-overrides.tfvars
@@ -13,4 +13,4 @@ lambda_min_concurrency      = 50
 client_registry_api_enabled = false
 ipv_api_enabled             = false
 ipv_capacity_allowed        = false
-spot_enabled                = false
+spot_enabled                = true

--- a/ci/terraform/oidc/spot-response.tf
+++ b/ci/terraform/oidc/spot-response.tf
@@ -58,7 +58,7 @@ resource "aws_iam_policy" "spot_response_sqs_read_policy" {
 }
 
 resource "aws_lambda_event_source_mapping" "spot_response_lambda_sqs_mapping" {
-  count            = var.ipv_api_enabled ? 1 : 0
+  count            = var.spot_enabled ? 1 : 0
   event_source_arn = aws_ssm_parameter.spot_response_queue_arn.value
   function_name    = aws_lambda_function.spot_response_lambda.arn
 


### PR DESCRIPTION
## What?

- Swap feature flag in aws_lambda_event_source_mapping to spot_enabled

## Why?

- We want to keep IPV disabled in Production but we want to connect to the SPOT queue. We still need a flag on the aws_lambda_event_source_mapping resource, as we don't have a SPOT response queue yet in build so the terraform will fail. By using the spot_enabled flag and enabling SPOT in production, we can test that we can connect to the SPOT queue.
 - Users still won't be able to use the identity journey as we check if Identity is enabled in both the IPV Authorize and IPV callback lambda and that will remain disabled
