### PR TITLE
Aut 30/add roles to common passwords dynamodb

### DIFF
--- a/ci/terraform/account-management/dynamo-policies.tf
+++ b/ci/terraform/account-management/dynamo-policies.tf
@@ -10,6 +10,10 @@ data "aws_dynamodb_table" "client_registry_table" {
   name = "${var.environment}-client-registry"
 }
 
+data "aws_dynamodb_table" "common_passwords_table" {
+  name = "${var.environment}-common-passwords"
+}
+
 data "aws_iam_policy_document" "dynamo_user_write_policy_document" {
   statement {
     sid    = "AllowAccessToDynamoTables"
@@ -86,6 +90,22 @@ data "aws_iam_policy_document" "dynamo_client_registration_read_policy_document"
   }
 }
 
+data "aws_iam_policy_document" "dynamo_common_passwords_read_access_policy_document" {
+  statement {
+    sid    = "AllowAccessToDynamoTables"
+    effect = "Allow"
+
+    actions = [
+      "dynamodb:DescribeTable",
+      "dynamodb:Get*",
+
+    ]
+    resources = [
+      data.aws_dynamodb_table.common_passwords_table.arn,
+    ]
+  }
+}
+
 resource "aws_iam_policy" "dynamo_am_client_registry_read_access_policy" {
   name_prefix = "dynamo-account-management-client-registry-read-policy"
   path        = "/${var.environment}/am-shared/"
@@ -116,4 +136,12 @@ resource "aws_iam_policy" "dynamo_am_user_write_access_policy" {
   description = "IAM policy for managing write permissions to the Dynamo User tables"
 
   policy = data.aws_iam_policy_document.dynamo_user_write_policy_document.json
+}
+
+resource "aws_iam_policy" "dynamo_common_passwords_read_access_policy" {
+  name_prefix = "dynamo-access-policy"
+  path        = "/${var.environment}/oidc-default/"
+  description = "IAM policy for managing read permissions to the Dynamo Common Passwords table"
+
+  policy = data.aws_iam_policy_document.dynamo_common_passwords_read_access_policy_document.json
 }

--- a/ci/terraform/account-management/update-password.tf
+++ b/ci/terraform/account-management/update-password.tf
@@ -7,7 +7,8 @@ module "account_management_api_update_password_role" {
   policies_to_attach = [
     aws_iam_policy.dynamo_am_user_read_access_policy.arn,
     aws_iam_policy.dynamo_am_user_write_access_policy.arn,
-    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    aws_iam_policy.dynamo_common_passwords_read_access_policy.arn,
   ]
 }
 

--- a/ci/terraform/oidc/dynamo-policies.tf
+++ b/ci/terraform/oidc/dynamo-policies.tf
@@ -34,7 +34,7 @@ data "aws_iam_policy_document" "dynamo_user_write_policy_document" {
     ]
     resources = [
       data.aws_dynamodb_table.user_credentials_table.arn,
-      data.aws_dynamodb_table.common_passwords_table.arn,
+      data.aws_dynamodb_table.user_profile_table.arn,
       "${data.aws_dynamodb_table.user_profile_table.arn}/index/*",
       "${data.aws_dynamodb_table.user_credentials_table.arn}/index/*",
     ]

--- a/ci/terraform/oidc/dynamo-policies.tf
+++ b/ci/terraform/oidc/dynamo-policies.tf
@@ -18,6 +18,10 @@ data "aws_dynamodb_table" "doc_app_cri_credential_table" {
   name = "${var.environment}-doc-app-credential"
 }
 
+data "aws_dynamodb_table" "common_passwords_table" {
+  name = "${var.environment}-common-passwords"
+}
+
 data "aws_iam_policy_document" "dynamo_user_write_policy_document" {
   statement {
     sid    = "AllowAccessToDynamoTables"
@@ -30,7 +34,7 @@ data "aws_iam_policy_document" "dynamo_user_write_policy_document" {
     ]
     resources = [
       data.aws_dynamodb_table.user_credentials_table.arn,
-      data.aws_dynamodb_table.user_profile_table.arn,
+      data.aws_dynamodb_table.common_passwords_table.arn,
       "${data.aws_dynamodb_table.user_profile_table.arn}/index/*",
       "${data.aws_dynamodb_table.user_credentials_table.arn}/index/*",
     ]
@@ -175,6 +179,22 @@ data "aws_iam_policy_document" "dynamo_doc_app_read_access_policy_document" {
   }
 }
 
+data "aws_iam_policy_document" "dynamo_common_passwords_read_access_policy_document" {
+  statement {
+    sid    = "AllowAccessToDynamoTables"
+    effect = "Allow"
+
+    actions = [
+      "dynamodb:DescribeTable",
+      "dynamodb:Get*",
+
+    ]
+    resources = [
+      data.aws_dynamodb_table.common_passwords_table.arn,
+    ]
+  }
+}
+
 resource "aws_iam_policy" "dynamo_client_registry_write_access_policy" {
   name_prefix = "dynamo-client-registry-write-policy"
   path        = "/${var.environment}/oidc-default/"
@@ -245,4 +265,12 @@ resource "aws_iam_policy" "dynamo_doc_app_read_access_policy" {
   description = "IAM policy for managing read permissions to the Dynamo Doc App CRI credential table"
 
   policy = data.aws_iam_policy_document.dynamo_doc_app_read_access_policy_document.json
+}
+
+resource "aws_iam_policy" "dynamo_common_passwords_read_access_policy" {
+  name_prefix = "dynamo-access-policy"
+  path        = "/${var.environment}/oidc-default/"
+  description = "IAM policy for managing read permissions to the Dynamo Common Passwords table"
+
+  policy = data.aws_iam_policy_document.dynamo_common_passwords_read_access_policy_document.json
 }

--- a/ci/terraform/oidc/reset_password.tf
+++ b/ci/terraform/oidc/reset_password.tf
@@ -10,7 +10,8 @@ module "frontend_api_reset_password_role" {
     aws_iam_policy.dynamo_user_write_access_policy.arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
-    aws_iam_policy.redis_parameter_policy.arn
+    aws_iam_policy.redis_parameter_policy.arn,
+    aws_iam_policy.dynamo_common_passwords_read_access_policy.arn,
   ]
 }
 

--- a/ci/terraform/oidc/signup.tf
+++ b/ci/terraform/oidc/signup.tf
@@ -11,6 +11,7 @@ module "frontend_api_signup_role" {
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
+    aws_iam_policy.dynamo_common_passwords_read_access_policy.arn,
   ]
 }
 


### PR DESCRIPTION
## What?

Add read permissions for new common passwords Dynamo table for three lambdas, which will use this to validate whether or not passwords is a common password and produce an error accordingly.

## Why?

So that password validation can consider common words

## Related PRs

https://github.com/alphagov/di-authentication-api/pull/1990 