### PR TITLE
BAU - Remove identity endpoint from wellknown

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/WellknownHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/WellknownHandler.java
@@ -117,9 +117,6 @@ public class WellknownHandler
                                 providerMetadata.setSupportsBackChannelLogout(true);
                                 providerMetadata.setCustomParameter(
                                         "trustmarks", buildURI(baseUrl, "/trustmark").toString());
-                                providerMetadata.setCustomParameter(
-                                        "identity_endpoint",
-                                        buildURI(baseUrl, "/identity").toString());
 
                                 return generateApiGatewayProxyResponse(
                                         200, providerMetadata.toString());

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/WellknownHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/WellknownHandlerTest.java
@@ -57,11 +57,6 @@ class WellknownHandlerTest {
                         .getCustomParameters()
                         .get("trustmarks"),
                 equalTo(expectedTrustMarkURI));
-        assertThat(
-                OIDCProviderMetadata.parse(result.getBody())
-                        .getCustomParameters()
-                        .get("identity_endpoint"),
-                equalTo(expectedIdentityURI));
     }
 
     @Test


### PR DESCRIPTION
## What?

- Remove identity endpoint from wellknown

## Why?

- We will no longer have an identity endpoint so we should remove it from our wellknown endpoint