### PR TITLE
AUT-537: Add generic pre-validation of supplied string auth app code to validity check

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/validation/AuthAppCodeValidator.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/validation/AuthAppCodeValidator.java
@@ -96,6 +96,10 @@ public class AuthAppCodeValidator extends MfaCodeValidator {
     }
 
     public boolean isCodeValid(String code, String secret) {
+        if (code.isEmpty() || code.length() > 6) {
+            return false;
+        }
+
         int codeToCheck = Integer.parseInt(code);
 
         if (secret == null) {

--- a/shared/src/test/java/uk/gov/di/authentication/shared/validation/AuthAppCodeValidatorTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/validation/AuthAppCodeValidatorTest.java
@@ -82,10 +82,14 @@ class AuthAppCodeValidatorTest {
 
     @Test
     void returnsCorrectErrorWhenAuthCodeIsInvalid() {
-        setUpInvalidAuthCode();
+        setUpValidAuthCode();
 
         assertEquals(
                 Optional.of(ErrorResponse.ERROR_1043), authAppCodeValidator.validateCode("111111"));
+        assertEquals(Optional.of(ErrorResponse.ERROR_1043), authAppCodeValidator.validateCode(""));
+        assertEquals(
+                Optional.of(ErrorResponse.ERROR_1043),
+                authAppCodeValidator.validateCode("999999999999"));
     }
 
     private void setUpBlockedUser() {
@@ -128,31 +132,6 @@ class AuthAppCodeValidatorTest {
                 .thenReturn(false);
         when(mockDynamoService.getUserCredentialsFromEmail("email-address"))
                 .thenReturn(mock(UserCredentials.class));
-
-        this.authAppCodeValidator =
-                new AuthAppCodeValidator(
-                        mockUserContext,
-                        mockCodeStorageService,
-                        mockConfigurationService,
-                        mockDynamoService,
-                        MAX_RETRIES);
-    }
-
-    private void setUpInvalidAuthCode() {
-        when(mockSession.getEmailAddress()).thenReturn("email-address");
-        when(mockSession.getRetryCount()).thenReturn(0);
-        when(mockUserContext.getSession()).thenReturn(mockSession);
-        when(mockCodeStorageService.isBlockedForEmail("email-address", CODE_BLOCKED_KEY_PREFIX))
-                .thenReturn(false);
-
-        UserCredentials mockUserCredentials = mock(UserCredentials.class);
-        MFAMethod mockMfaMethod = mock(MFAMethod.class);
-        when(mockMfaMethod.getMfaMethodType()).thenReturn(MFAMethodType.AUTH_APP.getValue());
-        when(mockMfaMethod.getCredentialValue()).thenReturn("test-credential-value");
-        List<MFAMethod> mockMfaMethodList = Collections.singletonList(mockMfaMethod);
-        when(mockUserCredentials.getMfaMethods()).thenReturn(mockMfaMethodList);
-        when(mockDynamoService.getUserCredentialsFromEmail("email-address"))
-                .thenReturn(mockUserCredentials);
 
         this.authAppCodeValidator =
                 new AuthAppCodeValidator(


### PR DESCRIPTION
## What?
- Add check that supplied auth app code string - transmitted from front end - which must be parsed to int as part of validation algorithm, is neither empty not too long
- This avoids `NumberFormatException` when in these cases the supplied code must by definition be invalid, as it is unprocessable by our algorithm, so simply returning a validity check result of `false` achieves the desired effect (Note: NumberFormatException was thrown silently until now for long numbers because `Integer.ParseInt` cannot handle any number larger than 2^31 - 1)
- Have also revisited the relevant unit test, which I only noticed when trying to run it with an example number that it was actually not setting up an invalid code correctly (it was giving the correct error response, but for the wrong reason - `secret not found`). In doing so I realised that the setup for a correct code was already doing everything needed, so reused that function and deleted the deficient function (`setUpInvalidAuthCode()`)

## Why?

The exception meant that the front end was receiving ERROR 1001, and going on to show 500 status code, when this was not at all reflective of what was going wrong.