### PR TITLE
AUT-35 - Check new phone number is not the same as current phone number

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
@@ -13,6 +13,7 @@ import uk.gov.di.accountmanagement.entity.SendNotificationRequest;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.helpers.RequestHeaderHelper;
@@ -129,8 +130,15 @@ public class SendOtpNotificationHandler
                                                 context);
                                     case VERIFY_PHONE_NUMBER:
                                         LOG.info("NotificationType is VERIFY_PHONE_NUMBER");
-                                        Optional<ErrorResponse> phoneNumberValidationError =
+                                        var existingPhoneNumber =
+                                                dynamoService
+                                                        .getUserProfileByEmailMaybe(
+                                                                sendNotificationRequest.getEmail())
+                                                        .map(UserProfile::getPhoneNumber)
+                                                        .orElse(null);
+                                        var phoneNumberValidationError =
                                                 ValidationHelper.validatePhoneNumber(
+                                                        existingPhoneNumber,
                                                         sendNotificationRequest.getPhoneNumber());
                                         if (phoneNumberValidationError.isPresent()) {
                                             return generateApiGatewayProxyErrorResponse(

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/SendOtpNotificationIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/SendOtpNotificationIntegrationTest.java
@@ -141,4 +141,26 @@ class SendOtpNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTes
 
         assertNoAuditEventsReceived(auditTopic);
     }
+
+    @Test
+    void shouldReturn400WhenNewPhoneNumberIsTheSameAsCurrentPhoneNumber()
+            throws Json.JsonException {
+        userStore.signUp(TEST_EMAIL, "password");
+        userStore.addPhoneNumber(TEST_EMAIL, "+447755551084");
+        var response =
+                makeRequest(
+                        Optional.of(
+                                new SendNotificationRequest(
+                                        TEST_EMAIL, VERIFY_PHONE_NUMBER, "07755551084")),
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        Collections.emptyMap());
+
+        assertThat(response, hasStatus(HttpStatus.SC_BAD_REQUEST));
+        assertThat(response, hasBody(objectMapper.writeValueAsString(ErrorResponse.ERROR_1044)));
+
+        NotificationAssertionHelper.assertNoNotificationsReceived(notificationsQueue);
+
+        assertNoAuditEventsReceived(auditTopic);
+    }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
@@ -48,7 +48,9 @@ public enum ErrorResponse {
     ERROR_1040(1040, "Password is too common"),
     ERROR_1041(1041, "Auth app secret is invalid"),
     ERROR_1042(1042, "User entered invalid authenticator app verification code too many times"),
-    ERROR_1043(1043, "User entered invalid authenticator app code");
+    ERROR_1043(1043, "User entered invalid authenticator app code"),
+    ERROR_1044(1044, "New phone number is the same as current phone number");
+    ;
 
     private int code;
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ValidationHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ValidationHelper.java
@@ -7,6 +7,7 @@ import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.Session;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -25,6 +26,15 @@ public class ValidationHelper {
     private static final List<String> ALLOWED_TEST_NUMBERS = List.of("07700900222");
 
     private ValidationHelper() {}
+
+    public static Optional<ErrorResponse> validatePhoneNumber(
+            String currentPhoneNumber, String newPhoneNumber) {
+        if (Objects.nonNull(currentPhoneNumber)
+                && currentPhoneNumber.equals(PhoneNumberHelper.formatPhoneNumber(newPhoneNumber))) {
+            return Optional.of(ErrorResponse.ERROR_1044);
+        }
+        return validatePhoneNumber(newPhoneNumber);
+    }
 
     public static Optional<ErrorResponse> validatePhoneNumber(String phoneNumberInput) {
         if (ALLOWED_TEST_NUMBERS.contains(phoneNumberInput)) return Optional.empty();

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ValidationHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ValidationHelperTest.java
@@ -284,6 +284,35 @@ class ValidationHelperTest {
                         STORED_VALID_CODE));
     }
 
+    @Test
+    void shouldSuccessfullyValidatePhoneNumberWhenNewNumberIsDifferentToCurrentNumber() {
+
+        assertThat(
+                ValidationHelper.validatePhoneNumber("+447911123456", "07700900222"),
+                equalTo(Optional.empty()));
+    }
+
+    @Test
+    void shouldSuccessfullyValidatePhoneNumberWhenCurrentNumberIsNotPresent() {
+        assertThat(
+                ValidationHelper.validatePhoneNumber(null, "07700900222"),
+                equalTo(Optional.empty()));
+    }
+
+    @Test
+    void shouldReturnErrorWhenNewInternationPhoneNumberIsSameToCurrentNumber() {
+        assertThat(
+                ValidationHelper.validatePhoneNumber("+33645453322", "+33645453322"),
+                equalTo(Optional.of(ErrorResponse.ERROR_1044)));
+    }
+
+    @Test
+    void shouldReturnErrorWhenNewNumberIsTheSameAsCurrentNumber() {
+        assertThat(
+                ValidationHelper.validatePhoneNumber("+447911123456", "07911123456"),
+                equalTo(Optional.of(ErrorResponse.ERROR_1044)));
+    }
+
     @ParameterizedTest
     @MethodSource("validateCodeTestParameters")
     void shouldReturnCorrectErrorForCodeValidationScenarios(


### PR DESCRIPTION
## What?

- Check new phone number is not the same as current phone number
- If it is, then return an error code to the account management frontend. The AM frontend will then display an error to the user.

## Why?

- The backend is the source of truth and will be able to inform the AM frontend whether or not the new number is the same as the current number. 
