### PR TITLE
AUT-393: Send repeat OTP code within 15 minutes

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
@@ -152,14 +152,24 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
         String notifyText;
         NotificationType notificationType;
         if (resetPasswordRequest.isUseCodeFlow()) {
-            code = codeGeneratorService.sixDigitCode();
-            notifyText = code;
             notificationType = RESET_PASSWORD_WITH_CODE;
-            codeStorageService.saveOtpCode(
-                    resetPasswordRequest.getEmail(),
-                    code,
-                    configurationService.getCodeExpiry(),
-                    notificationType);
+
+            code =
+                    codeStorageService
+                            .getOtpCode(resetPasswordRequest.getEmail(), notificationType)
+                            .orElseGet(
+                                    () -> {
+                                        String newCode = codeGeneratorService.sixDigitCode();
+                                        codeStorageService.saveOtpCode(
+                                                resetPasswordRequest.getEmail(),
+                                                newCode,
+                                                configurationService.getCodeExpiry(),
+                                                notificationType);
+                                        return newCode;
+                                    });
+
+            notifyText = code;
+
         } else {
             code = codeGeneratorService.twentyByteEncodedRandomCode();
             notifyText =


### PR DESCRIPTION
## What?

- If an OTP code is found in redis, resend it
- By definition this results in resending same code for 15 mins, as the code is only stored for 15 mins before it is deleted

## Why?

- This should help users from inadvertently inputting expired codes because they have requested a new one in the interim (invalidating their old one)
