### PR TITLE
BAU: Audit user info endpoint

### DIFF
--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -8,6 +8,7 @@ module "oidc_userinfo_role" {
     aws_iam_policy.dynamo_identity_credentials_read_access_policy.arn,
     aws_iam_policy.oidc_token_kms_signing_policy.arn,
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.dynamo_user_read_access_policy.arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
@@ -55,6 +55,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static uk.gov.di.authentication.oidc.domain.OidcAuditableEvent.USER_INFO_RETURNED;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceived;
 import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertNoAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.helper.IdentityTestData.ADDRESS_CLAIM;
 import static uk.gov.di.authentication.sharedtest.helper.IdentityTestData.PASSPORT_CLAIM;
@@ -130,7 +132,7 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(userInfoResponse.getSubject(), equalTo(PUBLIC_SUBJECT));
         assertThat(userInfoResponse.toJWTClaimsSet().getClaims().size(), equalTo(5));
 
-        assertNoAuditEventsReceived(auditTopic);
+        assertEventTypesReceived(auditTopic, singletonList(USER_INFO_RETURNED));
     }
 
     @Test
@@ -182,7 +184,7 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 equalTo(signedCredential.serialize()));
         assertThat(userInfoResponse.toJWTClaimsSet().getClaims().size(), equalTo(8));
 
-        assertNoAuditEventsReceived(auditTopic);
+        assertEventTypesReceived(auditTopic, singletonList(USER_INFO_RETURNED));
     }
 
     @Test
@@ -211,7 +213,7 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertNull(userInfoResponse.getClaim(ValidClaims.PASSPORT.getValue()));
         assertNull(userInfoResponse.getClaim(ValidClaims.CORE_IDENTITY_JWT.getValue()));
 
-        assertNoAuditEventsReceived(auditTopic);
+        assertEventTypesReceived(auditTopic, singletonList(USER_INFO_RETURNED));
     }
 
     @Test
@@ -232,7 +234,7 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertNull(userInfoResponse.getClaim(ValidClaims.PASSPORT.getValue()));
         assertNull(userInfoResponse.getClaim(ValidClaims.CORE_IDENTITY_JWT.getValue()));
 
-        assertNoAuditEventsReceived(auditTopic);
+        assertEventTypesReceived(auditTopic, singletonList(USER_INFO_RETURNED));
     }
 
     @Test
@@ -253,7 +255,7 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(userInfoResponse.getSubject(), equalTo(DOC_APP_PUBLIC_SUBJECT));
         assertThat(userInfoResponse.toJWTClaimsSet().getClaims().size(), equalTo(2));
 
-        assertNoAuditEventsReceived(auditTopic);
+        assertEventTypesReceived(auditTopic, singletonList(USER_INFO_RETURNED));
     }
 
     @Test

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/domain/OidcAuditableEvent.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/domain/OidcAuditableEvent.java
@@ -7,7 +7,8 @@ public enum OidcAuditableEvent implements AuditableEvent {
     AUTHORISATION_INITIATED,
     AUTHORISATION_REQUEST_RECEIVED,
     AUTH_CODE_ISSUED,
-    LOG_OUT_SUCCESS;
+    LOG_OUT_SUCCESS,
+    USER_INFO_RETURNED;
 
     public AuditableEvent parseFromName(String name) {
         return valueOf(name);

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandler.java
@@ -9,6 +9,7 @@ import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.app.services.DynamoDocAppService;
+import uk.gov.di.authentication.oidc.domain.OidcAuditableEvent;
 import uk.gov.di.authentication.oidc.entity.AccessTokenInfo;
 import uk.gov.di.authentication.oidc.services.AccessTokenService;
 import uk.gov.di.authentication.oidc.services.UserInfoService;
@@ -103,8 +104,9 @@ public class UserInfoHandler
                                                 .getHeaderMap());
                             }
                             UserInfo userInfo;
+                            AccessTokenInfo accessTokenInfo;
                             try {
-                                AccessTokenInfo accessTokenInfo =
+                                accessTokenInfo =
                                         accessTokenService.parse(
                                                 getHeaderValueFromHeaders(
                                                         input.getHeaders(),
@@ -125,6 +127,18 @@ public class UserInfoHandler
                             }
                             LOG.info(
                                     "Successfully processed UserInfo request. Sending back UserInfo response");
+
+                            auditService.submitAuditEvent(
+                                    OidcAuditableEvent.USER_INFO_RETURNED,
+                                    context.getAwsRequestId(),
+                                    AuditService.UNKNOWN,
+                                    accessTokenInfo.getClientID(),
+                                    accessTokenInfo.getSubject(),
+                                    AuditService.UNKNOWN,
+                                    AuditService.UNKNOWN,
+                                    AuditService.UNKNOWN,
+                                    AuditService.UNKNOWN);
+
                             return generateApiGatewayProxyResponse(200, userInfo.toJSONString());
                         });
     }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandler.java
@@ -13,6 +13,7 @@ import uk.gov.di.authentication.oidc.entity.AccessTokenInfo;
 import uk.gov.di.authentication.oidc.services.AccessTokenService;
 import uk.gov.di.authentication.oidc.services.UserInfoService;
 import uk.gov.di.authentication.shared.exceptions.AccessTokenException;
+import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoClientService;
@@ -38,14 +39,17 @@ public class UserInfoHandler
     private final ConfigurationService configurationService;
     private final UserInfoService userInfoService;
     private final AccessTokenService accessTokenService;
+    private final AuditService auditService;
 
     public UserInfoHandler(
             ConfigurationService configurationService,
             UserInfoService userInfoService,
-            AccessTokenService accessTokenService) {
+            AccessTokenService accessTokenService,
+            AuditService auditService) {
         this.configurationService = configurationService;
         this.userInfoService = userInfoService;
         this.accessTokenService = accessTokenService;
+        this.auditService = auditService;
     }
 
     public UserInfoHandler() {
@@ -69,6 +73,7 @@ public class UserInfoHandler
                                 new JwksService(
                                         configurationService,
                                         new KmsConnectionService(configurationService))));
+        this.auditService = new AuditService(configurationService);
     }
 
     @Override

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandlerTest.java
@@ -15,6 +15,7 @@ import uk.gov.di.authentication.oidc.entity.AccessTokenInfo;
 import uk.gov.di.authentication.oidc.services.AccessTokenService;
 import uk.gov.di.authentication.oidc.services.UserInfoService;
 import uk.gov.di.authentication.shared.exceptions.AccessTokenException;
+import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.util.List;
@@ -40,13 +41,17 @@ public class UserInfoHandlerTest {
     private final UserInfoService userInfoService = mock(UserInfoService.class);
     private final AccessTokenInfo accessTokenInfo = mock(AccessTokenInfo.class);
     private final AccessTokenService accessTokenService = mock(AccessTokenService.class);
+    private final AuditService auditService = mock(AuditService.class);
+
     private static final Map<String, List<String>> INVALID_TOKEN_RESPONSE =
             new UserInfoErrorResponse(INVALID_TOKEN).toHTTPResponse().getHeaderMap();
     private UserInfoHandler handler;
 
     @BeforeEach
     void setUp() {
-        handler = new UserInfoHandler(configurationService, userInfoService, accessTokenService);
+        handler =
+                new UserInfoHandler(
+                        configurationService, userInfoService, accessTokenService, auditService);
     }
 
     @Test


### PR DESCRIPTION
- BAU: Wire `AuditService` into `UserInfoHandler`
- BAU: Emit `USER_INFO_RETURNED` message on success
- BAU: Enable user-info endpoint to post audit messages to SNS
