### PR TITLE
AUT-583: Change IPV Callback exceptions to redirect to frontend

### DIFF
--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/IpvCallbackException.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/IpvCallbackException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.authentication.ipv.entity;
+
+public class IpvCallbackException extends RuntimeException {
+    public IpvCallbackException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
## What?

- Refactor all `RuntimeException`s to redirect back to frontend error page
- Add new custom exception type (`IpvCallbackException`)

## Why?

- So that a visual error page is displayed to the end user rather than raw JSON in the case of 500 status.

## Related PRs

- Mirrors implementation for DocAppCallbackHandler (x2): 
https://github.com/alphagov/di-authentication-api/pull/2181
https://github.com/alphagov/di-authentication-api/pull/2188