### PR TITLE
AUT-356: Update account managment API to use GSON

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/NotifyRequest.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/NotifyRequest.java
@@ -1,25 +1,23 @@
 package uk.gov.di.accountmanagement.entity;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import jakarta.validation.constraints.NotNull;
 
 public class NotifyRequest {
 
     @Expose
     @SerializedName("notificationType")
-    @JsonProperty
+    @NotNull
     private NotificationType notificationType;
 
-    @Expose @JsonProperty private String destination;
+    @Expose @NotNull private String destination;
 
-    @Expose @JsonProperty private String code;
+    @Expose private String code;
 
-    public NotifyRequest(
-            @JsonProperty(required = true, value = "destination") String destination,
-            @JsonProperty(required = true, value = "notificationType")
-                    NotificationType notificationType,
-            @JsonProperty(value = "code") String code) {
+    public NotifyRequest() {}
+
+    public NotifyRequest(String destination, NotificationType notificationType, String code) {
         this.destination = destination;
         this.notificationType = notificationType;
         this.code = code;

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/RemoveAccountRequest.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/RemoveAccountRequest.java
@@ -1,12 +1,14 @@
 package uk.gov.di.accountmanagement.entity;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.gson.annotations.Expose;
+import jakarta.validation.constraints.NotNull;
 
 public class RemoveAccountRequest {
-    @Expose private String email;
+    @Expose @NotNull private String email;
 
-    public RemoveAccountRequest(@JsonProperty(required = true, value = "email") String email) {
+    public RemoveAccountRequest() {}
+
+    public RemoveAccountRequest(String email) {
         this.email = email;
     }
 

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/SendNotificationRequest.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/SendNotificationRequest.java
@@ -1,26 +1,26 @@
 package uk.gov.di.accountmanagement.entity;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import jakarta.validation.constraints.NotNull;
 
 public class SendNotificationRequest {
 
     @Expose
     @SerializedName("notificationType")
+    @NotNull
     private NotificationType notificationType;
 
     @Expose
     @SerializedName("phoneNumber")
     private String phoneNumber;
 
-    @Expose private String email;
+    @Expose @NotNull private String email;
+
+    public SendNotificationRequest() {}
 
     public SendNotificationRequest(
-            @JsonProperty(required = true, value = "email") String email,
-            @JsonProperty(required = true, value = "notificationType")
-                    NotificationType notificationType,
-            @JsonProperty(value = "phoneNumber") String phoneNumber) {
+            String email, NotificationType notificationType, String phoneNumber) {
         this.email = email;
         this.notificationType = notificationType;
         this.phoneNumber = phoneNumber;

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/UpdateEmailRequest.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/UpdateEmailRequest.java
@@ -1,27 +1,27 @@
 package uk.gov.di.accountmanagement.entity;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import jakarta.validation.constraints.NotNull;
 
 public class UpdateEmailRequest {
 
     @Expose
     @SerializedName("existingEmailAddress")
+    @NotNull
     private String existingEmailAddress;
 
     @Expose
     @SerializedName("replacementEmailAddress")
+    @NotNull
     private String replacementEmailAddress;
 
-    @Expose private String otp;
+    @Expose @NotNull private String otp;
+
+    public UpdateEmailRequest() {}
 
     public UpdateEmailRequest(
-            @JsonProperty(required = true, value = "existingEmailAddress")
-                    String existingEmailAddress,
-            @JsonProperty(required = true, value = "replacementEmailAddress")
-                    String replacementEmailAddress,
-            @JsonProperty(required = true, value = "otp") String otp) {
+            String existingEmailAddress, String replacementEmailAddress, String otp) {
         this.existingEmailAddress = existingEmailAddress.toLowerCase();
         this.replacementEmailAddress = replacementEmailAddress.toLowerCase();
         this.otp = otp;

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/UpdatePasswordRequest.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/UpdatePasswordRequest.java
@@ -1,20 +1,21 @@
 package uk.gov.di.accountmanagement.entity;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import jakarta.validation.constraints.NotNull;
 
 public class UpdatePasswordRequest {
 
-    @Expose private String email;
+    @Expose @NotNull private String email;
 
     @Expose
     @SerializedName("newPassword")
+    @NotNull
     private String newPassword;
 
-    public UpdatePasswordRequest(
-            @JsonProperty(required = true, value = "email") String email,
-            @JsonProperty(required = true, value = "newPassword") String newPassword) {
+    public UpdatePasswordRequest() {}
+
+    public UpdatePasswordRequest(String email, String newPassword) {
         this.email = email;
         this.newPassword = newPassword;
     }

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/UpdatePhoneNumberRequest.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/UpdatePhoneNumberRequest.java
@@ -1,23 +1,23 @@
 package uk.gov.di.accountmanagement.entity;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import jakarta.validation.constraints.NotNull;
 
 public class UpdatePhoneNumberRequest {
 
-    @Expose private String email;
+    @Expose @NotNull private String email;
 
     @Expose
     @SerializedName("phoneNumber")
+    @NotNull
     private String phoneNumber;
 
-    @Expose private String otp;
+    @Expose @NotNull private String otp;
 
-    public UpdatePhoneNumberRequest(
-            @JsonProperty(required = true, value = "email") String email,
-            @JsonProperty(required = true, value = "phoneNumber") String phoneNumber,
-            @JsonProperty(required = true, value = "otp") String otp) {
+    public UpdatePhoneNumberRequest() {}
+
+    public UpdatePhoneNumberRequest(String email, String phoneNumber, String otp) {
         this.email = email;
         this.phoneNumber = phoneNumber;
         this.otp = otp;

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/NotificationHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/NotificationHandler.java
@@ -12,6 +12,7 @@ import uk.gov.di.accountmanagement.services.NotificationService;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.serialization.Json.JsonException;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.service.notify.NotificationClient;
 import uk.gov.service.notify.NotificationClientException;
 
@@ -25,7 +26,7 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
 
     private static final Logger LOG = LogManager.getLogger(NotificationHandler.class);
     private final NotificationService notificationService;
-    private final Json objectMapper = Json.jackson();
+    private final Json objectMapper = SerializationService.getInstance();
     private final ConfigurationService configurationService;
 
     public NotificationHandler(

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandler.java
@@ -24,6 +24,7 @@ import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
+import uk.gov.di.authentication.shared.services.SerializationService;
 
 import java.util.Map;
 
@@ -42,7 +43,7 @@ public class RemoveAccountHandler
     private final AuthenticationService authenticationService;
     private final AwsSqsClient sqsClient;
     private final AuditService auditService;
-    private final Json objectMapper = Json.jackson();
+    private final Json objectMapper = SerializationService.getInstance();
 
     public RemoveAccountHandler(
             AuthenticationService authenticationService,

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
@@ -24,6 +24,7 @@ import uk.gov.di.authentication.shared.services.CodeGeneratorService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
+import uk.gov.di.authentication.shared.services.SerializationService;
 
 import java.util.Optional;
 
@@ -48,7 +49,7 @@ public class SendOtpNotificationHandler
     private final CodeGeneratorService codeGeneratorService;
     private final CodeStorageService codeStorageService;
     private final DynamoService dynamoService;
-    private final Json objectMapper = Json.jackson();
+    private final Json objectMapper = SerializationService.getInstance();
     private final AuditService auditService;
 
     public SendOtpNotificationHandler(

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
@@ -26,6 +26,7 @@ import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
+import uk.gov.di.authentication.shared.services.SerializationService;
 
 import java.util.Map;
 import java.util.Optional;
@@ -40,7 +41,7 @@ import static uk.gov.di.authentication.shared.helpers.WarmerHelper.isWarming;
 public class UpdateEmailHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
-    private final Json objectMapper = Json.jackson();
+    private final Json objectMapper = SerializationService.getInstance();
     private final DynamoService dynamoService;
     private final AwsSqsClient sqsClient;
     private final CodeStorageService codeStorageService;

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandler.java
@@ -24,6 +24,7 @@ import uk.gov.di.authentication.shared.serialization.Json.JsonException;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
+import uk.gov.di.authentication.shared.services.SerializationService;
 
 import java.util.Map;
 
@@ -37,7 +38,7 @@ import static uk.gov.di.authentication.shared.helpers.WarmerHelper.isWarming;
 public class UpdatePasswordHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
-    private final Json objectMapper = Json.jackson();
+    private final Json objectMapper = SerializationService.getInstance();
     private final DynamoService dynamoService;
     private final AwsSqsClient sqsClient;
     private final AuditService auditService;

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandler.java
@@ -25,6 +25,7 @@ import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
+import uk.gov.di.authentication.shared.services.SerializationService;
 
 import java.util.Map;
 
@@ -38,7 +39,7 @@ import static uk.gov.di.authentication.shared.helpers.WarmerHelper.isWarming;
 public class UpdatePhoneNumberHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
-    private final Json objectMapper = Json.jackson();
+    private final Json objectMapper = SerializationService.getInstance();
     private final DynamoService dynamoService;
     private final AwsSqsClient sqsClient;
     private final CodeStorageService codeStorageService;

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/NotificationHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/NotificationHandlerTest.java
@@ -3,15 +3,14 @@ package uk.gov.di.accountmanagement.lambda;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.accountmanagement.services.NotificationService;
-import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
+import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.service.notify.NotificationClientException;
 
 import java.util.HashMap;
@@ -41,7 +40,7 @@ public class NotificationHandlerTest {
     private final NotificationService notificationService = mock(NotificationService.class);
     private final ConfigurationService configService = mock(ConfigurationService.class);
     private NotificationHandler handler;
-    private final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
+    private final Json objectMapper = SerializationService.getInstance();
 
     @BeforeEach
     public void setUp() {
@@ -52,7 +51,7 @@ public class NotificationHandlerTest {
 
     @Test
     public void shouldSuccessfullyProcessVerifyEmailMessageFromSQSQueue()
-            throws JsonProcessingException, NotificationClientException {
+            throws Json.JsonException, NotificationClientException {
         when(notificationService.getNotificationTemplateId(VERIFY_EMAIL)).thenReturn(TEMPLATE_ID);
 
         NotifyRequest notifyRequest = new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL, "654321");
@@ -73,7 +72,7 @@ public class NotificationHandlerTest {
 
     @Test
     public void shouldSuccessfullyProcessVerifyPhoneMessageFromSQSQueue()
-            throws JsonProcessingException, NotificationClientException {
+            throws Json.JsonException, NotificationClientException {
         when(notificationService.getNotificationTemplateId(VERIFY_PHONE_NUMBER))
                 .thenReturn(TEMPLATE_ID);
 
@@ -92,7 +91,7 @@ public class NotificationHandlerTest {
 
     @Test
     public void shouldSuccessfullyProcessUpdateEmailMessageFromSQSQueue()
-            throws JsonProcessingException, NotificationClientException {
+            throws Json.JsonException, NotificationClientException {
         when(notificationService.getNotificationTemplateId(EMAIL_UPDATED)).thenReturn(TEMPLATE_ID);
 
         NotifyRequest notifyRequest = new NotifyRequest(TEST_EMAIL_ADDRESS, EMAIL_UPDATED);
@@ -112,7 +111,7 @@ public class NotificationHandlerTest {
 
     @Test
     public void shouldSuccessfullyProcessUpdatePasswordMessageFromSQSQueue()
-            throws JsonProcessingException, NotificationClientException {
+            throws Json.JsonException, NotificationClientException {
         when(notificationService.getNotificationTemplateId(PASSWORD_UPDATED))
                 .thenReturn(TEMPLATE_ID);
 
@@ -132,7 +131,7 @@ public class NotificationHandlerTest {
 
     @Test
     public void shouldSuccessfullyProcessUpdatePhoneNumberMessageFromSQSQueue()
-            throws JsonProcessingException, NotificationClientException {
+            throws Json.JsonException, NotificationClientException {
         when(notificationService.getNotificationTemplateId(PHONE_NUMBER_UPDATED))
                 .thenReturn(TEMPLATE_ID);
 
@@ -152,7 +151,7 @@ public class NotificationHandlerTest {
 
     @Test
     public void shouldSuccessfullyProcessDeleteAccountMessageFromSQSQueue()
-            throws JsonProcessingException, NotificationClientException {
+            throws Json.JsonException, NotificationClientException {
         when(notificationService.getNotificationTemplateId(DELETE_ACCOUNT)).thenReturn(TEMPLATE_ID);
 
         NotifyRequest notifyRequest = new NotifyRequest(TEST_EMAIL_ADDRESS, DELETE_ACCOUNT);
@@ -185,7 +184,7 @@ public class NotificationHandlerTest {
 
     @Test
     public void shouldThrowExceptionIfNotifyIsUnableToSendEmail()
-            throws JsonProcessingException, NotificationClientException {
+            throws Json.JsonException, NotificationClientException {
         when(notificationService.getNotificationTemplateId(VERIFY_EMAIL)).thenReturn(TEMPLATE_ID);
 
         NotifyRequest notifyRequest = new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL, "654321");
@@ -216,7 +215,7 @@ public class NotificationHandlerTest {
 
     @Test
     public void shouldThrowExceptionIfNotifyIsUnableToSendText()
-            throws JsonProcessingException, NotificationClientException {
+            throws Json.JsonException, NotificationClientException {
         when(notificationService.getNotificationTemplateId(VERIFY_PHONE_NUMBER))
                 .thenReturn(TEMPLATE_ID);
 

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandlerTest.java
@@ -3,8 +3,6 @@ package uk.gov.di.accountmanagement.lambda;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -12,10 +10,11 @@ import uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.authentication.shared.entity.UserProfile;
-import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
+import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
+import uk.gov.di.authentication.shared.services.SerializationService;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -35,7 +34,7 @@ class RemoveAccountHandlerTest {
 
     private static final String EMAIL = "joe.bloggs@digital.cabinet-office.gov.uk";
     private static final Subject SUBJECT = new Subject();
-    private static final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
+    private final Json objectMapper = SerializationService.getInstance();
 
     private RemoveAccountHandler handler;
     private final Context context = mock(Context.class);
@@ -49,7 +48,7 @@ class RemoveAccountHandlerTest {
     }
 
     @Test
-    public void shouldReturn204IfAccountRemovalIsSuccessful() throws JsonProcessingException {
+    public void shouldReturn204IfAccountRemovalIsSuccessful() throws Json.JsonException {
         String persistentIdValue = "some-persistent-session-id";
         UserProfile userProfile = new UserProfile().setPublicSubjectID(SUBJECT.getValue());
         when(authenticationService.getUserProfileByEmailMaybe(EMAIL))

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandlerTest.java
@@ -3,8 +3,6 @@ package uk.gov.di.accountmanagement.lambda;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -15,12 +13,13 @@ import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
-import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
+import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.CodeGeneratorService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
+import uk.gov.di.authentication.shared.services.SerializationService;
 
 import java.util.Map;
 
@@ -49,8 +48,8 @@ class SendOtpNotificationHandlerTest {
     private static final String TEST_SIX_DIGIT_CODE = "123456";
     private static final String TEST_PHONE_NUMBER = "07755551084";
     private static final long CODE_EXPIRY_TIME = 900;
-    private static final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
 
+    private final Json objectMapper = SerializationService.getInstance();
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final AwsSqsClient awsSqsClient = mock(AwsSqsClient.class);
     private final CodeGeneratorService codeGeneratorService = mock(CodeGeneratorService.class);
@@ -75,7 +74,7 @@ class SendOtpNotificationHandlerTest {
     }
 
     @Test
-    void shouldReturn204AndPutMessageOnQueueForAValidEmailRequest() throws JsonProcessingException {
+    void shouldReturn204AndPutMessageOnQueueForAValidEmailRequest() throws Json.JsonException {
         String persistentIdValue = "some-persistent-session-id";
         NotifyRequest notifyRequest =
                 new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL, TEST_SIX_DIGIT_CODE);
@@ -112,7 +111,7 @@ class SendOtpNotificationHandlerTest {
     }
 
     @Test
-    void shouldReturn204AndPutMessageOnQueueForAValidPhoneRequest() throws JsonProcessingException {
+    void shouldReturn204AndPutMessageOnQueueForAValidPhoneRequest() throws Json.JsonException {
         NotifyRequest notifyRequest =
                 new NotifyRequest(TEST_PHONE_NUMBER, VERIFY_PHONE_NUMBER, TEST_SIX_DIGIT_CODE);
 
@@ -199,7 +198,7 @@ class SendOtpNotificationHandlerTest {
     }
 
     @Test
-    void shouldReturn500IfMessageCannotBeSentToQueue() throws JsonProcessingException {
+    void shouldReturn500IfMessageCannotBeSentToQueue() throws Json.JsonException {
         NotifyRequest notifyRequest =
                 new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL, TEST_SIX_DIGIT_CODE);
         String serialisedRequest = objectMapper.writeValueAsString(notifyRequest);

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandlerTest.java
@@ -3,8 +3,6 @@ package uk.gov.di.accountmanagement.lambda;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -15,10 +13,11 @@ import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.UserProfile;
-import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
+import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.DynamoService;
+import uk.gov.di.authentication.shared.services.SerializationService;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -49,8 +48,8 @@ class UpdateEmailHandlerTest {
     private static final String INVALID_EMAIL_ADDRESS = "igital.cabinet-office.gov.uk";
     private static final String OTP = "123456";
     private static final Subject SUBJECT = new Subject();
-    private static final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
 
+    private final Json objectMapper = SerializationService.getInstance();
     private final AuditService auditService = mock(AuditService.class);
 
     @BeforeEach
@@ -60,7 +59,7 @@ class UpdateEmailHandlerTest {
     }
 
     @Test
-    void shouldReturn204ForValidUpdateEmailRequest() throws JsonProcessingException {
+    void shouldReturn204ForValidUpdateEmailRequest() throws Json.JsonException {
         String persistentIdValue = "some-persistent-session-id";
         UserProfile userProfile = new UserProfile().setPublicSubjectID(SUBJECT.getValue());
         when(dynamoService.getUserProfileByEmail(EXISTING_EMAIL_ADDRESS)).thenReturn(userProfile);
@@ -101,7 +100,7 @@ class UpdateEmailHandlerTest {
     }
 
     @Test
-    void shouldReturn400WhenReplacementEmailAlreadyExists() throws JsonProcessingException {
+    void shouldReturn400WhenReplacementEmailAlreadyExists() throws Json.JsonException {
         when(dynamoService.getSubjectFromEmail(EXISTING_EMAIL_ADDRESS)).thenReturn(SUBJECT);
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setBody(
@@ -144,7 +143,7 @@ class UpdateEmailHandlerTest {
     }
 
     @Test
-    public void shouldReturnErrorWhenOtpCodeIsNotValid() throws JsonProcessingException {
+    public void shouldReturnErrorWhenOtpCodeIsNotValid() throws Json.JsonException {
         when(dynamoService.getSubjectFromEmail(EXISTING_EMAIL_ADDRESS)).thenReturn(SUBJECT);
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setBody(
@@ -170,7 +169,7 @@ class UpdateEmailHandlerTest {
     }
 
     @Test
-    void shouldReturn400AndNotUpdateEmailWhenEmailIsInvalid() throws JsonProcessingException {
+    void shouldReturn400AndNotUpdateEmailWhenEmailIsInvalid() throws Json.JsonException {
         when(dynamoService.getSubjectFromEmail(EXISTING_EMAIL_ADDRESS)).thenReturn(SUBJECT);
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setBody(

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandlerTest.java
@@ -3,8 +3,6 @@ package uk.gov.di.accountmanagement.lambda;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -16,10 +14,11 @@ import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.Argon2EncoderHelper;
-import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
+import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.DynamoService;
+import uk.gov.di.authentication.shared.services.SerializationService;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -47,7 +46,7 @@ class UpdatePasswordHandlerTest {
     private static final String NEW_PASSWORD = "password2";
     private static final String CURRENT_PASSWORD = "password1";
     private static final Subject SUBJECT = new Subject();
-    private static final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
+    private final Json objectMapper = SerializationService.getInstance();
 
     @BeforeEach
     public void setUp() {
@@ -55,7 +54,7 @@ class UpdatePasswordHandlerTest {
     }
 
     @Test
-    public void shouldReturn204ForValidRequest() throws JsonProcessingException {
+    public void shouldReturn204ForValidRequest() throws Json.JsonException {
         String persistentIdValue = "some-persistent-session-id";
         UserProfile userProfile = new UserProfile().setPublicSubjectID(SUBJECT.getValue());
         UserCredentials userCredentials = new UserCredentials().setPassword(CURRENT_PASSWORD);
@@ -117,8 +116,7 @@ class UpdatePasswordHandlerTest {
     }
 
     @Test
-    public void shouldReturn400WhenNewPasswordEqualsExistingPassword()
-            throws JsonProcessingException {
+    public void shouldReturn400WhenNewPasswordEqualsExistingPassword() throws Json.JsonException {
         UserProfile userProfile = new UserProfile().setPublicSubjectID(SUBJECT.getValue());
         UserCredentials userCredentials =
                 new UserCredentials().setPassword(Argon2EncoderHelper.argon2Hash(NEW_PASSWORD));

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandlerTest.java
@@ -3,8 +3,6 @@ package uk.gov.di.accountmanagement.lambda;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -14,10 +12,11 @@ import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.UserProfile;
-import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
+import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.DynamoService;
+import uk.gov.di.authentication.shared.services.SerializationService;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -49,8 +48,8 @@ class UpdatePhoneNumberHandlerTest {
     private static final String INVALID_PHONE_NUMBER = "12345";
     private static final String OTP = "123456";
     private static final Subject SUBJECT = new Subject();
-    private static final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
 
+    private final Json objectMapper = SerializationService.getInstance();
     private final AuditService auditService = mock(AuditService.class);
 
     @BeforeEach
@@ -61,7 +60,7 @@ class UpdatePhoneNumberHandlerTest {
     }
 
     @Test
-    public void shouldReturn204ForValidUpdatePhoneNumberRequest() throws JsonProcessingException {
+    public void shouldReturn204ForValidUpdatePhoneNumberRequest() throws Json.JsonException {
         String persistentIdValue = "some-persistent-session-id";
         UserProfile userProfile =
                 new UserProfile()
@@ -123,7 +122,7 @@ class UpdatePhoneNumberHandlerTest {
     }
 
     @Test
-    public void shouldReturnErrorWhenOtpCodeIsNotValid() throws JsonProcessingException {
+    public void shouldReturnErrorWhenOtpCodeIsNotValid() throws Json.JsonException {
         when(dynamoService.getSubjectFromEmail(EMAIL_ADDRESS)).thenReturn(SUBJECT);
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setBody(


### PR DESCRIPTION
## What?

- Update handlers to use `SerializationService` rather than Jackson
- Update entities to remove Jackson annotations

## Why?

We are migrating to GSON from Jackson