### PR TITLE
BAU -  Remove Nonce from Oauth request

### DIFF
--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppAuthorizeHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppAuthorizeHandler.java
@@ -144,7 +144,6 @@ public class DocAppAuthorizeHandler
                                                 .flatMap(clientService::getClient)
                                                 .orElseThrow();
                                 var state = new State();
-                                LOG.info("Generated State: {}", state);
                                 var encryptedJWT =
                                         authorisationService.constructRequestJWT(
                                                 state,

--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/services/DocAppAuthorisationService.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/services/DocAppAuthorisationService.java
@@ -23,7 +23,6 @@ import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.oauth2.sdk.id.Subject;
-import com.nimbusds.openid.connect.sdk.Nonce;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
@@ -170,7 +169,6 @@ public class DocAppAuthorisationService {
                         .notBeforeTime(NowHelper.now())
                         .jwtID(jwtID)
                         .claim("state", state.getValue())
-                        .claim("nonce", new Nonce(IdGenerator.generate()).getValue())
                         .claim(
                                 "redirect_uri",
                                 configurationService.getDocAppAuthorisationCallbackURI().toString())

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandler.java
@@ -10,7 +10,6 @@ import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
-import com.nimbusds.openid.connect.sdk.Nonce;
 import com.nimbusds.openid.connect.sdk.OIDCClaimsRequest;
 import com.nimbusds.openid.connect.sdk.claims.ClaimsSetRequest;
 import org.apache.logging.log4j.LogManager;
@@ -22,7 +21,6 @@ import uk.gov.di.authentication.ipv.services.IPVAuthorisationService;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
-import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
@@ -118,14 +116,9 @@ public class IPVAuthorisationHandler extends BaseFrontendHandler<IPVAuthorisatio
                     buildIpvClaimsRequest(authRequest)
                             .map(ClaimsSetRequest::toJSONString)
                             .orElse(null);
-            var nonce = new Nonce(IdGenerator.generate());
             var encryptedJWT =
                     authorisationService.constructRequestJWT(
-                            state,
-                            nonce,
-                            authRequest.getScope(),
-                            pairwiseSubject,
-                            claimsSetRequest);
+                            state, authRequest.getScope(), pairwiseSubject, claimsSetRequest);
             var authRequestBuilder =
                     new AuthorizationRequest.Builder(
                                     new ResponseType(ResponseType.Value.CODE), clientID)

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationService.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationService.java
@@ -24,7 +24,6 @@ import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.oauth2.sdk.id.Subject;
-import com.nimbusds.openid.connect.sdk.Nonce;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
@@ -134,7 +133,7 @@ public class IPVAuthorisationService {
     }
 
     public EncryptedJWT constructRequestJWT(
-            State state, Nonce nonce, Scope scope, Subject subject, String claims) {
+            State state, Scope scope, Subject subject, String claims) {
         LOG.info("Generating request JWT");
         var jwsHeader = new JWSHeader(SIGNING_ALGORITHM);
         var jwtID = IdGenerator.generate();
@@ -149,7 +148,6 @@ public class IPVAuthorisationService {
                         .jwtID(jwtID)
                         .notBeforeTime(NowHelper.now())
                         .claim("state", state.getValue())
-                        .claim("nonce", nonce.getValue())
                         .claim(
                                 "redirect_uri",
                                 configurationService.getIPVAuthorisationCallbackURI().toString())

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandlerTest.java
@@ -165,11 +165,7 @@ public class IPVAuthorisationHandlerTest {
             throws Json.JsonException, JOSEException, ParseException {
         var encryptedJWT = createEncryptedJWT();
         when(authorisationService.constructRequestJWT(
-                        any(State.class),
-                        any(Nonce.class),
-                        any(Scope.class),
-                        any(Subject.class),
-                        any()))
+                        any(State.class), any(Scope.class), any(Subject.class), any()))
                 .thenReturn(encryptedJWT);
         usingValidSession();
         usingValidClientSession();


### PR DESCRIPTION
## What?

-  Remove Nonce from Oauth request
- Remove debug logging

## Why?

- Nonce is part of the OIDC spec, not Oauth. The nonce isn't currently validated or used by either the DocApp or IPV and we do not validate it in the ID token as it is not sent back. Therefore remove it to avoid confusion.