### PR TITLE
BAU - Set TTL for 3 minutes from current time

### DIFF
--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/services/DynamoDocAppService.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/services/DynamoDocAppService.java
@@ -3,8 +3,10 @@ package uk.gov.di.authentication.app.services;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
 import uk.gov.di.authentication.app.entity.DocAppCredential;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
+import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 
 import static uk.gov.di.authentication.shared.dynamodb.DynamoClientHelper.createDynamoClient;
@@ -31,7 +33,8 @@ public class DynamoDocAppService {
                 new DocAppCredential()
                         .setSubjectID(subjectID)
                         .setCredential(credential)
-                        .setTimeToExist(timeToExist);
+                        .setTimeToExist(
+                                NowHelper.nowPlus(timeToExist, ChronoUnit.SECONDS).getTime());
 
         docAppCredentialMapper.save(docAppCredential);
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoIdentityService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoIdentityService.java
@@ -4,7 +4,9 @@ import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
 import uk.gov.di.authentication.shared.dynamodb.DynamoClientHelper;
 import uk.gov.di.authentication.shared.entity.IdentityCredentials;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
 
+import java.time.temporal.ChronoUnit;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -36,12 +38,14 @@ public class DynamoIdentityService {
                     new IdentityCredentials()
                             .setSubjectID(subjectID)
                             .setCoreIdentityJWT(coreIdentityJWT)
-                            .setTimeToExist(timeToExist));
+                            .setTimeToExist(
+                                    NowHelper.nowPlus(timeToExist, ChronoUnit.SECONDS).getTime()));
         } else {
             identityCredentialsMapper.save(
                     identityCredentials
                             .setCoreIdentityJWT(coreIdentityJWT)
-                            .setTimeToExist(timeToExist));
+                            .setTimeToExist(
+                                    NowHelper.nowPlus(timeToExist, ChronoUnit.SECONDS).getTime()));
         }
     }
 
@@ -63,7 +67,8 @@ public class DynamoIdentityService {
                 new IdentityCredentials()
                         .setSubjectID(subjectID)
                         .setAdditionalClaims(additionalClaims)
-                        .setTimeToExist(timeToExist);
+                        .setTimeToExist(
+                                NowHelper.nowPlus(timeToExist, ChronoUnit.SECONDS).getTime());
 
         identityCredentialsMapper.save(identityCredentials);
     }


### PR DESCRIPTION
## What?

- Set the TTL for 3 minutes from the current time.

## Why?

- Previously we were setting TTL as 180 seconds which equates to 1 January 1970 00:03:00 UTC in EPOCH. Dynamo states that The TTL attribute value must be a datetimestamp with an expiration of no more than five years in the past.