### PR TITLE
BAU - Add Stub RP config for integration app

### DIFF
--- a/ci/terraform/shared/integration-stub-clients.tfvars
+++ b/ci/terraform/shared/integration-stub-clients.tfvars
@@ -17,4 +17,21 @@ stub_rp_clients = [
       "phone",
     ]
   },
+  {
+    client_name = "di-auth-stub-relying-party-integration-app"
+    callback_urls = [
+      "https://di-auth-stub-relying-party-integration-app.london.cloudapps.digital/oidc/authorization-code/callback",
+    ]
+    logout_urls = [
+      "https://di-auth-stub-relying-party-integration-app.london.cloudapps.digital/signed-out",
+    ]
+    test_client                     = "1"
+    consent_required                = "0"
+    identity_verification_supported = "1"
+    client_type                     = "app"
+    scopes = [
+      "openid",
+      "doc-checking-app",
+    ]
+  },
 ]


### PR DESCRIPTION

## What?

- Add config for a Stub RP App in the Integration environment


## Why?
- So we can test out a app journey in Integration