### PR TITLE
AUT-471 - Add additional properties to SPOTRequest

### DIFF
--- a/doc-checking-app-api/src/main/resources/log4j2.xml
+++ b/doc-checking-app-api/src/main/resources/log4j2.xml
@@ -3,6 +3,10 @@
         <Lambda name="Lambda">
             <JsonLayout compact="true" eventEol="true" objectMessageAsJsonObject="true" >
                 <KeyValuePair key="session-id" value="$${ctx:sessionId:-unknown}"/>
+                <KeyValuePair key="persistent-session-id" value="$${ctx:persistentSessionId:-}"/>
+                <KeyValuePair key="client-session-id" value="$${ctx:clientSessionId:-}"/>
+                <KeyValuePair key="client-id" value="$${ctx:clientId:-}"/>
+                <KeyValuePair key="aws-request-id" value="$${ctx:awsRequestId:-}"/>
             </JsonLayout>
         </Lambda>
     </Appenders>

--- a/frontend-api/src/main/resources/log4j2.xml
+++ b/frontend-api/src/main/resources/log4j2.xml
@@ -3,6 +3,10 @@
         <Lambda name="Lambda">
             <JsonLayout compact="true" eventEol="true" objectMessageAsJsonObject="true" >
                 <KeyValuePair key="session-id" value="$${ctx:sessionId:-unknown}"/>
+                <KeyValuePair key="persistent-session-id" value="$${ctx:persistentSessionId:-}"/>
+                <KeyValuePair key="client-session-id" value="$${ctx:clientSessionId:-}"/>
+                <KeyValuePair key="client-id" value="$${ctx:clientId:-}"/>
+                <KeyValuePair key="aws-request-id" value="$${ctx:awsRequestId:-}"/>
             </JsonLayout>
         </Lambda>
     </Appenders>

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
@@ -142,7 +142,11 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                                 sectorId,
                                 pairwiseIdentifier,
                                 new LogIds(
-                                        sessionId, persistentSessionId, "request-i", CLIENT_ID))));
+                                        sessionId,
+                                        persistentSessionId,
+                                        "request-i",
+                                        CLIENT_ID,
+                                        clientSessionId))));
 
         var identityCredentials = identityStore.getIdentityCredentials(pairwiseIdentifier);
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
@@ -146,7 +146,8 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                                         persistentSessionId,
                                         "request-i",
                                         CLIENT_ID,
-                                        clientSessionId))));
+                                        clientSessionId),
+                                CLIENT_ID)));
 
         var identityCredentials = identityStore.getIdentityCredentials(pairwiseIdentifier);
 

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/LogIds.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/LogIds.java
@@ -12,11 +12,19 @@ public class LogIds {
 
     @Expose private String clientId;
 
-    public LogIds(String sessionId, String persistentSessionId, String requestId, String clientId) {
+    @Expose private String clientSessionId;
+
+    public LogIds(
+            String sessionId,
+            String persistentSessionId,
+            String requestId,
+            String clientId,
+            String clientSessionId) {
         this.sessionId = sessionId;
         this.persistentSessionId = persistentSessionId;
         this.requestId = requestId;
         this.clientId = clientId;
+        this.clientSessionId = clientSessionId;
     }
 
     public LogIds() {}
@@ -35,5 +43,9 @@ public class LogIds {
 
     public String getClientId() {
         return clientId;
+    }
+
+    public String getClientSessionId() {
+        return clientSessionId;
     }
 }

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/SPOTRequest.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/SPOTRequest.java
@@ -34,19 +34,25 @@ public class SPOTRequest {
     @Expose
     private LogIds logIds;
 
+    @SerializedName(value = "out_audience")
+    @Expose
+    private String audience;
+
     public SPOTRequest(
             Map<String, Object> spotClaims,
             String localAccountId,
             byte[] salt,
             String rpSectorId,
             String sub,
-            LogIds logIds) {
+            LogIds logIds,
+            String audience) {
         this.spotClaims = spotClaims;
         this.localAccountId = localAccountId;
         this.salt = salt;
         this.rpSectorId = rpSectorId;
         this.sub = sub;
         this.logIds = logIds;
+        this.audience = audience;
     }
 
     public SPOTRequest() {}
@@ -73,5 +79,9 @@ public class SPOTRequest {
 
     public LogIds getLogIds() {
         return logIds;
+    }
+
+    public String getAudience() {
+        return audience;
     }
 }

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -299,7 +299,8 @@ public class IPVCallbackHandler
                                                         session.getSessionId(),
                                                         persistentId,
                                                         context.getAwsRequestId(),
-                                                        clientId);
+                                                        clientId,
+                                                        sessionCookiesIds.getClientSessionId());
                                         queueSPOTRequest(
                                                 logIds,
                                                 getSectorIdentifierForClient(clientRegistry),

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -306,7 +306,8 @@ public class IPVCallbackHandler
                                                 getSectorIdentifierForClient(clientRegistry),
                                                 userProfile,
                                                 pairwiseSubject,
-                                                userIdentityUserInfo);
+                                                userIdentityUserInfo,
+                                                clientId);
 
                                         auditService.submitAuditEvent(
                                                 IPVAuditableEvent.IPV_SPOT_REQUESTED,
@@ -401,7 +402,8 @@ public class IPVCallbackHandler
             String sectorIdentifier,
             UserProfile userProfile,
             Subject pairwiseSubject,
-            UserInfo userIdentityUserInfo)
+            UserInfo userIdentityUserInfo,
+            String clientId)
             throws JsonException {
 
         var spotClaimsBuilder =
@@ -432,7 +434,8 @@ public class IPVCallbackHandler
                         dynamoService.getOrGenerateSalt(userProfile),
                         sectorIdentifier,
                         pairwiseSubject.getValue(),
-                        logIds);
+                        logIds,
+                        clientId);
         var spotRequestString = objectMapper.writeValueAsString(spotRequest);
         sqsClient.send(spotRequestString);
         if (configurationService.isIdentityTraceLoggingEnabled()) {

--- a/ipv-api/src/main/resources/log4j2.xml
+++ b/ipv-api/src/main/resources/log4j2.xml
@@ -3,6 +3,10 @@
         <Lambda name="Lambda">
             <JsonLayout compact="true" eventEol="true" objectMessageAsJsonObject="true" >
                 <KeyValuePair key="session-id" value="$${ctx:sessionId:-unknown}"/>
+                <KeyValuePair key="persistent-session-id" value="$${ctx:persistentSessionId:-}"/>
+                <KeyValuePair key="client-session-id" value="$${ctx:clientSessionId:-}"/>
+                <KeyValuePair key="client-id" value="$${ctx:clientId:-}"/>
+                <KeyValuePair key="aws-request-id" value="$${ctx:awsRequestId:-}"/>
             </JsonLayout>
         </Lambda>
     </Appenders>

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -268,7 +268,8 @@ class IPVCallbackHandlerTest {
                                                 session.getSessionId(),
                                                 PERSISTENT_SESSION_ID,
                                                 REQUEST_ID,
-                                                CLIENT_ID.getValue()))));
+                                                CLIENT_ID.getValue(),
+                                                CLIENT_SESSION_ID))));
 
         verify(dynamoIdentityService)
                 .addAdditionalClaims(expectedPairwiseSub.getValue(), additionalClaims);

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -269,7 +269,8 @@ class IPVCallbackHandlerTest {
                                                 PERSISTENT_SESSION_ID,
                                                 REQUEST_ID,
                                                 CLIENT_ID.getValue(),
-                                                CLIENT_SESSION_ID))));
+                                                CLIENT_SESSION_ID),
+                                        CLIENT_ID.getValue())));
 
         verify(dynamoIdentityService)
                 .addAdditionalClaims(expectedPairwiseSub.getValue(), additionalClaims);


### PR DESCRIPTION
## What?

- Add clientSessionId to SPOTRequest
- Add audience to SPOTRequest
- Add missing context logging to relevant repos

## Why?

- The audience will be set by the clientID. This will be the audience in the https://vocab.account.gov.uk/v1/coreIdentityJWT
- Add missing context logging to relevant repos. Without this the fields will be omitted in our logs.