### PR TITLE
AUT-459: IPV Capacity Switch

### DIFF
--- a/ci/tasks/ipv-status.yml
+++ b/ci/tasks/ipv-status.yml
@@ -1,0 +1,31 @@
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: governmentpaas/awscli
+    tag: "469ceea7a619b0abdd6cb27efd4d3bd5e9be3ddb"  # pragma: allowlist secret
+    username: ((docker-hub-username))
+    password: ((docker-hub-password))
+params:
+  ENVIRONMENT: build
+  DEPLOYER_ROLE_ARN: ((deployer-role-arn-non-prod))
+run:
+  path: sh
+  args:
+    - -c
+    - |
+      set -eu
+      export AWS_DEFAULT_REGION=eu-west-2
+      STS_TOKEN="$(aws sts assume-role --role-arn="${DEPLOYER_ROLE_ARN}" --role-session-name="concourse-ipv-status-${ENVIRONMENT}")"
+
+      export AWS_ACCESS_KEY_ID="$(echo ${STS_TOKEN} | jq -r .Credentials.AccessKeyId)"
+      export AWS_SECRET_ACCESS_KEY="$(echo ${STS_TOKEN} | jq -r .Credentials.SecretAccessKey)"
+      export AWS_SESSION_TOKEN="$(echo ${STS_TOKEN} | jq -r .Credentials.SessionToken)"
+
+      IPV_CAPACITY=$(aws ssm get-parameter --name build-ipv-capacity | jq -r .Parameter.Value)
+      
+      if [[ ${IPV_CAPACITY} -eq "1" ]]; then
+        echo "IPV is currently ON"
+      else
+        echo "IPV is currently OFF"
+      fi

--- a/ci/tasks/ipv-switch.yml
+++ b/ci/tasks/ipv-switch.yml
@@ -1,0 +1,37 @@
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: governmentpaas/awscli
+    tag: "469ceea7a619b0abdd6cb27efd4d3bd5e9be3ddb"  # pragma: allowlist secret
+    username: ((docker-hub-username))
+    password: ((docker-hub-password))
+params:
+  ENVIRONMENT: build
+  DEPLOYER_ROLE_ARN: ((deployer-role-arn-non-prod))
+  DESIRED_STATE: "0"
+run:
+  path: sh
+  args:
+    - -c
+    - |
+      set -eu
+      export AWS_DEFAULT_REGION=eu-west-2
+      STS_TOKEN="$(aws sts assume-role --role-arn="${DEPLOYER_ROLE_ARN}" --role-session-name="concourse-ipv-switch-${ENVIRONMENT}")"
+
+      export AWS_ACCESS_KEY_ID="$(echo ${STS_TOKEN} | jq -r .Credentials.AccessKeyId)"
+      export AWS_SECRET_ACCESS_KEY="$(echo ${STS_TOKEN} | jq -r .Credentials.SecretAccessKey)"
+      export AWS_SESSION_TOKEN="$(echo ${STS_TOKEN} | jq -r .Credentials.SessionToken)"
+
+      echo -n "Setting parameter to ${DESIRED_STATE} ... " 
+      aws ssm put-parameter --name "${ENVIRONMENT}-ipv-capacity" --overwrite --value "${DESIRED_STATE}" > /dev/null
+      echo " done!"
+      
+      echo "Checking state ..."       
+      IPV_CAPACITY=$(aws ssm get-parameter --name "${ENVIRONMENT}-ipv-capacity" | jq -r .Parameter.Value)
+      
+      if [[ ${IPV_CAPACITY} -eq "1" ]]; then
+        echo "IPV is now ON"
+      else
+        echo "IPV is now OFF"
+      fi

--- a/ci/terraform/oidc/ssm.tf
+++ b/ci/terraform/oidc/ssm.tf
@@ -26,6 +26,12 @@ resource "aws_ssm_parameter" "ipv-capacity" {
   name  = "${var.environment}-ipv-capacity"
   type  = "String"
   value = var.ipv_capacity_allowed ? "1" : "0"
+
+  lifecycle {
+    ignore_changes = [
+      value
+    ]
+  }
 }
 
 data "aws_iam_policy_document" "ipv_capacity_parameter_policy_document" {


### PR DESCRIPTION
## What?

- Tell Terraform to ignore any changes made to the `ipv-capacity` inside or outside of Terraform.
- Add a task to check current status
- Add a task to switch to a desired state (state to be override in a pipeline when called), defaults to off.

## Why?

We need an easy way of switching IPV on or off, we'll do this in a Concourse pipeline (to be written), that will call the tasks defined here.
