### PR TITLE
AUT-616: Update MFA SMS template ID in receipts API

### DIFF
--- a/ci/terraform/delivery-receipts/production-overrides.tfvars
+++ b/ci/terraform/delivery-receipts/production-overrides.tfvars
@@ -12,5 +12,5 @@ notify_template_map = {
   PHONE_NUMBER_UPDATED_TEMPLATE_ID         = "beaf3eb2-135c-4517-800b-ca6b5ed85804"
   PASSWORD_UPDATED_TEMPLATE_ID             = "8d4c4948-000a-4de0-a8ba-76c259c1f983"
   VERIFY_PHONE_NUMBER_TEMPLATE_ID          = "16608047-106e-4fe9-bf3a-b1676e29eca9"
-  MFA_SMS_TEMPLATE_ID                      = "16608047-106e-4fe9-bf3a-b1676e29eca9"
+  MFA_SMS_TEMPLATE_ID                      = "6b9b6c82-a8c0-4b39-990b-a10130467f1e"
 }

--- a/ci/terraform/delivery-receipts/variables.tf
+++ b/ci/terraform/delivery-receipts/variables.tf
@@ -100,6 +100,6 @@ variable "notify_template_map" {
     PHONE_NUMBER_UPDATED_TEMPLATE_ID         = "8274a2a3-5121-4630-a27e-e8578f8cba59"
     PASSWORD_UPDATED_TEMPLATE_ID             = "323ebef4-cfa7-414f-bfba-1db324acdd66"
     VERIFY_PHONE_NUMBER_TEMPLATE_ID          = "7dd388f1-e029-4fe7-92ff-18496dcb53e9"
-    MFA_SMS_TEMPLATE_ID                      = "7dd388f1-e029-4fe7-92ff-18496dcb53e9"
+    MFA_SMS_TEMPLATE_ID                      = "97b956c8-9a12-451a-994b-5d51741b63d4"
   }
 }


### PR DESCRIPTION
## What?

- Update MFA SMS template ID in receipts API

## Why?

We updated the template ID in OIDC but omitted to updated the delivery receipts API

## Related PRs

#2217 