### PR TITLE
AUT-621: Store new `accountVerified` flag

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -198,7 +198,8 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                     "MFA code has been successfully verified for MFA type: {}. RegistrationJourney: {}",
                     MFAMethodType.SMS.getValue(),
                     true);
-            authenticationService.updatePhoneNumberVerifiedStatus(session.getEmailAddress(), true);
+            authenticationService.updatePhoneNumberAndAccountVerifiedStatus(
+                    session.getEmailAddress(), true);
 
             var vectorOfTrust = VectorOfTrust.getDefaults();
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -191,6 +191,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
         if (isRegistration && errorResponse.isEmpty()) {
             authenticationService.setMFAMethodVerifiedTrue(
                     session.getEmailAddress(), mfaMethodType);
+            authenticationService.setAccountVerified(session.getEmailAddress());
         }
 
         if (ErrorResponse.ERROR_1042.equals(errorResponse.orElse(null))) {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -173,7 +173,8 @@ class VerifyCodeHandlerTest {
                 makeCallWithCode(CODE, VERIFY_PHONE_NUMBER.toString());
 
         verify(codeStorageService).deleteOtpCode(TEST_EMAIL_ADDRESS, VERIFY_PHONE_NUMBER);
-        verify(authenticationService).updatePhoneNumberVerifiedStatus(TEST_EMAIL_ADDRESS, true);
+        verify(authenticationService)
+                .updatePhoneNumberAndAccountVerifiedStatus(TEST_EMAIL_ADDRESS, true);
         assertThat(result, hasStatus(204));
         assertThat(session.getCurrentCredentialStrength(), equalTo(MEDIUM_LEVEL));
         assertThat(session.getVerifiedMfaMethodType(), equalTo(MFAMethodType.SMS));
@@ -219,7 +220,7 @@ class VerifyCodeHandlerTest {
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1037));
         verify(authenticationService, never())
-                .updatePhoneNumberVerifiedStatus(TEST_EMAIL_ADDRESS, true);
+                .updatePhoneNumberAndAccountVerifiedStatus(TEST_EMAIL_ADDRESS, true);
     }
 
     @Test
@@ -267,7 +268,7 @@ class VerifyCodeHandlerTest {
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1034));
         assertThat(session.getRetryCount(), equalTo(0));
         verify(authenticationService, never())
-                .updatePhoneNumberVerifiedStatus(TEST_EMAIL_ADDRESS, true);
+                .updatePhoneNumberAndAccountVerifiedStatus(TEST_EMAIL_ADDRESS, true);
         verify(codeStorageService)
                 .saveBlockedForEmail(
                         TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX, BLOCKED_EMAIL_DURATION);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -143,6 +143,7 @@ class VerifyMfaCodeHandlerTest {
         assertThat(session.getVerifiedMfaMethodType(), equalTo(MFAMethodType.AUTH_APP));
         verify(authenticationService)
                 .setMFAMethodVerifiedTrue(TEST_EMAIL_ADDRESS, MFAMethodType.AUTH_APP);
+        verify(authenticationService).setAccountVerified(TEST_EMAIL_ADDRESS);
         verify(codeStorageService, never())
                 .saveBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX, 900L);
         verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(TEST_EMAIL_ADDRESS);
@@ -205,6 +206,7 @@ class VerifyMfaCodeHandlerTest {
         assertThat(session.getVerifiedMfaMethodType(), equalTo(null));
         verify(authenticationService, never())
                 .setMFAMethodVerifiedTrue(TEST_EMAIL_ADDRESS, MFAMethodType.AUTH_APP);
+        verify(authenticationService, never()).setAccountVerified(TEST_EMAIL_ADDRESS);
         verifyNoInteractions(auditService);
         verifyNoInteractions(authAppCodeValidator);
         verifyNoInteractions(codeStorageService);
@@ -233,6 +235,7 @@ class VerifyMfaCodeHandlerTest {
                 .saveBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX, 900L);
         verify(authenticationService, never())
                 .setMFAMethodVerifiedTrue(TEST_EMAIL_ADDRESS, MFAMethodType.AUTH_APP);
+        verify(authenticationService, never()).setAccountVerified(TEST_EMAIL_ADDRESS);
         verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(TEST_EMAIL_ADDRESS);
         verify(auditService)
                 .submitAuditEvent(
@@ -267,6 +270,7 @@ class VerifyMfaCodeHandlerTest {
                 .saveBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX, 900L);
         verify(authenticationService, never())
                 .setMFAMethodVerifiedTrue(TEST_EMAIL_ADDRESS, MFAMethodType.AUTH_APP);
+        verify(authenticationService, never()).setAccountVerified(TEST_EMAIL_ADDRESS);
         verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(TEST_EMAIL_ADDRESS);
         verify(auditService)
                 .submitAuditEvent(

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/UserStoreExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/UserStoreExtension.java
@@ -80,11 +80,11 @@ public class UserStoreExtension extends DynamoExtension implements AfterEachCall
 
     public void addPhoneNumber(String email, String phoneNumber) {
         dynamoService.updatePhoneNumber(email, phoneNumber);
-        dynamoService.updatePhoneNumberVerifiedStatus(email, true);
+        dynamoService.updatePhoneNumberAndAccountVerifiedStatus(email, true);
     }
 
     public void setPhoneNumberVerified(String email, boolean isVerified) {
-        dynamoService.updatePhoneNumberVerifiedStatus(email, isVerified);
+        dynamoService.updatePhoneNumberAndAccountVerifiedStatus(email, isVerified);
     }
 
     public List<MFAMethod> getMfaMethod(String email) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/UserProfile.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/UserProfile.java
@@ -27,6 +27,7 @@ public class UserProfile implements DynamoDBItem {
     public static final String ATTRIBUTE_PUBLIC_SUBJECT_ID = "PublicSubjectID";
     public static final String ATTRIBUTE_LEGACY_SUBJECT_ID = "LegacySubjectID";
     public static final String ATTRIBUTE_SALT = "salt";
+    public static final String ATTRIBUTE_ACCOUNT_VERIFIED = "accountVerified";
 
     private String email;
     private String subjectID;
@@ -40,6 +41,7 @@ public class UserProfile implements DynamoDBItem {
     private String publicSubjectID;
     private String legacySubjectID;
     private ByteBuffer salt;
+    private Boolean accountVerified = null;
 
     public UserProfile() {}
 
@@ -182,6 +184,16 @@ public class UserProfile implements DynamoDBItem {
         return this;
     }
 
+    @DynamoDBAttribute(attributeName = ATTRIBUTE_ACCOUNT_VERIFIED)
+    public Boolean getAccountVerified() {
+        return accountVerified;
+    }
+
+    public UserProfile setAccountVerified(Boolean accountVerified) {
+        this.accountVerified = accountVerified;
+        return this;
+    }
+
     @Override
     public Map<String, AttributeValue> toItem() {
         Map<String, AttributeValue> attributes = new HashMap<>();
@@ -214,6 +226,11 @@ public class UserProfile implements DynamoDBItem {
             attributes.put(ATTRIBUTE_LEGACY_SUBJECT_ID, new AttributeValue(getLegacySubjectID()));
         if (getSalt() != null)
             attributes.put(ATTRIBUTE_SALT, new AttributeValue().withB(getSalt()));
+        if (getAccountVerified() != null) {
+            attributes.put(
+                    ATTRIBUTE_ACCOUNT_VERIFIED,
+                    new AttributeValue().withBOOL(getAccountVerified()));
+        }
         return attributes;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthenticationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthenticationService.java
@@ -39,6 +39,8 @@ public interface AuthenticationService {
 
     void updatePhoneNumberVerifiedStatus(String email, boolean verifiedStatus);
 
+    void setAccountVerified(String email);
+
     Optional<String> getPhoneNumber(String email);
 
     UserProfile getUserProfileFromSubject(String subject);

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthenticationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthenticationService.java
@@ -37,7 +37,7 @@ public interface AuthenticationService {
 
     Optional<List<ClientConsent>> getUserConsents(String email);
 
-    void updatePhoneNumberVerifiedStatus(String email, boolean verifiedStatus);
+    void updatePhoneNumberAndAccountVerifiedStatus(String email, boolean verifiedStatus);
 
     void setAccountVerified(String email);
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
@@ -284,12 +284,12 @@ public class DynamoService implements AuthenticationService {
     }
 
     @Override
-    public void updatePhoneNumberVerifiedStatus(String email, boolean verifiedStatus) {
+    public void updatePhoneNumberAndAccountVerifiedStatus(String email, boolean verifiedStatus) {
         userProfileMapper.save(
                 userProfileMapper
                         .load(UserProfile.class, email.toLowerCase(Locale.ROOT))
                         .setPhoneNumberVerified(verifiedStatus)
-                        .setAccountVerified(true));
+                        .setAccountVerified(verifiedStatus ? true : null));
     }
 
     @Override

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
@@ -288,7 +288,8 @@ public class DynamoService implements AuthenticationService {
         userProfileMapper.save(
                 userProfileMapper
                         .load(UserProfile.class, email.toLowerCase(Locale.ROOT))
-                        .setPhoneNumberVerified(verifiedStatus));
+                        .setPhoneNumberVerified(verifiedStatus)
+                        .setAccountVerified(true));
     }
 
     @Override
@@ -366,6 +367,14 @@ public class DynamoService implements AuthenticationService {
                         .withConsistentRead(false);
 
         return getUserProfile(queryExpression);
+    }
+
+    @Override
+    public void setAccountVerified(String email) {
+        userProfileMapper.save(
+                userProfileMapper
+                        .load(UserProfile.class, email.toLowerCase(Locale.ROOT))
+                        .setAccountVerified(true));
     }
 
     private UserProfile getUserProfile(DynamoDBQueryExpression<UserProfile> queryExpression) {


### PR DESCRIPTION
## What?

- Add new, nullable, field to the userProfile table. It should hold a boolean
- The field should initially be `null` (not `false`), as such, it won't be written to Dynamo and we can use a sparse Global Secondary Index for to query a count of verified accounts.
- Set the `accountVerified` flag on UserProfile when confirming verification of either phone number of MFA method.

## Why?

We need a simple way of getting the number of verified accounts (i.e. have had both e-mail and MFA verified). This new field will be used in a Dynamo index to provide this value.

(P.R to back-fill already existing accounts to follow)

## Related PRs

#2233
