### PR TITLE
AUT-277: tweak robots.txt redeploy

### DIFF
--- a/ci/terraform/oidc/api-gateway.tf
+++ b/ci/terraform/oidc/api-gateway.tf
@@ -133,7 +133,7 @@ resource "aws_api_gateway_deployment" "deployment" {
       module.ipv-capacity.method_trigger_value,
       var.doc_app_api_enabled ? module.doc-app-callback[0].integration_trigger_value : null,
       var.doc_app_api_enabled ? module.doc-app-callback[0].method_trigger_value : null,
-      var.use_robots_txt ? aws_api_gateway_integration_response.robots_txt_integration_response[0] : null,
+      var.use_robots_txt ? aws_api_gateway_integration_response.robots_txt_integration_response[0].response_templates : null,
     ]))
   }
 

--- a/ci/terraform/oidc/production-overrides.tfvars
+++ b/ci/terraform/oidc/production-overrides.tfvars
@@ -65,3 +65,4 @@ lambda_min_concurrency = 3
 keep_lambdas_warm      = false
 endpoint_memory_size   = 1024
 scaling_trigger        = 0.6
+use_robots_txt         = false


### PR DESCRIPTION

## What?

Tweak robots.txt redeploy trigger.
Switch off prod pending redeploy testing.

## Why?

The api gateway resource integration is being redeployed when there are no changes.
