### PR TITLE
AUT-277: Rollout OIDC API robots.txt to all environments

### DIFF
--- a/ci/terraform/oidc/build-overrides.tfvars
+++ b/ci/terraform/oidc/build-overrides.tfvars
@@ -6,7 +6,6 @@ doc_app_authorisation_client_id    = "authOrchestrator"
 doc_app_authorisation_callback_uri = "https://oidc.build.account.gov.uk/doc-app-callback"
 doc_app_authorisation_uri          = "https://build-doc-app-cri-stub.london.cloudapps.digital/authorize"
 spot_enabled                       = false
-use_robots_txt                     = true
 doc_app_auth_public_encryption_key = <<-EOT
 -----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvnQV8yrKnVObCMg+ZNLQ

--- a/ci/terraform/oidc/sandpit.tfvars
+++ b/ci/terraform/oidc/sandpit.tfvars
@@ -13,7 +13,6 @@ logging_endpoint_arns          = []
 
 enable_api_gateway_execution_request_tracing = true
 spot_enabled                                 = false
-use_robots_txt                               = true
 
 lambda_max_concurrency = 0
 lambda_min_concurrency = 0

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -378,7 +378,7 @@ variable "scaling_trigger" {
 }
 
 variable "use_robots_txt" {
-  default = false
+  default = true
   type    = bool
 }
 


### PR DESCRIPTION
## What?

Rollout OIDC API robots.txt to all environments.

## Why?

Following testing in build and switched-off terraform in other environments which did not create the new resource.

## Related PRs

#2109 