### PR TITLE
AUT-277: remove optional integration_http_method

### DIFF
--- a/ci/terraform/oidc/api-gateway.tf
+++ b/ci/terraform/oidc/api-gateway.tf
@@ -443,8 +443,7 @@ resource "aws_api_gateway_integration" "robots_txt_integration" {
   resource_id = aws_api_gateway_resource.robots_txt_resource[0].id
   http_method = aws_api_gateway_method.robots_txt_method[0].http_method
 
-  integration_http_method = "GET"
-  type                    = "MOCK"
+  type = "MOCK"
 
   request_templates = {
     "application/json" = jsonencode(


### PR DESCRIPTION
## What?

Remove optional integration_http_method

## Why?

Causing unnecessary redeploy of the integration whenever the terraform runs:

 aws_api_gateway_integration.robots_txt_integration[0] must be replaced
-/+ resource "aws_api_gateway_integration" "robots_txt_integration" {
      - cache_key_parameters    = [] -> null
      ~ cache_namespace         = "it9eq6" -> (known after apply)
      ~ id                      = "agi-6of9f4amvg-it9eq6-GET" -> (known after apply)
      + integration_http_method = "GET" # forces replacement
      ~ passthrough_behavior    = "WHEN_NO_MATCH" -> (known after apply)
      - request_parameters      = {} -> null
        # (7 unchanged attributes hidden)
    }

## Related PRs

#2112 
