### PR TITLE
AUT-607: Create SMS validator for updating phone number

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandler.java
@@ -12,8 +12,8 @@ import uk.gov.di.accountmanagement.entity.NotificationType;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.accountmanagement.entity.UpdatePhoneNumberRequest;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
-import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
@@ -21,11 +21,8 @@ import uk.gov.di.authentication.shared.helpers.RequestBodyHelper;
 import uk.gov.di.authentication.shared.helpers.RequestHeaderHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.serialization.Json.JsonException;
-import uk.gov.di.authentication.shared.services.AuditService;
-import uk.gov.di.authentication.shared.services.ConfigurationService;
-import uk.gov.di.authentication.shared.services.DynamoService;
-import uk.gov.di.authentication.shared.services.RedisConnectionService;
-import uk.gov.di.authentication.shared.services.SerializationService;
+import uk.gov.di.authentication.shared.services.*;
+import uk.gov.di.authentication.shared.validation.MfaCodeValidatorFactory;
 
 import java.util.Map;
 
@@ -35,6 +32,7 @@ import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.g
 import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachSessionIdToLogs;
 import static uk.gov.di.authentication.shared.helpers.WarmerHelper.isWarming;
+import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_BLOCKED_KEY_PREFIX;
 
 public class UpdatePhoneNumberHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -45,6 +43,7 @@ public class UpdatePhoneNumberHandler
     private final CodeStorageService codeStorageService;
     private static final Logger LOG = LogManager.getLogger(UpdatePhoneNumberHandler.class);
     private final AuditService auditService;
+    private MfaCodeValidatorFactory mfaCodeValidatorFactory;
 
     public UpdatePhoneNumberHandler() {
         this(ConfigurationService.getInstance());
@@ -54,11 +53,13 @@ public class UpdatePhoneNumberHandler
             DynamoService dynamoService,
             AwsSqsClient sqsClient,
             CodeStorageService codeStorageService,
-            AuditService auditService) {
+            AuditService auditService,
+            MfaCodeValidatorFactory mfaCodeValidatorFactory) {
         this.dynamoService = dynamoService;
         this.sqsClient = sqsClient;
         this.codeStorageService = codeStorageService;
         this.auditService = auditService;
+        this.mfaCodeValidatorFactory = mfaCodeValidatorFactory;
     }
 
     public UpdatePhoneNumberHandler(ConfigurationService configurationService) {
@@ -71,6 +72,9 @@ public class UpdatePhoneNumberHandler
         this.codeStorageService =
                 new CodeStorageService(new RedisConnectionService(configurationService));
         this.auditService = new AuditService(configurationService);
+        this.mfaCodeValidatorFactory =
+                new MfaCodeValidatorFactory(
+                        configurationService, codeStorageService, dynamoService);
     }
 
     @Override
@@ -95,15 +99,35 @@ public class UpdatePhoneNumberHandler
                                 UpdatePhoneNumberRequest updatePhoneNumberRequest =
                                         objectMapper.readValue(
                                                 input.getBody(), UpdatePhoneNumberRequest.class);
-                                boolean isValidOtpCode =
-                                        codeStorageService.isValidOtpCode(
-                                                updatePhoneNumberRequest.getEmail(),
-                                                updatePhoneNumberRequest.getOtp(),
-                                                NotificationType.VERIFY_PHONE_NUMBER);
-                                if (!isValidOtpCode) {
+
+                                var validator =
+                                        mfaCodeValidatorFactory.getMfaCodeValidator(
+                                                MFAMethodType.SMS,
+                                                false,
+                                                updatePhoneNumberRequest.getEmail());
+
+                                if (validator.isEmpty()) {
                                     return generateApiGatewayProxyErrorResponse(
-                                            400, ErrorResponse.ERROR_1020);
+                                            400, ErrorResponse.ERROR_1002);
                                 }
+
+                                var errorResponse =
+                                        validator
+                                                .get()
+                                                .validateCode(updatePhoneNumberRequest.getOtp());
+
+                                if (ErrorResponse.ERROR_1027.equals(errorResponse.orElse(null))) {
+                                    blockCodeForSessionAndResetCount(
+                                            updatePhoneNumberRequest.getEmail());
+                                    return generateApiGatewayProxyErrorResponse(
+                                            400, ErrorResponse.ERROR_1027);
+                                }
+
+                                if (ErrorResponse.ERROR_1035.equals(errorResponse.orElse(null))) {
+                                    return generateApiGatewayProxyErrorResponse(
+                                            400, ErrorResponse.ERROR_1035);
+                                }
+
                                 UserProfile userProfile =
                                         dynamoService.getUserProfileByEmail(
                                                 updatePhoneNumberRequest.getEmail());
@@ -143,5 +167,13 @@ public class UpdatePhoneNumberHandler
                                         400, ErrorResponse.ERROR_1001);
                             }
                         });
+    }
+
+    private void blockCodeForSessionAndResetCount(String email) {
+        codeStorageService.saveBlockedForEmail(
+                email,
+                CODE_BLOCKED_KEY_PREFIX,
+                ConfigurationService.getInstance().getBlockedEmailDuration());
+        codeStorageService.deleteIncorrectMfaCodeAttemptsCount(email);
     }
 }

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandler.java
@@ -21,7 +21,12 @@ import uk.gov.di.authentication.shared.helpers.RequestBodyHelper;
 import uk.gov.di.authentication.shared.helpers.RequestHeaderHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.serialization.Json.JsonException;
-import uk.gov.di.authentication.shared.services.*;
+import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.shared.services.CodeStorageService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.DynamoService;
+import uk.gov.di.authentication.shared.services.RedisConnectionService;
+import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.shared.validation.MfaCodeValidatorFactory;
 
 import java.util.Map;

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandlerTest.java
@@ -63,7 +63,7 @@ class UpdatePhoneNumberHandlerTest {
             new MfaCodeValidatorFactory(configurationService, codeStorageService, dynamoService);
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         when(configurationService.getCodeMaxRetries()).thenReturn(5);
         when(configurationService.getCodeMaxRetriesRegistration()).thenReturn(999999);
         handler =
@@ -76,7 +76,7 @@ class UpdatePhoneNumberHandlerTest {
     }
 
     @Test
-    public void shouldReturn204ForValidUpdatePhoneNumberRequest() throws Json.JsonException {
+    void shouldReturn204ForValidUpdatePhoneNumberRequest() throws Json.JsonException {
         String persistentIdValue = "some-persistent-session-id";
         UserProfile userProfile =
                 new UserProfile()
@@ -121,7 +121,7 @@ class UpdatePhoneNumberHandlerTest {
     }
 
     @Test
-    public void shouldReturn400WhenRequestIsMissingParameters() {
+    void shouldReturn400WhenRequestIsMissingParameters() {
         APIGatewayProxyRequestEvent.ProxyRequestContext proxyRequestContext =
                 new APIGatewayProxyRequestEvent.ProxyRequestContext();
         Map<String, Object> authorizerParams = new HashMap<>();
@@ -139,7 +139,7 @@ class UpdatePhoneNumberHandlerTest {
     }
 
     @Test
-    public void shouldReturnErrorWhenOtpCodeIsNotValid() throws Json.JsonException {
+    void shouldReturnErrorWhenOtpCodeIsNotValid() throws Json.JsonException {
         when(dynamoService.getSubjectFromEmail(EMAIL_ADDRESS)).thenReturn(SUBJECT);
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setBody(
@@ -167,7 +167,7 @@ class UpdatePhoneNumberHandlerTest {
     }
 
     @Test
-    public void shouldReturn400WhenOtpCodeEnteredTooManyTimes() throws Json.JsonException {
+    void shouldReturn400WhenOtpCodeEnteredTooManyTimes() throws Json.JsonException {
         var mfaCodeValidatorFactory = mock(MfaCodeValidatorFactory.class);
         when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), anyBoolean(), any()))
                 .thenReturn(Optional.of(smsCodeValidator));
@@ -197,8 +197,7 @@ class UpdatePhoneNumberHandlerTest {
         verify(dynamoService, times(0)).updatePhoneNumber(EMAIL_ADDRESS, INVALID_PHONE_NUMBER);
         NotifyRequest notifyRequest = new NotifyRequest(INVALID_PHONE_NUMBER, PHONE_NUMBER_UPDATED);
         verify(sqsClient, times(0)).send(objectMapper.writeValueAsString(notifyRequest));
-        String expectedResponse = objectMapper.writeValueAsString(ErrorResponse.ERROR_1027);
-        assertThat(result, hasBody(expectedResponse));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1027));
         verifyNoInteractions(auditService);
     }
 }

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdatePhoneNumberIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdatePhoneNumberIntegrationTest.java
@@ -111,7 +111,31 @@ class UpdatePhoneNumberIntegrationTest extends ApiGatewayHandlerIntegrationTest 
                         Map.of("principalId", publicSubjectID));
 
         assertThat(response, hasStatus(HttpStatus.SC_BAD_REQUEST));
-        assertThat(response, hasBody(objectMapper.writeValueAsString(ErrorResponse.ERROR_1020)));
+        assertThat(response, hasBody(objectMapper.writeValueAsString(ErrorResponse.ERROR_1035)));
+
+        assertNoNotificationsReceived(notificationsQueue);
+
+        assertNoAuditEventsReceivedByEitherService(auditTopic, txmaAuditQueue);
+    }
+
+    @Test
+    void shouldReturn400WhenOtpCodeEnteredTooManyTimes() throws Exception {
+        String publicSubjectID = userStore.signUp(TEST_EMAIL, "password-1", SUBJECT);
+        redis.generateAndSavePhoneNumberCode(TEST_EMAIL, 300);
+        redis.blockMfaCodesForEmail(TEST_EMAIL);
+        String badOtp = "This is not the correct OTP";
+
+        var response =
+                makeRequest(
+                        Optional.of(
+                                new UpdatePhoneNumberRequest(TEST_EMAIL, NEW_PHONE_NUMBER, badOtp)),
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        Map.of("principalId", publicSubjectID));
+
+        assertThat(response, hasStatus(HttpStatus.SC_BAD_REQUEST));
+        assertThat(response, hasBody(objectMapper.writeValueAsString(ErrorResponse.ERROR_1027)));
 
         assertNoNotificationsReceived(notificationsQueue);
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java
@@ -206,4 +206,16 @@ public class CodeStorageService {
         throw new RuntimeException(
                 String.format("No redis prefix key configured for %s", notificationType));
     }
+
+    public boolean isValidOtpCode(
+            String emailAddress, String code, NotificationType notificationType) {
+        String prefix = getPrefixForNotificationType(notificationType);
+        String codeFromRedis =
+                redisConnectionService.getValue(prefix + HashHelper.hashSha256String(emailAddress));
+        if (code.equals(codeFromRedis)) {
+            deleteOtpCode(emailAddress, notificationType);
+            return true;
+        }
+        return false;
+    }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/validation/MfaCodeValidator.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/validation/MfaCodeValidator.java
@@ -3,6 +3,7 @@ package uk.gov.di.authentication.shared.validation;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 
 import java.util.Optional;
@@ -39,4 +40,8 @@ public abstract class MfaCodeValidator {
     }
 
     public abstract Optional<ErrorResponse> validateCode(String code);
+
+    boolean isCodeValid(String code, NotificationType notificationType) {
+        return codeStorageService.isValidOtpCode(emailAddress, code, notificationType);
+    }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/validation/MfaCodeValidatorFactory.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/validation/MfaCodeValidatorFactory.java
@@ -25,17 +25,25 @@ public class MfaCodeValidatorFactory {
     public Optional<MfaCodeValidator> getMfaCodeValidator(
             MFAMethodType mfaMethodType, boolean isRegistration, String emailAddress) {
 
+        int codeMaxRetries =
+                isRegistration
+                        ? configurationService.getCodeMaxRetriesRegistration()
+                        : configurationService.getCodeMaxRetries();
+
         switch (mfaMethodType) {
             case AUTH_APP:
-                int codeMaxRetries =
-                        isRegistration
-                                ? configurationService.getCodeMaxRetriesRegistration()
-                                : configurationService.getCodeMaxRetries();
                 return Optional.of(
                         new AuthAppCodeValidator(
                                 emailAddress,
                                 codeStorageService,
                                 configurationService,
+                                authenticationService,
+                                codeMaxRetries));
+            case SMS:
+                return Optional.of(
+                        new SMSCodeValidator(
+                                emailAddress,
+                                codeStorageService,
                                 authenticationService,
                                 codeMaxRetries));
             default:

--- a/shared/src/main/java/uk/gov/di/authentication/shared/validation/MfaCodeValidatorFactory.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/validation/MfaCodeValidatorFactory.java
@@ -41,11 +41,7 @@ public class MfaCodeValidatorFactory {
                                 codeMaxRetries));
             case SMS:
                 return Optional.of(
-                        new SMSCodeValidator(
-                                emailAddress,
-                                codeStorageService,
-                                authenticationService,
-                                codeMaxRetries));
+                        new SMSCodeValidator(emailAddress, codeStorageService, codeMaxRetries));
             default:
                 return Optional.empty();
         }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/validation/SMSCodeValidator.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/validation/SMSCodeValidator.java
@@ -2,22 +2,14 @@ package uk.gov.di.authentication.shared.validation;
 
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.NotificationType;
-import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 
 import java.util.Optional;
 
 public class SMSCodeValidator extends MfaCodeValidator {
 
-    private final AuthenticationService dynamoService;
-
-    public SMSCodeValidator(
-            String email,
-            CodeStorageService codeStorageService,
-            AuthenticationService dynamoService,
-            int maxRetries) {
+    public SMSCodeValidator(String email, CodeStorageService codeStorageService, int maxRetries) {
         super(email, codeStorageService, maxRetries);
-        this.dynamoService = dynamoService;
     }
 
     @Override
@@ -38,7 +30,7 @@ public class SMSCodeValidator extends MfaCodeValidator {
         boolean isValidOtp = isCodeValid(code, NotificationType.VERIFY_PHONE_NUMBER);
 
         if (!isValidOtp) {
-            LOG.info("In");
+            LOG.info("Invalid OTP code");
             return Optional.of(ErrorResponse.ERROR_1035);
         }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/validation/SMSCodeValidator.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/validation/SMSCodeValidator.java
@@ -1,0 +1,50 @@
+package uk.gov.di.authentication.shared.validation;
+
+import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.NotificationType;
+import uk.gov.di.authentication.shared.services.AuthenticationService;
+import uk.gov.di.authentication.shared.services.CodeStorageService;
+
+import java.util.Optional;
+
+public class SMSCodeValidator extends MfaCodeValidator {
+
+    private final AuthenticationService dynamoService;
+
+    public SMSCodeValidator(
+            String email,
+            CodeStorageService codeStorageService,
+            AuthenticationService dynamoService,
+            int maxRetries) {
+        super(email, codeStorageService, maxRetries);
+        this.dynamoService = dynamoService;
+    }
+
+    @Override
+    public Optional<ErrorResponse> validateCode(String code) {
+
+        if (isCodeBlockedForSession()) {
+            LOG.info("Code blocked for session");
+            return Optional.of(ErrorResponse.ERROR_1027);
+        }
+
+        incrementRetryCount();
+
+        if (hasExceededRetryLimit()) {
+            LOG.info("Exceeded code retry limit");
+            return Optional.of(ErrorResponse.ERROR_1027);
+        }
+
+        boolean isValidOtp = isCodeValid(code, NotificationType.VERIFY_PHONE_NUMBER);
+
+        if (!isValidOtp) {
+            LOG.info("In");
+            return Optional.of(ErrorResponse.ERROR_1035);
+        }
+
+        LOG.info("SMS code valid. Resetting code request count");
+        resetCodeRequestCount();
+
+        return Optional.empty();
+    }
+}

--- a/shared/src/test/java/uk/gov/di/authentication/shared/validation/MfaCodeValidatorFactoryTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/validation/MfaCodeValidatorFactoryTest.java
@@ -39,4 +39,13 @@ class MfaCodeValidatorFactoryTest {
 
         assertInstanceOf(AuthAppCodeValidator.class, mfaCodeValidator.get());
     }
+
+    @Test
+    void whenMfaMethodGeneratesSMSAppCodeValidator() {
+        var mfaCodeValidator =
+                mfaCodeValidatorFactory.getMfaCodeValidator(
+                        MFAMethodType.SMS, false, "test@test.com");
+
+        assertInstanceOf(SMSCodeValidator.class, mfaCodeValidator.get());
+    }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/validation/SMSCodeValidatorTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/validation/SMSCodeValidatorTest.java
@@ -1,0 +1,106 @@
+package uk.gov.di.authentication.shared.validation;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.NotificationType;
+import uk.gov.di.authentication.shared.entity.Session;
+import uk.gov.di.authentication.shared.services.CodeStorageService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.DynamoService;
+import uk.gov.di.authentication.shared.state.UserContext;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_BLOCKED_KEY_PREFIX;
+
+public class SMSCodeValidatorTest {
+    SMSCodeValidator smsCodeValidator;
+    UserContext mockUserContext;
+    Session mockSession;
+    CodeStorageService mockCodeStorageService;
+    ConfigurationService mockConfigurationService;
+    DynamoService mockDynamoService;
+
+    private final int MAX_RETRIES = 5;
+    private final String EMAIL_ADDRESS = "email-address";
+
+    @BeforeEach
+    void setUp() {
+        this.mockUserContext = mock(UserContext.class);
+        this.mockSession = mock(Session.class);
+        this.mockCodeStorageService = mock(CodeStorageService.class);
+        this.mockConfigurationService = mock(ConfigurationService.class);
+        this.mockDynamoService = mock(DynamoService.class);
+    }
+
+    @Test
+    void returnsCorrectErrorWhenCodeBlockedForEmailAddress() {
+        setUpBlockedUser();
+
+        assertEquals(
+                Optional.of(ErrorResponse.ERROR_1027), smsCodeValidator.validateCode("any-code"));
+    }
+
+    @Test
+    void returnsCorrectErrorWhenRetryLimitExceeded() {
+        setUpRetryLimitExceededUser();
+
+        assertEquals(
+                Optional.of(ErrorResponse.ERROR_1027), smsCodeValidator.validateCode("any-code"));
+    }
+
+    @Test
+    void returnsCorrectErrorWhenOtpIsInvalid() {
+        setUpInvalidOtp();
+
+        assertEquals(
+                Optional.of(ErrorResponse.ERROR_1035), smsCodeValidator.validateCode("any-code"));
+    }
+
+    private void setUpBlockedUser() {
+        String BLOCKED_EMAIL_ADDRESS = "blocked-email-address";
+        when(mockSession.getEmailAddress()).thenReturn(BLOCKED_EMAIL_ADDRESS);
+        when(mockUserContext.getSession()).thenReturn(mockSession);
+        when(mockCodeStorageService.isBlockedForEmail(
+                        BLOCKED_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX))
+                .thenReturn(true);
+
+        this.smsCodeValidator =
+                new SMSCodeValidator(
+                        BLOCKED_EMAIL_ADDRESS,
+                        mockCodeStorageService,
+                        mockDynamoService,
+                        MAX_RETRIES);
+    }
+
+    private void setUpRetryLimitExceededUser() {
+        when(mockSession.getEmailAddress()).thenReturn(EMAIL_ADDRESS);
+        when(mockUserContext.getSession()).thenReturn(mockSession);
+        when(mockCodeStorageService.isBlockedForEmail(EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX))
+                .thenReturn(false);
+        when(mockCodeStorageService.getIncorrectMfaCodeAttemptsCount(EMAIL_ADDRESS))
+                .thenReturn(MAX_RETRIES + 1);
+
+        this.smsCodeValidator =
+                new SMSCodeValidator(
+                        EMAIL_ADDRESS, mockCodeStorageService, mockDynamoService, MAX_RETRIES);
+    }
+
+    private void setUpInvalidOtp() {
+        when(mockSession.getEmailAddress()).thenReturn(EMAIL_ADDRESS);
+        when(mockUserContext.getSession()).thenReturn(mockSession);
+        when(mockCodeStorageService.isValidOtpCode(
+                        EMAIL_ADDRESS,
+                        CODE_BLOCKED_KEY_PREFIX,
+                        NotificationType.VERIFY_PHONE_NUMBER))
+                .thenReturn(false);
+
+        this.smsCodeValidator =
+                new SMSCodeValidator(
+                        EMAIL_ADDRESS, mockCodeStorageService, mockDynamoService, MAX_RETRIES);
+    }
+}

--- a/shared/src/test/java/uk/gov/di/authentication/shared/validation/SMSCodeValidatorTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/validation/SMSCodeValidatorTest.java
@@ -7,7 +7,6 @@ import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
-import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.util.Optional;
@@ -23,7 +22,6 @@ public class SMSCodeValidatorTest {
     Session mockSession;
     CodeStorageService mockCodeStorageService;
     ConfigurationService mockConfigurationService;
-    DynamoService mockDynamoService;
 
     private final int MAX_RETRIES = 5;
     private final String EMAIL_ADDRESS = "email-address";
@@ -34,7 +32,6 @@ public class SMSCodeValidatorTest {
         this.mockSession = mock(Session.class);
         this.mockCodeStorageService = mock(CodeStorageService.class);
         this.mockConfigurationService = mock(ConfigurationService.class);
-        this.mockDynamoService = mock(DynamoService.class);
     }
 
     @Test
@@ -70,11 +67,7 @@ public class SMSCodeValidatorTest {
                 .thenReturn(true);
 
         this.smsCodeValidator =
-                new SMSCodeValidator(
-                        BLOCKED_EMAIL_ADDRESS,
-                        mockCodeStorageService,
-                        mockDynamoService,
-                        MAX_RETRIES);
+                new SMSCodeValidator(BLOCKED_EMAIL_ADDRESS, mockCodeStorageService, MAX_RETRIES);
     }
 
     private void setUpRetryLimitExceededUser() {
@@ -86,8 +79,7 @@ public class SMSCodeValidatorTest {
                 .thenReturn(MAX_RETRIES + 1);
 
         this.smsCodeValidator =
-                new SMSCodeValidator(
-                        EMAIL_ADDRESS, mockCodeStorageService, mockDynamoService, MAX_RETRIES);
+                new SMSCodeValidator(EMAIL_ADDRESS, mockCodeStorageService, MAX_RETRIES);
     }
 
     private void setUpInvalidOtp() {
@@ -100,7 +92,6 @@ public class SMSCodeValidatorTest {
                 .thenReturn(false);
 
         this.smsCodeValidator =
-                new SMSCodeValidator(
-                        EMAIL_ADDRESS, mockCodeStorageService, mockDynamoService, MAX_RETRIES);
+                new SMSCodeValidator(EMAIL_ADDRESS, mockCodeStorageService, MAX_RETRIES);
     }
 }


### PR DESCRIPTION
## What?

Create new SMS validator and refactor UpdatePhoneNumber handler to make use of the sms validator. This is required to validate OTP code when invalid or code entered too many times. These codes will then determine the routes for error messages in the accounts management page

## Why?

Required so that the error codes returned by the handler is reflected across pages for account management

## Related PRs

[Build UI components](https://github.com/alphagov/di-authentication-account-management/pull/561)