### PR TITLE
BAU: Fix provisioned concurrency deployment issues

### DIFF
--- a/ci/terraform/account-management/authorizer.tf
+++ b/ci/terraform/account-management/authorizer.tf
@@ -70,6 +70,10 @@ resource "aws_lambda_alias" "authorizer_alias" {
 resource "time_sleep" "wait_for_alias_to_reassign" {
   depends_on = [aws_lambda_alias.authorizer_alias]
 
+  triggers = {
+    function_name    = aws_lambda_function.authorizer.arn
+    function_version = aws_lambda_function.authorizer.version
+  }
   create_duration = "120s"
 }
 

--- a/ci/terraform/modules/endpoint-module/lambda.tf
+++ b/ci/terraform/modules/endpoint-module/lambda.tf
@@ -68,6 +68,10 @@ resource "aws_lambda_alias" "endpoint_lambda" {
 resource "time_sleep" "wait_for_alias_to_reassign" {
   depends_on = [aws_lambda_alias.endpoint_lambda]
 
+  triggers = {
+    function_name    = aws_lambda_function.endpoint_lambda.arn
+    function_version = aws_lambda_function.endpoint_lambda.version
+  }
   create_duration = "120s"
 }
 


### PR DESCRIPTION
## What?

- Add `triggers` attribute to the `time_sleep` resource. 

## Why?

This will ensure that the sleep occurs on every change of the lambda version and hence the sleep will be triggered. Currently, it seems that the sleep was only triggered on the first run, hence we were continuing to get issues on deployment of new endpoint versions.
