### PR TITLE
AUT-584: Migrate OIDC endpoints to TxMA audit (3)

### DIFF
--- a/ci/terraform/oidc/auth-code.tf
+++ b/ci/terraform/oidc/auth-code.tf
@@ -10,6 +10,7 @@ module "oidc_auth_code_role" {
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
+    module.oidc_txma_audit.access_policy_arn
   ]
 }
 
@@ -22,6 +23,8 @@ module "auth-code" {
 
   handler_environment_variables = {
     EVENTS_SNS_TOPIC_ARN     = aws_sns_topic.events.arn
+    TXMA_AUDIT_ENABLED       = contains(["staging"], var.environment)
+    TXMA_AUDIT_QUEUE_URL     = module.oidc_txma_audit.queue_url
     AUDIT_SIGNING_KEY_ALIAS  = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT      = var.use_localstack ? var.localstack_endpoint : null
     REDIS_KEY                = local.redis_key

--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -11,6 +11,7 @@ module "oidc_authorize_role" {
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.ipv_capacity_parameter_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
+    module.oidc_txma_audit.access_policy_arn
   ]
 }
 
@@ -28,6 +29,8 @@ module "authorize" {
     DOC_APP_API_ENABLED      = var.doc_app_api_enabled
     DYNAMO_ENDPOINT          = var.use_localstack ? var.lambda_dynamo_endpoint : null
     EVENTS_SNS_TOPIC_ARN     = aws_sns_topic.events.arn
+    TXMA_AUDIT_ENABLED       = contains(["staging"], var.environment)
+    TXMA_AUDIT_QUEUE_URL     = module.oidc_txma_audit.queue_url
     ENVIRONMENT              = var.environment
     HEADERS_CASE_INSENSITIVE = var.use_localstack ? "true" : "false"
     LOCALSTACK_ENDPOINT      = var.use_localstack ? var.localstack_endpoint : null

--- a/ci/terraform/oidc/doc-app-authorize.tf
+++ b/ci/terraform/oidc/doc-app-authorize.tf
@@ -10,6 +10,7 @@ module "doc_app_authorize_role" {
     aws_iam_policy.redis_parameter_policy.arn,
     aws_iam_policy.doc_app_auth_kms_policy.arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
+    module.oidc_txma_audit.access_policy_arn
   ]
 }
 
@@ -24,6 +25,8 @@ module "doc-app-authorize" {
   handler_environment_variables = {
     ENVIRONMENT                        = var.environment
     EVENTS_SNS_TOPIC_ARN               = aws_sns_topic.events.arn
+    TXMA_AUDIT_ENABLED                 = contains(["staging"], var.environment)
+    TXMA_AUDIT_QUEUE_URL               = module.oidc_txma_audit.queue_url
     AUDIT_SIGNING_KEY_ALIAS            = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT                = var.use_localstack ? var.localstack_endpoint : null
     REDIS_KEY                          = local.redis_key

--- a/ci/terraform/oidc/doc-app-callback.tf
+++ b/ci/terraform/oidc/doc-app-callback.tf
@@ -11,6 +11,7 @@ module "doc_app_callback_role" {
     aws_iam_policy.doc_app_auth_kms_policy.arn,
     aws_iam_policy.dynamo_doc_app_write_access_policy.arn,
     aws_iam_policy.dynamo_doc_app_read_access_policy.arn,
+    module.oidc_txma_audit.access_policy_arn
   ]
 }
 
@@ -25,6 +26,8 @@ module "doc-app-callback" {
   handler_environment_variables = {
     ENVIRONMENT                        = var.environment
     EVENTS_SNS_TOPIC_ARN               = aws_sns_topic.events.arn
+    TXMA_AUDIT_ENABLED                 = contains(["staging"], var.environment)
+    TXMA_AUDIT_QUEUE_URL               = module.oidc_txma_audit.queue_url
     AUDIT_SIGNING_KEY_ALIAS            = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT                = var.use_localstack ? var.localstack_endpoint : null
     LOGIN_URI                          = module.dns.frontend_url

--- a/ci/terraform/oidc/ipv-authorize.tf
+++ b/ci/terraform/oidc/ipv-authorize.tf
@@ -13,6 +13,7 @@ module "ipv_authorize_role" {
     aws_iam_policy.redis_parameter_policy.arn,
     aws_iam_policy.ipv_token_auth_kms_policy.arn,
     aws_iam_policy.ipv_public_encryption_key_parameter_policy.arn,
+    module.oidc_txma_audit.access_policy_arn
   ]
 }
 
@@ -27,6 +28,8 @@ module "ipv-authorize" {
   handler_environment_variables = {
     ENVIRONMENT                    = var.environment
     EVENTS_SNS_TOPIC_ARN           = aws_sns_topic.events.arn
+    TXMA_AUDIT_ENABLED             = contains(["staging"], var.environment)
+    TXMA_AUDIT_QUEUE_URL           = module.oidc_txma_audit.queue_url
     AUDIT_SIGNING_KEY_ALIAS        = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT            = var.use_localstack ? var.localstack_endpoint : null
     REDIS_KEY                      = local.redis_key

--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -15,6 +15,7 @@ module "ipv_callback_role" {
     aws_iam_policy.redis_parameter_policy.arn,
     aws_iam_policy.ipv_token_auth_kms_policy.arn,
     aws_iam_policy.spot_queue_encryption_policy.arn,
+    module.oidc_txma_audit.access_policy_arn
   ]
 }
 
@@ -30,6 +31,8 @@ module "ipv-callback" {
     AUDIT_SIGNING_KEY_ALIAS        = local.audit_signing_key_alias_name
     DYNAMO_ENDPOINT                = var.use_localstack ? var.lambda_dynamo_endpoint : null
     EVENTS_SNS_TOPIC_ARN           = aws_sns_topic.events.arn
+    TXMA_AUDIT_ENABLED             = contains(["staging"], var.environment)
+    TXMA_AUDIT_QUEUE_URL           = module.oidc_txma_audit.queue_url
     ENVIRONMENT                    = var.environment
     IDENTITY_ENABLED               = var.ipv_api_enabled
     IDENTITY_TRACE_LOGGING_ENABLED = var.identity_trace_logging_enabled

--- a/ci/terraform/oidc/ipv-capacity.tf
+++ b/ci/terraform/oidc/ipv-capacity.tf
@@ -8,6 +8,7 @@ module "ipv_capacity_role" {
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.ipv_capacity_parameter_policy.arn,
+    module.oidc_txma_audit.access_policy_arn
   ]
 }
 
@@ -22,6 +23,8 @@ module "ipv-capacity" {
   handler_environment_variables = {
     ENVIRONMENT                    = var.environment
     EVENTS_SNS_TOPIC_ARN           = aws_sns_topic.events.arn
+    TXMA_AUDIT_ENABLED             = contains(["staging"], var.environment)
+    TXMA_AUDIT_QUEUE_URL           = module.oidc_txma_audit.queue_url
     AUDIT_SIGNING_KEY_ALIAS        = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT            = var.use_localstack ? var.localstack_endpoint : null
     REDIS_KEY                      = local.redis_key

--- a/ci/terraform/oidc/login.tf
+++ b/ci/terraform/oidc/login.tf
@@ -12,6 +12,7 @@ module "frontend_api_login_role" {
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.pepper_parameter_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
+    module.oidc_txma_audit.access_policy_arn
   ]
 }
 
@@ -27,6 +28,8 @@ module "login" {
   handler_environment_variables = {
     ENVIRONMENT              = var.environment
     EVENTS_SNS_TOPIC_ARN     = aws_sns_topic.events.arn
+    TXMA_AUDIT_ENABLED       = contains(["staging"], var.environment)
+    TXMA_AUDIT_QUEUE_URL     = module.oidc_txma_audit.queue_url
     AUDIT_SIGNING_KEY_ALIAS  = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT      = var.use_localstack ? var.localstack_endpoint : null
     REDIS_KEY                = local.redis_key

--- a/ci/terraform/oidc/logout.tf
+++ b/ci/terraform/oidc/logout.tf
@@ -11,6 +11,7 @@ module "oidc_logout_role" {
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
+    module.oidc_txma_audit.access_policy_arn
   ]
 }
 
@@ -25,6 +26,8 @@ module "logout" {
   handler_environment_variables = {
     DEFAULT_LOGOUT_URI            = "${module.dns.frontend_url}signed-out"
     EVENTS_SNS_TOPIC_ARN          = aws_sns_topic.events.arn
+    TXMA_AUDIT_ENABLED            = contains(["staging"], var.environment)
+    TXMA_AUDIT_QUEUE_URL          = module.oidc_txma_audit.queue_url
     AUDIT_SIGNING_KEY_ALIAS       = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT           = var.use_localstack ? var.localstack_endpoint : null
     REDIS_KEY                     = local.redis_key

--- a/ci/terraform/oidc/mfa.tf
+++ b/ci/terraform/oidc/mfa.tf
@@ -9,7 +9,8 @@ module "frontend_api_mfa_role" {
     aws_iam_policy.dynamo_user_read_access_policy.arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
-    aws_iam_policy.redis_parameter_policy.arn
+    aws_iam_policy.redis_parameter_policy.arn,
+    module.oidc_txma_audit.access_policy_arn
   ]
 }
 
@@ -26,6 +27,8 @@ module "mfa" {
     BLOCKED_EMAIL_DURATION  = var.blocked_email_duration
     EMAIL_QUEUE_URL         = aws_sqs_queue.email_queue.id
     EVENTS_SNS_TOPIC_ARN    = aws_sns_topic.events.arn
+    TXMA_AUDIT_ENABLED      = contains(["staging"], var.environment)
+    TXMA_AUDIT_QUEUE_URL    = module.oidc_txma_audit.queue_url
     AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
     REDIS_KEY               = local.redis_key

--- a/ci/terraform/oidc/processing-identity.tf
+++ b/ci/terraform/oidc/processing-identity.tf
@@ -12,6 +12,7 @@ module "ipv_processing_identity_role" {
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.pepper_parameter_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
+    module.oidc_txma_audit.access_policy_arn
   ]
 }
 
@@ -27,6 +28,8 @@ module "processing-identity" {
     AUDIT_SIGNING_KEY_ALIAS  = local.audit_signing_key_alias_name
     DYNAMO_ENDPOINT          = var.use_localstack ? var.lambda_dynamo_endpoint : null
     EVENTS_SNS_TOPIC_ARN     = aws_sns_topic.events.arn
+    TXMA_AUDIT_ENABLED       = contains(["staging"], var.environment)
+    TXMA_AUDIT_QUEUE_URL     = module.oidc_txma_audit.queue_url
     ENVIRONMENT              = var.environment
     HEADERS_CASE_INSENSITIVE = var.use_localstack ? "true" : "false"
     LOCALSTACK_ENDPOINT      = var.use_localstack ? var.localstack_endpoint : null

--- a/ci/terraform/oidc/register.tf
+++ b/ci/terraform/oidc/register.tf
@@ -9,6 +9,7 @@ module "client_registry_role" {
     aws_iam_policy.dynamo_client_registry_write_access_policy.arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
+    module.oidc_txma_audit.access_policy_arn
   ]
 }
 
@@ -24,6 +25,8 @@ module "register" {
     ENVIRONMENT             = var.environment
     DYNAMO_ENDPOINT         = var.use_localstack ? var.lambda_dynamo_endpoint : null
     EVENTS_SNS_TOPIC_ARN    = aws_sns_topic.events.arn
+    TXMA_AUDIT_ENABLED      = contains(["staging"], var.environment)
+    TXMA_AUDIT_QUEUE_URL    = module.oidc_txma_audit.queue_url
     AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
   }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
@@ -29,7 +29,7 @@ import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.startsWith;
 import static uk.gov.di.authentication.oidc.domain.OidcAuditableEvent.AUTH_CODE_ISSUED;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceived;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class AuthCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -40,7 +40,8 @@ public class AuthCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @BeforeEach
     void setup() {
-        handler = new AuthCodeHandler(TEST_CONFIGURATION_SERVICE);
+        handler = new AuthCodeHandler(TXMA_ENABLED_CONFIGURATION_SERVICE);
+        txmaAuditQueue.clear();
     }
 
     @Test
@@ -70,7 +71,8 @@ public class AuthCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 startsWith(
                         "https://di-auth-stub-relying-party-build.london.cloudapps.digital/?code="));
 
-        assertEventTypesReceived(auditTopic, List.of(AUTH_CODE_ISSUED));
+        assertEventTypesReceivedByBothServices(
+                auditTopic, txmaAuditQueue, List.of(AUTH_CODE_ISSUED));
     }
 
     private AuthenticationRequest generateAuthRequest() {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -57,7 +57,7 @@ import static uk.gov.di.authentication.oidc.domain.OidcAuditableEvent.AUTHORISAT
 import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.LOW_LEVEL;
 import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.MEDIUM_LEVEL;
 import static uk.gov.di.authentication.shared.helpers.CookieHelper.getHttpCookieFromMultiValueResponseHeaders;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceived;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
 import static uk.gov.di.authentication.sharedtest.helper.JsonArrayHelper.jsonArrayOf;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
@@ -78,6 +78,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     void setup() {
         registerClient(CLIENT_ID, "test-client", singletonList("openid"), ClientType.WEB);
         handler = new AuthorisationHandler(configurationService);
+        txmaAuditQueue.clear();
     }
 
     @Test
@@ -96,8 +97,10 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         .isPresent(),
                 equalTo(true));
 
-        assertEventTypesReceived(
-                auditTopic, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
+        assertEventTypesReceivedByBothServices(
+                auditTopic,
+                txmaAuditQueue,
+                List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
     @Test
@@ -117,8 +120,10 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 equalTo(true));
         assertThat(URI.create(redirectUri).getQuery(), equalTo(null));
 
-        assertEventTypesReceived(
-                auditTopic, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
+        assertEventTypesReceivedByBothServices(
+                auditTopic,
+                txmaAuditQueue,
+                List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
     @Test
@@ -149,8 +154,10 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(persistentCookie.isPresent(), equalTo(true));
         assertThat(persistentCookie.get().getValue(), equalTo("persistent-id-value"));
 
-        assertEventTypesReceived(
-                auditTopic, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
+        assertEventTypesReceivedByBothServices(
+                auditTopic,
+                txmaAuditQueue,
+                List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
     @Test
@@ -176,8 +183,10 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         .isPresent(),
                 equalTo(true));
 
-        assertEventTypesReceived(
-                auditTopic, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
+        assertEventTypesReceivedByBothServices(
+                auditTopic,
+                txmaAuditQueue,
+                List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
     @Test
@@ -193,8 +202,10 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(redirectUri, containsString(OAuth2Error.INVALID_SCOPE.getCode()));
         assertThat(redirectUri, startsWith(RP_REDIRECT_URI));
 
-        assertEventTypesReceived(
-                auditTopic, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_REQUEST_ERROR));
+        assertEventTypesReceivedByBothServices(
+                auditTopic,
+                txmaAuditQueue,
+                List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_REQUEST_ERROR));
     }
 
     @Test
@@ -219,8 +230,10 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         .isPresent(),
                 equalTo(true));
 
-        assertEventTypesReceived(
-                auditTopic, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
+        assertEventTypesReceivedByBothServices(
+                auditTopic,
+                txmaAuditQueue,
+                List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
     @Test
@@ -246,8 +259,10 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         .isPresent(),
                 equalTo(true));
 
-        assertEventTypesReceived(
-                auditTopic, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
+        assertEventTypesReceivedByBothServices(
+                auditTopic,
+                txmaAuditQueue,
+                List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
     @Test
@@ -277,8 +292,10 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(cookie.isPresent(), equalTo(true));
         assertThat(cookie.get().getValue(), not(startsWith(sessionId)));
 
-        assertEventTypesReceived(
-                auditTopic, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
+        assertEventTypesReceivedByBothServices(
+                auditTopic,
+                txmaAuditQueue,
+                List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
     @Test
@@ -307,8 +324,10 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(cookie.isPresent(), equalTo(true));
         assertThat(cookie.get().getValue(), not(startsWith(sessionId)));
 
-        assertEventTypesReceived(
-                auditTopic, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
+        assertEventTypesReceivedByBothServices(
+                auditTopic,
+                txmaAuditQueue,
+                List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
     @Test
@@ -337,8 +356,10 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(cookie.isPresent(), equalTo(true));
         assertThat(cookie.get().getValue(), not(startsWith(sessionId)));
 
-        assertEventTypesReceived(
-                auditTopic, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
+        assertEventTypesReceivedByBothServices(
+                auditTopic,
+                txmaAuditQueue,
+                List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
     @Test
@@ -354,8 +375,10 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(redirectUri, startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
         assertThat(URI.create(redirectUri).getQuery(), equalTo(null));
 
-        assertEventTypesReceived(
-                auditTopic, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
+        assertEventTypesReceivedByBothServices(
+                auditTopic,
+                txmaAuditQueue,
+                List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
     @Test
@@ -388,8 +411,10 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 getLocationResponseHeader(response),
                 startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
 
-        assertEventTypesReceived(
-                auditTopic, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
+        assertEventTypesReceivedByBothServices(
+                auditTopic,
+                txmaAuditQueue,
+                List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
     @Test
@@ -422,8 +447,10 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(redirectUri, startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
         assertThat(URI.create(redirectUri).getQuery(), equalTo("prompt=login"));
 
-        assertEventTypesReceived(
-                auditTopic, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
+        assertEventTypesReceivedByBothServices(
+                auditTopic,
+                txmaAuditQueue,
+                List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
     @Test
@@ -456,8 +483,10 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         String redirectUri = getLocationResponseHeader(response);
         assertThat(redirectUri, startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
 
-        assertEventTypesReceived(
-                auditTopic, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
+        assertEventTypesReceivedByBothServices(
+                auditTopic,
+                txmaAuditQueue,
+                List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
     @Test
@@ -490,8 +519,10 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         String redirectUri = getLocationResponseHeader(response);
         assertThat(redirectUri, startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
 
-        assertEventTypesReceived(
-                auditTopic, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
+        assertEventTypesReceivedByBothServices(
+                auditTopic,
+                txmaAuditQueue,
+                List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
     @Test
@@ -533,8 +564,10 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var clientSession = redis.getClientSession(clientSessionID);
         var authRequest = AuthenticationRequest.parse(clientSession.getAuthRequestParams());
         assertTrue(authRequest.getScope().contains(CustomScopeValue.DOC_CHECKING_APP));
-        assertEventTypesReceived(
-                auditTopic, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
+        assertEventTypesReceivedByBothServices(
+                auditTopic,
+                txmaAuditQueue,
+                List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
     private String givenAnExistingSession(CredentialTrustLevel credentialTrustLevel)
@@ -637,6 +670,16 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                     spotQueue,
                     docAppPrivateKeyJwtSigner,
                     configurationParameters);
+        }
+
+        @Override
+        public boolean isTxmaAuditEnabled() {
+            return true;
+        }
+
+        @Override
+        public String getTxmaAuditQueueUrl() {
+            return txmaAuditQueue.getQueueUrl();
         }
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientRegistrationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientRegistrationIntegrationTest.java
@@ -25,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.authentication.clientregistry.domain.ClientRegistryAuditableEvent.REGISTER_CLIENT_REQUEST_RECEIVED;
 import static uk.gov.di.authentication.shared.entity.ServiceType.MANDATORY;
 import static uk.gov.di.authentication.shared.entity.ServiceType.OPTIONAL;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceived;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class ClientRegistrationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -35,7 +35,8 @@ public class ClientRegistrationIntegrationTest extends ApiGatewayHandlerIntegrat
 
     @BeforeEach
     void setup() {
-        handler = new ClientRegistrationHandler(TEST_CONFIGURATION_SERVICE);
+        handler = new ClientRegistrationHandler(TXMA_ENABLED_CONFIGURATION_SERVICE);
+        txmaAuditQueue.clear();
     }
 
     private static Stream<Arguments> registrationRequestParams() {
@@ -93,6 +94,7 @@ public class ClientRegistrationIntegrationTest extends ApiGatewayHandlerIntegrat
         assertThat(clientResponse.getBackChannelLogoutUri(), equalTo(backChannelLogoutUri));
         assertThat(clientResponse.getClientType(), equalTo(ClientType.WEB.getValue()));
 
-        assertEventTypesReceived(auditTopic, List.of(REGISTER_CLIENT_REQUEST_RECEIVED));
+        assertEventTypesReceivedByBothServices(
+                auditTopic, txmaAuditQueue, List.of(REGISTER_CLIENT_REQUEST_RECEIVED));
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppCallbackHandlerIntegrationTest.java
@@ -54,7 +54,7 @@ import static uk.gov.di.authentication.app.domain.DocAppAuditableEvent.DOC_APP_A
 import static uk.gov.di.authentication.app.domain.DocAppAuditableEvent.DOC_APP_SUCCESSFUL_CREDENTIAL_RESPONSE_RECEIVED;
 import static uk.gov.di.authentication.app.domain.DocAppAuditableEvent.DOC_APP_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED;
 import static uk.gov.di.authentication.app.domain.DocAppAuditableEvent.DOC_APP_UNSUCCESSFUL_CREDENTIAL_RESPONSE_RECEIVED;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceived;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 class DocAppCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -119,6 +119,7 @@ class DocAppCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
                 "pairwise",
                 true,
                 ClientType.APP);
+        txmaAuditQueue.clear();
     }
 
     @Test
@@ -137,8 +138,9 @@ class DocAppCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
                 response.getHeaders().get(ResponseHeaders.LOCATION),
                 startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
 
-        assertEventTypesReceived(
+        assertEventTypesReceivedByBothServices(
                 auditTopic,
+                txmaAuditQueue,
                 List.of(
                         DOC_APP_AUTHORISATION_RESPONSE_RECEIVED,
                         DOC_APP_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
@@ -173,8 +175,9 @@ class DocAppCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
                 startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
         assertThat(response.getHeaders().get(ResponseHeaders.LOCATION), endsWith("error"));
 
-        assertEventTypesReceived(
+        assertEventTypesReceivedByBothServices(
                 auditTopic,
+                txmaAuditQueue,
                 List.of(
                         DOC_APP_AUTHORISATION_RESPONSE_RECEIVED,
                         DOC_APP_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
@@ -200,8 +203,9 @@ class DocAppCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
                 startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
         assertThat(response.getHeaders().get(ResponseHeaders.LOCATION), endsWith("error"));
 
-        assertEventTypesReceived(
+        assertEventTypesReceivedByBothServices(
                 auditTopic,
+                txmaAuditQueue,
                 List.of(
                         DOC_APP_AUTHORISATION_RESPONSE_RECEIVED,
                         DOC_APP_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
@@ -227,8 +231,9 @@ class DocAppCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
                 startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
         assertThat(response.getHeaders().get(ResponseHeaders.LOCATION), endsWith("error"));
 
-        assertEventTypesReceived(
+        assertEventTypesReceivedByBothServices(
                 auditTopic,
+                txmaAuditQueue,
                 List.of(
                         DOC_APP_AUTHORISATION_RESPONSE_RECEIVED,
                         DOC_APP_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
@@ -313,6 +318,16 @@ class DocAppCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
         @Override
         public String getDocAppCriDataEndpoint() {
             return "/protected-resource";
+        }
+
+        @Override
+        public boolean isTxmaAuditEnabled() {
+            return true;
+        }
+
+        @Override
+        public String getTxmaAuditQueueUrl() {
+            return txmaAuditQueue.getQueueUrl();
         }
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
@@ -53,7 +53,7 @@ import static uk.gov.di.authentication.ipv.domain.IPVAuditableEvent.IPV_SUCCESSF
 import static uk.gov.di.authentication.shared.entity.IdentityClaims.VOT;
 import static uk.gov.di.authentication.shared.entity.IdentityClaims.VTM;
 import static uk.gov.di.authentication.shared.helpers.ClientSubjectHelper.calculatePairwiseIdentifier;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceived;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -80,6 +80,7 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
     void setup() {
         ipvStub.init();
         handler = new IPVCallbackHandler(configurationService);
+        txmaAuditQueue.clear();
     }
 
     @Test
@@ -119,8 +120,9 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                 response.getHeaders().get(ResponseHeaders.LOCATION),
                 startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
 
-        assertEventTypesReceived(
+        assertEventTypesReceivedByBothServices(
                 auditTopic,
+                txmaAuditQueue,
                 List.of(
                         IPV_AUTHORISATION_RESPONSE_RECEIVED,
                         IPV_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
@@ -273,6 +275,16 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
         @Override
         public boolean isIdentityEnabled() {
             return true;
+        }
+
+        @Override
+        public boolean isTxmaAuditEnabled() {
+            return true;
+        }
+
+        @Override
+        public String getTxmaAuditQueueUrl() {
+            return txmaAuditQueue.getQueueUrl();
         }
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCapacityHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCapacityHandlerIntegrationTest.java
@@ -1,0 +1,71 @@
+package uk.gov.di.authentication.api;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.ipv.lambda.IPVCapacityHandler;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.di.authentication.ipv.domain.IPVAuditableEvent.IPV_CAPACITY_REQUESTED;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
+
+class IPVCapacityHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
+
+    @Test
+    void shouldReturn503IfIpvCapacityNotEnabled() {
+        handler = new IPVCapacityHandler(capacityAwareConfiguration("0"));
+
+        var response =
+                makeRequest(Optional.empty(), Collections.emptyMap(), Collections.emptyMap());
+
+        assertThat(response, hasStatus(503));
+
+        assertEventTypesReceivedByBothServices(
+                auditTopic, txmaAuditQueue, List.of(IPV_CAPACITY_REQUESTED));
+    }
+
+    @Test
+    void shouldReturn200IfIpvCapacityEnabled() {
+        handler = new IPVCapacityHandler(capacityAwareConfiguration("1"));
+
+        var response =
+                makeRequest(Optional.empty(), Collections.emptyMap(), Collections.emptyMap());
+
+        assertThat(response, hasStatus(200));
+
+        assertEventTypesReceivedByBothServices(
+                auditTopic, txmaAuditQueue, List.of(IPV_CAPACITY_REQUESTED));
+    }
+
+    public ConfigurationService capacityAwareConfiguration(String value) {
+        return new IntegrationTestConfigurationService(
+                auditTopic,
+                notificationsQueue,
+                auditSigningKey,
+                tokenSigner,
+                ipvPrivateKeyJwtSigner,
+                spotQueue,
+                docAppPrivateKeyJwtSigner,
+                configurationParameters) {
+            @Override
+            public boolean isTxmaAuditEnabled() {
+                return true;
+            }
+
+            @Override
+            public String getTxmaAuditQueueUrl() {
+                return txmaAuditQueue.getQueueUrl();
+            }
+
+            @Override
+            public Optional<String> getIPVCapacity() {
+                return Optional.of(value);
+            }
+        };
+    }
+}

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
@@ -33,7 +33,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.hasEntry;
 import static uk.gov.di.authentication.oidc.domain.OidcAuditableEvent.LOG_OUT_SUCCESS;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceived;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.isRedirect;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.isRedirectTo;
 import static uk.gov.di.authentication.sharedtest.matchers.UriMatcher.baseUri;
@@ -50,7 +50,8 @@ public class LogoutIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @BeforeEach
     void setup() {
-        handler = new LogoutHandler(TEST_CONFIGURATION_SERVICE);
+        handler = new LogoutHandler(TXMA_ENABLED_CONFIGURATION_SERVICE);
+        txmaAuditQueue.clear();
     }
 
     @Test
@@ -78,7 +79,8 @@ public class LogoutIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                                 baseUri(URI.create(REDIRECT_URL)),
                                 redirectQueryParameters(hasEntry("state", STATE)))));
 
-        assertEventTypesReceived(auditTopic, List.of(LOG_OUT_SUCCESS));
+        assertEventTypesReceivedByBothServices(
+                auditTopic, txmaAuditQueue, List.of(LOG_OUT_SUCCESS));
     }
 
     @Test
@@ -107,7 +109,8 @@ public class LogoutIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                                 baseUri(URI.create(REDIRECT_URL)),
                                 redirectQueryParameters(hasEntry("state", STATE)))));
 
-        assertEventTypesReceived(auditTopic, List.of(LOG_OUT_SUCCESS));
+        assertEventTypesReceivedByBothServices(
+                auditTopic, txmaAuditQueue, List.of(LOG_OUT_SUCCESS));
     }
 
     @Test
@@ -129,7 +132,8 @@ public class LogoutIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                                 baseUri(TEST_CONFIGURATION_SERVICE.getDefaultLogoutURI()),
                                 redirectQueryParameters(hasEntry("state", STATE)))));
 
-        assertEventTypesReceived(auditTopic, List.of(LOG_OUT_SUCCESS));
+        assertEventTypesReceivedByBothServices(
+                auditTopic, txmaAuditQueue, List.of(LOG_OUT_SUCCESS));
     }
 
     @Test
@@ -159,7 +163,8 @@ public class LogoutIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                                 redirectQueryParameters(
                                         hasEntry("error_code", "invalid_request")))));
 
-        assertEventTypesReceived(auditTopic, List.of(LOG_OUT_SUCCESS));
+        assertEventTypesReceivedByBothServices(
+                auditTopic, txmaAuditQueue, List.of(LOG_OUT_SUCCESS));
     }
 
     private SignedJWT setupClientAndSession(String sessionId, String clientSessionId)

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ProcessingIdentityIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ProcessingIdentityIntegrationTest.java
@@ -24,6 +24,7 @@ import uk.gov.di.authentication.sharedtest.helper.SignedCredentialHelper;
 import java.net.URI;
 import java.time.LocalDateTime;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -31,8 +32,9 @@ import static java.lang.String.format;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static uk.gov.di.authentication.api.AuthorisationIntegrationTest.configurationService;
+import static uk.gov.di.authentication.ipv.domain.IPVAuditableEvent.PROCESSING_IDENTITY_REQUEST;
 import static uk.gov.di.authentication.shared.helpers.ClientSubjectHelper.calculatePairwiseIdentifier;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
@@ -49,7 +51,8 @@ public class ProcessingIdentityIntegrationTest extends ApiGatewayHandlerIntegrat
 
     @BeforeEach
     void setup() {
-        handler = new ProcessingIdentityHandler(configurationService);
+        handler = new ProcessingIdentityHandler(TXMA_ENABLED_CONFIGURATION_SERVICE);
+        txmaAuditQueue.clear();
     }
 
     @Test
@@ -78,6 +81,9 @@ public class ProcessingIdentityIntegrationTest extends ApiGatewayHandlerIntegrat
         assertThat(
                 response,
                 hasJsonBody(new ProcessingIdentityResponse(ProcessingIdentityStatus.COMPLETED)));
+
+        assertEventTypesReceivedByBothServices(
+                auditTopic, txmaAuditQueue, List.of(PROCESSING_IDENTITY_REQUEST));
     }
 
     @Test
@@ -105,6 +111,9 @@ public class ProcessingIdentityIntegrationTest extends ApiGatewayHandlerIntegrat
         assertThat(
                 response,
                 hasJsonBody(new ProcessingIdentityResponse(ProcessingIdentityStatus.PROCESSING)));
+
+        assertEventTypesReceivedByBothServices(
+                auditTopic, txmaAuditQueue, List.of(PROCESSING_IDENTITY_REQUEST));
     }
 
     @Test
@@ -129,6 +138,9 @@ public class ProcessingIdentityIntegrationTest extends ApiGatewayHandlerIntegrat
         assertThat(
                 response,
                 hasJsonBody(new ProcessingIdentityResponse(ProcessingIdentityStatus.ERROR)));
+
+        assertEventTypesReceivedByBothServices(
+                auditTopic, txmaAuditQueue, List.of(PROCESSING_IDENTITY_REQUEST));
     }
 
     @Test
@@ -153,6 +165,9 @@ public class ProcessingIdentityIntegrationTest extends ApiGatewayHandlerIntegrat
         assertThat(
                 response,
                 hasJsonBody(new ProcessingIdentityResponse(ProcessingIdentityStatus.NO_ENTRY)));
+
+        assertEventTypesReceivedByBothServices(
+                auditTopic, txmaAuditQueue, List.of(PROCESSING_IDENTITY_REQUEST));
     }
 
     private void setupSession(boolean incrementProcessIdentityAttempts) throws Json.JsonException {


### PR DESCRIPTION
- AUT-584: Publish TxMA events from `ClientRegistrationHandler`
- AUT-584: Publish TxMA events from `ProcessingIdentityHandler`
- AUT-584: Publish TxMA events from `LogoutHandler`
- AUT-584: Publish TxMA events from `LoginHandler`
- AUT-584: Publish TxMA events from `IpvCapacityHandler`
- AUT-584: Publish TxMA events from `IpvCallbackHandler`
- AUT-584: Publish TxMA events from `IpvAuthorisationHandler`
- AUT-584: Publish TxMA events from `DocAppCallbackHandler`
- AUT-584: Publish TxMA events from `DocAppAuthorizeHandler`
- AUT-584: Publish TxMA events from `AuthorisationHandler`
- AUT-584: Publish TxMA events from `AuthCodeHandler`
- AUT-584: Publish TxMA events from `MfaHandler`
