### PR TITLE
BAU - Increase Doc App JWT expiration time

### DIFF
--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/services/DocAppAuthorisationService.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/services/DocAppAuthorisationService.java
@@ -153,7 +153,7 @@ public class DocAppAuthorisationService {
                         .keyID(hashSha256String(signingKeyId))
                         .build();
         var jwtID = IdGenerator.generate();
-        var expiryDate = NowHelper.nowPlus(3, ChronoUnit.MINUTES);
+        var expiryDate = NowHelper.nowPlus(2880, ChronoUnit.MINUTES);
         var claimsBuilder =
                 new JWTClaimsSet.Builder()
                         .issuer(configurationService.getDocAppAuthorisationClientId())


### PR DESCRIPTION

## What?

- Increase the expiration time to 2 days. This will be reverted back once a JWT has been generated and supplied to the doc app team.

## Why?

- The Doc App need a valid JWE that works against the staging environment but which is not expired. They need a URL that they can pass to the Apples app review in order to start pushing out builds to their test team.
