### PR TITLE
BAU - Give DocAppAuthorize permissions to the Client dyanmo table

### DIFF
--- a/ci/terraform/oidc/doc-app-authorize.tf
+++ b/ci/terraform/oidc/doc-app-authorize.tf
@@ -9,6 +9,7 @@ module "doc_app_authorize_role" {
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
     aws_iam_policy.doc_app_auth_kms_policy.arn,
+    aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
   ]
 }
 


### PR DESCRIPTION


## What?

- Give DocAppAuthorize permissions to the Client dyanmo table
## Why?

- Because this lambda now reads from this table
