### PR TITLE
BAU - Test that the supported keys work for PrivateKeyJWT

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/WellknownHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/WellknownHandler.java
@@ -100,7 +100,10 @@ public class WellknownHandler
                                         List.of(
                                                 JWSAlgorithm.RS256,
                                                 JWSAlgorithm.RS384,
-                                                JWSAlgorithm.RS512));
+                                                JWSAlgorithm.RS512,
+                                                JWSAlgorithm.PS256,
+                                                JWSAlgorithm.PS384,
+                                                JWSAlgorithm.PS512));
                                 providerMetadata.setServiceDocsURI(
                                         new URI("https://docs.sign-in.service.gov.uk/"));
                                 providerMetadata.setEndSessionEndpointURI(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
@@ -432,6 +432,10 @@ public class TokenService {
             JWTClaimsSet claimsSet = signedJWT.getJWTClaimsSet();
             Date currentDateTime = NowHelper.now();
             if (DateUtils.isBefore(claimsSet.getExpirationTime(), currentDateTime, 30)) {
+                LOG.warn(
+                        "PrivateKeyJWT has expired. Expiration time: {}. Current time: {}",
+                        claimsSet.getExpirationTime(),
+                        currentDateTime);
                 return true;
             }
         } catch (java.text.ParseException e) {
@@ -465,6 +469,7 @@ public class TokenService {
                     KeyFactory kf = KeyFactory.getInstance("RSA");
                     return Collections.singletonList(kf.generatePublic(x509publicKey));
                 } catch (InvalidKeySpecException | NoSuchAlgorithmException e) {
+                    LOG.warn("Exception when selecting public key", e);
                     throw new RuntimeException(e);
                 }
             }


### PR DESCRIPTION
## What?

- Add tests to the TokenService to ensure we can support the keys we say we can support in the wellknown endpoint
- Add extra logging in the TokenService to make it easier to debug errors
- Re-introduce PS256, PS384 and PS512 to the wellknown endpoint as do support these algorithms

## Why?

- To give us more confidence we can support certain algorithms 
- To help us debug issues easier