### PR TITLE
BAU - Remove phoneNumberVerified from LoginResponse

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/LoginResponse.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/LoginResponse.java
@@ -26,11 +26,6 @@ public class LoginResponse {
     @Required
     private boolean mfaMethodVerified;
 
-    @SerializedName("phoneNumberVerified")
-    @Expose
-    @Required
-    private boolean phoneNumberVerified;
-
     @SerializedName(value = "latestTermsAndConditionsAccepted")
     @Expose
     @Required
@@ -46,14 +41,12 @@ public class LoginResponse {
     public LoginResponse(
             String redactedPhoneNumber,
             boolean mfaRequired,
-            boolean phoneNumberVerified,
             boolean latestTermsAndConditionsAccepted,
             boolean consentRequired,
             MFAMethodType mfaMethodType,
             boolean mfaMethodVerified) {
         this.redactedPhoneNumber = redactedPhoneNumber;
         this.mfaRequired = mfaRequired;
-        this.phoneNumberVerified = phoneNumberVerified;
         this.latestTermsAndConditionsAccepted = latestTermsAndConditionsAccepted;
         this.consentRequired = consentRequired;
         this.mfaMethodType = mfaMethodType;
@@ -66,10 +59,6 @@ public class LoginResponse {
 
     public boolean isMfaRequired() {
         return mfaRequired;
-    }
-
-    public boolean isPhoneNumberVerified() {
-        return phoneNumberVerified;
     }
 
     public boolean getLatestTermsAndConditionsAccepted() {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -182,15 +182,15 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
                     MfaHelper.mfaRequired(userContext.getClientSession().getAuthRequestParams());
             var consentRequired = ConsentHelper.userHasNotGivenConsent(userContext);
 
-            Optional<MFAMethod> mfaMethod = getPrimaryMFAMethod(userCredentials);
-            MFAMethodType mfaMethodType =
+            var mfaMethod = getPrimaryMFAMethod(userCredentials);
+            var mfaMethodType =
                     mfaMethod
                             .map(m -> MFAMethodType.valueOf(m.getMfaMethodType()))
                             .orElse(MFAMethodType.SMS);
             boolean mfaMethodVerified =
-                    mfaMethod.map(m -> m.isMethodVerified()).orElse(isPhoneNumberVerified);
+                    mfaMethod.map(MFAMethod::isMethodVerified).orElse(isPhoneNumberVerified);
 
-            LOG.info("User has successfully logged in");
+            LOG.info("User has successfully logged in with MFAType: {}", mfaMethodType);
 
             auditService.submitAuditEvent(
                     LOG_IN_SUCCESS,
@@ -208,7 +208,6 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
                     new LoginResponse(
                             redactedPhoneNumber,
                             isMfaRequired,
-                            isPhoneNumberVerified,
                             termsAndConditionsAccepted,
                             consentRequired,
                             mfaMethodType,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
@@ -3,7 +3,6 @@ package uk.gov.di.authentication.frontendapi.lambda;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.id.ClientID;
@@ -142,8 +141,7 @@ class LoginHandlerTest {
 
     @ParameterizedTest
     @EnumSource(MFAMethodType.class)
-    void shouldReturn200IfLoginIsSuccessful(MFAMethodType mfaMethodType)
-            throws JsonProcessingException, Json.JsonException {
+    void shouldReturn200IfLoginIsSuccessful(MFAMethodType mfaMethodType) throws Json.JsonException {
         when(configurationService.getTermsAndConditionsVersion()).thenReturn("1.0");
         String persistentId = "some-persistent-id-value";
         Map<String, String> headers = new HashMap<>();
@@ -190,7 +188,7 @@ class LoginHandlerTest {
     @ParameterizedTest
     @EnumSource(MFAMethodType.class)
     void shouldReturn200IfLoginIsSuccessfulAndTermsAndConditionsNotAccepted(
-            MFAMethodType mfaMethodType) throws JsonProcessingException, Json.JsonException {
+            MFAMethodType mfaMethodType) throws Json.JsonException {
         when(configurationService.getTermsAndConditionsVersion()).thenReturn("2.0");
         String persistentId = "some-persistent-id-value";
         Map<String, String> headers = new HashMap<>();
@@ -240,7 +238,7 @@ class LoginHandlerTest {
     @ParameterizedTest
     @EnumSource(MFAMethodType.class)
     void shouldReturn200IfMigratedUserHasBeenProcessesSuccessfully(MFAMethodType mfaMethodType)
-            throws JsonProcessingException, Json.JsonException {
+            throws Json.JsonException {
         when(configurationService.getTermsAndConditionsVersion()).thenReturn("1.0");
         String legacySubjectId = new Subject().getValue();
         UserProfile userProfile = generateUserProfile(legacySubjectId);
@@ -274,7 +272,7 @@ class LoginHandlerTest {
     @ParameterizedTest
     @EnumSource(MFAMethodType.class)
     void shouldReturn200IfPasswordIsEnteredAgain(MFAMethodType mfaMethodType)
-            throws JsonProcessingException, Json.JsonException {
+            throws Json.JsonException {
         UserProfile userProfile = generateUserProfile(null);
         when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
                 .thenReturn(Optional.of(userProfile));
@@ -356,7 +354,7 @@ class LoginHandlerTest {
     @ParameterizedTest
     @EnumSource(MFAMethodType.class)
     void shouldRemoveIncorrectPasswordCountRemovesUponSuccessfulLogin(MFAMethodType mfaMethodType)
-            throws JsonProcessingException, Json.JsonException {
+            throws Json.JsonException {
         UserProfile userProfile = generateUserProfile(null);
         when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
                 .thenReturn(Optional.of(userProfile));

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
@@ -125,14 +125,7 @@ public class LoginIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 equalTo(termsAndConditionsVersion.equals(CURRENT_TERMS_AND_CONDITIONS)));
 
         assertThat(loginResponse.getMfaMethodType(), equalTo(mfaMethodType));
-        if (mfaMethodType.equals(SMS)) {
-            assertThat(loginResponse.isPhoneNumberVerified(), equalTo(mfaMethodVerified));
-            assertThat(
-                    loginResponse.isMfaMethodVerified(),
-                    equalTo(loginResponse.isPhoneNumberVerified()));
-        } else {
-            assertThat(loginResponse.isMfaMethodVerified(), equalTo(mfaMethodVerified));
-        }
+        assertThat(loginResponse.isMfaMethodVerified(), equalTo(mfaMethodVerified));
 
         assertEventTypesReceived(auditTopic, List.of(LOG_IN_SUCCESS));
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/conditions/MfaHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/conditions/MfaHelper.java
@@ -32,9 +32,6 @@ public class MfaHelper {
     public static Optional<MFAMethod> getPrimaryMFAMethod(UserCredentials userCredentials) {
         return Optional.ofNullable(userCredentials.getMfaMethods())
                 .flatMap(
-                        mfaMethods ->
-                                mfaMethods.stream()
-                                        .filter(mfaMethod -> mfaMethod.isEnabled())
-                                        .findFirst());
+                        mfaMethods -> mfaMethods.stream().filter(MFAMethod::isEnabled).findFirst());
     }
 }


### PR DESCRIPTION
## What?

- Remove phoneNumberVerified from LoginResponse

## Why?

- We don't need to return the phoneNumberVerified attribute on the login response and instead rely on the mfaMethodVerified type.
