### PR TITLE
AUT-330: Enable detailed metrics on API gateway

### DIFF
--- a/ci/terraform/account-management/api-gateway.tf
+++ b/ci/terraform/account-management/api-gateway.tf
@@ -250,7 +250,7 @@ resource "aws_api_gateway_method_settings" "api_gateway_logging_settings" {
   method_path = "*/*"
 
   settings {
-    metrics_enabled    = false
+    metrics_enabled    = true
     data_trace_enabled = var.enable_api_gateway_execution_request_tracing && local.request_tracing_allowed
     logging_level      = "INFO"
   }

--- a/ci/terraform/delivery-receipts/api-gateway.tf
+++ b/ci/terraform/delivery-receipts/api-gateway.tf
@@ -95,7 +95,7 @@ resource "aws_api_gateway_method_settings" "api_gateway_delivery_receipts_loggin
   method_path = "*/*"
 
   settings {
-    metrics_enabled    = false
+    metrics_enabled    = true
     data_trace_enabled = false
     logging_level      = "INFO"
   }

--- a/ci/terraform/oidc/api-gateway-frontend.tf
+++ b/ci/terraform/oidc/api-gateway-frontend.tf
@@ -183,7 +183,7 @@ resource "aws_api_gateway_method_settings" "api_gateway_frontend_logging_setting
   method_path = "*/*"
 
   settings {
-    metrics_enabled    = false
+    metrics_enabled    = true
     data_trace_enabled = var.enable_api_gateway_execution_request_tracing && local.request_tracing_allowed
     logging_level      = "INFO"
   }

--- a/ci/terraform/oidc/api-gateway.tf
+++ b/ci/terraform/oidc/api-gateway.tf
@@ -263,7 +263,7 @@ resource "aws_api_gateway_method_settings" "api_gateway_logging_settings" {
   method_path = "*/*"
 
   settings {
-    metrics_enabled    = false
+    metrics_enabled    = true
     data_trace_enabled = var.enable_api_gateway_execution_request_tracing && local.request_tracing_allowed
     logging_level      = "INFO"
   }


### PR DESCRIPTION
## What?

- Enable metrics on API gateway methods to allows per method API calls and latencies

## Why?

This will help us identify a baseline for potential provisioned concurrency.
