### PR TITLE
AUT-584: Create separate TxMA queue for account management

### DIFF
--- a/ci/tasks/deploy-acct-mgmt-api.yml
+++ b/ci/tasks/deploy-acct-mgmt-api.yml
@@ -14,6 +14,7 @@ params:
   DNS_STATE_KEY: ((dns-state-key))
   NOTIFY_API_KEY: ((build-notify-api-key))
   STATE_BUCKET: digital-identity-dev-tfstate
+  TXMA_ACCOUNT_ID: ((build-txma-account-id))
 inputs:
   - name: api-terraform-src
   - name: api-release

--- a/ci/tasks/deploy-audit-processors.yml
+++ b/ci/tasks/deploy-audit-processors.yml
@@ -42,6 +42,7 @@ run:
         -var "audit_storage_expiry_days=${AUDIT_STORE_EXPIRY_DAYS}" \
         -var "txma_obfuscation_secret_arn=${TXMA_OBFUSCATION_SECRET_ARN}" \
         -var "txma_obfuscation_secret_kms_key_arn=${TXMA_OBFUSCATION_SECRET_KMS_KEY_ARN}" \
+        -var "txma_account_id=${TXMA_ACCOUNT_ID}" \
         -var-file "${DEPLOY_ENVIRONMENT}-overrides.tfvars" \
 
       terraform output --json > ../../../../terraform-outputs/${DEPLOY_ENVIRONMENT}-terraform-outputs.json

--- a/ci/terraform/account-management/audit.tf
+++ b/ci/terraform/account-management/audit.tf
@@ -1,0 +1,6 @@
+module "oidc_txma_audit" {
+  source          = "../modules/txma-audit-queue"
+  environment     = var.environment
+  txma_account_id = var.txma_account_id
+  service_name    = "acct-mgmt"
+}

--- a/ci/terraform/account-management/outputs.tf
+++ b/ci/terraform/account-management/outputs.tf
@@ -9,3 +9,11 @@ output "api_gateway_root_id" {
 output "email_queue" {
   value = aws_sqs_queue.email_queue.id
 }
+
+output "txma_audit_queue_arn" {
+  value = module.oidc_txma_audit.queue_arn
+}
+
+output "txma_audit_key_arn" {
+  value = module.oidc_txma_audit.kms_key_arn
+}

--- a/ci/terraform/account-management/variables.tf
+++ b/ci/terraform/account-management/variables.tf
@@ -198,6 +198,11 @@ variable "scaling_trigger" {
   default = 0.7
 }
 
+variable "txma_account_id" {
+  default = ""
+  type    = string
+}
+
 locals {
   default_performance_parameters = {
     memory          = var.endpoint_memory_size

--- a/ci/terraform/modules/txma-audit-queue/key.tf
+++ b/ci/terraform/modules/txma-audit-queue/key.tf
@@ -1,5 +1,5 @@
 resource "aws_kms_key" "txma_audit_queue_encryption_key" {
-  description              = "KMS signing key for encrypting TxMA audit queue at rest"
+  description              = "KMS signing key for encrypting ${var.service_name} TxMA audit queue at rest"
   deletion_window_in_days  = 30
   customer_master_key_spec = "SYMMETRIC_DEFAULT"
   key_usage                = "ENCRYPT_DECRYPT"

--- a/ci/terraform/modules/txma-audit-queue/queue.tf
+++ b/ci/terraform/modules/txma-audit-queue/queue.tf
@@ -1,5 +1,5 @@
 resource "aws_sqs_queue" "txma_audit_queue" {
-  name                      = "${var.environment}-txma-audit-queue"
+  name                      = "${var.environment}-${var.service_name}-txma-audit-queue"
   message_retention_seconds = 1209600
 
   kms_master_key_id                 = aws_kms_key.txma_audit_queue_encryption_key.arn
@@ -14,7 +14,7 @@ resource "aws_sqs_queue" "txma_audit_queue" {
 }
 
 resource "aws_sqs_queue" "txma_audit_dead_letter_queue" {
-  name = "${var.environment}-txma-audit-dead-letter-queue"
+  name = "${var.environment}-${var.service_name}-txma-audit-dlq"
 
   kms_master_key_id                 = aws_kms_key.txma_audit_queue_encryption_key.arn
   kms_data_key_reuse_period_seconds = 300

--- a/ci/terraform/modules/txma-audit-queue/variables.tf
+++ b/ci/terraform/modules/txma-audit-queue/variables.tf
@@ -12,3 +12,8 @@ variable "txma_account_id" {
   type        = string
   description = "Account id of the corresponding TxMA processor"
 }
+
+variable "service_name" {
+  type        = string
+  description = "Name of the service that will be using these queues. Used for disambiguation"
+}

--- a/ci/terraform/oidc/audit.tf
+++ b/ci/terraform/oidc/audit.tf
@@ -2,4 +2,5 @@ module "oidc_txma_audit" {
   source          = "../modules/txma-audit-queue"
   environment     = var.environment
   txma_account_id = var.txma_account_id
+  service_name    = "oidc"
 }

--- a/ci/terraform/oidc/outputs.tf
+++ b/ci/terraform/oidc/outputs.tf
@@ -38,3 +38,11 @@ output "analytics_cookie_domain" {
 output "events_sns_topic_arn" {
   value = aws_sns_topic.events.arn
 }
+
+output "txma_audit_queue_arn" {
+  value = module.oidc_txma_audit.queue_arn
+}
+
+output "txma_audit_key_arn" {
+  value = module.oidc_txma_audit.kms_key_arn
+}


### PR DESCRIPTION
This will help us further solidify the distinction between the Account Management RP and the rest of the wider Auth component
