### PR TITLE
AUT-437: Add common passwords transfer lambda log group to Terraform

### DIFF
--- a/ci/terraform/utils/production-overrides.tfvars
+++ b/ci/terraform/utils/production-overrides.tfvars
@@ -1,0 +1,1 @@
+cloudwatch_log_retention = 5

--- a/ci/terraform/utils/shared.tf
+++ b/ci/terraform/utils/shared.tf
@@ -1,0 +1,13 @@
+data "terraform_remote_state" "shared" {
+  backend = "s3"
+  config = {
+    bucket   = var.shared_state_bucket
+    key      = "${var.environment}-shared-terraform.tfstate"
+    role_arn = var.deployer_role_arn
+    region   = var.aws_region
+  }
+}
+
+locals {
+  cloudwatch_encryption_key_arn = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+}

--- a/ci/terraform/utils/variables.tf
+++ b/ci/terraform/utils/variables.tf
@@ -48,3 +48,9 @@ variable "logging_endpoint_arns" {
   default     = []
   description = "Amazon Resource Name (ARN) for the CSLS endpoints to ship logs to"
 }
+
+variable "cloudwatch_log_retention" {
+  default     = 1
+  type        = number
+  description = "The number of day to retain Cloudwatch logs for"
+}


### PR DESCRIPTION
## What?

- Add common passwords transfer lambda log group to Terraform
- Add variable for retention - default 1, but 5 days for production
- Add shared.tf to consume outputs of shared state bucket, including CloudWatch encryption key arn

## Why?

- To allow log groups to be created in each environment, so that logs can be viewed in CloudWatch for the new common passwords S3->Dynamo data transfer lambda

## Related PRs

https://github.com/alphagov/di-authentication-api/pull/2089 - base lambda including Terraform
https://github.com/alphagov/di-authentication-api/pull/2097 - addition of some logging variables (as placeholders at that point to match the input arguments of the deploy-utils-build task)