### PR TITLE
AUT-564 - Remove feature flag from Doc App lambdas

### DIFF
--- a/ci/terraform/oidc/api-gateway-frontend.tf
+++ b/ci/terraform/oidc/api-gateway-frontend.tf
@@ -60,8 +60,8 @@ resource "aws_api_gateway_deployment" "frontend_deployment" {
       module.reset-password-request.method_trigger_value,
       module.ipv-authorize.integration_trigger_value,
       module.ipv-authorize.method_trigger_value,
-      var.doc_app_api_enabled ? module.doc-app-authorize[0].integration_trigger_value : null,
-      var.doc_app_api_enabled ? module.doc-app-authorize[0].method_trigger_value : null,
+      module.doc-app-authorize.integration_trigger_value,
+      module.doc-app-authorize.method_trigger_value,
       module.processing-identity.integration_trigger_value,
       module.processing-identity.method_trigger_value,
     ]))

--- a/ci/terraform/oidc/api-gateway.tf
+++ b/ci/terraform/oidc/api-gateway.tf
@@ -131,8 +131,8 @@ resource "aws_api_gateway_deployment" "deployment" {
       module.ipv-callback.method_trigger_value,
       module.ipv-capacity.integration_trigger_value,
       module.ipv-capacity.method_trigger_value,
-      var.doc_app_api_enabled ? module.doc-app-callback[0].integration_trigger_value : null,
-      var.doc_app_api_enabled ? module.doc-app-callback[0].method_trigger_value : null,
+      module.doc-app-callback.integration_trigger_value,
+      module.doc-app-callback.method_trigger_value,
       var.use_robots_txt ? aws_api_gateway_integration_response.robots_txt_integration_response[0].response_templates : null,
     ]))
   }

--- a/ci/terraform/oidc/doc-app-authorize.tf
+++ b/ci/terraform/oidc/doc-app-authorize.tf
@@ -13,7 +13,6 @@ module "doc_app_authorize_role" {
 }
 
 module "doc-app-authorize" {
-  count  = var.doc_app_api_enabled ? 1 : 0
   source = "../modules/endpoint-module"
 
   endpoint_name   = "doc-app-authorize"
@@ -29,6 +28,7 @@ module "doc-app-authorize" {
     REDIS_KEY                          = local.redis_key
     DYNAMO_ENDPOINT                    = var.use_localstack ? var.lambda_dynamo_endpoint : null
     DOC_APP_AUTHORISATION_URI          = var.doc_app_authorisation_uri
+    DOC_APP_API_ENABLED                = var.doc_app_api_enabled
     DOC_APP_AUTHORISATION_CALLBACK_URI = var.doc_app_authorisation_callback_uri
     DOC_APP_AUTHORISATION_CLIENT_ID    = var.doc_app_authorisation_client_id
     DOC_APP_JWKS_URL                   = var.doc_app_jwks_endpoint

--- a/ci/terraform/oidc/doc-app-callback.tf
+++ b/ci/terraform/oidc/doc-app-callback.tf
@@ -15,7 +15,6 @@ module "doc_app_callback_role" {
 }
 
 module "doc-app-callback" {
-  count  = var.doc_app_api_enabled ? 1 : 0
   source = "../modules/endpoint-module"
 
   endpoint_name   = "doc-app-callback"

--- a/ci/terraform/oidc/production-overrides.tfvars
+++ b/ci/terraform/oidc/production-overrides.tfvars
@@ -11,6 +11,7 @@ notify_template_map = {
 cloudwatch_log_retention       = 5
 client_registry_api_enabled    = false
 spot_enabled                   = true
+doc_app_api_enabled            = false
 ipv_api_enabled                = true
 ipv_capacity_allowed           = true
 ipv_authorisation_uri          = "https://identity.account.gov.uk/oauth2/authorize"

--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppAuthorizeHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppAuthorizeHandler.java
@@ -95,7 +95,10 @@ public class DocAppAuthorizeHandler
                         () -> {
                             try {
                                 LOG.info("DocAppAuthorizeHandler received request");
-
+                                if (!configurationService.isDocAppApiEnabled()) {
+                                    LOG.error("Doc app api is not enabled");
+                                    throw new RuntimeException("Doc app api is not enabled");
+                                }
                                 var session =
                                         sessionService
                                                 .getSessionFromRequestHeaders(input.getHeaders())

--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppAuthorizeHandlerTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppAuthorizeHandlerTest.java
@@ -50,6 +50,7 @@ import java.util.Optional;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.startsWith;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
@@ -101,7 +102,23 @@ class DocAppAuthorizeHandlerTest {
                 .thenReturn(DOC_APP_CALLBACK_URI);
         when(configurationService.getDocAppAuthorisationURI())
                 .thenReturn(DOC_APP_AUTHORISATION_URI);
+        when(configurationService.isDocAppApiEnabled()).thenReturn(true);
         when(clientSession.getDocAppSubjectId()).thenReturn(DOC_APP_SUBJECT_ID);
+    }
+
+    @Test
+    void shouldThrowWhenDocAppApiIsNotEnabled() {
+        usingValidSession();
+        usingValidClientSession();
+        when(configurationService.isDocAppApiEnabled()).thenReturn(false);
+
+        var exception =
+                assertThrows(
+                        RuntimeException.class,
+                        this::makeHandlerRequest,
+                        "Expected to throw exception");
+
+        assertThat(exception.getMessage(), equalTo("Doc app api is not enabled"));
     }
 
     @Test


### PR DESCRIPTION
## What?

- Remove the terraform feature flag from the Doc App lambdas so they are deployed to every environment.
- Add a check in the DocAppAuthorize lambda to ensure that the DocApp api is enabled. This is for belt and braces and we already have a check in the authorize lambda.


## Why?

- So we have all lambads etc deployed to Production which will make us ready to integrate with the doc app service when the time comes