### PR TITLE
BAU - Fix sign up Identity bug

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -34,6 +34,7 @@ import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import static java.util.Map.entry;
@@ -196,11 +197,20 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
         if (notificationType.equals(VERIFY_PHONE_NUMBER)) {
             codeStorageService.deleteOtpCode(session.getEmailAddress(), notificationType);
             authenticationService.updatePhoneNumberVerifiedStatus(session.getEmailAddress(), true);
+
+            var vectorOfTrust = VectorOfTrust.getDefaults();
+
+            if (Objects.nonNull(userContext.getClientSession().getEffectiveVectorOfTrust())
+                    && userContext
+                            .getClientSession()
+                            .getEffectiveVectorOfTrust()
+                            .containsLevelOfConfidence()) {
+                vectorOfTrust = userContext.getClientSession().getEffectiveVectorOfTrust();
+            }
+
             clientSessionService.saveClientSession(
                     clientSessionId,
-                    userContext
-                            .getClientSession()
-                            .setEffectiveVectorOfTrust(VectorOfTrust.getDefaults()));
+                    userContext.getClientSession().setEffectiveVectorOfTrust(vectorOfTrust));
             sessionService.save(
                     session.setCurrentCredentialStrength(CredentialTrustLevel.MEDIUM_LEVEL));
 


### PR DESCRIPTION
- Previously an RP could request either Cl or Cl.Cm. This means that a user could access an RP which only requires Cl and then get redirect to auth to sign in or sign up. When a user signs up for the first time, they are required to use 2FA. This means the user has effectively accessed the service at a medium level (Cl.Cm). So when a user signed up we ensure that their credential trust level is always set to medium. This means if they were to access another RP which requested Cl.Cm, they would not be required to sign in using 2FA as they have already an authenticated session at that level.
- As we were always setting this to medium during the SignUp journey, this means that the vector of trust for users requiring identity was getting overwritten. Therefore when we went to populate the access token in the Token endpoint, as there wasn't a Level of confidence within that vector of trust we omitted the claims. So when userinfo was hit, as there was no identity claims in the access token we would not return any identity claims back to the RP.
- Update VerifyCode so that we never overwrite the VectorOfTrust if it contains a level of confidence. I.E - P2