### PR TITLE
AUT-542: Additional error handling for the doc-app-handler

### DIFF
--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
@@ -200,8 +200,7 @@ public class DocAppCallbackHandler
                                             AuditService.UNKNOWN,
                                             AuditService.UNKNOWN,
                                             AuditService.UNKNOWN);
-                                    throw new RuntimeException(
-                                            "Doc App TokenResponse was not successful");
+                                    return redirectToFrontendErrorPage();
                                 }
 
                                 try {
@@ -265,7 +264,10 @@ public class DocAppCallbackHandler
                                             AuditService.UNKNOWN,
                                             AuditService.UNKNOWN,
                                             AuditService.UNKNOWN);
-                                    throw e;
+                                    LOG.error(
+                                            "Doc App sendCriDataRequest was not successful: {}",
+                                            e.getMessage());
+                                    return redirectToFrontendErrorPage();
                                 }
                             } catch (DocAppCallbackException e) {
                                 LOG.warn(e.getMessage());


### PR DESCRIPTION

## What?

Additional error handling for the doc-app-handler.
Redirect to error page for remaining scenarios that threw exceptions.
Additional tests and test refactoring.

## Why?

Errors that threw a raw Exception would show the user unfriendly error text in the browser.  Replace this with a more user friendly error page.  The scenarios in question are not recoverable.

## Related PRs

#2186 
#2181 