### PR TITLE
AUT-472 - Fix rate limit OTP bug

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -136,8 +136,9 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                 return generateApiGatewayProxyErrorResponse(400, errorResponse.get());
             }
 
+            sessionService.save(session);
+
             if (errorResponse.isPresent()) {
-                sessionService.save(session);
                 processBlockedCodeSession(
                         errorResponse.get(),
                         session,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -43,6 +43,7 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.MEDIUM_LEVEL;
@@ -149,6 +150,7 @@ class VerifyCodeHandlerTest {
 
         verify(codeStorageService).deleteOtpCode(TEST_EMAIL_ADDRESS, VERIFY_EMAIL);
         assertThat(result, hasStatus(204));
+        verify(sessionService).save(session);
 
         verify(auditService)
                 .submitAuditEvent(
@@ -178,6 +180,7 @@ class VerifyCodeHandlerTest {
         assertThat(result, hasStatus(204));
         assertThat(session.getCurrentCredentialStrength(), equalTo(MEDIUM_LEVEL));
 
+        verify(sessionService, times(2)).save(session);
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CODE_VERIFIED,
@@ -353,7 +356,7 @@ class VerifyCodeHandlerTest {
 
         verify(codeStorageService).deleteOtpCode(TEST_EMAIL_ADDRESS, MFA_SMS);
         assertThat(result, hasStatus(204));
-
+        verify(sessionService).save(session);
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CODE_VERIFIED,

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
@@ -147,6 +147,14 @@ public class RedisExtension
         return objectMapper.readValue(redis.getValue(sessionId), Session.class);
     }
 
+    public void incrementSessionCodeRequestCount(String sessionId) throws Json.JsonException {
+        var session =
+                objectMapper
+                        .readValue(redis.getValue(sessionId), Session.class)
+                        .incrementCodeRequestCount();
+        redis.saveWithExpiry(sessionId, objectMapper.writeValueAsString(session), 3600);
+    }
+
     public String generateAndSaveEmailCode(String email, long codeExpiryTime) {
         var code = new CodeGeneratorService().sixDigitCode();
         new CodeStorageService(redis).saveOtpCode(email, code, codeExpiryTime, VERIFY_EMAIL);


### PR DESCRIPTION
## What?

- Change the VerifyCodeHandler to save the session when a user enters a valid code.
- Add additional checks and tests to confirm this behaviour

## Why?

- We were resetting the count in the session when a valid code was entered, but we were never saving the session so this reset was lost.
- A user should be able to request a max of 5 OTPs for each of email AND SMS however there was a bug which only allowed to request a max of 5 OTPs for both email AND SMS in total. I.E - 3 Email OTPs and then 3 SMS OTPs = blocked.