### PR TITLE
AUT-356: Migrate Delivery Receipts to GSON

### DIFF
--- a/delivery-receipts-api/build.gradle
+++ b/delivery-receipts-api/build.gradle
@@ -9,7 +9,7 @@ version "unspecified"
 dependencies {
     implementation configurations.govuk_notify,
             configurations.lambda,
-            configurations.jackson,
+            configurations.gson,
             configurations.libphonenumber,
             configurations.cloudwatch
 

--- a/delivery-receipts-api/src/main/java/uk/gov/di/authentication/deliveryreceiptsapi/entity/NotifyDeliveryReceipt.java
+++ b/delivery-receipts-api/src/main/java/uk/gov/di/authentication/deliveryreceiptsapi/entity/NotifyDeliveryReceipt.java
@@ -1,50 +1,43 @@
 package uk.gov.di.authentication.deliveryreceiptsapi.entity;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.gson.annotations.Expose;
+import jakarta.validation.constraints.NotNull;
 
 public class NotifyDeliveryReceipt {
 
-    @JsonProperty("id")
-    private String id;
+    @Expose @NotNull private String id;
 
-    @JsonProperty("reference")
-    private String reference;
+    @Expose private String reference;
 
-    @JsonProperty("to")
-    private String to;
+    @Expose @NotNull private String to;
 
-    @JsonProperty("status")
-    private String status;
+    @Expose @NotNull private String status;
 
-    @JsonProperty("created_at")
-    private String createdAt;
+    @Expose @NotNull private String createdAt;
 
-    @JsonProperty("completed_at")
-    private String completedAt;
+    @Expose @NotNull private String completedAt;
 
-    @JsonProperty("sent_at")
-    private String sentAt;
+    @Expose @NotNull private String sentAt;
 
-    @JsonProperty("notification_type")
-    private String notificationType;
+    @Expose @NotNull private String notificationType;
 
-    @JsonProperty("template_id")
-    private String templateId;
+    @Expose @NotNull private String templateId;
 
-    @JsonProperty("template_version")
-    private int templateVersion;
+    @Expose @NotNull private int templateVersion;
+
+    public NotifyDeliveryReceipt() {}
 
     public NotifyDeliveryReceipt(
-            @JsonProperty(required = true, value = "id") String id,
-            @JsonProperty(required = true, value = "reference") String reference,
-            @JsonProperty(required = true, value = "to") String to,
-            @JsonProperty(required = true, value = "status") String status,
-            @JsonProperty(required = true, value = "created_at") String createdAt,
-            @JsonProperty(required = true, value = "completed_at") String completedAt,
-            @JsonProperty(required = true, value = "sent_at") String sentAt,
-            @JsonProperty(required = true, value = "notification_type") String notificationType,
-            @JsonProperty(required = true, value = "template_id") String templateId,
-            @JsonProperty(required = true, value = "template_version") int templateVersion) {
+            String id,
+            String reference,
+            String to,
+            String status,
+            String createdAt,
+            String completedAt,
+            String sentAt,
+            String notificationType,
+            String templateId,
+            int templateVersion) {
         this.id = id;
         this.reference = reference;
         this.to = to;

--- a/delivery-receipts-api/src/main/java/uk/gov/di/authentication/deliveryreceiptsapi/lambda/NotifyCallbackHandler.java
+++ b/delivery-receipts-api/src/main/java/uk/gov/di/authentication/deliveryreceiptsapi/lambda/NotifyCallbackHandler.java
@@ -13,6 +13,7 @@ import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.serialization.Json.JsonException;
 import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.SerializationService;
 
 import java.util.Map;
 import java.util.Objects;
@@ -29,7 +30,7 @@ public class NotifyCallbackHandler
     private static final String AUTHORIZATION_HEADER = "Authorization";
     private final ConfigurationService configurationService;
     private final CloudwatchMetricsService cloudwatchMetricsService;
-    private final Json objectMapper = Json.jackson();
+    private final Json objectMapper = SerializationService.getInstance();
 
     private static final Logger LOG = LogManager.getLogger(NotifyCallbackHandler.class);
 

--- a/delivery-receipts-api/src/test/java/uk/gov/di/authentication/deliveryreceiptsapi/lambda/NotifyCallbackHandlerTest.java
+++ b/delivery-receipts-api/src/test/java/uk/gov/di/authentication/deliveryreceiptsapi/lambda/NotifyCallbackHandlerTest.java
@@ -2,8 +2,6 @@ package uk.gov.di.authentication.deliveryreceiptsapi.lambda;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -11,9 +9,10 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.authentication.deliveryreceiptsapi.entity.NotifyDeliveryReceipt;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
-import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
+import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.SerializationService;
 
 import java.util.Collections;
 import java.util.Date;
@@ -41,7 +40,7 @@ class NotifyCallbackHandlerTest {
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final CloudwatchMetricsService cloudwatchMetricsService =
             mock(CloudwatchMetricsService.class);
-    private final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
+    private final Json objectMapper = SerializationService.getInstance();
 
     @BeforeEach
     void setup() {
@@ -77,7 +76,7 @@ class NotifyCallbackHandlerTest {
     @MethodSource("phoneNumbers")
     void shouldCallCloudwatchMetricServiceWhenSmsReceiptIsReceived(
             String number, String expectedCountryCode, String status, String counterName)
-            throws JsonProcessingException {
+            throws Json.JsonException {
         var deliveryReceipt = createDeliveryReceipt(number, status, "sms");
         var event = new APIGatewayProxyRequestEvent();
         event.setHeaders(Map.of("Authorization", "Bearer " + BEARER_TOKEN));
@@ -99,7 +98,7 @@ class NotifyCallbackHandlerTest {
     }
 
     @Test
-    void shouldNotCallCloudwatchMetricWithEmailNotificationType() throws JsonProcessingException {
+    void shouldNotCallCloudwatchMetricWithEmailNotificationType() throws Json.JsonException {
         var deliveryReceipt = createDeliveryReceipt("jim@test.com", "delivered", "email");
         var event = new APIGatewayProxyRequestEvent();
         event.setHeaders(Map.of("Authorization", "Bearer " + BEARER_TOKEN));

--- a/delivery-receipts-integration-tests/src/test/java/uk/gov/di/deliveryreceipts/NotifyCallbackHandlerIntegrationTest.java
+++ b/delivery-receipts-integration-tests/src/test/java/uk/gov/di/deliveryreceipts/NotifyCallbackHandlerIntegrationTest.java
@@ -3,16 +3,15 @@ package uk.gov.di.deliveryreceipts;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.authentication.deliveryreceiptsapi.entity.NotifyDeliveryReceipt;
 import uk.gov.di.authentication.deliveryreceiptsapi.lambda.NotifyCallbackHandler;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
-import uk.gov.di.authentication.shared.helpers.ObjectMapperFactory;
+import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.sharedtest.extensions.ParameterStoreExtension;
 
 import java.util.Date;
@@ -26,7 +25,7 @@ import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyRespon
 public class NotifyCallbackHandlerIntegrationTest {
 
     private static final String BEARER_TOKEN = "notify-test-@bearer-token";
-    private static final ObjectMapper objectMapper = ObjectMapperFactory.getInstance();
+    private static final Json objectMapper = SerializationService.getInstance();
 
     private final Context context = mock(Context.class);
     private NotifyCallbackHandler handler;
@@ -70,7 +69,7 @@ public class NotifyCallbackHandlerIntegrationTest {
 
         try {
             request.withBody(objectMapper.writeValueAsString(body));
-        } catch (JsonProcessingException e) {
+        } catch (Json.JsonException e) {
             throw new RuntimeException("Could not serialise test body", e);
         }
         return handler.handleRequest(request, context);


### PR DESCRIPTION
## What?

- Update entities to use GSON annotations
- Update handlers to use `SerializationService` instead of Jackson

## Why?

We are moving to GSON rather than Jackson for performance reasons