### PR TITLE
AUT-323: Add configuration flag for ipv + spot trace logging

### DIFF
--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -32,6 +32,7 @@ module "ipv-callback" {
     EVENTS_SNS_TOPIC_ARN           = aws_sns_topic.events.arn
     ENVIRONMENT                    = var.environment
     IDENTITY_ENABLED               = var.ipv_api_enabled
+    IDENTITY_TRACE_LOGGING_ENABLED = var.identity_trace_logging_enabled
     IPV_TOKEN_SIGNING_KEY_ALIAS    = local.ipv_token_auth_key_alias_name
     IPV_AUTHORISATION_CLIENT_ID    = var.ipv_authorisation_client_id
     IPV_AUTHORISATION_CALLBACK_URI = var.ipv_authorisation_callback_uri

--- a/ci/terraform/oidc/staging-overrides.tfvars
+++ b/ci/terraform/oidc/staging-overrides.tfvars
@@ -10,6 +10,7 @@ ipv_audience                       = "https://identity.staging.account.gov.uk"
 ipv_backend_uri                    = "https://api.identity.staging.account.gov.uk"
 ipv_sector                         = "https://identity.staging.account.gov.uk"
 spot_enabled                       = true
+identity_trace_logging_enabled     = true
 ipv_auth_public_encryption_key     = <<-EOT
 -----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyB5V0Tc9KEV5/zGUHLu0

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -277,6 +277,11 @@ variable "spot_queue_url" {
   type    = string
 }
 
+variable "identity_trace_logging_enabled" {
+  default = false
+  type    = bool
+}
+
 variable "ipv_auth_public_encryption_key" {
   type    = string
   default = "undefined"

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -272,7 +272,8 @@ public class IPVCallbackHandler
                                 if (Objects.isNull(userIdentityUserInfo)) {
                                     LOG.error("IPV UserIdentityRequest failed.");
                                     throw new RuntimeException("IPV UserIdentityRequest failed.");
-                                } else {
+                                }
+                                if (configurationService.isIdentityTraceLoggingEnabled()) {
                                     LOG.info(
                                             "IPV UserIdentityRequest succeeded: {}",
                                             userIdentityUserInfo.toJSONObject().toJSONString());
@@ -431,7 +432,12 @@ public class IPVCallbackHandler
                         sectorIdentifier,
                         pairwiseSubject.getValue(),
                         logIds);
-        sqsClient.send(objectMapper.writeValueAsString(spotRequest));
-        LOG.info("SPOT request placed on queue");
+        var spotRequestString = objectMapper.writeValueAsString(spotRequest);
+        sqsClient.send(spotRequestString);
+        if (configurationService.isIdentityTraceLoggingEnabled()) {
+            LOG.info("SPOT request placed on queue: {}", spotRequestString);
+        } else {
+            LOG.info("SPOT request placed on queue");
+        }
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -186,6 +186,12 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return System.getenv().getOrDefault("SPOT_ENABLED", "false").equals("true");
     }
 
+    public boolean isIdentityTraceLoggingEnabled() {
+        return System.getenv()
+                .getOrDefault("IDENTITY_TRACE_LOGGING_ENABLED", "false")
+                .equals("true");
+    }
+
     public long getIDTokenExpiry() {
         return Long.parseLong(System.getenv().getOrDefault("ID_TOKEN_EXPIRY", "120"));
     }


### PR DESCRIPTION

## What?

Add configuration flag for ipv + spot trace logging.

## Why?

Ability to log ipv and spot messages in specific environments only.
We don't want to log these messages in prod or integration but they are useful for end to end integration testing so are worth keeping switched on in staging for the moment.
