### PR TITLE
BAU - Remove triggers for doc app lambdas

### DIFF
--- a/ci/terraform/oidc/api-gateway-frontend.tf
+++ b/ci/terraform/oidc/api-gateway-frontend.tf
@@ -60,8 +60,6 @@ resource "aws_api_gateway_deployment" "frontend_deployment" {
       module.reset-password-request.method_trigger_value,
       module.ipv-authorize.integration_trigger_value,
       module.ipv-authorize.method_trigger_value,
-      var.doc_app_api_enabled ? module.doc-app-authorize[0].integration_trigger_value : null,
-      var.doc_app_api_enabled ? module.doc-app-authorize[0].method_trigger_value : null,
       module.processing-identity.integration_trigger_value,
       module.processing-identity.method_trigger_value,
     ]))

--- a/ci/terraform/oidc/api-gateway.tf
+++ b/ci/terraform/oidc/api-gateway.tf
@@ -131,8 +131,6 @@ resource "aws_api_gateway_deployment" "deployment" {
       module.ipv-callback.method_trigger_value,
       module.ipv-capacity.integration_trigger_value,
       module.ipv-capacity.method_trigger_value,
-      var.doc_app_api_enabled ? module.doc-app-callback[0].integration_trigger_value : null,
-      var.doc_app_api_enabled ? module.doc-app-callback[0].method_trigger_value : null,
       var.use_robots_txt ? aws_api_gateway_integration_response.robots_txt_integration_response[0].response_templates : null,
     ]))
   }


### PR DESCRIPTION
## What?

 - Remove triggers for doc app lambdas

## Why?

- To try and get round the `Error: Cycle:` in the deploy-oidc-api-build job
