### PR TITLE
AUT-584: Publish TxMA-format audit messages to SQS for consumption

### DIFF
--- a/ci/terraform/modules/txma-audit-queue/output.tf
+++ b/ci/terraform/modules/txma-audit-queue/output.tf
@@ -2,6 +2,10 @@ output "queue_arn" {
   value = aws_sqs_queue.txma_audit_queue.arn
 }
 
+output "queue_url" {
+  value = aws_sqs_queue.txma_audit_queue.url
+}
+
 output "kms_key_arn" {
   value = var.use_localstack ? aws_kms_key.txma_audit_queue_encryption_key[0].arn : null
 }

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -26,6 +26,8 @@ module "userinfo" {
   handler_environment_variables = {
     ENVIRONMENT             = var.environment
     EVENTS_SNS_TOPIC_ARN    = aws_sns_topic.events.arn
+    TXMA_AUDIT_ENABLED      = contains(["build", "staging"], var.environment)
+    TXMA_AUDIT_QUEUE_URL    = contains(["build", "staging"], var.environment) ? module.oidc_txma_audit[0].queue_url : ""
     AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
     REDIS_KEY               = local.redis_key

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
@@ -60,6 +60,10 @@ public abstract class HandlerIntegrationTest<Q, S> {
     protected static final SqsQueueExtension spotQueue = new SqsQueueExtension("spot-queue");
 
     @RegisterExtension
+    protected static final SqsQueueExtension txmaAuditQueue =
+            new SqsQueueExtension("txma-audit-queue");
+
+    @RegisterExtension
     protected static final AuditSnsTopicExtension auditTopic =
             new AuditSnsTopicExtension("local-events");
 

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/SqsQueueExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/SqsQueueExtension.java
@@ -57,6 +57,12 @@ public class SqsQueueExtension extends BaseAwsResourceExtension implements Befor
         return getMessages(messageClass, DEFAULT_NUMBER_OF_MESSAGES);
     }
 
+    public List<String> getRawMessages() {
+        return getMessages(DEFAULT_NUMBER_OF_MESSAGES).stream()
+                .map(Message::getBody)
+                .collect(Collectors.toList());
+    }
+
     public <T> List<T> getMessages(Class<T> messageClass, int numberOfMessages) {
         return getMessages(numberOfMessages).stream()
                 .map(

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuditAssertionsHelper.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuditAssertionsHelper.java
@@ -1,9 +1,13 @@
 package uk.gov.di.authentication.sharedtest.helper;
 
+import com.google.gson.JsonElement;
 import uk.gov.di.authentication.shared.domain.AuditableEvent;
 import uk.gov.di.authentication.sharedtest.extensions.AuditSnsTopicExtension;
+import uk.gov.di.authentication.sharedtest.extensions.SqsQueueExtension;
+import uk.gov.di.authentication.sharedtest.matchers.JsonMatcher;
 
 import java.util.Collection;
+import java.util.stream.Collectors;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
@@ -25,6 +29,15 @@ public class AuditAssertionsHelper {
         }
 
         assertThat(auditTopic.getCountOfRequests(), equalTo(0));
+    }
+
+    public static void assertNoTxmaAuditEventsReceived(SqsQueueExtension txmaAuditQueue) {
+        try {
+            Thread.sleep(SNS_TIMEOUT_MILLIS);
+        } catch (InterruptedException ex) {
+            throw new RuntimeException(ex);
+        }
+        assertThat(txmaAuditQueue.getApproximateMessageCount(), equalTo(0));
     }
 
     public static void assertEventTypesReceived(
@@ -52,5 +65,33 @@ public class AuditAssertionsHelper {
 
         // Check that no more events came through while we were looking for the ones we expected.
         assertThat(auditTopic.getCountOfRequests(), equalTo(eventTypes.size()));
+    }
+
+    public static void assertTxmaAuditEventsReceived(
+            SqsQueueExtension tmxaAuditQueue, Collection<String> eventTypes) {
+        if (eventTypes.isEmpty()) {
+            throw new RuntimeException(
+                    "Do not call assertTxmaAuditEventsReceived() with an empty collection of event types; it won't wait to see if anything unexpected was received.  Instead, call Thread.sleep and then check the count of requests.");
+        }
+
+        await().atMost(SNS_TIMEOUT, SECONDS)
+                .untilAsserted(
+                        () ->
+                                assertThat(
+                                        tmxaAuditQueue.getApproximateMessageCount(),
+                                        equalTo(eventTypes.size())));
+
+        var receivedEvents =
+                tmxaAuditQueue.getRawMessages().stream()
+                        .peek(System.out::println)
+                        .map(JsonMatcher::asJson)
+                        .map(JsonElement::getAsJsonObject)
+                        .map(json -> json.get("event_name"))
+                        .map(JsonElement::getAsString)
+                        .collect(Collectors.toSet());
+
+        eventTypes.stream()
+                .map(Object::toString)
+                .forEach(expected -> assertThat(receivedEvents, hasItem(expected)));
     }
 }

--- a/shared/src/main/java/uk/gov/di/audit/TxmaAuditEvent.java
+++ b/shared/src/main/java/uk/gov/di/audit/TxmaAuditEvent.java
@@ -31,7 +31,7 @@ public class TxmaAuditEvent {
         this.timestamp = timestamp;
     }
 
-    protected static TxmaAuditEvent auditEventWithTime(
+    public static TxmaAuditEvent auditEventWithTime(
             AuditableEvent eventName, Supplier<Date> dateSupplier) {
         return new TxmaAuditEvent("AUTH_" + eventName.toString(), dateSupplier.get().getTime());
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/configuration/AuditPublisherConfiguration.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/configuration/AuditPublisherConfiguration.java
@@ -9,4 +9,12 @@ public interface AuditPublisherConfiguration extends BaseLambdaConfiguration {
     default String getEventsSnsTopicArn() {
         return System.getenv("EVENTS_SNS_TOPIC_ARN");
     }
+
+    default boolean isTxmaAuditEnabled() {
+        return Boolean.parseBoolean(System.getenv("TXMA_AUDIT_ENABLED"));
+    }
+
+    default String getTxmaAuditQueueUrl() {
+        return System.getenv("TXMA_AUDIT_QUEUE_URL");
+    }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
@@ -11,9 +11,13 @@ import java.nio.ByteBuffer;
 import java.time.Clock;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.Date;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Consumer;
+
+import static uk.gov.di.audit.TxmaAuditEvent.auditEventWithTime;
 
 public class AuditService {
 
@@ -80,6 +84,9 @@ public class AuditService {
                         phoneNumber,
                         persistentSessionId,
                         metadataPairs));
+
+        txmaQueueClient.send(
+                auditEventWithTime(event, () -> Date.from(clock.instant())).serialize());
     }
 
     String generateLogLine(
@@ -178,5 +185,9 @@ public class AuditService {
         public int hashCode() {
             return Objects.hash(key, value);
         }
+    }
+
+    static void addField(String value, Consumer<String> setter) {
+        Optional.ofNullable(value).ifPresent(setter);
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AwsSqsClient.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AwsSqsClient.java
@@ -35,6 +35,11 @@ public class AwsSqsClient {
         this.queueUrl = queueUrl;
     }
 
+    protected AwsSqsClient(SqsClient client, String queueUrl) {
+        this.client = client;
+        this.queueUrl = queueUrl;
+    }
+
     public void send(final String event) throws SdkClientException {
         SendMessageRequest messageRequest =
                 SendMessageRequest.builder().queueUrl(queueUrl).messageBody(event).build();
@@ -45,5 +50,22 @@ public class AwsSqsClient {
     public <T> void sendAsync(final T message) throws SdkClientException {
         CompletableFuture.runAsync(
                 () -> send(SerializationService.getInstance().writeValueAsString(message)));
+    }
+
+    static class NoOpSqsClient extends AwsSqsClient {
+
+        public NoOpSqsClient() {
+            super(null, null);
+        }
+
+        @Override
+        public void send(String event) throws SdkClientException {
+            // Do nothing
+        }
+
+        @Override
+        public <T> void sendAsync(T message) throws SdkClientException {
+            // Do nothing
+        }
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
@@ -47,6 +47,7 @@ class AuditServiceTest {
 
     private final SnsService snsService = mock(SnsService.class);
     private final KmsConnectionService kmsConnectionService = mock(KmsConnectionService.class);
+    private final AwsSqsClient awsSqsClient = mock(AwsSqsClient.class);
 
     @Captor private ArgumentCaptor<String> messageCaptor;
 
@@ -77,7 +78,8 @@ class AuditServiceTest {
                         FIXED_CLOCK,
                         snsService,
                         kmsConnectionService,
-                        mock(ConfigurationService.class));
+                        mock(ConfigurationService.class),
+                        awsSqsClient);
 
         auditService.submitAuditEvent(
                 TEST_EVENT_ONE,
@@ -112,7 +114,8 @@ class AuditServiceTest {
                         FIXED_CLOCK,
                         snsService,
                         kmsConnectionService,
-                        mock(ConfigurationService.class));
+                        mock(ConfigurationService.class),
+                        awsSqsClient);
 
         var signingRequestCaptor = ArgumentCaptor.forClass(SignRequest.class);
 
@@ -146,7 +149,8 @@ class AuditServiceTest {
                         FIXED_CLOCK,
                         snsService,
                         kmsConnectionService,
-                        mock(ConfigurationService.class));
+                        mock(ConfigurationService.class),
+                        awsSqsClient);
 
         auditService.submitAuditEvent(
                 TEST_EVENT_ONE,


### PR DESCRIPTION
Send the MVP audit payload to TxMA's audit queue from a single endpoint in build and staging