### PR TITLE
AUT-431: Return MFA method information from Login

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/LoginResponse.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/LoginResponse.java
@@ -2,6 +2,7 @@ package uk.gov.di.authentication.frontendapi.entity;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.validation.Required;
 
 public class LoginResponse {
@@ -14,6 +15,16 @@ public class LoginResponse {
     @Expose
     @Required
     private boolean mfaRequired;
+
+    @SerializedName("mfaMethodType")
+    @Expose
+    @Required
+    private MFAMethodType mfaMethodType;
+
+    @SerializedName("mfaMethodVerified")
+    @Expose
+    @Required
+    private boolean mfaMethodVerified;
 
     @SerializedName("phoneNumberVerified")
     @Expose
@@ -37,12 +48,16 @@ public class LoginResponse {
             boolean mfaRequired,
             boolean phoneNumberVerified,
             boolean latestTermsAndConditionsAccepted,
-            boolean consentRequired) {
+            boolean consentRequired,
+            MFAMethodType mfaMethodType,
+            boolean mfaMethodVerified) {
         this.redactedPhoneNumber = redactedPhoneNumber;
         this.mfaRequired = mfaRequired;
         this.phoneNumberVerified = phoneNumberVerified;
         this.latestTermsAndConditionsAccepted = latestTermsAndConditionsAccepted;
         this.consentRequired = consentRequired;
+        this.mfaMethodType = mfaMethodType;
+        this.mfaMethodVerified = mfaMethodVerified;
     }
 
     public String getRedactedPhoneNumber() {
@@ -63,5 +78,13 @@ public class LoginResponse {
 
     public boolean isConsentRequired() {
         return consentRequired;
+    }
+
+    public MFAMethodType getMfaMethodType() {
+        return mfaMethodType;
+    }
+
+    public boolean isMfaMethodVerified() {
+        return mfaMethodVerified;
     }
 }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
@@ -51,12 +51,13 @@ public class RedisExtension
     }
 
     public String createSession(String sessionId) throws Json.JsonException {
-        return createSession(sessionId, false);
+        return createSession(sessionId, false, Optional.empty());
     }
 
-    private String createSession(String sessionId, boolean isAuthenticated)
+    private String createSession(String sessionId, boolean isAuthenticated, Optional<String> email)
             throws Json.JsonException {
         Session session = new Session(sessionId).setAuthenticated(isAuthenticated);
+        email.ifPresent(session::setEmailAddress);
         redis.saveWithExpiry(
                 session.getSessionId(), objectMapper.writeValueAsString(session), 3600);
         return session.getSessionId();
@@ -67,7 +68,11 @@ public class RedisExtension
     }
 
     public String createSession(boolean isAuthenticated) throws Json.JsonException {
-        return createSession(IdGenerator.generate(), isAuthenticated);
+        return createSession(IdGenerator.generate(), isAuthenticated, Optional.empty());
+    }
+
+    public String createUnauthenticatedSessionWithEmail(String email) throws Json.JsonException {
+        return createSession(IdGenerator.generate(), false, Optional.of(email));
     }
 
     public void addDocAppSubjectIdToClientSession(Subject subject, String clientSessionId)

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/UserStoreExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/UserStoreExtension.java
@@ -10,6 +10,7 @@ import com.nimbusds.oauth2.sdk.id.Subject;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import uk.gov.di.authentication.shared.entity.ClientConsent;
+import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.TermsAndConditions;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.services.DynamoService;
@@ -97,6 +98,16 @@ public class UserStoreExtension extends DynamoExtension implements AfterEachCall
 
     public void updateTermsAndConditions(String email, String version) {
         dynamoService.updateTermsAndConditions(email, version);
+    }
+
+    public void updateMFAMethod(
+            String email,
+            MFAMethodType mfaMethodType,
+            boolean methodVerified,
+            boolean enabled,
+            String credentialValue) {
+        dynamoService.updateMFAMethod(
+                email, mfaMethodType, methodVerified, enabled, credentialValue);
     }
 
     @Override

--- a/shared/src/main/java/uk/gov/di/authentication/shared/conditions/MfaHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/conditions/MfaHelper.java
@@ -2,10 +2,13 @@ package uk.gov.di.authentication.shared.conditions;
 
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+import uk.gov.di.authentication.shared.entity.MFAMethod;
+import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.VectorOfTrust;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.LOW_LEVEL;
 
@@ -24,5 +27,14 @@ public class MfaHelper {
         VectorOfTrust vectorOfTrust = VectorOfTrust.parseFromAuthRequestAttribute(vtr);
 
         return !vectorOfTrust.getCredentialTrustLevel().equals(LOW_LEVEL);
+    }
+
+    public static Optional<MFAMethod> getPrimaryMFAMethod(UserCredentials userCredentials) {
+        return Optional.ofNullable(userCredentials.getMfaMethods())
+                .flatMap(
+                        mfaMethods ->
+                                mfaMethods.stream()
+                                        .filter(mfaMethod -> mfaMethod.isEnabled())
+                                        .findFirst());
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/MFAMethodType.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/MFAMethodType.java
@@ -1,7 +1,8 @@
 package uk.gov.di.authentication.shared.entity;
 
 public enum MFAMethodType {
-    AUTH_APP("AUTH_APP");
+    AUTH_APP("AUTH_APP"),
+    SMS("SMS");
 
     private String value;
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/lambda/BaseFrontendHandler.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/lambda/BaseFrontendHandler.java
@@ -42,6 +42,7 @@ public abstract class BaseFrontendHandler<T>
     protected final ClientService clientService;
     protected final AuthenticationService authenticationService;
     protected final Json objectMapper = SerializationService.getInstance();
+    protected boolean loadUserCredentials = false;
 
     protected BaseFrontendHandler(
             Class<T> clazz,
@@ -58,6 +59,24 @@ public abstract class BaseFrontendHandler<T>
         this.authenticationService = authenticationService;
     }
 
+    protected BaseFrontendHandler(
+            Class<T> clazz,
+            ConfigurationService configurationService,
+            SessionService sessionService,
+            ClientSessionService clientSessionService,
+            ClientService clientService,
+            AuthenticationService authenticationService,
+            boolean loadUserCredentials) {
+        this(
+                clazz,
+                configurationService,
+                sessionService,
+                clientSessionService,
+                clientService,
+                authenticationService);
+        this.loadUserCredentials = loadUserCredentials;
+    }
+
     protected BaseFrontendHandler(Class<T> clazz, ConfigurationService configurationService) {
         this.clazz = clazz;
         this.configurationService = configurationService;
@@ -65,6 +84,14 @@ public abstract class BaseFrontendHandler<T>
         this.clientSessionService = new ClientSessionService(configurationService);
         this.clientService = new DynamoClientService(configurationService);
         this.authenticationService = new DynamoService(configurationService);
+    }
+
+    protected BaseFrontendHandler(
+            Class<T> clazz,
+            ConfigurationService configurationService,
+            boolean loadUserCredentials) {
+        this(clazz, configurationService);
+        this.loadUserCredentials = loadUserCredentials;
     }
 
     @Override
@@ -133,6 +160,15 @@ public abstract class BaseFrontendHandler<T>
                                                                 .toLowerCase(Locale.ROOT)))
                                         .withUserAuthenticated(false);
                         });
+
+        if (loadUserCredentials) {
+            session.map(Session::getEmailAddress)
+                    .map(authenticationService::getUserCredentialsFromEmail)
+                    .ifPresent(
+                            userCredentials ->
+                                    userContextBuilder.withUserCredentials(
+                                            Optional.of(userCredentials)));
+        }
 
         return handleRequestWithUserContext(input, context, request, userContextBuilder.build());
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/state/UserContext.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/state/UserContext.java
@@ -3,6 +3,7 @@ package uk.gov.di.authentication.shared.state;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.Session;
+import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 
 import java.util.Optional;
@@ -10,6 +11,8 @@ import java.util.Optional;
 public class UserContext {
     private final Session session;
     private final Optional<UserProfile> userProfile;
+
+    private final Optional<UserCredentials> userCredentials;
     private final boolean userAuthenticated;
     private final Optional<ClientRegistry> client;
     private final ClientSession clientSession;
@@ -17,11 +20,13 @@ public class UserContext {
     protected UserContext(
             Session session,
             Optional<UserProfile> userProfile,
+            Optional<UserCredentials> userCredentials,
             boolean userAuthenticated,
             Optional<ClientRegistry> client,
             ClientSession clientSession) {
         this.session = session;
         this.userProfile = userProfile;
+        this.userCredentials = userCredentials;
         this.userAuthenticated = userAuthenticated;
         this.client = client;
         this.clientSession = clientSession;
@@ -33,6 +38,10 @@ public class UserContext {
 
     public Optional<UserProfile> getUserProfile() {
         return userProfile;
+    }
+
+    public Optional<UserCredentials> getUserCredentials() {
+        return userCredentials;
     }
 
     public boolean isUserAuthenticated() {
@@ -54,6 +63,7 @@ public class UserContext {
     public static class Builder {
         private Session session;
         private Optional<UserProfile> userProfile = Optional.empty();
+        private Optional<UserCredentials> userCredentials = Optional.empty();
         private boolean userAuthenticated = false;
         private Optional<ClientRegistry> client = Optional.empty();
         private ClientSession clientSession = null;
@@ -68,6 +78,11 @@ public class UserContext {
 
         public Builder withUserProfile(Optional<UserProfile> userProfile) {
             this.userProfile = userProfile;
+            return this;
+        }
+
+        public Builder withUserCredentials(Optional<UserCredentials> userCredentials) {
+            this.userCredentials = userCredentials;
             return this;
         }
 
@@ -91,7 +106,13 @@ public class UserContext {
         }
 
         public UserContext build() {
-            return new UserContext(session, userProfile, userAuthenticated, client, clientSession);
+            return new UserContext(
+                    session,
+                    userProfile,
+                    userCredentials,
+                    userAuthenticated,
+                    client,
+                    clientSession);
         }
     }
 }


### PR DESCRIPTION
## What?

Return MFA method information from Login.

Users will be able to choose between SMS and an Authenticator App as a second factor.  The data model for SMS is not being changed in the database in UserProfile, and an additional list of MFAMethod has been added to UserCredentials for a user.  When an auth app is added for a user this will be added to the list of MFAMethod, but for an existing user using SMS this list will be empty, and authentication will default to SMS.

This PR returns the user's MFAMethod from UserCredentials to the frontend from the 'login' lambda as additional fields on LoginResponse.  This information can then be used by the frontend to go down the correct path either to send a code by SMS for entry, or for the user to enter a code from their auth app.

## Why?

Support authentication apps as a second factor.

## Related PRs

#2009 
#2038 
