### PR TITLE
AUT-584: Migrate other OIDC handlers to TxMA

### DIFF
--- a/ci/terraform/oidc/update.tf
+++ b/ci/terraform/oidc/update.tf
@@ -9,6 +9,7 @@ module "client_update_role" {
     aws_iam_policy.dynamo_client_registry_write_access_policy.arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
+    module.oidc_txma_audit.access_policy_arn
   ]
 }
 
@@ -25,6 +26,8 @@ module "update" {
   handler_environment_variables = {
     ENVIRONMENT             = var.environment
     DYNAMO_ENDPOINT         = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    TXMA_AUDIT_ENABLED      = contains(["staging"], var.environment)
+    TXMA_AUDIT_QUEUE_URL    = module.oidc_txma_audit.queue_url
     EVENTS_SNS_TOPIC_ARN    = aws_sns_topic.events.arn
     AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null

--- a/ci/terraform/oidc/update_profile.tf
+++ b/ci/terraform/oidc/update_profile.tf
@@ -11,6 +11,7 @@ module "frontend_api_update_profile_role" {
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
+    module.oidc_txma_audit.access_policy_arn
   ]
 }
 
@@ -25,6 +26,8 @@ module "update_profile" {
   handler_environment_variables = {
     ENVIRONMENT              = var.environment
     EVENTS_SNS_TOPIC_ARN     = aws_sns_topic.events.arn
+    TXMA_AUDIT_ENABLED       = contains(["staging"], var.environment)
+    TXMA_AUDIT_QUEUE_URL     = module.oidc_txma_audit.queue_url
     AUDIT_SIGNING_KEY_ALIAS  = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT      = var.use_localstack ? var.localstack_endpoint : null
     REDIS_KEY                = local.redis_key

--- a/ci/terraform/oidc/userexists.tf
+++ b/ci/terraform/oidc/userexists.tf
@@ -10,6 +10,7 @@ module "frontend_api_user_exists_role" {
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
+    module.oidc_txma_audit.access_policy_arn
   ]
 }
 
@@ -23,6 +24,8 @@ module "userexists" {
 
   handler_environment_variables = {
     ENVIRONMENT              = var.environment
+    TXMA_AUDIT_ENABLED       = contains(["staging"], var.environment)
+    TXMA_AUDIT_QUEUE_URL     = module.oidc_txma_audit.queue_url
     EVENTS_SNS_TOPIC_ARN     = aws_sns_topic.events.arn
     AUDIT_SIGNING_KEY_ALIAS  = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT      = var.use_localstack ? var.localstack_endpoint : null

--- a/ci/terraform/oidc/verify_code.tf
+++ b/ci/terraform/oidc/verify_code.tf
@@ -11,6 +11,7 @@ module "frontend_api_verify_code_role" {
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
+    module.oidc_txma_audit.access_policy_arn
   ]
 }
 
@@ -26,6 +27,8 @@ module "verify_code" {
     ENVIRONMENT                         = var.environment
     BLOCKED_EMAIL_DURATION              = var.blocked_email_duration
     EVENTS_SNS_TOPIC_ARN                = aws_sns_topic.events.arn
+    TXMA_AUDIT_ENABLED                  = contains(["staging"], var.environment)
+    TXMA_AUDIT_QUEUE_URL                = module.oidc_txma_audit.queue_url
     AUDIT_SIGNING_KEY_ALIAS             = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT                 = var.use_localstack ? var.localstack_endpoint : null
     REDIS_KEY                           = local.redis_key

--- a/ci/terraform/oidc/verify_mfa_code.tf
+++ b/ci/terraform/oidc/verify_mfa_code.tf
@@ -11,6 +11,7 @@ module "frontend_api_verify_mfa_code_role" {
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
+    module.oidc_txma_audit.access_policy_arn
   ]
 }
 
@@ -26,6 +27,8 @@ module "verify_mfa_code" {
     ENVIRONMENT                         = var.environment
     BLOCKED_EMAIL_DURATION              = var.blocked_email_duration
     EVENTS_SNS_TOPIC_ARN                = aws_sns_topic.events.arn
+    TXMA_AUDIT_ENABLED                  = contains(["staging"], var.environment)
+    TXMA_AUDIT_QUEUE_URL                = module.oidc_txma_audit.queue_url
     AUDIT_SIGNING_KEY_ALIAS             = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT                 = var.use_localstack ? var.localstack_endpoint : null
     REDIS_KEY                           = local.redis_key

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateClientConfigIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateClientConfigIntegrationTest.java
@@ -18,7 +18,7 @@ import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static uk.gov.di.authentication.clientregistry.domain.ClientRegistryAuditableEvent.UPDATE_CLIENT_REQUEST_RECEIVED;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceived;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class UpdateClientConfigIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -29,7 +29,8 @@ public class UpdateClientConfigIntegrationTest extends ApiGatewayHandlerIntegrat
 
     @BeforeEach
     void setup() {
-        handler = new UpdateClientConfigHandler(TEST_CONFIGURATION_SERVICE);
+        handler = new UpdateClientConfigHandler(TXMA_ENABLED_CONFIGURATION_SERVICE);
+        txmaAuditQueue.clear();
     }
 
     @Test
@@ -64,7 +65,8 @@ public class UpdateClientConfigIntegrationTest extends ApiGatewayHandlerIntegrat
         assertThat(clientResponse.getClientName(), equalTo("new-client-name"));
         assertThat(clientResponse.getClientId(), equalTo(CLIENT_ID));
 
-        assertEventTypesReceived(auditTopic, List.of(UPDATE_CLIENT_REQUEST_RECEIVED));
+        assertEventTypesReceivedByBothServices(
+                auditTopic, txmaAuditQueue, List.of(UPDATE_CLIENT_REQUEST_RECEIVED));
     }
 
     @Test
@@ -84,8 +86,9 @@ public class UpdateClientConfigIntegrationTest extends ApiGatewayHandlerIntegrat
                 response.getBody(),
                 equalTo(OAuth2Error.INVALID_CLIENT.toJSONObject().toJSONString()));
 
-        assertEventTypesReceived(
+        assertEventTypesReceivedByBothServices(
                 auditTopic,
+                txmaAuditQueue,
                 List.of(UPDATE_CLIENT_REQUEST_RECEIVED, UPDATE_CLIENT_REQUEST_RECEIVED));
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateProfileIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateProfileIntegrationTest.java
@@ -38,7 +38,7 @@ import static uk.gov.di.authentication.frontendapi.entity.UpdateProfileType.ADD_
 import static uk.gov.di.authentication.frontendapi.entity.UpdateProfileType.CAPTURE_CONSENT;
 import static uk.gov.di.authentication.frontendapi.entity.UpdateProfileType.REGISTER_AUTH_APP;
 import static uk.gov.di.authentication.frontendapi.entity.UpdateProfileType.UPDATE_TERMS_CONDS;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceived;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class UpdateProfileIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -48,7 +48,8 @@ public class UpdateProfileIntegrationTest extends ApiGatewayHandlerIntegrationTe
 
     @BeforeEach
     void setup() {
-        handler = new UpdateProfileHandler(TEST_CONFIGURATION_SERVICE);
+        handler = new UpdateProfileHandler(TXMA_ENABLED_CONFIGURATION_SERVICE);
+        txmaAuditQueue.clear();
     }
 
     private static Stream<String> phoneNumbers() {
@@ -81,8 +82,9 @@ public class UpdateProfileIntegrationTest extends ApiGatewayHandlerIntegrationTe
 
         assertThat(response, hasStatus(204));
 
-        assertEventTypesReceived(
+        assertEventTypesReceivedByBothServices(
                 auditTopic,
+                txmaAuditQueue,
                 List.of(UPDATE_PROFILE_REQUEST_RECEIVED, UPDATE_PROFILE_REQUEST_RECEIVED));
     }
 
@@ -113,8 +115,9 @@ public class UpdateProfileIntegrationTest extends ApiGatewayHandlerIntegrationTe
         assertTrue(consent.get().getClaims().containsAll(OIDCScopeValue.OPENID.getClaimNames()));
         assertTrue(consent.get().getClaims().containsAll(OIDCScopeValue.EMAIL.getClaimNames()));
 
-        assertEventTypesReceived(
+        assertEventTypesReceivedByBothServices(
                 auditTopic,
+                txmaAuditQueue,
                 List.of(UPDATE_PROFILE_REQUEST_RECEIVED, UPDATE_PROFILE_REQUEST_RECEIVED));
     }
 
@@ -135,8 +138,9 @@ public class UpdateProfileIntegrationTest extends ApiGatewayHandlerIntegrationTe
                         Map.of());
 
         assertThat(response, hasStatus(204));
-        assertEventTypesReceived(
+        assertEventTypesReceivedByBothServices(
                 auditTopic,
+                txmaAuditQueue,
                 List.of(UPDATE_PROFILE_REQUEST_RECEIVED, UPDATE_PROFILE_REQUEST_RECEIVED));
     }
 
@@ -162,8 +166,9 @@ public class UpdateProfileIntegrationTest extends ApiGatewayHandlerIntegrationTe
         assertThat(mfaMethod.get(0).getCredentialValue(), equalTo(authAppSecret));
         assertThat(mfaMethod.get(0).isMethodVerified(), equalTo(false));
         assertThat(mfaMethod.get(0).isEnabled(), equalTo(true));
-        assertEventTypesReceived(
+        assertEventTypesReceivedByBothServices(
                 auditTopic,
+                txmaAuditQueue,
                 List.of(UPDATE_PROFILE_REQUEST_RECEIVED, UPDATE_PROFILE_REQUEST_RECEIVED));
     }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
@@ -56,10 +56,8 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static uk.gov.di.authentication.oidc.domain.OidcAuditableEvent.USER_INFO_RETURNED;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceived;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertNoAuditEventsReceived;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertNoTxmaAuditEventsReceived;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertNoAuditEventsReceivedByEitherService;
 import static uk.gov.di.authentication.sharedtest.helper.IdentityTestData.ADDRESS_CLAIM;
 import static uk.gov.di.authentication.sharedtest.helper.IdentityTestData.PASSPORT_CLAIM;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
@@ -156,8 +154,8 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(userInfoResponse.getSubject(), equalTo(PUBLIC_SUBJECT));
         assertThat(userInfoResponse.toJWTClaimsSet().getClaims().size(), equalTo(5));
 
-        assertEventTypesReceived(auditTopic, singletonList(USER_INFO_RETURNED));
-        assertTxmaAuditEventsReceived(txmaAuditQueue, singletonList("AUTH_USER_INFO_RETURNED"));
+        assertEventTypesReceivedByBothServices(
+                auditTopic, txmaAuditQueue, singletonList(USER_INFO_RETURNED));
     }
 
     @Test
@@ -174,8 +172,7 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                                 .getHeaderMap()
                                 .get("WWW-Authenticate")));
 
-        assertNoAuditEventsReceived(auditTopic);
-        assertNoTxmaAuditEventsReceived(txmaAuditQueue);
+        assertNoAuditEventsReceivedByEitherService(auditTopic, txmaAuditQueue);
     }
 
     @Test
@@ -210,8 +207,8 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 equalTo(signedCredential.serialize()));
         assertThat(userInfoResponse.toJWTClaimsSet().getClaims().size(), equalTo(8));
 
-        assertEventTypesReceived(auditTopic, singletonList(USER_INFO_RETURNED));
-        assertTxmaAuditEventsReceived(txmaAuditQueue, singletonList("AUTH_USER_INFO_RETURNED"));
+        assertEventTypesReceivedByBothServices(
+                auditTopic, txmaAuditQueue, singletonList(USER_INFO_RETURNED));
     }
 
     @Test
@@ -240,8 +237,8 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertNull(userInfoResponse.getClaim(ValidClaims.PASSPORT.getValue()));
         assertNull(userInfoResponse.getClaim(ValidClaims.CORE_IDENTITY_JWT.getValue()));
 
-        assertEventTypesReceived(auditTopic, singletonList(USER_INFO_RETURNED));
-        assertTxmaAuditEventsReceived(txmaAuditQueue, singletonList("AUTH_USER_INFO_RETURNED"));
+        assertEventTypesReceivedByBothServices(
+                auditTopic, txmaAuditQueue, singletonList(USER_INFO_RETURNED));
     }
 
     @Test
@@ -262,8 +259,8 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertNull(userInfoResponse.getClaim(ValidClaims.PASSPORT.getValue()));
         assertNull(userInfoResponse.getClaim(ValidClaims.CORE_IDENTITY_JWT.getValue()));
 
-        assertEventTypesReceived(auditTopic, singletonList(USER_INFO_RETURNED));
-        assertTxmaAuditEventsReceived(txmaAuditQueue, singletonList("AUTH_USER_INFO_RETURNED"));
+        assertEventTypesReceivedByBothServices(
+                auditTopic, txmaAuditQueue, singletonList(USER_INFO_RETURNED));
     }
 
     @Test
@@ -284,8 +281,8 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(userInfoResponse.getSubject(), equalTo(DOC_APP_PUBLIC_SUBJECT));
         assertThat(userInfoResponse.toJWTClaimsSet().getClaims().size(), equalTo(2));
 
-        assertEventTypesReceived(auditTopic, singletonList(USER_INFO_RETURNED));
-        assertTxmaAuditEventsReceived(txmaAuditQueue, singletonList("AUTH_USER_INFO_RETURNED"));
+        assertEventTypesReceivedByBothServices(
+                auditTopic, txmaAuditQueue, singletonList(USER_INFO_RETURNED));
     }
 
     @Test
@@ -300,8 +297,7 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 this::makeDocAppUserinfoRequest,
                 "Expected to throw exception");
 
-        assertNoAuditEventsReceived(auditTopic);
-        assertNoTxmaAuditEventsReceived(txmaAuditQueue);
+        assertNoAuditEventsReceivedByEitherService(auditTopic, txmaAuditQueue);
     }
 
     @Test
@@ -313,8 +309,7 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 this::makeDocAppUserinfoRequest,
                 "Expected to throw exception");
 
-        assertNoAuditEventsReceived(auditTopic);
-        assertNoTxmaAuditEventsReceived(txmaAuditQueue);
+        assertNoAuditEventsReceivedByEitherService(auditTopic, txmaAuditQueue);
     }
 
     public static SignedJWT generateSignedJWT(JWTClaimsSet jwtClaimsSet, KeyPair keyPair)

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
@@ -34,8 +34,8 @@ import static org.hamcrest.Matchers.equalTo;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.CODE_VERIFIED;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.INVALID_CODE_SENT;
 import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_EMAIL;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceived;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertNoAuditEventsReceived;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertNoAuditEventsReceivedByEitherService;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
@@ -48,7 +48,8 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
 
     @BeforeEach
     void setup() {
-        handler = new VerifyCodeHandler(TEST_CONFIGURATION_SERVICE);
+        handler = new VerifyCodeHandler(TXMA_ENABLED_CONFIGURATION_SERVICE);
+        txmaAuditQueue.clear();
     }
 
     @Test
@@ -65,7 +66,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
                         Map.of());
         assertThat(response, hasStatus(204));
 
-        assertEventTypesReceived(auditTopic, List.of(CODE_VERIFIED));
+        assertEventTypesReceivedByBothServices(auditTopic, txmaAuditQueue, List.of(CODE_VERIFIED));
     }
 
     @Test
@@ -87,7 +88,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
 
         assertThat(response, hasStatus(204));
         assertThat(redis.getMfaCodeAttemptsCount(EMAIL_ADDRESS), equalTo(0));
-        assertEventTypesReceived(auditTopic, List.of(CODE_VERIFIED));
+        assertEventTypesReceivedByBothServices(auditTopic, txmaAuditQueue, List.of(CODE_VERIFIED));
     }
 
     @Test
@@ -110,7 +111,8 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         assertThat(response, hasStatus(400));
         assertThat(response, hasJsonBody(ErrorResponse.ERROR_1036));
 
-        assertEventTypesReceived(auditTopic, List.of(INVALID_CODE_SENT));
+        assertEventTypesReceivedByBothServices(
+                auditTopic, txmaAuditQueue, List.of(INVALID_CODE_SENT));
     }
 
     @Test
@@ -138,7 +140,8 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         assertThat(response2, hasStatus(400));
         assertThat(response2, hasJsonBody(ErrorResponse.ERROR_1036));
 
-        assertEventTypesReceived(auditTopic, List.of(CODE_VERIFIED, INVALID_CODE_SENT));
+        assertEventTypesReceivedByBothServices(
+                auditTopic, txmaAuditQueue, List.of(CODE_VERIFIED, INVALID_CODE_SENT));
     }
 
     @Test
@@ -162,7 +165,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
                         Map.of());
 
         assertThat(response, hasStatus(204));
-        assertEventTypesReceived(auditTopic, List.of(CODE_VERIFIED));
+        assertEventTypesReceivedByBothServices(auditTopic, txmaAuditQueue, List.of(CODE_VERIFIED));
     }
 
     @Test
@@ -191,7 +194,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
 
         assertThat(response, hasStatus(204));
         assertThat(redis.getMfaCodeAttemptsCount(EMAIL_ADDRESS), equalTo(0));
-        assertEventTypesReceived(auditTopic, List.of(CODE_VERIFIED));
+        assertEventTypesReceivedByBothServices(auditTopic, txmaAuditQueue, List.of(CODE_VERIFIED));
     }
 
     @Test
@@ -215,7 +218,8 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         assertThat(response, hasStatus(400));
         assertThat(response, hasJsonBody(ErrorResponse.ERROR_1037));
 
-        assertEventTypesReceived(auditTopic, List.of(INVALID_CODE_SENT));
+        assertEventTypesReceivedByBothServices(
+                auditTopic, txmaAuditQueue, List.of(INVALID_CODE_SENT));
     }
 
     @Test
@@ -234,7 +238,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         assertThat(response, hasStatus(400));
         assertThat(response, hasJsonBody(ErrorResponse.ERROR_1034));
 
-        assertNoAuditEventsReceived(auditTopic);
+        assertNoAuditEventsReceivedByEitherService(auditTopic, txmaAuditQueue);
     }
 
     @Test
@@ -252,7 +256,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         assertThat(response, hasStatus(400));
         assertThat(response, hasJsonBody(ErrorResponse.ERROR_1033));
 
-        assertNoAuditEventsReceived(auditTopic);
+        assertNoAuditEventsReceivedByEitherService(auditTopic, txmaAuditQueue);
     }
 
     @Test
@@ -281,7 +285,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
                         Map.of());
 
         assertThat(response, hasStatus(204));
-        assertEventTypesReceived(auditTopic, List.of(CODE_VERIFIED));
+        assertEventTypesReceivedByBothServices(auditTopic, txmaAuditQueue, List.of(CODE_VERIFIED));
     }
 
     private void setUpTestWithoutSignUp(String sessionId, Scope scope) throws Json.JsonException {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.CODE_MAX_RETRIES_REACHED;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.CODE_VERIFIED;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.INVALID_CODE_SENT;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceived;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
@@ -47,7 +47,10 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @BeforeEach
     void beforeEachSetup() {
-        handler = new VerifyMfaCodeHandler(TEST_CONFIGURATION_SERVICE);
+        handler = new VerifyMfaCodeHandler(TXMA_ENABLED_CONFIGURATION_SERVICE);
+
+        txmaAuditQueue.clear();
+
         userStore.signUp(EMAIL_ADDRESS, USER_PASSWORD);
 
         try {
@@ -73,7 +76,8 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Map.of());
         assertThat(response, hasStatus(204));
 
-        assertEventTypesReceived(auditTopic, List.of(CODE_VERIFIED));
+        assertEventTypesReceivedByBothServices(
+                auditTopic, txmaAuditQueue, singletonList(CODE_VERIFIED));
     }
 
     @Test
@@ -92,7 +96,8 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Map.of());
 
         assertThat(response, hasStatus(204));
-        assertEventTypesReceived(auditTopic, List.of(CODE_VERIFIED));
+        assertEventTypesReceivedByBothServices(
+                auditTopic, txmaAuditQueue, singletonList(CODE_VERIFIED));
     }
 
     @Test
@@ -111,7 +116,8 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Map.of());
 
         assertThat(response, hasStatus(400));
-        assertEventTypesReceived(auditTopic, List.of(INVALID_CODE_SENT));
+        assertEventTypesReceivedByBothServices(
+                auditTopic, txmaAuditQueue, singletonList(INVALID_CODE_SENT));
     }
 
     @Test
@@ -130,7 +136,8 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         assertThat(response, hasStatus(400));
         assertThat(response, hasJsonBody(ErrorResponse.ERROR_1043));
-        assertEventTypesReceived(auditTopic, List.of(INVALID_CODE_SENT));
+        assertEventTypesReceivedByBothServices(
+                auditTopic, txmaAuditQueue, singletonList(INVALID_CODE_SENT));
     }
 
     @Test
@@ -149,7 +156,8 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         assertThat(response, hasStatus(400));
         assertThat(response, hasJsonBody(ErrorResponse.ERROR_1043));
-        assertEventTypesReceived(auditTopic, List.of(INVALID_CODE_SENT));
+        assertEventTypesReceivedByBothServices(
+                auditTopic, txmaAuditQueue, singletonList(INVALID_CODE_SENT));
     }
 
     @Test
@@ -187,7 +195,8 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         assertThat(response, hasStatus(400));
         assertThat(response, hasJsonBody(ErrorResponse.ERROR_1042));
-        assertEventTypesReceived(auditTopic, List.of(CODE_MAX_RETRIES_REACHED));
+        assertEventTypesReceivedByBothServices(
+                auditTopic, txmaAuditQueue, singletonList(CODE_MAX_RETRIES_REACHED));
     }
 
     @Test

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
@@ -113,6 +113,27 @@ public abstract class HandlerIntegrationTest<Q, S> {
                     docAppPrivateKeyJwtSigner,
                     configurationParameters);
 
+    protected static final ConfigurationService TXMA_ENABLED_CONFIGURATION_SERVICE =
+            new IntegrationTestConfigurationService(
+                    auditTopic,
+                    notificationsQueue,
+                    auditSigningKey,
+                    tokenSigner,
+                    ipvPrivateKeyJwtSigner,
+                    spotQueue,
+                    docAppPrivateKeyJwtSigner,
+                    configurationParameters) {
+                @Override
+                public boolean isTxmaAuditEnabled() {
+                    return true;
+                }
+
+                @Override
+                public String getTxmaAuditQueueUrl() {
+                    return txmaAuditQueue.getQueueUrl();
+                }
+            };
+
     protected RequestHandler<Q, S> handler;
     protected final Json objectMapper = SerializationService.getInstance();
     protected final Context context = mock(Context.class);

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/SqsQueueExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/SqsQueueExtension.java
@@ -106,4 +106,8 @@ public class SqsQueueExtension extends BaseAwsResourceExtension implements Befor
                         .withMaxNumberOfMessages(numberOfMessages);
         return sqsClient.receiveMessage(request).getMessages();
     }
+
+    public void clear() {
+        sqsClient.purgeQueue(new PurgeQueueRequest().withQueueUrl(this.queueUrl));
+    }
 }


### PR DESCRIPTION
- AUT-584: Unify audit integration test matchers to make rollout easier
- AUT-584: Declare TxMA-enabled integration test configuration
- AUT-584: Allow SqsQueueExtensions to be programmatically cleared
- AUT-584: Publish TxMA events from `VerifyMfaCodeHandler`
- AUT-584: Publish TxMA events from `VerifyCodeHandler`
- AUT-584: Publish TxMA events from `UserExistsHandler`
- AUT-584: Publish TxMA events from `UpdateProfileHandler`
- AUT-584: Publish TxMA events from `UpdateClientConfigHandler`

