### PR TITLE
AUT-584: Create TxMA-specified audit queue and key in build environment

### DIFF
--- a/ci/tasks/deploy-oidc-api.yml
+++ b/ci/tasks/deploy-oidc-api.yml
@@ -20,6 +20,7 @@ params:
   SPOT_ACCOUNT_NUMBER: ((staging-spot-account-number))
   SPOT_RESPONSE_QUEUE_ARN: ((staging-spot-response_queue_arn))
   SPOT_RESPONSE_QUEUE_KMS_ARN: ((staging-spot-response_queue_kms_arn))
+  TXMA_ACCOUNT_ID: ((build-txma-account-id))
   TEST_CLIENTS_ENABLED: false
 inputs:
   - name: api-terraform-src
@@ -68,6 +69,7 @@ run:
         -var "spot_account_number=${SPOT_ACCOUNT_NUMBER}" \
         -var "spot_response_queue_arn=${SPOT_RESPONSE_QUEUE_ARN}" \
         -var "spot_response_queue_kms_arn=${SPOT_RESPONSE_QUEUE_KMS_ARN}" \
+        -var "txma_account_id=${TXMA_ACCOUNT_ID}" \
         -var-file "${DEPLOY_ENVIRONMENT}-overrides.tfvars" \
 
       terraform output --json > ../../../../terraform-outputs/${DEPLOY_ENVIRONMENT}-terraform-outputs.json

--- a/ci/terraform/modules/txma-audit-queue/key.tf
+++ b/ci/terraform/modules/txma-audit-queue/key.tf
@@ -1,0 +1,47 @@
+resource "aws_kms_key" "txma_audit_queue_encryption_key" {
+  count                    = var.use_localstack ? 0 : 1
+  description              = "KMS signing key for encrypting TxMA audit queue at rest"
+  deletion_window_in_days  = 30
+  customer_master_key_spec = "SYMMETRIC_DEFAULT"
+  key_usage                = "ENCRYPT_DECRYPT"
+
+  policy = data.aws_iam_policy_document.txma_audit_queue_encryption_key_access_policy
+
+  tags = var.default_tags
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_policy_document" "txma_audit_queue_encryption_key_access_policy" {
+  count = var.use_localstack ? 0 : 1
+
+  statement {
+    sid    = "DefaultAccessPolicy"
+    effect = "Allow"
+
+    actions = [
+      "kms:*"
+    ]
+    resources = ["*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+  }
+
+  statement {
+    sid    = "AllowTxmaAccessToKmsAuditEncryptionKey-${var.environment}"
+    effect = "Allow"
+
+    actions = [
+      "kms:Decrypt"
+    ]
+    resources = ["*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${var.txma_account_id}:root"]
+    }
+  }
+}

--- a/ci/terraform/modules/txma-audit-queue/output.tf
+++ b/ci/terraform/modules/txma-audit-queue/output.tf
@@ -1,0 +1,7 @@
+output "queue_arn" {
+  value = aws_sqs_queue.txma_audit_queue.arn
+}
+
+output "kms_key_arn" {
+  value = var.use_localstack ? aws_kms_key.txma_audit_queue_encryption_key[0].arn : null
+}

--- a/ci/terraform/modules/txma-audit-queue/queue.tf
+++ b/ci/terraform/modules/txma-audit-queue/queue.tf
@@ -1,0 +1,53 @@
+resource "aws_sqs_queue" "txma_audit_queue" {
+  name                      = "${var.environment}-txma-audit-queue"
+  message_retention_seconds = 1209600
+
+  kms_master_key_id                 = var.use_localstack ? null : aws_kms_key.txma_audit_queue_encryption_key[0].arn
+  kms_data_key_reuse_period_seconds = var.use_localstack ? null : 300
+
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.txma_audit_dead_letter_queue.arn
+    maxReceiveCount     = 3
+  })
+
+  tags = var.default_tags
+}
+
+resource "aws_sqs_queue" "txma_audit_dead_letter_queue" {
+  name = "${var.environment}-txma-audit-dead-letter-queue"
+
+  kms_master_key_id                 = var.use_localstack ? null : aws_kms_key.txma_audit_queue_encryption_key[0].arn
+  kms_data_key_reuse_period_seconds = var.use_localstack ? null : 300
+
+  message_retention_seconds = 604800
+
+  tags = var.default_tags
+}
+
+resource "aws_sqs_queue_policy" "txma_audit_queue_subscription" {
+  queue_url = aws_sqs_queue.txma_audit_queue.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+
+    Statement = [{
+      Effect = "Allow"
+
+      Principal = {
+        AWS = ["arn:aws:iam::${var.txma_account_id}:root"]
+      }
+
+      Action = [
+        "sqs:ChangeMessageVisibility",
+        "sqs:DeleteMessage",
+        "sqs:GetQueueAttributes",
+        "sqs:ReceiveMessage",
+      ]
+
+      Resource = [
+        aws_sqs_queue.txma_audit_queue.arn,
+      ]
+    }]
+  })
+}
+

--- a/ci/terraform/modules/txma-audit-queue/variables.tf
+++ b/ci/terraform/modules/txma-audit-queue/variables.tf
@@ -1,0 +1,18 @@
+variable "environment" {
+  type = string
+}
+
+variable "default_tags" {
+  default     = {}
+  type        = map(string)
+  description = "Default tags to apply to all resources"
+}
+
+variable "txma_account_id" {
+  type        = string
+  description = "Account id of the corresponding TxMA processor"
+}
+
+variable "use_localstack" {
+  type = bool
+}

--- a/ci/terraform/oidc/audit.tf
+++ b/ci/terraform/oidc/audit.tf
@@ -1,0 +1,7 @@
+module "oidc_txma_audit" {
+  count           = contains(["build"], var.environment) ? 1 : 0
+  source          = "../modules/txma-audit-queue"
+  environment     = var.environment
+  txma_account_id = var.txma_account_id
+  use_localstack  = false
+}

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -381,6 +381,11 @@ variable "use_robots_txt" {
   type    = bool
 }
 
+variable "txma_account_id" {
+  default = ""
+  type    = string
+}
+
 locals {
   default_performance_parameters = {
     memory          = var.endpoint_memory_size


### PR DESCRIPTION
## What?

This creates a Terraform module which creates a queue and key that can be subscribed to by the TxMA team

## Why?

Migrating the auth-specific audit service to the programme-wide audit service
