### PR TITLE
BAU - Update Processing Identity Lambda to return additional status

### DIFF
--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/ProcessingIdentityStatus.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/ProcessingIdentityStatus.java
@@ -3,5 +3,6 @@ package uk.gov.di.authentication.ipv.entity;
 public enum ProcessingIdentityStatus {
     COMPLETED,
     PROCESSING,
-    ERROR
+    ERROR,
+    NO_ENTRY,
 }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
@@ -100,6 +100,14 @@ public class RedisExtension
                 session.getSessionId(), objectMapper.writeValueAsString(session), 3600);
     }
 
+    public void incrementInitialProcessingIdentityAttemptsInSession(String sessionId)
+            throws Json.JsonException {
+        Session session = objectMapper.readValue(redis.getValue(sessionId), Session.class);
+        session.incrementProcessingIdentityAttempts();
+        redis.saveWithExpiry(
+                session.getSessionId(), objectMapper.writeValueAsString(session), 3600);
+    }
+
     public void addAuthRequestToSession(
             String clientSessionId, String sessionId, Map<String, List<String>> authRequest)
             throws Json.JsonException {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
@@ -31,10 +31,13 @@ public class Session {
 
     @Expose private boolean authenticated;
 
+    @Expose private int processingIdentityAttempts;
+
     public Session(String sessionId) {
         this.sessionId = sessionId;
         this.clientSessions = new ArrayList<>();
         this.isNewAccount = AccountState.UNKNOWN;
+        this.processingIdentityAttempts = 0;
     }
 
     public Session(String sessionId, List<String> clientSessions, String emailAddress) {
@@ -141,5 +144,18 @@ public class Session {
     public Session setAuthenticated(boolean authenticated) {
         this.authenticated = authenticated;
         return this;
+    }
+
+    public int getProcessingIdentityAttempts() {
+        return processingIdentityAttempts;
+    }
+
+    public void resetProcessingIdentityAttempts() {
+        this.processingIdentityAttempts = 0;
+    }
+
+    public int incrementProcessingIdentityAttempts() {
+        this.processingIdentityAttempts += 1;
+        return processingIdentityAttempts;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/SessionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/SessionService.java
@@ -61,6 +61,7 @@ public class SessionService {
         try {
             String oldSessionId = session.getSessionId();
             session.setSessionId(IdGenerator.generate());
+            session.resetProcessingIdentityAttempts();
             save(session);
             redisConnectionService.deleteValue(oldSessionId);
         } catch (Exception e) {


### PR DESCRIPTION
## What?

- Add an attribute to the session which counts how many attempts there has been at calling the ProcessingIdentity lamda. If it's the first attempt and there's nothing in dynamo, then we assume that the user has got into a weird state and we will return the NO_ENTRY status back to the frontend.
- This count will be reset when the user hits authorize again, regardless of whether they have an existing session.
- Add a cloudwatch metric counter to track the different statuses returned from the ProcessingIdentity lambda
## Why?

- We currently return ERROR when there is nothing in the Identity Credentials table with the given subject ID. This may be because we received an error from SPOT and then went on to delete the credential. It could also happen if there was nothing ever in the Identity Credentials table for that subject ID, which can happen if the user does not complete the IPV journey, presses back and gets into a weird state. We want to be able to differentiate these 2 different use cases.
