### PR TITLE
AUT-356: Replace Hibernate Validator

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/AuthenticateRequest.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/AuthenticateRequest.java
@@ -1,13 +1,13 @@
 package uk.gov.di.accountmanagement.entity;
 
 import com.google.gson.annotations.Expose;
-import jakarta.validation.constraints.NotNull;
+import uk.gov.di.authentication.shared.validation.Required;
 
 public class AuthenticateRequest {
 
-    @Expose @NotNull private String email;
+    @Expose @Required private String email;
 
-    @Expose @NotNull private String password;
+    @Expose @Required private String password;
 
     public AuthenticateRequest() {}
 

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/NotifyRequest.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/NotifyRequest.java
@@ -2,16 +2,16 @@ package uk.gov.di.accountmanagement.entity;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
-import jakarta.validation.constraints.NotNull;
+import uk.gov.di.authentication.shared.validation.Required;
 
 public class NotifyRequest {
 
     @Expose
     @SerializedName("notificationType")
-    @NotNull
+    @Required
     private NotificationType notificationType;
 
-    @Expose @NotNull private String destination;
+    @Expose @Required private String destination;
 
     @Expose private String code;
 

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/RemoveAccountRequest.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/RemoveAccountRequest.java
@@ -1,10 +1,10 @@
 package uk.gov.di.accountmanagement.entity;
 
 import com.google.gson.annotations.Expose;
-import jakarta.validation.constraints.NotNull;
+import uk.gov.di.authentication.shared.validation.Required;
 
 public class RemoveAccountRequest {
-    @Expose @NotNull private String email;
+    @Expose @Required private String email;
 
     public RemoveAccountRequest() {}
 

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/SendNotificationRequest.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/SendNotificationRequest.java
@@ -2,20 +2,20 @@ package uk.gov.di.accountmanagement.entity;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
-import jakarta.validation.constraints.NotNull;
+import uk.gov.di.authentication.shared.validation.Required;
 
 public class SendNotificationRequest {
 
     @Expose
     @SerializedName("notificationType")
-    @NotNull
+    @Required
     private NotificationType notificationType;
 
     @Expose
     @SerializedName("phoneNumber")
     private String phoneNumber;
 
-    @Expose @NotNull private String email;
+    @Expose @Required private String email;
 
     public SendNotificationRequest() {}
 

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/UpdateEmailRequest.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/UpdateEmailRequest.java
@@ -2,21 +2,21 @@ package uk.gov.di.accountmanagement.entity;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
-import jakarta.validation.constraints.NotNull;
+import uk.gov.di.authentication.shared.validation.Required;
 
 public class UpdateEmailRequest {
 
     @Expose
     @SerializedName("existingEmailAddress")
-    @NotNull
+    @Required
     private String existingEmailAddress;
 
     @Expose
     @SerializedName("replacementEmailAddress")
-    @NotNull
+    @Required
     private String replacementEmailAddress;
 
-    @Expose @NotNull private String otp;
+    @Expose @Required private String otp;
 
     public UpdateEmailRequest() {}
 

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/UpdatePasswordRequest.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/UpdatePasswordRequest.java
@@ -2,15 +2,15 @@ package uk.gov.di.accountmanagement.entity;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
-import jakarta.validation.constraints.NotNull;
+import uk.gov.di.authentication.shared.validation.Required;
 
 public class UpdatePasswordRequest {
 
-    @Expose @NotNull private String email;
+    @Expose @Required private String email;
 
     @Expose
     @SerializedName("newPassword")
-    @NotNull
+    @Required
     private String newPassword;
 
     public UpdatePasswordRequest() {}

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/UpdatePhoneNumberRequest.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/UpdatePhoneNumberRequest.java
@@ -2,18 +2,18 @@ package uk.gov.di.accountmanagement.entity;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
-import jakarta.validation.constraints.NotNull;
+import uk.gov.di.authentication.shared.validation.Required;
 
 public class UpdatePhoneNumberRequest {
 
-    @Expose @NotNull private String email;
+    @Expose @Required private String email;
 
     @Expose
     @SerializedName("phoneNumber")
-    @NotNull
+    @Required
     private String phoneNumber;
 
-    @Expose @NotNull private String otp;
+    @Expose @Required private String otp;
 
     public UpdatePhoneNumberRequest() {}
 

--- a/build.gradle
+++ b/build.gradle
@@ -107,12 +107,7 @@ subprojects {
 
         govuk_notify "uk.gov.service.notify:notifications-java-client:3.17.3-RELEASE"
 
-        gson "com.google.code.gson:gson:${dependencyVersions.gson}",
-                "org.hibernate.validator:hibernate-validator:7.0.4.Final",
-                "org.glassfish:jakarta.el:4.0.2",
-                "jakarta.xml.bind:jakarta.xml.bind-api:4.0.0",
-                "com.sun.xml.bind:jaxb-impl:3.0.2"
-
+        gson "com.google.code.gson:gson:${dependencyVersions.gson}"
 
         hamcrest "org.hamcrest:hamcrest:2.2"
 

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/entity/ClientRegistrationRequest.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/entity/ClientRegistrationRequest.java
@@ -2,9 +2,9 @@ package uk.gov.di.authentication.clientregistry.entity;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
-import jakarta.validation.constraints.NotNull;
 import uk.gov.di.authentication.shared.entity.ClientType;
 import uk.gov.di.authentication.shared.entity.ServiceType;
+import uk.gov.di.authentication.shared.validation.Required;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -14,27 +14,27 @@ public class ClientRegistrationRequest {
 
     @SerializedName("client_name")
     @Expose
-    @NotNull
+    @Required
     private String clientName;
 
     @SerializedName("redirect_uris")
     @Expose
-    @NotNull
+    @Required
     private List<String> redirectUris;
 
     @SerializedName("contacts")
     @Expose
-    @NotNull
+    @Required
     private List<String> contacts;
 
     @SerializedName("public_key")
     @Expose
-    @NotNull
+    @Required
     private String publicKey;
 
     @SerializedName("scopes")
     @Expose
-    @NotNull
+    @Required
     private List<String> scopes;
 
     @SerializedName("post_logout_redirect_uris")
@@ -51,12 +51,12 @@ public class ClientRegistrationRequest {
 
     @SerializedName("sector_identifier_uri")
     @Expose
-    @NotNull
+    @Required
     private String sectorIdentifierUri;
 
     @SerializedName("subject_type")
     @Expose
-    @NotNull
+    @Required
     private String subjectType;
 
     @SerializedName("identity_verification_required")

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/entity/ClientRegistrationResponse.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/entity/ClientRegistrationResponse.java
@@ -2,7 +2,7 @@ package uk.gov.di.authentication.clientregistry.entity;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
-import jakarta.validation.constraints.NotNull;
+import uk.gov.di.authentication.shared.validation.Required;
 
 import java.util.List;
 
@@ -10,32 +10,32 @@ public class ClientRegistrationResponse {
 
     @SerializedName("client_name")
     @Expose
-    @NotNull
+    @Required
     private String clientName;
 
     @SerializedName("client_id")
     @Expose
-    @NotNull
+    @Required
     private String clientId;
 
     @SerializedName("redirect_uris")
     @Expose
-    @NotNull
+    @Required
     private List<String> redirectUris;
 
     @SerializedName("contacts")
     @Expose
-    @NotNull
+    @Required
     private List<String> contacts;
 
     @SerializedName("scopes")
     @Expose
-    @NotNull
+    @Required
     private List<String> scopes;
 
     @SerializedName("post_logout_redirect_uris")
     @Expose
-    @NotNull
+    @Required
     private List<String> postLogoutRedirectUris;
 
     @SerializedName("back_channel_logout_uri")
@@ -44,22 +44,22 @@ public class ClientRegistrationResponse {
 
     @SerializedName("subject_type")
     @Expose
-    @NotNull
+    @Required
     private String subjectType;
 
     @SerializedName("token_endpoint_auth_method")
     @Expose
-    @NotNull
+    @Required
     private final String tokenAuthMethod = "private_key_jwt";
 
     @SerializedName("response_type")
     @Expose
-    @NotNull
+    @Required
     private final String responseType = "code";
 
     @SerializedName("service_type")
     @Expose
-    @NotNull
+    @Required
     private String serviceType;
 
     @SerializedName("claims")

--- a/delivery-receipts-api/src/main/java/uk/gov/di/authentication/deliveryreceiptsapi/entity/NotifyDeliveryReceipt.java
+++ b/delivery-receipts-api/src/main/java/uk/gov/di/authentication/deliveryreceiptsapi/entity/NotifyDeliveryReceipt.java
@@ -1,29 +1,29 @@
 package uk.gov.di.authentication.deliveryreceiptsapi.entity;
 
 import com.google.gson.annotations.Expose;
-import jakarta.validation.constraints.NotNull;
+import uk.gov.di.authentication.shared.validation.Required;
 
 public class NotifyDeliveryReceipt {
 
-    @Expose @NotNull private String id;
+    @Expose @Required private String id;
 
     @Expose private String reference;
 
-    @Expose @NotNull private String to;
+    @Expose @Required private String to;
 
-    @Expose @NotNull private String status;
+    @Expose @Required private String status;
 
-    @Expose @NotNull private String createdAt;
+    @Expose @Required private String createdAt;
 
-    @Expose @NotNull private String completedAt;
+    @Expose @Required private String completedAt;
 
-    @Expose @NotNull private String sentAt;
+    @Expose @Required private String sentAt;
 
-    @Expose @NotNull private String notificationType;
+    @Expose @Required private String notificationType;
 
-    @Expose @NotNull private String templateId;
+    @Expose @Required private String templateId;
 
-    @Expose @NotNull private int templateVersion;
+    @Expose @Required private int templateVersion;
 
     public NotifyDeliveryReceipt() {}
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/LoginRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/LoginRequest.java
@@ -1,12 +1,12 @@
 package uk.gov.di.authentication.frontendapi.entity;
 
 import com.google.gson.annotations.Expose;
-import jakarta.validation.constraints.NotNull;
 import uk.gov.di.authentication.shared.entity.BaseFrontendRequest;
+import uk.gov.di.authentication.shared.validation.Required;
 
 public class LoginRequest extends BaseFrontendRequest {
 
-    @Expose @NotNull private String password;
+    @Expose @Required private String password;
 
     public LoginRequest() {}
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/LoginResponse.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/LoginResponse.java
@@ -2,7 +2,7 @@ package uk.gov.di.authentication.frontendapi.entity;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
-import jakarta.validation.constraints.NotNull;
+import uk.gov.di.authentication.shared.validation.Required;
 
 public class LoginResponse {
 
@@ -12,22 +12,22 @@ public class LoginResponse {
 
     @SerializedName("mfaRequired")
     @Expose
-    @NotNull
+    @Required
     private boolean mfaRequired;
 
     @SerializedName("phoneNumberVerified")
     @Expose
-    @NotNull
+    @Required
     private boolean phoneNumberVerified;
 
     @SerializedName(value = "latestTermsAndConditionsAccepted")
     @Expose
-    @NotNull
+    @Required
     private boolean latestTermsAndConditionsAccepted;
 
     @SerializedName(value = "consentRequired")
     @Expose
-    @NotNull
+    @Required
     private boolean consentRequired;
 
     public LoginResponse() {}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/ResetPasswordCompletionRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/ResetPasswordCompletionRequest.java
@@ -2,7 +2,7 @@ package uk.gov.di.authentication.frontendapi.entity;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
-import jakarta.validation.constraints.NotNull;
+import uk.gov.di.authentication.shared.validation.Required;
 
 public class ResetPasswordCompletionRequest {
 
@@ -12,7 +12,7 @@ public class ResetPasswordCompletionRequest {
 
     @SerializedName("password")
     @Expose
-    @NotNull
+    @Required
     private String password;
 
     public ResetPasswordCompletionRequest() {}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/SendNotificationRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/SendNotificationRequest.java
@@ -2,15 +2,15 @@ package uk.gov.di.authentication.frontendapi.entity;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
-import jakarta.validation.constraints.NotNull;
 import uk.gov.di.authentication.shared.entity.BaseFrontendRequest;
 import uk.gov.di.authentication.shared.entity.NotificationType;
+import uk.gov.di.authentication.shared.validation.Required;
 
 public class SendNotificationRequest extends BaseFrontendRequest {
 
     @SerializedName("notificationType")
     @Expose
-    @NotNull
+    @Required
     private NotificationType notificationType;
 
     @SerializedName("phoneNumber")

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/SignUpResponse.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/SignUpResponse.java
@@ -2,13 +2,13 @@ package uk.gov.di.authentication.frontendapi.entity;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
-import jakarta.validation.constraints.NotNull;
+import uk.gov.di.authentication.shared.validation.Required;
 
 public class SignUpResponse {
 
     @SerializedName("consentRequired")
     @Expose
-    @NotNull
+    @Required
     private boolean consentRequired;
 
     public SignUpResponse() {}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/SignupRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/SignupRequest.java
@@ -2,14 +2,14 @@ package uk.gov.di.authentication.frontendapi.entity;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
-import jakarta.validation.constraints.NotNull;
 import uk.gov.di.authentication.shared.entity.BaseFrontendRequest;
+import uk.gov.di.authentication.shared.validation.Required;
 
 public class SignupRequest extends BaseFrontendRequest {
 
     @SerializedName("password")
     @Expose
-    @NotNull
+    @Required
     private String password;
 
     public SignupRequest() {}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/StartResponse.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/StartResponse.java
@@ -2,17 +2,17 @@ package uk.gov.di.authentication.frontendapi.entity;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
-import jakarta.validation.constraints.NotNull;
+import uk.gov.di.authentication.shared.validation.Required;
 
 public class StartResponse {
 
     @SerializedName("user")
-    @NotNull
+    @Required
     @Expose
     private UserStartInfo user;
 
     @SerializedName("client")
-    @NotNull
+    @Required
     @Expose
     private ClientStartInfo client;
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/UpdateProfileRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/UpdateProfileRequest.java
@@ -2,19 +2,19 @@ package uk.gov.di.authentication.frontendapi.entity;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
-import jakarta.validation.constraints.NotNull;
 import uk.gov.di.authentication.shared.entity.BaseFrontendRequest;
+import uk.gov.di.authentication.shared.validation.Required;
 
 public class UpdateProfileRequest extends BaseFrontendRequest {
 
     @SerializedName("updateProfileType")
     @Expose
-    @NotNull
+    @Required
     private UpdateProfileType updateProfileType;
 
     @SerializedName("profileInformation")
     @Expose
-    @NotNull
+    @Required
     private String profileInformation;
 
     public UpdateProfileRequest() {}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/UserStartInfo.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/UserStartInfo.java
@@ -2,28 +2,28 @@ package uk.gov.di.authentication.frontendapi.entity;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
-import jakarta.validation.constraints.NotNull;
+import uk.gov.di.authentication.shared.validation.Required;
 
 public class UserStartInfo {
 
     @SerializedName("consentRequired")
     @Expose
-    @NotNull
+    @Required
     private boolean consentRequired;
 
     @SerializedName("upliftRequired")
     @Expose
-    @NotNull
+    @Required
     private boolean upliftRequired;
 
     @SerializedName("identityRequired")
     @Expose
-    @NotNull
+    @Required
     private boolean identityRequired;
 
     @SerializedName("authenticated")
     @Expose
-    @NotNull
+    @Required
     private boolean authenticated;
 
     @SerializedName("cookieConsent")

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/VerifyCodeRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/VerifyCodeRequest.java
@@ -2,8 +2,8 @@ package uk.gov.di.authentication.frontendapi.entity;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
-import jakarta.validation.constraints.NotNull;
 import uk.gov.di.authentication.shared.entity.NotificationType;
+import uk.gov.di.authentication.shared.validation.Required;
 
 public class VerifyCodeRequest {
 
@@ -16,12 +16,12 @@ public class VerifyCodeRequest {
 
     @SerializedName("notificationType")
     @Expose
-    @NotNull
+    @Required
     private NotificationType notificationType;
 
     @SerializedName("code")
     @Expose
-    @NotNull
+    @Required
     private String code;
 
     public NotificationType getNotificationType() {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
@@ -4,7 +4,6 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import jakarta.validation.ConstraintViolationException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
@@ -152,7 +151,7 @@ public class ResetPasswordHandler extends BaseFrontendHandler<ResetPasswordCompl
                     IpAddressHelper.extractIpAddress(input),
                     AuditService.UNKNOWN,
                     PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));
-        } catch (JsonException | ConstraintViolationException e) {
+        } catch (JsonException e) {
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
         }
         LOG.info("Generating successful response");

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/IPVAuthorisationResponse.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/IPVAuthorisationResponse.java
@@ -2,13 +2,13 @@ package uk.gov.di.authentication.ipv.entity;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
-import jakarta.validation.constraints.NotNull;
+import uk.gov.di.authentication.shared.validation.Required;
 
 public class IPVAuthorisationResponse {
 
     @SerializedName("redirectUri")
     @Expose
-    @NotNull
+    @Required
     private String redirectUri;
 
     public IPVAuthorisationResponse() {}

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/SPOTResponse.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/SPOTResponse.java
@@ -2,7 +2,7 @@ package uk.gov.di.authentication.ipv.entity;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
-import jakarta.validation.constraints.NotNull;
+import uk.gov.di.authentication.shared.validation.Required;
 
 import java.util.Map;
 
@@ -12,9 +12,9 @@ public class SPOTResponse {
     @SerializedName("claims")
     private Map<String, Object> claims;
 
-    @Expose @NotNull private String sub;
+    @Expose @Required private String sub;
 
-    @Expose @NotNull private SPOTStatus status;
+    @Expose @Required private SPOTStatus status;
 
     public SPOTResponse() {}
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/AuthCodeResponse.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/AuthCodeResponse.java
@@ -1,11 +1,11 @@
 package uk.gov.di.authentication.oidc.entity;
 
 import com.google.gson.annotations.Expose;
-import jakarta.validation.constraints.NotNull;
+import uk.gov.di.authentication.shared.validation.Required;
 
 public class AuthCodeResponse {
 
-    @Expose @NotNull private String location;
+    @Expose @Required private String location;
 
     public AuthCodeResponse() {}
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/BackChannelLogoutMessage.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/BackChannelLogoutMessage.java
@@ -1,15 +1,15 @@
 package uk.gov.di.authentication.oidc.entity;
 
 import com.google.gson.annotations.Expose;
-import jakarta.validation.constraints.NotNull;
+import uk.gov.di.authentication.shared.validation.Required;
 
 public class BackChannelLogoutMessage {
 
-    @Expose @NotNull private String clientId;
+    @Expose @Required private String clientId;
 
-    @Expose @NotNull private String logoutUri;
+    @Expose @Required private String logoutUri;
 
-    @Expose @NotNull private String subjectId;
+    @Expose @Required private String subjectId;
 
     public BackChannelLogoutMessage() {}
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/IdentityResponse.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/IdentityResponse.java
@@ -2,14 +2,14 @@ package uk.gov.di.authentication.oidc.entity;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
-import jakarta.validation.constraints.NotNull;
+import uk.gov.di.authentication.shared.validation.Required;
 
 public class IdentityResponse {
 
-    @Expose @NotNull private String sub;
+    @Expose @Required private String sub;
 
     @Expose
-    @NotNull
+    @Required
     @SerializedName("identityCredential")
     private String identityCredential;
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/TrustMarkResponse.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/TrustMarkResponse.java
@@ -2,26 +2,26 @@ package uk.gov.di.authentication.oidc.entity;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
-import jakarta.validation.constraints.NotNull;
+import uk.gov.di.authentication.shared.validation.Required;
 
 import java.util.List;
 
 public class TrustMarkResponse {
-    @Expose @NotNull private String idp;
+    @Expose @Required private String idp;
 
     @SerializedName("trustmark_provider")
     @Expose
-    @NotNull
+    @Required
     private String trustMark;
 
     @SerializedName("C")
     @Expose
-    @NotNull
+    @Required
     private List<String> c;
 
     @SerializedName("P")
     @Expose
-    @NotNull
+    @Required
     private List<String> p;
 
     public TrustMarkResponse() {}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/BaseFrontendRequest.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/BaseFrontendRequest.java
@@ -3,11 +3,11 @@ package uk.gov.di.authentication.shared.entity;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.annotations.SerializedName;
-import jakarta.validation.constraints.NotNull;
 import uk.gov.di.authentication.shared.serialization.EmailDeserializer;
+import uk.gov.di.authentication.shared.validation.Required;
 
 public abstract class BaseFrontendRequest {
-    @NotNull
+    @Required
     @Expose
     @SerializedName("email")
     @JsonAdapter(EmailDeserializer.class)

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/NotifyRequest.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/NotifyRequest.java
@@ -2,16 +2,16 @@ package uk.gov.di.authentication.shared.entity;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
-import jakarta.validation.constraints.NotNull;
+import uk.gov.di.authentication.shared.validation.Required;
 
 public class NotifyRequest {
 
     @Expose
     @SerializedName("notificationType")
-    @NotNull
+    @Required
     private NotificationType notificationType;
 
-    @Expose @NotNull private String destination;
+    @Expose @Required private String destination;
 
     @Expose private String code;
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/RequestUriPayload.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/RequestUriPayload.java
@@ -3,17 +3,17 @@ package uk.gov.di.authentication.shared.entity;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
-import jakarta.validation.constraints.NotNull;
+import uk.gov.di.authentication.shared.validation.Required;
 
 public class RequestUriPayload {
 
     @Expose
-    @NotNull
+    @Required
     @SerializedName("clientRegistry")
     private ClientRegistry clientRegistry;
 
     @Expose
-    @NotNull
+    @Required
     @SerializedName("authRequest")
     private AuthenticationRequest authRequest;
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/RequestUriResponsePayload.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/RequestUriResponsePayload.java
@@ -2,7 +2,7 @@ package uk.gov.di.authentication.shared.entity;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
-import jakarta.validation.constraints.NotNull;
+import uk.gov.di.authentication.shared.validation.Required;
 
 import java.util.List;
 import java.util.Map;
@@ -10,7 +10,7 @@ import java.util.Map;
 public class RequestUriResponsePayload {
 
     @Expose
-    @NotNull
+    @Required
     @SerializedName("successfulRequest")
     private boolean successfulRequest;
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/lambda/BaseFrontendHandler.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/lambda/BaseFrontendHandler.java
@@ -4,7 +4,6 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import jakarta.validation.ConstraintViolationException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.entity.BaseFrontendRequest;
@@ -101,7 +100,7 @@ public abstract class BaseFrontendHandler<T>
         final T request;
         try {
             request = objectMapper.readValue(input.getBody(), clazz);
-        } catch (JsonException | ConstraintViolationException e) {
+        } catch (JsonException e) {
             LOG.warn("Request is missing parameters.");
             onRequestValidationError(context);
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);

--- a/shared/src/main/java/uk/gov/di/authentication/shared/serialization/Json.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/serialization/Json.java
@@ -1,13 +1,21 @@
 package uk.gov.di.authentication.shared.serialization;
 
+import uk.gov.di.authentication.shared.validation.Validator;
+
 public interface Json {
     <T> T readValue(String body, Class<T> klass) throws JsonException;
+
+    <T> T readValue(String body, Class<T> klass, Validator validator) throws JsonException;
 
     String writeValueAsString(Object object) throws JsonException;
 
     class JsonException extends Exception {
         public JsonException(Exception e) {
             super(e);
+        }
+
+        public JsonException(String message) {
+            super(message);
         }
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/SerializationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/SerializationService.java
@@ -5,13 +5,12 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
 import com.nimbusds.oauth2.sdk.id.State;
-import jakarta.validation.ConstraintViolationException;
-import jakarta.validation.Validation;
-import jakarta.validation.Validator;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.serialization.StateAdapter;
+import uk.gov.di.authentication.shared.validation.RequiredFieldValidator;
+import uk.gov.di.authentication.shared.validation.Validator;
 
 import static java.util.Objects.isNull;
 import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
@@ -22,7 +21,7 @@ public class SerializationService implements Json {
     private static Logger LOG = LogManager.getLogger(SerializationService.class);
 
     private final Gson gson;
-    private final Validator validator;
+    private final RequiredFieldValidator defaultValidator = new RequiredFieldValidator();
 
     public SerializationService() {
         gson =
@@ -32,12 +31,16 @@ public class SerializationService implements Json {
                         .excludeFieldsWithoutExposeAnnotation()
                         .registerTypeAdapter(State.class, new StateAdapter())
                         .create();
-
-        validator = Validation.buildDefaultValidatorFactory().getValidator();
     }
 
     @Override
-    public <T> T readValue(String jsonString, Class<T> clazz) throws JsonException {
+    public <T> T readValue(String body, Class<T> klass) throws JsonException {
+        return readValue(body, klass, defaultValidator);
+    }
+
+    @Override
+    public <T> T readValue(String jsonString, Class<T> clazz, Validator validator)
+            throws JsonException {
         try {
             T value =
                     segmentedFunctionCall(
@@ -50,9 +53,11 @@ public class SerializationService implements Json {
             if (violations.isEmpty()) {
                 return value;
             }
-            violations.forEach(v -> LOG.warn("Json validation violation: {}", v.getMessage()));
+            violations.forEach(
+                    v -> LOG.warn("Json validation failed due to missing required field: {}", v));
             throw new JsonException(
-                    new ConstraintViolationException("JSON validation error", violations));
+                    "JSON validation error, missing required field(s): "
+                            + String.join(", ", violations));
         } catch (JsonSyntaxException | IllegalArgumentException e) {
             throw new JsonException(e);
         }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/validation/Required.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/validation/Required.java
@@ -1,0 +1,10 @@
+package uk.gov.di.authentication.shared.validation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+public @interface Required {}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/validation/RequiredFieldValidator.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/validation/RequiredFieldValidator.java
@@ -1,0 +1,43 @@
+package uk.gov.di.authentication.shared.validation;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
+
+public class RequiredFieldValidator implements Validator {
+
+    private static Logger LOG = LogManager.getLogger(RequiredFieldValidator.class);
+
+    @Override
+    public List<String> validate(Object object) {
+        if (isNull(object)) throw new IllegalArgumentException("Cannot validate a null object");
+        List<String> violations = new ArrayList<>();
+        Class clazz = object.getClass();
+        while (nonNull(clazz)) {
+            violations.addAll(validateRequiredFields(object, clazz));
+
+            clazz = clazz.getSuperclass();
+        }
+        return violations;
+    }
+
+    private List<String> validateRequiredFields(Object object, Class clazz) {
+        List<String> violations = new ArrayList<>();
+        for (var field : clazz.getDeclaredFields()) {
+            try {
+                field.setAccessible(true);
+                if (field.isAnnotationPresent(Required.class) && isNull(field.get(object))) {
+                    violations.add(field.getName());
+                }
+            } catch (IllegalAccessException e) {
+                LOG.warn("Could not validate field: {}", field.getName());
+            }
+        }
+        return violations;
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/validation/Validator.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/validation/Validator.java
@@ -1,0 +1,7 @@
+package uk.gov.di.authentication.shared.validation;
+
+import java.util.List;
+
+public interface Validator {
+    List<String> validate(Object object);
+}

--- a/shared/src/test/java/uk/gov/di/authentication/shared/validation/RequiredFieldValidatorTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/validation/RequiredFieldValidatorTest.java
@@ -1,0 +1,53 @@
+package uk.gov.di.authentication.shared.validation;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
+
+class RequiredFieldValidatorTest {
+
+    private RequiredFieldValidator validator = new RequiredFieldValidator();
+
+    @Test
+    void shouldReturnNoErrorsWhenAllFieldsPassValidation() {
+        var subject = new TestClass("value1", 2, null);
+
+        assertThat(validator.validate(subject), hasSize(0));
+    }
+
+    @ParameterizedTest
+    @MethodSource("failScenarios")
+    void shouldReturnCorrectViolationWhenFieldsFailValidation(
+            TestClass subject, String[] violations) {
+        assertThat(validator.validate(subject), containsInAnyOrder(violations));
+    }
+
+    public static Stream<Arguments> failScenarios() {
+        return Stream.of(
+                Arguments.of(new TestClass(null, 2, "3"), new String[] {"field1"}),
+                Arguments.of(new TestClass(null, null, "3"), new String[] {"field1", "field2"}),
+                Arguments.of(new TestClass("value1", null, "3"), new String[] {"field2"}));
+    }
+
+    private static class TestClass {
+
+        @Required private final String field1;
+
+        @Required private final Integer field2;
+
+        private final String field3;
+
+        private TestClass(String field1, Integer field2, String field3) {
+            this.field1 = field1;
+            this.field2 = field2;
+            this.field3 = field3;
+        }
+    }
+}


### PR DESCRIPTION
## What?

Replace Hibernate Validator with a custom, simple, validator.

## Why?

There is some, significant, time being taken by the validator. Hibernate providers all sorts of clever functionality that we don't need, we only require simple `null` checks.
