### PR TITLE
BAU: Differentiate test journeys in metrics

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -204,6 +204,11 @@ public class AuthCodeHandler
 
                                 LOG.info("Successfully processed request");
 
+                                var isTestJourney =
+                                        authorizationService.isTestJourney(
+                                                authenticationRequest.getClientID(),
+                                                session.getEmailAddress());
+
                                 cloudwatchMetricsService.incrementCounter(
                                         "SignIn",
                                         Map.of(
@@ -212,7 +217,9 @@ public class AuthCodeHandler
                                                 "Environment",
                                                 configurationService.getEnvironment(),
                                                 "Client",
-                                                authenticationRequest.getClientID().getValue()));
+                                                authenticationRequest.getClientID().getValue(),
+                                                "IsTest",
+                                                Boolean.toString(isTestJourney)));
 
                                 if (!isDocCheckingAppUserWithSubjectId(clientSession)) {
                                     sessionService.save(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthorizationService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthorizationService.java
@@ -28,6 +28,7 @@ import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static java.lang.String.format;
@@ -229,5 +230,19 @@ public class AuthorizationService {
 
     public String getExistingOrCreateNewPersistentSessionId(Map<String, String> headers) {
         return PersistentIdHelper.getExistingOrCreateNewPersistentSessionId(headers);
+    }
+
+    public boolean isTestJourney(ClientID clientID, String emailAddress)
+            throws ClientNotFoundException {
+        var client =
+                dynamoClientService
+                        .getClient(clientID.toString())
+                        .orElseThrow(() -> new ClientNotFoundException(clientID.toString()));
+
+        return Optional.ofNullable(client)
+                .map(ClientRegistry::getTestClientEmailAllowlist)
+                .filter(Predicate.not(List::isEmpty))
+                .map(list -> list.contains(emailAddress))
+                .orElse(false);
     }
 }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -191,6 +191,8 @@ class AuthCodeHandlerTest {
                         any(State.class)))
                 .thenReturn(authSuccessResponse);
 
+        when(authorizationService.isTestJourney(CLIENT_ID, EMAIL)).thenReturn(true);
+
         APIGatewayProxyResponseEvent response = generateApiRequest();
 
         assertThat(response, hasStatus(200));
@@ -223,7 +225,9 @@ class AuthCodeHandlerTest {
                                 "Environment",
                                 "unit-test",
                                 "Client",
-                                CLIENT_ID.getValue()));
+                                CLIENT_ID.getValue(),
+                                "IsTest",
+                                "true"));
     }
 
     @Test


### PR DESCRIPTION
- BAU: Expose `isTestJourney` method to determine if journey is "real"
- BAU: Add `IsTest` dimension to `SignIn` metric to differentiate test journey

We want to be able to exclude test journeys from some of our dashboards
