### PR TITLE
AUT-459: Correctly interpolate parameter name in IPV status job

### DIFF
--- a/ci/tasks/ipv-status.yml
+++ b/ci/tasks/ipv-status.yml
@@ -22,7 +22,7 @@ run:
       export AWS_SECRET_ACCESS_KEY="$(echo ${STS_TOKEN} | jq -r .Credentials.SecretAccessKey)"
       export AWS_SESSION_TOKEN="$(echo ${STS_TOKEN} | jq -r .Credentials.SessionToken)"
 
-      IPV_CAPACITY=$(aws ssm get-parameter --name build-ipv-capacity | jq -r .Parameter.Value)
+      IPV_CAPACITY=$(aws ssm get-parameter --name "${ENVIRONMENT}-ipv-capacity" | jq -r .Parameter.Value)
       
       if [[ ${IPV_CAPACITY} -eq "1" ]]; then
         echo "IPV is currently ON"


### PR DESCRIPTION
## What?

- Add the missing environment variable interpolation to the parameter name in `ipv-status.yml`

## Why?

We want to run this in different environments, so the hard-coded `build` won't work.