### PR TITLE
AUT-583: Handle 'no session found' error in IPV Callback Handler

### DIFF
--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
@@ -53,6 +53,7 @@ public class DocAppCallbackHandler
     private final ClientSessionService clientSessionService;
     private final AuditService auditService;
     private final DynamoDocAppService dynamoDocAppService;
+    private final CookieHelper cookieHelper;
     protected final Json objectMapper = SerializationService.getInstance();
     private static final String REDIRECT_PATH = "doc-app-callback";
 
@@ -69,7 +70,8 @@ public class DocAppCallbackHandler
             SessionService sessionService,
             ClientSessionService clientSessionService,
             AuditService auditService,
-            DynamoDocAppService dynamoDocAppService) {
+            DynamoDocAppService dynamoDocAppService,
+            CookieHelper cookieHelper) {
         this.configurationService = configurationService;
         this.authorisationService = responseService;
         this.tokenService = tokenService;
@@ -77,6 +79,7 @@ public class DocAppCallbackHandler
         this.clientSessionService = clientSessionService;
         this.auditService = auditService;
         this.dynamoDocAppService = dynamoDocAppService;
+        this.cookieHelper = cookieHelper;
     }
 
     public DocAppCallbackHandler(ConfigurationService configurationService) {
@@ -93,6 +96,7 @@ public class DocAppCallbackHandler
         this.clientSessionService = new ClientSessionService(configurationService);
         this.auditService = new AuditService(configurationService);
         this.dynamoDocAppService = new DynamoDocAppService(configurationService);
+        this.cookieHelper = new CookieHelper();
     }
 
     @Override
@@ -111,7 +115,8 @@ public class DocAppCallbackHandler
                             LOG.info("Request received to DocAppCallbackHandler");
                             try {
                                 var sessionCookiesIds =
-                                        CookieHelper.parseSessionCookie(input.getHeaders())
+                                        cookieHelper
+                                                .parseSessionCookie(input.getHeaders())
                                                 .orElseThrow(
                                                         () -> {
                                                             throw new DocAppCallbackException(

--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
@@ -33,6 +33,7 @@ import uk.gov.di.authentication.app.services.DynamoDocAppService;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.ResponseHeaders;
 import uk.gov.di.authentication.shared.entity.Session;
+import uk.gov.di.authentication.shared.helpers.CookieHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -52,6 +53,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -72,6 +74,7 @@ class DocAppCallbackHandlerTest {
     private final ClientSessionService clientSessionService = mock(ClientSessionService.class);
     private final AuditService auditService = mock(AuditService.class);
     private final DynamoDocAppService dynamoDocAppService = mock(DynamoDocAppService.class);
+    private final CookieHelper cookieHelper = mock(CookieHelper.class);
 
     private static final URI LOGIN_URL = URI.create("https://example.com");
     private static final String OIDC_BASE_URL = "https://base-url.com";
@@ -108,12 +111,14 @@ class DocAppCallbackHandlerTest {
                         sessionService,
                         clientSessionService,
                         auditService,
-                        dynamoDocAppService);
+                        dynamoDocAppService,
+                        cookieHelper);
         when(configService.getLoginURI()).thenReturn(LOGIN_URL);
         when(configService.getOidcApiBaseURL()).thenReturn(Optional.of(OIDC_BASE_URL));
         when(configService.isSpotEnabled()).thenReturn(true);
         when(configService.getDocAppBackendURI()).thenReturn(CRI_URI);
         when(context.getAwsRequestId()).thenReturn(REQUEST_ID);
+        when(cookieHelper.parseSessionCookie(anyMap())).thenCallRealMethod();
     }
 
     @Test

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
@@ -52,6 +52,7 @@ public class LogoutHandler
     private final TokenValidationService tokenValidationService;
     private final AuditService auditService;
     private final BackChannelLogoutService backChannelLogoutService;
+    private final CookieHelper cookieHelper;
 
     public LogoutHandler() {
         this(ConfigurationService.getInstance());
@@ -69,6 +70,7 @@ public class LogoutHandler
                                 new KmsConnectionService(configurationService)));
         this.auditService = new AuditService(configurationService);
         this.backChannelLogoutService = new BackChannelLogoutService(configurationService);
+        this.cookieHelper = new CookieHelper();
     }
 
     public LogoutHandler(
@@ -86,6 +88,7 @@ public class LogoutHandler
         this.tokenValidationService = tokenValidationService;
         this.auditService = auditService;
         this.backChannelLogoutService = backChannelLogoutService;
+        this.cookieHelper = new CookieHelper();
     }
 
     @Override
@@ -148,7 +151,7 @@ public class LogoutHandler
             Context context) {
 
         CookieHelper.SessionCookieIds sessionCookieIds =
-                CookieHelper.parseSessionCookie(input.getHeaders()).get();
+                cookieHelper.parseSessionCookie(input.getHeaders()).get();
 
         attachSessionIdToLogs(session);
         attachLogFieldToLogs(CLIENT_SESSION_ID, sessionCookieIds.getClientSessionId());

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
@@ -151,7 +151,7 @@ public class LogoutHandler
             Context context) {
 
         CookieHelper.SessionCookieIds sessionCookieIds =
-                cookieHelper.parseSessionCookie(input.getHeaders()).get();
+                cookieHelper.parseSessionCookie(input.getHeaders()).orElseThrow();
 
         attachSessionIdToLogs(session);
         attachLogFieldToLogs(CLIENT_SESSION_ID, sessionCookieIds.getClientSessionId());

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/CookieHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/CookieHelper.java
@@ -77,7 +77,7 @@ public class CookieHelper {
         return parseStringToHttpCookie(cookie);
     }
 
-    public static Optional<SessionCookieIds> parseSessionCookie(Map<String, String> headers) {
+    public Optional<SessionCookieIds> parseSessionCookie(Map<String, String> headers) {
         Optional<HttpCookie> httpCookie =
                 getHttpCookieFromRequestHeaders(headers, SESSION_COOKIE_NAME);
         if (httpCookie.isEmpty()) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/SessionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/SessionService.java
@@ -24,12 +24,14 @@ public class SessionService {
 
     private final ConfigurationService configurationService;
     private final RedisConnectionService redisConnectionService;
+    private final CookieHelper cookieHelper;
 
     public SessionService(
             ConfigurationService configurationService,
             RedisConnectionService redisConnectionService) {
         this.configurationService = configurationService;
         this.redisConnectionService = redisConnectionService;
+        this.cookieHelper = new CookieHelper();
     }
 
     public SessionService(ConfigurationService configurationService) {
@@ -98,7 +100,7 @@ public class SessionService {
 
     public Optional<Session> getSessionFromSessionCookie(Map<String, String> headers) {
         try {
-            Optional<CookieHelper.SessionCookieIds> ids = CookieHelper.parseSessionCookie(headers);
+            Optional<CookieHelper.SessionCookieIds> ids = cookieHelper.parseSessionCookie(headers);
             return ids.flatMap(s -> readSessionFromRedis(s.getSessionId()));
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/CookieHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/CookieHelperTest.java
@@ -19,9 +19,9 @@ import static uk.gov.di.authentication.shared.helpers.CookieHelper.RESPONSE_COOK
 import static uk.gov.di.authentication.shared.helpers.CookieHelper.getHttpCookieFromMultiValueResponseHeaders;
 import static uk.gov.di.authentication.shared.helpers.CookieHelper.getHttpCookieFromResponseHeaders;
 import static uk.gov.di.authentication.shared.helpers.CookieHelper.parsePersistentCookie;
-import static uk.gov.di.authentication.shared.helpers.CookieHelper.parseSessionCookie;
 
 public class CookieHelperTest {
+    private static final CookieHelper cookieHelper = new CookieHelper();
 
     static Stream<String> inputs() {
         return Stream.of(REQUEST_COOKIE_HEADER, REQUEST_COOKIE_HEADER.toLowerCase());
@@ -38,7 +38,7 @@ public class CookieHelperTest {
                 "Version=1; gs=session-id.456;cookies_preferences_set={\"analytics\":true};name=ts";
         Map<String, String> headers = Map.ofEntries(Map.entry(header, cookieString));
 
-        CookieHelper.SessionCookieIds ids = parseSessionCookie(headers).orElseThrow();
+        CookieHelper.SessionCookieIds ids = cookieHelper.parseSessionCookie(headers).orElseThrow();
 
         assertEquals("session-id", ids.getSessionId());
         assertEquals("456", ids.getClientSessionId());
@@ -62,7 +62,7 @@ public class CookieHelperTest {
         HttpCookie cookie = new HttpCookie("gs", "session-id.456");
         Map<String, String> headers = Map.ofEntries(Map.entry(header, cookie.toString()));
 
-        CookieHelper.SessionCookieIds ids = parseSessionCookie(headers).orElseThrow();
+        CookieHelper.SessionCookieIds ids = cookieHelper.parseSessionCookie(headers).orElseThrow();
 
         assertEquals("session-id", ids.getSessionId());
         assertEquals("456", ids.getClientSessionId());
@@ -82,20 +82,22 @@ public class CookieHelperTest {
     @ParameterizedTest(name = "with header {0}")
     @MethodSource("inputs")
     void shouldReturnEmptyIfSessionCookieNotPresent(String header) {
-        assertEmpty(parseSessionCookie(null));
-        assertEmpty(parseSessionCookie(Map.of()));
-        assertEmpty(parseSessionCookie(Map.of(header, "value")));
+        assertEmpty(cookieHelper.parseSessionCookie(null));
+        assertEmpty(cookieHelper.parseSessionCookie(Map.of()));
+        assertEmpty(cookieHelper.parseSessionCookie(Map.of(header, "value")));
     }
 
     @ParameterizedTest(name = "with header {0}")
     @MethodSource("inputs")
     void shouldReturnEmptyIfCookieMalformatted(String header) {
-        assertEmpty(parseSessionCookie(Map.of(header, "")));
-        assertEmpty(parseSessionCookie(Map.of(header, "someinvalidvalue")));
-        assertEmpty(parseSessionCookie(Map.of(header, "gs=this is bad")));
-        assertEmpty(parseSessionCookie(Map.of(header, "gs=no-dot")));
-        assertEmpty(parseSessionCookie(Map.of(header, "gs=one-value.two-value.three-value;")));
-        assertEmpty(parseSessionCookie(Map.of(header, "gsdsds=one-value.two-value")));
+        assertEmpty(cookieHelper.parseSessionCookie(Map.of(header, "")));
+        assertEmpty(cookieHelper.parseSessionCookie(Map.of(header, "someinvalidvalue")));
+        assertEmpty(cookieHelper.parseSessionCookie(Map.of(header, "gs=this is bad")));
+        assertEmpty(cookieHelper.parseSessionCookie(Map.of(header, "gs=no-dot")));
+        assertEmpty(
+                cookieHelper.parseSessionCookie(
+                        Map.of(header, "gs=one-value.two-value.three-value;")));
+        assertEmpty(cookieHelper.parseSessionCookie(Map.of(header, "gsdsds=one-value.two-value")));
     }
 
     @ParameterizedTest(name = "with header {0}")


### PR DESCRIPTION
## What?

- Change generic exception (`RuntimeException`) which is thrown when no session is found in the `IpvCallbackHandler`, to throw `IpvCallbackException`
- This has already been set up to be handled with a redirect to front end error page

Note: While not directly part of the ticket, I have also changed the `parseSessionCookie()` method in `CookieHelper` to be an instance method rather than a static method. This was to aid unit testing, and could be a pre-cursor to moving the entire class towards being instantiable rather than a collection of static methods, but doesn't have to be. As a result of this change, some other classes also needed updating since they were dependent on the static method.

## Why?

- Throwing `IpvCallbackException` means that the error handling set up in an earlier PR will catch this case too, and render a more visually appealing front end screen, rather than just JSON representation of 'bad request'. 

## Related PRs

- Initial error handling was done here: https://github.com/alphagov/di-authentication-api/pull/2202
- There is no reason that this is a separate PR beyond simple oversight on my part.