### PR TITLE
AUT-356: Migrate OIDC, IPV, DocApp and client registry APIs to GSON

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/NotifyRequest.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/NotifyRequest.java
@@ -1,14 +1,19 @@
 package uk.gov.di.accountmanagement.entity;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
 
 public class NotifyRequest {
 
-    @JsonProperty private NotificationType notificationType;
+    @Expose
+    @SerializedName("notificationType")
+    @JsonProperty
+    private NotificationType notificationType;
 
-    @JsonProperty private String destination;
+    @Expose @JsonProperty private String destination;
 
-    @JsonProperty private String code;
+    @Expose @JsonProperty private String code;
 
     public NotifyRequest(
             @JsonProperty(required = true, value = "destination") String destination,

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/RemoveAccountRequest.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/RemoveAccountRequest.java
@@ -1,9 +1,10 @@
 package uk.gov.di.accountmanagement.entity;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.annotations.Expose;
 
 public class RemoveAccountRequest {
-    private String email;
+    @Expose private String email;
 
     public RemoveAccountRequest(@JsonProperty(required = true, value = "email") String email) {
         this.email = email;

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/SendNotificationRequest.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/SendNotificationRequest.java
@@ -1,12 +1,20 @@
 package uk.gov.di.accountmanagement.entity;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
 
 public class SendNotificationRequest {
 
-    private final NotificationType notificationType;
-    private final String phoneNumber;
-    private final String email;
+    @Expose
+    @SerializedName("notificationType")
+    private NotificationType notificationType;
+
+    @Expose
+    @SerializedName("phoneNumber")
+    private String phoneNumber;
+
+    @Expose private String email;
 
     public SendNotificationRequest(
             @JsonProperty(required = true, value = "email") String email,

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/UpdateEmailRequest.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/UpdateEmailRequest.java
@@ -1,12 +1,20 @@
 package uk.gov.di.accountmanagement.entity;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
 
 public class UpdateEmailRequest {
 
-    private final String existingEmailAddress;
-    private final String replacementEmailAddress;
-    private final String otp;
+    @Expose
+    @SerializedName("existingEmailAddress")
+    private String existingEmailAddress;
+
+    @Expose
+    @SerializedName("replacementEmailAddress")
+    private String replacementEmailAddress;
+
+    @Expose private String otp;
 
     public UpdateEmailRequest(
             @JsonProperty(required = true, value = "existingEmailAddress")

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/UpdatePasswordRequest.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/UpdatePasswordRequest.java
@@ -1,11 +1,16 @@
 package uk.gov.di.accountmanagement.entity;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
 
 public class UpdatePasswordRequest {
 
-    private final String email;
-    private final String newPassword;
+    @Expose private String email;
+
+    @Expose
+    @SerializedName("newPassword")
+    private String newPassword;
 
     public UpdatePasswordRequest(
             @JsonProperty(required = true, value = "email") String email,

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/UpdatePhoneNumberRequest.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/UpdatePhoneNumberRequest.java
@@ -1,12 +1,18 @@
 package uk.gov.di.accountmanagement.entity;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
 
 public class UpdatePhoneNumberRequest {
 
-    private final String email;
-    private final String phoneNumber;
-    private final String otp;
+    @Expose private String email;
+
+    @Expose
+    @SerializedName("phoneNumber")
+    private String phoneNumber;
+
+    @Expose private String otp;
 
     public UpdatePhoneNumberRequest(
             @JsonProperty(required = true, value = "email") String email,

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/SendOtpNotificationIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/SendOtpNotificationIntegrationTest.java
@@ -1,6 +1,5 @@
 package uk.gov.di.accountmanagement.api;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.i18n.phonenumbers.PhoneNumberUtil;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
@@ -10,6 +9,7 @@ import uk.gov.di.accountmanagement.entity.SendNotificationRequest;
 import uk.gov.di.accountmanagement.lambda.SendOtpNotificationHandler;
 import uk.gov.di.accountmanagement.testsupport.helpers.NotificationAssertionHelper;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 
 import java.util.Collections;
@@ -122,7 +122,7 @@ class SendOtpNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTes
     }
 
     @Test
-    void shouldReturn400WhenPhoneNumberIsInvalid() throws JsonProcessingException {
+    void shouldReturn400WhenPhoneNumberIsInvalid() throws Json.JsonException {
         String badPhoneNumber = "This is not a valid phone number";
 
         var response =

--- a/client-registry-api/build.gradle
+++ b/client-registry-api/build.gradle
@@ -14,6 +14,7 @@ dependencies {
             configurations.dynamodb
 
     implementation configurations.nimbus,
+            configurations.gson,
             'commons-validator:commons-validator:1.7'
 
     implementation project(":shared")

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/entity/ClientRegistrationRequest.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/entity/ClientRegistrationRequest.java
@@ -1,6 +1,8 @@
 package uk.gov.di.authentication.clientregistry.entity;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import jakarta.validation.constraints.NotNull;
 import uk.gov.di.authentication.shared.entity.ClientType;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 
@@ -10,61 +12,81 @@ import java.util.Objects;
 
 public class ClientRegistrationRequest {
 
-    @JsonProperty("client_name")
+    @SerializedName("client_name")
+    @Expose
+    @NotNull
     private String clientName;
 
-    @JsonProperty("redirect_uris")
+    @SerializedName("redirect_uris")
+    @Expose
+    @NotNull
     private List<String> redirectUris;
 
-    @JsonProperty("contacts")
+    @SerializedName("contacts")
+    @Expose
+    @NotNull
     private List<String> contacts;
 
-    @JsonProperty("public_key")
+    @SerializedName("public_key")
+    @Expose
+    @NotNull
     private String publicKey;
 
-    @JsonProperty("scopes")
+    @SerializedName("scopes")
+    @Expose
+    @NotNull
     private List<String> scopes;
 
-    @JsonProperty("post_logout_redirect_uris")
+    @SerializedName("post_logout_redirect_uris")
+    @Expose
     private List<String> postLogoutRedirectUris = new ArrayList<>();
 
-    @JsonProperty("back_channel_logout_uri")
-    private final String backChannelLogoutUri;
+    @SerializedName("back_channel_logout_uri")
+    @Expose
+    private String backChannelLogoutUri;
 
-    @JsonProperty("service_type")
-    private String serviceType;
+    @SerializedName("service_type")
+    @Expose
+    private String serviceType = String.valueOf(ServiceType.MANDATORY);
 
-    @JsonProperty("sector_identifier_uri")
+    @SerializedName("sector_identifier_uri")
+    @Expose
+    @NotNull
     private String sectorIdentifierUri;
 
-    @JsonProperty("subject_type")
+    @SerializedName("subject_type")
+    @Expose
+    @NotNull
     private String subjectType;
 
-    @JsonProperty("identity_verification_required")
+    @SerializedName("identity_verification_required")
+    @Expose
     private boolean identityVerificationRequired;
 
-    @JsonProperty("claims")
+    @SerializedName("claims")
+    @Expose
     private List<String> claims = new ArrayList<>();
 
-    @JsonProperty("client_type")
-    private String clientType;
+    @SerializedName("client_type")
+    @Expose
+    private String clientType = ClientType.WEB.getValue();
+
+    public ClientRegistrationRequest() {}
 
     public ClientRegistrationRequest(
-            @JsonProperty(required = true, value = "client_name") String clientName,
-            @JsonProperty(required = true, value = "redirect_uris") List<String> redirectUris,
-            @JsonProperty(required = true, value = "contacts") List<String> contacts,
-            @JsonProperty(required = true, value = "public_key") String publicKey,
-            @JsonProperty(required = true, value = "scopes") List<String> scopes,
-            @JsonProperty(value = "post_logout_redirect_uris") List<String> postLogoutRedirectUris,
-            @JsonProperty(value = "back_channel_logout_uri") String backChannelLogoutUri,
-            @JsonProperty(value = "service_type") String serviceType,
-            @JsonProperty(required = true, value = "sector_identifier_uri")
-                    String sectorIdentifierUri,
-            @JsonProperty(required = true, value = "subject_type") String subjectType,
-            @JsonProperty(value = "identity_verification_required")
-                    boolean identityVerificationRequired,
-            @JsonProperty(value = "claims") List<String> claims,
-            @JsonProperty(value = "client_type") String clientType) {
+            String clientName,
+            List<String> redirectUris,
+            List<String> contacts,
+            String publicKey,
+            List<String> scopes,
+            List<String> postLogoutRedirectUris,
+            String backChannelLogoutUri,
+            String serviceType,
+            String sectorIdentifierUri,
+            String subjectType,
+            boolean identityVerificationRequired,
+            List<String> claims,
+            String clientType) {
         this.clientName = clientName;
         this.redirectUris = redirectUris;
         this.contacts = contacts;

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/entity/ClientRegistrationResponse.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/entity/ClientRegistrationResponse.java
@@ -1,51 +1,77 @@
 package uk.gov.di.authentication.clientregistry.entity;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import jakarta.validation.constraints.NotNull;
 
 import java.util.List;
 
 public class ClientRegistrationResponse {
 
-    @JsonProperty(required = true, value = "client_name")
+    @SerializedName("client_name")
+    @Expose
+    @NotNull
     private String clientName;
 
-    @JsonProperty(required = true, value = "client_id")
+    @SerializedName("client_id")
+    @Expose
+    @NotNull
     private String clientId;
 
-    @JsonProperty(required = true, value = "redirect_uris")
+    @SerializedName("redirect_uris")
+    @Expose
+    @NotNull
     private List<String> redirectUris;
 
-    @JsonProperty(required = true, value = "contacts")
+    @SerializedName("contacts")
+    @Expose
+    @NotNull
     private List<String> contacts;
 
-    @JsonProperty(required = true, value = "scopes")
+    @SerializedName("scopes")
+    @Expose
+    @NotNull
     private List<String> scopes;
 
-    @JsonProperty(value = "post_logout_redirect_uris")
+    @SerializedName("post_logout_redirect_uris")
+    @Expose
+    @NotNull
     private List<String> postLogoutRedirectUris;
 
-    @JsonProperty(value = "back_channel_logout_uri")
+    @SerializedName("back_channel_logout_uri")
+    @Expose
     private String backChannelLogoutUri;
 
-    @JsonProperty(required = true, value = "subject_type")
+    @SerializedName("subject_type")
+    @Expose
+    @NotNull
     private String subjectType;
 
-    @JsonProperty(required = true, value = "token_endpoint_auth_method")
+    @SerializedName("token_endpoint_auth_method")
+    @Expose
+    @NotNull
     private final String tokenAuthMethod = "private_key_jwt";
 
-    @JsonProperty(required = true, value = "response_type")
+    @SerializedName("response_type")
+    @Expose
+    @NotNull
     private final String responseType = "code";
 
-    @JsonProperty(required = true, value = "service_type")
+    @SerializedName("service_type")
+    @Expose
+    @NotNull
     private String serviceType;
 
-    @JsonProperty(value = "claims")
+    @SerializedName("claims")
+    @Expose
     private List<String> claims;
 
-    @JsonProperty("sector_identifier_uri")
+    @SerializedName("sector_identifier_uri")
+    @Expose
     private String sectorIdentifierUri;
 
-    @JsonProperty("client_type")
+    @SerializedName("client_type")
+    @Expose
     private String clientType;
 
     public ClientRegistrationResponse(

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandler.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandler.java
@@ -18,6 +18,7 @@ import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoClientService;
+import uk.gov.di.authentication.shared.services.SerializationService;
 
 import static uk.gov.di.authentication.clientregistry.domain.ClientRegistryAuditableEvent.REGISTER_CLIENT_REQUEST_ERROR;
 import static uk.gov.di.authentication.clientregistry.domain.ClientRegistryAuditableEvent.REGISTER_CLIENT_REQUEST_RECEIVED;
@@ -31,7 +32,7 @@ public class ClientRegistrationHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     private final ClientService clientService;
-    private final Json objectMapper = Json.jackson();
+    private final Json objectMapper = SerializationService.getInstance();
     private final ClientConfigValidationService validationService;
     private final AuditService auditService;
     private static final Logger LOG = LogManager.getLogger(ClientRegistrationHandler.class);

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandler.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandler.java
@@ -19,6 +19,7 @@ import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoClientService;
+import uk.gov.di.authentication.shared.services.SerializationService;
 
 import java.util.Optional;
 
@@ -36,7 +37,7 @@ public class UpdateClientConfigHandler
     private final ClientService clientService;
     private final ClientConfigValidationService validationService;
     private final AuditService auditService;
-    private final Json objectMapper = Json.jackson();
+    private final Json objectMapper = SerializationService.getInstance();
     private static final Logger LOG = LogManager.getLogger(UpdateClientConfigHandler.class);
 
     public UpdateClientConfigHandler(

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandlerTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandlerTest.java
@@ -3,8 +3,6 @@ package uk.gov.di.authentication.clientregistry.lambda;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import org.junit.jupiter.api.AfterEach;
@@ -18,9 +16,10 @@ import uk.gov.di.authentication.clientregistry.entity.ClientRegistrationResponse
 import uk.gov.di.authentication.clientregistry.services.ClientConfigValidationService;
 import uk.gov.di.authentication.shared.entity.ClientType;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
-import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
+import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ClientService;
+import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
 import java.util.List;
@@ -62,7 +61,7 @@ class ClientRegistrationHandlerTest {
     private final ClientConfigValidationService configValidationService =
             mock(ClientConfigValidationService.class);
     private final AuditService auditService = mock(AuditService.class);
-    private final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
+    private final Json objectMapper = SerializationService.getInstance();
     private ClientRegistrationHandler handler;
 
     @BeforeEach
@@ -83,7 +82,7 @@ class ClientRegistrationHandlerTest {
     }
 
     @Test
-    void shouldReturn200IfClientRegistrationRequestIsSuccessful() throws JsonProcessingException {
+    void shouldReturn200IfClientRegistrationRequestIsSuccessful() throws Json.JsonException {
         when(configValidationService.validateClientRegistrationConfig(
                         any(ClientRegistrationRequest.class)))
                 .thenReturn(Optional.empty());
@@ -124,7 +123,7 @@ class ClientRegistrationHandlerTest {
 
     @Test
     void shouldSetConsentRequiredToFalseWhenIdentityVerificationIsRequired()
-            throws JsonProcessingException {
+            throws Json.JsonException {
         when(configValidationService.validateClientRegistrationConfig(
                         any(ClientRegistrationRequest.class)))
                 .thenReturn(Optional.empty());
@@ -253,8 +252,7 @@ class ClientRegistrationHandlerTest {
 
     @ParameterizedTest
     @MethodSource("clientTypes")
-    void shouldReturnExpectedClientTypeInResponse(String clientType)
-            throws JsonProcessingException {
+    void shouldReturnExpectedClientTypeInResponse(String clientType) throws Json.JsonException {
         when(configValidationService.validateClientRegistrationConfig(
                         any(ClientRegistrationRequest.class)))
                 .thenReturn(Optional.empty());

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandlerTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandlerTest.java
@@ -3,8 +3,6 @@ package uk.gov.di.authentication.clientregistry.lambda;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -15,9 +13,10 @@ import uk.gov.di.authentication.clientregistry.services.ClientConfigValidationSe
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientType;
 import uk.gov.di.authentication.shared.entity.UpdateClientConfigRequest;
-import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
+import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ClientService;
+import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
 import java.util.List;
@@ -51,7 +50,7 @@ class UpdateClientConfigHandlerTest {
     private static final String CLIENT_NAME = "client-name-one";
     private static final List<String> SCOPES = singletonList("openid");
     private static final String SERVICE_TYPE = String.valueOf(MANDATORY);
-    private static final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
+    private static final Json objectMapper = SerializationService.getInstance();
 
     private final Context context = mock(Context.class);
     private final ClientService clientService = mock(ClientService.class);
@@ -78,7 +77,7 @@ class UpdateClientConfigHandlerTest {
     }
 
     @Test
-    public void shouldReturn200ForAValidRequest() throws JsonProcessingException {
+    public void shouldReturn200ForAValidRequest() throws Json.JsonException {
         when(clientService.isValidClient(CLIENT_ID)).thenReturn(true);
         when(clientValidationService.validateClientUpdateConfig(
                         any(UpdateClientConfigRequest.class)))

--- a/doc-checking-app-api/build.gradle
+++ b/doc-checking-app-api/build.gradle
@@ -12,6 +12,7 @@ dependencies {
             configurations.sns
 
     implementation configurations.jackson,
+            configurations.gson,
             configurations.nimbus,
             configurations.bouncycastle
 

--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/entity/DocAppAuthorisationResponse.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/entity/DocAppAuthorisationResponse.java
@@ -1,10 +1,14 @@
 package uk.gov.di.authentication.app.entity;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
 
 public class DocAppAuthorisationResponse {
 
     @JsonProperty("redirectUri")
+    @SerializedName("redirectUri")
+    @Expose
     private String redirectUri;
 
     public DocAppAuthorisationResponse(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.oidc.entity.AuthCodeResponse;
 import uk.gov.di.authentication.oidc.lambda.AuthCodeHandler;
 import uk.gov.di.authentication.shared.entity.ServiceType;
+import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.helper.KeyPairHelper;
 
@@ -43,7 +44,8 @@ public class AuthCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     }
 
     @Test
-    public void shouldReturn302WithSuccessfulAuthorisationResponse() throws IOException {
+    public void shouldReturn302WithSuccessfulAuthorisationResponse()
+            throws IOException, Json.JsonException {
         String sessionId = "some-session-id";
         String clientSessionId = "some-client-session-id";
         KeyPair keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientRegistrationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientRegistrationIntegrationTest.java
@@ -1,6 +1,5 @@
 package uk.gov.di.authentication.api;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -10,6 +9,7 @@ import uk.gov.di.authentication.clientregistry.entity.ClientRegistrationResponse
 import uk.gov.di.authentication.clientregistry.lambda.ClientRegistrationHandler;
 import uk.gov.di.authentication.shared.entity.ClientType;
 import uk.gov.di.authentication.shared.entity.ValidClaims;
+import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 
 import java.util.List;
@@ -65,7 +65,7 @@ public class ClientRegistrationIntegrationTest extends ApiGatewayHandlerIntegrat
             String backChannelLogoutUri,
             List<String> claims,
             String serviceType)
-            throws JsonProcessingException {
+            throws Json.JsonException {
         var clientRequest =
                 new ClientRegistrationRequest(
                         "The test client",

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppAuthorizeHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppAuthorizeHandlerIntegrationTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.app.entity.DocAppAuthorisationResponse;
 import uk.gov.di.authentication.app.lambda.DocAppAuthorizeHandler;
+import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 
@@ -61,7 +62,7 @@ class DocAppAuthorizeHandlerIntegrationTest extends ApiGatewayHandlerIntegration
     }
 
     @Test
-    void shouldReturn200WithValidDocAppAuthRequest() throws IOException {
+    void shouldReturn200WithValidDocAppAuthRequest() throws IOException, Json.JsonException {
         redis.addDocAppSubjectIdToClientSession(new Subject(), CLIENT_SESSION_ID);
         var response =
                 makeRequest(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVAuthorisationHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVAuthorisationHandlerIntegrationTest.java
@@ -15,6 +15,7 @@ import uk.gov.di.authentication.ipv.entity.IPVAuthorisationResponse;
 import uk.gov.di.authentication.ipv.lambda.IPVAuthorisationHandler;
 import uk.gov.di.authentication.shared.entity.ClientType;
 import uk.gov.di.authentication.shared.entity.ServiceType;
+import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.extensions.IPVStubExtension;
@@ -74,7 +75,7 @@ class IPVAuthorisationHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
     }
 
     @Test
-    void shouldReturn200WithValidIPVAuthorisationRequest() throws IOException {
+    void shouldReturn200WithValidIPVAuthorisationRequest() throws Json.JsonException {
         userStore.signUp(TEST_EMAIL_ADDRESS, "password-1");
         clientStore.registerClient(
                 CLIENT_ID.getValue(),

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
@@ -16,6 +16,7 @@ import uk.gov.di.authentication.frontendapi.entity.LoginResponse;
 import uk.gov.di.authentication.frontendapi.lambda.LoginHandler;
 import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.ServiceType;
+import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 
 import java.io.IOException;
@@ -55,7 +56,8 @@ public class LoginIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     @ParameterizedTest
     @MethodSource("vectorOfTrust")
     void shouldSuccessfullyProcessLoginRequestForDifferentVectorOfTrusts(
-            CredentialTrustLevel level, String termsAndConditionsVersion) throws IOException {
+            CredentialTrustLevel level, String termsAndConditionsVersion)
+            throws IOException, Json.JsonException {
         String email = "joe.bloggs+3@digital.cabinet-office.gov.uk";
         String password = "password-1";
         String phoneNumber = "01234567890";

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/SignupIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/SignupIntegrationTest.java
@@ -13,6 +13,7 @@ import uk.gov.di.authentication.frontendapi.entity.SignUpResponse;
 import uk.gov.di.authentication.frontendapi.entity.SignupRequest;
 import uk.gov.di.authentication.frontendapi.lambda.SignUpHandler;
 import uk.gov.di.authentication.shared.entity.ServiceType;
+import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 
 import java.io.IOException;
@@ -50,7 +51,8 @@ public class SignupIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @ParameterizedTest
     @MethodSource("consentValues")
-    void shouldReturn200WhenValidSignUpRequest(boolean consentRequired) throws IOException {
+    void shouldReturn200WhenValidSignUpRequest(boolean consentRequired)
+            throws IOException, Json.JsonException {
         String sessionId = redis.createSession();
 
         Map<String, String> headers = new HashMap<>();

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
@@ -25,6 +25,7 @@ import uk.gov.di.authentication.frontendapi.lambda.StartHandler;
 import uk.gov.di.authentication.shared.entity.ClientType;
 import uk.gov.di.authentication.shared.entity.CustomScopeValue;
 import uk.gov.di.authentication.shared.entity.ServiceType;
+import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.helper.KeyPairHelper;
 
@@ -77,7 +78,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             Map<String, String> customAuthParameters,
             boolean identityRequired,
             boolean isAuthenticated)
-            throws IOException {
+            throws IOException, Json.JsonException {
         String sessionId = redis.createSession(isAuthenticated);
 
         Scope scope = new Scope();
@@ -133,7 +134,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     void shouldReturn200WhenUserIsADocCheckingAppUser(boolean isAuthenticated)
-            throws IOException, JOSEException {
+            throws IOException, JOSEException, Json.JsonException {
         var keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
         var sessionId = redis.createSession(isAuthenticated);
         var scope = new Scope(OIDCScopeValue.OPENID, CustomScopeValue.DOC_CHECKING_APP);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateClientConfigIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateClientConfigIntegrationTest.java
@@ -1,6 +1,5 @@
 package uk.gov.di.authentication.api;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -8,6 +7,7 @@ import uk.gov.di.authentication.clientregistry.entity.ClientRegistrationResponse
 import uk.gov.di.authentication.clientregistry.lambda.UpdateClientConfigHandler;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.shared.entity.UpdateClientConfigRequest;
+import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 
 import java.util.List;
@@ -33,7 +33,7 @@ public class UpdateClientConfigIntegrationTest extends ApiGatewayHandlerIntegrat
     }
 
     @Test
-    public void shouldUpdateClientNameSuccessfully() throws JsonProcessingException {
+    public void shouldUpdateClientNameSuccessfully() throws Json.JsonException {
         clientStore.registerClient(
                 CLIENT_ID,
                 "The test client",

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserExistsIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserExistsIntegrationTest.java
@@ -6,6 +6,7 @@ import uk.gov.di.authentication.frontendapi.entity.CheckUserExistsRequest;
 import uk.gov.di.authentication.frontendapi.entity.CheckUserExistsResponse;
 import uk.gov.di.authentication.frontendapi.lambda.CheckUserExistsHandler;
 import uk.gov.di.authentication.shared.entity.BaseFrontendRequest;
+import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 
 import java.io.IOException;
@@ -31,7 +32,7 @@ public class UserExistsIntegrationTest extends ApiGatewayHandlerIntegrationTest 
 
     @Test
     public void shouldCallUserExistsEndpointAndReturnAuthenticationRequestStateWhenUserExists()
-            throws IOException {
+            throws IOException, Json.JsonException {
         String emailAddress = "joe.bloggs+1@digital.cabinet-office.gov.uk";
         String sessionId = redis.createSession();
         userStore.signUp(emailAddress, "password-1");
@@ -52,7 +53,7 @@ public class UserExistsIntegrationTest extends ApiGatewayHandlerIntegrationTest 
 
     @Test
     public void shouldCallUserExistsEndpointAndReturnUserNotFoundStateWhenUserDoesNotExist()
-            throws IOException {
+            throws IOException, Json.JsonException {
         String emailAddress = "joe.bloggs+2@digital.cabinet-office.gov.uk";
         String sessionId = redis.createSession();
         BaseFrontendRequest request = new CheckUserExistsRequest(emailAddress);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
@@ -1,6 +1,5 @@
 package uk.gov.di.authentication.api;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.Scope;
@@ -20,6 +19,7 @@ import uk.gov.di.authentication.shared.entity.CustomScopeValue;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.shared.entity.ValidClaims;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
+import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.helper.KeyPairHelper;
 import uk.gov.di.authentication.sharedtest.helper.SignedCredentialHelper;
@@ -71,8 +71,7 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     }
 
     @Test
-    void shouldCallUserInfoWithAccessTokenAndReturn200()
-            throws JsonProcessingException, ParseException {
+    void shouldCallUserInfoWithAccessTokenAndReturn200() throws Json.JsonException, ParseException {
         var claimsSet =
                 new JWTClaimsSet.Builder()
                         .claim("scope", SCOPES)
@@ -132,7 +131,7 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @Test
     void shouldReturn200WhenIdentityIsEnabledAndIdentityClaimsArePresent()
-            throws JsonProcessingException, ParseException {
+            throws Json.JsonException, ParseException {
         var configurationService = new UserInfoIntegrationTest.UserInfoConfigurationService();
         handler = new UserInfoHandler(configurationService);
         var claimsSetRequest =
@@ -194,7 +193,7 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @Test
     void shouldCallUserInfoWithAccessTokenAndReturn200ForDocAppUser()
-            throws JsonProcessingException, ParseException {
+            throws Json.JsonException, ParseException {
 
         documentAppCredentialStore.addCredential(
                 DOC_APP_PUBLIC_SUBJECT.getValue(), DOC_APP_CREDENTIAL);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/SpotResponseIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/SpotResponseIntegrationTest.java
@@ -2,7 +2,6 @@ package uk.gov.di.authentication.queuehandlers;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -10,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.ipv.entity.SPOTResponse;
 import uk.gov.di.authentication.ipv.entity.SPOTStatus;
 import uk.gov.di.authentication.ipv.lambda.SPOTResponseHandler;
+import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.sharedtest.basetest.HandlerIntegrationTest;
 
 import java.util.Arrays;
@@ -72,7 +72,7 @@ public class SpotResponseIntegrationTest extends HandlerIntegrationTest<SQSEvent
                                         message.setEventSourceArn(
                                                 "arn:aws:sqs:eu-west-2:123456789012:queue-name");
                                         return message;
-                                    } catch (JsonProcessingException e) {
+                                    } catch (Json.JsonException e) {
                                         throw new RuntimeException(e);
                                     }
                                 })

--- a/ipv-api/build.gradle
+++ b/ipv-api/build.gradle
@@ -14,6 +14,7 @@ dependencies {
             configurations.dynamodb
 
     implementation configurations.jackson,
+            configurations.gson,
             configurations.nimbus
 
     implementation project(":shared")

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/IPVAuthorisationResponse.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/IPVAuthorisationResponse.java
@@ -1,14 +1,19 @@
 package uk.gov.di.authentication.ipv.entity;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import jakarta.validation.constraints.NotNull;
 
 public class IPVAuthorisationResponse {
 
-    @JsonProperty("redirectUri")
+    @SerializedName("redirectUri")
+    @Expose
+    @NotNull
     private String redirectUri;
 
-    public IPVAuthorisationResponse(
-            @JsonProperty(required = true, value = "redirectUri") String redirectUri) {
+    public IPVAuthorisationResponse() {}
+
+    public IPVAuthorisationResponse(String redirectUri) {
         this.redirectUri = redirectUri;
     }
 

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/LogIds.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/LogIds.java
@@ -1,20 +1,16 @@
 package uk.gov.di.authentication.ipv.entity;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.annotations.Expose;
 
 public class LogIds {
 
-    @JsonProperty(value = "session_id")
-    private String sessionId;
+    @Expose private String sessionId;
 
-    @JsonProperty(value = "persistent_session_id")
-    private String persistentSessionId;
+    @Expose private String persistentSessionId;
 
-    @JsonProperty(value = "request_id")
-    private String requestId;
+    @Expose private String requestId;
 
-    @JsonProperty(value = "client_id")
-    private String clientId;
+    @Expose private String clientId;
 
     public LogIds(String sessionId, String persistentSessionId, String requestId, String clientId) {
         this.sessionId = sessionId;

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/SPOTRequest.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/SPOTRequest.java
@@ -1,27 +1,37 @@
 package uk.gov.di.authentication.ipv.entity;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.annotations.SerializedName;
+import uk.gov.di.authentication.shared.serialization.Base64ByteArrayAdapter;
 
 import java.util.Map;
 
 public class SPOTRequest {
 
-    @JsonProperty(value = "in_claims")
+    @SerializedName(value = "in_claims")
+    @Expose
     private Map<String, Object> spotClaims;
 
-    @JsonProperty(value = "in_local_account_id")
+    @SerializedName(value = "in_local_account_id")
+    @Expose
     private String localAccountId;
 
-    @JsonProperty(value = "in_salt")
+    @SerializedName(value = "in_salt")
+    @Expose
+    @JsonAdapter(Base64ByteArrayAdapter.class)
     private byte[] salt;
 
-    @JsonProperty(value = "in_rp_sector_id")
+    @SerializedName(value = "in_rp_sector_id")
+    @Expose
     private String rpSectorId;
 
-    @JsonProperty(value = "out_sub")
+    @SerializedName(value = "out_sub")
+    @Expose
     private String sub;
 
-    @JsonProperty(value = "log_ids")
+    @SerializedName(value = "log_ids")
+    @Expose
     private LogIds logIds;
 
     public SPOTRequest(

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/SPOTResponse.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/SPOTResponse.java
@@ -1,21 +1,24 @@
 package uk.gov.di.authentication.ipv.entity;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import jakarta.validation.constraints.NotNull;
 
 import java.util.Map;
 
 public class SPOTResponse {
 
-    @JsonProperty private Map<String, Object> claims;
+    @Expose
+    @SerializedName("claims")
+    private Map<String, Object> claims;
 
-    @JsonProperty private String sub;
+    @Expose @NotNull private String sub;
 
-    @JsonProperty private SPOTStatus status;
+    @Expose @NotNull private SPOTStatus status;
 
-    public SPOTResponse(
-            @JsonProperty(value = "claim") Map<String, Object> claims,
-            @JsonProperty(required = true, value = "sub") String sub,
-            @JsonProperty(required = true, value = "status") SPOTStatus status) {
+    public SPOTResponse() {}
+
+    public SPOTResponse(Map<String, Object> claims, String sub, SPOTStatus status) {
         this.claims = claims;
         this.sub = sub;
         this.status = status;

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -37,6 +37,7 @@ import uk.gov.di.authentication.shared.services.DynamoClientService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.KmsConnectionService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
+import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.shared.services.SessionService;
 
 import java.util.Map;
@@ -68,7 +69,7 @@ public class IPVCallbackHandler
     private final DynamoClientService dynamoClientService;
     private final AuditService auditService;
     private final AwsSqsClient sqsClient;
-    protected final Json objectMapper = Json.jackson();
+    protected final Json objectMapper = SerializationService.getInstance();
     private static final String REDIRECT_PATH = "ipv-callback";
 
     public IPVCallbackHandler() {

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandler.java
@@ -14,12 +14,13 @@ import uk.gov.di.authentication.shared.serialization.Json.JsonException;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoIdentityService;
+import uk.gov.di.authentication.shared.services.SerializationService;
 
 import java.util.NoSuchElementException;
 
 public class SPOTResponseHandler implements RequestHandler<SQSEvent, Object> {
 
-    private final Json objectMapper = Json.jackson();
+    private final Json objectMapper = SerializationService.getInstance();
     private final DynamoIdentityService dynamoIdentityService;
     private final AuditService auditService;
 

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/entity/SPOTRequestTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/entity/SPOTRequestTest.java
@@ -1,9 +1,8 @@
 package uk.gov.di.authentication.ipv.entity;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
-import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
+import uk.gov.di.authentication.shared.serialization.Json;
+import uk.gov.di.authentication.shared.services.SerializationService;
 
 import java.util.Base64;
 import java.util.List;
@@ -13,15 +12,16 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 class SPOTRequestTest {
 
+    private Json objectMapper = SerializationService.getInstance();
+
     @Test
-    void shouldReadSPOTRequestFromJson() throws JsonProcessingException {
+    void shouldReadSPOTRequestFromJson() throws Json.JsonException {
 
         String saltString =
                 Base64.getEncoder()
                         .encodeToString("Mmc48imEuO5kkVW7NtXVtx5h0mbCTfXsqXdWvbRMzdw=".getBytes());
         String spotRequestJson = buildSpotRequestJson("P2", "/trustmark", saltString);
 
-        ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
         SPOTRequest spotRequest = objectMapper.readValue(spotRequestJson, SPOTRequest.class);
 
         assertNotNull(spotRequest);

--- a/oidc-api/build.gradle
+++ b/oidc-api/build.gradle
@@ -14,7 +14,7 @@ dependencies {
             configurations.dynamodb
 
     implementation configurations.govuk_notify,
-            configurations.jackson,
+            configurations.gson,
             configurations.nimbus,
             configurations.bouncycastle,
             configurations.cloudwatch,

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/AuthCodeResponse.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/AuthCodeResponse.java
@@ -5,9 +5,7 @@ import jakarta.validation.constraints.NotNull;
 
 public class AuthCodeResponse {
 
-    @Expose
-    @NotNull
-    private String location;
+    @Expose @NotNull private String location;
 
     public AuthCodeResponse() {}
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/AuthCodeResponse.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/AuthCodeResponse.java
@@ -1,13 +1,17 @@
 package uk.gov.di.authentication.oidc.entity;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.annotations.Expose;
+import jakarta.validation.constraints.NotNull;
 
 public class AuthCodeResponse {
 
-    @JsonProperty("location")
+    @Expose
+    @NotNull
     private String location;
 
-    public AuthCodeResponse(@JsonProperty(required = true, value = "location") String location) {
+    public AuthCodeResponse() {}
+
+    public AuthCodeResponse(String location) {
         this.location = location;
     }
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/BackChannelLogoutMessage.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/BackChannelLogoutMessage.java
@@ -5,24 +5,15 @@ import jakarta.validation.constraints.NotNull;
 
 public class BackChannelLogoutMessage {
 
-    @Expose
-    @NotNull
-    private String clientId;
+    @Expose @NotNull private String clientId;
 
-    @Expose
-    @NotNull
-    private String logoutUri;
+    @Expose @NotNull private String logoutUri;
 
-    @Expose
-    @NotNull
-    private String subjectId;
+    @Expose @NotNull private String subjectId;
 
     public BackChannelLogoutMessage() {}
 
-    public BackChannelLogoutMessage(
-            String clientId,
-            String logoutUri,
-            String subjectId) {
+    public BackChannelLogoutMessage(String clientId, String logoutUri, String subjectId) {
         this.clientId = clientId;
         this.logoutUri = logoutUri;
         this.subjectId = subjectId;

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/BackChannelLogoutMessage.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/BackChannelLogoutMessage.java
@@ -1,22 +1,28 @@
 package uk.gov.di.authentication.oidc.entity;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.annotations.Expose;
+import jakarta.validation.constraints.NotNull;
 
 public class BackChannelLogoutMessage {
 
-    @JsonProperty("client_id")
+    @Expose
+    @NotNull
     private String clientId;
 
-    @JsonProperty("logout_uri")
+    @Expose
+    @NotNull
     private String logoutUri;
 
-    @JsonProperty("subject_id")
+    @Expose
+    @NotNull
     private String subjectId;
 
+    public BackChannelLogoutMessage() {}
+
     public BackChannelLogoutMessage(
-            @JsonProperty(required = true, value = "client_id") String clientId,
-            @JsonProperty(required = true, value = "logout_uri") String logoutUri,
-            @JsonProperty(required = true, value = "subject_id") String subjectId) {
+            String clientId,
+            String logoutUri,
+            String subjectId) {
         this.clientId = clientId;
         this.logoutUri = logoutUri;
         this.subjectId = subjectId;

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/IdentityResponse.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/IdentityResponse.java
@@ -6,20 +6,17 @@ import jakarta.validation.constraints.NotNull;
 
 public class IdentityResponse {
 
-    @Expose
-    @NotNull
-    private String sub;
+    @Expose @NotNull private String sub;
 
     @Expose
     @NotNull
     @SerializedName("identityCredential")
     private String identityCredential;
 
-    public IdentityResponse() {};
+    public IdentityResponse() {}
+    ;
 
-    public IdentityResponse(
-            String sub,
-            String identityCredential) {
+    public IdentityResponse(String sub, String identityCredential) {
         this.sub = sub;
         this.identityCredential = identityCredential;
     }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/IdentityResponse.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/IdentityResponse.java
@@ -1,19 +1,25 @@
 package uk.gov.di.authentication.oidc.entity;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import jakarta.validation.constraints.NotNull;
 
 public class IdentityResponse {
 
-    @JsonProperty("sub")
+    @Expose
+    @NotNull
     private String sub;
 
-    @JsonProperty("identityCredential")
+    @Expose
+    @NotNull
+    @SerializedName("identityCredential")
     private String identityCredential;
 
+    public IdentityResponse() {};
+
     public IdentityResponse(
-            @JsonProperty(required = true, value = "sub") String sub,
-            @JsonProperty(required = true, value = "identityCredential")
-                    String identityCredential) {
+            String sub,
+            String identityCredential) {
         this.sub = sub;
         this.identityCredential = identityCredential;
     }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/TrustMarkResponse.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/TrustMarkResponse.java
@@ -1,27 +1,40 @@
 package uk.gov.di.authentication.oidc.entity;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import jakarta.validation.constraints.NotNull;
 
 import java.util.List;
 
 public class TrustMarkResponse {
     @JsonProperty("idp")
+    @Expose
+    @NotNull
     private String idp;
 
-    @JsonProperty("trustmark_provider")
+    @SerializedName("trustmark_provider")
+    @Expose
+    @NotNull
     private String trustMark;
 
-    @JsonProperty("C")
+    @SerializedName("C")
+    @Expose
+    @NotNull
     private List<String> c;
 
-    @JsonProperty("P")
+    @SerializedName("P")
+    @Expose
+    @NotNull
     private List<String> p;
 
+    public TrustMarkResponse() {}
+
     public TrustMarkResponse(
-            @JsonProperty(required = true, value = "idp") String idp,
-            @JsonProperty(required = true, value = "trustmark_provider") String trustMark,
-            @JsonProperty(required = true, value = "C") List<String> c,
-            @JsonProperty(required = true, value = "P") List<String> p) {
+            String idp,
+            String trustMark,
+            List<String> c,
+            List<String> p) {
         this.idp = idp;
         this.trustMark = trustMark;
         this.c = c;

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/TrustMarkResponse.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/TrustMarkResponse.java
@@ -30,11 +30,7 @@ public class TrustMarkResponse {
 
     public TrustMarkResponse() {}
 
-    public TrustMarkResponse(
-            String idp,
-            String trustMark,
-            List<String> c,
-            List<String> p) {
+    public TrustMarkResponse(String idp, String trustMark, List<String> c, List<String> p) {
         this.idp = idp;
         this.trustMark = trustMark;
         this.c = c;

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/BackChannelLogoutRequestHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/BackChannelLogoutRequestHandler.java
@@ -10,10 +10,10 @@ import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.oidc.entity.BackChannelLogoutMessage;
 import uk.gov.di.authentication.oidc.services.HttpRequestService;
 import uk.gov.di.authentication.shared.helpers.NowHelper.NowClock;
-import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.serialization.Json.JsonException;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.KmsConnectionService;
+import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.shared.services.TokenService;
 
 import java.net.URI;
@@ -71,7 +71,7 @@ public class BackChannelLogoutRequestHandler implements RequestHandler<SQSEvent,
 
         try {
             var payload =
-                    Json.jackson().readValue(record.getBody(), BackChannelLogoutMessage.class);
+                    SerializationService.getInstance().readValue(record.getBody(), BackChannelLogoutMessage.class);
 
             var claims = generateClaims(payload);
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/BackChannelLogoutRequestHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/BackChannelLogoutRequestHandler.java
@@ -71,7 +71,8 @@ public class BackChannelLogoutRequestHandler implements RequestHandler<SQSEvent,
 
         try {
             var payload =
-                    SerializationService.getInstance().readValue(record.getBody(), BackChannelLogoutMessage.class);
+                    SerializationService.getInstance()
+                            .readValue(record.getBody(), BackChannelLogoutMessage.class);
 
             var claims = generateClaims(payload);
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
@@ -33,6 +33,7 @@ import uk.gov.di.authentication.shared.services.DynamoClientService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.KmsConnectionService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
+import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.shared.services.TokenService;
 import uk.gov.di.authentication.shared.services.TokenValidationService;
 
@@ -71,7 +72,7 @@ public class TokenHandler
     private final ClientSessionService clientSessionService;
     private final TokenValidationService tokenValidationService;
     private final RedisConnectionService redisConnectionService;
-    private final Json objectMapper = Json.jackson();
+    private final Json objectMapper = SerializationService.getInstance();
 
     private static final String TOKEN_PATH = "token";
     private static final String REFRESH_TOKEN_PREFIX = "REFRESH_TOKEN:";
@@ -107,7 +108,7 @@ public class TokenHandler
         this.dynamoService = new DynamoService(configurationService);
         this.authorisationCodeService =
                 new AuthorisationCodeService(
-                        configurationService, redisConnectionService, Json.jackson());
+                        configurationService, redisConnectionService, objectMapper);
         this.clientSessionService =
                 new ClientSessionService(configurationService, redisConnectionService);
         this.tokenValidationService = new TokenValidationService(configurationService, kms);

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/BackChannelLogoutRequestHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/BackChannelLogoutRequestHandlerTest.java
@@ -10,8 +10,8 @@ import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.oidc.entity.BackChannelLogoutMessage;
 import uk.gov.di.authentication.oidc.services.HttpRequestService;
 import uk.gov.di.authentication.shared.helpers.NowHelper.NowClock;
-import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.shared.services.TokenService;
 
 import java.net.URI;
@@ -124,7 +124,7 @@ class BackChannelLogoutRequestHandlerTest {
     private SQSEvent inputEvent(BackChannelLogoutMessage payload) {
         var messages =
                 Optional.ofNullable(payload)
-                        .map(unchecked(ObjectMapperFactory.getInstance()::writeValueAsString))
+                        .map(unchecked(SerializationService.getInstance()::writeValueAsString))
                         .map(
                                 body -> {
                                     var message = new SQSEvent.SQSMessage();

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TrustMarkHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TrustMarkHandlerTest.java
@@ -9,8 +9,9 @@ import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.oidc.entity.TrustMarkResponse;
 import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.LevelOfConfidence;
-import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
+import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.SerializationService;
 
 import java.util.List;
 import java.util.Optional;
@@ -27,6 +28,7 @@ class TrustMarkHandlerTest {
     private final Context context = mock(Context.class);
     private static final String BASE_URL = "https://example.com";
     private TrustMarkHandler handler;
+    private Json objectMapper = SerializationService.getInstance();
 
     @BeforeEach
     public void setUp() {
@@ -36,7 +38,7 @@ class TrustMarkHandlerTest {
     }
 
     @Test
-    public void shouldReturn200WhenRequestIsSuccessful() throws JsonProcessingException {
+    public void shouldReturn200WhenRequestIsSuccessful() throws JsonProcessingException, Json.JsonException {
         TrustMarkResponse trustMarkResponse =
                 new TrustMarkResponse(
                         configurationService.getOidcApiBaseURL().orElseThrow(),
@@ -51,9 +53,7 @@ class TrustMarkHandlerTest {
 
         assertThat(result, hasStatus(200));
 
-        TrustMarkResponse response =
-                ObjectMapperFactory.getInstance()
-                        .readValue(result.getBody(), TrustMarkResponse.class);
+        TrustMarkResponse response = objectMapper.readValue(result.getBody(), TrustMarkResponse.class);
 
         assertEquals(response.getIdp(), trustMarkResponse.getIdp());
         assertEquals(response.getTrustMark(), trustMarkResponse.getTrustMark());

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TrustMarkHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TrustMarkHandlerTest.java
@@ -38,7 +38,8 @@ class TrustMarkHandlerTest {
     }
 
     @Test
-    public void shouldReturn200WhenRequestIsSuccessful() throws JsonProcessingException, Json.JsonException {
+    public void shouldReturn200WhenRequestIsSuccessful()
+            throws JsonProcessingException, Json.JsonException {
         TrustMarkResponse trustMarkResponse =
                 new TrustMarkResponse(
                         configurationService.getOidcApiBaseURL().orElseThrow(),
@@ -53,7 +54,8 @@ class TrustMarkHandlerTest {
 
         assertThat(result, hasStatus(200));
 
-        TrustMarkResponse response = objectMapper.readValue(result.getBody(), TrustMarkResponse.class);
+        TrustMarkResponse response =
+                objectMapper.readValue(result.getBody(), TrustMarkResponse.class);
 
         assertEquals(response.getIdp(), trustMarkResponse.getIdp());
         assertEquals(response.getTrustMark(), trustMarkResponse.getTrustMark());

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/ApiGatewayHandlerIntegrationTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/ApiGatewayHandlerIntegrationTest.java
@@ -2,7 +2,7 @@ package uk.gov.di.authentication.sharedtest.basetest;
 
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.fasterxml.jackson.core.JsonProcessingException;
+import uk.gov.di.authentication.shared.serialization.Json;
 
 import java.util.Collections;
 import java.util.Map;
@@ -47,7 +47,7 @@ public abstract class ApiGatewayHandlerIntegrationTest
                     } else {
                         try {
                             request.withBody(objectMapper.writeValueAsString(o));
-                        } catch (JsonProcessingException e) {
+                        } catch (Json.JsonException e) {
                             throw new RuntimeException("Could not serialise test body", e);
                         }
                     }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
@@ -3,10 +3,11 @@ package uk.gov.di.authentication.sharedtest.basetest;
 import com.amazonaws.services.kms.model.KeyUsageType;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
+import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.sharedtest.extensions.AuditSnsTopicExtension;
 import uk.gov.di.authentication.sharedtest.extensions.ClientStoreExtension;
 import uk.gov.di.authentication.sharedtest.extensions.CloudwatchMetricsExtension;
@@ -107,7 +108,7 @@ public abstract class HandlerIntegrationTest<Q, S> {
                     docAppPrivateKeyJwtSigner);
 
     protected RequestHandler<Q, S> handler;
-    protected final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
+    protected final Json objectMapper = SerializationService.getInstance();
     protected final Context context = mock(Context.class);
 
     @RegisterExtension

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/SqsQueueExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/SqsQueueExtension.java
@@ -8,11 +8,10 @@ import com.amazonaws.services.sqs.model.PurgeQueueRequest;
 import com.amazonaws.services.sqs.model.QueueAttributeName;
 import com.amazonaws.services.sqs.model.QueueDoesNotExistException;
 import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
+import uk.gov.di.authentication.shared.serialization.Json;
+import uk.gov.di.authentication.shared.services.SerializationService;
 
 import java.util.List;
 import java.util.Optional;
@@ -26,7 +25,7 @@ public class SqsQueueExtension extends BaseAwsResourceExtension implements Befor
 
     private final String queueNameSuffix;
     private final AmazonSQS sqsClient;
-    private final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
+    private final Json objectMapper = SerializationService.getInstance();
 
     private String queueUrl;
 
@@ -64,7 +63,7 @@ public class SqsQueueExtension extends BaseAwsResourceExtension implements Befor
                         m -> {
                             try {
                                 return objectMapper.readValue(m.getBody(), messageClass);
-                            } catch (JsonProcessingException e) {
+                            } catch (Json.JsonException e) {
                                 throw new RuntimeException(e);
                             }
                         })

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AccessTokenStore.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AccessTokenStore.java
@@ -1,14 +1,19 @@
 package uk.gov.di.authentication.shared.entity;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.annotations.Expose;
 
 public class AccessTokenStore {
 
     @JsonProperty("token")
+    @Expose
     private String token;
 
     @JsonProperty("internal_subject_id")
+    @Expose
     private String internalSubjectId;
+
+    public AccessTokenStore() {}
 
     public AccessTokenStore(
             @JsonProperty(required = true, value = "token") String token,

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthCodeExchangeData.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthCodeExchangeData.java
@@ -1,14 +1,22 @@
 package uk.gov.di.authentication.shared.entity;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
 
 public class AuthCodeExchangeData {
 
-    @JsonProperty private String clientSessionId;
+    @JsonProperty
+    @Expose
+    @SerializedName("clientSessionId")
+    private String clientSessionId;
 
-    @JsonProperty private String email;
+    @JsonProperty @Expose private String email;
 
-    @JsonProperty private ClientSession clientSession;
+    @JsonProperty
+    @Expose
+    @SerializedName("clientSession")
+    private ClientSession clientSession;
 
     public String getClientSessionId() {
         return clientSessionId;

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ClientSession.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ClientSession.java
@@ -1,7 +1,10 @@
 package uk.gov.di.authentication.shared.entity;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.JsonAdapter;
 import com.nimbusds.oauth2.sdk.id.Subject;
+import uk.gov.di.authentication.shared.serialization.LocalDateTimeAdapter;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -10,18 +13,24 @@ import java.util.Map;
 public class ClientSession {
 
     @JsonProperty("auth_request_params")
+    @Expose
     private Map<String, List<String>> authRequestParams;
 
     @JsonProperty("id_token_hint")
+    @Expose
     private String idTokenHint;
 
     @JsonProperty("creation_date")
+    @Expose
+    @JsonAdapter(LocalDateTimeAdapter.class)
     private LocalDateTime creationDate;
 
     @JsonProperty("effective_vector_of_trust")
+    @Expose
     private VectorOfTrust effectiveVectorOfTrust;
 
     @JsonProperty("doc_app_subject_id")
+    @Expose
     private Subject docAppSubjectId;
 
     public ClientSession(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/RefreshTokenStore.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/RefreshTokenStore.java
@@ -1,13 +1,19 @@
 package uk.gov.di.authentication.shared.entity;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
 
 public class RefreshTokenStore {
 
     @JsonProperty("refresh_token")
+    @Expose
+    @SerializedName("refresh_token")
     private String refreshToken;
 
     @JsonProperty("internal_subject_id")
+    @Expose
+    @SerializedName("internal_subject_id")
     private String internalSubjectId;
 
     public RefreshTokenStore() {}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/UpdateClientConfigRequest.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/UpdateClientConfigRequest.java
@@ -1,42 +1,54 @@
 package uk.gov.di.authentication.shared.entity;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
 
 import java.util.List;
 
 public class UpdateClientConfigRequest {
 
-    @JsonProperty("client_id")
+    @SerializedName("client_id")
+    @Expose
     private String clientId;
 
-    @JsonProperty("client_name")
+    @SerializedName("client_name")
+    @Expose
     private String clientName;
 
-    @JsonProperty("redirect_uris")
+    @SerializedName("redirect_uris")
+    @Expose
     private List<String> redirectUris;
 
-    @JsonProperty("contacts")
+    @SerializedName("contacts")
+    @Expose
     private List<String> contacts;
 
-    @JsonProperty("public_key")
+    @SerializedName("public_key")
+    @Expose
     private String publicKey;
 
-    @JsonProperty("scopes")
+    @SerializedName("scopes")
+    @Expose
     private List<String> scopes;
 
-    @JsonProperty("post_logout_redirect_uris")
+    @SerializedName("post_logout_redirect_uris")
+    @Expose
     private List<String> postLogoutRedirectUris;
 
-    @JsonProperty("service_type")
+    @SerializedName("service_type")
+    @Expose
     private String serviceType;
 
-    @JsonProperty("claims")
+    @SerializedName("claims")
+    @Expose
     private List<String> claims;
 
-    @JsonProperty("sector_identifier_uri")
+    @SerializedName("sector_identifier_uri")
+    @Expose
     private String sectorIdentifierUri;
 
-    @JsonProperty("client_type")
+    @SerializedName("client_type")
+    @Expose
     private String clientType;
 
     public UpdateClientConfigRequest() {}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/VectorOfTrust.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/VectorOfTrust.java
@@ -2,6 +2,7 @@ package uk.gov.di.authentication.shared.entity;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.annotations.Expose;
 import net.minidev.json.JSONArray;
 import net.minidev.json.parser.JSONParser;
 import org.apache.logging.log4j.LogManager;
@@ -22,14 +23,18 @@ public class VectorOfTrust {
     private static final Logger LOG = LogManager.getLogger(VectorOfTrust.class);
 
     @JsonProperty("credential_trust_level")
-    private final CredentialTrustLevel credentialTrustLevel;
+    @Expose
+    private CredentialTrustLevel credentialTrustLevel;
 
     @JsonProperty("level_of_confidence")
-    private final LevelOfConfidence levelOfConfidence;
+    @Expose
+    private LevelOfConfidence levelOfConfidence;
 
     private VectorOfTrust(CredentialTrustLevel credentialTrustLevel) {
         this(credentialTrustLevel, null);
     }
+
+    public VectorOfTrust() {}
 
     @JsonCreator
     private VectorOfTrust(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ApiGatewayResponseHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ApiGatewayResponseHelper.java
@@ -7,6 +7,7 @@ import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.serialization.Json.JsonException;
+import uk.gov.di.authentication.shared.services.SerializationService;
 
 import java.util.List;
 import java.util.Map;
@@ -29,7 +30,7 @@ public class ApiGatewayResponseHelper {
     private static final String X_FRAME_OPTIONS_HEADER_VALUE = "DENY";
 
     private static final Logger LOG = LogManager.getLogger(ApiGatewayResponseHelper.class);
-    private static final Json objectMapper = Json.jackson();
+    private static final Json objectMapper = SerializationService.getInstance();
 
     public static <T> APIGatewayProxyResponseEvent generateApiGatewayProxyResponse(
             int statusCode, T body) throws JsonException {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/serialization/Base64ByteArrayAdapter.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/serialization/Base64ByteArrayAdapter.java
@@ -1,0 +1,20 @@
+package uk.gov.di.authentication.shared.serialization;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+import java.util.Base64;
+
+public class Base64ByteArrayAdapter extends TypeAdapter<byte[]> {
+    @Override
+    public void write(JsonWriter out, byte[] value) throws IOException {
+        out.value(Base64.getEncoder().encodeToString(value));
+    }
+
+    @Override
+    public byte[] read(JsonReader in) throws IOException {
+        return Base64.getDecoder().decode(in.nextString());
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/serialization/LocalDateTimeAdapter.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/serialization/LocalDateTimeAdapter.java
@@ -1,0 +1,40 @@
+package uk.gov.di.authentication.shared.serialization;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import com.google.gson.stream.MalformedJsonException;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+public class LocalDateTimeAdapter extends TypeAdapter<LocalDateTime> {
+    @Override
+    public void write(JsonWriter out, LocalDateTime value) throws IOException {
+        out.value(value.toString());
+    }
+
+    @Override
+    public LocalDateTime read(JsonReader in) throws IOException {
+        var token = in.peek();
+        switch (token) {
+            case BEGIN_ARRAY:
+                in.beginArray();
+                var year = in.nextInt();
+                var month = in.nextInt();
+                var day = in.nextInt();
+                var hour = in.nextInt();
+                var minute = in.nextInt();
+                var seconds = in.nextInt();
+                var nanos = in.nextInt();
+                in.endArray();
+                return LocalDateTime.of(year, month, day, hour, minute, seconds, nanos);
+            case STRING:
+                in.nextString();
+                return LocalDateTime.parse(in.nextString());
+            default:
+                throw new MalformedJsonException(
+                        "Expected BEGIN_ARRAY or STRING got " + token.name());
+        }
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/SerializationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/SerializationService.java
@@ -3,6 +3,7 @@ package uk.gov.di.authentication.shared.services;
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
 import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
@@ -49,7 +50,7 @@ public class SerializationService implements Json {
             violations.forEach(v -> LOG.warn("Json validation violation: {}", v.getMessage()));
             throw new JsonException(
                     new ConstraintViolationException("JSON validation error", violations));
-        } catch (IllegalArgumentException e) {
+        } catch (JsonSyntaxException | IllegalArgumentException e) {
             throw new JsonException(e);
         }
     }


### PR DESCRIPTION
## What?

- Add annotations to entity classes
- Change handlers to use `SerializationService` rather than Jackson
- Update integration tests to serialise requests using GSON rather than Jackson
- Update AM API entities to include GSON annotations (as well as Jackson)

## Why?

We are migrating from Jackson to GSON for performance benefits