### PR TITLE
AUT-330: Lambda provisioned concurrency (non-prod)

### DIFF
--- a/ci/terraform/account-management/authenticate.tf
+++ b/ci/terraform/account-management/authenticate.tf
@@ -29,7 +29,11 @@ module "authenticate" {
   rest_api_id      = aws_api_gateway_rest_api.di_account_management_api.id
   root_resource_id = aws_api_gateway_rest_api.di_account_management_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_account_management_api.execution_arn
-  memory_size      = var.endpoint_memory_size
+
+  memory_size                 = lookup(var.performance_tuning, "authenticate", local.default_performance_parameters).memory
+  provisioned_concurrency     = lookup(var.performance_tuning, "authenticate", local.default_performance_parameters).concurrency
+  max_provisioned_concurrency = lookup(var.performance_tuning, "authenticate", local.default_performance_parameters).max_concurrency
+  scaling_trigger             = lookup(var.performance_tuning, "authenticate", local.default_performance_parameters).scaling_trigger
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.account_management_api_release_zip.key

--- a/ci/terraform/account-management/build-overrides.tfvars
+++ b/ci/terraform/account-management/build-overrides.tfvars
@@ -1,0 +1,5 @@
+lambda_max_concurrency = 3
+lambda_min_concurrency = 1
+keep_lambdas_warm      = false
+endpoint_memory_size   = 1024
+scaling_trigger        = 0.6

--- a/ci/terraform/account-management/integration-overrides.tfvars
+++ b/ci/terraform/account-management/integration-overrides.tfvars
@@ -1,0 +1,5 @@
+lambda_max_concurrency = 3
+lambda_min_concurrency = 1
+keep_lambdas_warm      = false
+endpoint_memory_size   = 1024
+scaling_trigger        = 0.6

--- a/ci/terraform/account-management/production-overrides.tfvars
+++ b/ci/terraform/account-management/production-overrides.tfvars
@@ -8,4 +8,9 @@ notify_template_map = {
 }
 
 cloudwatch_log_retention = 5
-lambda_min_concurrency   = 25
+
+lambda_max_concurrency = 0
+lambda_min_concurrency = 25
+keep_lambdas_warm      = true
+endpoint_memory_size   = 4096
+scaling_trigger        = 0.6

--- a/ci/terraform/account-management/remove-account.tf
+++ b/ci/terraform/account-management/remove-account.tf
@@ -31,7 +31,11 @@ module "delete_account" {
   rest_api_id      = aws_api_gateway_rest_api.di_account_management_api.id
   root_resource_id = aws_api_gateway_rest_api.di_account_management_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_account_management_api.execution_arn
-  memory_size      = var.endpoint_memory_size
+
+  memory_size                 = lookup(var.performance_tuning, "delete-account", local.default_performance_parameters).memory
+  provisioned_concurrency     = lookup(var.performance_tuning, "delete-account", local.default_performance_parameters).concurrency
+  max_provisioned_concurrency = lookup(var.performance_tuning, "delete-account", local.default_performance_parameters).max_concurrency
+  scaling_trigger             = lookup(var.performance_tuning, "delete-account", local.default_performance_parameters).scaling_trigger
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.account_management_api_release_zip.key

--- a/ci/terraform/account-management/sandpit.tfvars
+++ b/ci/terraform/account-management/sandpit.tfvars
@@ -1,6 +1,5 @@
 environment         = "sandpit"
 use_localstack      = false
-keep_lambdas_warm   = false
 common_state_bucket = "digital-identity-dev-tfstate"
 dns_state_bucket    = null
 dns_state_key       = null
@@ -8,3 +7,8 @@ dns_state_role      = null
 
 logging_endpoint_enabled = false
 logging_endpoint_arns    = []
+
+keep_lambdas_warm      = false
+endpoint_memory_size   = 1024
+lambda_max_concurrency = 0
+lambda_min_concurrency = 0

--- a/ci/terraform/account-management/send_otp_notification.tf
+++ b/ci/terraform/account-management/send_otp_notification.tf
@@ -33,7 +33,11 @@ module "send_otp_notification" {
   rest_api_id      = aws_api_gateway_rest_api.di_account_management_api.id
   root_resource_id = aws_api_gateway_rest_api.di_account_management_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_account_management_api.execution_arn
-  memory_size      = var.endpoint_memory_size
+
+  memory_size                 = lookup(var.performance_tuning, "send-otp-notification", local.default_performance_parameters).memory
+  provisioned_concurrency     = lookup(var.performance_tuning, "send-otp-notification", local.default_performance_parameters).concurrency
+  max_provisioned_concurrency = lookup(var.performance_tuning, "send-otp-notification", local.default_performance_parameters).max_concurrency
+  scaling_trigger             = lookup(var.performance_tuning, "send-otp-notification", local.default_performance_parameters).scaling_trigger
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.account_management_api_release_zip.key

--- a/ci/terraform/account-management/staging-overrides.tfvars
+++ b/ci/terraform/account-management/staging-overrides.tfvars
@@ -1,0 +1,5 @@
+lambda_max_concurrency = 3
+lambda_min_concurrency = 1
+keep_lambdas_warm      = false
+endpoint_memory_size   = 1024
+scaling_trigger        = 0.6

--- a/ci/terraform/account-management/update-email.tf
+++ b/ci/terraform/account-management/update-email.tf
@@ -34,7 +34,11 @@ module "update_email" {
   rest_api_id      = aws_api_gateway_rest_api.di_account_management_api.id
   root_resource_id = aws_api_gateway_rest_api.di_account_management_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_account_management_api.execution_arn
-  memory_size      = var.endpoint_memory_size
+
+  memory_size                 = lookup(var.performance_tuning, "update-email", local.default_performance_parameters).memory
+  provisioned_concurrency     = lookup(var.performance_tuning, "update-email", local.default_performance_parameters).concurrency
+  max_provisioned_concurrency = lookup(var.performance_tuning, "update-email", local.default_performance_parameters).max_concurrency
+  scaling_trigger             = lookup(var.performance_tuning, "update-email", local.default_performance_parameters).scaling_trigger
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.account_management_api_release_zip.key

--- a/ci/terraform/account-management/update-password.tf
+++ b/ci/terraform/account-management/update-password.tf
@@ -31,7 +31,11 @@ module "update_password" {
   rest_api_id      = aws_api_gateway_rest_api.di_account_management_api.id
   root_resource_id = aws_api_gateway_rest_api.di_account_management_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_account_management_api.execution_arn
-  memory_size      = var.endpoint_memory_size
+
+  memory_size                 = lookup(var.performance_tuning, "update-password", local.default_performance_parameters).memory
+  provisioned_concurrency     = lookup(var.performance_tuning, "update-password", local.default_performance_parameters).concurrency
+  max_provisioned_concurrency = lookup(var.performance_tuning, "update-password", local.default_performance_parameters).max_concurrency
+  scaling_trigger             = lookup(var.performance_tuning, "update-password", local.default_performance_parameters).scaling_trigger
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.account_management_api_release_zip.key

--- a/ci/terraform/account-management/update-phone-number.tf
+++ b/ci/terraform/account-management/update-phone-number.tf
@@ -33,7 +33,11 @@ module "update_phone_number" {
   rest_api_id      = aws_api_gateway_rest_api.di_account_management_api.id
   root_resource_id = aws_api_gateway_rest_api.di_account_management_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_account_management_api.execution_arn
-  memory_size      = var.endpoint_memory_size
+
+  memory_size                 = lookup(var.performance_tuning, "update-phone-number", local.default_performance_parameters).memory
+  provisioned_concurrency     = lookup(var.performance_tuning, "update-phone-number", local.default_performance_parameters).concurrency
+  max_provisioned_concurrency = lookup(var.performance_tuning, "update-phone-number", local.default_performance_parameters).max_concurrency
+  scaling_trigger             = lookup(var.performance_tuning, "update-phone-number", local.default_performance_parameters).scaling_trigger
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.account_management_api_release_zip.key

--- a/ci/terraform/account-management/variables.tf
+++ b/ci/terraform/account-management/variables.tf
@@ -178,3 +178,31 @@ variable "endpoint_memory_size" {
   default = 4096
   type    = number
 }
+
+variable "performance_tuning" {
+  type = map(object({
+    memory : number,
+    concurrency : number,
+    max_concurrency : number,
+    scaling_trigger : number,
+  }))
+  description = "A map of performance tuning parameters per lambda"
+  default     = {}
+}
+
+variable "lambda_max_concurrency" {
+  default = 5
+}
+
+variable "scaling_trigger" {
+  default = 0.7
+}
+
+locals {
+  default_performance_parameters = {
+    memory          = var.endpoint_memory_size
+    concurrency     = var.keep_lambdas_warm ? 0 : var.lambda_min_concurrency
+    max_concurrency = var.lambda_max_concurrency
+    scaling_trigger = var.scaling_trigger
+  }
+}

--- a/ci/terraform/modules/endpoint-module/lambda.tf
+++ b/ci/terraform/modules/endpoint-module/lambda.tf
@@ -64,3 +64,12 @@ resource "aws_lambda_alias" "endpoint_lambda" {
   function_name    = aws_lambda_function.endpoint_lambda.arn
   function_version = aws_lambda_function.endpoint_lambda.version
 }
+
+resource "aws_lambda_provisioned_concurrency_config" "endpoint_lambda_concurrency_config" {
+  count = var.provisioned_concurrency == 0 ? 0 : 1
+
+  function_name = aws_lambda_function.endpoint_lambda.function_name
+  qualifier     = aws_lambda_alias.endpoint_lambda.name
+
+  provisioned_concurrent_executions = var.provisioned_concurrency
+}

--- a/ci/terraform/modules/endpoint-module/variables.tf
+++ b/ci/terraform/modules/endpoint-module/variables.tf
@@ -198,3 +198,11 @@ variable "memory_size" {
 variable "provisioned_concurrency" {
   default = 0
 }
+
+variable "max_provisioned_concurrency" {
+  default = 5
+}
+
+variable "scaling_trigger" {
+  default = 0.7
+}

--- a/ci/terraform/modules/endpoint-module/variables.tf
+++ b/ci/terraform/modules/endpoint-module/variables.tf
@@ -194,3 +194,7 @@ variable "code_signing_config_arn" {
 variable "memory_size" {
   type = number
 }
+
+variable "provisioned_concurrency" {
+  default = 0
+}

--- a/ci/terraform/oidc/auth-code.tf
+++ b/ci/terraform/oidc/auth-code.tf
@@ -35,7 +35,9 @@ module "auth-code" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
-  memory_size      = var.endpoint_memory_size
+
+  memory_size             = lookup(var.performance_tuning, "auth-code", local.default_performance_parameters).memory
+  provisioned_concurrency = lookup(var.performance_tuning, "auth-code", local.default_performance_parameters).concurrency
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.oidc_api_release_zip.key

--- a/ci/terraform/oidc/auth-code.tf
+++ b/ci/terraform/oidc/auth-code.tf
@@ -36,8 +36,10 @@ module "auth-code" {
   root_resource_id = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
 
-  memory_size             = lookup(var.performance_tuning, "auth-code", local.default_performance_parameters).memory
-  provisioned_concurrency = lookup(var.performance_tuning, "auth-code", local.default_performance_parameters).concurrency
+  memory_size                 = lookup(var.performance_tuning, "auth-code", local.default_performance_parameters).memory
+  provisioned_concurrency     = lookup(var.performance_tuning, "auth-code", local.default_performance_parameters).concurrency
+  max_provisioned_concurrency = lookup(var.performance_tuning, "auth-code", local.default_performance_parameters).max_concurrency
+  scaling_trigger             = lookup(var.performance_tuning, "auth-code", local.default_performance_parameters).scaling_trigger
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.oidc_api_release_zip.key

--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -40,7 +40,9 @@ module "authorize" {
   rest_api_id           = aws_api_gateway_rest_api.di_authentication_api.id
   root_resource_id      = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
   execution_arn         = aws_api_gateway_rest_api.di_authentication_api.execution_arn
-  memory_size           = var.endpoint_memory_size
+
+  memory_size             = lookup(var.performance_tuning, "authorize", local.default_performance_parameters).memory
+  provisioned_concurrency = lookup(var.performance_tuning, "authorize", local.default_performance_parameters).concurrency
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.oidc_api_release_zip.key

--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -41,8 +41,10 @@ module "authorize" {
   root_resource_id      = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
   execution_arn         = aws_api_gateway_rest_api.di_authentication_api.execution_arn
 
-  memory_size             = lookup(var.performance_tuning, "authorize", local.default_performance_parameters).memory
-  provisioned_concurrency = lookup(var.performance_tuning, "authorize", local.default_performance_parameters).concurrency
+  memory_size                 = lookup(var.performance_tuning, "authorize", local.default_performance_parameters).memory
+  provisioned_concurrency     = lookup(var.performance_tuning, "authorize", local.default_performance_parameters).concurrency
+  max_provisioned_concurrency = lookup(var.performance_tuning, "authorize", local.default_performance_parameters).max_concurrency
+  scaling_trigger             = lookup(var.performance_tuning, "authorize", local.default_performance_parameters).scaling_trigger
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.oidc_api_release_zip.key

--- a/ci/terraform/oidc/build-overrides.tfvars
+++ b/ci/terraform/oidc/build-overrides.tfvars
@@ -31,11 +31,6 @@ logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]
 
-endpoint_memory_size   = 1024
-lambda_min_concurrency = 1
-lambda_max_concurrency = 1
-keep_lambdas_warm      = false
-
 performance_tuning = {
   register = {
     memory          = 512
@@ -51,3 +46,8 @@ performance_tuning = {
     scaling_trigger = 0
   }
 }
+lambda_max_concurrency = 3
+lambda_min_concurrency = 1
+keep_lambdas_warm      = false
+endpoint_memory_size   = 1024
+scaling_trigger        = 0.6

--- a/ci/terraform/oidc/build-overrides.tfvars
+++ b/ci/terraform/oidc/build-overrides.tfvars
@@ -30,3 +30,24 @@ logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod",
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]
+
+endpoint_memory_size   = 1024
+lambda_min_concurrency = 1
+lambda_max_concurrency = 1
+keep_lambdas_warm      = false
+
+performance_tuning = {
+  register = {
+    memory          = 512
+    concurrency     = 0
+    max_concurrency = 0
+    scaling_trigger = 0
+  }
+
+  update = {
+    memory          = 512
+    concurrency     = 0
+    max_concurrency = 0
+    scaling_trigger = 0
+  }
+}

--- a/ci/terraform/oidc/doc-app-authorize.tf
+++ b/ci/terraform/oidc/doc-app-authorize.tf
@@ -41,8 +41,10 @@ module "doc-app-authorize" {
   root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
 
-  memory_size             = lookup(var.performance_tuning, "doc-checking-app-authorize", local.default_performance_parameters).memory
-  provisioned_concurrency = lookup(var.performance_tuning, "doc-checking-app-authorize", local.default_performance_parameters).concurrency
+  memory_size                 = lookup(var.performance_tuning, "doc-checking-app-authorize", local.default_performance_parameters).memory
+  provisioned_concurrency     = lookup(var.performance_tuning, "doc-checking-app-authorize", local.default_performance_parameters).concurrency
+  max_provisioned_concurrency = lookup(var.performance_tuning, "doc-checking-app-authorize", local.default_performance_parameters).max_concurrency
+  scaling_trigger             = lookup(var.performance_tuning, "doc-checking-app-authorize", local.default_performance_parameters).scaling_trigger
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.doc_checking_app_api_release_zip.key

--- a/ci/terraform/oidc/doc-app-authorize.tf
+++ b/ci/terraform/oidc/doc-app-authorize.tf
@@ -40,7 +40,9 @@ module "doc-app-authorize" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
-  memory_size      = var.endpoint_memory_size
+
+  memory_size             = lookup(var.performance_tuning, "doc-checking-app-authorize", local.default_performance_parameters).memory
+  provisioned_concurrency = lookup(var.performance_tuning, "doc-checking-app-authorize", local.default_performance_parameters).concurrency
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.doc_checking_app_api_release_zip.key

--- a/ci/terraform/oidc/doc-app-callback.tf
+++ b/ci/terraform/oidc/doc-app-callback.tf
@@ -45,8 +45,10 @@ module "doc-app-callback" {
   root_resource_id = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
 
-  memory_size             = lookup(var.performance_tuning, "doc-checking-app-callback", local.default_performance_parameters).memory
-  provisioned_concurrency = lookup(var.performance_tuning, "doc-checking-app-callback", local.default_performance_parameters).concurrency
+  memory_size                 = lookup(var.performance_tuning, "doc-checking-app-callback", local.default_performance_parameters).memory
+  provisioned_concurrency     = lookup(var.performance_tuning, "doc-checking-app-callback", local.default_performance_parameters).concurrency
+  max_provisioned_concurrency = lookup(var.performance_tuning, "doc-checking-app-callback", local.default_performance_parameters).max_concurrency
+  scaling_trigger             = lookup(var.performance_tuning, "doc-checking-app-callback", local.default_performance_parameters).scaling_trigger
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.doc_checking_app_api_release_zip.key

--- a/ci/terraform/oidc/doc-app-callback.tf
+++ b/ci/terraform/oidc/doc-app-callback.tf
@@ -44,7 +44,9 @@ module "doc-app-callback" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
-  memory_size      = var.endpoint_memory_size
+
+  memory_size             = lookup(var.performance_tuning, "doc-checking-app-callback", local.default_performance_parameters).memory
+  provisioned_concurrency = lookup(var.performance_tuning, "doc-checking-app-callback", local.default_performance_parameters).concurrency
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.doc_checking_app_api_release_zip.key

--- a/ci/terraform/oidc/integration-overrides.tfvars
+++ b/ci/terraform/oidc/integration-overrides.tfvars
@@ -22,3 +22,24 @@ logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod",
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]
+
+performance_tuning = {
+  register = {
+    memory          = 512
+    concurrency     = 0
+    max_concurrency = 0
+    scaling_trigger = 0
+  }
+
+  update = {
+    memory          = 512
+    concurrency     = 0
+    max_concurrency = 0
+    scaling_trigger = 0
+  }
+}
+lambda_max_concurrency = 3
+lambda_min_concurrency = 1
+keep_lambdas_warm      = false
+endpoint_memory_size   = 1024
+scaling_trigger        = 0.6

--- a/ci/terraform/oidc/ipv-authorize.tf
+++ b/ci/terraform/oidc/ipv-authorize.tf
@@ -46,8 +46,10 @@ module "ipv-authorize" {
   root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
 
-  memory_size             = lookup(var.performance_tuning, "ipv-authorize", local.default_performance_parameters).memory
-  provisioned_concurrency = lookup(var.performance_tuning, "ipv-authorize", local.default_performance_parameters).concurrency
+  memory_size                 = lookup(var.performance_tuning, "ipv-authorize", local.default_performance_parameters).memory
+  provisioned_concurrency     = lookup(var.performance_tuning, "ipv-authorize", local.default_performance_parameters).concurrency
+  max_provisioned_concurrency = lookup(var.performance_tuning, "ipv-authorize", local.default_performance_parameters).max_concurrency
+  scaling_trigger             = lookup(var.performance_tuning, "ipv-authorize", local.default_performance_parameters).scaling_trigger
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.ipv_api_release_zip.key

--- a/ci/terraform/oidc/ipv-authorize.tf
+++ b/ci/terraform/oidc/ipv-authorize.tf
@@ -45,7 +45,9 @@ module "ipv-authorize" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
-  memory_size      = var.endpoint_memory_size
+
+  memory_size             = lookup(var.performance_tuning, "ipv-authorize", local.default_performance_parameters).memory
+  provisioned_concurrency = lookup(var.performance_tuning, "ipv-authorize", local.default_performance_parameters).concurrency
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.ipv_api_release_zip.key

--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -51,7 +51,9 @@ module "ipv-callback" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
-  memory_size      = var.endpoint_memory_size
+
+  memory_size             = lookup(var.performance_tuning, "ipv-callback", local.default_performance_parameters).memory
+  provisioned_concurrency = lookup(var.performance_tuning, "ipv-callback", local.default_performance_parameters).concurrency
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.ipv_api_release_zip.key

--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -52,8 +52,10 @@ module "ipv-callback" {
   root_resource_id = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
 
-  memory_size             = lookup(var.performance_tuning, "ipv-callback", local.default_performance_parameters).memory
-  provisioned_concurrency = lookup(var.performance_tuning, "ipv-callback", local.default_performance_parameters).concurrency
+  memory_size                 = lookup(var.performance_tuning, "ipv-callback", local.default_performance_parameters).memory
+  provisioned_concurrency     = lookup(var.performance_tuning, "ipv-callback", local.default_performance_parameters).concurrency
+  max_provisioned_concurrency = lookup(var.performance_tuning, "ipv-callback", local.default_performance_parameters).max_concurrency
+  scaling_trigger             = lookup(var.performance_tuning, "ipv-callback", local.default_performance_parameters).scaling_trigger
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.ipv_api_release_zip.key

--- a/ci/terraform/oidc/ipv-capacity.tf
+++ b/ci/terraform/oidc/ipv-capacity.tf
@@ -36,7 +36,9 @@ module "ipv-capacity" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
-  memory_size      = var.endpoint_memory_size
+
+  memory_size             = lookup(var.performance_tuning, "ipv-capacity", local.default_performance_parameters).memory
+  provisioned_concurrency = lookup(var.performance_tuning, "ipv-capacity", local.default_performance_parameters).concurrency
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.ipv_api_release_zip.key

--- a/ci/terraform/oidc/ipv-capacity.tf
+++ b/ci/terraform/oidc/ipv-capacity.tf
@@ -37,8 +37,10 @@ module "ipv-capacity" {
   root_resource_id = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
 
-  memory_size             = lookup(var.performance_tuning, "ipv-capacity", local.default_performance_parameters).memory
-  provisioned_concurrency = lookup(var.performance_tuning, "ipv-capacity", local.default_performance_parameters).concurrency
+  memory_size                 = lookup(var.performance_tuning, "ipv-capacity", local.default_performance_parameters).memory
+  provisioned_concurrency     = lookup(var.performance_tuning, "ipv-capacity", local.default_performance_parameters).concurrency
+  max_provisioned_concurrency = lookup(var.performance_tuning, "ipv-capacity", local.default_performance_parameters).max_concurrency
+  scaling_trigger             = lookup(var.performance_tuning, "ipv-capacity", local.default_performance_parameters).scaling_trigger
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.ipv_api_release_zip.key

--- a/ci/terraform/oidc/jwks.tf
+++ b/ci/terraform/oidc/jwks.tf
@@ -30,8 +30,10 @@ module "jwks" {
   root_resource_id = aws_api_gateway_resource.wellknown_resource.id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
 
-  memory_size             = lookup(var.performance_tuning, "jwks", local.default_performance_parameters).memory
-  provisioned_concurrency = lookup(var.performance_tuning, "jwks", local.default_performance_parameters).concurrency
+  memory_size                 = lookup(var.performance_tuning, "jwks", local.default_performance_parameters).memory
+  provisioned_concurrency     = lookup(var.performance_tuning, "jwks", local.default_performance_parameters).concurrency
+  max_provisioned_concurrency = lookup(var.performance_tuning, "jwks", local.default_performance_parameters).max_concurrency
+  scaling_trigger             = lookup(var.performance_tuning, "jwks", local.default_performance_parameters).scaling_trigger
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.oidc_api_release_zip.key

--- a/ci/terraform/oidc/jwks.tf
+++ b/ci/terraform/oidc/jwks.tf
@@ -29,7 +29,9 @@ module "jwks" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
   root_resource_id = aws_api_gateway_resource.wellknown_resource.id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
-  memory_size      = var.endpoint_memory_size
+
+  memory_size             = lookup(var.performance_tuning, "jwks", local.default_performance_parameters).memory
+  provisioned_concurrency = lookup(var.performance_tuning, "jwks", local.default_performance_parameters).concurrency
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.oidc_api_release_zip.key

--- a/ci/terraform/oidc/login.tf
+++ b/ci/terraform/oidc/login.tf
@@ -39,7 +39,9 @@ module "login" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
-  memory_size      = var.endpoint_memory_size
+
+  memory_size             = lookup(var.performance_tuning, "login", local.default_performance_parameters).memory
+  provisioned_concurrency = lookup(var.performance_tuning, "login", local.default_performance_parameters).concurrency
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.frontend_api_release_zip.key

--- a/ci/terraform/oidc/login.tf
+++ b/ci/terraform/oidc/login.tf
@@ -40,8 +40,10 @@ module "login" {
   root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
 
-  memory_size             = lookup(var.performance_tuning, "login", local.default_performance_parameters).memory
-  provisioned_concurrency = lookup(var.performance_tuning, "login", local.default_performance_parameters).concurrency
+  memory_size                 = lookup(var.performance_tuning, "login", local.default_performance_parameters).memory
+  provisioned_concurrency     = lookup(var.performance_tuning, "login", local.default_performance_parameters).concurrency
+  max_provisioned_concurrency = lookup(var.performance_tuning, "login", local.default_performance_parameters).max_concurrency
+  scaling_trigger             = lookup(var.performance_tuning, "login", local.default_performance_parameters).scaling_trigger
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.frontend_api_release_zip.key

--- a/ci/terraform/oidc/logout.tf
+++ b/ci/terraform/oidc/logout.tf
@@ -40,8 +40,10 @@ module "logout" {
   root_resource_id = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
 
-  memory_size             = lookup(var.performance_tuning, "logout", local.default_performance_parameters).memory
-  provisioned_concurrency = lookup(var.performance_tuning, "logout", local.default_performance_parameters).concurrency
+  memory_size                 = lookup(var.performance_tuning, "logout", local.default_performance_parameters).memory
+  provisioned_concurrency     = lookup(var.performance_tuning, "logout", local.default_performance_parameters).concurrency
+  max_provisioned_concurrency = lookup(var.performance_tuning, "logout", local.default_performance_parameters).max_concurrency
+  scaling_trigger             = lookup(var.performance_tuning, "logout", local.default_performance_parameters).scaling_trigger
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.oidc_api_release_zip.key

--- a/ci/terraform/oidc/logout.tf
+++ b/ci/terraform/oidc/logout.tf
@@ -39,7 +39,9 @@ module "logout" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
-  memory_size      = var.endpoint_memory_size
+
+  memory_size             = lookup(var.performance_tuning, "logout", local.default_performance_parameters).memory
+  provisioned_concurrency = lookup(var.performance_tuning, "logout", local.default_performance_parameters).concurrency
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.oidc_api_release_zip.key

--- a/ci/terraform/oidc/mfa.tf
+++ b/ci/terraform/oidc/mfa.tf
@@ -37,7 +37,9 @@ module "mfa" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
-  memory_size      = var.endpoint_memory_size
+
+  memory_size             = lookup(var.performance_tuning, "mfa", local.default_performance_parameters).memory
+  provisioned_concurrency = lookup(var.performance_tuning, "mfa", local.default_performance_parameters).concurrency
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.frontend_api_release_zip.key

--- a/ci/terraform/oidc/mfa.tf
+++ b/ci/terraform/oidc/mfa.tf
@@ -38,8 +38,10 @@ module "mfa" {
   root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
 
-  memory_size             = lookup(var.performance_tuning, "mfa", local.default_performance_parameters).memory
-  provisioned_concurrency = lookup(var.performance_tuning, "mfa", local.default_performance_parameters).concurrency
+  memory_size                 = lookup(var.performance_tuning, "mfa", local.default_performance_parameters).memory
+  provisioned_concurrency     = lookup(var.performance_tuning, "mfa", local.default_performance_parameters).concurrency
+  max_provisioned_concurrency = lookup(var.performance_tuning, "mfa", local.default_performance_parameters).max_concurrency
+  scaling_trigger             = lookup(var.performance_tuning, "mfa", local.default_performance_parameters).scaling_trigger
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.frontend_api_release_zip.key

--- a/ci/terraform/oidc/processing-identity.tf
+++ b/ci/terraform/oidc/processing-identity.tf
@@ -38,8 +38,10 @@ module "processing-identity" {
   root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
 
-  memory_size             = lookup(var.performance_tuning, "processing-identity", local.default_performance_parameters).memory
-  provisioned_concurrency = lookup(var.performance_tuning, "processing-identity", local.default_performance_parameters).concurrency
+  memory_size                 = lookup(var.performance_tuning, "processing-identity", local.default_performance_parameters).memory
+  provisioned_concurrency     = lookup(var.performance_tuning, "processing-identity", local.default_performance_parameters).concurrency
+  max_provisioned_concurrency = lookup(var.performance_tuning, "processing-identity", local.default_performance_parameters).max_concurrency
+  scaling_trigger             = lookup(var.performance_tuning, "processing-identity", local.default_performance_parameters).scaling_trigger
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.ipv_api_release_zip.key

--- a/ci/terraform/oidc/processing-identity.tf
+++ b/ci/terraform/oidc/processing-identity.tf
@@ -37,7 +37,9 @@ module "processing-identity" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
-  memory_size      = var.endpoint_memory_size
+
+  memory_size             = lookup(var.performance_tuning, "processing-identity", local.default_performance_parameters).memory
+  provisioned_concurrency = lookup(var.performance_tuning, "processing-identity", local.default_performance_parameters).concurrency
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.ipv_api_release_zip.key

--- a/ci/terraform/oidc/production-overrides.tfvars
+++ b/ci/terraform/oidc/production-overrides.tfvars
@@ -9,7 +9,6 @@ notify_template_map = {
 }
 
 cloudwatch_log_retention       = 5
-lambda_min_concurrency         = 50
 client_registry_api_enabled    = false
 spot_enabled                   = true
 ipv_api_enabled                = false
@@ -31,3 +30,24 @@ rbeA0zSUxxfdffFH/L0cTgzdTQtv6iGQrkfHnTTk1TQe0+wxJEQz5FlcXYl6qSrh
 swIDAQAB
 -----END PUBLIC KEY-----
 EOT
+
+performance_tuning = {
+  register = {
+    memory          = 512
+    concurrency     = 0
+    max_concurrency = 0
+    scaling_trigger = 0
+  }
+
+  update = {
+    memory          = 512
+    concurrency     = 0
+    max_concurrency = 0
+    scaling_trigger = 0
+  }
+}
+lambda_max_concurrency = 0
+lambda_min_concurrency = 50
+keep_lambdas_warm      = true
+endpoint_memory_size   = 4096
+scaling_trigger        = 0.6

--- a/ci/terraform/oidc/register.tf
+++ b/ci/terraform/oidc/register.tf
@@ -35,8 +35,10 @@ module "register" {
   execution_arn          = aws_api_gateway_rest_api.di_authentication_api.execution_arn
   authentication_vpc_arn = local.authentication_vpc_arn
 
-  memory_size             = lookup(var.performance_tuning, "register", local.default_performance_parameters).memory
-  provisioned_concurrency = lookup(var.performance_tuning, "register", local.default_performance_parameters).concurrency
+  memory_size                 = lookup(var.performance_tuning, "register", local.default_performance_parameters).memory
+  provisioned_concurrency     = lookup(var.performance_tuning, "register", local.default_performance_parameters).concurrency
+  max_provisioned_concurrency = lookup(var.performance_tuning, "register", local.default_performance_parameters).max_concurrency
+  scaling_trigger             = lookup(var.performance_tuning, "register", local.default_performance_parameters).scaling_trigger
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.client_api_release_zip.key

--- a/ci/terraform/oidc/register.tf
+++ b/ci/terraform/oidc/register.tf
@@ -34,7 +34,9 @@ module "register" {
   root_resource_id       = aws_api_gateway_resource.register_resource.id
   execution_arn          = aws_api_gateway_rest_api.di_authentication_api.execution_arn
   authentication_vpc_arn = local.authentication_vpc_arn
-  memory_size            = var.endpoint_memory_size
+
+  memory_size             = lookup(var.performance_tuning, "register", local.default_performance_parameters).memory
+  provisioned_concurrency = lookup(var.performance_tuning, "register", local.default_performance_parameters).concurrency
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.client_api_release_zip.key

--- a/ci/terraform/oidc/reset-password-request.tf
+++ b/ci/terraform/oidc/reset-password-request.tf
@@ -40,8 +40,10 @@ module "reset-password-request" {
   root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
 
-  memory_size             = lookup(var.performance_tuning, "reset-password-request", local.default_performance_parameters).memory
-  provisioned_concurrency = lookup(var.performance_tuning, "reset-password-request", local.default_performance_parameters).concurrency
+  memory_size                 = lookup(var.performance_tuning, "reset-password-request", local.default_performance_parameters).memory
+  provisioned_concurrency     = lookup(var.performance_tuning, "reset-password-request", local.default_performance_parameters).concurrency
+  max_provisioned_concurrency = lookup(var.performance_tuning, "reset-password-request", local.default_performance_parameters).max_concurrency
+  scaling_trigger             = lookup(var.performance_tuning, "reset-password-request", local.default_performance_parameters).scaling_trigger
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.frontend_api_release_zip.key

--- a/ci/terraform/oidc/reset-password-request.tf
+++ b/ci/terraform/oidc/reset-password-request.tf
@@ -39,7 +39,9 @@ module "reset-password-request" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
-  memory_size      = var.endpoint_memory_size
+
+  memory_size             = lookup(var.performance_tuning, "reset-password-request", local.default_performance_parameters).memory
+  provisioned_concurrency = lookup(var.performance_tuning, "reset-password-request", local.default_performance_parameters).concurrency
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.frontend_api_release_zip.key

--- a/ci/terraform/oidc/reset_password.tf
+++ b/ci/terraform/oidc/reset_password.tf
@@ -39,8 +39,10 @@ module "reset_password" {
   root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
 
-  memory_size             = lookup(var.performance_tuning, "reset-password", local.default_performance_parameters).memory
-  provisioned_concurrency = lookup(var.performance_tuning, "reset-password", local.default_performance_parameters).concurrency
+  memory_size                 = lookup(var.performance_tuning, "reset-password", local.default_performance_parameters).memory
+  provisioned_concurrency     = lookup(var.performance_tuning, "reset-password", local.default_performance_parameters).concurrency
+  max_provisioned_concurrency = lookup(var.performance_tuning, "reset-password", local.default_performance_parameters).max_concurrency
+  scaling_trigger             = lookup(var.performance_tuning, "reset-password", local.default_performance_parameters).scaling_trigger
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.frontend_api_release_zip.key

--- a/ci/terraform/oidc/reset_password.tf
+++ b/ci/terraform/oidc/reset_password.tf
@@ -38,7 +38,9 @@ module "reset_password" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
-  memory_size      = var.endpoint_memory_size
+
+  memory_size             = lookup(var.performance_tuning, "reset-password", local.default_performance_parameters).memory
+  provisioned_concurrency = lookup(var.performance_tuning, "reset-password", local.default_performance_parameters).concurrency
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.frontend_api_release_zip.key

--- a/ci/terraform/oidc/sandpit.tfvars
+++ b/ci/terraform/oidc/sandpit.tfvars
@@ -11,6 +11,19 @@ ipv_authorisation_uri          = ""
 ipv_authorisation_client_id    = ""
 logging_endpoint_enabled       = false
 logging_endpoint_arns          = []
+endpoint_memory_size           = 512
 
 enable_api_gateway_execution_request_tracing = true
 spot_enabled                                 = false
+
+performance_tuning = {
+  register = {
+    memory      = 512
+    concurrency = 0
+  }
+
+  update = {
+    memory      = 512
+    concurrency = 0
+  }
+}

--- a/ci/terraform/oidc/sandpit.tfvars
+++ b/ci/terraform/oidc/sandpit.tfvars
@@ -1,5 +1,4 @@
 environment                    = "sandpit"
-keep_lambdas_warm              = false
 dns_state_bucket               = null
 dns_state_key                  = null
 dns_state_role                 = null
@@ -11,19 +10,11 @@ ipv_authorisation_uri          = ""
 ipv_authorisation_client_id    = ""
 logging_endpoint_enabled       = false
 logging_endpoint_arns          = []
-endpoint_memory_size           = 512
 
 enable_api_gateway_execution_request_tracing = true
 spot_enabled                                 = false
 
-performance_tuning = {
-  register = {
-    memory      = 512
-    concurrency = 0
-  }
-
-  update = {
-    memory      = 512
-    concurrency = 0
-  }
-}
+lambda_max_concurrency = 0
+lambda_min_concurrency = 0
+keep_lambdas_warm      = false
+endpoint_memory_size   = 1024

--- a/ci/terraform/oidc/send_notification.tf
+++ b/ci/terraform/oidc/send_notification.tf
@@ -37,8 +37,10 @@ module "send_notification" {
   root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
 
-  memory_size             = lookup(var.performance_tuning, "send-notification", local.default_performance_parameters).memory
-  provisioned_concurrency = lookup(var.performance_tuning, "send-notification", local.default_performance_parameters).concurrency
+  memory_size                 = lookup(var.performance_tuning, "send-notification", local.default_performance_parameters).memory
+  provisioned_concurrency     = lookup(var.performance_tuning, "send-notification", local.default_performance_parameters).concurrency
+  max_provisioned_concurrency = lookup(var.performance_tuning, "send-notification", local.default_performance_parameters).max_concurrency
+  scaling_trigger             = lookup(var.performance_tuning, "send-notification", local.default_performance_parameters).scaling_trigger
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.frontend_api_release_zip.key

--- a/ci/terraform/oidc/send_notification.tf
+++ b/ci/terraform/oidc/send_notification.tf
@@ -36,7 +36,9 @@ module "send_notification" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
-  memory_size      = var.endpoint_memory_size
+
+  memory_size             = lookup(var.performance_tuning, "send-notification", local.default_performance_parameters).memory
+  provisioned_concurrency = lookup(var.performance_tuning, "send-notification", local.default_performance_parameters).concurrency
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.frontend_api_release_zip.key

--- a/ci/terraform/oidc/signup.tf
+++ b/ci/terraform/oidc/signup.tf
@@ -36,7 +36,9 @@ module "signup" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
-  memory_size      = var.endpoint_memory_size
+
+  memory_size             = lookup(var.performance_tuning, "signup", local.default_performance_parameters).memory
+  provisioned_concurrency = lookup(var.performance_tuning, "signup", local.default_performance_parameters).concurrency
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.frontend_api_release_zip.key

--- a/ci/terraform/oidc/signup.tf
+++ b/ci/terraform/oidc/signup.tf
@@ -37,8 +37,10 @@ module "signup" {
   root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
 
-  memory_size             = lookup(var.performance_tuning, "signup", local.default_performance_parameters).memory
-  provisioned_concurrency = lookup(var.performance_tuning, "signup", local.default_performance_parameters).concurrency
+  memory_size                 = lookup(var.performance_tuning, "signup", local.default_performance_parameters).memory
+  provisioned_concurrency     = lookup(var.performance_tuning, "signup", local.default_performance_parameters).concurrency
+  max_provisioned_concurrency = lookup(var.performance_tuning, "signup", local.default_performance_parameters).max_concurrency
+  scaling_trigger             = lookup(var.performance_tuning, "signup", local.default_performance_parameters).scaling_trigger
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.frontend_api_release_zip.key

--- a/ci/terraform/oidc/staging-overrides.tfvars
+++ b/ci/terraform/oidc/staging-overrides.tfvars
@@ -32,3 +32,24 @@ bJ5G58qyvEL0h3BMEBayDN1cT3/Q7NU3jkaa1ODynLjkvXEtlccgsrAa2he7OQUY
 ZQIDAQAB
 -----END PUBLIC KEY-----
 EOT
+
+performance_tuning = {
+  register = {
+    memory          = 512
+    concurrency     = 0
+    max_concurrency = 0
+    scaling_trigger = 0
+  }
+
+  update = {
+    memory          = 512
+    concurrency     = 0
+    max_concurrency = 0
+    scaling_trigger = 0
+  }
+}
+lambda_max_concurrency = 3
+lambda_min_concurrency = 1
+keep_lambdas_warm      = false
+endpoint_memory_size   = 1024
+scaling_trigger        = 0.6

--- a/ci/terraform/oidc/start.tf
+++ b/ci/terraform/oidc/start.tf
@@ -37,7 +37,9 @@ module "start" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
-  memory_size      = var.endpoint_memory_size
+
+  memory_size             = lookup(var.performance_tuning, "start", local.default_performance_parameters).memory
+  provisioned_concurrency = lookup(var.performance_tuning, "start", local.default_performance_parameters).concurrency
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.frontend_api_release_zip.key

--- a/ci/terraform/oidc/start.tf
+++ b/ci/terraform/oidc/start.tf
@@ -38,8 +38,10 @@ module "start" {
   root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
 
-  memory_size             = lookup(var.performance_tuning, "start", local.default_performance_parameters).memory
-  provisioned_concurrency = lookup(var.performance_tuning, "start", local.default_performance_parameters).concurrency
+  memory_size                 = lookup(var.performance_tuning, "start", local.default_performance_parameters).memory
+  provisioned_concurrency     = lookup(var.performance_tuning, "start", local.default_performance_parameters).concurrency
+  max_provisioned_concurrency = lookup(var.performance_tuning, "start", local.default_performance_parameters).max_concurrency
+  scaling_trigger             = lookup(var.performance_tuning, "start", local.default_performance_parameters).scaling_trigger
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.frontend_api_release_zip.key

--- a/ci/terraform/oidc/token.tf
+++ b/ci/terraform/oidc/token.tf
@@ -62,7 +62,9 @@ module "token" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
-  memory_size      = var.endpoint_memory_size
+
+  memory_size             = lookup(var.performance_tuning, "token", local.default_performance_parameters).memory
+  provisioned_concurrency = lookup(var.performance_tuning, "token", local.default_performance_parameters).concurrency
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.oidc_api_release_zip.key

--- a/ci/terraform/oidc/token.tf
+++ b/ci/terraform/oidc/token.tf
@@ -63,8 +63,10 @@ module "token" {
   root_resource_id = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
 
-  memory_size             = lookup(var.performance_tuning, "token", local.default_performance_parameters).memory
-  provisioned_concurrency = lookup(var.performance_tuning, "token", local.default_performance_parameters).concurrency
+  memory_size                 = lookup(var.performance_tuning, "token", local.default_performance_parameters).memory
+  provisioned_concurrency     = lookup(var.performance_tuning, "token", local.default_performance_parameters).concurrency
+  max_provisioned_concurrency = lookup(var.performance_tuning, "token", local.default_performance_parameters).max_concurrency
+  scaling_trigger             = lookup(var.performance_tuning, "token", local.default_performance_parameters).scaling_trigger
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.oidc_api_release_zip.key

--- a/ci/terraform/oidc/trustmarks.tf
+++ b/ci/terraform/oidc/trustmarks.tf
@@ -28,7 +28,9 @@ module "trustmarks" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
-  memory_size      = var.endpoint_memory_size
+
+  memory_size             = lookup(var.performance_tuning, "trustmark", local.default_performance_parameters).memory
+  provisioned_concurrency = lookup(var.performance_tuning, "trustmark", local.default_performance_parameters).concurrency
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.oidc_api_release_zip.key

--- a/ci/terraform/oidc/trustmarks.tf
+++ b/ci/terraform/oidc/trustmarks.tf
@@ -29,8 +29,10 @@ module "trustmarks" {
   root_resource_id = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
 
-  memory_size             = lookup(var.performance_tuning, "trustmark", local.default_performance_parameters).memory
-  provisioned_concurrency = lookup(var.performance_tuning, "trustmark", local.default_performance_parameters).concurrency
+  memory_size                 = lookup(var.performance_tuning, "trustmark", local.default_performance_parameters).memory
+  provisioned_concurrency     = lookup(var.performance_tuning, "trustmark", local.default_performance_parameters).concurrency
+  max_provisioned_concurrency = lookup(var.performance_tuning, "trustmark", local.default_performance_parameters).max_concurrency
+  scaling_trigger             = lookup(var.performance_tuning, "trustmark", local.default_performance_parameters).scaling_trigger
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.oidc_api_release_zip.key

--- a/ci/terraform/oidc/update.tf
+++ b/ci/terraform/oidc/update.tf
@@ -34,7 +34,9 @@ module "update" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
   root_resource_id = aws_api_gateway_resource.register_resource.id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
-  memory_size      = var.endpoint_memory_size
+
+  memory_size             = lookup(var.performance_tuning, "update-client-info", local.default_performance_parameters).memory
+  provisioned_concurrency = lookup(var.performance_tuning, "update-client-info", local.default_performance_parameters).concurrency
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.client_api_release_zip.key

--- a/ci/terraform/oidc/update.tf
+++ b/ci/terraform/oidc/update.tf
@@ -35,8 +35,10 @@ module "update" {
   root_resource_id = aws_api_gateway_resource.register_resource.id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
 
-  memory_size             = lookup(var.performance_tuning, "update-client-info", local.default_performance_parameters).memory
-  provisioned_concurrency = lookup(var.performance_tuning, "update-client-info", local.default_performance_parameters).concurrency
+  memory_size                 = lookup(var.performance_tuning, "update-client-info", local.default_performance_parameters).memory
+  provisioned_concurrency     = lookup(var.performance_tuning, "update-client-info", local.default_performance_parameters).concurrency
+  max_provisioned_concurrency = lookup(var.performance_tuning, "update-client-info", local.default_performance_parameters).max_concurrency
+  scaling_trigger             = lookup(var.performance_tuning, "update-client-info", local.default_performance_parameters).scaling_trigger
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.client_api_release_zip.key

--- a/ci/terraform/oidc/update_profile.tf
+++ b/ci/terraform/oidc/update_profile.tf
@@ -38,8 +38,10 @@ module "update_profile" {
   root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
 
-  memory_size             = lookup(var.performance_tuning, "update-profile", local.default_performance_parameters).memory
-  provisioned_concurrency = lookup(var.performance_tuning, "update-profile", local.default_performance_parameters).concurrency
+  memory_size                 = lookup(var.performance_tuning, "update-profile", local.default_performance_parameters).memory
+  provisioned_concurrency     = lookup(var.performance_tuning, "update-profile", local.default_performance_parameters).concurrency
+  max_provisioned_concurrency = lookup(var.performance_tuning, "update-profile", local.default_performance_parameters).max_concurrency
+  scaling_trigger             = lookup(var.performance_tuning, "update-profile", local.default_performance_parameters).scaling_trigger
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.frontend_api_release_zip.key

--- a/ci/terraform/oidc/update_profile.tf
+++ b/ci/terraform/oidc/update_profile.tf
@@ -37,7 +37,9 @@ module "update_profile" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
-  memory_size      = var.endpoint_memory_size
+
+  memory_size             = lookup(var.performance_tuning, "update-profile", local.default_performance_parameters).memory
+  provisioned_concurrency = lookup(var.performance_tuning, "update-profile", local.default_performance_parameters).concurrency
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.frontend_api_release_zip.key

--- a/ci/terraform/oidc/userexists.tf
+++ b/ci/terraform/oidc/userexists.tf
@@ -37,8 +37,10 @@ module "userexists" {
   root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
 
-  memory_size             = lookup(var.performance_tuning, "user-exists", local.default_performance_parameters).memory
-  provisioned_concurrency = lookup(var.performance_tuning, "user-exists", local.default_performance_parameters).concurrency
+  memory_size                 = lookup(var.performance_tuning, "user-exists", local.default_performance_parameters).memory
+  provisioned_concurrency     = lookup(var.performance_tuning, "user-exists", local.default_performance_parameters).concurrency
+  max_provisioned_concurrency = lookup(var.performance_tuning, "user-exists", local.default_performance_parameters).max_concurrency
+  scaling_trigger             = lookup(var.performance_tuning, "user-exists", local.default_performance_parameters).scaling_trigger
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.frontend_api_release_zip.key

--- a/ci/terraform/oidc/userexists.tf
+++ b/ci/terraform/oidc/userexists.tf
@@ -36,7 +36,9 @@ module "userexists" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
-  memory_size      = var.endpoint_memory_size
+
+  memory_size             = lookup(var.performance_tuning, "user-exists", local.default_performance_parameters).memory
+  provisioned_concurrency = lookup(var.performance_tuning, "user-exists", local.default_performance_parameters).concurrency
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.frontend_api_release_zip.key

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -38,8 +38,10 @@ module "userinfo" {
   root_resource_id = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
 
-  memory_size             = lookup(var.performance_tuning, "userinfo", local.default_performance_parameters).memory
-  provisioned_concurrency = lookup(var.performance_tuning, "userinfo", local.default_performance_parameters).concurrency
+  memory_size                 = lookup(var.performance_tuning, "userinfo", local.default_performance_parameters).memory
+  provisioned_concurrency     = lookup(var.performance_tuning, "userinfo", local.default_performance_parameters).concurrency
+  max_provisioned_concurrency = lookup(var.performance_tuning, "userinfo", local.default_performance_parameters).max_concurrency
+  scaling_trigger             = lookup(var.performance_tuning, "userinfo", local.default_performance_parameters).scaling_trigger
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.oidc_api_release_zip.key

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -37,7 +37,9 @@ module "userinfo" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
-  memory_size      = var.endpoint_memory_size
+
+  memory_size             = lookup(var.performance_tuning, "userinfo", local.default_performance_parameters).memory
+  provisioned_concurrency = lookup(var.performance_tuning, "userinfo", local.default_performance_parameters).concurrency
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.oidc_api_release_zip.key

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -347,3 +347,19 @@ variable "spot_response_queue_kms_arn" {
   default     = "undefined"
   description = "The ARN for the KMS key used by the SPOT response queue"
 }
+
+variable "performance_tuning" {
+  type = map(object({
+    memory : number,
+    concurrency : number,
+  }))
+  description = "A map of performance tuning parameters per lambda"
+  default     = {}
+}
+
+locals {
+  default_performance_parameters = {
+    memory      = var.endpoint_memory_size
+    concurrency = var.keep_lambdas_warm ? 0 : 1
+  }
+}

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -352,14 +352,26 @@ variable "performance_tuning" {
   type = map(object({
     memory : number,
     concurrency : number,
+    max_concurrency : number,
+    scaling_trigger : number,
   }))
   description = "A map of performance tuning parameters per lambda"
   default     = {}
 }
 
+variable "lambda_max_concurrency" {
+  default = 5
+}
+
+variable "scaling_trigger" {
+  default = 0.7
+}
+
 locals {
   default_performance_parameters = {
-    memory      = var.endpoint_memory_size
-    concurrency = var.keep_lambdas_warm ? 0 : 1
+    memory          = var.endpoint_memory_size
+    concurrency     = var.keep_lambdas_warm ? 0 : var.lambda_min_concurrency
+    max_concurrency = var.lambda_max_concurrency
+    scaling_trigger = var.scaling_trigger
   }
 }

--- a/ci/terraform/oidc/verify_code.tf
+++ b/ci/terraform/oidc/verify_code.tf
@@ -41,7 +41,9 @@ module "verify_code" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
   root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
-  memory_size      = var.endpoint_memory_size
+
+  memory_size             = lookup(var.performance_tuning, "verify-code", local.default_performance_parameters).memory
+  provisioned_concurrency = lookup(var.performance_tuning, "verify-code", local.default_performance_parameters).concurrency
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.frontend_api_release_zip.key

--- a/ci/terraform/oidc/verify_code.tf
+++ b/ci/terraform/oidc/verify_code.tf
@@ -42,8 +42,10 @@ module "verify_code" {
   root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
 
-  memory_size             = lookup(var.performance_tuning, "verify-code", local.default_performance_parameters).memory
-  provisioned_concurrency = lookup(var.performance_tuning, "verify-code", local.default_performance_parameters).concurrency
+  memory_size                 = lookup(var.performance_tuning, "verify-code", local.default_performance_parameters).memory
+  provisioned_concurrency     = lookup(var.performance_tuning, "verify-code", local.default_performance_parameters).concurrency
+  max_provisioned_concurrency = lookup(var.performance_tuning, "verify-code", local.default_performance_parameters).max_concurrency
+  scaling_trigger             = lookup(var.performance_tuning, "verify-code", local.default_performance_parameters).scaling_trigger
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.frontend_api_release_zip.key

--- a/ci/terraform/oidc/wellknown.tf
+++ b/ci/terraform/oidc/wellknown.tf
@@ -25,8 +25,10 @@ module "openid_configuration_discovery" {
   root_resource_id = aws_api_gateway_resource.wellknown_resource.id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
 
-  memory_size             = lookup(var.performance_tuning, "openid-configuration", local.default_performance_parameters).memory
-  provisioned_concurrency = lookup(var.performance_tuning, "openid-configuration", local.default_performance_parameters).concurrency
+  memory_size                 = lookup(var.performance_tuning, "openid-configuration", local.default_performance_parameters).memory
+  provisioned_concurrency     = lookup(var.performance_tuning, "openid-configuration", local.default_performance_parameters).concurrency
+  max_provisioned_concurrency = lookup(var.performance_tuning, "openid-configuration", local.default_performance_parameters).max_concurrency
+  scaling_trigger             = lookup(var.performance_tuning, "openid-configuration", local.default_performance_parameters).scaling_trigger
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.oidc_api_release_zip.key

--- a/ci/terraform/oidc/wellknown.tf
+++ b/ci/terraform/oidc/wellknown.tf
@@ -24,7 +24,9 @@ module "openid_configuration_discovery" {
   rest_api_id      = aws_api_gateway_rest_api.di_authentication_api.id
   root_resource_id = aws_api_gateway_resource.wellknown_resource.id
   execution_arn    = aws_api_gateway_rest_api.di_authentication_api.execution_arn
-  memory_size      = var.endpoint_memory_size
+
+  memory_size             = lookup(var.performance_tuning, "openid-configuration", local.default_performance_parameters).memory
+  provisioned_concurrency = lookup(var.performance_tuning, "openid-configuration", local.default_performance_parameters).concurrency
 
   source_bucket                  = aws_s3_bucket.source_bucket.bucket
   lambda_zip_file                = aws_s3_bucket_object.oidc_api_release_zip.key


### PR DESCRIPTION
## What?

- Add ability to configure provisioned lambda concurrency for the OIDC, frontend, client registry and account management APIs
- Also allow configuration of autoscaling of the provisioned concurrency
- Enable provisioned concurrency of 1 in non-prod environments.
- Lower memory allocated to lambdas to 1024 to reduce cost of provisioned concurrency (this is a trade off, as provisioned concurrency should decrease latency and we won't need the increased CPU that comes with the larger memory allocation)
- Keep the warmers switched on prod for the time being

## Why?

We would like to move to provisioned concurrency to better manage out API latency. The warmers do a reasonable job, but provisioned concurrency is the AWS recommended method for achieving this.