### PR TITLE
AUT-330: Async SNS and SQS

### DIFF
--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/testsupport/helpers/NotificationAssertionHelper.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/testsupport/helpers/NotificationAssertionHelper.java
@@ -18,7 +18,7 @@ import static uk.gov.di.accountmanagement.testsupport.matchers.NotifyRequestMatc
 
 public class NotificationAssertionHelper {
 
-    private static final int NOTIFICATIONS_TIMEOUT = 1;
+    private static final int NOTIFICATIONS_TIMEOUT = 5;
     public static final int NOTIFICATIONS_TIMEOUT_MILLIS = NOTIFICATIONS_TIMEOUT * 1000;
 
     public static void assertNoNotificationsReceived(SqsQueueExtension notificationsQueue) {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordIntegrationTest.java
@@ -13,6 +13,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -47,11 +49,18 @@ public class ResetPasswordIntegrationTest extends ApiGatewayHandlerIntegrationTe
 
         assertThat(response, hasStatus(204));
 
-        List<NotifyRequest> requests = notificationsQueue.getMessages(NotifyRequest.class);
+        await().atMost(10, SECONDS)
+                .untilAsserted(
+                        () -> {
+                            List<NotifyRequest> requests =
+                                    notificationsQueue.getMessages(NotifyRequest.class);
 
-        assertThat(requests, hasSize(1));
-        assertThat(requests.get(0).getDestination(), equalTo(EMAIL_ADDRESS));
-        assertThat(requests.get(0).getNotificationType(), equalTo(PASSWORD_RESET_CONFIRMATION));
+                            assertThat(requests, hasSize(1));
+                            assertThat(requests.get(0).getDestination(), equalTo(EMAIL_ADDRESS));
+                            assertThat(
+                                    requests.get(0).getNotificationType(),
+                                    equalTo(PASSWORD_RESET_CONFIRMATION));
+                        });
 
         assertEventTypesReceived(auditTopic, List.of(PASSWORD_RESET_SUCCESSFUL));
     }
@@ -71,11 +80,18 @@ public class ResetPasswordIntegrationTest extends ApiGatewayHandlerIntegrationTe
 
         assertThat(response, hasStatus(204));
 
-        List<NotifyRequest> requests = notificationsQueue.getMessages(NotifyRequest.class);
+        await().atMost(10, SECONDS)
+                .untilAsserted(
+                        () -> {
+                            List<NotifyRequest> requests =
+                                    notificationsQueue.getMessages(NotifyRequest.class);
 
-        assertThat(requests, hasSize(1));
-        assertThat(requests.get(0).getDestination(), equalTo(EMAIL_ADDRESS));
-        assertThat(requests.get(0).getNotificationType(), equalTo(PASSWORD_RESET_CONFIRMATION));
+                            assertThat(requests, hasSize(1));
+                            assertThat(requests.get(0).getDestination(), equalTo(EMAIL_ADDRESS));
+                            assertThat(
+                                    requests.get(0).getNotificationType(),
+                                    equalTo(PASSWORD_RESET_CONFIRMATION));
+                        });
 
         assertEventTypesReceived(auditTopic, List.of(PASSWORD_RESET_SUCCESSFUL));
     }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordRequestIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordRequestIntegrationTest.java
@@ -12,6 +12,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasLength;
@@ -47,19 +49,28 @@ public class ResetPasswordRequestIntegrationTest extends ApiGatewayHandlerIntegr
 
         assertThat(response, hasStatus(204));
 
-        List<NotifyRequest> requests = notificationsQueue.getMessages(NotifyRequest.class);
+        await().atMost(10, SECONDS)
+                .untilAsserted(
+                        () -> {
+                            List<NotifyRequest> requests =
+                                    notificationsQueue.getMessages(NotifyRequest.class);
 
-        assertThat(requests, hasSize(1));
-        assertThat(requests.get(0).getDestination(), equalTo(email));
-        assertThat(requests.get(0).getNotificationType(), equalTo(RESET_PASSWORD));
-        assertTrue(
-                requests.get(0).getCode().startsWith("http://localhost:3000/reset-password?code="));
+                            assertThat(requests, hasSize(1));
+                            assertThat(requests.get(0).getDestination(), equalTo(email));
+                            assertThat(
+                                    requests.get(0).getNotificationType(), equalTo(RESET_PASSWORD));
+                            assertTrue(
+                                    requests.get(0)
+                                            .getCode()
+                                            .startsWith(
+                                                    "http://localhost:3000/reset-password?code="));
 
-        String[] resetLinkSplit = requests.get(0).getCode().split("\\.");
+                            String[] resetLinkSplit = requests.get(0).getCode().split("\\.");
 
-        assertThat(resetLinkSplit.length, equalTo(4));
-        assertThat(resetLinkSplit[2], equalTo(sessionId));
-        assertThat(resetLinkSplit[3], equalTo(persistentSessionId));
+                            assertThat(resetLinkSplit.length, equalTo(4));
+                            assertThat(resetLinkSplit[2], equalTo(sessionId));
+                            assertThat(resetLinkSplit[3], equalTo(persistentSessionId));
+                        });
     }
 
     @Test
@@ -82,11 +93,18 @@ public class ResetPasswordRequestIntegrationTest extends ApiGatewayHandlerIntegr
 
         assertThat(response, hasStatus(204));
 
-        List<NotifyRequest> requests = notificationsQueue.getMessages(NotifyRequest.class);
+        await().atMost(10, SECONDS)
+                .untilAsserted(
+                        () -> {
+                            List<NotifyRequest> requests =
+                                    notificationsQueue.getMessages(NotifyRequest.class);
 
-        assertThat(requests, hasSize(1));
-        assertThat(requests.get(0).getDestination(), equalTo(email));
-        assertThat(requests.get(0).getNotificationType(), equalTo(RESET_PASSWORD_WITH_CODE));
-        assertThat(requests.get(0).getCode(), hasLength(6));
+                            assertThat(requests, hasSize(1));
+                            assertThat(requests.get(0).getDestination(), equalTo(email));
+                            assertThat(
+                                    requests.get(0).getNotificationType(),
+                                    equalTo(RESET_PASSWORD_WITH_CODE));
+                            assertThat(requests.get(0).getCode(), hasLength(6));
+                        });
     }
 }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/BackChannelLogoutService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/BackChannelLogoutService.java
@@ -8,6 +8,7 @@ import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.AwsSqsClient;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
+import uk.gov.di.authentication.shared.services.SerializationService;
 
 import static org.apache.logging.log4j.util.Strings.isBlank;
 import static uk.gov.di.authentication.shared.helpers.ClientSubjectHelper.getSubject;
@@ -62,6 +63,6 @@ public class BackChannelLogoutService {
                         clientRegistry.getBackChannelLogoutUri(),
                         subjectId);
 
-        awsSqsClient.sendAsync(message);
+        awsSqsClient.send(SerializationService.getInstance().writeValueAsString(message));
     }
 }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/BackChannelLogoutServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/BackChannelLogoutServiceTest.java
@@ -5,8 +5,10 @@ import org.mockito.ArgumentCaptor;
 import uk.gov.di.authentication.oidc.entity.BackChannelLogoutMessage;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.AwsSqsClient;
+import uk.gov.di.authentication.shared.services.SerializationService;
 
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -27,7 +29,7 @@ class BackChannelLogoutServiceTest {
             new BackChannelLogoutService(sqs, authenticationService);
 
     @Test
-    void shouldPostBackChannelLogoutMessageToSqsForPairwiseClients() {
+    void shouldPostBackChannelLogoutMessageToSqsForPairwiseClients() throws Json.JsonException {
         var user = new UserProfile().setPublicSubjectID("public").setSubjectID("subject");
 
         when(authenticationService.getUserProfileByEmailMaybe("test@test.com"))
@@ -42,16 +44,19 @@ class BackChannelLogoutServiceTest {
                         .setBackChannelLogoutUri("http://localhost:8080/back-channel-logout"),
                 "test@test.com");
 
-        var captor = ArgumentCaptor.forClass(BackChannelLogoutMessage.class);
+        var captor = ArgumentCaptor.forClass(String.class);
 
-        verify(sqs).sendAsync(captor.capture());
+        verify(sqs).send(captor.capture());
 
         var message = captor.getValue();
 
-        assertThat(message.getClientId(), is("client-id"));
-        assertThat(message.getLogoutUri(), is("http://localhost:8080/back-channel-logout"));
+        var request =
+                SerializationService.getInstance()
+                        .readValue(message, BackChannelLogoutMessage.class);
+        assertThat(request.getClientId(), is("client-id"));
+        assertThat(request.getLogoutUri(), is("http://localhost:8080/back-channel-logout"));
         assertThat(
-                message.getSubjectId(),
+                request.getSubjectId(),
                 is("urn:fdc:gov.uk:2022:tGOB5t5fRAX_Fio6qRIj8KPDL7vOg5gCqI4l5nDZCDs"));
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AwsSqsClient.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AwsSqsClient.java
@@ -6,23 +6,22 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.sqs.SqsClient;
-import software.amazon.awssdk.services.sqs.SqsClientBuilder;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.SqsAsyncClientBuilder;
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 
 import java.net.URI;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 
 public class AwsSqsClient {
 
     private static Logger LOG = LogManager.getLogger(AwsSqsClient.class);
 
-    private final SqsClient client;
+    private final SqsAsyncClient client;
     private final String queueUrl;
 
     public AwsSqsClient(String region, String queueUrl, Optional<String> sqsEndpoint) {
-        SqsClientBuilder amazonSqsBuilder = SqsClient.builder().region(Region.of(region));
+        SqsAsyncClientBuilder amazonSqsBuilder = SqsAsyncClient.builder().region(Region.of(region));
 
         if (sqsEndpoint.isPresent()) {
             amazonSqsBuilder
@@ -40,10 +39,5 @@ public class AwsSqsClient {
                 SendMessageRequest.builder().queueUrl(queueUrl).messageBody(event).build();
 
         client.sendMessage(messageRequest);
-    }
-
-    public <T> void sendAsync(final T message) throws SdkClientException {
-        CompletableFuture.runAsync(
-                () -> send(SerializationService.getInstance().writeValueAsString(message)));
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/SnsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/SnsService.java
@@ -1,8 +1,8 @@
 package uk.gov.di.authentication.shared.services;
 
 import com.amazonaws.client.builder.AwsClientBuilder;
-import com.amazonaws.services.sns.AmazonSNS;
-import com.amazonaws.services.sns.AmazonSNSClientBuilder;
+import com.amazonaws.services.sns.AmazonSNSAsync;
+import com.amazonaws.services.sns.AmazonSNSAsyncClientBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.configuration.AuditPublisherConfiguration;
@@ -10,7 +10,7 @@ import uk.gov.di.authentication.shared.configuration.AuditPublisherConfiguration
 public class SnsService {
 
     private final String topicArn;
-    private final AmazonSNS snsClient;
+    private final AmazonSNSAsync snsClient;
     private static final Logger LOG = LogManager.getLogger(SnsService.class);
 
     public SnsService(AuditPublisherConfiguration configService) {
@@ -20,17 +20,17 @@ public class SnsService {
         if (localstackEndpointUri.isPresent()) {
             LOG.info("Localstack endpoint URI is present: " + localstackEndpointUri.get());
             this.snsClient =
-                    AmazonSNSClientBuilder.standard()
+                    AmazonSNSAsyncClientBuilder.standard()
                             .withEndpointConfiguration(
                                     new AwsClientBuilder.EndpointConfiguration(
                                             localstackEndpointUri.get(), awsRegion))
                             .build();
         } else {
-            this.snsClient = AmazonSNSClientBuilder.standard().withRegion(awsRegion).build();
+            this.snsClient = AmazonSNSAsyncClientBuilder.standard().withRegion(awsRegion).build();
         }
     }
 
     public void publishAuditMessage(String message) {
-        snsClient.publish(topicArn, message);
+        snsClient.publishAsync(topicArn, message);
     }
 }


### PR DESCRIPTION
## What?

- Use the async client for SNS
- Use the async client for SQS

## Why?

With both our SQS and SNS use cases we can just "fire and forget" our calls to these services, we don't inspect the result.

The calls to both these services provided a noticeable block of latency on the Xray traces, so calling them asynchronously seems to be a sensible approach.
