### PR TITLE
AUT-607-validate-otp: Implement new sms validator to validate otp cod…

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java
@@ -206,4 +206,16 @@ public class CodeStorageService {
         throw new RuntimeException(
                 String.format("No redis prefix key configured for %s", notificationType));
     }
+
+    public boolean isValidOtpCode(
+            String emailAddress, String code, NotificationType notificationType) {
+        String prefix = getPrefixForNotificationType(notificationType);
+        String codeFromRedis =
+                redisConnectionService.getValue(prefix + HashHelper.hashSha256String(emailAddress));
+        if (code.equals(codeFromRedis)) {
+            deleteOtpCode(emailAddress, notificationType);
+            return true;
+        }
+        return false;
+    }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/validation/MfaCodeValidator.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/validation/MfaCodeValidator.java
@@ -3,6 +3,7 @@ package uk.gov.di.authentication.shared.validation;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
@@ -41,4 +42,8 @@ public abstract class MfaCodeValidator {
     }
 
     public abstract Optional<ErrorResponse> validateCode(String code);
+
+    boolean isCodeValid(String code, NotificationType notificationType) {
+        return codeStorageService.isValidOtpCode(emailAddress, code, notificationType);
+    }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/validation/SMSCodeValidator.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/validation/SMSCodeValidator.java
@@ -1,0 +1,53 @@
+package uk.gov.di.authentication.shared.validation;
+
+import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.NotificationType;
+import uk.gov.di.authentication.shared.services.AuthenticationService;
+import uk.gov.di.authentication.shared.services.CodeStorageService;
+import uk.gov.di.authentication.shared.state.UserContext;
+
+import java.util.Optional;
+
+public class SMSCodeValidator extends MfaCodeValidator {
+
+    private final AuthenticationService dynamoService;
+    private final UserContext userContext;
+
+    public SMSCodeValidator(
+            UserContext userContext,
+            CodeStorageService codeStorageService,
+            AuthenticationService dynamoService,
+            int maxRetries) {
+        super(userContext, codeStorageService, maxRetries);
+        this.dynamoService = dynamoService;
+        this.userContext = userContext;
+    }
+
+    @Override
+    public Optional<ErrorResponse> validateCode(String code) {
+
+        if (isCodeBlockedForSession()) {
+            LOG.info("Code blocked for session");
+            return Optional.of(ErrorResponse.ERROR_1027);
+        }
+
+        incrementRetryCount();
+
+        if (hasExceededRetryLimit()) {
+            LOG.info("Exceeded code retry limit");
+            return Optional.of(ErrorResponse.ERROR_1027);
+        }
+
+        boolean isValidOtp = isCodeValid(code, NotificationType.VERIFY_PHONE_NUMBER);
+
+        if (!isValidOtp) {
+            LOG.info("In");
+            return Optional.of(ErrorResponse.ERROR_1035);
+        }
+
+        LOG.info("SMS code valid. Resetting code request count");
+        resetCodeRequestCount();
+
+        return Optional.empty();
+    }
+}

--- a/shared/src/test/java/uk/gov/di/authentication/shared/validation/SMSCodeValidatorTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/validation/SMSCodeValidatorTest.java
@@ -1,0 +1,101 @@
+package uk.gov.di.authentication.shared.validation;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.NotificationType;
+import uk.gov.di.authentication.shared.entity.Session;
+import uk.gov.di.authentication.shared.services.CodeStorageService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.DynamoService;
+import uk.gov.di.authentication.shared.state.UserContext;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_BLOCKED_KEY_PREFIX;
+
+public class SMSCodeValidatorTest {
+    SMSCodeValidator smsCodeValidator;
+    UserContext mockUserContext;
+    Session mockSession;
+    CodeStorageService mockCodeStorageService;
+    ConfigurationService mockConfigurationService;
+    DynamoService mockDynamoService;
+
+    private final int MAX_RETRIES = 5;
+
+    @BeforeEach
+    void setUp() {
+        this.mockUserContext = mock(UserContext.class);
+        this.mockSession = mock(Session.class);
+        this.mockCodeStorageService = mock(CodeStorageService.class);
+        this.mockConfigurationService = mock(ConfigurationService.class);
+        this.mockDynamoService = mock(DynamoService.class);
+    }
+
+    @Test
+    void returnsCorrectErrorWhenCodeBlockedForEmailAddress() {
+        setUpBlockedUser();
+
+        assertEquals(
+                Optional.of(ErrorResponse.ERROR_1027), smsCodeValidator.validateCode("any-code"));
+    }
+
+    @Test
+    void returnsCorrectErrorWhenRetryLimitExceeded() {
+        setUpRetryLimitExceededUser();
+
+        assertEquals(
+                Optional.of(ErrorResponse.ERROR_1027), smsCodeValidator.validateCode("any-code"));
+    }
+
+    @Test
+    void returnsCorrectErrorWhenOtpIsInvalid() {
+        setUpInvalidOtp();
+
+        assertEquals(
+                Optional.of(ErrorResponse.ERROR_1035), smsCodeValidator.validateCode("any-code"));
+    }
+
+    private void setUpBlockedUser() {
+        when(mockSession.getEmailAddress()).thenReturn("blocked-email-address");
+        when(mockUserContext.getSession()).thenReturn(mockSession);
+        when(mockCodeStorageService.isBlockedForEmail(
+                        "blocked-email-address", CODE_BLOCKED_KEY_PREFIX))
+                .thenReturn(true);
+
+        this.smsCodeValidator =
+                new SMSCodeValidator(
+                        mockUserContext, mockCodeStorageService, mockDynamoService, MAX_RETRIES);
+    }
+
+    private void setUpRetryLimitExceededUser() {
+        when(mockSession.getEmailAddress()).thenReturn("email-address");
+        when(mockUserContext.getSession()).thenReturn(mockSession);
+        when(mockCodeStorageService.isBlockedForEmail("email-address", CODE_BLOCKED_KEY_PREFIX))
+                .thenReturn(false);
+        when(mockCodeStorageService.getIncorrectMfaCodeAttemptsCount("email-address"))
+                .thenReturn(MAX_RETRIES + 1);
+
+        this.smsCodeValidator =
+                new SMSCodeValidator(
+                        mockUserContext, mockCodeStorageService, mockDynamoService, MAX_RETRIES);
+    }
+
+    private void setUpInvalidOtp() {
+        when(mockSession.getEmailAddress()).thenReturn("email-address");
+        when(mockUserContext.getSession()).thenReturn(mockSession);
+        when(mockCodeStorageService.isValidOtpCode(
+                        "email-address",
+                        CODE_BLOCKED_KEY_PREFIX,
+                        NotificationType.VERIFY_PHONE_NUMBER))
+                .thenReturn(false);
+
+        this.smsCodeValidator =
+                new SMSCodeValidator(
+                        mockUserContext, mockCodeStorageService, mockDynamoService, MAX_RETRIES);
+    }
+}


### PR DESCRIPTION
## What?

Create new SMS validator for validating error codes

## Why?

A new validator is required to capture error codes when user attempts to their update phone number in the accounts manager. The validator will return error codes when OTP code is blocked for session, request has been exceeded and invalid OTP code. These different error codes will the then determine the UI page/route to be displayed from the PR below.

## Related PRs

[AUT-607: Build UI pages to represent different error codes](https://github.com/alphagov/di-authentication-account-management/pull/561)