### PR TITLE
BAU: Refactor security headers and add to API

### DIFF
--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 
+import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
 import static uk.gov.di.authentication.shared.helpers.WarmerHelper.isWarming;
 
@@ -206,12 +207,13 @@ public class DocAppCallbackHandler
                                             ConstructUriHelper.buildURI(
                                                     configurationService.getLoginURI().toString(),
                                                     REDIRECT_PATH);
-                                    return new APIGatewayProxyResponseEvent()
-                                            .withStatusCode(302)
-                                            .withHeaders(
-                                                    Map.of(
-                                                            ResponseHeaders.LOCATION,
-                                                            redirectURI.toString()));
+                                    return generateApiGatewayProxyResponse(
+                                            302,
+                                            "",
+                                            Map.of(
+                                                    ResponseHeaders.LOCATION,
+                                                    redirectURI.toString()),
+                                            null);
 
                                 } catch (UnsuccesfulCredentialResponseException e) {
                                     auditService.submitAuditEvent(

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -52,6 +52,7 @@ import java.util.Optional;
 import static com.nimbusds.oauth2.sdk.OAuth2Error.ACCESS_DENIED_CODE;
 import static uk.gov.di.authentication.shared.entity.IdentityClaims.VOT;
 import static uk.gov.di.authentication.shared.entity.IdentityClaims.VTM;
+import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.authentication.shared.helpers.ClientSubjectHelper.getSectorIdentifierForClient;
 import static uk.gov.di.authentication.shared.helpers.ConstructUriHelper.buildURI;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.CLIENT_SESSION_ID;
@@ -192,12 +193,13 @@ public class IPVCallbackHandler
                                                             errorObject.get().getDescription()),
                                                     authRequest.getState(),
                                                     authRequest.getResponseMode());
-                                    return new APIGatewayProxyResponseEvent()
-                                            .withStatusCode(302)
-                                            .withHeaders(
-                                                    Map.of(
-                                                            ResponseHeaders.LOCATION,
-                                                            errorResponse.toURI().toString()));
+                                    return generateApiGatewayProxyResponse(
+                                            302,
+                                            "",
+                                            Map.of(
+                                                    ResponseHeaders.LOCATION,
+                                                    errorResponse.toURI().toString()),
+                                            null);
                                 }
                                 var userProfile =
                                         dynamoService
@@ -325,12 +327,13 @@ public class IPVCallbackHandler
                                                         userIdentityError.get(),
                                                         authRequest.getState(),
                                                         authRequest.getResponseMode());
-                                        return new APIGatewayProxyResponseEvent()
-                                                .withStatusCode(302)
-                                                .withHeaders(
-                                                        Map.of(
-                                                                ResponseHeaders.LOCATION,
-                                                                errorResponse.toURI().toString()));
+                                        return generateApiGatewayProxyResponse(
+                                                302,
+                                                "",
+                                                Map.of(
+                                                        ResponseHeaders.LOCATION,
+                                                        errorResponse.toURI().toString()),
+                                                null);
                                     }
                                 }
                                 saveAdditionalClaimsToDynamo(pairwiseSubject, userIdentityUserInfo);
@@ -338,12 +341,11 @@ public class IPVCallbackHandler
                                         ConstructUriHelper.buildURI(
                                                 configurationService.getLoginURI().toString(),
                                                 REDIRECT_PATH);
-                                return new APIGatewayProxyResponseEvent()
-                                        .withStatusCode(302)
-                                        .withHeaders(
-                                                Map.of(
-                                                        ResponseHeaders.LOCATION,
-                                                        redirectURI.toString()));
+                                return generateApiGatewayProxyResponse(
+                                        302,
+                                        "",
+                                        Map.of(ResponseHeaders.LOCATION, redirectURI.toString()),
+                                        null);
                             } catch (NoSuchElementException e) {
                                 LOG.warn("Session not found", e);
                                 throw new RuntimeException("Session not found", e);

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -38,6 +38,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.AWS_REQUEST_ID;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.CLIENT_ID;
@@ -285,10 +286,11 @@ public class AuthorisationHandler
                                 configurationService.getPersistentCookieMaxAge(),
                                 configurationService.getSessionCookieAttributes(),
                                 configurationService.getDomainName()));
-        return new APIGatewayProxyResponseEvent()
-                .withStatusCode(302)
-                .withHeaders(Map.of(ResponseHeaders.LOCATION, redirectURI))
-                .withMultiValueHeaders(Map.of(ResponseHeaders.SET_COOKIE, cookies));
+        return generateApiGatewayProxyResponse(
+                302,
+                "",
+                Map.of(ResponseHeaders.LOCATION, redirectURI),
+                Map.of(ResponseHeaders.SET_COOKIE, cookies));
     }
 
     private APIGatewayProxyResponseEvent generateErrorResponse(
@@ -317,8 +319,8 @@ public class AuthorisationHandler
                 errorObject.getCode(),
                 errorObject.getDescription());
         var error = new AuthenticationErrorResponse(redirectUri, errorObject, state, responseMode);
-        return new APIGatewayProxyResponseEvent()
-                .withStatusCode(302)
-                .withHeaders(Map.of(ResponseHeaders.LOCATION, error.toURI().toString()));
+
+        return generateApiGatewayProxyResponse(
+                302, "", Map.of(ResponseHeaders.LOCATION, error.toURI().toString()), null);
     }
 }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
@@ -32,6 +32,7 @@ import java.text.ParseException;
 import java.util.Map;
 import java.util.Optional;
 
+import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.CLIENT_SESSION_ID;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachLogFieldToLogs;
@@ -368,9 +369,9 @@ public class LogoutHandler
                 IpAddressHelper.extractIpAddress(input),
                 AuditService.UNKNOWN,
                 PersistentIdHelper.extractPersistentIdFromCookieHeader(input.getHeaders()));
-        return new APIGatewayProxyResponseEvent()
-                .withStatusCode(302)
-                .withHeaders(Map.of(ResponseHeaders.LOCATION, uri.toString()));
+
+        return generateApiGatewayProxyResponse(
+                302, "", Map.of(ResponseHeaders.LOCATION, uri.toString()), null);
     }
 
     private void destroySessions(Session session) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ApiGatewayResponseHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ApiGatewayResponseHelper.java
@@ -12,11 +12,12 @@ import uk.gov.di.authentication.shared.services.SerializationService;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class ApiGatewayResponseHelper {
 
-    enum SecurityHeaders {
+    public enum SecurityHeaders {
         XSS_PROTECTION("X-XSS-Protection", "1; mode=block"),
         CONTENT_TYPE_OPTIONS("X-Content-Type-Options", "nosniff"),
         CONTENT_SECURITY_POLICY("Content-Security-Policy", "frame-ancestors 'none'"),
@@ -83,6 +84,29 @@ public class ApiGatewayResponseHelper {
                         .withStatusCode(statusCode)
                         .withBody(body)
                         .withHeaders(SecurityHeaders.headers());
+
+        if (multiValueHeaders != null) {
+            response.setMultiValueHeaders(multiValueHeaders);
+        }
+
+        return response;
+    }
+
+    public static APIGatewayProxyResponseEvent generateApiGatewayProxyResponse(
+            int statusCode,
+            String body,
+            Map<String, String> headers,
+            Map<String, List<String>> multiValueHeaders) {
+
+        var allHeaders = SecurityHeaders.headers();
+
+        Optional.ofNullable(headers).ifPresent(allHeaders::putAll);
+
+        var response =
+                new APIGatewayProxyResponseEvent()
+                        .withStatusCode(statusCode)
+                        .withBody(body)
+                        .withHeaders(allHeaders);
 
         if (multiValueHeaders != null) {
             response.setMultiValueHeaders(multiValueHeaders);

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ApiGatewayResponseHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ApiGatewayResponseHelper.java
@@ -77,17 +77,17 @@ public class ApiGatewayResponseHelper {
 
     public static APIGatewayProxyResponseEvent generateApiGatewayProxyResponse(
             int statusCode, String body, Map<String, List<String>> multiValueHeaders) {
-        APIGatewayProxyResponseEvent apiGatewayProxyResponseEvent =
-                new APIGatewayProxyResponseEvent();
-        apiGatewayProxyResponseEvent.setStatusCode(statusCode);
-        apiGatewayProxyResponseEvent.setBody(body);
+
+        var response =
+                new APIGatewayProxyResponseEvent()
+                        .withStatusCode(statusCode)
+                        .withBody(body)
+                        .withHeaders(SecurityHeaders.headers());
 
         if (multiValueHeaders != null) {
-            apiGatewayProxyResponseEvent.setMultiValueHeaders(multiValueHeaders);
+            response.setMultiValueHeaders(multiValueHeaders);
         }
 
-        apiGatewayProxyResponseEvent.setHeaders(SecurityHeaders.headers());
-
-        return apiGatewayProxyResponseEvent;
+        return response;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ApiGatewayResponseHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ApiGatewayResponseHelper.java
@@ -9,8 +9,10 @@ import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.serialization.Json.JsonException;
 import uk.gov.di.authentication.shared.services.SerializationService;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class ApiGatewayResponseHelper {
 
@@ -31,22 +33,12 @@ public class ApiGatewayResponseHelper {
             this.headerName = headerName;
             this.headerValue = headerValue;
         }
+
+        public static Map<String, String> headers() {
+            return Arrays.stream(SecurityHeaders.values())
+                    .collect(Collectors.toMap(x -> x.headerName, x -> x.headerValue));
+        }
     }
-
-    private static final String XSS_PROTECTION_HEADER_NAME = "X-XSS-Protection";
-    private static final String CONTENT_TYPE_OPTIONS_HEADER_NAME = "X-Content-Type-Options";
-    private static final String CONTENT_SECURITY_POLICY_HEADER_NAME = "Content-Security-Policy";
-    private static final String STRICT_TRANSPORT_SECURITY_HEADER_NAME = "Strict-Transport-Security";
-    private static final String X_FRAME_OPTIONS_HEADER_NAME = "X-Frame-Options";
-
-    private static final String CACHE_CONTROL_HEADER_VALUE = "no-cache, no-store";
-    private static final String PRAGMA_HEADER_VALUE = "no-cache";
-    private static final String XSS_PROTECTION_HEADER_VALUE = "1; mode=block";
-    private static final String CONTENT_TYPE_OPTIONS_HEADER_VALUE = "nosniff";
-    private static final String CONTENT_SECURITY_POLICY_HEADER_VALUE = "frame-ancestors 'none'";
-    private static final String STRICT_TRANSPORT_SECURITY_HEADER_VALUE =
-            "max-age=31536000; includeSubDomains; preload";
-    private static final String X_FRAME_OPTIONS_HEADER_VALUE = "DENY";
 
     private static final Logger LOG = LogManager.getLogger(ApiGatewayResponseHelper.class);
     private static final Json objectMapper = SerializationService.getInstance();
@@ -94,22 +86,7 @@ public class ApiGatewayResponseHelper {
             apiGatewayProxyResponseEvent.setMultiValueHeaders(multiValueHeaders);
         }
 
-        Map<String, String> securityHeaders =
-                Map.ofEntries(
-                        Map.entry(HttpHeaders.CACHE_CONTROL, CACHE_CONTROL_HEADER_VALUE),
-                        Map.entry(HttpHeaders.PRAGMA, PRAGMA_HEADER_VALUE),
-                        Map.entry(XSS_PROTECTION_HEADER_NAME, XSS_PROTECTION_HEADER_VALUE),
-                        Map.entry(
-                                CONTENT_TYPE_OPTIONS_HEADER_NAME,
-                                CONTENT_TYPE_OPTIONS_HEADER_VALUE),
-                        Map.entry(
-                                CONTENT_SECURITY_POLICY_HEADER_NAME,
-                                CONTENT_SECURITY_POLICY_HEADER_VALUE),
-                        Map.entry(
-                                STRICT_TRANSPORT_SECURITY_HEADER_NAME,
-                                STRICT_TRANSPORT_SECURITY_HEADER_VALUE),
-                        Map.entry(X_FRAME_OPTIONS_HEADER_NAME, X_FRAME_OPTIONS_HEADER_VALUE));
-        apiGatewayProxyResponseEvent.setHeaders(securityHeaders);
+        apiGatewayProxyResponseEvent.setHeaders(SecurityHeaders.headers());
 
         return apiGatewayProxyResponseEvent;
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ApiGatewayResponseHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ApiGatewayResponseHelper.java
@@ -14,6 +14,25 @@ import java.util.Map;
 
 public class ApiGatewayResponseHelper {
 
+    enum SecurityHeaders {
+        XSS_PROTECTION("X-XSS-Protection", "1; mode=block"),
+        CONTENT_TYPE_OPTIONS("X-Content-Type-Options", "nosniff"),
+        CONTENT_SECURITY_POLICY("Content-Security-Policy", "frame-ancestors 'none'"),
+        STRICT_TRANSPORT_SECURITY(
+                "Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload"),
+        FRAME_OPTIONS("X-Frame-Options", "DENY"),
+        CACHE_CONTROL(HttpHeaders.CACHE_CONTROL, "no-cache, no-store"),
+        PRAGMA(HttpHeaders.PRAGMA, "no-cache");
+
+        private final String headerName;
+        private final String headerValue;
+
+        SecurityHeaders(String headerName, String headerValue) {
+            this.headerName = headerName;
+            this.headerValue = headerValue;
+        }
+    }
+
     private static final String XSS_PROTECTION_HEADER_NAME = "X-XSS-Protection";
     private static final String CONTENT_TYPE_OPTIONS_HEADER_NAME = "X-Content-Type-Options";
     private static final String CONTENT_SECURITY_POLICY_HEADER_NAME = "Content-Security-Policy";


### PR DESCRIPTION
- BAU: Create enum for security headers
- BAU: Generate security headers map from enum
- BAU: Use builder-esque pattern to create responses rather than setters
- BAU: Attach default headers to existing APIs that don't use helper
