### PR TITLE
AUT-561: Limit OTP/MFA code retry by email not browser session

### DIFF
--- a/ci/terraform/oidc/sandpit.tfvars
+++ b/ci/terraform/oidc/sandpit.tfvars
@@ -18,3 +18,5 @@ lambda_max_concurrency = 0
 lambda_min_concurrency = 0
 keep_lambdas_warm      = false
 endpoint_memory_size   = 1024
+
+blocked_email_duration = 30

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -30,7 +30,6 @@ import uk.gov.di.authentication.shared.services.ClientSessionService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
-import uk.gov.di.authentication.shared.services.RedisConnectionService;
 import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
@@ -77,8 +76,7 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
 
     public LoginHandler(ConfigurationService configurationService) {
         super(LoginRequest.class, configurationService, true);
-        this.codeStorageService =
-                new CodeStorageService(new RedisConnectionService(configurationService));
+        this.codeStorageService = new CodeStorageService(configurationService);
         this.userMigrationService =
                 new UserMigrationService(
                         new DynamoService(configurationService), configurationService);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
@@ -27,7 +27,6 @@ import uk.gov.di.authentication.shared.services.ClientSessionService;
 import uk.gov.di.authentication.shared.services.CodeGeneratorService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
-import uk.gov.di.authentication.shared.services.RedisConnectionService;
 import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
@@ -84,8 +83,7 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
     public MfaHandler(ConfigurationService configurationService) {
         super(MfaRequest.class, configurationService);
         this.codeGeneratorService = new CodeGeneratorService();
-        this.codeStorageService =
-                new CodeStorageService(new RedisConnectionService(configurationService));
+        this.codeStorageService = new CodeStorageService(configurationService);
         this.auditService = new AuditService(configurationService);
         this.sqsClient =
                 new AwsSqsClient(
@@ -97,8 +95,7 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
     public MfaHandler() {
         super(MfaRequest.class, ConfigurationService.getInstance());
         this.codeGeneratorService = new CodeGeneratorService();
-        this.codeStorageService =
-                new CodeStorageService(new RedisConnectionService(configurationService));
+        this.codeStorageService = new CodeStorageService(configurationService);
         this.auditService = new AuditService(configurationService);
         this.sqsClient =
                 new AwsSqsClient(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
@@ -27,7 +27,6 @@ import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.CommonPasswordsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
-import uk.gov.di.authentication.shared.services.RedisConnectionService;
 import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.state.UserContext;
 import uk.gov.di.authentication.shared.validation.PasswordValidator;
@@ -88,8 +87,7 @@ public class ResetPasswordHandler extends BaseFrontendHandler<ResetPasswordCompl
                         configurationService.getAwsRegion(),
                         configurationService.getEmailQueueUri(),
                         configurationService.getSqsEndpointUri());
-        this.codeStorageService =
-                new CodeStorageService(new RedisConnectionService(configurationService));
+        this.codeStorageService = new CodeStorageService(configurationService);
         this.auditService = new AuditService(configurationService);
         this.commonPasswordsService = new CommonPasswordsService(configurationService);
         this.passwordValidator = new PasswordValidator(commonPasswordsService);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
@@ -26,7 +26,6 @@ import uk.gov.di.authentication.shared.services.ClientSessionService;
 import uk.gov.di.authentication.shared.services.CodeGeneratorService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
-import uk.gov.di.authentication.shared.services.RedisConnectionService;
 import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
@@ -89,8 +88,7 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
                         configurationService.getEmailQueueUri(),
                         configurationService.getSqsEndpointUri());
         this.codeGeneratorService = new CodeGeneratorService();
-        this.codeStorageService =
-                new CodeStorageService(new RedisConnectionService(configurationService));
+        this.codeStorageService = new CodeStorageService(configurationService);
         this.auditService = new AuditService(configurationService);
         this.resetPasswordService = new ResetPasswordService(configurationService);
     }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
@@ -25,7 +25,6 @@ import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.CodeGeneratorService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
-import uk.gov.di.authentication.shared.services.RedisConnectionService;
 import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
@@ -86,8 +85,7 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
                         configurationService.getEmailQueueUri(),
                         configurationService.getSqsEndpointUri());
         this.codeGeneratorService = new CodeGeneratorService();
-        this.codeStorageService =
-                new CodeStorageService(new RedisConnectionService(configurationService));
+        this.codeStorageService = new CodeStorageService(configurationService);
     }
 
     @Override

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -23,7 +23,6 @@ import uk.gov.di.authentication.shared.services.ClientSessionService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
-import uk.gov.di.authentication.shared.services.RedisConnectionService;
 import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
@@ -78,8 +77,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
 
     public VerifyMfaCodeHandler(ConfigurationService configurationService) {
         super(VerifyMfaCodeRequest.class, configurationService);
-        this.codeStorageService =
-                new CodeStorageService(new RedisConnectionService(configurationService));
+        this.codeStorageService = new CodeStorageService(configurationService);
         this.auditService = new AuditService(configurationService);
         this.dynamoService = new DynamoService(configurationService);
     }
@@ -205,6 +203,6 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                 session.getEmailAddress(),
                 CODE_BLOCKED_KEY_PREFIX,
                 configurationService.getBlockedEmailDuration());
-        session.resetRetryCount();
+        codeStorageService.deleteIncorrectMfaCodeAttemptsCount(session.getEmailAddress());
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -261,9 +261,9 @@ class VerifyCodeHandlerTest {
     void shouldUpdateRedisWhenUserHasReachedMaxPhoneNumberCodeAttempts() {
         when(configurationService.getCodeMaxRetries()).thenReturn(0);
         when(configurationService.getBlockedEmailDuration()).thenReturn(BLOCKED_EMAIL_DURATION);
-
         when(codeStorageService.getOtpCode(TEST_EMAIL_ADDRESS, VERIFY_PHONE_NUMBER))
                 .thenReturn(Optional.of(CODE));
+        when(codeStorageService.getIncorrectMfaCodeAttemptsCount(TEST_EMAIL_ADDRESS)).thenReturn(1);
 
         APIGatewayProxyResponseEvent result =
                 makeCallWithCode(INVALID_CODE, VERIFY_PHONE_NUMBER.toString());
@@ -311,6 +311,8 @@ class VerifyCodeHandlerTest {
         when(configurationService.getBlockedEmailDuration()).thenReturn(BLOCKED_EMAIL_DURATION);
         when(codeStorageService.getOtpCode(TEST_EMAIL_ADDRESS, VERIFY_EMAIL))
                 .thenReturn(Optional.of(CODE));
+
+        when(codeStorageService.getIncorrectMfaCodeAttemptsCount(TEST_EMAIL_ADDRESS)).thenReturn(1);
 
         APIGatewayProxyResponseEvent result =
                 makeCallWithCode(INVALID_CODE, VERIFY_EMAIL.toString());
@@ -389,6 +391,7 @@ class VerifyCodeHandlerTest {
         when(configurationService.getBlockedEmailDuration()).thenReturn(BLOCKED_EMAIL_DURATION);
         when(codeStorageService.getOtpCode(TEST_EMAIL_ADDRESS, MFA_SMS))
                 .thenReturn(Optional.of(CODE));
+        when(codeStorageService.getIncorrectMfaCodeAttemptsCount(TEST_EMAIL_ADDRESS)).thenReturn(1);
 
         APIGatewayProxyResponseEvent result = makeCallWithCode(INVALID_CODE, MFA_SMS.toString());
 
@@ -472,14 +475,6 @@ class VerifyCodeHandlerTest {
         when(clientSessionService.getClientSessionFromRequestHeaders(event.getHeaders()))
                 .thenReturn(Optional.of(clientSession));
         return handler.handleRequest(event, context);
-    }
-
-    private void maxOutSessionRetryCount() {
-        session.incrementRetryCount();
-        session.incrementRetryCount();
-        session.incrementRetryCount();
-        session.incrementRetryCount();
-        session.incrementRetryCount();
     }
 
     private AuthenticationRequest withAuthenticationRequest(String clientId) {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -635,7 +635,8 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                     tokenSigner,
                     ipvPrivateKeyJwtSigner,
                     spotQueue,
-                    docAppPrivateKeyJwtSigner);
+                    docAppPrivateKeyJwtSigner,
+                    configurationParameters);
         }
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppAuthorizeHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppAuthorizeHandlerIntegrationTest.java
@@ -159,7 +159,8 @@ class DocAppAuthorizeHandlerIntegrationTest extends ApiGatewayHandlerIntegration
                     tokenSigner,
                     ipvPrivateKeyJwtSigner,
                     spotQueue,
-                    docAppPrivateKeyJwtSigner);
+                    docAppPrivateKeyJwtSigner,
+                    configurationParameters);
             this.jwksExtension = jwksExtension;
         }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppCallbackHandlerIntegrationTest.java
@@ -280,7 +280,8 @@ class DocAppCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
                     tokenSigningKey,
                     ipvPrivateKeyJwtSigner,
                     spotQueue,
-                    docAppPrivateKeyJwtSigner);
+                    docAppPrivateKeyJwtSigner,
+                    configurationParameters);
             this.criStubExtension = criStubExtension;
         }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVAuthorisationHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVAuthorisationHandlerIntegrationTest.java
@@ -160,7 +160,8 @@ class IPVAuthorisationHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
                     tokenSigner,
                     ipvPrivateKeyJwtSigner,
                     spotQueue,
-                    docAppPrivateKeyJwtSigner);
+                    docAppPrivateKeyJwtSigner,
+                    configurationParameters);
             this.ipvStubExtension = ipvStub;
         }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
@@ -228,7 +228,8 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                     tokenSigningKey,
                     ipvPrivateKeyJwtSigner,
                     spotQueue,
-                    docAppPrivateKeyJwtSigner);
+                    docAppPrivateKeyJwtSigner,
+                    configurationParameters);
             this.ipvStubExtension = ipvStub;
         }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/JwksIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/JwksIntegrationTest.java
@@ -52,7 +52,8 @@ public class JwksIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                     tokenSigner,
                     ipvPrivateKeyJwtSigner,
                     spotQueue,
-                    docAppPrivateKeyJwtSigner);
+                    docAppPrivateKeyJwtSigner,
+                    configurationParameters);
             this.docAppEnabled = docAppEnabled;
         }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
@@ -239,7 +239,8 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                     tokenSigner,
                     ipvPrivateKeyJwtSigner,
                     spotQueue,
-                    docAppPrivateKeyJwtSigner);
+                    docAppPrivateKeyJwtSigner,
+                    configurationParameters);
         }
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
@@ -424,7 +424,8 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                     tokenSigner,
                     ipvPrivateKeyJwtSigner,
                     spotQueue,
-                    docAppPrivateKeyJwtSigner);
+                    docAppPrivateKeyJwtSigner,
+                    configurationParameters);
         }
 
         @Override

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
@@ -87,7 +87,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         var session = redis.getSession(sessionId);
 
         assertThat(response, hasStatus(204));
-        assertThat(session.getCodeRequestCount(), equalTo(0));
+        assertThat(redis.getMfaCodeAttemptsCount(EMAIL_ADDRESS), equalTo(0));
         assertEventTypesReceived(auditTopic, List.of(CODE_VERIFIED));
     }
 
@@ -193,7 +193,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         var session = redis.getSession(sessionId);
 
         assertThat(response, hasStatus(204));
-        assertThat(session.getCodeRequestCount(), equalTo(0));
+        assertThat(redis.getMfaCodeAttemptsCount(EMAIL_ADDRESS), equalTo(0));
         assertEventTypesReceived(auditTopic, List.of(CODE_VERIFIED));
     }
 

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
@@ -28,6 +28,10 @@ import java.util.Optional;
 import static org.mockito.Mockito.mock;
 
 public abstract class HandlerIntegrationTest<Q, S> {
+    private static final String REDIS_HOST = "localhost";
+    private static final int REDIS_PORT = 6379;
+    private static final String REDIS_PASSWORD = null;
+    private static final boolean DOES_REDIS_USE_TLS = false;
     protected static final String LOCAL_ENDPOINT_FORMAT =
             "http://localhost:45678/restapis/%s/local/_user_request_";
     protected static final String LOCAL_API_GATEWAY_ID =
@@ -82,14 +86,16 @@ public abstract class HandlerIntegrationTest<Q, S> {
     protected static final ParameterStoreExtension configurationParameters =
             new ParameterStoreExtension(
                     Map.of(
-                            "local-session-redis-master-host", "localhost",
-                            "local-session-redis-password", "null",
-                            "local-session-redis-port", "6379",
-                            "local-session-redis-tls", "false",
-                            "local-account-management-redis-master-host", "localhost",
-                            "local-account-management-redis-password", "null",
-                            "local-account-management-redis-port", "6379",
-                            "local-account-management-redis-tls", "false",
+                            "local-session-redis-master-host", REDIS_HOST,
+                            "local-session-redis-password", String.valueOf(REDIS_PASSWORD),
+                            "local-session-redis-port", String.valueOf(REDIS_PORT),
+                            "local-session-redis-tls", String.valueOf(DOES_REDIS_USE_TLS),
+                            "local-account-management-redis-master-host", REDIS_HOST,
+                            "local-account-management-redis-password",
+                                    String.valueOf(REDIS_PASSWORD),
+                            "local-account-management-redis-port", String.valueOf(REDIS_PORT),
+                            "local-account-management-redis-tls",
+                                    String.valueOf(DOES_REDIS_USE_TLS),
                             "local-password-pepper", "pepper"));
 
     protected static final ConfigurationService TEST_CONFIGURATION_SERVICE =
@@ -194,6 +200,26 @@ public abstract class HandlerIntegrationTest<Q, S> {
         @Override
         public String getEmailQueueUri() {
             return notificationQueue.getQueueUrl();
+        }
+
+        @Override
+        public String getRedisHost() {
+            return REDIS_HOST;
+        }
+
+        @Override
+        public int getRedisPort() {
+            return REDIS_PORT;
+        }
+
+        @Override
+        public Optional<String> getRedisPassword() {
+            return Optional.ofNullable(REDIS_PASSWORD);
+        }
+
+        @Override
+        public boolean getUseRedisTLS() {
+            return DOES_REDIS_USE_TLS;
         }
 
         @Override

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
@@ -106,7 +106,8 @@ public abstract class HandlerIntegrationTest<Q, S> {
                     tokenSigner,
                     ipvPrivateKeyJwtSigner,
                     spotQueue,
-                    docAppPrivateKeyJwtSigner);
+                    docAppPrivateKeyJwtSigner,
+                    configurationParameters);
 
     protected RequestHandler<Q, S> handler;
     protected final Json objectMapper = SerializationService.getInstance();
@@ -187,7 +188,9 @@ public abstract class HandlerIntegrationTest<Q, S> {
                 TokenSigningExtension tokenSigningKey,
                 TokenSigningExtension ipvPrivateKeyJwtSigner,
                 SqsQueueExtension spotQueue,
-                TokenSigningExtension docAppPrivateKeyJwtSigner) {
+                TokenSigningExtension docAppPrivateKeyJwtSigner,
+                ParameterStoreExtension parameterStoreExtension) {
+            super(parameterStoreExtension.getClient());
             this.auditEventTopic = auditEventTopic;
             this.notificationQueue = notificationQueue;
             this.tokenSigningKey = tokenSigningKey;
@@ -200,26 +203,6 @@ public abstract class HandlerIntegrationTest<Q, S> {
         @Override
         public String getEmailQueueUri() {
             return notificationQueue.getQueueUrl();
-        }
-
-        @Override
-        public String getRedisHost() {
-            return REDIS_HOST;
-        }
-
-        @Override
-        public int getRedisPort() {
-            return REDIS_PORT;
-        }
-
-        @Override
-        public Optional<String> getRedisPassword() {
-            return Optional.ofNullable(REDIS_PASSWORD);
-        }
-
-        @Override
-        public boolean getUseRedisTLS() {
-            return DOES_REDIS_USE_TLS;
         }
 
         @Override

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
@@ -92,7 +92,7 @@ public abstract class HandlerIntegrationTest<Q, S> {
                             "local-account-management-redis-tls", "false",
                             "local-password-pepper", "pepper"));
 
-    protected final ConfigurationService TEST_CONFIGURATION_SERVICE =
+    protected static final ConfigurationService TEST_CONFIGURATION_SERVICE =
             new IntegrationTestConfigurationService(
                     auditTopic,
                     notificationsQueue,
@@ -108,7 +108,7 @@ public abstract class HandlerIntegrationTest<Q, S> {
 
     @RegisterExtension
     protected static final RedisExtension redis =
-            new RedisExtension(SerializationService.getInstance());
+            new RedisExtension(SerializationService.getInstance(), TEST_CONFIGURATION_SERVICE);
 
     @RegisterExtension
     protected static final UserStoreExtension userStore = new UserStoreExtension();

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/ParameterStoreExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/ParameterStoreExtension.java
@@ -12,24 +12,21 @@ import java.util.Map;
 import static com.amazonaws.services.simplesystemsmanagement.model.ParameterType.SecureString;
 
 public class ParameterStoreExtension extends BaseAwsResourceExtension implements BeforeAllCallback {
-
-    private final Map<String, String> parameters;
     private final AWSSimpleSystemsManagement ssmClient;
 
     public ParameterStoreExtension(Map<String, String> parameters) {
-        this.parameters = parameters;
         this.ssmClient =
                 AWSSimpleSystemsManagementClient.builder()
                         .withEndpointConfiguration(
                                 new AwsClientBuilder.EndpointConfiguration(
                                         LOCALSTACK_ENDPOINT, REGION))
                         .build();
+
+        parameters.forEach(this::createOrOverwriteParameter);
     }
 
     @Override
-    public void beforeAll(ExtensionContext context) {
-        parameters.forEach(this::createOrOverwriteParameter);
-    }
+    public void beforeAll(ExtensionContext context) {}
 
     private void createOrOverwriteParameter(String key, String value) {
         PutParameterRequest parameterRequest =
@@ -39,5 +36,9 @@ public class ParameterStoreExtension extends BaseAwsResourceExtension implements
                         .withOverwrite(true)
                         .withValue(value);
         ssmClient.putParameter(parameterRequest);
+    }
+
+    public AWSSimpleSystemsManagement getClient() {
+        return ssmClient;
     }
 }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
@@ -37,11 +37,6 @@ import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_B
 
 public class RedisExtension
         implements Extension, BeforeAllCallback, AfterAllCallback, AfterEachCallback {
-
-    private static final String REDIS_HOST =
-            System.getenv().getOrDefault("REDIS_HOST", "localhost");
-    private static final Optional<String> REDIS_PASSWORD =
-            Optional.ofNullable(System.getenv("REDIS_PASSWORD"));
     private final ConfigurationService configurationService;
     private final CodeStorageService codeStorageService;
 
@@ -276,8 +271,9 @@ public class RedisExtension
                         .withHost(configurationService.getRedisHost())
                         .withPort(configurationService.getRedisPort())
                         .withSsl(configurationService.getUseRedisTLS());
-        if (configurationService.getRedisPassword().isPresent())
-            builder.withPassword(configurationService.getRedisPassword().get().toCharArray());
+        configurationService
+                .getRedisPassword()
+                .ifPresent(redisPassword -> builder.withPassword(redisPassword.toCharArray()));
         RedisURI redisURI = builder.build();
         client = RedisClient.create(redisURI);
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
@@ -81,16 +81,6 @@ public class Session {
         return retryCount;
     }
 
-    public Session incrementRetryCount() {
-        this.retryCount = retryCount + 1;
-        return this;
-    }
-
-    public Session resetRetryCount() {
-        this.retryCount = 0;
-        return this;
-    }
-
     public int getPasswordResetCount() {
         return passwordResetCount;
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java
@@ -16,7 +16,7 @@ public class CodeStorageService {
     public static final String PASSWORD_RESET_BLOCKED_KEY_PREFIX = "password-reset-blocked:";
 
     private static final Logger LOG = LogManager.getLogger(CodeStorageService.class);
-    private final ConfigurationService configurationService;
+
     private final RedisConnectionService redisConnectionService;
     private static final String EMAIL_KEY_PREFIX = "email-code:";
     private static final String PHONE_NUMBER_KEY_PREFIX = "phone-number-code:";
@@ -31,13 +31,10 @@ public class CodeStorageService {
     private static final long MFA_ATTEMPTS_COUNTER_TIME_TO_LIVE_SECONDS = 900;
 
     public CodeStorageService(ConfigurationService configurationService) {
-        this(configurationService, new RedisConnectionService(configurationService));
+        this(new RedisConnectionService(configurationService));
     }
 
-    public CodeStorageService(
-            ConfigurationService configurationService,
-            RedisConnectionService redisConnectionService) {
-        this.configurationService = configurationService;
+    public CodeStorageService(RedisConnectionService redisConnectionService) {
         this.redisConnectionService = redisConnectionService;
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -40,7 +40,7 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
 
     public ConfigurationService() {}
 
-    ConfigurationService(AWSSimpleSystemsManagement ssmClient) {
+    protected ConfigurationService(AWSSimpleSystemsManagement ssmClient) {
         this.ssmClient = ssmClient;
     }
 

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/CodeStorageServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/CodeStorageServiceTest.java
@@ -1,7 +1,6 @@
 package uk.gov.di.authentication.shared.services;
 
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
@@ -27,10 +26,8 @@ class CodeStorageServiceTest {
     private static final String SUBJECT = "some-subject";
     private final RedisConnectionService redisConnectionService =
             mock(RedisConnectionService.class);
-    private static final ConfigurationService configurationService =
-            mock(ConfigurationService.class);
     private final CodeStorageService codeStorageService =
-            new CodeStorageService(configurationService, redisConnectionService);
+            new CodeStorageService(redisConnectionService);
     private static final String REDIS_EMAIL_KEY =
             "email-code:f660ab912ec121d1b1e928a0bb4bc61b15f5ad44d5efdc4e1c92a25e99b8e44a";
     private static final String REDIS_INCORRECT_PASSWORDS_KEY =
@@ -51,11 +48,6 @@ class CodeStorageServiceTest {
     private static final long CODE_EXPIRY_TIME = 900;
     private static final long AUTH_CODE_EXPIRY_TIME = 300;
     private static final String CODE_BLOCKED_VALUE = "blocked";
-
-    @BeforeAll
-    static void init() {
-        when(configurationService.getBlockedEmailDuration()).thenReturn(CODE_EXPIRY_TIME);
-    }
 
     @Test
     void shouldCallRedisWithValidEmailCodeAndHashedEmail() {

--- a/shared/src/test/java/uk/gov/di/authentication/shared/validation/AuthAppCodeValidatorTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/validation/AuthAppCodeValidatorTest.java
@@ -31,7 +31,7 @@ class AuthAppCodeValidatorTest {
     ConfigurationService mockConfigurationService;
     DynamoService mockDynamoService;
 
-    int MAX_RETRIES = 5;
+    private final int MAX_RETRIES = 5;
 
     @BeforeEach
     void setUp() {
@@ -110,10 +110,11 @@ class AuthAppCodeValidatorTest {
 
     private void setUpRetryLimitExceededUser() {
         when(mockSession.getEmailAddress()).thenReturn("email-address");
-        when(mockSession.getRetryCount()).thenReturn(6);
         when(mockUserContext.getSession()).thenReturn(mockSession);
         when(mockCodeStorageService.isBlockedForEmail("email-address", CODE_BLOCKED_KEY_PREFIX))
                 .thenReturn(false);
+        when(mockCodeStorageService.getIncorrectMfaCodeAttemptsCount("email-address"))
+                .thenReturn(MAX_RETRIES + 1);
 
         this.authAppCodeValidator =
                 new AuthAppCodeValidator(

--- a/shared/src/test/java/uk/gov/di/authentication/shared/validation/MfaCodeValidatorFactoryTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/validation/MfaCodeValidatorFactoryTest.java
@@ -3,6 +3,7 @@ package uk.gov.di.authentication.shared.validation;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
+import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
@@ -11,14 +12,17 @@ import uk.gov.di.authentication.shared.state.UserContext;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.shared.validation.MfaCodeValidatorFactory.getMfaCodeValidator;
 
 class MfaCodeValidatorFactoryTest {
     private ConfigurationService configurationService;
     private UserContext userContext;
     private CodeStorageService codeStorageService;
     private DynamoService dynamoService;
+    private Session session;
     private final int CODE_MAX_RETRIES = 5;
     private final int CODE_MAX_RETRIES_REGISTRATION = 999999;
+    private final String EMAIL_ADDRESS = "test@test.com";
 
     @BeforeEach
     void setUp() {
@@ -26,7 +30,13 @@ class MfaCodeValidatorFactoryTest {
         when(configurationService.getCodeMaxRetries()).thenReturn(CODE_MAX_RETRIES);
         when(configurationService.getCodeMaxRetriesRegistration())
                 .thenReturn(CODE_MAX_RETRIES_REGISTRATION);
+
+        this.session = mock(Session.class);
+        when(session.getEmailAddress()).thenReturn(EMAIL_ADDRESS);
+
         this.userContext = mock(UserContext.class);
+        when(userContext.getSession()).thenReturn(session);
+
         this.codeStorageService = mock(CodeStorageService.class);
         this.dynamoService = mock(DynamoService.class);
     }
@@ -34,14 +44,13 @@ class MfaCodeValidatorFactoryTest {
     @Test
     void whenMfaMethodGeneratesAuthAppCodeValidator() {
         var mfaCodeValidator =
-                uk.gov.di.authentication.shared.validation.MfaCodeValidatorFactory
-                        .getMfaCodeValidator(
-                                MFAMethodType.AUTH_APP,
-                                true,
-                                userContext,
-                                codeStorageService,
-                                configurationService,
-                                dynamoService);
+                getMfaCodeValidator(
+                        MFAMethodType.AUTH_APP,
+                        true,
+                        userContext,
+                        codeStorageService,
+                        configurationService,
+                        dynamoService);
 
         assertInstanceOf(AuthAppCodeValidator.class, mfaCodeValidator.get());
     }


### PR DESCRIPTION
## What?

- Increment and save MFA code attempts against email address (persistent) rather than session (temporary) in Redis 
- Make counter clear itself after 15 minutes (aligned to 'lifespan' of OTP codes themselves)
- Remove simple counter of retries currently stored within session object in Redis
- Refactor `CodeStorageService` to take in `ConfigurationService` rather than `RedisService(ConfigurationService)` in its constructor, in order to remove Redis implementation detail from handlers, and to make accessing other config parameters in future easier e.g. if we want to set the MFA counter's 'time to live' via config rather than the current hard-coding of `900L`.

Note: Whilst not directly part of the functionality, also in this PR is a change to Sandpit default var of how long a code block lasts, so that we only need to wait 30 seconds in manual tests rather than the default 15 minutes until the email address is 'released' from the block. I used this whilst testing this ticket and think it is a generally useful default in Sandpit.

## Why?

- So that it is not possible to gain unlimited attempts at brute forcing MFA code by starting a new browser session after `MAX_WRONG_ATTEMPTS - 1` attempts