### PR TITLE
AUT-401: change session timeout to 2hrs

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -310,7 +310,7 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
     }
 
     public int getSessionCookieMaxAge() {
-        return Integer.parseInt(System.getenv().getOrDefault("SESSION_COOKIE_MAX_AGE", "3600"));
+        return Integer.parseInt(System.getenv().getOrDefault("SESSION_COOKIE_MAX_AGE", "7200"));
     }
 
     public int getPersistentCookieMaxAge() {
@@ -319,7 +319,7 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
     }
 
     public long getSessionExpiry() {
-        return Long.parseLong(System.getenv().getOrDefault("SESSION_EXPIRY", "3600"));
+        return Long.parseLong(System.getenv().getOrDefault("SESSION_EXPIRY", "7200"));
     }
 
     public String getSmoketestBucketName() {

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/ConfigurationServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/ConfigurationServiceTest.java
@@ -29,7 +29,7 @@ class ConfigurationServiceTest {
     @Test
     void sessionCookieMaxAgeShouldEqualDefaultWhenEnvVarUnset() {
         ConfigurationService configurationService = new ConfigurationService();
-        assertEquals(3600, configurationService.getSessionCookieMaxAge());
+        assertEquals(7200, configurationService.getSessionCookieMaxAge());
     }
 
     @Test


### PR DESCRIPTION
## What?

Change session timeout to 2hrs.

## Why?

Support long-running identity proofing.