### PR TITLE
AUT-435: Replay events mechanism

### DIFF
--- a/audit-processors/src/main/java/uk/gov/di/authentication/audit/lambda/CounterFraudAuditReplayLambda.java
+++ b/audit-processors/src/main/java/uk/gov/di/authentication/audit/lambda/CounterFraudAuditReplayLambda.java
@@ -1,0 +1,108 @@
+package uk.gov.di.authentication.audit.lambda;
+
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.S3Event;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.util.JsonFormat;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ObjectMessage;
+import uk.gov.di.audit.AuditPayload.AuditEvent;
+import uk.gov.di.audit.AuditPayload.AuditEvent.User;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+import java.util.HashMap;
+
+import static org.apache.commons.codec.binary.Hex.encodeHexString;
+import static uk.gov.di.authentication.audit.helper.HmacSha256Helper.hmacSha256;
+
+public class CounterFraudAuditReplayLambda implements RequestHandler<S3Event, Void> {
+
+    private static final Logger LOG = LogManager.getLogger(CounterFraudAuditReplayLambda.class);
+
+    private final ConfigurationService configurationService;
+    private final String hmacKey;
+    private final AmazonS3 client;
+
+    public CounterFraudAuditReplayLambda(
+            ConfigurationService configurationService, AmazonS3 client) {
+        this.configurationService = configurationService;
+        this.hmacKey = configurationService.getAuditHmacSecret();
+        this.client = client;
+    }
+
+    public CounterFraudAuditReplayLambda() {
+        this(
+                ConfigurationService.getInstance(),
+                AmazonS3Client.builder().withRegion(Regions.EU_WEST_2).build());
+    }
+
+    @Override
+    public Void handleRequest(S3Event input, Context context) {
+
+        input.getRecords()
+                .forEach(
+                        s3 -> {
+                            var key = s3.getS3().getObject().getKey();
+                            var bucket = s3.getS3().getBucket().getName();
+
+                            LOG.info("Processing file {}", key);
+                            var content = client.getObjectAsString(bucket, key);
+                            try {
+                                var builder = AuditEvent.newBuilder();
+                                JsonFormat.parser().merge(content, builder);
+                                var auditEvent = builder.build();
+
+                                handleAuditEvent(auditEvent);
+                                client.deleteObject(bucket, key);
+                            } catch (InvalidProtocolBufferException e) {
+                                LOG.error("Error parsing file content", e);
+                            }
+                        });
+
+        return null;
+    }
+
+    void handleAuditEvent(AuditEvent auditEvent) {
+        var eventData = new HashMap<String, String>();
+
+        eventData.put("event-id", auditEvent.getEventId());
+        eventData.put("request-id", auditEvent.getRequestId());
+        eventData.put("session-id", auditEvent.getSessionId());
+        eventData.put("client-id", auditEvent.getClientId());
+        eventData.put("timestamp", auditEvent.getTimestamp());
+        eventData.put("event-name", auditEvent.getEventName());
+        eventData.put("persistent-session-id", auditEvent.getPersistentSessionId());
+
+        User user = auditEvent.getUser();
+
+        eventData.put("user.ip-address", user.getIpAddress());
+
+        if (isPresent(user.getId())) {
+            eventData.put("user.id", encodeHexString(hmacSha256(user.getId(), hmacKey)));
+        }
+
+        if (isPresent(user.getEmail())) {
+            eventData.put("user.email", encodeHexString(hmacSha256(user.getEmail(), hmacKey)));
+        }
+
+        if (isPresent(user.getPhoneNumber())) {
+            eventData.put(
+                    "user.phone", encodeHexString(hmacSha256(user.getPhoneNumber(), hmacKey)));
+        }
+
+        auditEvent
+                .getExtensionsMap()
+                .forEach((key, value) -> eventData.put("extensions." + key, value));
+
+        LOG.info(new ObjectMessage(eventData));
+    }
+
+    private boolean isPresent(String field) {
+        return !(field == null || field.isBlank());
+    }
+}

--- a/audit-processors/src/test/java/uk/gov/di/authentication/audit/lambda/CounterFraudAuditReplayLambdaTest.java
+++ b/audit-processors/src/test/java/uk/gov/di/authentication/audit/lambda/CounterFraudAuditReplayLambdaTest.java
@@ -1,0 +1,112 @@
+package uk.gov.di.authentication.audit.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.S3Event;
+import com.amazonaws.services.lambda.runtime.events.models.s3.S3EventNotification;
+import com.amazonaws.services.s3.AmazonS3;
+import org.apache.logging.log4j.core.LogEvent;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.sharedtest.logging.LogEventMatcher.hasObjectMessageProperty;
+
+class CounterFraudAuditReplayLambdaTest {
+
+    @RegisterExtension
+    public final CaptureLoggingExtension logging =
+            new CaptureLoggingExtension(CounterFraudAuditReplayLambda.class);
+
+    private final AmazonS3 client = mock(AmazonS3.class);
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+
+    @Test
+    void shouldDeserialiseAndLogValidRecordsFromS3() {
+        final var bucket = "a-bucket";
+        final var file = "a-key";
+        final var auditRecord =
+                "{"
+                        + "\"eventId\": \"test-event-id\","
+                        + "\"requestId\": \"test-request-id\","
+                        + "\"sessionId\": \"test-session-id\","
+                        + "\"clientId\": \"test-client-id\","
+                        + "\"timestamp\": \"test-timestamp\","
+                        + "\"eventName\": \"test-event-name\","
+                        + "\"user\": {"
+                        + "\"id\": \"test-id\","
+                        + "\"email\": \"test-example@digital.cabinet-office.gov.uk\","
+                        + "\"phoneNumber\": \"test-phone-number\","
+                        + "\"ipAddress\": \"test-ip-address\""
+                        + "},"
+                        + "\"extensions\": {"
+                        + "\"extension-type\": \"test-extension-type\""
+                        + "},"
+                        + "\"persistentSessionId\": \"test-persistent-session-id\""
+                        + "}";
+
+        when(client.getObjectAsString(bucket, file)).thenReturn(auditRecord);
+        when(configurationService.getAuditHmacSecret()).thenReturn("i-am-a-fake-hash-key");
+
+        var handler = new CounterFraudAuditReplayLambda(configurationService, client);
+        var input = mock(S3Event.class);
+        var record = generateEventRecord(bucket, file);
+        when(input.getRecords()).thenReturn(List.of(record));
+        handler.handleRequest(input, mock(Context.class));
+
+        LogEvent logEvent = logging.events().get(1);
+
+        assertThat(logEvent, hasObjectMessageProperty("event-id", "test-event-id"));
+        assertThat(logEvent, hasObjectMessageProperty("request-id", "test-request-id"));
+        assertThat(logEvent, hasObjectMessageProperty("session-id", "test-session-id"));
+        assertThat(logEvent, hasObjectMessageProperty("client-id", "test-client-id"));
+        assertThat(logEvent, hasObjectMessageProperty("timestamp", "test-timestamp"));
+        assertThat(logEvent, hasObjectMessageProperty("event-name", "test-event-name"));
+        assertThat(
+                logEvent,
+                hasObjectMessageProperty("persistent-session-id", "test-persistent-session-id"));
+        assertThat(
+                logEvent,
+                hasObjectMessageProperty(
+                        "user.email",
+                        "dbc2c80d5e663075eb736f52df8446c109878f1a27b9d2f7db634d4e64923c94"));
+        assertThat(
+                logEvent,
+                hasObjectMessageProperty(
+                        "user.id",
+                        "fe3ad3ffe725ab111628ea3df4b04fb0fda486479fb621c8d4ac325c9e1ce91b"));
+        assertThat(
+                logEvent,
+                hasObjectMessageProperty(
+                        "user.phone",
+                        "889340bac0d98dc4f74eeef79c907ea763f3915277d641176fa081d8f7b48cd7"));
+
+        assertThat(logEvent, hasObjectMessageProperty("user.ip-address", "test-ip-address"));
+        assertThat(
+                logEvent,
+                hasObjectMessageProperty("extensions.extension-type", "test-extension-type"));
+
+        verify(client).deleteObject(bucket, file);
+    }
+
+    private S3EventNotification.S3EventNotificationRecord generateEventRecord(
+            String bucketName, String key) {
+        var eventRecord = mock(S3EventNotification.S3EventNotificationRecord.class);
+        var s3 = mock(S3EventNotification.S3Entity.class);
+        var bucket = mock(S3EventNotification.S3BucketEntity.class);
+        var file = mock(S3EventNotification.S3ObjectEntity.class);
+        when(file.getKey()).thenReturn(key);
+        when(bucket.getName()).thenReturn(bucketName);
+        when(s3.getBucket()).thenReturn(bucket);
+        when(s3.getObject()).thenReturn(file);
+        when(eventRecord.getS3()).thenReturn(s3);
+
+        return eventRecord;
+    }
+}

--- a/audit-processors/src/test/java/uk/gov/di/authentication/audit/lambda/CounterFraudAuditReplayLambdaTest.java
+++ b/audit-processors/src/test/java/uk/gov/di/authentication/audit/lambda/CounterFraudAuditReplayLambdaTest.java
@@ -95,6 +95,112 @@ class CounterFraudAuditReplayLambdaTest {
         verify(client).deleteObject(bucket, file);
     }
 
+    @Test
+    void shouldDeserialiseAndLogValidRecordsWithMultipleRecordsFromS3() {
+        final var bucket = "a-bucket";
+        final var file = "a-key";
+        final var auditRecords =
+                "{"
+                        + "\"eventId\": \"test-event-id\","
+                        + "\"requestId\": \"test-request-id\","
+                        + "\"sessionId\": \"test-session-id\","
+                        + "\"clientId\": \"test-client-id\","
+                        + "\"timestamp\": \"test-timestamp\","
+                        + "\"eventName\": \"test-event-name\","
+                        + "\"user\": {"
+                        + "\"id\": \"test-id\","
+                        + "\"email\": \"test-example@digital.cabinet-office.gov.uk\","
+                        + "\"phoneNumber\": \"test-phone-number\","
+                        + "\"ipAddress\": \"test-ip-address\""
+                        + "},"
+                        + "\"extensions\": {"
+                        + "\"extension-type\": \"test-extension-value\""
+                        + "},"
+                        + "\"persistentSessionId\": \"test-persistent-session-id\""
+                        + "}\n"
+                        + "{"
+                        + "\"eventId\": \"a-second-test-event-id\","
+                        + "\"requestId\": \"a-second-test-request-id\","
+                        + "\"sessionId\": \"a-second-test-session-id\","
+                        + "\"clientId\": \"a-second-test-client-id\","
+                        + "\"timestamp\": \"a-second-test-timestamp\","
+                        + "\"eventName\": \"a-second-test-event-name\","
+                        + "\"user\": {"
+                        + "\"id\": \"a-second-test-id\","
+                        + "\"email\": \"a-second-test-example@digital.cabinet-office.gov.uk\","
+                        + "\"phoneNumber\": \"a-second-test-phone-number\","
+                        + "\"ipAddress\": \"a-second-test-ip-address\""
+                        + "},"
+                        + "\"extensions\": {"
+                        + "\"a-second-extension-type\": \"a-second-test-extension-value\""
+                        + "},"
+                        + "\"persistentSessionId\": \"a-second-test-persistent-session-id\""
+                        + "}";
+
+        when(client.getObjectAsString(bucket, file)).thenReturn(auditRecords);
+        when(configurationService.getAuditHmacSecret()).thenReturn("i-am-a-fake-hash-key");
+
+        var handler = new CounterFraudAuditReplayLambda(configurationService, client);
+        var input = mock(S3Event.class);
+        var record = generateEventRecord(bucket, file);
+        when(input.getRecords()).thenReturn(List.of(record));
+        handler.handleRequest(input, mock(Context.class));
+
+        LogEvent logEvent = logging.events().get(1);
+
+        assertThat(logEvent, hasObjectMessageProperty("event-id", "test-event-id"));
+        assertThat(logEvent, hasObjectMessageProperty("request-id", "test-request-id"));
+        assertThat(logEvent, hasObjectMessageProperty("session-id", "test-session-id"));
+        assertThat(logEvent, hasObjectMessageProperty("client-id", "test-client-id"));
+        assertThat(logEvent, hasObjectMessageProperty("timestamp", "test-timestamp"));
+        assertThat(logEvent, hasObjectMessageProperty("event-name", "test-event-name"));
+        assertThat(
+                logEvent,
+                hasObjectMessageProperty("persistent-session-id", "test-persistent-session-id"));
+        assertThat(
+                logEvent,
+                hasObjectMessageProperty(
+                        "user.email",
+                        "dbc2c80d5e663075eb736f52df8446c109878f1a27b9d2f7db634d4e64923c94"));
+        assertThat(
+                logEvent,
+                hasObjectMessageProperty(
+                        "user.id",
+                        "fe3ad3ffe725ab111628ea3df4b04fb0fda486479fb621c8d4ac325c9e1ce91b"));
+        assertThat(
+                logEvent,
+                hasObjectMessageProperty(
+                        "user.phone",
+                        "889340bac0d98dc4f74eeef79c907ea763f3915277d641176fa081d8f7b48cd7"));
+
+        assertThat(logEvent, hasObjectMessageProperty("user.ip-address", "test-ip-address"));
+        assertThat(
+                logEvent,
+                hasObjectMessageProperty("extensions.extension-type", "test-extension-value"));
+
+        logEvent = logging.events().get(2);
+
+        assertThat(logEvent, hasObjectMessageProperty("event-id", "a-second-test-event-id"));
+        assertThat(logEvent, hasObjectMessageProperty("request-id", "a-second-test-request-id"));
+        assertThat(logEvent, hasObjectMessageProperty("session-id", "a-second-test-session-id"));
+        assertThat(logEvent, hasObjectMessageProperty("client-id", "a-second-test-client-id"));
+        assertThat(logEvent, hasObjectMessageProperty("timestamp", "a-second-test-timestamp"));
+        assertThat(logEvent, hasObjectMessageProperty("event-name", "a-second-test-event-name"));
+        assertThat(
+                logEvent,
+                hasObjectMessageProperty(
+                        "persistent-session-id", "a-second-test-persistent-session-id"));
+
+        assertThat(
+                logEvent, hasObjectMessageProperty("user.ip-address", "a-second-test-ip-address"));
+        assertThat(
+                logEvent,
+                hasObjectMessageProperty(
+                        "extensions.a-second-extension-type", "a-second-test-extension-value"));
+
+        verify(client).deleteObject(bucket, file);
+    }
+
     private S3EventNotification.S3EventNotificationRecord generateEventRecord(
             String bucketName, String key) {
         var eventRecord = mock(S3EventNotification.S3EventNotificationRecord.class);

--- a/ci/terraform/audit-processors/counter_fraud_replay.tf
+++ b/ci/terraform/audit-processors/counter_fraud_replay.tf
@@ -1,0 +1,141 @@
+resource "aws_s3_bucket" "fraud_replay_bucket" {
+  bucket = "${var.environment}-fraud-replay-bucket"
+  acl    = "private"
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
+  versioning {
+    enabled = false
+  }
+
+  tags = local.default_tags
+}
+
+resource "aws_s3_bucket_public_access_block" "replay_bucket_access" {
+  bucket                  = aws_s3_bucket.fraud_replay_bucket.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_iam_policy" "replay_bucket_s3_access" {
+  name_prefix = "lambda-s3-access"
+  path        = "/${var.environment}/replay-storage/"
+  description = "IAM policy for managing s3 access to replay lambda"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "s3:GetObject",
+        "s3:DeleteObject",
+      ]
+
+      Resource = [
+        aws_s3_bucket.fraud_replay_bucket.arn,
+        "${aws_s3_bucket.fraud_replay_bucket.arn}/*"
+      ]
+    }]
+  })
+}
+
+module "fraud_realtime_logging_replay_role" {
+  source = "../modules/lambda-role"
+
+  environment = var.environment
+  role_name   = "fraud-realtime-logging-replay"
+  vpc_arn     = local.authentication_vpc_arn
+
+  policies_to_attach = [
+    aws_iam_policy.replay_bucket_s3_access.arn,
+  ]
+}
+
+resource "aws_lambda_function" "fraud_realtime_logging_replay_lambda" {
+  function_name = "${var.environment}-fraud-realtime-logging-replay-lambda"
+  role          = module.fraud_realtime_logging_replay_role.arn
+  handler       = "uk.gov.di.authentication.audit.lambda.CounterFraudAuditReplayLambda::handleRequest"
+  timeout       = 900
+  memory_size   = var.lambda_memory_size
+  publish       = true
+
+  tracing_config {
+    mode = "Active"
+  }
+
+  s3_bucket         = aws_s3_bucket.source_bucket.bucket
+  s3_key            = aws_s3_bucket_object.audit_processor_release_zip.key
+  s3_object_version = aws_s3_bucket_object.audit_processor_release_zip.version_id
+
+  code_signing_config_arn = local.lambda_code_signing_configuration_arn
+
+  vpc_config {
+    security_group_ids = [local.authentication_security_group_id]
+    subnet_ids         = local.authentication_subnet_ids
+  }
+  environment {
+    variables = {
+      AUDIT_HMAC_SECRET = random_password.hmac_key.result
+    }
+  }
+  kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn
+
+  runtime = "java11"
+
+  tags = local.default_tags
+}
+
+resource "aws_lambda_permission" "s3_can_execute_subscriber_fraud_realtime_logging_replay_lambda" {
+  statement_id  = "AllowExecutionFromS3"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.fraud_realtime_logging_replay_lambda.function_name
+  principal     = "s3.amazonaws.com"
+  source_arn    = aws_s3_bucket.fraud_replay_bucket.arn
+}
+
+resource "aws_s3_bucket_notification" "bucket_notification" {
+  bucket = aws_s3_bucket.fraud_replay_bucket.id
+
+  lambda_function {
+    lambda_function_arn = aws_lambda_function.fraud_realtime_logging_replay_lambda.arn
+    events              = ["s3:ObjectCreated:*"]
+    filter_suffix       = ".json"
+  }
+
+  depends_on = [aws_lambda_permission.s3_can_execute_subscriber_fraud_realtime_logging_replay_lambda]
+}
+
+resource "aws_cloudwatch_log_group" "fraud_realtime_logging_replay_lambda_log_group" {
+  count = var.use_localstack ? 0 : 1
+
+  name              = "/aws/lambda/${aws_lambda_function.fraud_realtime_logging_replay_lambda.function_name}"
+  tags              = local.default_tags
+  kms_key_id        = local.cloudwatch_key_arn
+  retention_in_days = 1 # We shouldn't hold onto this for long
+
+  depends_on = [
+    aws_lambda_function.fraud_realtime_logging_replay_lambda
+  ]
+}
+
+# Comment out so we can dry run
+#resource "aws_cloudwatch_log_subscription_filter" "fraud_realtime_logging_replay_log_subscription" {
+#  count           = length(var.logging_endpoint_arns)
+#  name            = "${aws_lambda_function.fraud_realtime_logging_replay_lambda.function_name}-log-subscription-${count.index}"
+#  log_group_name  = aws_cloudwatch_log_group.fraud_realtime_logging_replay_lambda_log_group[0].name
+#  filter_pattern  = ""
+#  destination_arn = var.logging_endpoint_arns[count.index]
+#
+#  lifecycle {
+#    create_before_destroy = false
+#  }
+#}

--- a/tools/replay-messages.sh
+++ b/tools/replay-messages.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+SOURCE=/dev/stdin
+ACCOUNT=digital-identity-prod
+
+function usage() {
+  cat <<USAGE
+  A script to replay audit events from cold storage to the fraud queue via an S3 bucket.
+  Expects a list of S3 URLs point at the source files (in cold storage) to replay.
+
+  Usage:
+    $0 -d <desination s3 url> [-f <filename>]
+
+  Options:
+    -d   the destination s3 url e.g. s3://replay-bucket/
+    -a   the gds cli account alias to use to authenticate to AWS. Defaults to digital-identity-prod.
+    -f   the name of the file to read the list of files from. Defaults to stdin.
+USAGE
+}
+
+if [[ $# == 0 ]]; then
+  usage
+fi
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -f)
+      shift
+      SOURCE=$1
+      ;;
+    -d)
+      shift
+      DESTINATION=$1
+      ;;
+    -a)
+      shift
+      ACCOUNT=$1
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+while read f; do
+  gds aws "${ACCOUNT}" -- aws s3 cp "${f}" "${DESTINATION}"
+done < "${SOURCE}"


### PR DESCRIPTION
## What?

- Add a lambda to replay fraud messages that are placed in a specific S3 bucket
- Add a script that will copy a given list of audit events from audit cold storage to a given S3 bucket (where they can be picked up for replay)
- Add terraform to create the replay bucket
- Add terraform to create the lambda function and execution role
- Add terraform to trigger lambda when objects created in the replay bucket
- DO NOT ENABLE Splunk log subscription.

## Why?

We had an issue where some fraud events were dropped from logging and we need to replay them. This PR gives us a mechanism to pickup the missing events from the S3 "cold storage" and copy them to a different bucket where they can be picked up to replay.

The missing events have been identified using an Athena query. The query gives the S3 URLs for the individual events, these can be fed into the shell script (included in this PR) to copy those events to the replay bucket.

Not enabling the Splunk log subscription, gives the ability to dry run this process before enabling to do the real transfer.
