### PR TITLE
AUT-468 - Use the 2 additional fields added to the SPOT response

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/SpotResponseIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/SpotResponseIntegrationTest.java
@@ -2,22 +2,20 @@ package uk.gov.di.authentication.queuehandlers;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent;
+import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import uk.gov.di.authentication.ipv.entity.SPOTResponse;
-import uk.gov.di.authentication.ipv.entity.SPOTStatus;
 import uk.gov.di.authentication.ipv.lambda.SPOTResponseHandler;
-import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.sharedtest.basetest.HandlerIntegrationTest;
 
 import java.util.Arrays;
 import java.util.Locale;
-import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import static java.lang.String.format;
 import static java.util.Collections.emptyMap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -26,6 +24,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 public class SpotResponseIntegrationTest extends HandlerIntegrationTest<SQSEvent, Object> {
+
+    private static final String SESSION_ID = "a-session-id";
+    private static final String PERSISTENT_SESSION_ID = "a-persistent-id";
+    private static final ClientID CLIENT_ID = new ClientID();
+    private static final String REQUEST_ID = "request-id";
 
     @BeforeEach
     void setup() {
@@ -36,15 +39,17 @@ public class SpotResponseIntegrationTest extends HandlerIntegrationTest<SQSEvent
     void shouldAddSpotCredentialToDBForValidResponse() {
         var signedCredential = "some-signed-credential";
         var pairwiseIdentifier = new Subject();
-        handler.handleRequest(
-                createSqsEvent(
-                        new SPOTResponse(
-                                Map.of(
-                                        "https://vocab.sign-in.service.gov.uk/v1/verifiableIdentityJWT",
-                                        signedCredential),
-                                pairwiseIdentifier.getValue(),
-                                SPOTStatus.ACCEPTED)),
-                mock(Context.class));
+        var spotResponse =
+                format(
+                        "{\"sub\":\"%s\",\"status\":\"ACCEPTED\","
+                                + "\"claims\":{\"http://something/v1/verifiableIdentityJWT\":\"%s\"}, \"log_ids\":{\"session_id\":\"%s\",\"persistent_session_id\":\"%s\",\"request_id\":\"%s\",\"client_id\":\"%s\"}}",
+                        pairwiseIdentifier,
+                        signedCredential,
+                        SESSION_ID,
+                        PERSISTENT_SESSION_ID,
+                        REQUEST_ID,
+                        CLIENT_ID);
+        handler.handleRequest(createSqsEvent(spotResponse), mock(Context.class));
 
         assertTrue(identityStore.getIdentityCredentials(pairwiseIdentifier.getValue()).isPresent());
 
@@ -59,12 +64,17 @@ public class SpotResponseIntegrationTest extends HandlerIntegrationTest<SQSEvent
     @Test
     void shouldDeleteIdentityCredentialFromDBForInvalidResponse() {
         var pairwiseIdentifier = new Subject();
+        var spotResponse =
+                format(
+                        "{\"sub\":\"%s\",\"status\":\"REJECTED\","
+                                + "\"log_ids\":{\"session_id\":\"%s\",\"persistent_session_id\":\"%s\",\"request_id\":\"%s\",\"client_id\":\"%s\"}}",
+                        pairwiseIdentifier,
+                        SESSION_ID,
+                        PERSISTENT_SESSION_ID,
+                        REQUEST_ID,
+                        CLIENT_ID);
         identityStore.addAdditionalClaims(pairwiseIdentifier.getValue(), emptyMap());
-        handler.handleRequest(
-                createSqsEvent(
-                        new SPOTResponse(
-                                emptyMap(), pairwiseIdentifier.getValue(), SPOTStatus.REJECTED)),
-                mock(Context.class));
+        handler.handleRequest(createSqsEvent(spotResponse), mock(Context.class));
 
         assertFalse(
                 identityStore.getIdentityCredentials(pairwiseIdentifier.getValue()).isPresent());
@@ -76,21 +86,17 @@ public class SpotResponseIntegrationTest extends HandlerIntegrationTest<SQSEvent
                 Arrays.stream(request)
                         .map(
                                 r -> {
-                                    try {
-                                        var message = new SQSEvent.SQSMessage();
-                                        message.setBody(objectMapper.writeValueAsString(r));
-                                        message.setMessageId(UUID.randomUUID().toString());
-                                        message.setMd5OfBody(
-                                                DigestUtils.md5Hex(message.getBody())
-                                                        .toUpperCase(Locale.ROOT));
-                                        message.setEventSource("aws:sqs");
-                                        message.setAwsRegion("eu-west-2");
-                                        message.setEventSourceArn(
-                                                "arn:aws:sqs:eu-west-2:123456789012:queue-name");
-                                        return message;
-                                    } catch (Json.JsonException e) {
-                                        throw new RuntimeException(e);
-                                    }
+                                    var message = new SQSEvent.SQSMessage();
+                                    message.setBody((String) r);
+                                    message.setMessageId(UUID.randomUUID().toString());
+                                    message.setMd5OfBody(
+                                            DigestUtils.md5Hex(message.getBody())
+                                                    .toUpperCase(Locale.ROOT));
+                                    message.setEventSource("aws:sqs");
+                                    message.setAwsRegion("eu-west-2");
+                                    message.setEventSourceArn(
+                                            "arn:aws:sqs:eu-west-2:123456789012:queue-name");
+                                    return message;
                                 })
                         .collect(Collectors.toList()));
         return event;

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/domain/IPVAuditableEvent.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/domain/IPVAuditableEvent.java
@@ -11,7 +11,8 @@ public enum IPVAuditableEvent implements AuditableEvent {
     IPV_CAPACITY_REQUESTED,
     IPV_SPOT_REQUESTED,
     PROCESSING_IDENTITY_REQUEST,
-    SPOT_RESPONSE_RECEIVED;
+    IPV_SUCCESSFUL_SPOT_RESPONSE_RECEIVED,
+    IPV_UNSUCCESSFUL_SPOT_RESPONSE_RECEIVED;
 
     public AuditableEvent parseFromName(String name) {
         return valueOf(name);

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/SPOTResponse.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/SPOTResponse.java
@@ -16,12 +16,26 @@ public class SPOTResponse {
 
     @Expose @Required private SPOTStatus status;
 
+    @Expose private String reason;
+
+    @SerializedName(value = "log_ids")
+    @Expose
+    @Required
+    private LogIds logIds;
+
     public SPOTResponse() {}
 
-    public SPOTResponse(Map<String, Object> claims, String sub, SPOTStatus status) {
+    public SPOTResponse(
+            Map<String, Object> claims,
+            String sub,
+            SPOTStatus status,
+            String reason,
+            LogIds logIds) {
         this.claims = claims;
         this.sub = sub;
         this.status = status;
+        this.reason = reason;
+        this.logIds = logIds;
     }
 
     public Map<String, Object> getClaims() {
@@ -34,5 +48,13 @@ public class SPOTResponse {
 
     public SPOTStatus getStatus() {
         return status;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public LogIds getLogIds() {
+        return logIds;
     }
 }

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandler.java
@@ -7,8 +7,10 @@ import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.ipv.domain.IPVAuditableEvent;
+import uk.gov.di.authentication.ipv.entity.LogIds;
 import uk.gov.di.authentication.ipv.entity.SPOTResponse;
 import uk.gov.di.authentication.ipv.entity.SPOTStatus;
+import uk.gov.di.authentication.shared.domain.AuditableEvent;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.serialization.Json.JsonException;
 import uk.gov.di.authentication.shared.services.AuditService;
@@ -17,6 +19,11 @@ import uk.gov.di.authentication.shared.services.DynamoIdentityService;
 import uk.gov.di.authentication.shared.services.SerializationService;
 
 import java.util.NoSuchElementException;
+
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.CLIENT_ID;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.PERSISTENT_SESSION_ID;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachLogFieldToLogs;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachSessionIdToLogs;
 
 public class SPOTResponseHandler implements RequestHandler<SQSEvent, Object> {
 
@@ -43,35 +50,41 @@ public class SPOTResponseHandler implements RequestHandler<SQSEvent, Object> {
 
     @Override
     public Object handleRequest(SQSEvent event, Context context) {
-        auditService.submitAuditEvent(
-                IPVAuditableEvent.SPOT_RESPONSE_RECEIVED,
-                context.getAwsRequestId(),
-                AuditService.UNKNOWN,
-                AuditService.UNKNOWN,
-                AuditService.UNKNOWN,
-                AuditService.UNKNOWN,
-                AuditService.UNKNOWN,
-                AuditService.UNKNOWN,
-                AuditService.UNKNOWN);
-
         for (SQSMessage msg : event.getRecords()) {
             try {
                 var spotResponse = objectMapper.readValue(msg.getBody(), SPOTResponse.class);
-                if (spotResponse.getStatus() != SPOTStatus.ACCEPTED) {
-                    LOG.warn(
-                            "SPOTResponse Status is not Accepted. Deleting Identity Credential. Actual Status: {}",
+                attachSessionIdToLogs(spotResponse.getLogIds().getSessionId());
+                attachLogFieldToLogs(
+                        PERSISTENT_SESSION_ID, spotResponse.getLogIds().getPersistentSessionId());
+                attachLogFieldToLogs(CLIENT_ID, spotResponse.getLogIds().getSessionId());
+
+                if (spotResponse.getStatus().equals(SPOTStatus.ACCEPTED)) {
+                    LOG.info(
+                            "SPOTResponse Status is {}. Adding CoreIdentityJWT to Dynamo",
                             spotResponse.getStatus());
+                    submitAuditEvent(
+                            IPVAuditableEvent.IPV_SUCCESSFUL_SPOT_RESPONSE_RECEIVED,
+                            spotResponse.getLogIds(),
+                            context.getAwsRequestId());
+                    dynamoIdentityService.addCoreIdentityJWT(
+                            spotResponse.getSub(),
+                            spotResponse.getClaims().values().stream()
+                                    .map(Object::toString)
+                                    .findFirst()
+                                    .orElseThrow());
+                    return null;
+                } else {
+                    LOG.warn(
+                            "SPOTResponse Status is {}. Rejection reason: {}. Deleting Identity Credential.",
+                            spotResponse.getStatus(),
+                            spotResponse.getReason());
+                    submitAuditEvent(
+                            IPVAuditableEvent.IPV_UNSUCCESSFUL_SPOT_RESPONSE_RECEIVED,
+                            spotResponse.getLogIds(),
+                            context.getAwsRequestId());
                     dynamoIdentityService.deleteIdentityCredentials(spotResponse.getSub());
                     return null;
                 }
-                LOG.info("SPOTResponse Status is Accepted. Adding CoreIdentityJWT to Dynamo");
-
-                dynamoIdentityService.addCoreIdentityJWT(
-                        spotResponse.getSub(),
-                        spotResponse.getClaims().values().stream()
-                                .map(Object::toString)
-                                .findFirst()
-                                .orElseThrow());
             } catch (JsonException e) {
                 LOG.error("Unable to deserialize SPOT response from SQS queue");
                 return null;
@@ -81,5 +94,19 @@ public class SPOTResponseHandler implements RequestHandler<SQSEvent, Object> {
             }
         }
         return null;
+    }
+
+    private void submitAuditEvent(
+            AuditableEvent auditableEvent, LogIds logIds, String awsRequestId) {
+        auditService.submitAuditEvent(
+                auditableEvent,
+                awsRequestId,
+                logIds.getSessionId(),
+                logIds.getClientId(),
+                AuditService.UNKNOWN,
+                AuditService.UNKNOWN,
+                AuditService.UNKNOWN,
+                AuditService.UNKNOWN,
+                logIds.getPersistentSessionId());
     }
 }


### PR DESCRIPTION
## What?

- Use the 2 additional fields added to the SPOT response
- Attach the log ids to the relevant log lines so we can track user journeys.
- Add 2 Audit events which differentiates between a successful and unsuccessful SPOT response.

## Why?

- The SPOT response has had 2 additional fields added. 'log_ids' which is the same as passed in in the SPOT request and 'reason' which will only be present if the status is REJECTED.