### PR TITLE
AUT-356: Jackson to GSON migration for frontend API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,12 @@ subprojects {
 
         govuk_notify "uk.gov.service.notify:notifications-java-client:3.17.3-RELEASE"
 
-        gson "com.google.code.gson:gson:${dependencyVersions.gson}"
+        gson "com.google.code.gson:gson:${dependencyVersions.gson}",
+                "org.hibernate.validator:hibernate-validator:7.0.4.Final",
+                "org.glassfish:jakarta.el:4.0.2",
+                "jakarta.xml.bind:jakarta.xml.bind-api:4.0.0",
+                "com.sun.xml.bind:jaxb-impl:3.0.2"
+
 
         hamcrest "org.hamcrest:hamcrest:2.2"
 

--- a/frontend-api/build.gradle
+++ b/frontend-api/build.gradle
@@ -16,7 +16,7 @@ dependencies {
             configurations.dynamodb
 
     implementation configurations.govuk_notify,
-            configurations.jackson,
+            configurations.gson,
             configurations.nimbus,
             configurations.cloudwatch,
             configurations.bouncycastle

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/CheckUserExistsResponse.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/CheckUserExistsResponse.java
@@ -1,18 +1,24 @@
 package uk.gov.di.authentication.frontendapi.entity;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
 
 public class CheckUserExistsResponse {
 
     @JsonProperty("email")
+    @SerializedName("email")
+    @Expose
     private String email;
 
     @JsonProperty("doesUserExist")
+    @SerializedName("doesUserExist")
+    @Expose
     private boolean doesUserExist;
 
-    public CheckUserExistsResponse(
-            @JsonProperty(required = true, value = "email") String email,
-            @JsonProperty(required = true, value = "doesUserExist") boolean doesUserExist) {
+    public CheckUserExistsResponse() {}
+
+    public CheckUserExistsResponse(String email, boolean doesUserExist) {
         this.email = email;
         this.doesUserExist = doesUserExist;
     }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/ClientStartInfo.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/ClientStartInfo.java
@@ -1,33 +1,41 @@
 package uk.gov.di.authentication.frontendapi.entity;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
 
 import java.net.URI;
 import java.util.List;
 
 public class ClientStartInfo {
 
-    @JsonProperty("clientName")
+    @SerializedName("clientName")
+    @Expose
     private String clientName;
 
-    @JsonProperty("scopes")
+    @SerializedName("scopes")
+    @Expose
     private List<String> scopes;
 
-    @JsonProperty("serviceType")
+    @SerializedName("serviceType")
+    @Expose
     private String serviceType;
 
-    @JsonProperty("cookieConsentShared")
+    @SerializedName("cookieConsentShared")
+    @Expose
     private boolean cookieConsentShared;
 
-    @JsonProperty("redirectUri")
+    @SerializedName("redirectUri")
+    @Expose
     private URI redirectUri;
 
+    public ClientStartInfo() {}
+
     public ClientStartInfo(
-            @JsonProperty(required = true, value = "clientName") String clientName,
-            @JsonProperty(required = true, value = "scopes") List<String> scopes,
-            @JsonProperty(required = true, value = "serviceType") String serviceType,
-            @JsonProperty(value = "cookieConsentShared") boolean cookieConsentShared,
-            @JsonProperty(value = "redirectUri") URI redirectUri) {
+            String clientName,
+            List<String> scopes,
+            String serviceType,
+            boolean cookieConsentShared,
+            URI redirectUri) {
         this.clientName = clientName;
         this.scopes = scopes;
         this.serviceType = serviceType;

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/LoginRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/LoginRequest.java
@@ -1,14 +1,12 @@
 package uk.gov.di.authentication.frontendapi.entity;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.annotations.Expose;
 import jakarta.validation.constraints.NotNull;
 import uk.gov.di.authentication.shared.entity.BaseFrontendRequest;
 
 public class LoginRequest extends BaseFrontendRequest {
 
-    @JsonProperty(required = true, value = "password")
-    @NotNull
-    private String password;
+    @Expose @NotNull private String password;
 
     public LoginRequest() {}
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/LoginResponse.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/LoginResponse.java
@@ -1,32 +1,43 @@
 package uk.gov.di.authentication.frontendapi.entity;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import jakarta.validation.constraints.NotNull;
 
 public class LoginResponse {
 
-    @JsonProperty("redactedPhoneNumber")
+    @SerializedName("redactedPhoneNumber")
+    @Expose
     private String redactedPhoneNumber;
 
-    @JsonProperty("mfaRequired")
+    @SerializedName("mfaRequired")
+    @Expose
+    @NotNull
     private boolean mfaRequired;
 
-    @JsonProperty("phoneNumberVerified")
+    @SerializedName("phoneNumberVerified")
+    @Expose
+    @NotNull
     private boolean phoneNumberVerified;
 
-    @JsonProperty(value = "latestTermsAndConditionsAccepted")
+    @SerializedName(value = "latestTermsAndConditionsAccepted")
+    @Expose
+    @NotNull
     private boolean latestTermsAndConditionsAccepted;
 
-    @JsonProperty(value = "consentRequired")
+    @SerializedName(value = "consentRequired")
+    @Expose
+    @NotNull
     private boolean consentRequired;
 
+    public LoginResponse() {}
+
     public LoginResponse(
-            @JsonProperty(value = "redactedPhoneNumber") String redactedPhoneNumber,
-            @JsonProperty(value = "mfaRequired", required = true) boolean mfaRequired,
-            @JsonProperty(value = "phoneNumberVerified", required = true)
-                    boolean phoneNumberVerified,
-            @JsonProperty(value = "latestTermsAndConditionsAccepted", required = true)
-                    boolean latestTermsAndConditionsAccepted,
-            @JsonProperty(value = "consentRequired", required = true) boolean consentRequired) {
+            String redactedPhoneNumber,
+            boolean mfaRequired,
+            boolean phoneNumberVerified,
+            boolean latestTermsAndConditionsAccepted,
+            boolean consentRequired) {
         this.redactedPhoneNumber = redactedPhoneNumber;
         this.mfaRequired = mfaRequired;
         this.phoneNumberVerified = phoneNumberVerified;

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/ResetPasswordCompletionRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/ResetPasswordCompletionRequest.java
@@ -1,13 +1,17 @@
 package uk.gov.di.authentication.frontendapi.entity;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
 import jakarta.validation.constraints.NotNull;
 
 public class ResetPasswordCompletionRequest {
-    @JsonProperty(value = "code")
+
+    @SerializedName(value = "code")
+    @Expose
     private String code;
 
-    @JsonProperty(required = true, value = "password")
+    @SerializedName("password")
+    @Expose
     @NotNull
     private String password;
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/ResetPasswordRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/ResetPasswordRequest.java
@@ -1,9 +1,13 @@
 package uk.gov.di.authentication.frontendapi.entity;
 
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
 import uk.gov.di.authentication.shared.entity.BaseFrontendRequest;
 
 public class ResetPasswordRequest extends BaseFrontendRequest {
 
+    @Expose
+    @SerializedName("useCodeFlow")
     private boolean useCodeFlow = false;
 
     public ResetPasswordRequest() {}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/SendNotificationRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/SendNotificationRequest.java
@@ -1,17 +1,20 @@
 package uk.gov.di.authentication.frontendapi.entity;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
 import jakarta.validation.constraints.NotNull;
 import uk.gov.di.authentication.shared.entity.BaseFrontendRequest;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 
 public class SendNotificationRequest extends BaseFrontendRequest {
 
-    @JsonProperty(required = true, value = "notificationType")
+    @SerializedName("notificationType")
+    @Expose
     @NotNull
     private NotificationType notificationType;
 
-    @JsonProperty(value = "phoneNumber")
+    @SerializedName("phoneNumber")
+    @Expose
     private String phoneNumber;
 
     public NotificationType getNotificationType() {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/SignUpResponse.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/SignUpResponse.java
@@ -1,14 +1,19 @@
 package uk.gov.di.authentication.frontendapi.entity;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import jakarta.validation.constraints.NotNull;
 
 public class SignUpResponse {
 
-    @JsonProperty(value = "consentRequired")
+    @SerializedName("consentRequired")
+    @Expose
+    @NotNull
     private boolean consentRequired;
 
-    public SignUpResponse(
-            @JsonProperty(value = "consentRequired", required = true) boolean consentRequired) {
+    public SignUpResponse() {}
+
+    public SignUpResponse(boolean consentRequired) {
         this.consentRequired = consentRequired;
     }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/SignupRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/SignupRequest.java
@@ -1,12 +1,14 @@
 package uk.gov.di.authentication.frontendapi.entity;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
 import jakarta.validation.constraints.NotNull;
 import uk.gov.di.authentication.shared.entity.BaseFrontendRequest;
 
 public class SignupRequest extends BaseFrontendRequest {
 
-    @JsonProperty(required = true, value = "password")
+    @SerializedName("password")
+    @Expose
     @NotNull
     private String password;
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/StartResponse.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/StartResponse.java
@@ -1,18 +1,24 @@
 package uk.gov.di.authentication.frontendapi.entity;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import jakarta.validation.constraints.NotNull;
 
 public class StartResponse {
 
-    @JsonProperty("user")
+    @SerializedName("user")
+    @NotNull
+    @Expose
     private UserStartInfo user;
 
-    @JsonProperty("client")
+    @SerializedName("client")
+    @NotNull
+    @Expose
     private ClientStartInfo client;
 
-    public StartResponse(
-            @JsonProperty(required = true, value = "user") UserStartInfo user,
-            @JsonProperty(required = true, value = "client") ClientStartInfo client) {
+    public StartResponse() {}
+
+    public StartResponse(UserStartInfo user, ClientStartInfo client) {
         this.user = user;
         this.client = client;
     }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/UpdateProfileRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/UpdateProfileRequest.java
@@ -1,16 +1,19 @@
 package uk.gov.di.authentication.frontendapi.entity;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
 import jakarta.validation.constraints.NotNull;
 import uk.gov.di.authentication.shared.entity.BaseFrontendRequest;
 
 public class UpdateProfileRequest extends BaseFrontendRequest {
 
-    @JsonProperty(required = true, value = "updateProfileType")
+    @SerializedName("updateProfileType")
+    @Expose
     @NotNull
     private UpdateProfileType updateProfileType;
 
-    @JsonProperty(required = true, value = "profileInformation")
+    @SerializedName("profileInformation")
+    @Expose
     @NotNull
     private String profileInformation;
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/UserStartInfo.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/UserStartInfo.java
@@ -1,38 +1,53 @@
 package uk.gov.di.authentication.frontendapi.entity;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import jakarta.validation.constraints.NotNull;
 
 public class UserStartInfo {
 
-    @JsonProperty("consentRequired")
+    @SerializedName("consentRequired")
+    @Expose
+    @NotNull
     private boolean consentRequired;
 
-    @JsonProperty("upliftRequired")
+    @SerializedName("upliftRequired")
+    @Expose
+    @NotNull
     private boolean upliftRequired;
 
-    @JsonProperty("identityRequired")
+    @SerializedName("identityRequired")
+    @Expose
+    @NotNull
     private boolean identityRequired;
 
-    @JsonProperty("authenticated")
+    @SerializedName("authenticated")
+    @Expose
+    @NotNull
     private boolean authenticated;
 
-    @JsonProperty("cookieConsent")
+    @SerializedName("cookieConsent")
+    @Expose
     private String cookieConsent;
 
-    @JsonProperty("gaCrossDomainTrackingId")
+    @SerializedName("gaCrossDomainTrackingId")
+    @Expose
     private String gaCrossDomainTrackingId;
 
-    @JsonProperty("docCheckingAppUser")
+    @SerializedName("docCheckingAppUser")
+    @Expose
     private boolean docCheckingAppUser;
 
+    public UserStartInfo() {}
+
     public UserStartInfo(
-            @JsonProperty(required = true, value = "consentRequired") boolean consentRequired,
-            @JsonProperty(required = true, value = "upliftRequired") boolean upliftRequired,
-            @JsonProperty(required = true, value = "identityRequired") boolean identityRequired,
-            @JsonProperty(required = true, value = "authenticated") boolean authenticated,
-            @JsonProperty(value = "cookieConsent") String cookieConsent,
-            @JsonProperty(value = "gaCrossDomainTrackingId") String gaCrossDomainTrackingId,
-            @JsonProperty(value = "docCheckingAppUser") boolean docCheckingAppUser) {
+            boolean consentRequired,
+            boolean upliftRequired,
+            boolean identityRequired,
+            boolean authenticated,
+            String cookieConsent,
+            String gaCrossDomainTrackingId,
+            boolean docCheckingAppUser) {
         this.consentRequired = consentRequired;
         this.upliftRequired = upliftRequired;
         this.identityRequired = identityRequired;

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/VerifyCodeRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/VerifyCodeRequest.java
@@ -1,6 +1,7 @@
 package uk.gov.di.authentication.frontendapi.entity;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
 import jakarta.validation.constraints.NotNull;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 
@@ -13,11 +14,13 @@ public class VerifyCodeRequest {
         this.code = code;
     }
 
-    @JsonProperty(required = true, value = "notificationType")
+    @SerializedName("notificationType")
+    @Expose
     @NotNull
     private NotificationType notificationType;
 
-    @JsonProperty(required = true, value = "code")
+    @SerializedName("code")
+    @Expose
     @NotNull
     private String code;
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandler.java
@@ -13,6 +13,7 @@ import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.serialization.Json.JsonException;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.NotificationService;
+import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.service.notify.NotificationClient;
 import uk.gov.service.notify.NotificationClientException;
 
@@ -34,7 +35,7 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
     private static final Logger LOG = LogManager.getLogger(NotificationHandler.class);
 
     private final NotificationService notificationService;
-    private final Json objectMapper = Json.jackson();
+    private final Json objectMapper = SerializationService.getInstance();
     private final AmazonS3 s3Client;
     private final ConfigurationService configurationService;
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
@@ -19,7 +19,6 @@ import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.helpers.ValidationHelper;
 import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
-import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.serialization.Json.JsonException;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
@@ -46,7 +45,6 @@ public class ResetPasswordHandler extends BaseFrontendHandler<ResetPasswordCompl
     private final AwsSqsClient sqsClient;
     private final CodeStorageService codeStorageService;
     private final AuditService auditService;
-    private final Json objectMapper = Json.jackson();
 
     private static final Logger LOG = LogManager.getLogger(ResetPasswordHandler.class);
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
@@ -4,7 +4,6 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -14,13 +13,14 @@ import uk.gov.di.authentication.frontendapi.entity.CheckUserExistsResponse;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
-import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
+import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
@@ -56,7 +56,7 @@ class CheckUserExistsHandlerTest {
     private final ClientService clientService = mock(ClientService.class);
 
     private CheckUserExistsHandler handler;
-    private static final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
+    private static final Json objectMapper = SerializationService.getInstance();
 
     private final Session session = new Session(IdGenerator.generate());
 
@@ -85,7 +85,7 @@ class CheckUserExistsHandlerTest {
     }
 
     @Test
-    void shouldReturn200IfUserExists() throws JsonProcessingException {
+    void shouldReturn200IfUserExists() throws JsonProcessingException, Json.JsonException {
         usingValidSession();
         String persistentId = "some-persistent-id-value";
         Map<String, String> headers = new HashMap<>();
@@ -121,7 +121,7 @@ class CheckUserExistsHandlerTest {
     }
 
     @Test
-    void shouldReturn200IfUserDoesNotExist() throws JsonProcessingException {
+    void shouldReturn200IfUserDoesNotExist() throws JsonProcessingException, Json.JsonException {
         usingValidSession();
         when(authenticationService.userExists(eq("joe.bloggs@digital.cabinet-office.gov.uk")))
                 .thenReturn(false);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
@@ -4,7 +4,6 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.id.ClientID;
@@ -30,14 +29,15 @@ import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.VectorOfTrust;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
-import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
+import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
@@ -75,7 +75,7 @@ class LoginHandlerTest {
             new UserCredentials().setEmail(EMAIL).setPassword(PASSWORD);
     private static final String PHONE_NUMBER = "01234567890";
     private static final ClientID CLIENT_ID = new ClientID();
-    private static final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
+    private static final Json objectMapper = SerializationService.getInstance();
 
     private LoginHandler handler;
     private final Context context = mock(Context.class);
@@ -128,7 +128,7 @@ class LoginHandlerTest {
     }
 
     @Test
-    void shouldReturn200IfLoginIsSuccessful() throws JsonProcessingException {
+    void shouldReturn200IfLoginIsSuccessful() throws JsonProcessingException, Json.JsonException {
         when(configurationService.getTermsAndConditionsVersion()).thenReturn("1.0");
         String persistentId = "some-persistent-id-value";
         Map<String, String> headers = new HashMap<>();
@@ -173,7 +173,7 @@ class LoginHandlerTest {
 
     @Test
     void shouldReturn200IfLoginIsSuccessfulAndTermsAndConditionsNotAccepted()
-            throws JsonProcessingException {
+            throws JsonProcessingException, Json.JsonException {
         when(configurationService.getTermsAndConditionsVersion()).thenReturn("2.0");
         String persistentId = "some-persistent-id-value";
         Map<String, String> headers = new HashMap<>();
@@ -222,7 +222,7 @@ class LoginHandlerTest {
 
     @Test
     void shouldReturn200IfMigratedUserHasBeenProcessesSuccessfully()
-            throws JsonProcessingException {
+            throws JsonProcessingException, Json.JsonException {
         when(configurationService.getTermsAndConditionsVersion()).thenReturn("1.0");
         String legacySubjectId = new Subject().getValue();
         UserProfile userProfile = generateUserProfile(legacySubjectId);
@@ -252,7 +252,8 @@ class LoginHandlerTest {
     }
 
     @Test
-    void shouldReturn200IfPasswordIsEnteredAgain() throws JsonProcessingException {
+    void shouldReturn200IfPasswordIsEnteredAgain()
+            throws JsonProcessingException, Json.JsonException {
         UserProfile userProfile = generateUserProfile(null);
         when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
                 .thenReturn(Optional.of(userProfile));
@@ -331,7 +332,7 @@ class LoginHandlerTest {
 
     @Test
     void shouldRemoveIncorrectPasswordCountRemovesUponSuccessfulLogin()
-            throws JsonProcessingException {
+            throws JsonProcessingException, Json.JsonException {
         UserProfile userProfile = generateUserProfile(null);
         when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
                 .thenReturn(Optional.of(userProfile));

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
@@ -3,8 +3,6 @@ package uk.gov.di.authentication.frontendapi.lambda;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.id.ClientID;
@@ -22,8 +20,8 @@ import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.NotifyRequest;
 import uk.gov.di.authentication.shared.entity.Session;
-import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
+import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.AwsSqsClient;
@@ -32,6 +30,7 @@ import uk.gov.di.authentication.shared.services.ClientSessionService;
 import uk.gov.di.authentication.shared.services.CodeGeneratorService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
@@ -81,7 +80,7 @@ public class MfaHandlerTest {
     private final ClientService clientService = mock(ClientService.class);
     private final ClientSession clientSession = mock(ClientSession.class);
     private final AwsSqsClient sqsClient = mock(AwsSqsClient.class);
-    private final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
+    private static final Json objectMapper = SerializationService.getInstance();
     private final Session session = new Session("a-session-id").setEmailAddress(TEST_EMAIL_ADDRESS);
     private final ClientRegistry testClientRegistry =
             new ClientRegistry()
@@ -123,7 +122,7 @@ public class MfaHandlerTest {
     }
 
     @Test
-    void shouldReturn204ForSuccessfulMfaRequest() throws JsonProcessingException {
+    void shouldReturn204ForSuccessfulMfaRequest() throws Json.JsonException {
         usingValidSession();
         String persistentId = "some-persistent-id-value";
         Map<String, String> headers = new HashMap<>();
@@ -158,7 +157,7 @@ public class MfaHandlerTest {
     }
 
     @Test
-    void shouldReturn204AndAllowMfaRequestDuringUplift() throws JsonProcessingException {
+    void shouldReturn204AndAllowMfaRequestDuringUplift() throws Json.JsonException {
         usingValidSession();
 
         when(authenticationService.getPhoneNumber(TEST_EMAIL_ADDRESS))
@@ -358,7 +357,7 @@ public class MfaHandlerTest {
 
     @Test
     void shouldReturn204AndNotSendMessageForSuccessfulMfaRequestOnTestClient()
-            throws JsonProcessingException {
+            throws Json.JsonException {
         usingValidSession();
         usingValidClientSession(TEST_CLIENT_ID);
         when(configurationService.isTestClientsEnabled()).thenReturn(true);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandlerTest.java
@@ -4,15 +4,14 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
 import com.amazonaws.services.s3.AmazonS3;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import uk.gov.di.authentication.shared.entity.NotifyRequest;
-import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
+import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.NotificationService;
+import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.service.notify.NotificationClientException;
 
 import java.util.HashMap;
@@ -48,7 +47,7 @@ public class NotificationHandlerTest {
     private final ConfigurationService configService = mock(ConfigurationService.class);
     private final AmazonS3 s3Client = mock(AmazonS3.class);
     private NotificationHandler handler;
-    private final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
+    private static final Json objectMapper = SerializationService.getInstance();
 
     @BeforeEach
     void setUp() {
@@ -61,7 +60,7 @@ public class NotificationHandlerTest {
 
     @Test
     void shouldSuccessfullyProcessEmailMessageFromSQSQueue()
-            throws JsonProcessingException, NotificationClientException {
+            throws Json.JsonException, NotificationClientException {
 
         NotifyRequest notifyRequest = new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL, "654321");
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
@@ -81,7 +80,7 @@ public class NotificationHandlerTest {
 
     @Test
     void shouldSuccessfullyProcessResetPasswordConfirmationFromSQSQueue()
-            throws JsonProcessingException, NotificationClientException {
+            throws Json.JsonException, NotificationClientException {
         NotifyRequest notifyRequest =
                 new NotifyRequest(TEST_EMAIL_ADDRESS, PASSWORD_RESET_CONFIRMATION);
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
@@ -100,7 +99,7 @@ public class NotificationHandlerTest {
 
     @Test
     void shouldSuccessfullyProcessResetPasswordEmailFromSQSQueue()
-            throws JsonProcessingException, NotificationClientException {
+            throws Json.JsonException, NotificationClientException {
         NotifyRequest notifyRequest =
                 new NotifyRequest(TEST_EMAIL_ADDRESS, RESET_PASSWORD, TEST_RESET_PASSWORD_LINK);
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
@@ -119,7 +118,7 @@ public class NotificationHandlerTest {
 
     @Test
     void shouldSuccessfullyProcessAccountCreatedConfirmationFromSQSQueue()
-            throws JsonProcessingException, NotificationClientException {
+            throws Json.JsonException, NotificationClientException {
         String baseUrl = "http://account-management";
         var contactUsLinkUrl =
                 "https://localhost:8080/frontend/contact-us?referer=accountCreatedEmail";
@@ -141,7 +140,7 @@ public class NotificationHandlerTest {
 
     @Test
     void shouldSuccessfullyProcessPhoneMessageFromSQSQueue()
-            throws JsonProcessingException, NotificationClientException {
+            throws Json.JsonException, NotificationClientException {
         NotifyRequest notifyRequest =
                 new NotifyRequest(TEST_PHONE_NUMBER, VERIFY_PHONE_NUMBER, "654321");
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
@@ -172,7 +171,7 @@ public class NotificationHandlerTest {
 
     @Test
     void shouldThrowExceptionIfNotifyIsUnableToSendEmail()
-            throws JsonProcessingException, NotificationClientException {
+            throws Json.JsonException, NotificationClientException {
         NotifyRequest notifyRequest = new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL, "654321");
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
@@ -200,7 +199,7 @@ public class NotificationHandlerTest {
 
     @Test
     void shouldThrowExceptionIfNotifyIsUnableToSendText()
-            throws JsonProcessingException, NotificationClientException {
+            throws Json.JsonException, NotificationClientException {
         NotifyRequest notifyRequest =
                 new NotifyRequest(TEST_PHONE_NUMBER, VERIFY_PHONE_NUMBER, "654321");
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
@@ -225,7 +224,7 @@ public class NotificationHandlerTest {
 
     @Test
     void shouldSuccessfullyProcessPhoneMessageFromSQSQueueAndWriteToS3WhenTestClient()
-            throws JsonProcessingException, NotificationClientException {
+            throws Json.JsonException, NotificationClientException {
         NotifyRequest notifyRequest =
                 new NotifyRequest(NOTIFY_PHONE_NUMBER, VERIFY_PHONE_NUMBER, "654321");
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
@@ -243,7 +242,7 @@ public class NotificationHandlerTest {
 
     @Test
     void shouldSuccessfullyProcessMfaMessageFromSQSQueue()
-            throws JsonProcessingException, NotificationClientException {
+            throws Json.JsonException, NotificationClientException {
         NotifyRequest notifyRequest = new NotifyRequest(TEST_PHONE_NUMBER, MFA_SMS, "654321");
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
@@ -259,7 +258,7 @@ public class NotificationHandlerTest {
 
     @Test
     void shouldSuccessfullyProcessMfaMessageFromSQSQueueAndWriteToS3WhenTestClient()
-            throws JsonProcessingException, NotificationClientException {
+            throws Json.JsonException, NotificationClientException {
         NotifyRequest notifyRequest = new NotifyRequest(NOTIFY_PHONE_NUMBER, MFA_SMS, "654321");
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
@@ -276,7 +275,7 @@ public class NotificationHandlerTest {
 
     @Test
     void shouldSuccessfullyProcessPasswordResetWithCodeMessageFromSQSQueue()
-            throws JsonProcessingException, NotificationClientException {
+            throws Json.JsonException, NotificationClientException {
         NotifyRequest notifyRequest =
                 new NotifyRequest(TEST_EMAIL_ADDRESS, RESET_PASSWORD_WITH_CODE, "654321");
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandlerTest.java
@@ -3,8 +3,6 @@ package uk.gov.di.authentication.frontendapi.lambda;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
@@ -15,8 +13,8 @@ import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.helpers.Argon2EncoderHelper;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
-import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
+import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.AwsSqsClient;
@@ -24,6 +22,7 @@ import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.shared.services.SessionService;
 
 import java.util.HashMap;
@@ -59,7 +58,7 @@ class ResetPasswordHandlerTest {
     private static final String SUBJECT = "some-subject";
     private static final String EMAIL = "joe.bloggs@digital.cabinet-office.gov.uk";
     private static final String PERSISTENT_ID = "some-persistent-id-value";
-    private static final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
+    private static final Json objectMapper = SerializationService.getInstance();
 
     private ResetPasswordHandler handler;
     private final Session session = new Session(IdGenerator.generate()).setEmailAddress(EMAIL);
@@ -79,7 +78,7 @@ class ResetPasswordHandlerTest {
     }
 
     @Test
-    public void shouldReturn204ForSuccessfulRequestContainingCode() throws JsonProcessingException {
+    public void shouldReturn204ForSuccessfulRequestContainingCode() throws Json.JsonException {
         when(codeStorageService.getSubjectWithPasswordResetCode(CODE))
                 .thenReturn(Optional.of(SUBJECT));
         when(authenticationService.getUserCredentialsFromSubject(SUBJECT))
@@ -115,7 +114,7 @@ class ResetPasswordHandlerTest {
     }
 
     @Test
-    public void shouldReturn204ForSuccessfulRequestWithNoCode() throws JsonProcessingException {
+    public void shouldReturn204ForSuccessfulRequestWithNoCode() throws Json.JsonException {
 
         when(authenticationService.getUserCredentialsFromEmail(EMAIL))
                 .thenReturn(generateUserCredentials());
@@ -149,7 +148,7 @@ class ResetPasswordHandlerTest {
     }
 
     @Test
-    public void shouldReturn204ForSuccessfulMigratedUserRequest() throws JsonProcessingException {
+    public void shouldReturn204ForSuccessfulMigratedUserRequest() throws Json.JsonException {
         when(codeStorageService.getSubjectWithPasswordResetCode(CODE))
                 .thenReturn(Optional.of(SUBJECT));
         when(authenticationService.getUserCredentialsFromSubject(SUBJECT))
@@ -213,8 +212,7 @@ class ResetPasswordHandlerTest {
     }
 
     @Test
-    public void shouldReturn400IfNewPasswordEqualsExistingPassword()
-            throws JsonProcessingException {
+    public void shouldReturn400IfNewPasswordEqualsExistingPassword() throws Json.JsonException {
         usingValidSession();
         when(codeStorageService.getSubjectWithPasswordResetCode(CODE))
                 .thenReturn(Optional.of(SUBJECT));

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandlerTest.java
@@ -4,7 +4,6 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.id.ClientID;
@@ -27,13 +26,14 @@ import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.TermsAndConditions;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
-import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
+import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
@@ -73,7 +73,7 @@ class SignUpHandlerTest {
     private static final String CLIENT_SESSION_ID = "a-client-session-id";
     private static final ClientID CLIENT_ID = new ClientID();
     private static final URI REDIRECT_URI = URI.create("test-uri");
-    private static final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
+    private static final Json objectMapper = SerializationService.getInstance();
 
     private SignUpHandler handler;
 
@@ -110,7 +110,7 @@ class SignUpHandlerTest {
     @ParameterizedTest
     @MethodSource("consentValues")
     void shouldReturn200IfSignUpIsSuccessful(boolean consentRequired)
-            throws JsonProcessingException {
+            throws JsonProcessingException, Json.JsonException {
         String email = "joe.bloggs@test.com";
         String password = "computer-1";
         String persistentId = "some-persistent-id-value";

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/matchers/JsonArgumentMatcher.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/matchers/JsonArgumentMatcher.java
@@ -1,0 +1,24 @@
+package uk.gov.di.authentication.sharedtest.matchers;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import org.mockito.ArgumentMatcher;
+
+public class JsonArgumentMatcher implements ArgumentMatcher<String> {
+
+    private final JsonElement expected;
+
+    public JsonArgumentMatcher(String expected) {
+        this.expected = JsonParser.parseString(expected);
+    }
+
+    @Override
+    public boolean matches(String argument) {
+        var actual = JsonParser.parseString(argument);
+        return actual.equals(expected);
+    }
+
+    public static JsonArgumentMatcher containsJsonString(String expected) {
+        return new JsonArgumentMatcher(expected);
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/BaseFrontendRequest.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/BaseFrontendRequest.java
@@ -1,16 +1,18 @@
 package uk.gov.di.authentication.shared.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.annotations.SerializedName;
 import jakarta.validation.constraints.NotNull;
 import uk.gov.di.authentication.shared.serialization.EmailDeserializer;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class BaseFrontendRequest {
     @NotNull
-    @JsonProperty("email")
-    @JsonDeserialize(using = EmailDeserializer.class)
+    @Expose
+    @SerializedName("email")
+    @JsonAdapter(EmailDeserializer.class)
     protected String email;
 
     public String getEmail() {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
@@ -2,8 +2,11 @@ package uk.gov.di.authentication.shared.entity;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.annotations.JsonAdapter;
+import uk.gov.di.authentication.shared.serialization.ErrorResponseAdapter;
 
 @JsonFormat(shape = JsonFormat.Shape.OBJECT)
+@JsonAdapter(ErrorResponseAdapter.class)
 public enum ErrorResponse {
     ERROR_1000(1000, "Session-Id is missing or invalid"),
     ERROR_1001(1001, "Request is missing parameters"),

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/NotifyRequest.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/NotifyRequest.java
@@ -3,11 +3,16 @@ package uk.gov.di.authentication.shared.entity;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
 import jakarta.validation.constraints.NotNull;
 
 public class NotifyRequest {
 
-    @JsonProperty @Expose @NotNull private NotificationType notificationType;
+    @JsonProperty
+    @Expose
+    @SerializedName("notificationType")
+    @NotNull
+    private NotificationType notificationType;
 
     @JsonProperty @Expose @NotNull private String destination;
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/NotifyRequest.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/NotifyRequest.java
@@ -1,15 +1,21 @@
 package uk.gov.di.authentication.shared.entity;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.annotations.Expose;
+import jakarta.validation.constraints.NotNull;
 
 public class NotifyRequest {
 
-    @JsonProperty private NotificationType notificationType;
+    @JsonProperty @Expose @NotNull private NotificationType notificationType;
 
-    @JsonProperty private String destination;
+    @JsonProperty @Expose @NotNull private String destination;
 
-    @JsonProperty private String code;
+    @JsonProperty @Expose private String code;
 
+    public NotifyRequest() {}
+
+    @JsonCreator
     public NotifyRequest(
             @JsonProperty(required = true, value = "destination") String destination,
             @JsonProperty(required = true, value = "notificationType")

--- a/shared/src/main/java/uk/gov/di/authentication/shared/lambda/BaseFrontendHandler.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/lambda/BaseFrontendHandler.java
@@ -19,6 +19,7 @@ import uk.gov.di.authentication.shared.services.ClientSessionService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoClientService;
 import uk.gov.di.authentication.shared.services.DynamoService;
+import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
@@ -41,7 +42,7 @@ public abstract class BaseFrontendHandler<T>
     protected final ClientSessionService clientSessionService;
     protected final ClientService clientService;
     protected final AuthenticationService authenticationService;
-    protected final Json objectMapper = Json.jackson();
+    protected final Json objectMapper = SerializationService.getInstance();
 
     protected BaseFrontendHandler(
             Class<T> clazz,

--- a/shared/src/main/java/uk/gov/di/authentication/shared/serialization/EmailDeserializer.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/serialization/EmailDeserializer.java
@@ -1,15 +1,20 @@
 package uk.gov.di.authentication.shared.serialization;
 
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
 
 import java.io.IOException;
 import java.util.Locale;
 
-public class EmailDeserializer extends JsonDeserializer<String> {
+public class EmailDeserializer extends TypeAdapter<String> {
     @Override
-    public String deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
-        return p.getText().toLowerCase(Locale.ROOT);
+    public void write(JsonWriter out, String value) throws IOException {
+        out.value(value);
+    }
+
+    @Override
+    public String read(JsonReader in) throws IOException {
+        return in.nextString().toLowerCase(Locale.ROOT);
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/serialization/ErrorResponseAdapter.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/serialization/ErrorResponseAdapter.java
@@ -1,0 +1,23 @@
+package uk.gov.di.authentication.shared.serialization;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import uk.gov.di.authentication.shared.entity.ErrorResponse;
+
+import java.io.IOException;
+
+public class ErrorResponseAdapter extends TypeAdapter<ErrorResponse> {
+    @Override
+    public void write(JsonWriter out, ErrorResponse value) throws IOException {
+        out.beginObject();
+        out.name("code").value(value.getCode());
+        out.name("message").value(value.getMessage());
+        out.endObject();
+    }
+
+    @Override
+    public ErrorResponse read(JsonReader in) throws IOException {
+        return null;
+    }
+}


### PR DESCRIPTION
## What?

- Create a Mockito ArgumentMatcher that will match JSON strings regardless of order of fields to avoid discrepancies between serialization frameworks (GSON or Jackson)
- Convert the `EmailDeserializer` class to a GSON TypeAdapter
- Create a TypeAdapter to correct serialize the `ErrorResponse` enum.
- Add the Jakarta validation packages to the GSON configuration
- Convert all the frontend API entities to use GSON serialization rather than Jackson
- Include shared classes, keeping these Jackson compatible where required
- When presented with an empty input the GSON parser throws an `IllegalArgumentException` we need to wrap this in a `JsonException` to keep consistent behaviour with Jackson
- Change the all frontend handlers to use the new `SerializationService` rather than Jackson ObjectMapper

## Why?

GSON provides better performance than Jackson.
