### PR TITLE
AUT-435: Inject TXMA Hash Secret ARN into Counter Fraud lambda

### DIFF
--- a/audit-processors/src/main/java/uk/gov/di/authentication/audit/configuration/TXMAConfiguration.java
+++ b/audit-processors/src/main/java/uk/gov/di/authentication/audit/configuration/TXMAConfiguration.java
@@ -31,7 +31,11 @@ public class TXMAConfiguration {
     }
 
     public Optional<String> getObfuscationHMACSecretArn() {
-        return Optional.ofNullable(System.getenv().get("TXMA_OBFUSCATION_SECRET_ARN"));
+        var arn = System.getenv().get("TXMA_OBFUSCATION_SECRET_ARN");
+        if (isNull(arn) || arn.isBlank()) {
+            return Optional.empty();
+        }
+        return Optional.of(arn);
     }
 
     public Optional<String> getObfuscationHMACSecret() {

--- a/ci/tasks/deploy-audit-processors.yml
+++ b/ci/tasks/deploy-audit-processors.yml
@@ -11,6 +11,7 @@ params:
   DEPLOY_ENVIRONMENT: build
   STATE_BUCKET: digital-identity-dev-tfstate
   AUDIT_STORE_EXPIRY_DAYS: 7
+  TXMA_OBFUSCATION_SECRET_ARN: ""
 inputs:
   - name: shared-terraform-outputs
   - name: api-terraform-src
@@ -38,6 +39,7 @@ run:
         -var 'logging_endpoint_arn=arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod' \
         -var 'logging_endpoint_arns=["arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"]' \
         -var "audit_storage_expiry_days=${AUDIT_STORE_EXPIRY_DAYS}" \
+        -var "txma_obfuscation_secret_arn=${TXMA_OBFUSCATION_SECRET_ARN}" \
         -var-file "${DEPLOY_ENVIRONMENT}-overrides.tfvars" \
 
       terraform output --json > ../../../../terraform-outputs/${DEPLOY_ENVIRONMENT}-terraform-outputs.json

--- a/ci/terraform/audit-processors/variables.tf
+++ b/ci/terraform/audit-processors/variables.tf
@@ -65,3 +65,7 @@ variable "lambda_memory_size" {
   default = 4096
   type    = number
 }
+
+variable "txma_obfuscation_secret_arn" {
+  default = ""
+}


### PR DESCRIPTION
## What?

- Amend Terraform to add the `TXMA_OBFUSCATION_SECRET_ARN` environment variable to the counter fraud lambda. The value should be passed to Terraform as a variable as it will be per environment.
- If the TXMA_OBFUSCATION_SECRET_ARN environment variable is blank then return `Optional.empty()`

## Why?

#2026 introduces the code to optionally hash with TXMA key. This enables it by adding the required environment variable, which will be blank by default. [This related PR](https://github.com/alphagov/di-infrastructure/pull/275) will add a real value for the `staging` environment.

## Related PRs

#2026 
https://github.com/alphagov/di-infrastructure/pull/275