### PR TITLE
BAU - Return the state param from the Start lambda

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/ClientStartInfo.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/ClientStartInfo.java
@@ -2,6 +2,7 @@ package uk.gov.di.authentication.frontendapi.entity;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.nimbusds.oauth2.sdk.id.State;
 
 import java.net.URI;
 import java.util.List;
@@ -28,6 +29,10 @@ public class ClientStartInfo {
     @Expose
     private URI redirectUri;
 
+    @SerializedName("state")
+    @Expose
+    private State state;
+
     public ClientStartInfo() {}
 
     public ClientStartInfo(
@@ -35,12 +40,14 @@ public class ClientStartInfo {
             List<String> scopes,
             String serviceType,
             boolean cookieConsentShared,
-            URI redirectUri) {
+            URI redirectUri,
+            State state) {
         this.clientName = clientName;
         this.scopes = scopes;
         this.serviceType = serviceType;
         this.cookieConsentShared = cookieConsentShared;
         this.redirectUri = redirectUri;
+        this.state = state;
     }
 
     public String getClientName() {
@@ -61,5 +68,9 @@ public class ClientStartInfo {
 
     public URI getRedirectUri() {
         return redirectUri;
+    }
+
+    public State getState() {
+        return state;
     }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
@@ -2,6 +2,7 @@ package uk.gov.di.authentication.frontendapi.services;
 
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.Scope;
+import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -68,6 +69,7 @@ public class StartService {
     public ClientStartInfo buildClientStartInfo(UserContext userContext) throws ParseException {
         List<String> scopes;
         URI redirectURI;
+        State state;
         try {
             var authenticationRequest =
                     AuthenticationRequest.parse(
@@ -76,9 +78,11 @@ public class StartService {
                 var claimSet = authenticationRequest.getRequestObject().getJWTClaimsSet();
                 scopes = Scope.parse((String) claimSet.getClaim("scope")).toStringList();
                 redirectURI = URI.create((String) claimSet.getClaim("redirect_uri"));
+                state = State.parse((String) claimSet.getClaim("state"));
             } else {
                 scopes = authenticationRequest.getScope().toStringList();
                 redirectURI = authenticationRequest.getRedirectionURI();
+                state = authenticationRequest.getState();
             }
         } catch (ParseException e) {
             throw new ParseException("Unable to parse authentication request");
@@ -92,7 +96,8 @@ public class StartService {
                         scopes,
                         clientRegistry.getServiceType(),
                         clientRegistry.isCookieConsentShared(),
-                        redirectURI);
+                        redirectURI,
+                        state);
         LOG.info(
                 "Found ClientStartInfo for ClientName: {} Scopes: {} ServiceType: {}",
                 clientRegistry.getClientName(),

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -7,6 +7,7 @@ import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import org.junit.jupiter.api.BeforeEach;
@@ -64,6 +65,7 @@ class StartHandlerTest {
     public static final String SESSION_ID_HEADER = "Session-Id";
     public static final String CLIENT_SESSION_ID = "known-client-session-id";
     public static final String SESSION_ID = "some-session-id";
+    public static final State STATE = new State();
     public static final String PERSISTENT_ID = "some-persistent-id-value";
     public static final URI REDIRECT_URL = URI.create("https://localhost/redirect");
     private static final Json objectMapper = SerializationService.getInstance();
@@ -109,7 +111,7 @@ class StartHandlerTest {
     @ParameterizedTest
     @MethodSource("cookieConsentGaTrackingIdValues")
     void shouldReturn200WithStartResponse(String cookieConsentValue, String gaTrackingId)
-            throws Json.JsonException, ParseException, Json.JsonException {
+            throws ParseException, Json.JsonException {
         var userStartInfo = getUserStartInfo(cookieConsentValue, gaTrackingId);
         when(startService.buildUserContext(session, clientSession)).thenReturn(userContext);
         when(startService.buildClientStartInfo(userContext)).thenReturn(getClientStartInfo());
@@ -170,7 +172,7 @@ class StartHandlerTest {
 
     @Test
     void shouldReturn200WhenDocCheckingAppUserIsPresent()
-            throws Json.JsonException, ParseException, Json.JsonException {
+            throws ParseException, Json.JsonException {
         when(configurationService.getDocAppDomain()).thenReturn(URI.create("https://doc-app"));
         var userStartInfo = new UserStartInfo(false, false, false, false, null, null, true);
         when(startService.buildUserContext(session, clientSession)).thenReturn(userContext);
@@ -182,7 +184,8 @@ class StartHandlerTest {
                                 scope.toStringList(),
                                 "MANDATORY",
                                 false,
-                                REDIRECT_URL));
+                                REDIRECT_URL,
+                                STATE));
         when(startService.getGATrackingId(anyMap())).thenReturn(null);
         when(startService.getCookieConsentValue(anyMap(), anyString())).thenReturn(null);
         when(startService.buildUserStartInfo(userContext, null, null, true))
@@ -329,7 +332,7 @@ class StartHandlerTest {
         Scope scope = new Scope(OIDCScopeValue.OPENID.getValue());
 
         return new ClientStartInfo(
-                TEST_CLIENT_NAME, scope.toStringList(), "MANDATORY", false, REDIRECT_URL);
+                TEST_CLIENT_NAME, scope.toStringList(), "MANDATORY", false, REDIRECT_URL, STATE);
     }
 
     private UserStartInfo getUserStartInfo(String cookieConsent, String gaCrossDomainTrackingId) {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
@@ -245,6 +245,7 @@ class StartServiceTest {
         assertThat(clientStartInfo.getCookieConsentShared(), equalTo(cookieConsentShared));
         assertThat(clientStartInfo.getClientName(), equalTo(CLIENT_NAME));
         assertThat(clientStartInfo.getRedirectUri(), equalTo(REDIRECT_URI));
+        assertThat(clientStartInfo.getState().getValue(), equalTo(STATE.getValue()));
 
         var expectedScopes = SCOPES;
         if (Objects.nonNull(signedJWT)) {
@@ -373,7 +374,7 @@ class StartServiceTest {
                                     SCOPES,
                                     CLIENT_ID,
                                     REDIRECT_URI)
-                            .state(new State())
+                            .state(STATE)
                             .nonce(new Nonce())
                             .customParameter("vtr", vtrValue)
                             .build();
@@ -403,7 +404,7 @@ class StartServiceTest {
                         .claim("response_type", ResponseType.CODE.toString())
                         .claim("scope", DOC_APP_SCOPES.toString())
                         .claim("client_id", CLIENT_ID.getValue())
-                        .claim("state", STATE)
+                        .claim("state", STATE.getValue())
                         .issuer(CLIENT_ID.getValue())
                         .build();
         var keyPair = KeyPairGenerator.getInstance("RSA").generateKeyPair();


### PR DESCRIPTION
## What?

 - Return the state param from the Start lambda

## Why?

- If the user selects 'Prove your identity another way' on the '/prove-identity-welcome' page, it will redirect back to the RP with an error. The RP expects the state param to form part of that redirect, so they can validate it and confirm it matches up with a request they have sent.
- The frontend does not know about the state param so it needs to be returned from the start lambda.