### PR TITLE
AUT-619 - MFA metric and logging amendments

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -25,7 +25,6 @@ import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
-import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SessionService;
@@ -58,7 +57,6 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
 
     private final CodeStorageService codeStorageService;
     private final AuditService auditService;
-    private final CloudwatchMetricsService cloudwatchMetricsService;
 
     protected VerifyCodeHandler(
             ConfigurationService configurationService,
@@ -67,8 +65,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
             ClientService clientService,
             AuthenticationService authenticationService,
             CodeStorageService codeStorageService,
-            AuditService auditService,
-            CloudwatchMetricsService cloudwatchMetricsService) {
+            AuditService auditService) {
         super(
                 VerifyCodeRequest.class,
                 configurationService,
@@ -78,7 +75,6 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                 authenticationService);
         this.codeStorageService = codeStorageService;
         this.auditService = auditService;
-        this.cloudwatchMetricsService = cloudwatchMetricsService;
     }
 
     public VerifyCodeHandler() {
@@ -89,7 +85,6 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
         super(VerifyCodeRequest.class, configurationService);
         this.codeStorageService = new CodeStorageService(configurationService);
         this.auditService = new AuditService(configurationService);
-        this.cloudwatchMetricsService = new CloudwatchMetricsService();
     }
 
     @Override
@@ -219,13 +214,6 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                             .map(ClientRegistry::getClientID)
                             .orElse(AuditService.UNKNOWN);
 
-            cloudwatchMetricsService.incrementCounter(
-                    "NewAccount",
-                    Map.of(
-                            "Environment",
-                            configurationService.getEnvironment(),
-                            "Client",
-                            clientName));
         } else {
             codeStorageService.deleteOtpCode(session.getEmailAddress(), notificationType);
         }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -194,6 +194,10 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                     pair("notification-type", notificationType.name())
                 };
         if (notificationType.equals(VERIFY_PHONE_NUMBER)) {
+            LOG.info(
+                    "MFA code has been successfully verified for MFA type: {}. RegistrationJourney: {}",
+                    MFAMethodType.SMS.getValue(),
+                    true);
             authenticationService.updatePhoneNumberVerifiedStatus(session.getEmailAddress(), true);
 
             var vectorOfTrust = VectorOfTrust.getDefaults();
@@ -219,6 +223,10 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                     };
 
         } else if (notificationType.equals(MFA_SMS)) {
+            LOG.info(
+                    "MFA code has been successfully verified for MFA type: {}. RegistrationJourney: {}",
+                    MFAMethodType.SMS.getValue(),
+                    false);
             sessionService.save(session.setVerifiedMfaMethodType(MFAMethodType.SMS));
             metadataPairs =
                     new AuditService.MetadataPair[] {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -81,8 +81,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
 
     public VerifyMfaCodeHandler(ConfigurationService configurationService) {
         super(VerifyMfaCodeRequest.class, configurationService);
-        var codeStorageService = new CodeStorageService(configurationService);
-        this.codeStorageService = codeStorageService;
+        this.codeStorageService = new CodeStorageService(configurationService);
         this.auditService = new AuditService(configurationService);
         this.mfaCodeValidatorFactory =
                 new MfaCodeValidatorFactory(
@@ -144,6 +143,10 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                     .map(response -> generateApiGatewayProxyErrorResponse(400, response))
                     .orElseGet(
                             () -> {
+                                LOG.info(
+                                        "MFA code has been successfully verified for MFA type: {}. RegistrationJourney: {}",
+                                        MFAMethodType.AUTH_APP.getValue(),
+                                        codeRequest.isRegistration());
                                 sessionService.save(
                                         session.setVerifiedMfaMethodType(MFAMethodType.AUTH_APP));
                                 return ApiGatewayResponseHelper

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -18,6 +18,7 @@ import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
@@ -175,6 +176,7 @@ class VerifyCodeHandlerTest {
         verify(authenticationService).updatePhoneNumberVerifiedStatus(TEST_EMAIL_ADDRESS, true);
         assertThat(result, hasStatus(204));
         assertThat(session.getCurrentCredentialStrength(), equalTo(MEDIUM_LEVEL));
+        assertThat(session.getVerifiedMfaMethodType(), equalTo(MFAMethodType.SMS));
 
         verify(sessionService, times(2)).save(session);
         verify(auditService)
@@ -350,7 +352,8 @@ class VerifyCodeHandlerTest {
 
         verify(codeStorageService).deleteOtpCode(TEST_EMAIL_ADDRESS, MFA_SMS);
         assertThat(result, hasStatus(204));
-        verify(sessionService).save(session);
+        assertThat(session.getVerifiedMfaMethodType(), equalTo(MFAMethodType.SMS));
+        verify(sessionService, times(2)).save(session);
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CODE_VERIFIED,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -25,7 +25,6 @@ import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
-import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SessionService;
@@ -84,8 +83,6 @@ class VerifyCodeHandlerTest {
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
     private final ClientSession clientSession = mock(ClientSession.class);
     private final AuditService auditService = mock(AuditService.class);
-    private final CloudwatchMetricsService cloudwatchMetricsService =
-            mock(CloudwatchMetricsService.class);
 
     private final ClientRegistry clientRegistry =
             new ClientRegistry().setTestClient(false).setClientID(CLIENT_ID);
@@ -125,8 +122,7 @@ class VerifyCodeHandlerTest {
                         clientService,
                         authenticationService,
                         codeStorageService,
-                        auditService,
-                        cloudwatchMetricsService);
+                        auditService);
 
         when(authenticationService.getUserProfileFromEmail(TEST_EMAIL_ADDRESS))
                 .thenReturn(Optional.of(userProfile));
@@ -193,10 +189,6 @@ class VerifyCodeHandlerTest {
                         AuditService.UNKNOWN,
                         PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
                         pair("notification-type", VERIFY_PHONE_NUMBER.name()));
-
-        verify(cloudwatchMetricsService)
-                .incrementCounter(
-                        "NewAccount", Map.of("Environment", "unit-test", "Client", "client-id"));
     }
 
     @Test

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -190,7 +190,8 @@ class VerifyCodeHandlerTest {
                         "123.123.123.123",
                         AuditService.UNKNOWN,
                         PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
-                        pair("notification-type", VERIFY_PHONE_NUMBER.name()));
+                        pair("notification-type", VERIFY_PHONE_NUMBER.name()),
+                        pair("mfa-type", MFAMethodType.SMS.getValue()));
     }
 
     @Test
@@ -281,7 +282,8 @@ class VerifyCodeHandlerTest {
                         "123.123.123.123",
                         AuditService.UNKNOWN,
                         PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
-                        pair("notification-type", VERIFY_PHONE_NUMBER.name()));
+                        pair("notification-type", VERIFY_PHONE_NUMBER.name()),
+                        pair("mfa-type", MFAMethodType.SMS.getValue()));
     }
 
     @Test
@@ -365,7 +367,8 @@ class VerifyCodeHandlerTest {
                         "123.123.123.123",
                         AuditService.UNKNOWN,
                         PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
-                        pair("notification-type", MFA_SMS.name()));
+                        pair("notification-type", MFA_SMS.name()),
+                        pair("mfa-type", MFAMethodType.SMS.getValue()));
     }
 
     @Test
@@ -407,7 +410,8 @@ class VerifyCodeHandlerTest {
                         "123.123.123.123",
                         AuditService.UNKNOWN,
                         PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
-                        pair("notification-type", MFA_SMS.name()));
+                        pair("notification-type", MFA_SMS.name()),
+                        pair("mfa-type", MFAMethodType.SMS.getValue()));
     }
 
     @Test

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -1,0 +1,316 @@
+package uk.gov.di.authentication.frontendapi.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.nimbusds.oauth2.sdk.ResponseType;
+import com.nimbusds.oauth2.sdk.Scope;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.id.State;
+import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+import com.nimbusds.openid.connect.sdk.Nonce;
+import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
+import uk.gov.di.authentication.frontendapi.entity.VerifyMfaCodeRequest;
+import uk.gov.di.authentication.shared.entity.ClientRegistry;
+import uk.gov.di.authentication.shared.entity.ClientSession;
+import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.MFAMethodType;
+import uk.gov.di.authentication.shared.entity.Session;
+import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
+import uk.gov.di.authentication.shared.serialization.Json;
+import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.shared.services.AuthenticationService;
+import uk.gov.di.authentication.shared.services.ClientService;
+import uk.gov.di.authentication.shared.services.ClientSessionService;
+import uk.gov.di.authentication.shared.services.CodeStorageService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.SerializationService;
+import uk.gov.di.authentication.shared.services.SessionService;
+import uk.gov.di.authentication.shared.validation.AuthAppCodeValidator;
+import uk.gov.di.authentication.shared.validation.MfaCodeValidatorFactory;
+import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_EMAIL;
+import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
+import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_BLOCKED_KEY_PREFIX;
+import static uk.gov.di.authentication.sharedtest.helper.RequestEventHelper.contextWithSourceIp;
+import static uk.gov.di.authentication.sharedtest.logging.LogEventMatcher.withMessageContaining;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
+
+class VerifyMfaCodeHandlerTest {
+
+    private static final String TEST_EMAIL_ADDRESS = "test@test.com";
+    private static final String CODE = "123456";
+    private static final String CLIENT_ID = "client-id";
+    private static final String TEST_CLIENT_CODE = "654321";
+    private static final String CLIENT_SESSION_ID = "client-session-id";
+    private static final String SUBJECT_ID = "test-subject-id";
+    private final Session session = new Session("session-id").setEmailAddress(TEST_EMAIL_ADDRESS);
+    private final Json objectMapper = SerializationService.getInstance();
+    public VerifyMfaCodeHandler handler;
+
+    private final Context context = mock(Context.class);
+    private final SessionService sessionService = mock(SessionService.class);
+    private final CodeStorageService codeStorageService = mock(CodeStorageService.class);
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private final MfaCodeValidatorFactory mfaCodeValidatorFactory =
+            mock(MfaCodeValidatorFactory.class);
+    private final AuthAppCodeValidator authAppCodeValidator = mock(AuthAppCodeValidator.class);
+    private final ClientSessionService clientSessionService = mock(ClientSessionService.class);
+    private final ClientRegistry clientRegistry = mock(ClientRegistry.class);
+    private final ClientService clientService = mock(ClientService.class);
+    private final UserProfile userProfile = mock(UserProfile.class);
+    private final AuthenticationService authenticationService = mock(AuthenticationService.class);
+    private final ClientSession clientSession = mock(ClientSession.class);
+    private final AuditService auditService = mock(AuditService.class);
+
+    @RegisterExtension
+    private final CaptureLoggingExtension logging =
+            new CaptureLoggingExtension(VerifyCodeHandler.class);
+
+    @BeforeEach
+    void setUp() {
+        when(authenticationService.getUserProfileFromEmail(TEST_EMAIL_ADDRESS))
+                .thenReturn(Optional.of(userProfile));
+        when(clientService.getClient(CLIENT_ID)).thenReturn(Optional.of(clientRegistry));
+        when(clientRegistry.getClientID()).thenReturn(CLIENT_ID);
+        when(clientSession.getAuthRequestParams())
+                .thenReturn(withAuthenticationRequest().toParameters());
+
+        when(userProfile.getSubjectID()).thenReturn(SUBJECT_ID);
+        when(configurationService.getBlockedEmailDuration()).thenReturn(900L);
+        when(configurationService.getCodeMaxRetries()).thenReturn(5);
+        handler =
+                new VerifyMfaCodeHandler(
+                        configurationService,
+                        sessionService,
+                        clientSessionService,
+                        clientService,
+                        authenticationService,
+                        codeStorageService,
+                        auditService,
+                        mfaCodeValidatorFactory);
+    }
+
+    @AfterEach
+    void tearDown() {
+        assertThat(
+                logging.events(),
+                not(
+                        hasItem(
+                                withMessageContaining(
+                                        CLIENT_ID,
+                                        TEST_CLIENT_CODE,
+                                        session.getSessionId(),
+                                        CLIENT_SESSION_ID))));
+    }
+
+    @Test
+    void shouldReturn204WhenSuccessfulAuthCodeRegistrationRequest() throws Json.JsonException {
+        when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), anyBoolean(), any()))
+                .thenReturn(Optional.of(authAppCodeValidator));
+        when(authAppCodeValidator.validateCode(CODE)).thenReturn(Optional.empty());
+        when(codeStorageService.getOtpCode(TEST_EMAIL_ADDRESS, VERIFY_EMAIL))
+                .thenReturn(Optional.of(CODE));
+        var result = makeCallWithCode(true);
+
+        assertThat(result, hasStatus(204));
+        assertThat(session.getVerifiedMfaMethodType(), equalTo(MFAMethodType.AUTH_APP));
+        verify(authenticationService)
+                .setMFAMethodVerifiedTrue(TEST_EMAIL_ADDRESS, MFAMethodType.AUTH_APP);
+        verify(codeStorageService, never())
+                .saveBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX, 900L);
+        verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(TEST_EMAIL_ADDRESS);
+
+        verify(auditService)
+                .submitAuditEvent(
+                        FrontendAuditableEvent.CODE_VERIFIED,
+                        context.getAwsRequestId(),
+                        session.getSessionId(),
+                        CLIENT_ID,
+                        SUBJECT_ID,
+                        TEST_EMAIL_ADDRESS,
+                        "123.123.123.123",
+                        AuditService.UNKNOWN,
+                        PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
+                        pair("mfa-type", MFAMethodType.AUTH_APP.getValue()));
+    }
+
+    @Test
+    void shouldReturn204WhenSuccessfulAuthCodeLoginRequest() throws Json.JsonException {
+        when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), anyBoolean(), any()))
+                .thenReturn(Optional.of(authAppCodeValidator));
+        when(authAppCodeValidator.validateCode(CODE)).thenReturn(Optional.empty());
+        when(codeStorageService.getOtpCode(TEST_EMAIL_ADDRESS, VERIFY_EMAIL))
+                .thenReturn(Optional.of(CODE));
+        var result = makeCallWithCode(false);
+
+        assertThat(result, hasStatus(204));
+        assertThat(session.getVerifiedMfaMethodType(), equalTo(MFAMethodType.AUTH_APP));
+        verify(authenticationService, never())
+                .setMFAMethodVerifiedTrue(TEST_EMAIL_ADDRESS, MFAMethodType.AUTH_APP);
+        verify(codeStorageService, never())
+                .saveBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX, 900L);
+        verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(TEST_EMAIL_ADDRESS);
+
+        verify(auditService)
+                .submitAuditEvent(
+                        FrontendAuditableEvent.CODE_VERIFIED,
+                        context.getAwsRequestId(),
+                        session.getSessionId(),
+                        CLIENT_ID,
+                        SUBJECT_ID,
+                        TEST_EMAIL_ADDRESS,
+                        "123.123.123.123",
+                        AuditService.UNKNOWN,
+                        PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
+                        pair("mfa-type", MFAMethodType.AUTH_APP.getValue()));
+    }
+
+    @Test
+    void shouldReturn400IfMfaCodeValidatorCannotBeFound() throws Json.JsonException {
+        when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), anyBoolean(), any()))
+                .thenReturn(Optional.empty());
+        when(codeStorageService.getOtpCode(TEST_EMAIL_ADDRESS, VERIFY_EMAIL))
+                .thenReturn(Optional.of(CODE));
+        var result = makeCallWithCode(true);
+
+        assertThat(result, hasStatus(400));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1002));
+        assertThat(session.getVerifiedMfaMethodType(), equalTo(null));
+        verify(authenticationService, never())
+                .setMFAMethodVerifiedTrue(TEST_EMAIL_ADDRESS, MFAMethodType.AUTH_APP);
+        verifyNoInteractions(auditService);
+        verifyNoInteractions(authAppCodeValidator);
+        verifyNoInteractions(codeStorageService);
+    }
+
+    private static Stream<Boolean> registration() {
+        return Stream.of(true, false);
+    }
+
+    @ParameterizedTest
+    @MethodSource("registration")
+    void shouldReturn400AndBlockCodeWhenUserEnteredInvalidAuthAppCodeTooManyTimes(
+            boolean registration) throws Json.JsonException {
+        when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), anyBoolean(), any()))
+                .thenReturn(Optional.of(authAppCodeValidator));
+        when(authAppCodeValidator.validateCode(CODE))
+                .thenReturn(Optional.of(ErrorResponse.ERROR_1042));
+        when(codeStorageService.getOtpCode(TEST_EMAIL_ADDRESS, VERIFY_EMAIL))
+                .thenReturn(Optional.of(CODE));
+        var result = makeCallWithCode(registration);
+
+        assertThat(result, hasStatus(400));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1042));
+        assertThat(session.getVerifiedMfaMethodType(), equalTo(null));
+        verify(codeStorageService)
+                .saveBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX, 900L);
+        verify(authenticationService, never())
+                .setMFAMethodVerifiedTrue(TEST_EMAIL_ADDRESS, MFAMethodType.AUTH_APP);
+        verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(TEST_EMAIL_ADDRESS);
+        verify(auditService)
+                .submitAuditEvent(
+                        FrontendAuditableEvent.CODE_MAX_RETRIES_REACHED,
+                        context.getAwsRequestId(),
+                        session.getSessionId(),
+                        CLIENT_ID,
+                        SUBJECT_ID,
+                        TEST_EMAIL_ADDRESS,
+                        "123.123.123.123",
+                        AuditService.UNKNOWN,
+                        PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
+                        pair("mfa-type", MFAMethodType.AUTH_APP.getValue()));
+    }
+
+    @ParameterizedTest
+    @MethodSource("registration")
+    void shouldReturn400WhenUserEnteredInvalidAuthAppCode(boolean registration)
+            throws Json.JsonException {
+        when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), anyBoolean(), any()))
+                .thenReturn(Optional.of(authAppCodeValidator));
+        when(authAppCodeValidator.validateCode(CODE))
+                .thenReturn(Optional.of(ErrorResponse.ERROR_1043));
+        when(codeStorageService.getOtpCode(TEST_EMAIL_ADDRESS, VERIFY_EMAIL))
+                .thenReturn(Optional.of(CODE));
+        var result = makeCallWithCode(registration);
+
+        assertThat(result, hasStatus(400));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1043));
+        assertThat(session.getVerifiedMfaMethodType(), equalTo(null));
+        verify(codeStorageService, never())
+                .saveBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX, 900L);
+        verify(authenticationService, never())
+                .setMFAMethodVerifiedTrue(TEST_EMAIL_ADDRESS, MFAMethodType.AUTH_APP);
+        verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(TEST_EMAIL_ADDRESS);
+        verify(auditService)
+                .submitAuditEvent(
+                        FrontendAuditableEvent.INVALID_CODE_SENT,
+                        context.getAwsRequestId(),
+                        session.getSessionId(),
+                        CLIENT_ID,
+                        SUBJECT_ID,
+                        TEST_EMAIL_ADDRESS,
+                        "123.123.123.123",
+                        AuditService.UNKNOWN,
+                        PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
+                        pair("mfa-type", MFAMethodType.AUTH_APP.getValue()));
+    }
+
+    private APIGatewayProxyResponseEvent makeCallWithCode(boolean registration)
+            throws Json.JsonException {
+        var event = new APIGatewayProxyRequestEvent();
+        event.setRequestContext(contextWithSourceIp("123.123.123.123"));
+        event.setHeaders(
+                Map.of(
+                        "Session-Id",
+                        session.getSessionId(),
+                        "Client-Session-Id",
+                        CLIENT_SESSION_ID));
+        var mfaCodeRequest = new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, CODE, registration);
+        event.setBody(objectMapper.writeValueAsString(mfaCodeRequest));
+        when(sessionService.getSessionFromRequestHeaders(event.getHeaders()))
+                .thenReturn(Optional.of(session));
+        when(clientSessionService.getClientSessionFromRequestHeaders(event.getHeaders()))
+                .thenReturn(Optional.of(clientSession));
+        when(clientSessionService.getClientSessionFromRequestHeaders(event.getHeaders()))
+                .thenReturn(Optional.of(clientSession));
+        return handler.handleRequest(event, context);
+    }
+
+    private AuthenticationRequest withAuthenticationRequest() {
+        return new AuthenticationRequest.Builder(
+                        new ResponseType(ResponseType.Value.CODE),
+                        new Scope(OIDCScopeValue.OPENID),
+                        new ClientID(CLIENT_ID),
+                        URI.create("https://redirectUri"))
+                .state(new State())
+                .nonce(new Nonce())
+                .build();
+    }
+}

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.oidc.entity.AuthCodeResponse;
 import uk.gov.di.authentication.oidc.lambda.AuthCodeHandler;
+import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
@@ -48,6 +49,7 @@ public class AuthCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         String clientSessionId = "some-client-session-id";
         KeyPair keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
         redis.createSession(sessionId);
+        redis.setVerifiedMfaMethodType(sessionId, MFAMethodType.AUTH_APP);
         redis.addAuthRequestToSession(
                 clientSessionId, sessionId, generateAuthRequest().toParameters());
         setUpDynamo(keyPair);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
@@ -84,7 +84,6 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
                         Optional.of(codeRequest),
                         constructFrontendHeaders(sessionId, CLIENT_SESSION_ID),
                         Map.of());
-        var session = redis.getSession(sessionId);
 
         assertThat(response, hasStatus(204));
         assertThat(redis.getMfaCodeAttemptsCount(EMAIL_ADDRESS), equalTo(0));
@@ -190,7 +189,6 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
                         constructFrontendHeaders(sessionId, CLIENT_SESSION_ID),
                         Map.of());
 
-        var session = redis.getSession(sessionId);
 
         assertThat(response, hasStatus(204));
         assertThat(redis.getMfaCodeAttemptsCount(EMAIL_ADDRESS), equalTo(0));

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
@@ -189,7 +189,6 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
                         constructFrontendHeaders(sessionId, CLIENT_SESSION_ID),
                         Map.of());
 
-
         assertThat(response, hasStatus(204));
         assertThat(redis.getMfaCodeAttemptsCount(EMAIL_ADDRESS), equalTo(0));
         assertEventTypesReceived(auditTopic, List.of(CODE_VERIFIED));

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
@@ -77,7 +77,7 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     }
 
     @Test
-    void whenTwoMinuteOldValidAuthAppCodeReturn204() throws Json.JsonException {
+    void whenTwoMinuteOldValidAuthAppCodeReturn204() {
         userStore.addMfaMethod(
                 EMAIL_ADDRESS, MFAMethodType.AUTH_APP, true, true, AUTH_APP_SECRET_BASE_32);
         long oneMinuteAgo = NowHelper.nowMinus(2, ChronoUnit.MINUTES).getTime();
@@ -96,7 +96,7 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     }
 
     @Test
-    void whenFiveMinuteOldAuthAppCodeReturn400() throws Json.JsonException {
+    void whenFiveMinuteOldAuthAppCodeReturn400() {
         userStore.addMfaMethod(
                 EMAIL_ADDRESS, MFAMethodType.AUTH_APP, true, true, AUTH_APP_SECRET_BASE_32);
         long tenMinutesAgo = NowHelper.nowMinus(5, ChronoUnit.MINUTES).getTime();
@@ -153,7 +153,7 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     }
 
     @Test
-    void whenParametersMissingReturn400() throws Json.JsonException {
+    void whenParametersMissingReturn400() {
         userStore.addMfaMethod(
                 EMAIL_ADDRESS, MFAMethodType.AUTH_APP, true, true, AUTH_APP_SECRET_BASE_32);
         String code = AUTH_APP_STUB.getAuthAppOneTimeCode(AUTH_APP_SECRET_BASE_32);
@@ -170,7 +170,7 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     }
 
     @Test
-    void whenCodeSubmissionBlockedReturn400() throws Json.JsonException {
+    void whenCodeSubmissionBlockedReturn400() {
         userStore.addMfaMethod(
                 EMAIL_ADDRESS, MFAMethodType.AUTH_APP, true, true, AUTH_APP_SECRET_BASE_32);
         String code = AUTH_APP_STUB.getAuthAppOneTimeCode(AUTH_APP_SECRET_BASE_32);

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import uk.gov.di.authentication.shared.entity.AuthCodeExchangeData;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
+import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.VectorOfTrust;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
@@ -62,6 +63,14 @@ public class RedisExtension
         redis.saveWithExpiry(
                 session.getSessionId(), objectMapper.writeValueAsString(session), 3600);
         return session.getSessionId();
+    }
+
+    public void setVerifiedMfaMethodType(String sessionId, MFAMethodType mfaMethodType)
+            throws Json.JsonException {
+        var session = objectMapper.readValue(redis.getValue(sessionId), Session.class);
+        session.setVerifiedMfaMethodType(mfaMethodType);
+        redis.saveWithExpiry(
+                session.getSessionId(), objectMapper.writeValueAsString(session), 3600);
     }
 
     public String createSession() throws Json.JsonException {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
@@ -50,7 +50,6 @@ public enum ErrorResponse {
     ERROR_1042(1042, "User entered invalid authenticator app verification code too many times"),
     ERROR_1043(1043, "User entered invalid authenticator app code"),
     ERROR_1044(1044, "New phone number is the same as current phone number");
-    ;
 
     private int code;
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
@@ -33,6 +33,8 @@ public class Session {
 
     @Expose private int processingIdentityAttempts;
 
+    @Expose private MFAMethodType verifiedMfaMethodType;
+
     public Session(String sessionId) {
         this.sessionId = sessionId;
         this.clientSessions = new ArrayList<>();
@@ -147,5 +149,14 @@ public class Session {
     public int incrementProcessingIdentityAttempts() {
         this.processingIdentityAttempts += 1;
         return processingIdentityAttempts;
+    }
+
+    public MFAMethodType getVerifiedMfaMethodType() {
+        return verifiedMfaMethodType;
+    }
+
+    public Session setVerifiedMfaMethodType(MFAMethodType verifiedMfaMethodType) {
+        this.verifiedMfaMethodType = verifiedMfaMethodType;
+        return this;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/validation/AuthAppCodeValidator.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/validation/AuthAppCodeValidator.java
@@ -5,9 +5,9 @@ import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.MFAMethod;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
+import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
-import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
 import javax.crypto.Mac;
@@ -22,14 +22,14 @@ public class AuthAppCodeValidator extends MfaCodeValidator {
 
     private final int windowTime;
     private final int allowedWindows;
-    private final DynamoService dynamoService;
+    private final AuthenticationService dynamoService;
     private final UserContext userContext;
 
     public AuthAppCodeValidator(
             UserContext userContext,
             CodeStorageService codeStorageService,
             ConfigurationService configurationService,
-            DynamoService dynamoService,
+            AuthenticationService dynamoService,
             int maxRetries) {
         super(userContext, codeStorageService, maxRetries);
         this.dynamoService = dynamoService;

--- a/shared/src/main/java/uk/gov/di/authentication/shared/validation/MfaCodeValidatorFactory.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/validation/MfaCodeValidatorFactory.java
@@ -1,23 +1,30 @@
 package uk.gov.di.authentication.shared.validation;
 
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
+import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
-import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.util.Optional;
 
 public class MfaCodeValidatorFactory {
-    private MfaCodeValidatorFactory() {}
 
-    public static Optional<MfaCodeValidator> getMfaCodeValidator(
-            MFAMethodType mfaMethodType,
-            boolean isRegistration,
-            UserContext userContext,
-            CodeStorageService codeStorageService,
+    private final ConfigurationService configurationService;
+    private final CodeStorageService codeStorageService;
+    private final AuthenticationService authenticationService;
+
+    public MfaCodeValidatorFactory(
             ConfigurationService configurationService,
-            DynamoService dynamoService) {
+            CodeStorageService codeStorageService,
+            AuthenticationService authenticationService) {
+        this.configurationService = configurationService;
+        this.codeStorageService = codeStorageService;
+        this.authenticationService = authenticationService;
+    }
+
+    public Optional<MfaCodeValidator> getMfaCodeValidator(
+            MFAMethodType mfaMethodType, boolean isRegistration, UserContext userContext) {
 
         switch (mfaMethodType) {
             case AUTH_APP:
@@ -30,7 +37,7 @@ public class MfaCodeValidatorFactory {
                                 userContext,
                                 codeStorageService,
                                 configurationService,
-                                dynamoService,
+                                authenticationService,
                                 codeMaxRetries));
             default:
                 return Optional.empty();


### PR DESCRIPTION
## What?

- Add the MfaMethodType to the session so we can expose it in the SignIn cloudwatch metric in the AuthCodeHandler. This will dimension will be omitted when the users is either using SSO or is signing in from a low level service and has not need to use MFA.
- Make audit events consistent for when either SMS or AUTH_APPS are used as the users MFA method. 
- Create and add unit tests for the VerifyMfaCodeHandler.java. Refactor the VerifyMfaCodeHandler so external classes can be mocked out.
- Add detailed logging of what MFA type is used and whether it the user is signing up or signing in
- Remove NewAccount metric in the VerifyCodeHandler 


## Why?

- By adding the MfaMethodType to the SignIn cloudwatch metric, we will be able to see the amount of users using AuthApps vs those that use SMS 
- Ensure that when either SMS or AUTH_APPS are used then the audit event has a metadata pair called `mfa-type` which is set to the correct value. This will give us consistency in our audit events across Auth apps and SMS. 
- The VerifyMfaCodeHandler was not covered in unit tests so added them to increase test coverage 
- The NewAccount metric was redundant as it was superseded by the SignIn metric in the AuthCodeHandler
- Consistent logging will help us debug journeys easier 