### PR TITLE
AUT-277: Switch robots.txt back on in prod

### DIFF
--- a/ci/terraform/oidc/production-overrides.tfvars
+++ b/ci/terraform/oidc/production-overrides.tfvars
@@ -65,4 +65,3 @@ lambda_min_concurrency = 3
 keep_lambdas_warm      = false
 endpoint_memory_size   = 1024
 scaling_trigger        = 0.6
-use_robots_txt         = false


### PR DESCRIPTION

## What?

Switch robots.txt back on in prod.

## Why?

Terraform working in other environments, resolve terraform deployment issue by applying the same config to prod.

## Related PRs

#2113 
#2112 