### PR TITLE
BAU: Make the production stub a test client

### DIFF
--- a/ci/terraform/shared/production-stub-clients.tfvars
+++ b/ci/terraform/shared/production-stub-clients.tfvars
@@ -7,7 +7,7 @@ stub_rp_clients = [
     logout_urls = [
       "https://di-auth-stub-relying-party-production.london.cloudapps.digital/signed-out",
     ]
-    test_client                     = "0"
+    test_client                     = "1"
     consent_required                = "0"
     client_type                     = "web"
     identity_verification_supported = "1"


### PR DESCRIPTION
## What?

- Set the `test_client` value to `1` for the production stub.

## Why?

We need to bypass the IPV capacity flag when using the production stub, this is done by making it a test client.