### PR TITLE
BAU: Measure sent SMS by country code

### DIFF
--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
@@ -135,6 +135,7 @@ class SendNotificationHandlerTest {
         when(configurationService.getBlockedEmailDuration()).thenReturn(BLOCKED_EMAIL_DURATION);
         when(codeGeneratorService.sixDigitCode()).thenReturn(TEST_SIX_DIGIT_CODE);
         when(configurationService.getCodeMaxRetries()).thenReturn(5);
+        when(configurationService.getEnvironment()).thenReturn("unit-test");
         when(clientService.getClient(CLIENT_ID)).thenReturn(Optional.of(clientRegistry));
         when(clientService.getClient(TEST_CLIENT_ID)).thenReturn(Optional.of(testClientRegistry));
         when(clientSessionService.getClientSessionFromRequestHeaders(anyMap()))

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/PhoneNumberHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/PhoneNumberHelper.java
@@ -20,6 +20,16 @@ public class PhoneNumberHelper {
         }
     }
 
+    public static String getCountry(String phoneNumber) {
+        try {
+            return Integer.toString(
+                    PhoneNumberUtil.getInstance().parse(phoneNumber, "GB").getCountryCode());
+        } catch (NumberParseException e) {
+            LOG.warn("Error when trying to parse phone number");
+            throw new RuntimeException(e);
+        }
+    }
+
     public static String removeWhitespaceFromPhoneNumber(String phoneNumber) {
         return phoneNumber.replaceAll("\\s+", "");
     }


### PR DESCRIPTION
This publishes a metric `SendingSms` broken down by environment and country code, so we can compare "sent SMS" to successfully registered accounts.
