### PR TITLE
BAU: Switch consent to share off in the acceptance test client

### DIFF
--- a/ci/terraform/shared/build-stub-clients.tfvars
+++ b/ci/terraform/shared/build-stub-clients.tfvars
@@ -26,7 +26,7 @@ stub_rp_clients = [
       "https://di-auth-stub-relying-party-build-s2.london.cloudapps.digital/signed-out",
     ]
     test_client                     = "1"
-    consent_required                = "1"
+    consent_required                = "0"
     identity_verification_supported = "1"
     client_type                     = "web"
     scopes = [


### PR DESCRIPTION
## What?

Switch consent to share off in the acceptance test client.

## Why?

Consent to share is still switched-on in the acceptance test client because there were existing tests that had been built to use it while it was still required, and in case it was brought back into use (all the code is still there).  The decision has been made the consent will be off for all clients so it makes more sense to remove these steps from the tests in order to reflect what is live.

## Related PRs

