### PR TITLE
BAU - Generate TTL in seconds instead of milliseconds

### DIFF
--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/services/DynamoDocAppService.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/services/DynamoDocAppService.java
@@ -34,7 +34,9 @@ public class DynamoDocAppService {
                         .setSubjectID(subjectID)
                         .setCredential(credential)
                         .setTimeToExist(
-                                NowHelper.nowPlus(timeToExist, ChronoUnit.SECONDS).getTime());
+                                NowHelper.nowPlus(timeToExist, ChronoUnit.SECONDS)
+                                        .toInstant()
+                                        .getEpochSecond());
 
         docAppCredentialMapper.save(docAppCredential);
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoIdentityService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoIdentityService.java
@@ -39,13 +39,17 @@ public class DynamoIdentityService {
                             .setSubjectID(subjectID)
                             .setCoreIdentityJWT(coreIdentityJWT)
                             .setTimeToExist(
-                                    NowHelper.nowPlus(timeToExist, ChronoUnit.SECONDS).getTime()));
+                                    NowHelper.nowPlus(timeToExist, ChronoUnit.SECONDS)
+                                            .toInstant()
+                                            .getEpochSecond()));
         } else {
             identityCredentialsMapper.save(
                     identityCredentials
                             .setCoreIdentityJWT(coreIdentityJWT)
                             .setTimeToExist(
-                                    NowHelper.nowPlus(timeToExist, ChronoUnit.SECONDS).getTime()));
+                                    NowHelper.nowPlus(timeToExist, ChronoUnit.SECONDS)
+                                            .toInstant()
+                                            .getEpochSecond()));
         }
     }
 
@@ -68,7 +72,9 @@ public class DynamoIdentityService {
                         .setSubjectID(subjectID)
                         .setAdditionalClaims(additionalClaims)
                         .setTimeToExist(
-                                NowHelper.nowPlus(timeToExist, ChronoUnit.SECONDS).getTime());
+                                NowHelper.nowPlus(timeToExist, ChronoUnit.SECONDS)
+                                        .toInstant()
+                                        .getEpochSecond());
 
         identityCredentialsMapper.save(identityCredentials);
     }


### PR DESCRIPTION


## What?
- Generate TTL in seconds instead of milliseconds

## Why?

- Dynamo expects this to be in seconds otherwise it thinks the TTL is something like `18 March 54410 12:06:32 GMT`