### PR TITLE
AUT-584: Migrate other OIDC handlers to TxMA (2)

### DIFF
--- a/ci/terraform/oidc/reset-password-request.tf
+++ b/ci/terraform/oidc/reset-password-request.tf
@@ -9,7 +9,8 @@ module "frontend_api_reset_password_request_role" {
     aws_iam_policy.dynamo_user_read_access_policy.arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
-    aws_iam_policy.redis_parameter_policy.arn
+    aws_iam_policy.redis_parameter_policy.arn,
+    module.oidc_txma_audit.access_policy_arn
   ]
 }
 
@@ -28,6 +29,8 @@ module "reset-password-request" {
     BLOCKED_EMAIL_DURATION  = var.blocked_email_duration
     SQS_ENDPOINT            = var.use_localstack ? "http://localhost:45678/" : null
     EMAIL_QUEUE_URL         = aws_sqs_queue.email_queue.id
+    TXMA_AUDIT_ENABLED      = contains(["staging"], var.environment)
+    TXMA_AUDIT_QUEUE_URL    = module.oidc_txma_audit.queue_url
     EVENTS_SNS_TOPIC_ARN    = aws_sns_topic.events.arn
     AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null

--- a/ci/terraform/oidc/reset_password.tf
+++ b/ci/terraform/oidc/reset_password.tf
@@ -12,6 +12,7 @@ module "frontend_api_reset_password_role" {
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
     aws_iam_policy.dynamo_common_passwords_read_access_policy.arn,
+    module.oidc_txma_audit.access_policy_arn
   ]
 }
 
@@ -29,6 +30,8 @@ module "reset_password" {
     EMAIL_QUEUE_URL          = aws_sqs_queue.email_queue.id
     ENVIRONMENT              = var.environment
     EVENTS_SNS_TOPIC_ARN     = aws_sns_topic.events.arn
+    TXMA_AUDIT_ENABLED       = contains(["staging"], var.environment)
+    TXMA_AUDIT_QUEUE_URL     = module.oidc_txma_audit.queue_url
     AUDIT_SIGNING_KEY_ALIAS  = local.audit_signing_key_alias_name
     REDIS_KEY                = local.redis_key
     SQS_ENDPOINT             = var.use_localstack ? "http://localhost:45678/" : null

--- a/ci/terraform/oidc/send_notification.tf
+++ b/ci/terraform/oidc/send_notification.tf
@@ -9,7 +9,8 @@ module "frontend_api_send_notification_role" {
     aws_iam_policy.dynamo_user_read_access_policy.arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
-    aws_iam_policy.redis_parameter_policy.arn
+    aws_iam_policy.redis_parameter_policy.arn,
+    module.oidc_txma_audit.access_policy_arn
   ]
 }
 
@@ -26,6 +27,8 @@ module "send_notification" {
     BLOCKED_EMAIL_DURATION  = var.blocked_email_duration
     EMAIL_QUEUE_URL         = aws_sqs_queue.email_queue.id
     EVENTS_SNS_TOPIC_ARN    = aws_sns_topic.events.arn
+    TXMA_AUDIT_ENABLED      = contains(["staging"], var.environment)
+    TXMA_AUDIT_QUEUE_URL    = module.oidc_txma_audit.queue_url
     AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
     REDIS_KEY               = local.redis_key

--- a/ci/terraform/oidc/signup.tf
+++ b/ci/terraform/oidc/signup.tf
@@ -12,6 +12,7 @@ module "frontend_api_signup_role" {
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
     aws_iam_policy.dynamo_common_passwords_read_access_policy.arn,
+    module.oidc_txma_audit.access_policy_arn
   ]
 }
 
@@ -26,6 +27,8 @@ module "signup" {
   handler_environment_variables = {
     ENVIRONMENT              = var.environment
     EVENTS_SNS_TOPIC_ARN     = aws_sns_topic.events.arn
+    TXMA_AUDIT_ENABLED       = contains(["staging"], var.environment)
+    TXMA_AUDIT_QUEUE_URL     = module.oidc_txma_audit.queue_url
     AUDIT_SIGNING_KEY_ALIAS  = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT      = var.use_localstack ? var.localstack_endpoint : null
     REDIS_KEY                = local.redis_key

--- a/ci/terraform/oidc/spot-response.tf
+++ b/ci/terraform/oidc/spot-response.tf
@@ -11,6 +11,7 @@ module "ipv_spot_response_role" {
     aws_iam_policy.spot_response_sqs_read_policy.arn,
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
+    module.oidc_txma_audit.access_policy_arn
   ]
 
   depends_on = [
@@ -94,6 +95,8 @@ resource "aws_lambda_function" "spot_response_lambda" {
       DYNAMO_ENDPOINT         = var.use_localstack ? var.lambda_dynamo_endpoint : null
       ENVIRONMENT             = var.environment
       EVENTS_SNS_TOPIC_ARN    = aws_sns_topic.events.arn
+      TXMA_AUDIT_ENABLED      = contains(["staging"], var.environment)
+      TXMA_AUDIT_QUEUE_URL    = module.oidc_txma_audit.queue_url
       FRONTEND_BASE_URL       = module.dns.frontend_url
     })
   }

--- a/ci/terraform/oidc/start.tf
+++ b/ci/terraform/oidc/start.tf
@@ -9,7 +9,8 @@ module "frontend_api_start_role" {
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
-    aws_iam_policy.dynamo_user_read_access_policy.arn
+    aws_iam_policy.dynamo_user_read_access_policy.arn,
+    module.oidc_txma_audit.access_policy_arn
   ]
 }
 
@@ -23,6 +24,8 @@ module "start" {
 
   handler_environment_variables = {
     EVENTS_SNS_TOPIC_ARN     = aws_sns_topic.events.arn
+    TXMA_AUDIT_ENABLED       = contains(["staging"], var.environment)
+    TXMA_AUDIT_QUEUE_URL     = module.oidc_txma_audit.queue_url
     AUDIT_SIGNING_KEY_ALIAS  = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT      = var.use_localstack ? var.localstack_endpoint : null
     DOC_APP_DOMAIN           = var.doc_app_domain

--- a/ci/terraform/oidc/token.tf
+++ b/ci/terraform/oidc/token.tf
@@ -11,6 +11,7 @@ module "oidc_token_role" {
     aws_iam_policy.dynamo_user_write_access_policy.arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
+    module.oidc_txma_audit.access_policy_arn
   ]
 }
 
@@ -50,6 +51,8 @@ module "token" {
     OIDC_API_BASE_URL         = local.api_base_url
     DYNAMO_ENDPOINT           = var.use_localstack ? var.lambda_dynamo_endpoint : null
     EVENTS_SNS_TOPIC_ARN      = aws_sns_topic.events.arn
+    TXMA_AUDIT_ENABLED        = contains(["staging"], var.environment)
+    TXMA_AUDIT_QUEUE_URL      = module.oidc_txma_audit.queue_url
     AUDIT_SIGNING_KEY_ALIAS   = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT       = var.use_localstack ? var.localstack_endpoint : null
     REDIS_KEY                 = local.redis_key

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordIntegrationTest.java
@@ -21,7 +21,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.PASSWORD_RESET_SUCCESSFUL;
 import static uk.gov.di.authentication.shared.entity.NotificationType.PASSWORD_RESET_CONFIRMATION;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceived;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class ResetPasswordIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -32,7 +32,8 @@ public class ResetPasswordIntegrationTest extends ApiGatewayHandlerIntegrationTe
 
     @BeforeEach
     public void setUp() {
-        handler = new ResetPasswordHandler(TEST_CONFIGURATION_SERVICE);
+        handler = new ResetPasswordHandler(TXMA_ENABLED_CONFIGURATION_SERVICE);
+        txmaAuditQueue.clear();
     }
 
     @Test
@@ -56,7 +57,8 @@ public class ResetPasswordIntegrationTest extends ApiGatewayHandlerIntegrationTe
         assertThat(requests.get(0).getDestination(), equalTo(EMAIL_ADDRESS));
         assertThat(requests.get(0).getNotificationType(), equalTo(PASSWORD_RESET_CONFIRMATION));
 
-        assertEventTypesReceived(auditTopic, List.of(PASSWORD_RESET_SUCCESSFUL));
+        assertEventTypesReceivedByBothServices(
+                auditTopic, txmaAuditQueue, List.of(PASSWORD_RESET_SUCCESSFUL));
     }
 
     @Test
@@ -80,7 +82,8 @@ public class ResetPasswordIntegrationTest extends ApiGatewayHandlerIntegrationTe
         assertThat(requests.get(0).getDestination(), equalTo(EMAIL_ADDRESS));
         assertThat(requests.get(0).getNotificationType(), equalTo(PASSWORD_RESET_CONFIRMATION));
 
-        assertEventTypesReceived(auditTopic, List.of(PASSWORD_RESET_SUCCESSFUL));
+        assertEventTypesReceivedByBothServices(
+                auditTopic, txmaAuditQueue, List.of(PASSWORD_RESET_SUCCESSFUL));
     }
 
     @Test

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordRequestIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordRequestIntegrationTest.java
@@ -8,6 +8,7 @@ import uk.gov.di.authentication.shared.entity.NotifyRequest;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -17,15 +18,17 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasLength;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.*;
 import static uk.gov.di.authentication.shared.entity.NotificationType.RESET_PASSWORD;
 import static uk.gov.di.authentication.shared.entity.NotificationType.RESET_PASSWORD_WITH_CODE;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class ResetPasswordRequestIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @BeforeEach
     public void setUp() {
-        handler = new ResetPasswordRequestHandler(TEST_CONFIGURATION_SERVICE);
+        handler = new ResetPasswordRequestHandler(TXMA_ENABLED_CONFIGURATION_SERVICE);
     }
 
     @Test
@@ -60,6 +63,9 @@ public class ResetPasswordRequestIntegrationTest extends ApiGatewayHandlerIntegr
         assertThat(resetLinkSplit.length, equalTo(4));
         assertThat(resetLinkSplit[2], equalTo(sessionId));
         assertThat(resetLinkSplit[3], equalTo(persistentSessionId));
+
+        assertEventTypesReceivedByBothServices(
+                auditTopic, txmaAuditQueue, Collections.singletonList(PASSWORD_RESET_REQUESTED));
     }
 
     @Test
@@ -88,5 +94,8 @@ public class ResetPasswordRequestIntegrationTest extends ApiGatewayHandlerIntegr
         assertThat(requests.get(0).getDestination(), equalTo(email));
         assertThat(requests.get(0).getNotificationType(), equalTo(RESET_PASSWORD_WITH_CODE));
         assertThat(requests.get(0).getCode(), hasLength(6));
+
+        assertEventTypesReceivedByBothServices(
+                auditTopic, txmaAuditQueue, Collections.singletonList(PASSWORD_RESET_REQUESTED));
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
@@ -72,7 +72,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.authentication.shared.entity.IdentityClaims.VOT;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertNoAuditEventsReceived;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertNoAuditEventsReceivedByEitherService;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
@@ -87,7 +87,8 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @BeforeEach
     void setup() {
-        handler = new TokenHandler(TEST_CONFIGURATION_SERVICE);
+        handler = new TokenHandler(TXMA_ENABLED_CONFIGURATION_SERVICE);
+        txmaAuditQueue.clear();
     }
 
     private static Stream<Arguments> validVectorValues() {
@@ -137,7 +138,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         .getClaim(VOT.getValue()),
                 equalTo(expectedVotClaim));
 
-        assertNoAuditEventsReceived(auditTopic);
+        assertNoAuditEventsReceivedByEitherService(auditTopic, txmaAuditQueue);
     }
 
     @Test
@@ -190,7 +191,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         .getSubject(),
                 equalTo(userStore.getPublicSubjectIdForEmail(TEST_EMAIL)));
 
-        assertNoAuditEventsReceived(auditTopic);
+        assertNoAuditEventsReceivedByEitherService(auditTopic, txmaAuditQueue);
     }
 
     @Test
@@ -224,7 +225,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         .getSubject(),
                 not(equalTo(userStore.getPublicSubjectIdForEmail(TEST_EMAIL))));
 
-        assertNoAuditEventsReceived(auditTopic);
+        assertNoAuditEventsReceivedByEitherService(auditTopic, txmaAuditQueue);
     }
 
     @Test
@@ -268,7 +269,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         assertTrue(jsonarray.contains("nickname"));
         assertTrue(jsonarray.contains("birthdate"));
-        assertNoAuditEventsReceived(auditTopic);
+        assertNoAuditEventsReceivedByEitherService(auditTopic, txmaAuditQueue);
     }
 
     @Test
@@ -294,7 +295,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         .getTokens()
                         .getBearerAccessToken());
 
-        assertNoAuditEventsReceived(auditTopic);
+        assertNoAuditEventsReceivedByEitherService(auditTopic, txmaAuditQueue);
     }
 
     @Test
@@ -346,7 +347,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         .getTokens()
                         .getBearerAccessToken());
 
-        assertNoAuditEventsReceived(auditTopic);
+        assertNoAuditEventsReceivedByEitherService(auditTopic, txmaAuditQueue);
     }
 
     private SignedJWT generateSignedRefreshToken(Scope scope, Subject publicSubject) {


### PR DESCRIPTION
- AUT-584: Publish TxMA events from `TokenHandler`
- AUT-584: Publish TxMA events from `StartHandler`
- AUT-584: Publish TxMA events from `SPOTResponseHandler`
- AUT-584: Publish TxMA events from `SignupHandler`
- AUT-584: Publish TxMA events from `SendNotificationHandler`
- AUT-584: Publish TxMA events from `ResetPasswordHandler`
- AUT-584: Publish TxMA events from `ResetPasswordRequestHandler`

