### PR TITLE
AUT-435: Add missing comma in Gradle

### DIFF
--- a/audit-processors/build.gradle
+++ b/audit-processors/build.gradle
@@ -17,8 +17,8 @@ dependencies {
             configurations.ssm,
             configurations.sns,
             configurations.s3,
-            configurations.secretsmanager
-    configurations.dynamodb
+            configurations.secretsmanager,
+            configurations.dynamodb
 
     implementation "com.google.protobuf:protobuf-java:${dependencyVersions.protobuf_version}",
             "com.google.protobuf:protobuf-java-util:${dependencyVersions.protobuf_version}",


### PR DESCRIPTION
## What?

- Add missing comma in Gradle `compileOnly` dependency directive

## Why?

We are seeing `ClassNotFoundExceptions`
