### PR TITLE
BAU - Remove usercontext from the MfaCodeValidator

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -118,7 +118,10 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
 
             var mfaCodeValidator =
                     mfaCodeValidatorFactory
-                            .getMfaCodeValidator(mfaMethodType, isRegistration, userContext)
+                            .getMfaCodeValidator(
+                                    mfaMethodType,
+                                    isRegistration,
+                                    userContext.getSession().getEmailAddress())
                             .orElse(null);
 
             if (Objects.isNull(mfaCodeValidator)) {

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuthAppStubTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuthAppStubTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
-import uk.gov.di.authentication.shared.state.UserContext;
 import uk.gov.di.authentication.shared.validation.AuthAppCodeValidator;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -20,7 +19,7 @@ class AuthAppStubTest {
         this.authAppStub = new AuthAppStub();
         this.authAppCodeValidator =
                 new AuthAppCodeValidator(
-                        mock(UserContext.class),
+                        mock(String.class),
                         mock(CodeStorageService.class),
                         mock(ConfigurationService.class),
                         mock(DynamoService.class),

--- a/shared/src/main/java/uk/gov/di/authentication/shared/validation/AuthAppCodeValidator.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/validation/AuthAppCodeValidator.java
@@ -8,7 +8,6 @@ import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
-import uk.gov.di.authentication.shared.state.UserContext;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
@@ -23,17 +22,17 @@ public class AuthAppCodeValidator extends MfaCodeValidator {
     private final int windowTime;
     private final int allowedWindows;
     private final AuthenticationService dynamoService;
-    private final UserContext userContext;
+    private final String emailAddress;
 
     public AuthAppCodeValidator(
-            UserContext userContext,
+            String emailAddress,
             CodeStorageService codeStorageService,
             ConfigurationService configurationService,
             AuthenticationService dynamoService,
             int maxRetries) {
-        super(userContext, codeStorageService, maxRetries);
+        super(emailAddress, codeStorageService, maxRetries);
         this.dynamoService = dynamoService;
-        this.userContext = userContext;
+        this.emailAddress = emailAddress;
         this.windowTime = configurationService.getAuthAppCodeWindowLength();
         this.allowedWindows = configurationService.getAuthAppCodeAllowedWindows();
     }
@@ -71,9 +70,7 @@ public class AuthAppCodeValidator extends MfaCodeValidator {
     }
 
     public Optional<String> getMfaCredentialValue() {
-        var userCredentials =
-                dynamoService.getUserCredentialsFromEmail(
-                        userContext.getSession().getEmailAddress());
+        var userCredentials = dynamoService.getUserCredentialsFromEmail(emailAddress);
 
         if (userCredentials == null) {
             LOG.info("User credentials not found");

--- a/shared/src/main/java/uk/gov/di/authentication/shared/validation/MfaCodeValidator.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/validation/MfaCodeValidator.java
@@ -4,7 +4,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
-import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.util.Optional;
 
@@ -13,12 +12,11 @@ import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_B
 public abstract class MfaCodeValidator {
     protected final Logger LOG = LogManager.getLogger(this.getClass());
     private final CodeStorageService codeStorageService;
-    private final String emailAddress;
     private final int maxRetries;
+    private final String emailAddress;
 
-    MfaCodeValidator(
-            UserContext userContext, CodeStorageService codeStorageService, int maxRetries) {
-        this.emailAddress = userContext.getSession().getEmailAddress();
+    MfaCodeValidator(String emailAddress, CodeStorageService codeStorageService, int maxRetries) {
+        this.emailAddress = emailAddress;
         this.codeStorageService = codeStorageService;
         this.maxRetries = maxRetries;
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/validation/MfaCodeValidatorFactory.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/validation/MfaCodeValidatorFactory.java
@@ -4,7 +4,6 @@ import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
-import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.util.Optional;
 
@@ -24,7 +23,7 @@ public class MfaCodeValidatorFactory {
     }
 
     public Optional<MfaCodeValidator> getMfaCodeValidator(
-            MFAMethodType mfaMethodType, boolean isRegistration, UserContext userContext) {
+            MFAMethodType mfaMethodType, boolean isRegistration, String emailAddress) {
 
         switch (mfaMethodType) {
             case AUTH_APP:
@@ -34,7 +33,7 @@ public class MfaCodeValidatorFactory {
                                 : configurationService.getCodeMaxRetries();
                 return Optional.of(
                         new AuthAppCodeValidator(
-                                userContext,
+                                emailAddress,
                                 codeStorageService,
                                 configurationService,
                                 authenticationService,

--- a/shared/src/test/java/uk/gov/di/authentication/shared/validation/AuthAppCodeValidatorTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/validation/AuthAppCodeValidatorTest.java
@@ -11,7 +11,6 @@ import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
-import uk.gov.di.authentication.shared.state.UserContext;
 import uk.gov.di.authentication.sharedtest.helper.AuthAppStub;
 
 import java.util.Collections;
@@ -25,7 +24,6 @@ import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_B
 
 class AuthAppCodeValidatorTest {
     AuthAppCodeValidator authAppCodeValidator;
-    UserContext mockUserContext;
     Session mockSession;
     CodeStorageService mockCodeStorageService;
     ConfigurationService mockConfigurationService;
@@ -35,7 +33,6 @@ class AuthAppCodeValidatorTest {
 
     @BeforeEach
     void setUp() {
-        this.mockUserContext = mock(UserContext.class);
         this.mockSession = mock(Session.class);
         this.mockCodeStorageService = mock(CodeStorageService.class);
         this.mockConfigurationService = mock(ConfigurationService.class);
@@ -93,15 +90,13 @@ class AuthAppCodeValidatorTest {
     }
 
     private void setUpBlockedUser() {
-        when(mockSession.getEmailAddress()).thenReturn("blocked-email-address");
-        when(mockUserContext.getSession()).thenReturn(mockSession);
         when(mockCodeStorageService.isBlockedForEmail(
                         "blocked-email-address", CODE_BLOCKED_KEY_PREFIX))
                 .thenReturn(true);
 
         this.authAppCodeValidator =
                 new AuthAppCodeValidator(
-                        mockUserContext,
+                        "blocked-email-address",
                         mockCodeStorageService,
                         mockConfigurationService,
                         mockDynamoService,
@@ -109,8 +104,6 @@ class AuthAppCodeValidatorTest {
     }
 
     private void setUpRetryLimitExceededUser() {
-        when(mockSession.getEmailAddress()).thenReturn("email-address");
-        when(mockUserContext.getSession()).thenReturn(mockSession);
         when(mockCodeStorageService.isBlockedForEmail("email-address", CODE_BLOCKED_KEY_PREFIX))
                 .thenReturn(false);
         when(mockCodeStorageService.getIncorrectMfaCodeAttemptsCount("email-address"))
@@ -118,7 +111,7 @@ class AuthAppCodeValidatorTest {
 
         this.authAppCodeValidator =
                 new AuthAppCodeValidator(
-                        mockUserContext,
+                        "email-address",
                         mockCodeStorageService,
                         mockConfigurationService,
                         mockDynamoService,
@@ -126,9 +119,6 @@ class AuthAppCodeValidatorTest {
     }
 
     private void setUpNoAuthCodeForUser() {
-        when(mockSession.getEmailAddress()).thenReturn("email-address");
-        when(mockSession.getRetryCount()).thenReturn(0);
-        when(mockUserContext.getSession()).thenReturn(mockSession);
         when(mockCodeStorageService.isBlockedForEmail("email-address", CODE_BLOCKED_KEY_PREFIX))
                 .thenReturn(false);
         when(mockDynamoService.getUserCredentialsFromEmail("email-address"))
@@ -136,7 +126,7 @@ class AuthAppCodeValidatorTest {
 
         this.authAppCodeValidator =
                 new AuthAppCodeValidator(
-                        mockUserContext,
+                        "email-address",
                         mockCodeStorageService,
                         mockConfigurationService,
                         mockDynamoService,
@@ -146,7 +136,6 @@ class AuthAppCodeValidatorTest {
     private void setUpValidAuthCode() {
         when(mockSession.getEmailAddress()).thenReturn("email-address");
         when(mockSession.getRetryCount()).thenReturn(0);
-        when(mockUserContext.getSession()).thenReturn(mockSession);
         when(mockCodeStorageService.isBlockedForEmail("email-address", CODE_BLOCKED_KEY_PREFIX))
                 .thenReturn(false);
         when(mockConfigurationService.getAuthAppCodeAllowedWindows()).thenReturn(9);
@@ -164,7 +153,7 @@ class AuthAppCodeValidatorTest {
 
         this.authAppCodeValidator =
                 new AuthAppCodeValidator(
-                        mockUserContext,
+                        "email-address",
                         mockCodeStorageService,
                         mockConfigurationService,
                         mockDynamoService,

--- a/shared/src/test/java/uk/gov/di/authentication/shared/validation/MfaCodeValidatorFactoryTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/validation/MfaCodeValidatorFactoryTest.java
@@ -27,7 +27,6 @@ class MfaCodeValidatorFactoryTest {
     void setUp() {
         when(configurationService.getCodeMaxRetries()).thenReturn(5);
         when(configurationService.getCodeMaxRetriesRegistration()).thenReturn(999999);
-        when(session.getEmailAddress()).thenReturn("test@test.com");
 
         when(userContext.getSession()).thenReturn(session);
     }
@@ -36,7 +35,7 @@ class MfaCodeValidatorFactoryTest {
     void whenMfaMethodGeneratesAuthAppCodeValidator() {
         var mfaCodeValidator =
                 mfaCodeValidatorFactory.getMfaCodeValidator(
-                        MFAMethodType.AUTH_APP, true, userContext);
+                        MFAMethodType.AUTH_APP, true, "test@test.com");
 
         assertInstanceOf(AuthAppCodeValidator.class, mfaCodeValidator.get());
     }


### PR DESCRIPTION
## What?
- Remove usercontext from the MfaCodeValidator

## Why?


- Currently the MfaCodeValidator is dependent on the usercontext being passed into the constructor. This restricts this class to just be used on the frontend-api as the account management api does not currently use the BaseFrontendHandler which builds the usercontext. To add the BasefrontendHandler to the account management api will require a bit of work as the account management api redis instance does not store the user session. By passing the emailaddress in the constructor removes the need to have a usercontext to use the MfaCodeValidator