### PR TITLE
AUT-562: Use the rp client rather than the doc app client

### DIFF
--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppAuthorizeHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppAuthorizeHandler.java
@@ -135,14 +135,20 @@ public class DocAppAuthorizeHandler
                                                 configurationService
                                                         .getDocAppAuthorisationClientId());
                                 attachLogFieldToLogs(CLIENT_ID, clientID.getValue());
+                                var clientRegistry =
+                                        clientSession
+                                                .getAuthRequestParams()
+                                                .get("client_id")
+                                                .stream()
+                                                .findFirst()
+                                                .flatMap(clientService::getClient)
+                                                .orElseThrow();
                                 var state = new State();
                                 var encryptedJWT =
                                         authorisationService.constructRequestJWT(
                                                 state,
                                                 clientSession.getDocAppSubjectId(),
-                                                clientService
-                                                        .getClient(clientID.getValue())
-                                                        .orElseThrow());
+                                                clientRegistry);
                                 var authRequestBuilder =
                                         new AuthorizationRequest.Builder(
                                                         new ResponseType(ResponseType.Value.CODE),

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppAuthorizeHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppAuthorizeHandlerIntegrationTest.java
@@ -81,7 +81,7 @@ class DocAppAuthorizeHandlerIntegrationTest extends ApiGatewayHandlerIntegration
     void shouldReturn200WithValidDocAppAuthRequest() throws Json.JsonException {
         redis.addDocAppSubjectIdToClientSession(new Subject(), CLIENT_SESSION_ID);
         clientStore.registerClient(
-                DOC_APP_CLIENT_ID,
+                RP_CLIENT_ID.getValue(),
                 "test-client",
                 singletonList("http://localhost/redirect"),
                 singletonList("contact@example.com"),


### PR DESCRIPTION
## What?

Use the rp client rather than the doc app client for stub testing behaviour.

## Why?

The doc app client is not available in the client registry when trying to check whether the stub is a test client.

## Related PRs

#2165 
#2166 