### PR TITLE
AUT-435: Add KMS statement to secrets manager policy

### DIFF
--- a/ci/tasks/deploy-audit-processors.yml
+++ b/ci/tasks/deploy-audit-processors.yml
@@ -12,6 +12,7 @@ params:
   STATE_BUCKET: digital-identity-dev-tfstate
   AUDIT_STORE_EXPIRY_DAYS: 7
   TXMA_OBFUSCATION_SECRET_ARN: ""
+  TXMA_OBFUSCATION_SECRET_KMS_KEY_ARN: ""
 inputs:
   - name: shared-terraform-outputs
   - name: api-terraform-src
@@ -40,6 +41,7 @@ run:
         -var 'logging_endpoint_arns=["arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"]' \
         -var "audit_storage_expiry_days=${AUDIT_STORE_EXPIRY_DAYS}" \
         -var "txma_obfuscation_secret_arn=${TXMA_OBFUSCATION_SECRET_ARN}" \
+        -var "txma_obfuscation_secret_kms_key_arn=${TXMA_OBFUSCATION_SECRET_KMS_KEY_ARN}" \
         -var-file "${DEPLOY_ENVIRONMENT}-overrides.tfvars" \
 
       terraform output --json > ../../../../terraform-outputs/${DEPLOY_ENVIRONMENT}-terraform-outputs.json

--- a/ci/terraform/audit-processors/counter_fraud.tf
+++ b/ci/terraform/audit-processors/counter_fraud.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_policy" "txma_secrets_policy" {
-  count = var.txma_obfuscation_secret_arn == "" ? 0 : 1
+  count = var.txma_obfuscation_secret_arn == "" || var.txma_obfuscation_secret_kms_key_arn ? 0 : 1
 
   name_prefix = "txma-hmac-key-secret-"
   path        = "/${var.environment}/fraud-realtime-logging/"
@@ -17,12 +17,21 @@ resource "aws_iam_policy" "txma_secrets_policy" {
       Resource = [
         var.txma_obfuscation_secret_arn,
       ]
+      }, {
+      Effect = "Allow"
+      Action = [
+        "kms:Decrypt"
+      ]
+
+      Resource = [
+        var.txma_obfuscation_secret_kms_key_arn,
+      ]
     }]
   })
 }
 
 resource "aws_iam_role_policy_attachment" "txma_secrets_policy" {
-  count = var.txma_obfuscation_secret_arn == "" ? 0 : 1
+  count = var.txma_obfuscation_secret_arn == "" || var.txma_obfuscation_secret_kms_key_arn ? 0 : 1
 
   role       = module.fraud_realtime_logging_role.name
   policy_arn = aws_iam_policy.txma_secrets_policy[0].arn

--- a/ci/terraform/audit-processors/variables.tf
+++ b/ci/terraform/audit-processors/variables.tf
@@ -69,3 +69,7 @@ variable "lambda_memory_size" {
 variable "txma_obfuscation_secret_arn" {
   default = ""
 }
+
+variable "txma_obfuscation_secret_kms_key_arn" {
+  default = ""
+}


### PR DESCRIPTION
## What?

- The policy also needs KMS decrypt permissions for the given KMS key

## Why?

We need to have explicit permissions to the given KMS key as well as permissions to the secret

## Related PRs

https://github.com/alphagov/di-infrastructure/pull/278