### PR TITLE
AUT-435: Optionally hash sensitive data with TXMA hash secret

### DIFF
--- a/audit-processors/build.gradle
+++ b/audit-processors/build.gradle
@@ -17,7 +17,8 @@ dependencies {
             configurations.ssm,
             configurations.sns,
             configurations.s3,
-            configurations.dynamodb
+            configurations.secretsmanager
+    configurations.dynamodb
 
     implementation "com.google.protobuf:protobuf-java:${dependencyVersions.protobuf_version}",
             "com.google.protobuf:protobuf-java-util:${dependencyVersions.protobuf_version}",

--- a/audit-processors/build.gradle
+++ b/audit-processors/build.gradle
@@ -33,7 +33,8 @@ dependencies {
             project(":shared-test"),
             configurations.lambda,
             configurations.sqs,
-            configurations.dynamodb
+            configurations.dynamodb,
+            configurations.secretsmanager
 
     testRuntimeOnly configurations.test_runtime
 }

--- a/audit-processors/src/main/java/uk/gov/di/authentication/audit/configuration/TXMAConfiguration.java
+++ b/audit-processors/src/main/java/uk/gov/di/authentication/audit/configuration/TXMAConfiguration.java
@@ -1,0 +1,64 @@
+package uk.gov.di.authentication.audit.configuration;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.model.DecryptionFailureException;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
+import software.amazon.awssdk.services.secretsmanager.model.InternalServiceErrorException;
+import software.amazon.awssdk.services.secretsmanager.model.InvalidParameterException;
+import software.amazon.awssdk.services.secretsmanager.model.InvalidRequestException;
+import software.amazon.awssdk.services.secretsmanager.model.ResourceNotFoundException;
+
+import java.util.Optional;
+
+import static java.util.Objects.isNull;
+
+public class TXMAConfiguration {
+
+    private static final Logger LOG = LogManager.getLogger(TXMAConfiguration.class);
+
+    private final SecretsManagerClient secretsManagerClient;
+
+    private Optional<String> cachedObfuscationHMACSecret;
+
+    public TXMAConfiguration() {
+        this.secretsManagerClient = SecretsManagerClient.builder().build();
+    }
+
+    public TXMAConfiguration(SecretsManagerClient secretsManagerClient) {
+        this.secretsManagerClient = secretsManagerClient;
+    }
+
+    public Optional<String> getObfuscationHMACSecretArn() {
+        return Optional.ofNullable(System.getenv().get("TXMA_OBFUSCATION_SECRET_ARN"));
+    }
+
+    public Optional<String> getObfuscationHMACSecret() {
+        if (isNull(cachedObfuscationHMACSecret)) {
+            cachedObfuscationHMACSecret =
+                    getObfuscationHMACSecretArn()
+                            .map(
+                                    secretArn -> {
+                                        GetSecretValueRequest getSecretValueRequest =
+                                                GetSecretValueRequest.builder()
+                                                        .secretId(secretArn)
+                                                        .build();
+                                        try {
+                                            var getSecretValueResponse =
+                                                    secretsManagerClient.getSecretValue(
+                                                            getSecretValueRequest);
+                                            return getSecretValueResponse.secretString();
+                                        } catch (DecryptionFailureException
+                                                | InternalServiceErrorException
+                                                | InvalidParameterException
+                                                | InvalidRequestException
+                                                | ResourceNotFoundException e) {
+                                            LOG.error("Could not get secret from TXMA", e);
+                                            return null;
+                                        }
+                                    });
+        }
+        return cachedObfuscationHMACSecret;
+    }
+}

--- a/audit-processors/src/test/java/uk/gov/di/authentication/audit/configuration/TXMAConfigurationTest.java
+++ b/audit-processors/src/test/java/uk/gov/di/authentication/audit/configuration/TXMAConfigurationTest.java
@@ -1,0 +1,70 @@
+package uk.gov.di.authentication.audit.configuration;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
+import software.amazon.awssdk.services.secretsmanager.model.ResourceNotFoundException;
+
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TXMAConfigurationTest {
+
+    private final SecretsManagerClient secretsManagerClient = mock(SecretsManagerClient.class);
+    private TXMAConfiguration txmaConfiguration = new TXMAConfiguration(secretsManagerClient);
+
+    @Test
+    void returnsHmacSecretWhenArnProvidedAndSubsequentRequestShouldNotCallSecretsManager() {
+        var config = spy(txmaConfiguration);
+        var result = GetSecretValueResponse.builder().secretString("a-valid-hmac-key").build();
+        doReturn(Optional.of("a-valid-arn")).when(config).getObfuscationHMACSecretArn();
+        when(secretsManagerClient.getSecretValue(any(GetSecretValueRequest.class)))
+                .thenReturn(result);
+
+        var hmac = config.getObfuscationHMACSecret();
+
+        assertThat(hmac.get(), equalTo("a-valid-hmac-key"));
+        verify(secretsManagerClient, times(1)).getSecretValue(any(GetSecretValueRequest.class));
+
+        hmac = config.getObfuscationHMACSecret();
+
+        assertThat(hmac.get(), equalTo("a-valid-hmac-key"));
+        verify(secretsManagerClient, times(1)).getSecretValue(any(GetSecretValueRequest.class));
+    }
+
+    @Test
+    void returnsEmptySecretWhenNoArnProvided() {
+        var config = spy(txmaConfiguration);
+        var result = GetSecretValueResponse.builder().secretString("a-valid-hmac-key").build();
+        doReturn(Optional.empty()).when(config).getObfuscationHMACSecretArn();
+        when(secretsManagerClient.getSecretValue(any(GetSecretValueRequest.class)))
+                .thenReturn(result);
+
+        var hmac = config.getObfuscationHMACSecret();
+
+        assertThat(hmac, equalTo(Optional.empty()));
+    }
+
+    @Test
+    void returnsEmptySecretWhenExceptionOccurs() {
+        var config = spy(txmaConfiguration);
+        var result = GetSecretValueResponse.builder().secretString("a-valid-hmac-key").build();
+        doReturn(Optional.of("a-valid-arn")).when(config).getObfuscationHMACSecretArn();
+        when(secretsManagerClient.getSecretValue(any(GetSecretValueRequest.class)))
+                .thenThrow(ResourceNotFoundException.class);
+
+        var hmac = config.getObfuscationHMACSecret();
+
+        assertThat(hmac, equalTo(Optional.empty()));
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,7 @@ subprojects {
         libphonenumber
         logging_runtime
         nimbus
+        secretsmanager
         s3
         sns
         sqs
@@ -127,6 +128,8 @@ subprojects {
 
         nimbus "com.nimbusds:oauth2-oidc-sdk:${dependencyVersions.nimbusds_oauth_version}",
                 "com.nimbusds:nimbus-jose-jwt:${dependencyVersions.nimbusds_jwt_version}"
+
+        secretsmanager "software.amazon.awssdk:secretsmanager:${dependencyVersions.aws_sdk_v2_version}"
 
         sns "com.amazonaws:aws-java-sdk-sns:${dependencyVersions.aws_sdk_version}"
 


### PR DESCRIPTION
## What?

- Add version 2 of the AWS secrets manager SDK to the audit processors module
- Add a new class used to retrieve configuration specific for the audit processors.
- Amend the `CounterFraudAuditLambda` to optionally hash sensitive attributes using the TXMA key if provided.
- The optional properties should have a different name

## Why?

We are migrating to a new key, provided by the TXMA team. We'll do this in two steps, first dual running of keys (which this PR enables) followed by switch over. The dual running is done by hashing with the new key into new fields in the message, just to give us some confidence that its working as anticipated.

This PR should not result in any functional change, yet, as the required infrastructure configuration is not included. This will follow in another PR.

## Related PRs

https://github.com/alphagov/di-authentication-api/pull/2027
https://github.com/alphagov/di-infrastructure/pull/275