### PR TITLE
AUT-452 - Only read records from the Identity Credentials table where the TTL has not expired

### DIFF
--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/services/DynamoDocAppService.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/services/DynamoDocAppService.java
@@ -42,7 +42,8 @@ public class DynamoDocAppService {
     }
 
     public Optional<DocAppCredential> getDocAppCredential(String subjectID) {
-        return Optional.ofNullable(docAppCredentialMapper.load(DocAppCredential.class, subjectID));
+        return Optional.ofNullable(docAppCredentialMapper.load(DocAppCredential.class, subjectID))
+                .filter(t -> t.getTimeToExist() > NowHelper.now().toInstant().getEpochSecond());
     }
 
     public void deleteDocAppCredential(String subjectID) {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppCallbackHandlerIntegrationTest.java
@@ -80,7 +80,7 @@ class DocAppCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
 
     @RegisterExtension
     protected static final DocumentAppCredentialStoreExtension credentialExtension =
-            new DocumentAppCredentialStoreExtension();
+            new DocumentAppCredentialStoreExtension(180);
 
     protected final ConfigurationService configurationService =
             new DocAppCallbackHandlerIntegrationTest.TestConfigurationService(

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
@@ -121,7 +121,7 @@ public abstract class HandlerIntegrationTest<Q, S> {
 
     @RegisterExtension
     protected static final DocumentAppCredentialStoreExtension documentAppCredentialStore =
-            new DocumentAppCredentialStoreExtension();
+            new DocumentAppCredentialStoreExtension(180);
 
     @RegisterExtension
     protected static final CommonPasswordsExtension commonPasswords =

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
@@ -117,7 +117,7 @@ public abstract class HandlerIntegrationTest<Q, S> {
     protected static final ClientStoreExtension clientStore = new ClientStoreExtension();
 
     @RegisterExtension
-    protected static final IdentityStoreExtension identityStore = new IdentityStoreExtension();
+    protected static final IdentityStoreExtension identityStore = new IdentityStoreExtension(180);
 
     @RegisterExtension
     protected static final DocumentAppCredentialStoreExtension documentAppCredentialStore =

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/DocumentAppCredentialStoreExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/DocumentAppCredentialStoreExtension.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import uk.gov.di.authentication.app.entity.DocAppCredential;
 import uk.gov.di.authentication.app.services.DynamoDocAppService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.sharedtest.basetest.DynamoTestConfiguration;
 
 import java.util.Optional;
@@ -22,18 +23,23 @@ public class DocumentAppCredentialStoreExtension extends DynamoExtension
     public static final String SUBJECT_ID_FIELD = "SubjectID";
 
     private DynamoDocAppService dynamoDocAppService;
+    private final ConfigurationService configuration;
+
+    public DocumentAppCredentialStoreExtension(long ttl) {
+        createInstance();
+        this.configuration =
+                new DynamoTestConfiguration(REGION, ENVIRONMENT, DYNAMO_ENDPOINT) {
+                    @Override
+                    public long getAccessTokenExpiry() {
+                        return ttl;
+                    }
+                };
+        dynamoDocAppService = new DynamoDocAppService(configuration);
+    }
 
     @Override
     public void beforeAll(ExtensionContext context) throws Exception {
         super.beforeAll(context);
-
-        var configuration =
-                new DynamoTestConfiguration(REGION, ENVIRONMENT, DYNAMO_ENDPOINT) {
-                    @Override
-                    public long getAccessTokenExpiry() {
-                        return 180;
-                    }
-                };
 
         dynamoDocAppService = new DynamoDocAppService(configuration);
     }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/DynamoExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/DynamoExtension.java
@@ -33,6 +33,16 @@ public abstract class DynamoExtension extends BaseAwsResourceExtension
         createTables();
     }
 
+    protected void createInstance() {
+        dynamoDB =
+                AmazonDynamoDBClientBuilder.standard()
+                        .withEndpointConfiguration(
+                                new AwsClientBuilder.EndpointConfiguration(DYNAMO_ENDPOINT, REGION))
+                        .build();
+
+        createTables();
+    }
+
     protected abstract void createTables();
 
     protected boolean tableExists(String tableName) {

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/IdentityStoreExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/IdentityStoreExtension.java
@@ -27,14 +27,13 @@ public class IdentityStoreExtension extends DynamoExtension implements AfterEach
 
     public IdentityStoreExtension(long ttl) {
         createInstance();
-        var configuration =
+        this.configuration =
                 new DynamoTestConfiguration(REGION, ENVIRONMENT, DYNAMO_ENDPOINT) {
                     @Override
                     public long getAccessTokenExpiry() {
                         return ttl;
                     }
                 };
-        this.configuration = configuration;
         dynamoService = new DynamoIdentityService(configuration);
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoIdentityService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoIdentityService.java
@@ -55,7 +55,8 @@ public class DynamoIdentityService {
 
     public Optional<IdentityCredentials> getIdentityCredentials(String subjectID) {
         return Optional.ofNullable(
-                identityCredentialsMapper.load(IdentityCredentials.class, subjectID));
+                        identityCredentialsMapper.load(IdentityCredentials.class, subjectID))
+                .filter(t -> t.getTimeToExist() > NowHelper.now().toInstant().getEpochSecond());
     }
 
     public void deleteIdentityCredentials(String subjectID) {


### PR DESCRIPTION
## What?

- Only read records from the Identity Credentials table where the TTL has not expired by filtering out the entry if it has expired. 
- Add more integration tests to ensure that this works. This has meant adding a constructor to the IdentityStoreExtension, so we can overwrite the TTL of the table as required.

## Why?

- We have a TTL attribute on the Identity Credentials table. At some point after the TTL has expired, the record will be deleted from Dynamo. This does not happen straight away and consequently we can still read the records until they are deleted.
- As per the Dynamo Docs `Items that have expired, but haven’t yet been deleted by TTL, still appear in reads, queries, and scans. If you do not want expired items in the result set, you must filter them out.`
