### PR TITLE
AUT-584: Enrich payloads with existing data

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
@@ -5,6 +5,7 @@ import com.amazonaws.services.kms.model.SigningAlgorithmSpec;
 import com.google.protobuf.ByteString;
 import uk.gov.di.audit.AuditPayload.AuditEvent;
 import uk.gov.di.audit.AuditPayload.SignedAuditEvent;
+import uk.gov.di.audit.TxmaAuditUser;
 import uk.gov.di.authentication.shared.domain.AuditableEvent;
 
 import java.nio.ByteBuffer;
@@ -85,11 +86,20 @@ public class AuditService {
                         persistentSessionId,
                         metadataPairs));
 
+        var user =
+                TxmaAuditUser.user()
+                        .withUserId(subjectId)
+                        .withPhone(phoneNumber)
+                        .withEmail(email)
+                        .withIpAddress(ipAddress)
+                        .withSessionId(sessionId)
+                        .withPersistentSessionId(persistentSessionId);
+
         var txmaAuditEvent =
                 auditEventWithTime(event, () -> Date.from(clock.instant()))
                         .withClientId(clientId)
-                        .withComponentId(
-                                configurationService.getOidcApiBaseURL().orElse("UNKNOWN"));
+                        .withComponentId(configurationService.getOidcApiBaseURL().orElse("UNKNOWN"))
+                        .withUser(user);
 
         txmaQueueClient.send(txmaAuditEvent.serialize());
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
@@ -85,8 +85,13 @@ public class AuditService {
                         persistentSessionId,
                         metadataPairs));
 
-        txmaQueueClient.send(
-                auditEventWithTime(event, () -> Date.from(clock.instant())).serialize());
+        var txmaAuditEvent =
+                auditEventWithTime(event, () -> Date.from(clock.instant()))
+                        .withClientId(clientId)
+                        .withComponentId(
+                                configurationService.getOidcApiBaseURL().orElse("UNKNOWN"));
+
+        txmaQueueClient.send(txmaAuditEvent.serialize());
     }
 
     String generateLogLine(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
@@ -101,6 +101,9 @@ public class AuditService {
                         .withComponentId(configurationService.getOidcApiBaseURL().orElse("UNKNOWN"))
                         .withUser(user);
 
+        Arrays.stream(metadataPairs)
+                .forEach(pair -> txmaAuditEvent.addExtension(pair.getKey(), pair.getValue()));
+
         txmaQueueClient.send(txmaAuditEvent.serialize());
     }
 

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
@@ -122,6 +122,17 @@ class AuditServiceTest {
         assertThat(txmaMessage, hasNumericFieldWithValue("timestamp", equalTo(1630534200L)));
         assertThat(txmaMessage, hasFieldWithValue("client_id", equalTo("client-id")));
         assertThat(txmaMessage, hasFieldWithValue("component_id", equalTo("oidc-base-url")));
+
+        var userObject = txmaMessage.getAsJsonObject().get("user").getAsJsonObject();
+
+        assertThat(userObject, hasFieldWithValue("session_id", equalTo("session-id")));
+        assertThat(
+                userObject,
+                hasFieldWithValue("persistent_session_id", equalTo("persistent-session-id")));
+        assertThat(userObject, hasFieldWithValue("user_id", equalTo("subject-id")));
+        assertThat(userObject, hasFieldWithValue("email", equalTo("email")));
+        assertThat(userObject, hasFieldWithValue("phone", equalTo("phone-number")));
+        assertThat(userObject, hasFieldWithValue("ip_address", equalTo("ip-address")));
     }
 
     @Test

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
@@ -206,5 +206,10 @@ class AuditServiceTest {
 
         assertThat(txmaMessage, hasFieldWithValue("event_name", equalTo("AUTH_TEST_EVENT_ONE")));
         assertThat(txmaMessage, hasNumericFieldWithValue("timestamp", equalTo(1630534200L)));
+
+        var extensions = txmaMessage.getAsJsonObject().get("extensions").getAsJsonObject();
+
+        assertThat(extensions, hasFieldWithValue("key", equalTo("value")));
+        assertThat(extensions, hasFieldWithValue("key2", equalTo("value2")));
     }
 }


### PR DESCRIPTION
- AUT-584: Use `JsonMatcher` for testing TxMA payloads
- AUT-584: Add client id and component id to top level audit payload
- AUT-584: Add user fields to TxMA payload
- AUT-584: Add extensions to TxMA payload
