### PR TITLE
AUT-393: Add optional isResendCodeRequest field to MFA Handler

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/MfaRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/MfaRequest.java
@@ -1,5 +1,22 @@
 package uk.gov.di.authentication.frontendapi.entity;
 
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
 import uk.gov.di.authentication.shared.entity.BaseFrontendRequest;
 
-public class MfaRequest extends BaseFrontendRequest {}
+public class MfaRequest extends BaseFrontendRequest {
+    @Expose
+    @SerializedName("isResendCodeRequest")
+    private boolean isResendCodeRequest = false;
+
+    public MfaRequest() {}
+
+    public MfaRequest(String email, boolean isResendCodeRequest) {
+        this.email = email;
+        this.isResendCodeRequest = isResendCodeRequest;
+    }
+
+    public boolean isResendCodeRequest() {
+        return isResendCodeRequest;
+    }
+}


### PR DESCRIPTION
## What?

- Add optional `isResendCodeRequest` field to MFA Handler
- This will allow it to be called and simply to re-issue to same phone verification code as was issued in the account creation journey when phone number is given for the first time (just after the user inputs their phone number into a form and submits it).
- The existing lambda when that initial submission happens - `SendNotificationHandler` - cannot be used because a `SendNotificationRequest` must have a phone number input, which is not available to the front end at that later point of the journey
- Similarly the `MfaHandler` cannot be used without modification as it checks Redis for a code specifically associated with `MFA_SMS` `NotificationType`, and saves new codes to that same type. This cannot work, since in the previous screen, an existing code will have been stored in association with the `VERIFY_PHONE_NUMBER` type, which would not then be 'found' in Redis as an existing code, and therefore a fresh one would be generated. That new code would similarly be rejected on the `/enter-code` page (because of a similar mismatched expectation of `NotificationType`, but this time in the opposite direction)

## Why?

- To allow verify phone number codes to be resent in the account creation journey
