### PR TITLE
AUT-596: Cross-programme journey id

### DIFF
--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandler.java
@@ -118,7 +118,11 @@ public class IPVAuthorisationHandler extends BaseFrontendHandler<IPVAuthorisatio
                             .orElse(null);
             var encryptedJWT =
                     authorisationService.constructRequestJWT(
-                            state, authRequest.getScope(), pairwiseSubject, claimsSetRequest);
+                            state,
+                            authRequest.getScope(),
+                            pairwiseSubject,
+                            claimsSetRequest,
+                            "unknown");
             var authRequestBuilder =
                     new AuthorizationRequest.Builder(
                                     new ResponseType(ResponseType.Value.CODE), clientID)

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationService.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationService.java
@@ -133,7 +133,7 @@ public class IPVAuthorisationService {
     }
 
     public EncryptedJWT constructRequestJWT(
-            State state, Scope scope, Subject subject, String claims) {
+            State state, Scope scope, Subject subject, String claims, String clientSessionId) {
         LOG.info("Generating request JWT");
         var jwsHeader = new JWSHeader(SIGNING_ALGORITHM);
         var jwtID = IdGenerator.generate();
@@ -148,6 +148,7 @@ public class IPVAuthorisationService {
                         .jwtID(jwtID)
                         .notBeforeTime(NowHelper.now())
                         .claim("state", state.getValue())
+                        .claim("govuk_signin_journey_id", clientSessionId)
                         .claim(
                                 "redirect_uri",
                                 configurationService.getIPVAuthorisationCallbackURI().toString())

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandlerTest.java
@@ -70,6 +70,7 @@ import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -165,7 +166,7 @@ public class IPVAuthorisationHandlerTest {
             throws Json.JsonException, JOSEException, ParseException {
         var encryptedJWT = createEncryptedJWT();
         when(authorisationService.constructRequestJWT(
-                        any(State.class), any(Scope.class), any(Subject.class), any()))
+                        any(State.class), any(Scope.class), any(Subject.class), any(), anyString()))
                 .thenReturn(encryptedJWT);
         usingValidSession();
         usingValidClientSession();

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandlerTest.java
@@ -179,7 +179,6 @@ public class IPVAuthorisationHandlerTest {
         assertThat(response, hasStatus(200));
         var body =
                 SerializationService.getInstance()
-                        .getInstance()
                         .readValue(response.getBody(), IPVAuthorisationResponse.class);
         assertThat(body.getRedirectUri(), startsWith(IPV_AUTHORISATION_URI.toString()));
         assertThat(

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandlerTest.java
@@ -70,7 +70,6 @@ import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -166,7 +165,11 @@ public class IPVAuthorisationHandlerTest {
             throws Json.JsonException, JOSEException, ParseException {
         var encryptedJWT = createEncryptedJWT();
         when(authorisationService.constructRequestJWT(
-                        any(State.class), any(Scope.class), any(Subject.class), any(), anyString()))
+                        any(State.class),
+                        any(Scope.class),
+                        any(Subject.class),
+                        any(),
+                        eq(CLIENT_SESSION_ID)))
                 .thenReturn(encryptedJWT);
         usingValidSession();
         usingValidClientSession();
@@ -287,6 +290,7 @@ public class IPVAuthorisationHandlerTest {
                         .claim("redirect_uri", REDIRECT_URI)
                         .claim("response_type", ResponseType.CODE.toString())
                         .claim("client_id", CLIENT_ID)
+                        .claim("govuk_signin_journey_id", CLIENT_SESSION_ID)
                         .issuer(CLIENT_ID)
                         .build();
         var jwsHeader = new JWSHeader(JWSAlgorithm.ES256);

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationServiceTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationServiceTest.java
@@ -209,7 +209,9 @@ class IPVAuthorisationServiceTest {
         var pairwise = new Subject("pairwise-identifier");
         var claims = "{\"name\":{\"essential\":true}}";
 
-        var encryptedJWT = authorisationService.constructRequestJWT(state, scope, pairwise, claims);
+        var encryptedJWT =
+                authorisationService.constructRequestJWT(
+                        state, scope, pairwise, claims, "journey-id");
 
         var signedJWTResponse = decryptJWT(encryptedJWT);
 
@@ -226,6 +228,9 @@ class IPVAuthorisationServiceTest {
                 equalTo(singletonList(IPV_URI.toString())));
         assertThat(signedJWTResponse.getJWTClaimsSet().getClaim("response_type"), equalTo("code"));
         assertThat(signedJWTResponse.getJWTClaimsSet().getClaim("claims"), equalTo(claims));
+        assertThat(
+                signedJWTResponse.getJWTClaimsSet().getClaim("govuk_signin_journey_id"),
+                equalTo("journey-id"));
     }
 
     private SignedJWT decryptJWT(EncryptedJWT encryptedJWT) throws JOSEException {


### PR DESCRIPTION
## What?

This propagates the client session id to IPV Core as a claim called `govuk_signin_journey_id`

## Why?

This lets us have an end-to-end identifier across systems that corresponds to a single sign in journey.
