### PR TITLE
BAU: Open Redis client in a Master/Replica aware way

### DIFF
--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
@@ -240,11 +240,11 @@ public class RedisExtension
 
     @Override
     public void beforeAll(ExtensionContext context) throws Exception {
-        redis = new RedisConnectionService(REDIS_HOST, 6379, false, REDIS_PASSWORD, false);
         RedisURI.Builder builder =
                 RedisURI.builder().withHost(REDIS_HOST).withPort(6379).withSsl(false);
         if (REDIS_PASSWORD.isPresent()) builder.withPassword(REDIS_PASSWORD.get().toCharArray());
         RedisURI redisURI = builder.build();
+        redis = new RedisConnectionService(List.of(redisURI), false);
         client = RedisClient.create(redisURI);
     }
 


### PR DESCRIPTION
## What?

- Change the `RedisConnectionService` to use `MasterReplica` connect and to read from the replica where possible.

## Why?

We store the replica hostname in parameter store, but we never use it. We should provide this to the `MasterReplica.connect()` method to allow Lettuce to operate in fault tolerant way.

We should also redirect read requests to the replica where possible.
