### PR TITLE
DCP-147: add `preload` directive to Strict-Transport-Security header

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ApiGatewayResponseHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ApiGatewayResponseHelper.java
@@ -26,7 +26,7 @@ public class ApiGatewayResponseHelper {
     private static final String CONTENT_TYPE_OPTIONS_HEADER_VALUE = "nosniff";
     private static final String CONTENT_SECURITY_POLICY_HEADER_VALUE = "frame-ancestors 'none'";
     private static final String STRICT_TRANSPORT_SECURITY_HEADER_VALUE =
-            "max-age=31536000; includeSubDomains";
+            "max-age=31536000; includeSubDomains; preload";
     private static final String X_FRAME_OPTIONS_HEADER_VALUE = "DENY";
 
     private static final Logger LOG = LogManager.getLogger(ApiGatewayResponseHelper.class);

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ApiGatewayResponseHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ApiGatewayResponseHelperTest.java
@@ -24,7 +24,7 @@ public class ApiGatewayResponseHelperTest {
                 result.getHeaders(), hasEntry("Content-Security-Policy", "frame-ancestors 'none'"));
         assertThat(
                 result.getHeaders(),
-                hasEntry("Strict-Transport-Security", "max-age=31536000; includeSubDomains"));
+                hasEntry("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload"));
         assertThat(result.getHeaders(), hasEntry("X-Frame-Options", "DENY"));
     }
 
@@ -41,7 +41,7 @@ public class ApiGatewayResponseHelperTest {
                 result.getHeaders(), hasEntry("Content-Security-Policy", "frame-ancestors 'none'"));
         assertThat(
                 result.getHeaders(),
-                hasEntry("Strict-Transport-Security", "max-age=31536000; includeSubDomains"));
+                hasEntry("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload"));
         assertThat(result.getHeaders(), hasEntry("X-Frame-Options", "DENY"));
     }
 
@@ -58,7 +58,7 @@ public class ApiGatewayResponseHelperTest {
                 result.getHeaders(), hasEntry("Content-Security-Policy", "frame-ancestors 'none'"));
         assertThat(
                 result.getHeaders(),
-                hasEntry("Strict-Transport-Security", "max-age=31536000; includeSubDomains"));
+                hasEntry("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload"));
         assertThat(result.getHeaders(), hasEntry("X-Frame-Options", "DENY"));
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ApiGatewayResponseHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ApiGatewayResponseHelperTest.java
@@ -24,7 +24,9 @@ public class ApiGatewayResponseHelperTest {
                 result.getHeaders(), hasEntry("Content-Security-Policy", "frame-ancestors 'none'"));
         assertThat(
                 result.getHeaders(),
-                hasEntry("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload"));
+                hasEntry(
+                        "Strict-Transport-Security",
+                        "max-age=31536000; includeSubDomains; preload"));
         assertThat(result.getHeaders(), hasEntry("X-Frame-Options", "DENY"));
     }
 
@@ -41,7 +43,9 @@ public class ApiGatewayResponseHelperTest {
                 result.getHeaders(), hasEntry("Content-Security-Policy", "frame-ancestors 'none'"));
         assertThat(
                 result.getHeaders(),
-                hasEntry("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload"));
+                hasEntry(
+                        "Strict-Transport-Security",
+                        "max-age=31536000; includeSubDomains; preload"));
         assertThat(result.getHeaders(), hasEntry("X-Frame-Options", "DENY"));
     }
 
@@ -58,7 +62,9 @@ public class ApiGatewayResponseHelperTest {
                 result.getHeaders(), hasEntry("Content-Security-Policy", "frame-ancestors 'none'"));
         assertThat(
                 result.getHeaders(),
-                hasEntry("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload"));
+                hasEntry(
+                        "Strict-Transport-Security",
+                        "max-age=31536000; includeSubDomains; preload"));
         assertThat(result.getHeaders(), hasEntry("X-Frame-Options", "DENY"));
     }
 }


### PR DESCRIPTION
## What?

add `preload` directive to Strict-Transport-Security header

## Why?

So that we can add all of *.account.gov.uk to the HSTS preload list:
https://hstspreload.org/

Also so I can feel like I write code for once