### PR TITLE
BAU - Add extra logging for DocApp journey

### DIFF
--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppAuthorizeHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppAuthorizeHandler.java
@@ -139,7 +139,8 @@ public class DocAppAuthorizeHandler
                                         PersistentIdHelper.extractPersistentIdFromHeaders(
                                                 input.getHeaders()));
                                 LOG.info(
-                                        "DocAppAuthorizeHandler successfully processed request, redirect URI {}",
+                                        "DocAppAuthorizeHandler successfully processed request with SubjectID: {}, redirect URI {}",
+                                        clientSession.getDocAppSubjectId(),
                                         authorisationRequest.toURI().toString());
 
                                 return generateApiGatewayProxyResponse(

--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
@@ -198,6 +198,9 @@ public class DocAppCallbackHandler
                                             AuditService.UNKNOWN,
                                             AuditService.UNKNOWN,
                                             AuditService.UNKNOWN);
+                                    LOG.info(
+                                            "Adding DocAppCredential to DB with Subject: {}",
+                                            clientSession.getDocAppSubjectId());
                                     dynamoDocAppService.addDocAppCredential(
                                             clientSession.getDocAppSubjectId().getValue(),
                                             credential);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -123,10 +123,11 @@ public class StartHandler
                                                 configurationService.isIdentityEnabled());
                                 if (userStartInfo.isDocCheckingAppUser()) {
                                     var docAppSubjectId =
-                                            ClientSubjectHelper.calculatePairwiseIdentifier(
-                                                    new Subject().getValue(),
-                                                    configurationService.getDocAppDomain(),
-                                                    SaltHelper.generateNewSalt());
+                                            new Subject(
+                                                    ClientSubjectHelper.calculatePairwiseIdentifier(
+                                                            new Subject().getValue(),
+                                                            configurationService.getDocAppDomain(),
+                                                            SaltHelper.generateNewSalt()));
                                     var clientSessionId =
                                             getHeaderValueFromHeaders(
                                                     input.getHeaders(),
@@ -137,10 +138,10 @@ public class StartHandler
                                             clientSessionId,
                                             clientSession
                                                     .get()
-                                                    .setDocAppSubjectId(
-                                                            new Subject(docAppSubjectId)));
+                                                    .setDocAppSubjectId(docAppSubjectId));
                                     LOG.info(
-                                            "Subject saved to ClientSession for DocCheckingAppUser");
+                                            "Subject saved to ClientSession for DocCheckingAppUser: {}",
+                                            docAppSubjectId);
                                 }
 
                                 var startResponse =


### PR DESCRIPTION
## What?

- Add extra logging for DocApp journey

## Why?

- It is persisting the DocAppCredential without the expected Subject prefix. Add logging to find out what subject is being generated.