### PR TITLE
BAU - Downgrade logging in DocAppCallback lambda to WARN

### DIFF
--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
@@ -282,7 +282,7 @@ public class DocAppCallbackHandler
 
     private APIGatewayProxyResponseEvent generateAuthenticationErrorResponse(
             AuthenticationRequest authenticationRequest, ErrorObject errorObject) {
-        LOG.error(
+        LOG.warn(
                 "Error in Doc App AuthorisationResponse. ErrorCode: {}. ErrorDescription: {}",
                 errorObject.getCode(),
                 errorObject.getDescription());


### PR DESCRIPTION
## What?

- Downgrade logging in DocAppCallback lambda to WARN

## Why?

- These errors were previously logged as ERROR, however they occur when a user aborts a journey on the DocApp. We are currently being sent back the `invalid_request` error code which isn't correct but for now downgrade the logging so we are not alerting on something that doesn't need to be actioned.
