### PR TITLE
AUT-330: Scale back provisioned concurrency in prod

### DIFF
--- a/ci/terraform/account-management/production-overrides.tfvars
+++ b/ci/terraform/account-management/production-overrides.tfvars
@@ -9,8 +9,17 @@ notify_template_map = {
 
 cloudwatch_log_retention = 5
 
+performance_tuning = {
+  authorizer = {
+    memory          = 1024
+    concurrency     = 3
+    max_concurrency = 10
+    scaling_trigger = 0.6
+  }
+}
+
 lambda_max_concurrency = 10
-lambda_min_concurrency = 3
+lambda_min_concurrency = 1
 keep_lambdas_warm      = false
 endpoint_memory_size   = 1024
-scaling_trigger        = 0.6
+scaling_trigger        = 0.8

--- a/ci/terraform/oidc/production-overrides.tfvars
+++ b/ci/terraform/oidc/production-overrides.tfvars
@@ -45,9 +45,30 @@ performance_tuning = {
     max_concurrency = 0
     scaling_trigger = 0
   }
+
+  start = {
+    memory          = 1024
+    concurrency     = 3
+    max_concurrency = 10
+    scaling_trigger = 0.6
+  }
+
+  reset-password = {
+    memory          = 1024
+    concurrency     = 1
+    max_concurrency = 10
+    scaling_trigger = 0.8
+  }
+
+  reset-password-request = {
+    memory          = 1024
+    concurrency     = 1
+    max_concurrency = 10
+    scaling_trigger = 0.8
+  }
 }
 lambda_max_concurrency = 10
-lambda_min_concurrency = 5
+lambda_min_concurrency = 2
 keep_lambdas_warm      = false
 endpoint_memory_size   = 1024
 scaling_trigger        = 0.8


### PR DESCRIPTION
## What?

- Scale back to minimum concurrency of 2 for all OIDC & frontend lambdas
- Add an override for start to have minimum concurrency of 3 as, according to metrics, this is the busiest lambda and sometime peaks above concurrent executions of 2.
- Add overrides for the reset password lambdas to further scale back to a minimum of 1 as they have not gone above a concurrency execution of 1
- Scale back all of account management API to min concurrency of 1, this a very quiet API, except the authorizer
- Override the authorizer to have min concurrency of 3

## Why?

Please include reason for the change and any other relevant context.

## Related PRs

#1995
#1998 