### PR TITLE
AUT-277: Add a robots.txt to the OIDC API - Build only

### DIFF
--- a/ci/terraform/oidc/build-overrides.tfvars
+++ b/ci/terraform/oidc/build-overrides.tfvars
@@ -6,6 +6,7 @@ doc_app_authorisation_client_id    = "authOrchestrator"
 doc_app_authorisation_callback_uri = "https://oidc.build.account.gov.uk/doc-app-callback"
 doc_app_authorisation_uri          = "https://build-doc-app-cri-stub.london.cloudapps.digital/authorize"
 spot_enabled                       = false
+use_robots_txt                     = true
 doc_app_auth_public_encryption_key = <<-EOT
 -----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvnQV8yrKnVObCMg+ZNLQ

--- a/ci/terraform/oidc/sandpit.tfvars
+++ b/ci/terraform/oidc/sandpit.tfvars
@@ -13,6 +13,7 @@ logging_endpoint_arns          = []
 
 enable_api_gateway_execution_request_tracing = true
 spot_enabled                                 = false
+use_robots_txt                               = true
 
 lambda_max_concurrency = 0
 lambda_min_concurrency = 0

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -377,6 +377,11 @@ variable "scaling_trigger" {
   default = 0.7
 }
 
+variable "use_robots_txt" {
+  default = false
+  type    = bool
+}
+
 locals {
   default_performance_parameters = {
     memory          = var.endpoint_memory_size


### PR DESCRIPTION
## What?

Add a robots.txt to the OIDC API - Build only.

## Why?

As this is a public API it's being scraped by robots which creates unecessary noise in the logs.
Adding a robots.txt to keep them away.