### PR TITLE
BAU: Reduce time to wait for alias to update

### DIFF
--- a/ci/terraform/account-management/authorizer.tf
+++ b/ci/terraform/account-management/authorizer.tf
@@ -74,7 +74,7 @@ resource "time_sleep" "wait_for_alias_to_reassign" {
     function_name    = aws_lambda_function.authorizer.arn
     function_version = aws_lambda_function.authorizer.version
   }
-  create_duration = "120s"
+  create_duration = "60s"
 }
 
 resource "aws_lambda_provisioned_concurrency_config" "endpoint_lambda_concurrency_config" {

--- a/ci/terraform/modules/endpoint-module/lambda.tf
+++ b/ci/terraform/modules/endpoint-module/lambda.tf
@@ -72,7 +72,7 @@ resource "time_sleep" "wait_for_alias_to_reassign" {
     function_name    = aws_lambda_function.endpoint_lambda.arn
     function_version = aws_lambda_function.endpoint_lambda.version
   }
-  create_duration = "120s"
+  create_duration = "60s"
 }
 
 resource "aws_lambda_provisioned_concurrency_config" "endpoint_lambda_concurrency_config" {


### PR DESCRIPTION
## What?

- Reduce the wait time from 120s to 60s, 

## Why?

We have fixed the issue with the `time_sleep` resource not working properly on update, we now need to find the optimum wait time as 2 mins is possibly too long.

## Related PRs

#2201 