### PR TITLE
BAU: Remove sqs queue delay seconds

### DIFF
--- a/ci/terraform/account-management/sqs.tf
+++ b/ci/terraform/account-management/sqs.tf
@@ -7,7 +7,6 @@ module "account_management_sqs_role" {
 
 resource "aws_sqs_queue" "email_queue" {
   name                      = "${var.environment}-account-management-notification-queue"
-  delay_seconds             = 10
   max_message_size          = 2048
   message_retention_seconds = 1209600
   receive_wait_time_seconds = 10

--- a/ci/terraform/oidc/logout-sqs.tf
+++ b/ci/terraform/oidc/logout-sqs.tf
@@ -1,6 +1,5 @@
 resource "aws_sqs_queue" "back_channel_logout_queue" {
   name                      = "${var.environment}-back-channel-logout-queue"
-  delay_seconds             = 10
   max_message_size          = 2048
   message_retention_seconds = 1209600
   receive_wait_time_seconds = 10

--- a/ci/terraform/oidc/spot-sqs.tf
+++ b/ci/terraform/oidc/spot-sqs.tf
@@ -1,6 +1,5 @@
 resource "aws_sqs_queue" "spot_request_queue" {
   name                       = "${var.environment}-spot-request-queue"
-  delay_seconds              = 10
   max_message_size           = 256000
   message_retention_seconds  = 1209600
   receive_wait_time_seconds  = 10

--- a/ci/terraform/oidc/sqs.tf
+++ b/ci/terraform/oidc/sqs.tf
@@ -11,7 +11,6 @@ module "oidc_email_role" {
 
 resource "aws_sqs_queue" "email_queue" {
   name                      = "${var.environment}-email-notification-queue"
-  delay_seconds             = 10
   max_message_size          = 2048
   message_retention_seconds = 1209600
   receive_wait_time_seconds = 10


### PR DESCRIPTION
## What?

Remove sqs queue delay seconds.

## Why?

From the console:

"The delivery delay is the amount of time to delay the first delivery of each message added to the queue. Any messages that you send to the queue remain invisible to consumers for the duration of the delay period."

Sets back to default zero seconds.
Removes 10 second delay for message deliveries.
