### PR TITLE
BAU - Refactor endpoint alias

### DIFF
--- a/ci/terraform/modules/endpoint-module/lambda.tf
+++ b/ci/terraform/modules/endpoint-module/lambda.tf
@@ -59,7 +59,7 @@ resource "aws_cloudwatch_log_subscription_filter" "log_subscription" {
 }
 
 resource "aws_lambda_alias" "endpoint_lambda" {
-  name             = replace("${var.environment}-${var.endpoint_name}-lambda-active", ".", "")
+  name             = "active"
   description      = "Alias pointing at active version of Lambda"
   function_name    = aws_lambda_function.endpoint_lambda.arn
   function_version = aws_lambda_function.endpoint_lambda.version


### PR DESCRIPTION
## What?

- Refactor endpoint alias

## Why?

- Remove the endpoint name from the endpoint alias name. We don't need to add the endpoint name to the alias as it just repeats the endpoint name.