### PR TITLE
BAU - Upgrade AWS S3 to use version2 of the SDK

### DIFF
--- a/audit-processors/build.gradle
+++ b/audit-processors/build.gradle
@@ -33,6 +33,7 @@ dependencies {
             project(":shared-test"),
             configurations.lambda,
             configurations.sqs,
+            configurations.s3,
             configurations.dynamodb,
             configurations.secretsmanager
 

--- a/audit-processors/src/main/java/uk/gov/di/authentication/audit/services/S3Service.java
+++ b/audit-processors/src/main/java/uk/gov/di/authentication/audit/services/S3Service.java
@@ -1,14 +1,16 @@
 package uk.gov.di.authentication.audit.services;
 
-import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
-import com.amazonaws.services.s3.AmazonS3;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
+import java.net.URI;
 import java.time.Clock;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 
-import static com.amazonaws.services.s3.AmazonS3ClientBuilder.standard;
 import static uk.gov.di.authentication.shared.helpers.HashHelper.hashSha256String;
 
 public class S3Service {
@@ -16,25 +18,27 @@ public class S3Service {
             DateTimeFormatter.ofPattern("yyyy/MM/dd/'audit'-HHmmss").withZone(ZoneId.of("UTC"));
 
     private final String bucket;
-    private final AmazonS3 s3Client;
+    private final S3Client s3Client;
     private final Clock clock;
 
     public S3Service(ConfigurationService configService) {
         this.bucket = configService.getAuditStorageS3Bucket();
         var awsRegion = configService.getAwsRegion();
-
         this.s3Client =
                 configService
                         .getLocalstackEndpointUri()
-                        .map(endpoint -> new EndpointConfiguration(endpoint, awsRegion))
-                        .map(standard()::withEndpointConfiguration)
-                        .orElse(standard().withRegion(awsRegion))
+                        .map(
+                                endpoint ->
+                                        S3Client.builder()
+                                                .endpointOverride(URI.create(endpoint))
+                                                .region(Region.of(awsRegion)))
+                        .orElse(S3Client.builder().region(Region.of(awsRegion)))
                         .build();
 
         this.clock = Clock.systemUTC();
     }
 
-    protected S3Service(AmazonS3 s3Client, String bucket, Clock clock) {
+    protected S3Service(S3Client s3Client, String bucket, Clock clock) {
         this.s3Client = s3Client;
         this.bucket = bucket;
         this.clock = clock;
@@ -42,7 +46,7 @@ public class S3Service {
 
     public void storeRecords(String payloads) {
         var key = FORMATTER.format(clock.instant()) + "-" + hashSha256String(payloads) + ".json";
-
-        this.s3Client.putObject(this.bucket, key, payloads);
+        var putObjectRequest = PutObjectRequest.builder().bucket(bucket).key(key).build();
+        s3Client.putObject(putObjectRequest, RequestBody.fromString(payloads));
     }
 }

--- a/audit-processors/src/test/java/uk/gov/di/authentication/audit/services/S3ServiceTest.java
+++ b/audit-processors/src/test/java/uk/gov/di/authentication/audit/services/S3ServiceTest.java
@@ -1,12 +1,16 @@
 package uk.gov.di.authentication.audit.services;
 
-import com.amazonaws.services.s3.AmazonS3;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -14,7 +18,7 @@ class S3ServiceTest {
 
     @Test
     void shouldPushContentToBucket() {
-        var s3Client = mock(AmazonS3.class);
+        var s3Client = mock(S3Client.class);
 
         var service =
                 new S3Service(
@@ -29,6 +33,9 @@ class S3ServiceTest {
                         + "0a8cac771ca188eacc57e2c96c31f5611925c5ecedccb16b8c236d6c0d325112" // content hash
                         + ".json";
 
-        verify(s3Client).putObject("some-bucket", expectedKey, "some-content");
+        var putObjectRequest =
+                PutObjectRequest.builder().bucket("some-bucket").key(expectedKey).build();
+
+        verify(s3Client).putObject(eq(putObjectRequest), any(RequestBody.class));
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -137,7 +137,7 @@ subprojects {
 
         ssm "software.amazon.awssdk:ssm:${dependencyVersions.aws_sdk_v2_version}"
 
-        s3 "com.amazonaws:aws-java-sdk-s3:${dependencyVersions.aws_sdk_version}"
+        s3 "software.amazon.awssdk:s3:${dependencyVersions.aws_sdk_v2_version}"
 
         tests "org.junit.jupiter:junit-jupiter-api:${dependencyVersions.junit}",
                 "org.junit.jupiter:junit-jupiter-params:${dependencyVersions.junit}",

--- a/frontend-api/build.gradle
+++ b/frontend-api/build.gradle
@@ -30,6 +30,7 @@ dependencies {
             project(":shared-test"),
             configurations.lambda,
             configurations.sqs,
+            configurations.s3,
             configurations.dynamodb
 
     testRuntimeOnly configurations.test_runtime

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandlerTest.java
@@ -3,10 +3,12 @@ package uk.gov.di.authentication.frontendapi.lambda;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
-import com.amazonaws.services.s3.AmazonS3;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import uk.gov.di.authentication.shared.entity.NotifyRequest;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -22,6 +24,8 @@ import java.util.Map;
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -46,7 +50,7 @@ public class NotificationHandlerTest {
     private final Context context = mock(Context.class);
     private final NotificationService notificationService = mock(NotificationService.class);
     private final ConfigurationService configService = mock(ConfigurationService.class);
-    private final AmazonS3 s3Client = mock(AmazonS3.class);
+    private final S3Client s3Client = mock(S3Client.class);
     private NotificationHandler handler;
     private static final Json objectMapper = SerializationService.getInstance();
 
@@ -241,7 +245,9 @@ public class NotificationHandlerTest {
 
         verify(notificationService)
                 .sendText(notifyRequest.getDestination(), personalisation, VERIFY_PHONE_NUMBER);
-        verify(s3Client).putObject(BUCKET_NAME, NOTIFY_PHONE_NUMBER, "654321");
+        var putObjectRequest =
+                PutObjectRequest.builder().bucket(BUCKET_NAME).key(NOTIFY_PHONE_NUMBER).build();
+        verify(s3Client).putObject(eq(putObjectRequest), any(RequestBody.class));
     }
 
     @Test
@@ -274,7 +280,9 @@ public class NotificationHandlerTest {
 
         verify(notificationService)
                 .sendText(notifyRequest.getDestination(), personalisation, MFA_SMS);
-        verify(s3Client).putObject(BUCKET_NAME, NOTIFY_PHONE_NUMBER, "654321");
+        var putObjectRequest =
+                PutObjectRequest.builder().bucket(BUCKET_NAME).key(NOTIFY_PHONE_NUMBER).build();
+        verify(s3Client).putObject(eq(putObjectRequest), any(RequestBody.class));
     }
 
     @Test

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -13,6 +13,7 @@ dependencies {
             configurations.nimbus,
             configurations.bouncycastle,
             configurations.sqs,
+            configurations.s3,
             configurations.cloudwatch,
             configurations.dynamodb,
             configurations.lettuce,

--- a/integration-tests/src/test/java/uk/gov/di/authentication/utils/CommonPasswordsS3ToDynamoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/utils/CommonPasswordsS3ToDynamoIntegrationTest.java
@@ -1,20 +1,20 @@
 package uk.gov.di.authentication.utils;
 
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.S3Event;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3Client;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
 import uk.gov.di.authentication.sharedtest.basetest.HandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.extensions.CommonPasswordsS3Extension;
 import uk.gov.di.authentication.sharedtest.helper.S3TestEventHelper;
 import uk.gov.di.authentication.utils.lambda.S3ToDynamoDbHandler;
 
+import java.net.URI;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -47,14 +47,13 @@ class CommonPasswordsS3ToDynamoIntegrationTest extends HandlerIntegrationTest<S3
 
     @BeforeEach
     void setup() {
-        var mockS3Credentials = new BasicAWSCredentials("access", "secret");
+        var mockS3Credentials = AwsBasicCredentials.create("access", "secret");
 
-        AmazonS3 testS3Client =
-                AmazonS3Client.builder()
-                        .withEndpointConfiguration(
-                                new AwsClientBuilder.EndpointConfiguration(S3_ENDPOINT, REGION))
-                        .withCredentials(new AWSStaticCredentialsProvider(mockS3Credentials))
-                        .withPathStyleAccessEnabled(true)
+        var testS3Client =
+                S3Client.builder()
+                        .endpointOverride(URI.create(S3_ENDPOINT))
+                        .region(Region.of(REGION))
+                        .credentialsProvider(StaticCredentialsProvider.create(mockS3Credentials))
                         .build();
         handler = new S3ToDynamoDbHandler(TEST_CONFIGURATION_SERVICE, testS3Client);
     }

--- a/shared-test/build.gradle
+++ b/shared-test/build.gradle
@@ -13,6 +13,7 @@ dependencies {
             configurations.lettuce,
             configurations.dynamodb,
             configurations.sns,
+            configurations.s3,
             configurations.ssm,
             configurations.cloudwatch,
             "org.eclipse.jetty:jetty-server:11.0.11",

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/CommonPasswordsS3Extension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/CommonPasswordsS3Extension.java
@@ -1,8 +1,9 @@
 package uk.gov.di.authentication.sharedtest.extensions;
 
-import com.amazonaws.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.DeleteBucketRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
-import java.io.File;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Paths;
@@ -14,7 +15,8 @@ public class CommonPasswordsS3Extension extends S3Extension {
     @Override
     protected void createBuckets() throws URISyntaxException {
         if (!bucketExists(COMMON_PASSWORDS_BUCKET)) {
-            s3Client.createBucket(COMMON_PASSWORDS_BUCKET);
+            s3Client.createBucket(
+                    CreateBucketRequest.builder().bucket(COMMON_PASSWORDS_BUCKET).build());
         }
 
         addTestFileToCommonPasswordsBucket();
@@ -24,7 +26,8 @@ public class CommonPasswordsS3Extension extends S3Extension {
     void deleteBuckets() {
         if (bucketExists(COMMON_PASSWORDS_BUCKET)) {
             deleteS3BucketContents(COMMON_PASSWORDS_BUCKET);
-            s3Client.deleteBucket(COMMON_PASSWORDS_BUCKET);
+            s3Client.deleteBucket(
+                    DeleteBucketRequest.builder().bucket(COMMON_PASSWORDS_BUCKET).build());
         }
     }
 
@@ -34,9 +37,11 @@ public class CommonPasswordsS3Extension extends S3Extension {
                         .getContextClassLoader()
                         .getResource("common_passwords_integration_test.txt");
 
-        File testFile = Paths.get(testFileUrl.toURI()).toFile();
-        PutObjectRequest request =
-                new PutObjectRequest(COMMON_PASSWORDS_BUCKET, TEST_FILE_NAME, testFile);
-        s3Client.putObject(request);
+        var putObjectRequest =
+                PutObjectRequest.builder()
+                        .bucket(COMMON_PASSWORDS_BUCKET)
+                        .key(TEST_FILE_NAME)
+                        .build();
+        s3Client.putObject(putObjectRequest, Paths.get(testFileUrl.toURI()));
     }
 }

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -17,6 +17,7 @@ dependencies {
             configurations.libphonenumber,
             configurations.hamcrest,
             configurations.sns,
+            configurations.s3,
             configurations.sqs,
             configurations.ssm,
             configurations.xray,

--- a/utils/src/test/java/uk/gov/di/authentication/utils/lambda/S3ToDynamoDbHandlerTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/lambda/S3ToDynamoDbHandlerTest.java
@@ -3,29 +3,29 @@ package uk.gov.di.authentication.utils.lambda;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.S3Event;
 import com.amazonaws.services.lambda.runtime.events.models.s3.S3EventNotification;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.S3Object;
-import com.amazonaws.services.s3.model.S3ObjectInputStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.http.AbortableInputStream;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import uk.gov.di.authentication.shared.services.CommonPasswordsService;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -35,52 +35,48 @@ import static org.mockito.Mockito.when;
 class S3ToDynamoDbHandlerTest {
 
     private S3ToDynamoDbHandler handler;
-    private CommonPasswordsService mockCommonPasswordsService;
-    private S3Event mockS3Event;
-    private Context mockContext;
+    private final CommonPasswordsService mockCommonPasswordsService =
+            mock(CommonPasswordsService.class);
+    private final S3Event mockS3Event = mock(S3Event.class);
+    private final Context mockContext = mock(Context.class);
+    private final S3Client mockS3Client = mock(S3Client.class);
     private String mockS3TextContent;
     private static final int LINES_PER_BATCH_WRITE = 500;
+    private static final String BUCKET_NAME = "test-bucket";
+    private static final String BUCKET_KEY = "test-key";
 
     @BeforeEach
     void setUp() throws URISyntaxException, IOException {
-        URL resource =
+        var resource =
                 Thread.currentThread()
                         .getContextClassLoader()
                         .getResource("common_passwords_unit_test.txt");
 
-        Path path;
-
-        path = Paths.get(resource.toURI());
+        var path = Paths.get(resource.toURI());
         this.mockS3TextContent = Files.readString(path, StandardCharsets.UTF_8);
 
-        InputStream mockInputStream = new ByteArrayInputStream(mockS3TextContent.getBytes());
-        var mockS3ObjectInputStream = new S3ObjectInputStream(mockInputStream, null);
+        var getObjectResponse = GetObjectResponse.builder().build();
+        var mockInputStream = new ByteArrayInputStream(mockS3TextContent.getBytes());
+        var mockS3ObjectInputStream =
+                new ResponseInputStream<>(
+                        getObjectResponse, AbortableInputStream.create(mockInputStream));
 
-        var mockS3Object = mock(S3Object.class);
-        when(mockS3Object.getObjectContent()).thenReturn(mockS3ObjectInputStream);
-
-        var mockS3Client = mock(AmazonS3.class);
-        when(mockS3Client.getObject("test-bucket", "test-key")).thenReturn(mockS3Object);
-
-        this.mockCommonPasswordsService = mock(CommonPasswordsService.class);
+        when(mockS3Client.getObject(any(GetObjectRequest.class)))
+                .thenReturn(mockS3ObjectInputStream);
 
         this.handler = new S3ToDynamoDbHandler(mockCommonPasswordsService, mockS3Client);
 
-        this.mockS3Event = mock(S3Event.class);
         when(mockS3Event.getRecords())
                 .thenReturn(List.of(mock(S3EventNotification.S3EventNotificationRecord.class)));
         when(mockS3Event.getRecords().get(0).getS3())
                 .thenReturn(mock(S3EventNotification.S3Entity.class));
         when(mockS3Event.getRecords().get(0).getS3().getBucket())
                 .thenReturn(mock(S3EventNotification.S3BucketEntity.class));
-        when(mockS3Event.getRecords().get(0).getS3().getBucket().getName())
-                .thenReturn("test-bucket");
+        when(mockS3Event.getRecords().get(0).getS3().getBucket().getName()).thenReturn(BUCKET_NAME);
 
         when(mockS3Event.getRecords().get(0).getS3().getObject())
                 .thenReturn(mock(S3EventNotification.S3ObjectEntity.class));
-        when(mockS3Event.getRecords().get(0).getS3().getObject().getKey()).thenReturn("test-key");
-
-        this.mockContext = mock(Context.class);
+        when(mockS3Event.getRecords().get(0).getS3().getObject().getKey()).thenReturn(BUCKET_KEY);
     }
 
     @Test
@@ -90,8 +86,8 @@ class S3ToDynamoDbHandlerTest {
 
         handler.handleRequest(mockS3Event, mockContext);
 
-        String[] mockInputAsArray = mockS3TextContent.split("\r?\n|\r");
-        List<String> mockInputAsArrayList = new ArrayList<>(Arrays.asList(mockInputAsArray));
+        var mockInputAsArray = mockS3TextContent.split("\r?\n|\r");
+        var mockInputAsArrayList = new ArrayList<>(Arrays.asList(mockInputAsArray));
         mockInputAsArrayList.removeAll(Collections.singleton(null));
         mockInputAsArrayList.removeAll(Collections.singleton(""));
 
@@ -101,6 +97,6 @@ class S3ToDynamoDbHandlerTest {
                 .addBatchCommonPasswords(any(List.class));
 
         verify(mockCommonPasswordsService).addBatchCommonPasswords(argument.capture());
-        assertEquals(argument.getValue(), mockInputAsArrayList);
+        assertThat(argument.getValue(), equalTo(mockInputAsArrayList));
     }
 }


### PR DESCRIPTION
## What?

- Upgrade AWS S3 to use version2 of the SDK

## Why?

- Version 2 is the latest and greatest and offers us more features. It also means when we migrate completely away from version 1, we will only be managing one version of the SDK.