### PR TITLE
AUT-330: Reduce production memory allocation

### DIFF
--- a/ci/terraform/account-management/production-overrides.tfvars
+++ b/ci/terraform/account-management/production-overrides.tfvars
@@ -12,5 +12,5 @@ cloudwatch_log_retention = 5
 lambda_max_concurrency = 10
 lambda_min_concurrency = 3
 keep_lambdas_warm      = false
-endpoint_memory_size   = 4096
+endpoint_memory_size   = 1024
 scaling_trigger        = 0.6

--- a/ci/terraform/oidc/production-overrides.tfvars
+++ b/ci/terraform/oidc/production-overrides.tfvars
@@ -49,5 +49,5 @@ performance_tuning = {
 lambda_max_concurrency = 10
 lambda_min_concurrency = 5
 keep_lambdas_warm      = false
-endpoint_memory_size   = 2048
+endpoint_memory_size   = 1024
 scaling_trigger        = 0.8


### PR DESCRIPTION
## What?

- Reduce memory to 1024MB for production endpoints

## Why?

To reduce provisioned concurrency costs

## Related PRs

#1995 