### PR TITLE
AUT-435: Stop dual running obfuscation keys

### DIFF
--- a/audit-processors/src/main/java/uk/gov/di/authentication/audit/configuration/TXMAConfiguration.java
+++ b/audit-processors/src/main/java/uk/gov/di/authentication/audit/configuration/TXMAConfiguration.java
@@ -15,7 +15,7 @@ public class TXMAConfiguration {
 
     private final SecretsManagerClient secretsManagerClient;
 
-    private Optional<String> cachedObfuscationHMACSecret;
+    private String cachedObfuscationHMACSecret;
 
     public TXMAConfiguration() {
         this.secretsManagerClient = SecretsManagerClient.builder().build();
@@ -33,7 +33,7 @@ public class TXMAConfiguration {
         return Optional.of(arn);
     }
 
-    public Optional<String> getObfuscationHMACSecret() {
+    public String getObfuscationHMACSecret() {
         if (isNull(cachedObfuscationHMACSecret)) {
             cachedObfuscationHMACSecret =
                     getObfuscationHMACSecretArn()
@@ -50,9 +50,15 @@ public class TXMAConfiguration {
                                             return getSecretValueResponse.secretString();
                                         } catch (Exception e) {
                                             LOG.error("Could not get secret from TXMA", e);
-                                            return null;
+                                            throw new RuntimeException(
+                                                    "Invalid configuration. HMAC secret key cannot be read.",
+                                                    e);
                                         }
-                                    });
+                                    })
+                            .orElseThrow(
+                                    () ->
+                                            new RuntimeException(
+                                                    "Invalid configuration. HMAC secret key not specified."));
         }
         return cachedObfuscationHMACSecret;
     }

--- a/audit-processors/src/main/java/uk/gov/di/authentication/audit/lambda/CounterFraudAuditLambda.java
+++ b/audit-processors/src/main/java/uk/gov/di/authentication/audit/lambda/CounterFraudAuditLambda.java
@@ -24,18 +24,13 @@ public class CounterFraudAuditLambda extends BaseAuditHandler {
             ConfigurationService service,
             TXMAConfiguration txmaConfiguration) {
         super(kmsConnectionService, service);
-        this.hmacKey =
-                txmaConfiguration
-                        .getObfuscationHMACSecret()
-                        .orElseGet(() -> this.service.getAuditHmacSecret());
+        this.hmacKey = txmaConfiguration.getObfuscationHMACSecret();
     }
 
     public CounterFraudAuditLambda() {
         super();
         var config = new TXMAConfiguration();
-        this.hmacKey =
-                config.getObfuscationHMACSecret()
-                        .orElseGet(() -> this.service.getAuditHmacSecret());
+        this.hmacKey = config.getObfuscationHMACSecret();
     }
 
     @Override

--- a/audit-processors/src/test/java/uk/gov/di/authentication/audit/lambda/CounterFraudAuditLambdaTest.java
+++ b/audit-processors/src/test/java/uk/gov/di/authentication/audit/lambda/CounterFraudAuditLambdaTest.java
@@ -12,7 +12,6 @@ import uk.gov.di.authentication.shared.services.KmsConnectionService;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
 import java.nio.ByteBuffer;
-import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -37,8 +36,7 @@ public class CounterFraudAuditLambdaTest {
     @BeforeEach
     public void setUp() {
         when(config.getAuditSigningKeyAlias()).thenReturn("key_alias");
-        when(txmaConfiguration.getObfuscationHMACSecret())
-                .thenReturn(Optional.of("i-am-a-fake-hash-key"));
+        when(txmaConfiguration.getObfuscationHMACSecret()).thenReturn("i-am-a-fake-hash-key");
         when(kms.validateSignature(any(ByteBuffer.class), any(ByteBuffer.class), eq("key_alias")))
                 .thenReturn(true);
         handler = new CounterFraudAuditLambda(kms, config, txmaConfiguration);

--- a/ci/terraform/audit-processors/site.tf
+++ b/ci/terraform/audit-processors/site.tf
@@ -33,6 +33,7 @@ provider "aws" {
     sns    = var.aws_endpoint
   }
 }
+
 locals {
   // Using a local rather than the default_tags option on the AWS provider, as the latter has known issues which produce errors on apply.
   default_tags = {
@@ -40,3 +41,8 @@ locals {
     application = "audit-processors"
   }
 }
+
+
+data "aws_caller_identity" "current" {}
+
+data "aws_partition" "current" {}


### PR DESCRIPTION
## What?

- Use only the TXMA obfuscation key, fall back to locally provided one if secret does not exist (this will only occur in certain non-prod environments).
- Only output the a single version of the sensitive fields. (Remove the `.txma` version)
- In environments that are not linked to a "real" TXMA using Secrets Manager to store the generated HMAC secret to make the application code cleaner.

## Why?

We have dual run the HMAC secrets and are happy that things are working as they should. Let's shut off the old key all environments that are linked to real TXMA envs.