### PR TITLE
AUT-567 - Publish DocAppCredential issued to cloudwatch per client

### DIFF
--- a/ci/terraform/oidc/cloudwatch-policies.tf
+++ b/ci/terraform/oidc/cloudwatch-policies.tf
@@ -1,0 +1,14 @@
+resource "aws_iam_policy" "cloudwatch_metrics_putdata_policy" {
+  name_prefix = "cloudwatch-put-metrics-policy-"
+  path        = "/${var.environment}/frontend-shared/"
+  description = "IAM policy enabling pushing metrics to CloudWatch"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["cloudwatch:PutMetricData"]
+      Resource = ["*"]
+    }]
+  })
+}

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -10,7 +10,8 @@ module "oidc_userinfo_role" {
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
     aws_iam_policy.dynamo_user_read_access_policy.arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
-    aws_iam_policy.redis_parameter_policy.arn
+    aws_iam_policy.redis_parameter_policy.arn,
+    aws_iam_policy.cloudwatch_metrics_putdata_policy.arn,
   ]
 }
 

--- a/ci/terraform/oidc/verify_code.tf
+++ b/ci/terraform/oidc/verify_code.tf
@@ -84,18 +84,3 @@ module "verify_code" {
     aws_sqs_queue.email_queue,
   ]
 }
-
-resource "aws_iam_policy" "cloudwatch_metrics_putdata_policy" {
-  name_prefix = "cloudwatch-put-metrics-policy-"
-  path        = "/${var.environment}/frontend-shared/"
-  description = "IAM policy enabling pushing metrics to CloudWatch"
-
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [{
-      Effect   = "Allow"
-      Action   = ["cloudwatch:PutMetricData"]
-      Resource = ["*"]
-    }]
-  })
-}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/AccessTokenInfo.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/AccessTokenInfo.java
@@ -1,6 +1,7 @@
 package uk.gov.di.authentication.oidc.entity;
 
 import uk.gov.di.authentication.shared.entity.AccessTokenStore;
+import uk.gov.di.authentication.shared.entity.ClientRegistry;
 
 import java.util.List;
 
@@ -10,16 +11,19 @@ public class AccessTokenInfo {
     private final String subject;
     private final List<String> scopes;
     private final List<String> identityClaims;
+    private final ClientRegistry clientRegistry;
 
     public AccessTokenInfo(
             AccessTokenStore accessTokenStore,
             String subject,
             List<String> scopes,
-            List<String> identityClaims) {
+            List<String> identityClaims,
+            ClientRegistry clientRegistry) {
         this.accessTokenStore = accessTokenStore;
         this.subject = subject;
         this.scopes = scopes;
         this.identityClaims = identityClaims;
+        this.clientRegistry = clientRegistry;
     }
 
     public AccessTokenStore getAccessTokenStore() {
@@ -36,5 +40,9 @@ public class AccessTokenInfo {
 
     public List<String> getIdentityClaims() {
         return identityClaims;
+    }
+
+    public ClientRegistry getClientRegistry() {
+        return clientRegistry;
     }
 }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/AccessTokenInfo.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/AccessTokenInfo.java
@@ -1,7 +1,6 @@
 package uk.gov.di.authentication.oidc.entity;
 
 import uk.gov.di.authentication.shared.entity.AccessTokenStore;
-import uk.gov.di.authentication.shared.entity.ClientRegistry;
 
 import java.util.List;
 
@@ -11,19 +10,19 @@ public class AccessTokenInfo {
     private final String subject;
     private final List<String> scopes;
     private final List<String> identityClaims;
-    private final ClientRegistry clientRegistry;
+    private final String clientID;
 
     public AccessTokenInfo(
             AccessTokenStore accessTokenStore,
             String subject,
             List<String> scopes,
             List<String> identityClaims,
-            ClientRegistry clientRegistry) {
+            String clientID) {
         this.accessTokenStore = accessTokenStore;
         this.subject = subject;
         this.scopes = scopes;
         this.identityClaims = identityClaims;
-        this.clientRegistry = clientRegistry;
+        this.clientID = clientID;
     }
 
     public AccessTokenStore getAccessTokenStore() {
@@ -42,7 +41,7 @@ public class AccessTokenInfo {
         return identityClaims;
     }
 
-    public ClientRegistry getClientRegistry() {
-        return clientRegistry;
+    public String getClientID() {
+        return clientID;
     }
 }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandler.java
@@ -13,6 +13,7 @@ import uk.gov.di.authentication.oidc.entity.AccessTokenInfo;
 import uk.gov.di.authentication.oidc.services.AccessTokenService;
 import uk.gov.di.authentication.oidc.services.UserInfoService;
 import uk.gov.di.authentication.shared.exceptions.AccessTokenException;
+import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoClientService;
 import uk.gov.di.authentication.shared.services.DynamoIdentityService;
@@ -57,7 +58,9 @@ public class UserInfoHandler
                 new UserInfoService(
                         new DynamoService(configurationService),
                         new DynamoIdentityService(configurationService),
-                        new DynamoDocAppService(configurationService));
+                        new DynamoDocAppService(configurationService),
+                        new CloudwatchMetricsService(),
+                        configurationService);
         this.accessTokenService =
                 new AccessTokenService(
                         new RedisConnectionService(configurationService),
@@ -104,10 +107,7 @@ public class UserInfoHandler
                                                         configurationService
                                                                 .getHeadersCaseInsensitive()),
                                                 configurationService.isIdentityEnabled());
-                                userInfo =
-                                        userInfoService.populateUserInfo(
-                                                accessTokenInfo,
-                                                configurationService.isIdentityEnabled());
+                                userInfo = userInfoService.populateUserInfo(accessTokenInfo);
                             } catch (AccessTokenException e) {
                                 LOG.warn(
                                         "AccessTokenException. Sending back UserInfoErrorResponse");

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AccessTokenService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AccessTokenService.java
@@ -128,7 +128,8 @@ public class AccessTokenService {
                 throw new AccessTokenException(
                         INVALID_ACCESS_TOKEN, BearerTokenError.INVALID_TOKEN);
             }
-            return new AccessTokenInfo(accessTokenStore.get(), subject, scopes, identityClaims);
+            return new AccessTokenInfo(
+                    accessTokenStore.get(), subject, scopes, identityClaims, client);
         } catch (ParseException e) {
             LOG.warn("Unable to parse AccessToken to SignedJWT");
             throw new AccessTokenException(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AccessTokenService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AccessTokenService.java
@@ -129,7 +129,7 @@ public class AccessTokenService {
                         INVALID_ACCESS_TOKEN, BearerTokenError.INVALID_TOKEN);
             }
             return new AccessTokenInfo(
-                    accessTokenStore.get(), subject, scopes, identityClaims, client);
+                    accessTokenStore.get(), subject, scopes, identityClaims, client.getClientID());
         } catch (ParseException e) {
             LOG.warn("Unable to parse AccessToken to SignedJWT");
             throw new AccessTokenException(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandlerTest.java
@@ -60,7 +60,7 @@ public class UserInfoHandlerTest {
         userInfo.setEmailAddress(EMAIL_ADDRESS);
         when(accessTokenService.parse(accessToken.toAuthorizationHeader(), false))
                 .thenReturn(accessTokenInfo);
-        when(userInfoService.populateUserInfo(accessTokenInfo, false)).thenReturn(userInfo);
+        when(userInfoService.populateUserInfo(accessTokenInfo)).thenReturn(userInfo);
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setHeaders(Map.of("Authorization", accessToken.toAuthorizationHeader()));


### PR DESCRIPTION
## What?

- Create count metric for doc-app-credential claims issued
- Give the userinfo lambda permissions to publish a new cloudwatch metric.

## Why?

- Create a new cloudwatch metric in userinfo to count the number of doc-app-credential claims issued back to the RP.
- This will give us data to create a graph in Grafana to display the count on a per client basis 
