### PR TITLE
AUT-430: Store alternative mfa in the database

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoServiceIntegrationTest.java
@@ -116,7 +116,7 @@ class DynamoServiceIntegrationTest {
         setUpDynamo();
 
         dynamoService.updateMFAMethod(
-                TEST_EMAIL, MFAMethodType.AUTH_APP, true, TEST_MFA_APP_CREDENTIAL);
+                TEST_EMAIL, MFAMethodType.AUTH_APP, false, true, TEST_MFA_APP_CREDENTIAL);
         UserProfile userProfile =
                 dynamoService.getUserProfileByEmailMaybe(TEST_EMAIL).orElseThrow();
 
@@ -137,13 +137,14 @@ class DynamoServiceIntegrationTest {
     void shouldAddAuthAppMFAMethod() {
         setUpDynamo();
         dynamoService.updateMFAMethod(
-                TEST_EMAIL, MFAMethodType.AUTH_APP, true, TEST_MFA_APP_CREDENTIAL);
+                TEST_EMAIL, MFAMethodType.AUTH_APP, true, true, TEST_MFA_APP_CREDENTIAL);
         UserCredentials updatedUserCredentials =
                 dynamoService.getUserCredentialsFromEmail(TEST_EMAIL);
 
         assertThat(updatedUserCredentials.getMfaMethods().size(), equalTo(1));
         MFAMethod mfaMethod = updatedUserCredentials.getMfaMethods().get(0);
         assertThat(mfaMethod.getMfaMethodType(), equalTo(MFAMethodType.AUTH_APP.getValue()));
+        assertThat(mfaMethod.isMethodVerified(), equalTo(true));
         assertThat(mfaMethod.isEnabled(), equalTo(true));
         assertThat(mfaMethod.getCredentialValue(), equalTo(TEST_MFA_APP_CREDENTIAL));
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/MFAMethod.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/MFAMethod.java
@@ -1,0 +1,104 @@
+package uk.gov.di.authentication.shared.entity;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBAttribute;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBDocument;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+
+import java.util.Map;
+import java.util.Objects;
+
+@DynamoDBDocument
+public class MFAMethod {
+
+    public static final String ATTRIBUTE_MFA_METHOD_TYPE = "MfaMethodType";
+    public static final String ATTRIBUTE_CREDENTIAL_VALUE = "CredentialValue";
+    public static final String ATTRIBUTE_ENABLED = "Enabled";
+    public static final String ATTRIBUTE_UPDATED = "Updated";
+
+    private String mfaMethodType;
+    private String credentialValue;
+    private boolean enabled;
+    private String updated;
+
+    public MFAMethod() {}
+
+    public MFAMethod(
+            String mfaMethodType, String credentialValue, boolean enabled, String updated) {
+        this.mfaMethodType = mfaMethodType;
+        this.credentialValue = credentialValue;
+        this.enabled = enabled;
+        this.updated = updated;
+    }
+
+    @DynamoDBAttribute(attributeName = ATTRIBUTE_MFA_METHOD_TYPE)
+    public String getMfaMethodType() {
+        return mfaMethodType;
+    }
+
+    public MFAMethod setMfaMethodType(String mfaMethodType) {
+        this.mfaMethodType = mfaMethodType;
+        return this;
+    }
+
+    @DynamoDBAttribute(attributeName = ATTRIBUTE_CREDENTIAL_VALUE)
+    public String getCredentialValue() {
+        return credentialValue;
+    }
+
+    public MFAMethod setCredentialValue(String credentialValue) {
+        this.credentialValue = credentialValue;
+        return this;
+    }
+
+    @DynamoDBAttribute(attributeName = ATTRIBUTE_ENABLED)
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public MFAMethod setEnabled(boolean enabled) {
+        this.enabled = enabled;
+        return this;
+    }
+
+    @DynamoDBAttribute(attributeName = ATTRIBUTE_UPDATED)
+    public String getUpdated() {
+        return updated;
+    }
+
+    public MFAMethod setUpdated(String updated) {
+        this.updated = updated;
+        return this;
+    }
+
+    AttributeValue toAttributeValue() {
+        return new AttributeValue()
+                .withM(
+                        Map.ofEntries(
+                                Map.entry(
+                                        ATTRIBUTE_MFA_METHOD_TYPE,
+                                        new AttributeValue(getMfaMethodType())),
+                                Map.entry(
+                                        ATTRIBUTE_CREDENTIAL_VALUE,
+                                        new AttributeValue(getCredentialValue())),
+                                Map.entry(
+                                        ATTRIBUTE_ENABLED,
+                                        new AttributeValue().withN(isEnabled() ? "1" : "0")),
+                                Map.entry(ATTRIBUTE_UPDATED, new AttributeValue(getUpdated()))));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        MFAMethod that = (MFAMethod) o;
+        return Objects.equals(mfaMethodType, that.mfaMethodType)
+                && Objects.equals(credentialValue, that.credentialValue)
+                && Objects.equals(enabled, that.enabled)
+                && Objects.equals(updated, that.updated);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(mfaMethodType, credentialValue, enabled, updated);
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/MFAMethod.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/MFAMethod.java
@@ -13,19 +13,26 @@ public class MFAMethod {
     public static final String ATTRIBUTE_MFA_METHOD_TYPE = "MfaMethodType";
     public static final String ATTRIBUTE_CREDENTIAL_VALUE = "CredentialValue";
     public static final String ATTRIBUTE_ENABLED = "Enabled";
+    public static final String ATTRIBUTE_METHOD_VERIFIED = "MethodVerified";
     public static final String ATTRIBUTE_UPDATED = "Updated";
 
     private String mfaMethodType;
     private String credentialValue;
+    private boolean methodVerified;
     private boolean enabled;
     private String updated;
 
     public MFAMethod() {}
 
     public MFAMethod(
-            String mfaMethodType, String credentialValue, boolean enabled, String updated) {
+            String mfaMethodType,
+            String credentialValue,
+            boolean methodVerified,
+            boolean enabled,
+            String updated) {
         this.mfaMethodType = mfaMethodType;
         this.credentialValue = credentialValue;
+        this.methodVerified = methodVerified;
         this.enabled = enabled;
         this.updated = updated;
     }
@@ -47,6 +54,16 @@ public class MFAMethod {
 
     public MFAMethod setCredentialValue(String credentialValue) {
         this.credentialValue = credentialValue;
+        return this;
+    }
+
+    @DynamoDBAttribute(attributeName = ATTRIBUTE_METHOD_VERIFIED)
+    public boolean isMethodVerified() {
+        return methodVerified;
+    }
+
+    public MFAMethod setMethodVerified(boolean methodVerified) {
+        this.methodVerified = methodVerified;
         return this;
     }
 
@@ -81,6 +98,9 @@ public class MFAMethod {
                                         ATTRIBUTE_CREDENTIAL_VALUE,
                                         new AttributeValue(getCredentialValue())),
                                 Map.entry(
+                                        ATTRIBUTE_METHOD_VERIFIED,
+                                        new AttributeValue().withN(isMethodVerified() ? "1" : "0")),
+                                Map.entry(
                                         ATTRIBUTE_ENABLED,
                                         new AttributeValue().withN(isEnabled() ? "1" : "0")),
                                 Map.entry(ATTRIBUTE_UPDATED, new AttributeValue(getUpdated()))));
@@ -93,12 +113,13 @@ public class MFAMethod {
         MFAMethod that = (MFAMethod) o;
         return Objects.equals(mfaMethodType, that.mfaMethodType)
                 && Objects.equals(credentialValue, that.credentialValue)
+                && Objects.equals(methodVerified, that.methodVerified)
                 && Objects.equals(enabled, that.enabled)
                 && Objects.equals(updated, that.updated);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(mfaMethodType, credentialValue, enabled, updated);
+        return Objects.hash(mfaMethodType, credentialValue, methodVerified, enabled, updated);
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/MFAMethodType.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/MFAMethodType.java
@@ -1,0 +1,15 @@
+package uk.gov.di.authentication.shared.entity;
+
+public enum MFAMethodType {
+    AUTH_APP("AUTH_APP");
+
+    private String value;
+
+    MFAMethodType(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/NowHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/NowHelper.java
@@ -9,9 +9,6 @@ public class NowHelper {
 
     private static final NowClock clock = new NowClock(Clock.systemUTC());
 
-    private static final SimpleDateFormat timestampFormat =
-            new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSSSS");
-
     public static Date now() {
         return clock.now();
     }
@@ -25,7 +22,7 @@ public class NowHelper {
     }
 
     public static String toTimestampString(Date date) {
-        return timestampFormat.format(date);
+        return new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSSSS").format(date);
     }
 
     public static class NowClock {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/NowHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/NowHelper.java
@@ -1,5 +1,6 @@
 package uk.gov.di.authentication.shared.helpers;
 
+import java.text.SimpleDateFormat;
 import java.time.Clock;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
@@ -7,6 +8,9 @@ import java.util.Date;
 public class NowHelper {
 
     private static final NowClock clock = new NowClock(Clock.systemUTC());
+
+    private static final SimpleDateFormat timestampFormat =
+            new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSSSS");
 
     public static Date now() {
         return clock.now();
@@ -18,6 +22,10 @@ public class NowHelper {
 
     public static Date nowMinus(long amount, ChronoUnit unit) {
         return clock.nowMinus(amount, unit);
+    }
+
+    public static String toTimestampString(Date date) {
+        return timestampFormat.format(date);
     }
 
     public static class NowClock {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthenticationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthenticationService.java
@@ -2,6 +2,7 @@ package uk.gov.di.authentication.shared.services;
 
 import com.nimbusds.oauth2.sdk.id.Subject;
 import uk.gov.di.authentication.shared.entity.ClientConsent;
+import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.TermsAndConditions;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
@@ -65,4 +66,7 @@ public interface AuthenticationService {
     void bulkAdd(List<UserCredentials> userCredentialsList, List<UserProfile> userProfileList);
 
     byte[] getOrGenerateSalt(UserProfile userProfile);
+
+    public void updateMFAMethod(
+            String email, MFAMethodType mfaMethodType, boolean enabled, String credentialValue);
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthenticationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthenticationService.java
@@ -68,5 +68,9 @@ public interface AuthenticationService {
     byte[] getOrGenerateSalt(UserProfile userProfile);
 
     public void updateMFAMethod(
-            String email, MFAMethodType mfaMethodType, boolean enabled, String credentialValue);
+            String email,
+            MFAMethodType mfaMethodType,
+            boolean methodVerified,
+            boolean enabled,
+            String credentialValue);
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
@@ -13,6 +13,8 @@ import com.nimbusds.oauth2.sdk.id.Subject;
 import uk.gov.di.authentication.shared.dynamodb.DynamoClientHelper;
 import uk.gov.di.authentication.shared.dynamodb.DynamoDBSchemaHelper;
 import uk.gov.di.authentication.shared.entity.ClientConsent;
+import uk.gov.di.authentication.shared.entity.MFAMethod;
+import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.TermsAndConditions;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
@@ -294,6 +296,19 @@ public class DynamoService implements AuthenticationService {
                 userProfileMapper
                         .load(UserProfile.class, email.toLowerCase(Locale.ROOT))
                         .getPhoneNumber());
+    }
+
+    @Override
+    public void updateMFAMethod(
+            String email, MFAMethodType mfaMethodType, boolean enabled, String credentialValue) {
+        String dateTime = LocalDateTime.now().toString();
+        MFAMethod mfaMethod =
+                new MFAMethod(
+                        MFAMethodType.AUTH_APP.getValue(), credentialValue, enabled, dateTime);
+        userCredentialsMapper.save(
+                userCredentialsMapper
+                        .load(UserCredentials.class, email.toLowerCase(Locale.ROOT))
+                        .setMfaMethod(mfaMethod));
     }
 
     @Override

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
@@ -20,6 +20,7 @@ import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.Argon2EncoderHelper;
 import uk.gov.di.authentication.shared.helpers.Argon2MatcherHelper;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.helpers.PhoneNumberHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 
@@ -301,7 +302,7 @@ public class DynamoService implements AuthenticationService {
     @Override
     public void updateMFAMethod(
             String email, MFAMethodType mfaMethodType, boolean enabled, String credentialValue) {
-        String dateTime = LocalDateTime.now().toString();
+        String dateTime = NowHelper.toTimestampString(NowHelper.now());
         MFAMethod mfaMethod =
                 new MFAMethod(
                         MFAMethodType.AUTH_APP.getValue(), credentialValue, enabled, dateTime);

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
@@ -301,11 +301,19 @@ public class DynamoService implements AuthenticationService {
 
     @Override
     public void updateMFAMethod(
-            String email, MFAMethodType mfaMethodType, boolean enabled, String credentialValue) {
+            String email,
+            MFAMethodType mfaMethodType,
+            boolean methodVerified,
+            boolean enabled,
+            String credentialValue) {
         String dateTime = NowHelper.toTimestampString(NowHelper.now());
         MFAMethod mfaMethod =
                 new MFAMethod(
-                        MFAMethodType.AUTH_APP.getValue(), credentialValue, enabled, dateTime);
+                        MFAMethodType.AUTH_APP.getValue(),
+                        credentialValue,
+                        methodVerified,
+                        enabled,
+                        dateTime);
         userCredentialsMapper.save(
                 userCredentialsMapper
                         .load(UserCredentials.class, email.toLowerCase(Locale.ROOT))


### PR DESCRIPTION
## What?

Store alternative mfa in the database.

- Draft data model for storing a list of mfa methods in the database.

## Why?

We will need to store a secret key for a registered authentication app in order to validate OTP.

