### PR TITLE
AUT-549 - Update response we receive back from Doc App userinfo

### DIFF
--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/entity/DocAppCredential.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/entity/DocAppCredential.java
@@ -3,10 +3,12 @@ package uk.gov.di.authentication.app.entity;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBAttribute;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
 
+import java.util.List;
+
 public class DocAppCredential {
 
     private String subjectID;
-    private String credential;
+    private List<String> credential;
     private long timeToExist;
 
     public DocAppCredential() {}
@@ -22,11 +24,11 @@ public class DocAppCredential {
     }
 
     @DynamoDBAttribute(attributeName = "Credential")
-    public String getCredential() {
+    public List<String> getCredential() {
         return credential;
     }
 
-    public DocAppCredential setCredential(String credential) {
+    public DocAppCredential setCredential(List<String> credential) {
         this.credential = credential;
         return this;
     }

--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/services/DocAppAuthorisationService.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/services/DocAppAuthorisationService.java
@@ -107,6 +107,7 @@ public class DocAppAuthorisationService {
 
     public void storeState(String sessionId, State state) {
         try {
+            LOG.info("Storing state");
             redisConnectionService.saveWithExpiry(
                     STATE_STORAGE_PREFIX + sessionId,
                     objectMapper.writeValueAsString(state),

--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/services/DynamoDocAppService.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/services/DynamoDocAppService.java
@@ -7,6 +7,7 @@ import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.time.temporal.ChronoUnit;
+import java.util.List;
 import java.util.Optional;
 
 import static uk.gov.di.authentication.shared.dynamodb.DynamoClientHelper.createDynamoClient;
@@ -28,7 +29,7 @@ public class DynamoDocAppService {
         warmUp(tableName);
     }
 
-    public void addDocAppCredential(String subjectID, String credential) {
+    public void addDocAppCredential(String subjectID, List<String> credential) {
         var docAppCredential =
                 new DocAppCredential()
                         .setSubjectID(subjectID)

--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
@@ -37,6 +37,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -118,7 +119,7 @@ class DocAppCallbackHandlerTest {
         when(tokenService.constructTokenRequest(AUTH_CODE.getValue())).thenReturn(tokenRequest);
         when(tokenService.sendTokenRequest(tokenRequest)).thenReturn(successfulTokenResponse);
         when(tokenService.sendCriDataRequest(any(HTTPRequest.class)))
-                .thenReturn("a-verifiable-credential");
+                .thenReturn(List.of("a-verifiable-credential"));
 
         var event = new APIGatewayProxyRequestEvent();
         event.setQueryStringParameters(responseHeaders);
@@ -168,7 +169,8 @@ class DocAppCallbackHandlerTest {
         verifyNoMoreInteractions(auditService);
 
         verify(dynamoDocAppService)
-                .addDocAppCredential(PAIRWISE_SUBJECT_ID.getValue(), "a-verifiable-credential");
+                .addDocAppCredential(
+                        PAIRWISE_SUBJECT_ID.getValue(), List.of("a-verifiable-credential"));
     }
 
     @Test

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppCallbackHandlerIntegrationTest.java
@@ -49,6 +49,7 @@ import java.util.UUID;
 
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -153,8 +154,9 @@ class DocAppCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
                         DOC_APP_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
                         DOC_APP_SUCCESSFUL_CREDENTIAL_RESPONSE_RECEIVED));
 
-        assertTrue(
-                documentAppCredentialStore.getCredential(docAppSubjectId.getValue()).isPresent());
+        var docAppCredential = documentAppCredentialStore.getCredential(docAppSubjectId.getValue());
+        assertTrue(docAppCredential.isPresent());
+        assertThat(docAppCredential.get().getCredential().size(), equalTo(1));
     }
 
     @Test

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/CriStubExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/CriStubExtension.java
@@ -56,7 +56,16 @@ public class CriStubExtension extends HttpStubExtension {
                                 + "}",
                         getHttpPort()));
 
-        register("/protected-resource", 200, "application/jwt", signedResponse(signingKey));
+        register(
+                "/protected-resource",
+                200,
+                "application/json",
+                format(
+                        "{"
+                                + "  \"https://vocab.account.gov.uk/v1/credentialJWT\": [\"%s\"],"
+                                + "  \"sub\": \"urn:fdc:gov.uk:2022:740e58343a2946b49a6f16142fde533a\""
+                                + "}",
+                        signedResponse(signingKey)));
     }
 
     private String signedResponse(ECKey signingKey) throws JOSEException {

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/DocumentAppCredentialStoreExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/DocumentAppCredentialStoreExtension.java
@@ -11,6 +11,7 @@ import uk.gov.di.authentication.app.services.DynamoDocAppService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.sharedtest.basetest.DynamoTestConfiguration;
 
+import java.util.List;
 import java.util.Optional;
 
 import static com.amazonaws.services.dynamodbv2.model.KeyType.HASH;
@@ -66,8 +67,8 @@ public class DocumentAppCredentialStoreExtension extends DynamoExtension
         dynamoDB.createTable(request);
     }
 
-    public void addCredential(String subjectId, String credential) {
-        dynamoDocAppService.addDocAppCredential(subjectId, credential);
+    public void addCredential(String subjectId, List<String> credentials) {
+        dynamoDocAppService.addDocAppCredential(subjectId, credentials);
     }
 
     public Optional<DocAppCredential> getCredential(String subjectId) {


### PR DESCRIPTION
## What?

- Update response we receive back from Doc App userinfo
- Add additional logging

## Why?

- The format of the response is similar to IPV core and will be JSON rather than a single JWT. Change how we parse the response and save the credentials in dynamo.
    - The response may contain mutliple JWTs so we need to verify the signature for each and save all in dynamo before returning them to the RP.