### PR TITLE
BAU: Set max-age on JWKs endpoint

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/JwksHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/JwksHandler.java
@@ -11,6 +11,8 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.KmsConnectionService;
 import uk.gov.di.authentication.shared.services.TokenValidationService;
 
+import java.util.Map;
+
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
 import static uk.gov.di.authentication.shared.helpers.WarmerHelper.isWarming;
@@ -65,7 +67,9 @@ public class JwksHandler
                                 return generateApiGatewayProxyResponse(
                                         200,
                                         segmentedFunctionCall(
-                                                "serialiseJWKSet", () -> jwks.toString(true)));
+                                                "serialiseJWKSet", () -> jwks.toString(true)),
+                                        Map.of("Cache-Control", "max-age=86400"),
+                                        null);
                             } catch (Exception e) {
                                 LOG.error("Error in JWKs lambda", e);
                                 return generateApiGatewayProxyResponse(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/JwksHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/JwksHandlerTest.java
@@ -18,6 +18,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasHeader;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 class JwksHandlerTest {
@@ -57,5 +58,15 @@ class JwksHandlerTest {
 
         assertThat(result, hasStatus(500));
         assertThat(result, hasBody("Error providing JWKs data"));
+    }
+
+    @Test
+    public void shouldSetACacheHeaderOfOneDayOnSuccess() throws JOSEException {
+        JWK opaqueSigningKey =
+                new RSAKeyGenerator(2048).keyID(UUID.randomUUID().toString()).generate();
+        when(tokenValidationService.getPublicJwkWithOpaqueId()).thenReturn(opaqueSigningKey);
+
+        var response = handler.handleRequest(new APIGatewayProxyRequestEvent(), context);
+        assertThat(response, hasHeader("Cache-Control", "max-age=86400"));
     }
 }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/matchers/APIGatewayProxyResponseEventMatcher.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/matchers/APIGatewayProxyResponseEventMatcher.java
@@ -7,9 +7,11 @@ import org.hamcrest.TypeSafeDiagnosingMatcher;
 import uk.gov.di.authentication.shared.services.SerializationService;
 
 import java.net.URI;
+import java.util.Map;
 import java.util.function.Function;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
 import static uk.gov.di.authentication.sharedtest.exceptions.Unchecked.unchecked;
 
 public class APIGatewayProxyResponseEventMatcher<T>
@@ -49,8 +51,7 @@ public class APIGatewayProxyResponseEventMatcher<T>
         return "an APIGatewayProxyResponseEvent with " + name + ": " + value;
     }
 
-    public static APIGatewayProxyResponseEventMatcher<Integer> hasStatus(
-            int statusCode) {
+    public static APIGatewayProxyResponseEventMatcher<Integer> hasStatus(int statusCode) {
         return new APIGatewayProxyResponseEventMatcher<>(
                 "status code", APIGatewayProxyResponseEvent::getStatusCode, equalTo(statusCode));
     }
@@ -61,14 +62,12 @@ public class APIGatewayProxyResponseEventMatcher<T>
                 "status code", APIGatewayProxyResponseEvent::getStatusCode, statusCodeMatcher);
     }
 
-    public static APIGatewayProxyResponseEventMatcher<String> hasBody(
-            String body) {
+    public static APIGatewayProxyResponseEventMatcher<String> hasBody(String body) {
         return new APIGatewayProxyResponseEventMatcher<>(
                 "body", APIGatewayProxyResponseEvent::getBody, equalTo(body));
     }
 
-    public static APIGatewayProxyResponseEventMatcher<String> hasJsonBody(
-            Object body) {
+    public static APIGatewayProxyResponseEventMatcher<String> hasJsonBody(Object body) {
         var expectedValue =
                 unchecked(SerializationService.getInstance()::writeValueAsString).apply(body);
 
@@ -76,12 +75,18 @@ public class APIGatewayProxyResponseEventMatcher<T>
                 "body", APIGatewayProxyResponseEvent::getBody, equalTo(expectedValue));
     }
 
+    public static APIGatewayProxyResponseEventMatcher<Map<? extends String, ? extends String>>
+            hasHeader(String key, String value) {
+
+        return new APIGatewayProxyResponseEventMatcher<>(
+                "body", APIGatewayProxyResponseEvent::getHeaders, hasEntry(key, value));
+    }
+
     public static APIGatewayProxyResponseEventMatcher<Integer> isRedirect() {
         return hasStatus(302);
     }
 
-    public static APIGatewayProxyResponseEventMatcher<URI> isRedirectTo(
-            Matcher<URI> expected) {
+    public static APIGatewayProxyResponseEventMatcher<URI> isRedirectTo(Matcher<URI> expected) {
         return new APIGatewayProxyResponseEventMatcher<>(
                 "redirect to",
                 apiGatewayProxyResponseEvent ->

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/matchers/APIGatewayProxyResponseEventMatcher.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/matchers/APIGatewayProxyResponseEventMatcher.java
@@ -12,15 +12,15 @@ import java.util.function.Function;
 import static org.hamcrest.Matchers.equalTo;
 import static uk.gov.di.authentication.sharedtest.exceptions.Unchecked.unchecked;
 
-public class APIGatewayProxyResponseEventMatcher<T, M extends Matcher>
+public class APIGatewayProxyResponseEventMatcher<T>
         extends TypeSafeDiagnosingMatcher<APIGatewayProxyResponseEvent> {
 
     private final String name;
     private final Function<APIGatewayProxyResponseEvent, T> mapper;
-    private final M matcher;
+    private final Matcher<T> matcher;
 
     private APIGatewayProxyResponseEventMatcher(
-            String name, Function<APIGatewayProxyResponseEvent, T> mapper, M matcher) {
+            String name, Function<APIGatewayProxyResponseEvent, T> mapper, Matcher<T> matcher) {
         this.name = name;
         this.mapper = mapper;
         this.matcher = matcher;
@@ -49,25 +49,25 @@ public class APIGatewayProxyResponseEventMatcher<T, M extends Matcher>
         return "an APIGatewayProxyResponseEvent with " + name + ": " + value;
     }
 
-    public static APIGatewayProxyResponseEventMatcher<Integer, Matcher<Integer>> hasStatus(
+    public static APIGatewayProxyResponseEventMatcher<Integer> hasStatus(
             int statusCode) {
         return new APIGatewayProxyResponseEventMatcher<>(
                 "status code", APIGatewayProxyResponseEvent::getStatusCode, equalTo(statusCode));
     }
 
-    public static APIGatewayProxyResponseEventMatcher<Integer, Matcher<Integer>> hasStatus(
+    public static APIGatewayProxyResponseEventMatcher<Integer> hasStatus(
             Matcher<Integer> statusCodeMatcher) {
         return new APIGatewayProxyResponseEventMatcher<>(
                 "status code", APIGatewayProxyResponseEvent::getStatusCode, statusCodeMatcher);
     }
 
-    public static APIGatewayProxyResponseEventMatcher<String, Matcher<String>> hasBody(
+    public static APIGatewayProxyResponseEventMatcher<String> hasBody(
             String body) {
         return new APIGatewayProxyResponseEventMatcher<>(
                 "body", APIGatewayProxyResponseEvent::getBody, equalTo(body));
     }
 
-    public static APIGatewayProxyResponseEventMatcher<String, Matcher<String>> hasJsonBody(
+    public static APIGatewayProxyResponseEventMatcher<String> hasJsonBody(
             Object body) {
         var expectedValue =
                 unchecked(SerializationService.getInstance()::writeValueAsString).apply(body);
@@ -76,11 +76,11 @@ public class APIGatewayProxyResponseEventMatcher<T, M extends Matcher>
                 "body", APIGatewayProxyResponseEvent::getBody, equalTo(expectedValue));
     }
 
-    public static APIGatewayProxyResponseEventMatcher<Integer, Matcher<Integer>> isRedirect() {
+    public static APIGatewayProxyResponseEventMatcher<Integer> isRedirect() {
         return hasStatus(302);
     }
 
-    public static APIGatewayProxyResponseEventMatcher<URI, Matcher<URI>> isRedirectTo(
+    public static APIGatewayProxyResponseEventMatcher<URI> isRedirectTo(
             Matcher<URI> expected) {
         return new APIGatewayProxyResponseEventMatcher<>(
                 "redirect to",


### PR DESCRIPTION
## What?

This sets a max-age of one day on the contents from the JWKs endpoint.

## Why?

This should encourage relying parties to periodically refresh the keys and enable us to do shorter duration key additions and removals.

https://openid.net/specs/openid-connect-core-1_0.html#RotateEncKeys
