### PR TITLE
BAU - Update SSM sdk to AWS SDK v2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -135,7 +135,7 @@ subprojects {
 
         sqs "software.amazon.awssdk:sqs:${dependencyVersions.aws_sdk_v2_version}"
 
-        ssm "com.amazonaws:aws-java-sdk-ssm:${dependencyVersions.aws_sdk_version}"
+        ssm "software.amazon.awssdk:ssm:${dependencyVersions.aws_sdk_v2_version}"
 
         s3 "com.amazonaws:aws-java-sdk-s3:${dependencyVersions.aws_sdk_version}"
 


### PR DESCRIPTION
## What?

 - Update SSM sdk to AWS SDK v2

## Why?

- We want to gradually move away from AWS SDK v1. This moves the SSM client over to SDK v2.

