### PR TITLE
BAU - Fix logging typo

### DIFF
--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandler.java
@@ -56,7 +56,7 @@ public class SPOTResponseHandler implements RequestHandler<SQSEvent, Object> {
                 attachSessionIdToLogs(spotResponse.getLogIds().getSessionId());
                 attachLogFieldToLogs(
                         PERSISTENT_SESSION_ID, spotResponse.getLogIds().getPersistentSessionId());
-                attachLogFieldToLogs(CLIENT_ID, spotResponse.getLogIds().getSessionId());
+                attachLogFieldToLogs(CLIENT_ID, spotResponse.getLogIds().getClientId());
 
                 if (spotResponse.getStatus().equals(SPOTStatus.ACCEPTED)) {
                     LOG.info(


### PR DESCRIPTION
## What?

- Fix logging typo

## Why?

- This should be ClientID not sessionID