### PR TITLE
AUT-584: Migrate account management audit to TxMA

### DIFF
--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/AuthenticateIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/AuthenticateIntegrationTest.java
@@ -12,15 +12,16 @@ import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.ACCOUNT_MANAGEMENT_AUTHENTICATE;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceived;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertNoAuditEventsReceived;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertNoAuditEventsReceivedByEitherService;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class AuthenticateIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @BeforeEach
     void setup() {
-        handler = new AuthenticateHandler(TEST_CONFIGURATION_SERVICE);
+        handler = new AuthenticateHandler(TXMA_ENABLED_CONFIGURATION_SERVICE);
+        txmaAuditQueue.clear();
     }
 
     @Test
@@ -35,7 +36,8 @@ public class AuthenticateIntegrationTest extends ApiGatewayHandlerIntegrationTes
 
         assertThat(response, hasStatus(204));
 
-        assertEventTypesReceived(auditTopic, List.of(ACCOUNT_MANAGEMENT_AUTHENTICATE));
+        assertEventTypesReceivedByBothServices(
+                auditTopic, txmaAuditQueue, List.of(ACCOUNT_MANAGEMENT_AUTHENTICATE));
     }
 
     @Test
@@ -50,6 +52,6 @@ public class AuthenticateIntegrationTest extends ApiGatewayHandlerIntegrationTes
 
         assertThat(response, hasStatus(401));
 
-        assertNoAuditEventsReceived(auditTopic);
+        assertNoAuditEventsReceivedByEitherService(auditTopic, txmaAuditQueue);
     }
 }

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/RemoveAccountIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/RemoveAccountIntegrationTest.java
@@ -18,14 +18,15 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.DELETE_ACCOUNT;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceived;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class RemoveAccountIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @BeforeEach
     void setup() {
-        handler = new RemoveAccountHandler(TEST_CONFIGURATION_SERVICE);
+        handler = new RemoveAccountHandler(TXMA_ENABLED_CONFIGURATION_SERVICE);
+        txmaAuditQueue.clear();
     }
 
     @Test
@@ -47,7 +48,7 @@ public class RemoveAccountIntegrationTest extends ApiGatewayHandlerIntegrationTe
 
         assertFalse(userStore.userExists(email));
 
-        assertEventTypesReceived(auditTopic, List.of(DELETE_ACCOUNT));
+        assertEventTypesReceivedByBothServices(auditTopic, txmaAuditQueue, List.of(DELETE_ACCOUNT));
     }
 
     @Test

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/SendOtpNotificationIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/SendOtpNotificationIntegrationTest.java
@@ -21,8 +21,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.SEND_OTP;
 import static uk.gov.di.accountmanagement.entity.NotificationType.VERIFY_EMAIL;
 import static uk.gov.di.accountmanagement.entity.NotificationType.VERIFY_PHONE_NUMBER;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceived;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertNoAuditEventsReceived;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertNoAuditEventsReceivedByEitherService;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
@@ -37,7 +37,8 @@ class SendOtpNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTes
 
     @BeforeEach
     void setup() {
-        handler = new SendOtpNotificationHandler(TEST_CONFIGURATION_SERVICE);
+        handler = new SendOtpNotificationHandler(TXMA_ENABLED_CONFIGURATION_SERVICE);
+        txmaAuditQueue.clear();
     }
 
     @Test
@@ -55,7 +56,7 @@ class SendOtpNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTes
         NotificationAssertionHelper.assertNotificationsReceived(
                 notificationsQueue, List.of(new NotifyRequest(TEST_EMAIL, VERIFY_EMAIL)));
 
-        assertEventTypesReceived(auditTopic, List.of(SEND_OTP));
+        assertEventTypesReceivedByBothServices(auditTopic, txmaAuditQueue, List.of(SEND_OTP));
     }
 
     @Test
@@ -76,7 +77,7 @@ class SendOtpNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTes
 
         NotificationAssertionHelper.assertNoNotificationsReceived(notificationsQueue);
 
-        assertNoAuditEventsReceived(auditTopic);
+        assertNoAuditEventsReceivedByEitherService(auditTopic, txmaAuditQueue);
     }
 
     @Test
@@ -95,7 +96,7 @@ class SendOtpNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTes
                 notificationsQueue,
                 List.of(new NotifyRequest(TEST_PHONE_NUMBER, VERIFY_PHONE_NUMBER)));
 
-        assertEventTypesReceived(auditTopic, List.of(SEND_OTP));
+        assertEventTypesReceivedByBothServices(auditTopic, txmaAuditQueue, List.of(SEND_OTP));
     }
 
     @Test
@@ -118,7 +119,7 @@ class SendOtpNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTes
                 notificationsQueue,
                 List.of(new NotifyRequest(TEST_PHONE_NUMBER, VERIFY_PHONE_NUMBER)));
 
-        assertEventTypesReceived(auditTopic, List.of(SEND_OTP));
+        assertEventTypesReceivedByBothServices(auditTopic, txmaAuditQueue, List.of(SEND_OTP));
     }
 
     @Test
@@ -139,7 +140,7 @@ class SendOtpNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTes
 
         NotificationAssertionHelper.assertNoNotificationsReceived(notificationsQueue);
 
-        assertNoAuditEventsReceived(auditTopic);
+        assertNoAuditEventsReceivedByEitherService(auditTopic, txmaAuditQueue);
     }
 
     @Test
@@ -161,6 +162,6 @@ class SendOtpNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTes
 
         NotificationAssertionHelper.assertNoNotificationsReceived(notificationsQueue);
 
-        assertNoAuditEventsReceived(auditTopic);
+        assertNoAuditEventsReceivedByEitherService(auditTopic, txmaAuditQueue);
     }
 }

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdateEmailIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdateEmailIntegrationTest.java
@@ -22,8 +22,8 @@ import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent
 import static uk.gov.di.accountmanagement.entity.NotificationType.EMAIL_UPDATED;
 import static uk.gov.di.accountmanagement.testsupport.helpers.NotificationAssertionHelper.assertNoNotificationsReceived;
 import static uk.gov.di.accountmanagement.testsupport.helpers.NotificationAssertionHelper.assertNotificationsReceived;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceived;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertNoAuditEventsReceived;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertNoAuditEventsReceivedByEitherService;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
@@ -35,7 +35,8 @@ class UpdateEmailIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @BeforeEach
     void setup() {
-        handler = new UpdateEmailHandler(TEST_CONFIGURATION_SERVICE);
+        handler = new UpdateEmailHandler(TXMA_ENABLED_CONFIGURATION_SERVICE);
+        txmaAuditQueue.clear();
     }
 
     @Test
@@ -58,7 +59,7 @@ class UpdateEmailIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertNotificationsReceived(
                 notificationsQueue, List.of(new NotifyRequest(NEW_EMAIL_ADDRESS, EMAIL_UPDATED)));
 
-        assertEventTypesReceived(auditTopic, List.of(UPDATE_EMAIL));
+        assertEventTypesReceivedByBothServices(auditTopic, txmaAuditQueue, List.of(UPDATE_EMAIL));
     }
 
     @Test
@@ -82,7 +83,7 @@ class UpdateEmailIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         assertNoNotificationsReceived(notificationsQueue);
 
-        assertNoAuditEventsReceived(auditTopic);
+        assertNoAuditEventsReceivedByEitherService(auditTopic, txmaAuditQueue);
     }
 
     @Test
@@ -105,7 +106,7 @@ class UpdateEmailIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         assertNoNotificationsReceived(notificationsQueue);
 
-        assertNoAuditEventsReceived(auditTopic);
+        assertNoAuditEventsReceivedByEitherService(auditTopic, txmaAuditQueue);
     }
 
     @Test
@@ -129,12 +130,12 @@ class UpdateEmailIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         assertNoNotificationsReceived(notificationsQueue);
 
-        assertNoAuditEventsReceived(auditTopic);
+        assertNoAuditEventsReceivedByEitherService(auditTopic, txmaAuditQueue);
     }
 
     @Test
     void shouldThrowExceptionWhenUserAttemptsToUpdateDifferentAccount() {
-        String correctSubjectID = userStore.signUp(EXISTING_EMAIL_ADDRESS, "password-1", SUBJECT);
+        userStore.signUp(EXISTING_EMAIL_ADDRESS, "password-1", SUBJECT);
         String otherSubjectID =
                 userStore.signUp(
                         "other.user@digital.cabinet-office.gov.uk", "password-2", new Subject());

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdatePhoneNumberIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdatePhoneNumberIntegrationTest.java
@@ -27,8 +27,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.UPDATE_PHONE_NUMBER;
 import static uk.gov.di.accountmanagement.entity.NotificationType.PHONE_NUMBER_UPDATED;
 import static uk.gov.di.accountmanagement.testsupport.helpers.NotificationAssertionHelper.assertNoNotificationsReceived;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceived;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertNoAuditEventsReceived;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertNoAuditEventsReceivedByEitherService;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
@@ -44,7 +44,8 @@ class UpdatePhoneNumberIntegrationTest extends ApiGatewayHandlerIntegrationTest 
 
     @BeforeEach
     void setup() {
-        handler = new UpdatePhoneNumberHandler(TEST_CONFIGURATION_SERVICE);
+        handler = new UpdatePhoneNumberHandler(TXMA_ENABLED_CONFIGURATION_SERVICE);
+        txmaAuditQueue.clear();
     }
 
     private static Stream<String> phoneNumbers() {
@@ -90,7 +91,8 @@ class UpdatePhoneNumberIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         NotificationAssertionHelper.assertNotificationsReceived(
                 notificationsQueue, List.of(new NotifyRequest(TEST_EMAIL, PHONE_NUMBER_UPDATED)));
 
-        assertEventTypesReceived(auditTopic, List.of(UPDATE_PHONE_NUMBER));
+        assertEventTypesReceivedByBothServices(
+                auditTopic, txmaAuditQueue, List.of(UPDATE_PHONE_NUMBER));
     }
 
     @Test
@@ -113,7 +115,7 @@ class UpdatePhoneNumberIntegrationTest extends ApiGatewayHandlerIntegrationTest 
 
         assertNoNotificationsReceived(notificationsQueue);
 
-        assertNoAuditEventsReceived(auditTopic);
+        assertNoAuditEventsReceivedByEitherService(auditTopic, txmaAuditQueue);
     }
 
     @Test

--- a/ci/terraform/account-management/audit.tf
+++ b/ci/terraform/account-management/audit.tf
@@ -1,4 +1,4 @@
-module "oidc_txma_audit" {
+module "acct_mgmt_txma_audit" {
   source          = "../modules/txma-audit-queue"
   environment     = var.environment
   txma_account_id = var.txma_account_id

--- a/ci/terraform/account-management/authenticate.tf
+++ b/ci/terraform/account-management/authenticate.tf
@@ -6,7 +6,8 @@ module "account_management_api_authenticate_role" {
 
   policies_to_attach = [
     aws_iam_policy.dynamo_am_user_read_access_policy.arn,
-    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    module.acct_mgmt_txma_audit.access_policy_arn
   ]
 }
 
@@ -21,6 +22,8 @@ module "authenticate" {
     DYNAMO_ENDPOINT         = var.use_localstack ? var.lambda_dynamo_endpoint : null
     LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
     EVENTS_SNS_TOPIC_ARN    = data.aws_sns_topic.events.arn
+    TXMA_AUDIT_ENABLED      = contains(["staging"], var.environment)
+    TXMA_AUDIT_QUEUE_URL    = module.acct_mgmt_txma_audit.queue_url
     AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name
   }
   handler_function_name = "uk.gov.di.accountmanagement.lambda.AuthenticateHandler::handleRequest"

--- a/ci/terraform/account-management/outputs.tf
+++ b/ci/terraform/account-management/outputs.tf
@@ -11,9 +11,9 @@ output "email_queue" {
 }
 
 output "txma_audit_queue_arn" {
-  value = module.oidc_txma_audit.queue_arn
+  value = module.acct_mgmt_txma_audit.queue_arn
 }
 
 output "txma_audit_key_arn" {
-  value = module.oidc_txma_audit.kms_key_arn
+  value = module.acct_mgmt_txma_audit.kms_key_arn
 }

--- a/ci/terraform/account-management/remove-account.tf
+++ b/ci/terraform/account-management/remove-account.tf
@@ -7,7 +7,8 @@ module "account_management_api_remove_account_role" {
   policies_to_attach = [
     aws_iam_policy.dynamo_am_user_read_access_policy.arn,
     aws_iam_policy.dynamo_am_user_delete_access_policy.arn,
-    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    module.acct_mgmt_txma_audit.access_policy_arn
   ]
 }
 
@@ -23,6 +24,8 @@ module "delete_account" {
     LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
     EMAIL_QUEUE_URL         = aws_sqs_queue.email_queue.id
     EVENTS_SNS_TOPIC_ARN    = data.aws_sns_topic.events.arn
+    TXMA_AUDIT_ENABLED      = contains(["staging"], var.environment)
+    TXMA_AUDIT_QUEUE_URL    = module.acct_mgmt_txma_audit.queue_url
     AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name
   }
   handler_function_name = "uk.gov.di.accountmanagement.lambda.RemoveAccountHandler::handleRequest"

--- a/ci/terraform/account-management/send_otp_notification.tf
+++ b/ci/terraform/account-management/send_otp_notification.tf
@@ -7,7 +7,8 @@ module "account_management_api_send_notification_role" {
   policies_to_attach = [
     aws_iam_policy.dynamo_am_user_read_access_policy.arn,
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
-    aws_iam_policy.parameter_policy.arn
+    aws_iam_policy.parameter_policy.arn,
+    module.acct_mgmt_txma_audit.access_policy_arn
   ]
 }
 
@@ -26,6 +27,8 @@ module "send_otp_notification" {
     LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
     REDIS_KEY               = local.redis_key
     EVENTS_SNS_TOPIC_ARN    = data.aws_sns_topic.events.arn
+    TXMA_AUDIT_ENABLED      = contains(["staging"], var.environment)
+    TXMA_AUDIT_QUEUE_URL    = module.acct_mgmt_txma_audit.queue_url
     AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name
   }
   handler_function_name = "uk.gov.di.accountmanagement.lambda.SendOtpNotificationHandler::handleRequest"

--- a/ci/terraform/account-management/update-email.tf
+++ b/ci/terraform/account-management/update-email.tf
@@ -9,7 +9,8 @@ module "account_management_api_update_email_role" {
     aws_iam_policy.dynamo_am_user_write_access_policy.arn,
     aws_iam_policy.dynamo_am_user_delete_access_policy.arn,
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
-    aws_iam_policy.parameter_policy.arn
+    aws_iam_policy.parameter_policy.arn,
+    module.acct_mgmt_txma_audit.access_policy_arn
   ]
 }
 
@@ -26,6 +27,8 @@ module "update_email" {
     LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
     REDIS_KEY               = local.redis_key
     EVENTS_SNS_TOPIC_ARN    = data.aws_sns_topic.events.arn
+    TXMA_AUDIT_ENABLED      = contains(["staging"], var.environment)
+    TXMA_AUDIT_QUEUE_URL    = module.acct_mgmt_txma_audit.queue_url
     AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name
   }
   handler_function_name = "uk.gov.di.accountmanagement.lambda.UpdateEmailHandler::handleRequest"

--- a/ci/terraform/account-management/update-password.tf
+++ b/ci/terraform/account-management/update-password.tf
@@ -9,6 +9,7 @@ module "account_management_api_update_password_role" {
     aws_iam_policy.dynamo_am_user_write_access_policy.arn,
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
     aws_iam_policy.dynamo_common_passwords_read_access_policy.arn,
+    module.acct_mgmt_txma_audit.access_policy_arn
   ]
 }
 
@@ -24,6 +25,8 @@ module "update_password" {
     LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
     EMAIL_QUEUE_URL         = aws_sqs_queue.email_queue.id
     EVENTS_SNS_TOPIC_ARN    = data.aws_sns_topic.events.arn
+    TXMA_AUDIT_ENABLED      = contains(["staging"], var.environment)
+    TXMA_AUDIT_QUEUE_URL    = module.acct_mgmt_txma_audit.queue_url
     AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name
   }
   handler_function_name = "uk.gov.di.accountmanagement.lambda.UpdatePasswordHandler::handleRequest"

--- a/ci/terraform/account-management/update-phone-number.tf
+++ b/ci/terraform/account-management/update-phone-number.tf
@@ -8,7 +8,8 @@ module "account_management_api_update_phone_number_role" {
     aws_iam_policy.dynamo_am_user_read_access_policy.arn,
     aws_iam_policy.dynamo_am_user_write_access_policy.arn,
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
-    aws_iam_policy.parameter_policy.arn
+    aws_iam_policy.parameter_policy.arn,
+    module.acct_mgmt_txma_audit.access_policy_arn
   ]
 }
 
@@ -25,6 +26,8 @@ module "update_phone_number" {
     LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
     REDIS_KEY               = local.redis_key
     EVENTS_SNS_TOPIC_ARN    = data.aws_sns_topic.events.arn
+    TXMA_AUDIT_ENABLED      = contains(["staging"], var.environment)
+    TXMA_AUDIT_QUEUE_URL    = module.acct_mgmt_txma_audit.queue_url
     AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name
   }
   handler_function_name = "uk.gov.di.accountmanagement.lambda.UpdatePhoneNumberHandler::handleRequest"

--- a/ci/terraform/shared/grafana-read-only-role.tf
+++ b/ci/terraform/shared/grafana-read-only-role.tf
@@ -17,7 +17,7 @@ data "aws_iam_policy_document" "tools_account_assume_role_policy" {
 }
 
 resource "aws_iam_role" "grafana_metrics_read_only_role" {
-  count = contains(["integration", "production"], var.environment) ? 1 : 0
+  count = contains(["integration", "production", "staging"], var.environment) ? 1 : 0
   name  = "grafana-metrics-read-only"
 
   assume_role_policy = data.aws_iam_policy_document.tools_account_assume_role_policy.json


### PR DESCRIPTION
- AUT-584: Rename queue within terraform
- AUT-584: Publish TxMA events from `UpdatePhoneNumberHandler`
- AUT-584: Publish TxMA events from `UpdatePasswordHandler`
- AUT-584: Publish TxMA events from `UpdateEmailHandler`
- AUT-584: Publish TxMA events from `SendOtpNotificationHandler`
- AUT-584: Publish TxMA events from `RemoveAccountHandler`
- AUT-584: Publish TxMA events from `AuthenticateHandler`

