### PR TITLE
AUT-402 - Return additional identity claims back to the RP

### DIFF
--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -9,6 +9,8 @@ module "ipv_callback_role" {
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.dynamo_user_read_access_policy.arn,
     aws_iam_policy.dynamo_user_write_access_policy.arn,
+    aws_iam_policy.dynamo_identity_credentials_write_access_policy.arn,
+    aws_iam_policy.dynamo_identity_credentials_read_access_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
     aws_iam_policy.ipv_token_auth_kms_policy.arn,

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/UserInfoService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/UserInfoService.java
@@ -78,6 +78,11 @@ public class UserInfoService {
                     ValidClaims.CORE_IDENTITY_JWT.getValue(),
                     identityCredentials.getCoreIdentityJWT());
         }
+        if (Objects.nonNull(identityCredentials.getAdditionalClaims())) {
+            identityCredentials.getAdditionalClaims().entrySet().stream()
+                    .filter(t -> accessTokenInfo.getIdentityClaims().contains(t.getKey()))
+                    .forEach(t -> userInfo.setClaim(t.getKey(), t.getValue()));
+        }
         return userInfo;
     }
 

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/IPVStubExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/IPVStubExtension.java
@@ -36,7 +36,8 @@ public class IPVStubExtension extends HttpStubExtension {
                         + "  \"sub\": \"740e5834-3a29-46b4-9a6f-16142fde533a\","
                         + "  \"vot\": \"P2\","
                         + "  \"vtm\": \"http://localhost/trustmark\","
-                        + "  \"https://vocab.sign-in.service.gov.uk/v1/verifiableIdentityCredential\": \"some-encoded-credential\""
+                        + "  \"https://vocab.account.gov.uk/v1/coreIdentityJWT\": \"some-encoded-credential\","
+                        + "  \"https://vocab.account.gov.uk/v1/address\": \"some-address-claim\""
                         + "}");
     }
 }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/IdentityStoreExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/IdentityStoreExtension.java
@@ -10,6 +10,7 @@ import uk.gov.di.authentication.shared.entity.IdentityCredentials;
 import uk.gov.di.authentication.shared.services.DynamoIdentityService;
 import uk.gov.di.authentication.sharedtest.basetest.DynamoTestConfiguration;
 
+import java.util.Map;
 import java.util.Optional;
 
 import static com.amazonaws.services.dynamodbv2.model.KeyType.HASH;
@@ -51,6 +52,10 @@ public class IdentityStoreExtension extends DynamoExtension implements AfterEach
 
     public void addCoreIdentityJWT(String subjectID, String coreIdentityJWT) {
         dynamoService.addCoreIdentityJWT(subjectID, coreIdentityJWT);
+    }
+
+    public void addAdditionalClaims(String subjectID, Map<String, String> additionalClaims) {
+        dynamoService.addAdditionalClaims(subjectID, additionalClaims);
     }
 
     public Optional<IdentityCredentials> getIdentityCredentials(String subjectID) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/IdentityCredentials.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/IdentityCredentials.java
@@ -3,10 +3,13 @@ package uk.gov.di.authentication.shared.entity;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBAttribute;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
 
+import java.util.Map;
+
 public class IdentityCredentials {
 
     private String subjectID;
     private String coreIdentityJWT;
+    private Map<String, String> additionalClaims;
     private long timeToExist;
 
     public IdentityCredentials() {}
@@ -38,6 +41,16 @@ public class IdentityCredentials {
 
     public IdentityCredentials setTimeToExist(long timeToExist) {
         this.timeToExist = timeToExist;
+        return this;
+    }
+
+    @DynamoDBAttribute(attributeName = "AdditionalClaims")
+    public Map<String, String> getAdditionalClaims() {
+        return additionalClaims;
+    }
+
+    public IdentityCredentials setAdditionalClaims(Map<String, String> additionalClaims) {
+        this.additionalClaims = additionalClaims;
         return this;
     }
 }


### PR DESCRIPTION
## What?

- Check the IPV user-identity response to see if any supported claims are present. If they are, then we will persist them to DB (with the exception of the CoreIdentityJWT which is sent to SPOT) 
- Return additional claims back to the RP in userinfo

## Why?

- In the user-identity response back from IPV, check to see if any ValidClaims are present. Save any claims who's name are present in the ValidClaims.java class apart from the CoreIdentityJWT claim.
- If the RP has requested additional identity claims, then we we check the IdentityCredential table to see if any of these requested claims appear in the additionalClaims map. If they do then we will return these to the RP. 