### PR TITLE
BAU: Read redis configuration from statically-initialised parameters

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/configuration/RedisConfiguration.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/configuration/RedisConfiguration.java
@@ -1,0 +1,22 @@
+package uk.gov.di.authentication.shared.configuration;
+
+import java.util.Map;
+
+import static java.text.MessageFormat.format;
+
+public class RedisConfiguration extends SsmAwareConfiguration {
+
+    private static final String ENVIRONMENT = System.getenv().getOrDefault("ENVIRONMENT", "test");
+    private static final String REDIS_KEY = System.getenv("REDIS_KEY");
+
+    private static final Map<String, String> REDIS_SSM_PARAMETERS =
+            getParameters(
+                    format("{0}-{1}-redis-master-host", ENVIRONMENT, REDIS_KEY),
+                    format("{0}-{1}-redis-password", ENVIRONMENT, REDIS_KEY),
+                    format("{0}-{1}-redis-port", ENVIRONMENT, REDIS_KEY),
+                    format("{0}-{1}-redis-tls", ENVIRONMENT, REDIS_KEY));
+
+    public static Map<String, String> getSsmRedisParameters() {
+        return REDIS_SSM_PARAMETERS;
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/configuration/RedisConfiguration.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/configuration/RedisConfiguration.java
@@ -16,7 +16,7 @@ public class RedisConfiguration extends SsmAwareConfiguration {
                     format("{0}-{1}-redis-port", ENVIRONMENT, REDIS_KEY),
                     format("{0}-{1}-redis-tls", ENVIRONMENT, REDIS_KEY));
 
-    public static Map<String, String> getSsmRedisParameters() {
+    public Map<String, String> getSsmRedisParameters() {
         return REDIS_SSM_PARAMETERS;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/configuration/SsmAwareConfiguration.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/configuration/SsmAwareConfiguration.java
@@ -1,0 +1,18 @@
+package uk.gov.di.authentication.shared.configuration;
+
+import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
+import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement;
+import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagementClient;
+
+import java.util.Optional;
+
+public class SsmAwareConfiguration {
+    private static final String REGION = System.getenv("AWS_REGION");
+
+    private static final AWSSimpleSystemsManagement SSM_CLIENT =
+            Optional.ofNullable(System.getenv("LOCALSTACK_ENDPOINT"))
+                    .map(l -> new EndpointConfiguration(l, REGION))
+                    .map(AWSSimpleSystemsManagementClient.builder()::withEndpointConfiguration)
+                    .orElse(AWSSimpleSystemsManagementClient.builder().withRegion(REGION))
+                    .build();
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/configuration/SsmAwareConfiguration.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/configuration/SsmAwareConfiguration.java
@@ -1,18 +1,52 @@
 package uk.gov.di.authentication.shared.configuration;
 
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
+import com.amazonaws.client.builder.AwsSyncClientBuilder;
 import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagement;
-import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagementClient;
+import com.amazonaws.services.simplesystemsmanagement.model.GetParametersRequest;
+import com.amazonaws.services.simplesystemsmanagement.model.GetParametersResult;
+import com.amazonaws.services.simplesystemsmanagement.model.Parameter;
+import com.amazonaws.services.simplesystemsmanagement.model.ParameterNotFoundException;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+
+import static com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagementClient.builder;
+import static java.util.stream.Collectors.toMap;
 
 public class SsmAwareConfiguration {
     private static final String REGION = System.getenv("AWS_REGION");
 
-    private static final AWSSimpleSystemsManagement SSM_CLIENT =
-            Optional.ofNullable(System.getenv("LOCALSTACK_ENDPOINT"))
-                    .map(l -> new EndpointConfiguration(l, REGION))
-                    .map(AWSSimpleSystemsManagementClient.builder()::withEndpointConfiguration)
-                    .orElse(AWSSimpleSystemsManagementClient.builder().withRegion(REGION))
-                    .build();
+    private static final Optional<AWSSimpleSystemsManagement> SSM_CLIENT;
+
+    static {
+        if (System.getenv("ENVIRONMENT") == null) {
+            SSM_CLIENT = Optional.empty();
+        } else if (System.getenv().containsKey("LOCALSTACK_ENDPOINT")) {
+            SSM_CLIENT =
+                    Optional.ofNullable(System.getenv("LOCALSTACK_ENDPOINT"))
+                            .map(l -> new EndpointConfiguration(l, REGION))
+                            .map(builder()::withEndpointConfiguration)
+                            .map(AwsSyncClientBuilder::build);
+        } else {
+            SSM_CLIENT = Optional.of(builder().withRegion(REGION).build());
+        }
+    }
+
+    public static Map<String, String> getParameters(String... names) {
+        try {
+            var request = new GetParametersRequest().withWithDecryption(true).withNames(names);
+
+            return SSM_CLIENT
+                    .map(client -> client.getParameters(request))
+                    .map(GetParametersResult::getParameters)
+                    .stream()
+                    .flatMap(List::stream)
+                    .collect(toMap(Parameter::getName, Parameter::getValue));
+        } catch (ParameterNotFoundException e) {
+            return Collections.emptyMap();
+        }
+    }
 }


### PR DESCRIPTION
## What?

These reads configuration for Redis at startup rather than lazily.

## Why?

This takes advantage of provisioned concurrency by putting the heavy-lifting into the initialisation phase rather than the execution of the handler.
