### PR TITLE
AUT-564 - Disable doc app journey in build and staging

### DIFF
--- a/ci/terraform/oidc/build-overrides.tfvars
+++ b/ci/terraform/oidc/build-overrides.tfvars
@@ -1,4 +1,4 @@
-doc_app_api_enabled                = true
+doc_app_api_enabled                = false
 doc_app_cri_data_endpoint          = "credentials/issue"
 doc_app_backend_uri                = "https://build-doc-app-cri-stub.london.cloudapps.digital"
 doc_app_domain                     = "https://build-doc-app-cri-stub.london.cloudapps.digital"

--- a/ci/terraform/oidc/staging-overrides.tfvars
+++ b/ci/terraform/oidc/staging-overrides.tfvars
@@ -1,4 +1,4 @@
-doc_app_api_enabled                = true
+doc_app_api_enabled                = false
 ipv_capacity_allowed               = true
 ipv_api_enabled                    = true
 doc_app_authorisation_client_id    = "authOrchestratorDocApp"


### PR DESCRIPTION
## What?

- Disable doc app journey in build and staging

## Why?

- This is to allow us to remove the feature flag on the terraform and prevent any circular dependencies.

