### PR TITLE
AUT-562: Add client for the prod app stub

### DIFF
--- a/ci/terraform/shared/production-stub-clients.tfvars
+++ b/ci/terraform/shared/production-stub-clients.tfvars
@@ -17,4 +17,21 @@ stub_rp_clients = [
       "phone",
     ]
   },
+  {
+    client_name = "di-auth-stub-relying-party-production-app"
+    callback_urls = [
+      "https://di-auth-stub-relying-party-production-app.london.cloudapps.digital/oidc/authorization-code/callback",
+    ]
+    logout_urls = [
+      "https://di-auth-stub-relying-party-production-app.london.cloudapps.digital/signed-out",
+    ]
+    test_client                     = "1"
+    consent_required                = "0"
+    identity_verification_supported = "1"
+    client_type                     = "app"
+    scopes = [
+      "openid",
+      "doc-checking-app",
+    ]
+  },
 ]


### PR DESCRIPTION
## What?

Add client for the prod app stub.

## Why?

A stub RP client app is needed in production to facilitate the Apple app review process.

