### PR TITLE
BAU - Create custom adapter for Nimbus Subject object 

### DIFF
--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppAuthorizeHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppAuthorizeHandler.java
@@ -139,8 +139,7 @@ public class DocAppAuthorizeHandler
                                         PersistentIdHelper.extractPersistentIdFromHeaders(
                                                 input.getHeaders()));
                                 LOG.info(
-                                        "DocAppAuthorizeHandler successfully processed request with SubjectID: {}, redirect URI {}",
-                                        clientSession.getDocAppSubjectId(),
+                                        "DocAppAuthorizeHandler successfully processed request, redirect URI {}",
                                         authorisationRequest.toURI().toString());
 
                                 return generateApiGatewayProxyResponse(

--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
@@ -198,9 +198,6 @@ public class DocAppCallbackHandler
                                             AuditService.UNKNOWN,
                                             AuditService.UNKNOWN,
                                             AuditService.UNKNOWN);
-                                    LOG.info(
-                                            "Adding DocAppCredential to DB with Subject: {}",
-                                            clientSession.getDocAppSubjectId());
                                     dynamoDocAppService.addDocAppCredential(
                                             clientSession.getDocAppSubjectId().getValue(),
                                             credential);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -123,11 +123,10 @@ public class StartHandler
                                                 configurationService.isIdentityEnabled());
                                 if (userStartInfo.isDocCheckingAppUser()) {
                                     var docAppSubjectId =
-                                            new Subject(
-                                                    ClientSubjectHelper.calculatePairwiseIdentifier(
-                                                            new Subject().getValue(),
-                                                            configurationService.getDocAppDomain(),
-                                                            SaltHelper.generateNewSalt()));
+                                            ClientSubjectHelper.calculatePairwiseIdentifier(
+                                                    new Subject().getValue(),
+                                                    configurationService.getDocAppDomain(),
+                                                    SaltHelper.generateNewSalt());
                                     var clientSessionId =
                                             getHeaderValueFromHeaders(
                                                     input.getHeaders(),
@@ -138,10 +137,10 @@ public class StartHandler
                                             clientSessionId,
                                             clientSession
                                                     .get()
-                                                    .setDocAppSubjectId(docAppSubjectId));
+                                                    .setDocAppSubjectId(
+                                                            new Subject(docAppSubjectId)));
                                     LOG.info(
-                                            "Subject saved to ClientSession for DocCheckingAppUser: {}",
-                                            docAppSubjectId);
+                                            "Subject saved to ClientSession for DocCheckingAppUser");
                                 }
 
                                 var startResponse =

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/DocumentAppCredentialStoreExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/DocumentAppCredentialStoreExtension.java
@@ -6,8 +6,11 @@ import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
 import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import uk.gov.di.authentication.app.entity.DocAppCredential;
 import uk.gov.di.authentication.app.services.DynamoDocAppService;
 import uk.gov.di.authentication.sharedtest.basetest.DynamoTestConfiguration;
+
+import java.util.Optional;
 
 import static com.amazonaws.services.dynamodbv2.model.KeyType.HASH;
 import static com.amazonaws.services.dynamodbv2.model.ScalarAttributeType.S;
@@ -59,5 +62,9 @@ public class DocumentAppCredentialStoreExtension extends DynamoExtension
 
     public void addCredential(String subjectId, String credential) {
         dynamoDocAppService.addDocAppCredential(subjectId, credential);
+    }
+
+    public Optional<DocAppCredential> getCredential(String subjectId) {
+        return dynamoDocAppService.getDocAppCredential(subjectId);
     }
 }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
@@ -72,7 +72,7 @@ public class RedisExtension
 
     public void addDocAppSubjectIdToClientSession(Subject subject, String clientSessionId)
             throws Json.JsonException {
-        ClientSession clientSession =
+        var clientSession =
                 objectMapper.readValue(
                         redis.getValue(CLIENT_SESSION_PREFIX.concat(clientSessionId)),
                         ClientSession.class);

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ClientSession.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ClientSession.java
@@ -1,10 +1,7 @@
 package uk.gov.di.authentication.shared.entity;
 
 import com.google.gson.annotations.Expose;
-import com.google.gson.annotations.JsonAdapter;
 import com.nimbusds.oauth2.sdk.id.Subject;
-import uk.gov.di.authentication.shared.serialization.LocalDateTimeAdapter;
-import uk.gov.di.authentication.shared.serialization.SubjectAdapter;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -16,15 +13,11 @@ public class ClientSession {
 
     @Expose private String idTokenHint;
 
-    @Expose
-    @JsonAdapter(LocalDateTimeAdapter.class)
-    private LocalDateTime creationDate;
+    @Expose private LocalDateTime creationDate;
 
     @Expose private VectorOfTrust effectiveVectorOfTrust;
 
-    @JsonAdapter(SubjectAdapter.class)
-    @Expose
-    private Subject docAppSubjectId;
+    @Expose private Subject docAppSubjectId;
 
     public ClientSession(
             Map<String, List<String>> authRequestParams,

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ClientSession.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ClientSession.java
@@ -4,6 +4,7 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.JsonAdapter;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import uk.gov.di.authentication.shared.serialization.LocalDateTimeAdapter;
+import uk.gov.di.authentication.shared.serialization.SubjectAdapter;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -21,7 +22,9 @@ public class ClientSession {
 
     @Expose private VectorOfTrust effectiveVectorOfTrust;
 
-    @Expose private Subject docAppSubjectId;
+    @JsonAdapter(SubjectAdapter.class)
+    @Expose
+    private Subject docAppSubjectId;
 
     public ClientSession(
             Map<String, List<String>> authRequestParams,

--- a/shared/src/main/java/uk/gov/di/authentication/shared/serialization/SubjectAdapter.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/serialization/SubjectAdapter.java
@@ -1,0 +1,21 @@
+package uk.gov.di.authentication.shared.serialization;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import com.google.gson.stream.MalformedJsonException;
+import com.nimbusds.oauth2.sdk.id.Subject;
+
+import java.io.IOException;
+
+public class SubjectAdapter extends TypeAdapter<Subject> {
+    @Override
+    public void write(JsonWriter out, Subject value) throws IOException {
+        out.value(value.getValue());
+    }
+
+    @Override
+    public Subject read(JsonReader in) throws IOException {
+        return new Subject(in.nextString());
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/serialization/SubjectAdapter.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/serialization/SubjectAdapter.java
@@ -7,15 +7,29 @@ import com.google.gson.stream.MalformedJsonException;
 import com.nimbusds.oauth2.sdk.id.Subject;
 
 import java.io.IOException;
+import java.util.Objects;
 
 public class SubjectAdapter extends TypeAdapter<Subject> {
     @Override
     public void write(JsonWriter out, Subject value) throws IOException {
-        out.value(value.getValue());
+        if (Objects.nonNull(value)) {
+            out.value(value.getValue());
+        } else {
+            out.nullValue();
+        }
     }
 
     @Override
     public Subject read(JsonReader in) throws IOException {
-        return new Subject(in.nextString());
+        var token = in.peek();
+        switch (token) {
+            case STRING:
+                return new Subject(in.nextString());
+            case NULL:
+                in.nextNull();
+                return null;
+            default:
+                throw new MalformedJsonException("Expected NULL or STRING got " + token.name());
+        }
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/SerializationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/SerializationService.java
@@ -5,12 +5,17 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
 import com.nimbusds.oauth2.sdk.id.State;
+import com.nimbusds.oauth2.sdk.id.Subject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.serialization.Json;
+import uk.gov.di.authentication.shared.serialization.LocalDateTimeAdapter;
 import uk.gov.di.authentication.shared.serialization.StateAdapter;
+import uk.gov.di.authentication.shared.serialization.SubjectAdapter;
 import uk.gov.di.authentication.shared.validation.RequiredFieldValidator;
 import uk.gov.di.authentication.shared.validation.Validator;
+
+import java.time.LocalDateTime;
 
 import static java.util.Objects.isNull;
 import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
@@ -30,6 +35,8 @@ public class SerializationService implements Json {
                         .serializeNulls()
                         .excludeFieldsWithoutExposeAnnotation()
                         .registerTypeAdapter(State.class, new StateAdapter())
+                        .registerTypeAdapter(LocalDateTime.class, new LocalDateTimeAdapter())
+                        .registerTypeAdapter(Subject.class, new SubjectAdapter())
                         .create();
     }
 


### PR DESCRIPTION
## What?

- Write a custom adapter for searlization of the Subject in the ClientSession. 
- Add an asserts to an existing test
- Remove debugging logging


## Why? 

- We no longer use Jackson so we need to manually write a custom adapter now that we use GSON to be able to searlize the Subject as expected. 
