### PR TITLE
BAU: Use `AmazonCorrettoCryptoProvider` in build environment

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -70,7 +70,10 @@ jobs:
       - name: Run Unit Tests
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew --parallel test jacocoTestReport -x integration-tests:test -x account-management-integration-tests:test -x delivery-receipts-integration-tests:test -x spotlessApply -x spotlessCheck
+          ENVIRONMENT: CI
+        run: |
+          echo $ENVIRONMENT
+          ./gradlew --stacktrace --parallel test jacocoTestReport -x integration-tests:test -x account-management-integration-tests:test -x delivery-receipts-integration-tests:test -x spotlessApply -x spotlessCheck
       - name: Upload Unit Test Reports
         uses: actions/upload-artifact@v2
         if: failure()
@@ -153,6 +156,8 @@ jobs:
             !*/build/jacoco
           key: ${{ runner.os }}-build-${{ github.sha }}
       - name: Run Integration Tests
+        env:
+          ENVIRONMENT: CI
         run: |
           ./gradlew :integration-tests:test :integration-tests:jacocoTestReport -x spotlessApply -x spotlessCheck -x composeUp
       - name: Upload Integration Test Reports

--- a/build.gradle
+++ b/build.gradle
@@ -98,7 +98,8 @@ subprojects {
         apache "commons-codec:commons-codec:1.15",
                 "org.apache.httpcomponents:httpclient:4.5.13"
 
-        bouncycastle "org.bouncycastle:bcpkix-jdk15on:1.70"
+        bouncycastle "org.bouncycastle:bcpkix-jdk15on:1.70",
+                "software.amazon.cryptools:AmazonCorrettoCryptoProvider:1.+:linux-x86_64"
 
         cloudwatch "software.amazon.cloudwatchlogs:aws-embedded-metrics:2.0.0"
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/EnvironmentAwareCryptoProvider.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/EnvironmentAwareCryptoProvider.java
@@ -1,0 +1,32 @@
+package uk.gov.di.authentication.shared.helpers;
+
+import com.amazon.corretto.crypto.provider.AmazonCorrettoCryptoProvider;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+
+import java.security.Provider;
+import java.util.Arrays;
+import java.util.List;
+
+public class EnvironmentAwareCryptoProvider {
+
+    private static final List<String> ENABLED_ENVIRONMENTS = Arrays.asList("CI", "build");
+
+    static {
+        if (ENABLED_ENVIRONMENTS.contains(System.getenv("ENVIRONMENT"))) {
+            AmazonCorrettoCryptoProvider.install();
+        }
+    }
+
+    public static Provider provider() {
+        if (AmazonCorrettoCryptoProvider.INSTANCE.getLoadingError() != null) {
+            System.out.println(
+                    AmazonCorrettoCryptoProvider.INSTANCE.getLoadingError().getMessage());
+        }
+
+        if (ENABLED_ENVIRONMENTS.contains(System.getenv("ENVIRONMENT"))) {
+            return new AmazonCorrettoCryptoProvider();
+        } else {
+            return new BouncyCastleProvider();
+        }
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/JwksService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/JwksService.java
@@ -14,7 +14,7 @@ import org.bouncycastle.openssl.PEMException;
 import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
 import software.amazon.awssdk.services.kms.model.GetPublicKeyRequest;
 import software.amazon.awssdk.services.kms.model.GetPublicKeyResponse;
-import uk.gov.di.authentication.shared.helpers.CryptoProviderHelper;
+import uk.gov.di.authentication.shared.helpers.EnvironmentAwareCryptoProvider;
 
 import java.io.IOException;
 import java.net.URL;
@@ -94,7 +94,7 @@ public class JwksService {
 
         try {
             return new JcaPEMKeyConverter()
-                    .setProvider(CryptoProviderHelper.bouncyCastle())
+                    .setProvider(EnvironmentAwareCryptoProvider.provider())
                     .getPublicKey(subjectKeyInfo);
         } catch (PEMException e) {
             LOG.error("Error getting the PublicKey using the JcaPEMKeyConverter", e);


### PR DESCRIPTION
This is to compare performance versus BouncyCastle

Once we're sure that we have functional parity, we can feature-toggle this in a live environment.
