### PR TITLE
AUT-586: TxMA-requested tweaks to payload structure

### DIFF
--- a/shared/src/main/java/uk/gov/di/audit/TxmaAuditEvent.java
+++ b/shared/src/main/java/uk/gov/di/audit/TxmaAuditEvent.java
@@ -33,7 +33,8 @@ public class TxmaAuditEvent {
 
     public static TxmaAuditEvent auditEventWithTime(
             AuditableEvent eventName, Supplier<Date> dateSupplier) {
-        return new TxmaAuditEvent("AUTH_" + eventName.toString(), dateSupplier.get().getTime());
+        return new TxmaAuditEvent(
+                "AUTH_" + eventName.toString(), dateSupplier.get().toInstant().getEpochSecond());
     }
 
     public static TxmaAuditEvent auditEvent(AuditableEvent event) {

--- a/shared/src/main/java/uk/gov/di/audit/TxmaAuditEvent.java
+++ b/shared/src/main/java/uk/gov/di/audit/TxmaAuditEvent.java
@@ -18,7 +18,7 @@ public class TxmaAuditEvent {
 
     @Expose private String clientId;
 
-    @Expose private String componentName;
+    @Expose private String componentId;
 
     @Expose private TxmaAuditUser user;
 
@@ -44,8 +44,8 @@ public class TxmaAuditEvent {
         return SerializationService.getInstance().writeValueAsString(this);
     }
 
-    public TxmaAuditEvent withComponentName(String componentName) {
-        this.componentName = componentName;
+    public TxmaAuditEvent withComponentId(String componentId) {
+        this.componentId = componentId;
         return this;
     }
 

--- a/shared/src/test/java/uk/gov/di/audit/TxmaAuditEventTest.java
+++ b/shared/src/test/java/uk/gov/di/audit/TxmaAuditEventTest.java
@@ -39,14 +39,12 @@ class TxmaAuditEventTest {
     @Test
     void shouldSerializeEventWithNonMandatoryFields() {
         var event =
-                auditEvent(TEST_EVENT)
-                        .withClientId("client-id")
-                        .withComponentName("component-name");
+                auditEvent(TEST_EVENT).withClientId("client-id").withComponentId("component-id");
 
         var payload = asJson(event.serialize());
 
         assertThat(payload, hasFieldWithValue("client_id", is("client-id")));
-        assertThat(payload, hasFieldWithValue("component_name", is("component-name")));
+        assertThat(payload, hasFieldWithValue("component_id", is("component-id")));
     }
 
     @Test

--- a/shared/src/test/java/uk/gov/di/audit/TxmaAuditEventTest.java
+++ b/shared/src/test/java/uk/gov/di/audit/TxmaAuditEventTest.java
@@ -33,7 +33,9 @@ class TxmaAuditEventTest {
         var payload = asJson(auditEventWithTime(TEST_EVENT, () -> now).serialize());
 
         assertThat(payload, hasFieldWithValue("event_name", is("AUTH_TEST_EVENT")));
-        assertThat(payload, hasNumericFieldWithValue("timestamp", is(now.getTime())));
+        assertThat(
+                payload,
+                hasNumericFieldWithValue("timestamp", is(now.toInstant().getEpochSecond())));
     }
 
     @Test

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
@@ -117,7 +117,7 @@ class AuditServiceTest {
                         hasFields(
                                 ofEntries(
                                         entry("event_name", "AUTH_TEST_EVENT_ONE"),
-                                        entry("timestamp", "1630534200012"))));
+                                        entry("timestamp", "1630534200"))));
     }
 
     @Test


### PR DESCRIPTION
- AUT-584: `component_name` should be `component_id`
- AUT-584: Send timestamp in seconds rather than milliseconds
