### PR TITLE
AUT-559: Add validation userinfo vs client session docAppSubjectId 

### DIFF
--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
@@ -219,7 +219,10 @@ public class DocAppCallbackHandler
                                                     .getTokens()
                                                     .getAccessToken()
                                                     .toAuthorizationHeader());
-                                    var credential = tokenService.sendCriDataRequest(request);
+                                    var credential =
+                                            tokenService.sendCriDataRequest(
+                                                    request,
+                                                    clientSession.getDocAppSubjectId().getValue());
                                     auditService.submitAuditEvent(
                                             DocAppAuditableEvent
                                                     .DOC_APP_SUCCESSFUL_CREDENTIAL_RESPONSE_RECEIVED,

--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
@@ -118,7 +118,7 @@ class DocAppCallbackHandlerTest {
                 .thenReturn(Optional.empty());
         when(tokenService.constructTokenRequest(AUTH_CODE.getValue())).thenReturn(tokenRequest);
         when(tokenService.sendTokenRequest(tokenRequest)).thenReturn(successfulTokenResponse);
-        when(tokenService.sendCriDataRequest(any(HTTPRequest.class)))
+        when(tokenService.sendCriDataRequest(any(HTTPRequest.class), any(String.class)))
                 .thenReturn(List.of("a-verifiable-credential"));
 
         var event = new APIGatewayProxyRequestEvent();

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/CriStubExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/CriStubExtension.java
@@ -42,7 +42,7 @@ public class CriStubExtension extends HttpStubExtension {
         super();
     }
 
-    public void init(ECKey signingKey) throws JOSEException {
+    public void init(ECKey signingKey, String docAppSubjectId) throws JOSEException {
         register(
                 "/token",
                 200,
@@ -63,9 +63,9 @@ public class CriStubExtension extends HttpStubExtension {
                 format(
                         "{"
                                 + "  \"https://vocab.account.gov.uk/v1/credentialJWT\": [\"%s\"],"
-                                + "  \"sub\": \"urn:fdc:gov.uk:2022:740e58343a2946b49a6f16142fde533a\""
+                                + "  \"sub\": \"%s\""
                                 + "}",
-                        signedResponse(signingKey)));
+                        signedResponse(signingKey), docAppSubjectId));
     }
 
     private String signedResponse(ECKey signingKey) throws JOSEException {


### PR DESCRIPTION
## What?

- Validate that the 'sub' field in the /userinfo response is the same as the docAppSubjectID in the client session
- If not, throw an exception rather than persisting the signedJWTs returned from the endpoind to Dynamo
- Make this conditional on the environment being anything other than build - because the build environment has a stub running presently that has a hard-coded `sub` value, and this would break our ability to persist the `userinfo` response in dynamo.

## Why?

- To avoid persisting incorrect data 
