### PR TITLE
AUT-435: Add Secrets Manager dependency as an `implementation` dep

### DIFF
--- a/audit-processors/build.gradle
+++ b/audit-processors/build.gradle
@@ -17,10 +17,10 @@ dependencies {
             configurations.ssm,
             configurations.sns,
             configurations.s3,
-            configurations.secretsmanager,
             configurations.dynamodb
 
-    implementation "com.google.protobuf:protobuf-java:${dependencyVersions.protobuf_version}",
+    implementation configurations.secretsmanager,
+            "com.google.protobuf:protobuf-java:${dependencyVersions.protobuf_version}",
             "com.google.protobuf:protobuf-java-util:${dependencyVersions.protobuf_version}",
             "com.google.code.gson:gson:2.9.0"
 


### PR DESCRIPTION
## What?

- Add Secrets Manager dependency as an `implementation` dependency
- Swallow initialisation errors in `CounterFraudAuditLambda`

## Why?

We seeing `ClassDefNotFound` exceptions for the `SecretManagerClient` class.