### PR TITLE
AUT-439 - Add additional doc app signing key when doc app api is enabled

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthoriseAccessTokenHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthoriseAccessTokenHandler.java
@@ -17,6 +17,7 @@ import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoClientService;
 import uk.gov.di.authentication.shared.services.DynamoService;
+import uk.gov.di.authentication.shared.services.JwksService;
 import uk.gov.di.authentication.shared.services.KmsConnectionService;
 import uk.gov.di.authentication.shared.services.TokenValidationService;
 
@@ -52,7 +53,9 @@ public class AuthoriseAccessTokenHandler
         configurationService = ConfigurationService.getInstance();
         tokenValidationService =
                 new TokenValidationService(
-                        configurationService, new KmsConnectionService(configurationService));
+                        new JwksService(
+                                configurationService,
+                                new KmsConnectionService(configurationService)));
         dynamoService = new DynamoService(configurationService);
         clientService = new DynamoClientService(configurationService);
     }
@@ -61,7 +64,9 @@ public class AuthoriseAccessTokenHandler
         this.configurationService = configurationService;
         tokenValidationService =
                 new TokenValidationService(
-                        configurationService, new KmsConnectionService(configurationService));
+                        new JwksService(
+                                configurationService,
+                                new KmsConnectionService(configurationService)));
         dynamoService = new DynamoService(configurationService);
         clientService = new DynamoClientService(configurationService);
     }

--- a/ci/terraform/oidc/jwks.tf
+++ b/ci/terraform/oidc/jwks.tf
@@ -6,6 +6,7 @@ module "oidc_jwks_role" {
 
   policies_to_attach = [
     aws_iam_policy.oidc_default_id_token_public_key_kms_policy.arn,
+    aws_iam_policy.doc_app_auth_kms_policy.arn,
   ]
 }
 
@@ -19,6 +20,7 @@ module "jwks" {
 
   handler_environment_variables = {
     EVENTS_SNS_TOPIC_ARN     = aws_sns_topic.events.arn
+    DOC_APP_API_ENABLED      = var.doc_app_api_enabled
     AUDIT_SIGNING_KEY_ALIAS  = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT      = var.use_localstack ? var.localstack_endpoint : null
     TOKEN_SIGNING_KEY_ALIAS  = local.id_token_signing_key_alias_name

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/JwksHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/JwksHandler.java
@@ -8,8 +8,8 @@ import com.nimbusds.jose.jwk.JWKSet;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.JwksService;
 import uk.gov.di.authentication.shared.services.KmsConnectionService;
-import uk.gov.di.authentication.shared.services.TokenValidationService;
 
 import java.util.Map;
 
@@ -20,21 +20,16 @@ import static uk.gov.di.authentication.shared.helpers.WarmerHelper.isWarming;
 public class JwksHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
-    private final TokenValidationService tokenValidationService;
-    private final ConfigurationService configurationService;
+    private final JwksService jwksService;
     private static final Logger LOG = LogManager.getLogger(JwksHandler.class);
 
-    public JwksHandler(
-            TokenValidationService tokenValidationService,
-            ConfigurationService configurationService) {
-        this.tokenValidationService = tokenValidationService;
-        this.configurationService = configurationService;
+    public JwksHandler(JwksService jwksService) {
+        this.jwksService = jwksService;
     }
 
     public JwksHandler(ConfigurationService configurationService) {
-        this.configurationService = configurationService;
-        this.tokenValidationService =
-                new TokenValidationService(
+        this.jwksService =
+                new JwksService(
                         configurationService, new KmsConnectionService(configurationService));
     }
 
@@ -58,9 +53,7 @@ public class JwksHandler
                             try {
                                 LOG.info("JWKs request received");
 
-                                var jwks =
-                                        new JWKSet(
-                                                tokenValidationService.getPublicJwkWithOpaqueId());
+                                var jwks = new JWKSet(jwksService.getPublicTokenJwkWithOpaqueId());
 
                                 LOG.info("Generating JWKs successful response");
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
@@ -22,6 +22,7 @@ import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoClientService;
+import uk.gov.di.authentication.shared.services.JwksService;
 import uk.gov.di.authentication.shared.services.KmsConnectionService;
 import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.services.TokenValidationService;
@@ -63,7 +64,9 @@ public class LogoutHandler
         this.clientSessionService = new ClientSessionService(configurationService);
         this.tokenValidationService =
                 new TokenValidationService(
-                        configurationService, new KmsConnectionService(configurationService));
+                        new JwksService(
+                                configurationService,
+                                new KmsConnectionService(configurationService)));
         this.auditService = new AuditService(configurationService);
         this.backChannelLogoutService = new BackChannelLogoutService(configurationService);
     }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
@@ -31,6 +31,7 @@ import uk.gov.di.authentication.shared.services.ClientSessionService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoClientService;
 import uk.gov.di.authentication.shared.services.DynamoService;
+import uk.gov.di.authentication.shared.services.JwksService;
 import uk.gov.di.authentication.shared.services.KmsConnectionService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
 import uk.gov.di.authentication.shared.services.SerializationService;
@@ -111,7 +112,8 @@ public class TokenHandler
                         configurationService, redisConnectionService, objectMapper);
         this.clientSessionService =
                 new ClientSessionService(configurationService, redisConnectionService);
-        this.tokenValidationService = new TokenValidationService(configurationService, kms);
+        this.tokenValidationService =
+                new TokenValidationService(new JwksService(configurationService, kms));
     }
 
     public TokenHandler() {

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandler.java
@@ -17,6 +17,7 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoClientService;
 import uk.gov.di.authentication.shared.services.DynamoIdentityService;
 import uk.gov.di.authentication.shared.services.DynamoService;
+import uk.gov.di.authentication.shared.services.JwksService;
 import uk.gov.di.authentication.shared.services.KmsConnectionService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
 import uk.gov.di.authentication.shared.services.TokenValidationService;
@@ -62,8 +63,9 @@ public class UserInfoHandler
                         new RedisConnectionService(configurationService),
                         new DynamoClientService(configurationService),
                         new TokenValidationService(
-                                configurationService,
-                                new KmsConnectionService(configurationService)));
+                                new JwksService(
+                                        configurationService,
+                                        new KmsConnectionService(configurationService))));
     }
 
     @Override

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/JwksHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/JwksHandlerTest.java
@@ -2,15 +2,16 @@ package uk.gov.di.authentication.oidc.lambda;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
-import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.nimbusds.jose.JOSEException;
-import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.Curve;
 import com.nimbusds.jose.jwk.JWKSet;
-import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.JwksService;
 
+import java.util.List;
 import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -24,23 +25,44 @@ class JwksHandlerTest {
 
     private final Context context = mock(Context.class);
     private final JwksService jwksService = mock(JwksService.class);
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private JwksHandler handler;
 
     @BeforeEach
     public void setUp() {
-        handler = new JwksHandler(jwksService);
+        handler = new JwksHandler(configurationService, jwksService);
+        when(configurationService.isDocAppApiEnabled()).thenReturn(false);
+    }
+
+    @Test
+    public void shouldReturnMultipleJwksWhenDocAppIsEnabled() throws JOSEException {
+        when(configurationService.isDocAppApiEnabled()).thenReturn(true);
+        var tokenSigningKey =
+                new ECKeyGenerator(Curve.P_256).keyID(UUID.randomUUID().toString()).generate();
+        var docAppSigningKey =
+                new ECKeyGenerator(Curve.P_256).keyID(UUID.randomUUID().toString()).generate();
+        when(jwksService.getPublicTokenJwkWithOpaqueId()).thenReturn(tokenSigningKey);
+        when(jwksService.getPublicDocAppSigningJwkWithOpaqueId()).thenReturn(docAppSigningKey);
+
+        var event = new APIGatewayProxyRequestEvent();
+        var result = handler.handleRequest(event, context);
+
+        var expectedJWKSet = new JWKSet(List.of(tokenSigningKey, docAppSigningKey));
+
+        assertThat(result, hasStatus(200));
+        assertThat(result, hasBody(expectedJWKSet.toString(true)));
     }
 
     @Test
     public void shouldReturn200WhenRequestIsSuccessful() throws JOSEException {
-        JWK opaqueSigningKey =
-                new RSAKeyGenerator(2048).keyID(UUID.randomUUID().toString()).generate();
+        var opaqueSigningKey =
+                new ECKeyGenerator(Curve.P_256).keyID(UUID.randomUUID().toString()).generate();
         when(jwksService.getPublicTokenJwkWithOpaqueId()).thenReturn(opaqueSigningKey);
 
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
+        var event = new APIGatewayProxyRequestEvent();
+        var result = handler.handleRequest(event, context);
 
-        JWKSet expectedJWKSet = new JWKSet(opaqueSigningKey);
+        var expectedJWKSet = new JWKSet(opaqueSigningKey);
 
         assertThat(result, hasStatus(200));
         assertThat(result, hasBody(expectedJWKSet.toString(true)));
@@ -50,8 +72,8 @@ class JwksHandlerTest {
     public void shouldReturn500WhenSigningKeyIsNotPresent() {
         when(jwksService.getPublicTokenJwkWithOpaqueId()).thenReturn(null);
 
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
+        var event = new APIGatewayProxyRequestEvent();
+        var result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(500));
         assertThat(result, hasBody("Error providing JWKs data"));
@@ -59,8 +81,8 @@ class JwksHandlerTest {
 
     @Test
     public void shouldSetACacheHeaderOfOneDayOnSuccess() throws JOSEException {
-        JWK opaqueSigningKey =
-                new RSAKeyGenerator(2048).keyID(UUID.randomUUID().toString()).generate();
+        var opaqueSigningKey =
+                new ECKeyGenerator(Curve.P_256).keyID(UUID.randomUUID().toString()).generate();
         when(jwksService.getPublicTokenJwkWithOpaqueId()).thenReturn(opaqueSigningKey);
 
         var response = handler.handleRequest(new APIGatewayProxyRequestEvent(), context);

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/JwksService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/JwksService.java
@@ -37,13 +37,13 @@ public class JwksService {
     }
 
     public JWK getPublicTokenJwkWithOpaqueId() {
+        return getPublicJWKWithKeyId(configurationService.getTokenSigningKeyAlias());
+    }
+
+    private JWK getPublicJWKWithKeyId(String keyId) {
         var jwk =
                 segmentedFunctionCall(
-                        "createJwk",
-                        () ->
-                                KEY_CACHE.computeIfAbsent(
-                                        configurationService.getTokenSigningKeyAlias(),
-                                        this::createJwk));
+                        "createJwk", () -> KEY_CACHE.computeIfAbsent(keyId, this::createJwk));
 
         return segmentedFunctionCall(
                 "parseJwk",
@@ -51,7 +51,7 @@ public class JwksService {
                     try {
                         return JWK.parse(jwk.toString());
                     } catch (java.text.ParseException e) {
-                        LOG.error("Error parsing the ECKey to JWK", e);
+                        LOG.error("Error parsing the public key to JWK", e);
                         throw new RuntimeException(e);
                     }
                 });

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/JwksService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/JwksService.java
@@ -40,6 +40,10 @@ public class JwksService {
         return getPublicJWKWithKeyId(configurationService.getTokenSigningKeyAlias());
     }
 
+    public JWK getPublicDocAppSigningJwkWithOpaqueId() {
+        return getPublicJWKWithKeyId(configurationService.getDocAppTokenSigningKeyAlias());
+    }
+
     private JWK getPublicJWKWithKeyId(String keyId) {
         var jwk =
                 segmentedFunctionCall(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/JwksService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/JwksService.java
@@ -1,0 +1,87 @@
+package uk.gov.di.authentication.shared.services;
+
+import com.amazonaws.services.kms.model.GetPublicKeyRequest;
+import com.amazonaws.services.kms.model.GetPublicKeyResult;
+import com.nimbusds.jose.Algorithm;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.KeyUse;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
+import org.bouncycastle.openssl.PEMException;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
+import uk.gov.di.authentication.shared.helpers.CryptoProviderHelper;
+
+import java.security.PublicKey;
+import java.security.interfaces.ECPublicKey;
+import java.util.HashMap;
+import java.util.Map;
+
+import static uk.gov.di.authentication.shared.helpers.HashHelper.hashSha256String;
+import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
+
+public class JwksService {
+
+    private final ConfigurationService configurationService;
+    private final KmsConnectionService kmsConnectionService;
+    private final Map<String, ECKey> KEY_CACHE = new HashMap<>();
+    private static final Logger LOG = LogManager.getLogger(JwksService.class);
+
+    public JwksService(
+            ConfigurationService configurationService, KmsConnectionService kmsConnectionService) {
+        this.configurationService = configurationService;
+        this.kmsConnectionService = kmsConnectionService;
+    }
+
+    public JWK getPublicTokenJwkWithOpaqueId() {
+        var jwk =
+                segmentedFunctionCall(
+                        "createJwk",
+                        () ->
+                                KEY_CACHE.computeIfAbsent(
+                                        configurationService.getTokenSigningKeyAlias(),
+                                        this::createJwk));
+
+        return segmentedFunctionCall(
+                "parseJwk",
+                () -> {
+                    try {
+                        return JWK.parse(jwk.toString());
+                    } catch (java.text.ParseException e) {
+                        LOG.error("Error parsing the ECKey to JWK", e);
+                        throw new RuntimeException(e);
+                    }
+                });
+    }
+
+    private ECKey createJwk(String keyId) {
+        GetPublicKeyRequest getPublicKeyRequest = new GetPublicKeyRequest();
+        getPublicKeyRequest.setKeyId(keyId);
+        GetPublicKeyResult publicKeyResult = kmsConnectionService.getPublicKey(getPublicKeyRequest);
+
+        PublicKey publicKey = createPublicKey(publicKeyResult);
+
+        return new ECKey.Builder(Curve.P_256, (ECPublicKey) publicKey)
+                .keyID(hashSha256String(publicKeyResult.getKeyId()))
+                .keyUse(KeyUse.SIGNATURE)
+                .algorithm(new Algorithm(JWSAlgorithm.ES256.getName()))
+                .build();
+    }
+
+    private PublicKey createPublicKey(GetPublicKeyResult publicKeyResult) {
+        SubjectPublicKeyInfo subjectKeyInfo =
+                SubjectPublicKeyInfo.getInstance(publicKeyResult.getPublicKey().array());
+
+        try {
+            return new JcaPEMKeyConverter()
+                    .setProvider(CryptoProviderHelper.bouncyCastle())
+                    .getPublicKey(subjectKeyInfo);
+        } catch (PEMException e) {
+            LOG.error("Error getting the PublicKey using the JcaPEMKeyConverter", e);
+            throw new RuntimeException();
+        }
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenValidationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenValidationService.java
@@ -1,16 +1,8 @@
 package uk.gov.di.authentication.shared.services;
 
-import com.amazonaws.services.kms.model.GetPublicKeyRequest;
-import com.amazonaws.services.kms.model.GetPublicKeyResult;
-import com.nimbusds.jose.Algorithm;
 import com.nimbusds.jose.JOSEException;
-import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSVerifier;
 import com.nimbusds.jose.crypto.ECDSAVerifier;
-import com.nimbusds.jose.jwk.Curve;
-import com.nimbusds.jose.jwk.ECKey;
-import com.nimbusds.jose.jwk.JWK;
-import com.nimbusds.jose.jwk.KeyUse;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.jwt.util.DateUtils;
@@ -19,33 +11,18 @@ import com.nimbusds.oauth2.sdk.token.RefreshToken;
 import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
-import org.bouncycastle.openssl.PEMException;
-import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
-import uk.gov.di.authentication.shared.helpers.CryptoProviderHelper;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 
-import java.security.PublicKey;
-import java.security.interfaces.ECPublicKey;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-
-import static uk.gov.di.authentication.shared.helpers.HashHelper.hashSha256String;
-import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
 
 public class TokenValidationService {
 
-    private final Map<String, ECKey> KEY_CACHE = new HashMap<>();
-    private final ConfigurationService configService;
-    private final KmsConnectionService kmsConnectionService;
+    private final JwksService jwksService;
     private static final Logger LOG = LogManager.getLogger(TokenValidationService.class);
 
-    public TokenValidationService(
-            ConfigurationService configService, KmsConnectionService kmsConnectionService) {
-        this.configService = configService;
-        this.kmsConnectionService = kmsConnectionService;
+    public TokenValidationService(JwksService jwksService) {
+        this.jwksService = jwksService;
     }
 
     public boolean validateAccessTokenSignature(AccessToken accessToken) {
@@ -80,7 +57,8 @@ public class TokenValidationService {
 
     public boolean isTokenSignatureValid(String tokenValue) {
         try {
-            JWSVerifier verifier = new ECDSAVerifier(getPublicJwkWithOpaqueId().toECKey());
+            JWSVerifier verifier =
+                    new ECDSAVerifier(jwksService.getPublicTokenJwkWithOpaqueId().toECKey());
 
             return SignedJWT.parse(tokenValue).verify(verifier);
         } catch (JOSEException | java.text.ParseException e) {
@@ -100,53 +78,5 @@ public class TokenValidationService {
             return false;
         }
         return true;
-    }
-
-    public JWK getPublicJwkWithOpaqueId() {
-        var jwk =
-                segmentedFunctionCall(
-                        "createJwk",
-                        () ->
-                                KEY_CACHE.computeIfAbsent(
-                                        configService.getTokenSigningKeyAlias(), this::createJwk));
-
-        return segmentedFunctionCall(
-                "parseJwk",
-                () -> {
-                    try {
-                        return JWK.parse(jwk.toString());
-                    } catch (java.text.ParseException e) {
-                        LOG.error("Error parsing the ECKey to JWK", e);
-                        throw new RuntimeException(e);
-                    }
-                });
-    }
-
-    private ECKey createJwk(String keyId) {
-        GetPublicKeyRequest getPublicKeyRequest = new GetPublicKeyRequest();
-        getPublicKeyRequest.setKeyId(keyId);
-        GetPublicKeyResult publicKeyResult = kmsConnectionService.getPublicKey(getPublicKeyRequest);
-
-        PublicKey publicKey = createPublicKey(publicKeyResult);
-
-        return new ECKey.Builder(Curve.P_256, (ECPublicKey) publicKey)
-                .keyID(hashSha256String(publicKeyResult.getKeyId()))
-                .keyUse(KeyUse.SIGNATURE)
-                .algorithm(new Algorithm(JWSAlgorithm.ES256.getName()))
-                .build();
-    }
-
-    private PublicKey createPublicKey(GetPublicKeyResult publicKeyResult) {
-        SubjectPublicKeyInfo subjectKeyInfo =
-                SubjectPublicKeyInfo.getInstance(publicKeyResult.getPublicKey().array());
-
-        try {
-            return new JcaPEMKeyConverter()
-                    .setProvider(CryptoProviderHelper.bouncyCastle())
-                    .getPublicKey(subjectKeyInfo);
-        } catch (PEMException e) {
-            LOG.error("Error getting the PublicKey using the JcaPEMKeyConverter", e);
-            throw new RuntimeException();
-        }
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ValidationHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ValidationHelperTest.java
@@ -63,7 +63,8 @@ class ValidationHelperTest {
 
     @Test
     void shouldAcceptValidBritishPhoneNumbers() {
-        assertThat(ValidationHelper.validatePhoneNumber("07911123456"), equalTo(Optional.empty()));
+        assertThat(
+                ValidationHelper.validatePhoneNumber("+4407911123456"), equalTo(Optional.empty()));
     }
 
     @Test

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/JwksServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/JwksServiceTest.java
@@ -1,0 +1,81 @@
+package uk.gov.di.authentication.shared.services;
+
+import com.amazonaws.services.kms.model.GetPublicKeyRequest;
+import com.amazonaws.services.kms.model.GetPublicKeyResult;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+import java.util.Base64;
+
+import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.shared.helpers.HashHelper.hashSha256String;
+
+class JwksServiceTest {
+
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private final KmsConnectionService kmsConnectionService = mock(KmsConnectionService.class);
+    private final JwksService jwksService =
+            new JwksService(configurationService, kmsConnectionService);
+    private static final String KEY_ID = "14342354354353";
+    private static final String HASHED_KEY_ID = hashSha256String(KEY_ID);
+    private ECKey ecJWK;
+
+    @BeforeEach
+    void setUp() throws JOSEException {
+        ecJWK = generateECKeyPair();
+        when(configurationService.getTokenSigningKeyAlias()).thenReturn(KEY_ID);
+        GetPublicKeyResult getPublicKeyResult = new GetPublicKeyResult();
+        getPublicKeyResult.setKeyUsage("SIGN_VERIFY");
+        getPublicKeyResult.setKeyId(KEY_ID);
+        getPublicKeyResult.setSigningAlgorithms(singletonList(JWSAlgorithm.ES256.getName()));
+        getPublicKeyResult.setPublicKey(
+                ByteBuffer.wrap(ecJWK.toPublicJWK().toECPublicKey().getEncoded()));
+        when(kmsConnectionService.getPublicKey(any(GetPublicKeyRequest.class)))
+                .thenReturn(getPublicKeyResult);
+    }
+
+    @Test
+    void shouldRetrievePublicTokenSigningKeyFromKmsAndParseToJwk() {
+        byte[] publicKey =
+                Base64.getDecoder()
+                        .decode(
+                                "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEpRm+QZsh2IkUWcqXUhBI9ulOzO8dz0Z8HIS6m77tI4eWoZgKYUcbByshDtN4gWPql7E5mN4uCLsg5+6SDXlQcA==");
+
+        when(configurationService.getTokenSigningKeyAlias()).thenReturn(KEY_ID);
+
+        var result =
+                new GetPublicKeyResult()
+                        .withKeyUsage("SIGN_VERIFY")
+                        .withKeyId(KEY_ID)
+                        .withSigningAlgorithms(singletonList(JWSAlgorithm.ES256.getName()))
+                        .withPublicKey(ByteBuffer.wrap(publicKey));
+
+        when(kmsConnectionService.getPublicKey(any(GetPublicKeyRequest.class))).thenReturn(result);
+
+        JWK publicKeyJwk = jwksService.getPublicTokenJwkWithOpaqueId();
+
+        assertEquals(publicKeyJwk.getKeyID(), HASHED_KEY_ID);
+        assertEquals(publicKeyJwk.getAlgorithm(), JWSAlgorithm.ES256);
+        assertEquals(publicKeyJwk.getKeyUse(), KeyUse.SIGNATURE);
+    }
+
+    private ECKey generateECKeyPair() {
+        try {
+            return new ECKeyGenerator(Curve.P_256).keyID(KEY_ID).generate();
+        } catch (JOSEException e) {
+            throw new RuntimeException();
+        }
+    }
+}

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenValidationServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenValidationServiceTest.java
@@ -1,15 +1,10 @@
 package uk.gov.di.authentication.shared.services;
 
-import com.amazonaws.services.kms.model.GetPublicKeyRequest;
-import com.amazonaws.services.kms.model.GetPublicKeyResult;
 import com.nimbusds.jose.JOSEException;
-import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSSigner;
 import com.nimbusds.jose.crypto.ECDSASigner;
 import com.nimbusds.jose.jwk.Curve;
 import com.nimbusds.jose.jwk.ECKey;
-import com.nimbusds.jose.jwk.JWK;
-import com.nimbusds.jose.jwk.KeyUse;
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
 import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.id.Subject;
@@ -20,53 +15,34 @@ import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.sharedtest.helper.TokenGeneratorHelper;
 
-import java.nio.ByteBuffer;
 import java.time.temporal.ChronoUnit;
-import java.util.Base64;
 import java.util.Date;
 import java.util.List;
-import java.util.Optional;
 
-import static java.util.Collections.singletonList;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.authentication.shared.helpers.HashHelper.hashSha256String;
 
 class TokenValidationServiceTest {
 
-    private final ConfigurationService configurationService = mock(ConfigurationService.class);
-    private final KmsConnectionService kmsConnectionService = mock(KmsConnectionService.class);
+    private final JwksService jwksService = mock(JwksService.class);
     private final TokenValidationService tokenValidationService =
-            new TokenValidationService(configurationService, kmsConnectionService);
+            new TokenValidationService(jwksService);
     private static final Subject SUBJECT = new Subject("some-subject");
     private static final List<String> SCOPES = List.of("openid", "email", "phone");
     private static final List<String> REFRESH_SCOPES = List.of("openid", "email", "offline_access");
     private static final String CLIENT_ID = "client-id";
-    private static final String BASE_URL = "http://example.com";
+    private static final String BASE_URL = "https://example.com";
     private static final String KEY_ID = "14342354354353";
-    private static final String HASHED_KEY_ID = hashSha256String(KEY_ID);
     private JWSSigner signer;
     private ECKey ecJWK;
 
     @BeforeEach
     void setUp() throws JOSEException {
-        Optional<String> baseUrl = Optional.of(BASE_URL);
-        when(configurationService.getOidcApiBaseURL()).thenReturn(baseUrl);
         ecJWK = generateECKeyPair();
         signer = new ECDSASigner(ecJWK);
-        when(configurationService.getTokenSigningKeyAlias()).thenReturn(KEY_ID);
-        GetPublicKeyResult getPublicKeyResult = new GetPublicKeyResult();
-        getPublicKeyResult.setKeyUsage("SIGN_VERIFY");
-        getPublicKeyResult.setKeyId(KEY_ID);
-        getPublicKeyResult.setSigningAlgorithms(singletonList(JWSAlgorithm.ES256.getName()));
-        getPublicKeyResult.setPublicKey(
-                ByteBuffer.wrap(ecJWK.toPublicJWK().toECPublicKey().getEncoded()));
-        when(kmsConnectionService.getPublicKey(any(GetPublicKeyRequest.class)))
-                .thenReturn(getPublicKeyResult);
+        when(jwksService.getPublicTokenJwkWithOpaqueId()).thenReturn(ecJWK.toPublicJWK());
     }
 
     @Test
@@ -109,31 +85,6 @@ class TokenValidationServiceTest {
         assertFalse(
                 tokenValidationService.validateRefreshTokenSignatureAndExpiry(
                         new RefreshToken(signedAccessToken.serialize())));
-    }
-
-    @Test
-    void shouldRetrievePublicKeyFromKmsAndParseToJwk() {
-        byte[] publicKey =
-                Base64.getDecoder()
-                        .decode(
-                                "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEpRm+QZsh2IkUWcqXUhBI9ulOzO8dz0Z8HIS6m77tI4eWoZgKYUcbByshDtN4gWPql7E5mN4uCLsg5+6SDXlQcA==");
-
-        when(configurationService.getTokenSigningKeyAlias()).thenReturn(KEY_ID);
-
-        var result =
-                new GetPublicKeyResult()
-                        .withKeyUsage("SIGN_VERIFY")
-                        .withKeyId(KEY_ID)
-                        .withSigningAlgorithms(singletonList(JWSAlgorithm.ES256.getName()))
-                        .withPublicKey(ByteBuffer.wrap(publicKey));
-
-        when(kmsConnectionService.getPublicKey(any(GetPublicKeyRequest.class))).thenReturn(result);
-
-        JWK publicKeyJwk = tokenValidationService.getPublicJwkWithOpaqueId();
-
-        assertEquals(publicKeyJwk.getKeyID(), HASHED_KEY_ID);
-        assertEquals(publicKeyJwk.getAlgorithm(), JWSAlgorithm.ES256);
-        assertEquals(publicKeyJwk.getKeyUse(), KeyUse.SIGNATURE);
     }
 
     @Test


### PR DESCRIPTION
## What?

- When the doc app api is enabled, add the doc app signing key to the JWKS endpoint. This is currently enabled in all evironments apart from production. 
- Pull out where we retreieve the JWKs key into their own service so it is decoupled from the TokenValidationService. 

## Why?

- The Doc app team will be retrieveing our public key via the JWKs endpoint. 