### PR TITLE
BAU: Set content type for backchannel logout requests

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/HttpRequestService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/HttpRequestService.java
@@ -20,7 +20,12 @@ public class HttpRequestService {
 
     public void post(URI uri, String body) {
 
-        var request = HttpRequest.newBuilder().uri(uri).POST(ofString(body)).build();
+        var request =
+                HttpRequest.newBuilder()
+                        .uri(uri)
+                        .POST(ofString(body))
+                        .header("Content-Type", "application/x-www-form-urlencoded")
+                        .build();
 
         try {
             var response = newHttpClient().send(request, BodyHandlers.discarding());


### PR DESCRIPTION
The spec requires application/x-www-form-urlencoded but we were sending nothing.
