### PR TITLE
AUT-564 - Renable doc app journeys in non-prod environments

### DIFF
--- a/ci/terraform/oidc/build-overrides.tfvars
+++ b/ci/terraform/oidc/build-overrides.tfvars
@@ -1,4 +1,4 @@
-doc_app_api_enabled                = false
+doc_app_api_enabled                = true
 doc_app_cri_data_endpoint          = "credentials/issue"
 doc_app_backend_uri                = "https://build-doc-app-cri-stub.london.cloudapps.digital"
 doc_app_domain                     = "https://build-doc-app-cri-stub.london.cloudapps.digital"

--- a/ci/terraform/oidc/integration-overrides.tfvars
+++ b/ci/terraform/oidc/integration-overrides.tfvars
@@ -1,4 +1,4 @@
-doc_app_api_enabled                = false
+doc_app_api_enabled                = true
 doc_app_cri_data_endpoint          = "userinfo"
 doc_app_backend_uri                = "https://api-backend-api.review-b.integration.account.gov.uk"
 doc_app_domain                     = "https://api.review-b.integration.account.gov.uk"

--- a/ci/terraform/oidc/staging-overrides.tfvars
+++ b/ci/terraform/oidc/staging-overrides.tfvars
@@ -1,4 +1,4 @@
-doc_app_api_enabled                = false
+doc_app_api_enabled                = true
 ipv_capacity_allowed               = true
 ipv_api_enabled                    = true
 doc_app_authorisation_client_id    = "authOrchestratorDocApp"


### PR DESCRIPTION
## What?

- Renable doc app journeys in non-prod environments

## Why?

- So journeys can be tested