### PR TITLE
AUT-583: Redirect to the frontend error page for doc-app-callback session errors

### DIFF
--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/exception/DocAppCallbackException.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/exception/DocAppCallbackException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.authentication.app.exception;
+
+public class DocAppCallbackException extends RuntimeException {
+    public DocAppCallbackException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
## What?

Redirect to the frontend error page for doc-app-callback session errors.

This only covers session errors for the moment, other errors will be handled differently once we know how to return them to the HMRC RP.

## Why?

The doc-app-callback lambda returns a 500 directly in case of error, which is displayed in the browser in a rather unfriendly way. Instead route to the more user friendly error page when something goes wrong, where links to contact support etc are available.

## Related PRs

https://github.com/alphagov/di-authentication-frontend/pull/687