### PR TITLE
AUT-386: Add stub rp client for prod

### DIFF
--- a/ci/terraform/shared/production-stub-clients.tfvars
+++ b/ci/terraform/shared/production-stub-clients.tfvars
@@ -1,0 +1,19 @@
+stub_rp_clients = [
+  {
+    client_name = "di-auth-stub-relying-party-production"
+    callback_urls = [
+      "https://di-auth-stub-relying-party-production.london.cloudapps.digital/oidc/authorization-code/callback",
+    ]
+    logout_urls = [
+      "https://di-auth-stub-relying-party-production.london.cloudapps.digital/signed-out",
+    ]
+    test_client                     = "0"
+    client_type                     = "web"
+    identity_verification_supported = "1"
+    scopes = [
+      "openid",
+      "email",
+      "phone",
+    ]
+  },
+]


### PR DESCRIPTION
## What?

Add stub rp client for prod.

## Why?

To be used by the restricted prod stub rp

## Related PRs

#131
#135