### PR TITLE
AUT-569 - Remove signing validation of doc app credential

### DIFF
--- a/ci/terraform/oidc/build-overrides.tfvars
+++ b/ci/terraform/oidc/build-overrides.tfvars
@@ -7,7 +7,6 @@ doc_app_authorisation_callback_uri = "https://oidc.build.account.gov.uk/doc-app-
 doc_app_authorisation_uri          = "https://build-doc-app-cri-stub.london.cloudapps.digital/authorize"
 doc_app_jwks_endpoint              = "https://build-doc-app-cri-stub.london.cloudapps.digital/.well-known/jwks.json"
 doc_app_encryption_key_id          = "7788bc975abd44e8b4fd7646d08ea9428476e37bff3e4365804b41cc29f8ef21"
-doc_app_signing_key_id             = "dbcc71593ef84309afe9413a2567897b0c134828151147509b655c2dbd9f60b2"
 spot_enabled                       = false
 
 blocked_email_duration = 30

--- a/ci/terraform/oidc/doc-app-callback.tf
+++ b/ci/terraform/oidc/doc-app-callback.tf
@@ -35,7 +35,6 @@ module "doc-app-callback" {
     DOC_APP_TOKEN_SIGNING_KEY_ALIAS    = local.doc_app_auth_key_alias_name
     DOC_APP_BACKEND_URI                = var.doc_app_backend_uri
     DOC_APP_CRI_DATA_ENDPOINT          = var.doc_app_cri_data_endpoint
-    DOC_APP_SIGNING_KEY_ID             = var.doc_app_signing_key_id
     DOC_APP_JWKS_URL                   = var.doc_app_jwks_endpoint
   }
   handler_function_name = "uk.gov.di.authentication.app.lambda.DocAppCallbackHandler::handleRequest"

--- a/ci/terraform/oidc/integration-overrides.tfvars
+++ b/ci/terraform/oidc/integration-overrides.tfvars
@@ -7,7 +7,6 @@ doc_app_authorisation_callback_uri = "https://oidc.integration.account.gov.uk/do
 doc_app_authorisation_uri          = "https://www.review-b.integration.account.gov.uk/dca/oauth2/authorize"
 doc_app_jwks_endpoint              = "https://api-backend-api.review-b.integration.account.gov.uk/.well-known/jwks.json"
 doc_app_encryption_key_id          = "0948190d-384c-498d-81e2-a20dd30f147c"
-doc_app_signing_key_id             = "fce55d1c-d099-40e5-8555-30c6938fdc47"
 
 ipv_api_enabled                = true
 ipv_capacity_allowed           = true

--- a/ci/terraform/oidc/staging-overrides.tfvars
+++ b/ci/terraform/oidc/staging-overrides.tfvars
@@ -7,7 +7,6 @@ doc_app_backend_uri                = "https://api-backend-api.review-b.staging.a
 doc_app_domain                     = "https://api.review-b.staging.account.gov.uk"
 doc_app_authorisation_callback_uri = "https://oidc.staging.account.gov.uk/doc-app-callback"
 doc_app_encryption_key_id          = "ca6d5930-77a6-41a4-8192-125df996c084"
-doc_app_signing_key_id             = "991d4f12-0367-4eb6-b166-607565a3e2d8"
 doc_app_cri_data_endpoint          = "userinfo"
 doc_app_jwks_endpoint              = "https://api-backend-api.review-b.staging.account.gov.uk/.well-known/jwks.json"
 ipv_authorisation_client_id        = "authOrchestrator"

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -334,11 +334,6 @@ variable "doc_app_encryption_key_id" {
   default = "undefined"
 }
 
-variable "doc_app_signing_key_id" {
-  type    = string
-  default = "undefined"
-}
-
 variable "doc_app_jwks_endpoint" {
   type    = string
   default = "undefined"

--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
@@ -83,11 +83,7 @@ public class DocAppCallbackHandler
                         new RedisConnectionService(configurationService),
                         kmsConnectionService,
                         new JwksService(configurationService, kmsConnectionService));
-        this.tokenService =
-                new DocAppCriService(
-                        configurationService,
-                        kmsConnectionService,
-                        new JwksService(configurationService, kmsConnectionService));
+        this.tokenService = new DocAppCriService(configurationService, kmsConnectionService);
         this.sessionService = new SessionService(configurationService);
         this.clientSessionService = new ClientSessionService(configurationService);
         this.auditService = new AuditService(configurationService);

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -117,10 +117,6 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return System.getenv().getOrDefault("DOC_APP_ENCRYPTION_KEY_ID", "");
     }
 
-    public String getDocAppSigningKeyID() {
-        return System.getenv().getOrDefault("DOC_APP_SIGNING_KEY_ID", "");
-    }
-
     public URI getDocAppJwksUri() {
         return URI.create(System.getenv().getOrDefault("DOC_APP_JWKS_URL", ""));
     }


### PR DESCRIPTION
## What?

- Remove signing validation of doc app credential
- Remove signing kid from confog

## Why?

- Having discussed this with the architects, it was agreed we don't need to worry about validating the signature of the credential and can just leave it to up to the RP to validate. 
- As we no longer will be validating the credential, we no longer need to store the signing kid in config