### PR TITLE
AUT-437: Add Terraform variable definitions for logging and shared state

### DIFF
--- a/ci/terraform/utils/variables.tf
+++ b/ci/terraform/utils/variables.tf
@@ -32,3 +32,19 @@ variable "utils_release_zip_file" {
   description = "Location of the Utils distribution ZIP file"
   type        = string
 }
+
+variable "shared_state_bucket" {
+  type = string
+}
+
+variable "logging_endpoint_arn" {
+  type        = string
+  default     = ""
+  description = "Amazon Resource Name (ARN) for the endpoint to ship logs to"
+}
+
+variable "logging_endpoint_arns" {
+  type        = list(string)
+  default     = []
+  description = "Amazon Resource Name (ARN) for the CSLS endpoints to ship logs to"
+}


### PR DESCRIPTION
## What?

- Add Terraform variable definitions for logging and shared state bucket

## Why?

Removes error in deploy-utils-build due to variables being passed without a definition. These variables will be used when logging is configued.