### PR TITLE
BAU: Switch off ConsentRequired in stubs

### DIFF
--- a/ci/terraform/shared/build-stub-clients.tfvars
+++ b/ci/terraform/shared/build-stub-clients.tfvars
@@ -8,6 +8,7 @@ stub_rp_clients = [
       "https://di-auth-stub-relying-party-build.london.cloudapps.digital/signed-out",
     ]
     test_client                     = "0"
+    consent_required                = "0"
     client_type                     = "web"
     identity_verification_supported = "1"
     scopes = [
@@ -25,6 +26,7 @@ stub_rp_clients = [
       "https://di-auth-stub-relying-party-build-s2.london.cloudapps.digital/signed-out",
     ]
     test_client                     = "1"
+    consent_required                = "1"
     identity_verification_supported = "1"
     client_type                     = "web"
     scopes = [
@@ -42,6 +44,7 @@ stub_rp_clients = [
       "https://di-auth-stub-relying-party-build-app.london.cloudapps.digital/signed-out",
     ]
     test_client                     = "1"
+    consent_required                = "0"
     identity_verification_supported = "1"
     client_type                     = "app"
     scopes = [

--- a/ci/terraform/shared/integration-stub-clients.tfvars
+++ b/ci/terraform/shared/integration-stub-clients.tfvars
@@ -8,6 +8,7 @@ stub_rp_clients = [
       "https://di-auth-stub-relying-party-integration.london.cloudapps.digital/signed-out",
     ]
     test_client                     = "0"
+    consent_required                = "0"
     client_type                     = "web"
     identity_verification_supported = "1"
     scopes = [

--- a/ci/terraform/shared/production-stub-clients.tfvars
+++ b/ci/terraform/shared/production-stub-clients.tfvars
@@ -8,6 +8,7 @@ stub_rp_clients = [
       "https://di-auth-stub-relying-party-production.london.cloudapps.digital/signed-out",
     ]
     test_client                     = "0"
+    consent_required                = "0"
     client_type                     = "web"
     identity_verification_supported = "1"
     scopes = [

--- a/ci/terraform/shared/staging-stub-clients.tfvars
+++ b/ci/terraform/shared/staging-stub-clients.tfvars
@@ -8,6 +8,7 @@ stub_rp_clients = [
       "https://di-auth-stub-relying-party-staging.london.cloudapps.digital/signed-out",
     ]
     test_client                     = "0"
+    consent_required                = "0"
     identity_verification_supported = "1"
     client_type                     = "web"
     scopes = [
@@ -25,6 +26,7 @@ stub_rp_clients = [
       "https://di-auth-stub-relying-party-staging-app.london.cloudapps.digital/signed-out",
     ]
     test_client                     = "1"
+    consent_required                = "0"
     identity_verification_supported = "1"
     client_type                     = "app"
     scopes = [

--- a/ci/terraform/shared/stub-rp-clients.tf
+++ b/ci/terraform/shared/stub-rp-clients.tf
@@ -78,7 +78,7 @@ resource "aws_dynamodb_table_item" "stub_rp_client" {
       N = "1"
     }
     ConsentRequired = {
-      N = "1"
+      N = var.stub_rp_clients[count.index].consent_required
     }
     IdentityVerificationSupported = {
       N = var.stub_rp_clients[count.index].identity_verification_supported


### PR DESCRIPTION

## What?

Switch off ConsentRequired in stubs.

## Why?

Consent to share is not currently in use but is switched on in some stubs.
Will be switched off in build-s2 when acceptance tests updated.

