### PR TITLE
AUT-475: Create a custom `resource-id` scope for non-urn format subject ID

### DIFF
--- a/ci/terraform/oidc/token.tf
+++ b/ci/terraform/oidc/token.tf
@@ -46,16 +46,17 @@ module "token" {
   environment     = var.environment
 
   handler_environment_variables = {
-    ENVIRONMENT              = var.environment
-    OIDC_API_BASE_URL        = local.api_base_url
-    DYNAMO_ENDPOINT          = var.use_localstack ? var.lambda_dynamo_endpoint : null
-    EVENTS_SNS_TOPIC_ARN     = aws_sns_topic.events.arn
-    AUDIT_SIGNING_KEY_ALIAS  = local.audit_signing_key_alias_name
-    LOCALSTACK_ENDPOINT      = var.use_localstack ? var.localstack_endpoint : null
-    REDIS_KEY                = local.redis_key
-    TOKEN_SIGNING_KEY_ALIAS  = local.id_token_signing_key_alias_name
-    LOCALSTACK_ENDPOINT      = var.use_localstack ? var.localstack_endpoint : null
-    HEADERS_CASE_INSENSITIVE = var.use_localstack ? "true" : "false"
+    ENVIRONMENT               = var.environment
+    OIDC_API_BASE_URL         = local.api_base_url
+    DYNAMO_ENDPOINT           = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    EVENTS_SNS_TOPIC_ARN      = aws_sns_topic.events.arn
+    AUDIT_SIGNING_KEY_ALIAS   = local.audit_signing_key_alias_name
+    LOCALSTACK_ENDPOINT       = var.use_localstack ? var.localstack_endpoint : null
+    REDIS_KEY                 = local.redis_key
+    TOKEN_SIGNING_KEY_ALIAS   = local.id_token_signing_key_alias_name
+    LOCALSTACK_ENDPOINT       = var.use_localstack ? var.localstack_endpoint : null
+    HEADERS_CASE_INSENSITIVE  = var.use_localstack ? "true" : "false"
+    RESOURCE_ID_SCOPE_ENABLED = var.environment == "integration" ? "true" : false
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.TokenHandler::handleRequest"
 

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/SubjectHelper.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/SubjectHelper.java
@@ -1,0 +1,10 @@
+package uk.gov.di.authentication.sharedtest.helper;
+
+import com.nimbusds.oauth2.sdk.id.Subject;
+import uk.gov.di.authentication.shared.helpers.IdGenerator;
+
+public class SubjectHelper {
+    public static Subject govUkSignInSubject() {
+        return new Subject("urn:fdc:gov.uk:2022:" + IdGenerator.generate());
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/CustomScopeValue.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/CustomScopeValue.java
@@ -19,6 +19,9 @@ public class CustomScopeValue extends Scope.Value {
             new CustomScopeValue(
                     "doc-checking-app", Requirement.OPTIONAL, new String[] {"read"}, true);
 
+    public static final CustomScopeValue RESOURCE_ID =
+            new CustomScopeValue("resource-id", Requirement.OPTIONAL, new String[] {"read"}, true);
+
     private final String[] claims;
 
     private boolean privateScope = true;

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -373,6 +373,11 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return System.getenv().getOrDefault("TEST_CLIENTS_ENABLED", "false").equals("true");
     }
 
+    public boolean isResourceIdScopeEnabled() {
+        return Boolean.parseBoolean(
+                System.getenv().getOrDefault("RESOURCE_ID_SCOPE_ENABLED", "false"));
+    }
+
     public String getTokenSigningKeyAlias() {
         return System.getenv("TOKEN_SIGNING_KEY_ALIAS");
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
@@ -306,7 +306,7 @@ public class TokenService {
             idTokenClaims.setClaim("vot", vot);
         }
         idTokenClaims.setClaim("vtm", trustMarkUri.toString());
-        if (requiresResourceId) {
+        if (requiresResourceId && configService.isResourceIdScopeEnabled()) {
             idTokenClaims.setClaim(
                     CustomScopeValue.RESOURCE_ID.getValue(), subject.getValue().split(":")[4]);
         }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
@@ -42,6 +42,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.entity.AccessTokenStore;
 import uk.gov.di.authentication.shared.entity.ClientConsent;
+import uk.gov.di.authentication.shared.entity.CustomScopeValue;
 import uk.gov.di.authentication.shared.entity.RefreshTokenStore;
 import uk.gov.di.authentication.shared.entity.ValidScopes;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
@@ -127,6 +128,9 @@ public class TokenService {
                 segmentedFunctionCall(
                         "AccessTokenHash.compute",
                         () -> AccessTokenHash.compute(accessToken, TOKEN_ALGORITHM, null));
+
+        var requiresResourceId = scopesForToken.contains(CustomScopeValue.RESOURCE_ID.getValue());
+
         SignedJWT idToken =
                 segmentedFunctionCall(
                         "generateIDToken",
@@ -137,7 +141,8 @@ public class TokenService {
                                         additionalTokenClaims,
                                         accessTokenHash,
                                         vot,
-                                        isDocAppJourney));
+                                        isDocAppJourney,
+                                        requiresResourceId));
         if (scopesForToken.contains(OIDCScopeValue.OFFLINE_ACCESS.getValue())) {
             RefreshToken refreshToken =
                     segmentedFunctionCall(
@@ -282,7 +287,8 @@ public class TokenService {
             Map<String, Object> additionalTokenClaims,
             AccessTokenHash accessTokenHash,
             String vot,
-            boolean isDocAppJourney) {
+            boolean isDocAppJourney,
+            boolean requiresResourceId) {
 
         LOG.info("Generating IdToken");
         URI trustMarkUri = buildURI(configService.getOidcApiBaseURL().get(), "/trustmark");
@@ -300,6 +306,11 @@ public class TokenService {
             idTokenClaims.setClaim("vot", vot);
         }
         idTokenClaims.setClaim("vtm", trustMarkUri.toString());
+        if (requiresResourceId) {
+            idTokenClaims.setClaim(
+                    CustomScopeValue.RESOURCE_ID.getValue(), subject.getValue().split(":")[4]);
+        }
+
         try {
             return generateSignedJWT(idTokenClaims.toJWTClaimsSet(), Optional.empty());
         } catch (com.nimbusds.oauth2.sdk.ParseException e) {

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
@@ -198,6 +198,7 @@ public class TokenServiceTest {
     void shouldIncludeResourceIdWhenRequired()
             throws ParseException, JOSEException, Json.JsonException {
         when(configurationService.getTokenSigningKeyAlias()).thenReturn(KEY_ID);
+        when(configurationService.isResourceIdScopeEnabled()).thenReturn(true);
         createSignedIdToken();
         createSignedAccessToken();
         Map<String, Object> additionalTokenClaims = new HashMap<>();

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
@@ -43,6 +43,7 @@ import org.mockito.ArgumentCaptor;
 import uk.gov.di.authentication.shared.entity.AccessTokenStore;
 import uk.gov.di.authentication.shared.entity.ClientConsent;
 import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
+import uk.gov.di.authentication.shared.entity.CustomScopeValue;
 import uk.gov.di.authentication.shared.entity.RefreshTokenStore;
 import uk.gov.di.authentication.shared.entity.ValidScopes;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
@@ -73,6 +74,7 @@ import java.util.stream.Stream;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.core.Is.is;
@@ -168,6 +170,11 @@ public class TokenServiceTest {
                         false);
 
         assertSuccessfulTokenResponse(tokenResponse);
+
+        assertThat(
+                tokenResponse.getOIDCTokens().getIDToken().getJWTClaimsSet().getClaims(),
+                not(hasKey(CustomScopeValue.RESOURCE_ID.getValue())));
+
         assertNotNull(tokenResponse.getOIDCTokens().getRefreshToken());
         RefreshTokenStore refreshTokenStore =
                 new RefreshTokenStore(
@@ -185,6 +192,46 @@ public class TokenServiceTest {
         var jti = refreshToken.getJWTClaimsSet().getJWTID();
         assertThat(redisKey.getValue(), startsWith(REFRESH_TOKEN_PREFIX));
         assertThat(redisKey.getValue().split(":")[1], equalTo(jti));
+    }
+
+    @Test
+    void shouldIncludeResourceIdWhenRequired()
+            throws ParseException, JOSEException, Json.JsonException {
+        when(configurationService.getTokenSigningKeyAlias()).thenReturn(KEY_ID);
+        createSignedIdToken();
+        createSignedAccessToken();
+        Map<String, Object> additionalTokenClaims = new HashMap<>();
+        additionalTokenClaims.put("nonce", nonce);
+
+        var scopes = new Scope(CustomScopeValue.RESOURCE_ID);
+
+        Set<String> claimsForListOfScopes =
+                ValidScopes.getClaimsForListOfScopes(scopes.toStringList());
+
+        OIDCTokenResponse tokenResponse =
+                tokenService.generateTokenResponse(
+                        CLIENT_ID,
+                        INTERNAL_SUBJECT,
+                        scopes,
+                        additionalTokenClaims,
+                        PUBLIC_SUBJECT,
+                        VOT,
+                        Collections.singletonList(
+                                new ClientConsent(
+                                        CLIENT_ID,
+                                        claimsForListOfScopes,
+                                        LocalDateTime.now(ZoneId.of("UTC")).toString())),
+                        false,
+                        null,
+                        false);
+
+        assertSuccessfulTokenResponse(tokenResponse);
+
+        var jwtClaimsSet = tokenResponse.getOIDCTokens().getIDToken().getJWTClaimsSet();
+
+        assertThat(
+                jwtClaimsSet.getStringClaim(CustomScopeValue.RESOURCE_ID.getValue()),
+                equalTo(PUBLIC_SUBJECT.getValue().substring(20)));
     }
 
     @Test
@@ -220,6 +267,10 @@ public class TokenServiceTest {
                         false);
 
         assertSuccessfulTokenResponse(tokenResponse);
+
+        assertThat(
+                tokenResponse.getOIDCTokens().getIDToken().getJWTClaimsSet().getClaims(),
+                not(hasKey(CustomScopeValue.RESOURCE_ID.getValue())));
 
         assertNotNull(tokenResponse.getOIDCTokens().getRefreshToken());
         assertNull(
@@ -284,6 +335,10 @@ public class TokenServiceTest {
                         false);
 
         assertSuccessfulTokenResponse(tokenResponse);
+
+        assertThat(
+                tokenResponse.getOIDCTokens().getIDToken().getJWTClaimsSet().getClaims(),
+                not(hasKey(CustomScopeValue.RESOURCE_ID.getValue())));
 
         assertNull(tokenResponse.getOIDCTokens().getRefreshToken());
     }
@@ -570,9 +625,6 @@ public class TokenServiceTest {
                 header.getKeyID(),
                 is("1d504aece298a14d74ee0a02b6740b4372a1fab4206778e486ba72770ff4beb8"));
 
-        assertThat(
-                tokenResponse.getOIDCTokens().getIDToken().getJWTClaimsSet().getClaims().size(),
-                equalTo(9));
         assertThat(
                 tokenResponse.getOIDCTokens().getIDToken().getJWTClaimsSet().getClaim("sub"),
                 equalTo(PUBLIC_SUBJECT.getValue()));

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
@@ -47,6 +47,7 @@ import uk.gov.di.authentication.shared.entity.RefreshTokenStore;
 import uk.gov.di.authentication.shared.entity.ValidScopes;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
+import uk.gov.di.authentication.sharedtest.helper.SubjectHelper;
 import uk.gov.di.authentication.sharedtest.helper.TokenGeneratorHelper;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
@@ -94,8 +95,8 @@ public class TokenServiceTest {
             mock(RedisConnectionService.class);
     private final TokenService tokenService =
             new TokenService(configurationService, redisConnectionService, kmsConnectionService);
-    private static final Subject PUBLIC_SUBJECT = new Subject("public-subject");
-    private static final Subject INTERNAL_SUBJECT = new Subject("internal-subject");
+    private static final Subject PUBLIC_SUBJECT = SubjectHelper.govUkSignInSubject();
+    private static final Subject INTERNAL_SUBJECT = SubjectHelper.govUkSignInSubject();
     private static final Scope SCOPES =
             new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL, OIDCScopeValue.PHONE);
     private static final String VOT = CredentialTrustLevel.MEDIUM_LEVEL.getValue();


### PR DESCRIPTION
This is needed for a spike into a service which does not (yet) support URN-format subject identifiers
