### PR TITLE
AUT-330: Lambda provisioned concurrency - production

### DIFF
--- a/ci/terraform/account-management/build-overrides.tfvars
+++ b/ci/terraform/account-management/build-overrides.tfvars
@@ -1,4 +1,4 @@
-lambda_max_concurrency = 3
+lambda_max_concurrency = 0
 lambda_min_concurrency = 1
 keep_lambdas_warm      = false
 endpoint_memory_size   = 1024

--- a/ci/terraform/account-management/integration-overrides.tfvars
+++ b/ci/terraform/account-management/integration-overrides.tfvars
@@ -1,4 +1,4 @@
-lambda_max_concurrency = 3
+lambda_max_concurrency = 0
 lambda_min_concurrency = 1
 keep_lambdas_warm      = false
 endpoint_memory_size   = 1024

--- a/ci/terraform/account-management/production-overrides.tfvars
+++ b/ci/terraform/account-management/production-overrides.tfvars
@@ -9,8 +9,8 @@ notify_template_map = {
 
 cloudwatch_log_retention = 5
 
-lambda_max_concurrency = 0
-lambda_min_concurrency = 25
-keep_lambdas_warm      = true
+lambda_max_concurrency = 10
+lambda_min_concurrency = 3
+keep_lambdas_warm      = false
 endpoint_memory_size   = 4096
 scaling_trigger        = 0.6

--- a/ci/terraform/oidc/build-overrides.tfvars
+++ b/ci/terraform/oidc/build-overrides.tfvars
@@ -46,7 +46,7 @@ performance_tuning = {
     scaling_trigger = 0
   }
 }
-lambda_max_concurrency = 3
+lambda_max_concurrency = 0
 lambda_min_concurrency = 1
 keep_lambdas_warm      = false
 endpoint_memory_size   = 1024

--- a/ci/terraform/oidc/integration-overrides.tfvars
+++ b/ci/terraform/oidc/integration-overrides.tfvars
@@ -38,7 +38,7 @@ performance_tuning = {
     scaling_trigger = 0
   }
 }
-lambda_max_concurrency = 3
+lambda_max_concurrency = 0
 lambda_min_concurrency = 1
 keep_lambdas_warm      = false
 endpoint_memory_size   = 1024

--- a/ci/terraform/oidc/production-overrides.tfvars
+++ b/ci/terraform/oidc/production-overrides.tfvars
@@ -46,8 +46,8 @@ performance_tuning = {
     scaling_trigger = 0
   }
 }
-lambda_max_concurrency = 0
-lambda_min_concurrency = 50
-keep_lambdas_warm      = true
-endpoint_memory_size   = 4096
-scaling_trigger        = 0.6
+lambda_max_concurrency = 10
+lambda_min_concurrency = 5
+keep_lambdas_warm      = false
+endpoint_memory_size   = 2048
+scaling_trigger        = 0.8


### PR DESCRIPTION
## What?

- Disable auto-scaling in build and integration
- Enable provisioned concurrency and autoscaling in production. Use slightly higher numbers initially, will scale back after some monitoring.
- Decrease memory allocation to 2048 initially (further decrease may be possible)

## Why?

We want to enable to provisioned concurrency to decrease our latencies

## Related PRs

#1991