### PR TITLE
BAU - Upgrade SQS and SNS to version 2 of the AWS SDK

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -131,7 +131,7 @@ subprojects {
 
         secretsmanager "software.amazon.awssdk:secretsmanager:${dependencyVersions.aws_sdk_v2_version}"
 
-        sns "com.amazonaws:aws-java-sdk-sns:${dependencyVersions.aws_sdk_version}"
+        sns "software.amazon.awssdk:sns:${dependencyVersions.aws_sdk_v2_version}"
 
         sqs "software.amazon.awssdk:sqs:${dependencyVersions.aws_sdk_v2_version}"
 

--- a/shared-test/build.gradle
+++ b/shared-test/build.gradle
@@ -14,6 +14,7 @@ dependencies {
             configurations.dynamodb,
             configurations.sns,
             configurations.s3,
+            configurations.sqs,
             configurations.ssm,
             configurations.cloudwatch,
             "org.eclipse.jetty:jetty-server:11.0.11",

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/SnsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/SnsService.java
@@ -1,16 +1,19 @@
 package uk.gov.di.authentication.shared.services;
 
-import com.amazonaws.client.builder.AwsClientBuilder;
-import com.amazonaws.services.sns.AmazonSNS;
-import com.amazonaws.services.sns.AmazonSNSClientBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sns.SnsClient;
+import software.amazon.awssdk.services.sns.model.PublishRequest;
 import uk.gov.di.authentication.shared.configuration.AuditPublisherConfiguration;
+
+import java.net.URI;
 
 public class SnsService {
 
     private final String topicArn;
-    private final AmazonSNS snsClient;
+    private final SnsClient snsClient;
     private static final Logger LOG = LogManager.getLogger(SnsService.class);
 
     public SnsService(AuditPublisherConfiguration configService) {
@@ -19,18 +22,18 @@ public class SnsService {
         var awsRegion = configService.getAwsRegion();
         if (localstackEndpointUri.isPresent()) {
             LOG.info("Localstack endpoint URI is present: " + localstackEndpointUri.get());
-            this.snsClient =
-                    AmazonSNSClientBuilder.standard()
-                            .withEndpointConfiguration(
-                                    new AwsClientBuilder.EndpointConfiguration(
-                                            localstackEndpointUri.get(), awsRegion))
+            snsClient =
+                    SnsClient.builder()
+                            .region(Region.of(awsRegion))
+                            .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
+                            .endpointOverride(URI.create(localstackEndpointUri.get()))
                             .build();
         } else {
-            this.snsClient = AmazonSNSClientBuilder.standard().withRegion(awsRegion).build();
+            snsClient = SnsClient.builder().region(Region.of(awsRegion)).build();
         }
     }
 
     public void publishAuditMessage(String message) {
-        snsClient.publish(topicArn, message);
+        snsClient.publish(PublishRequest.builder().message(message).topicArn(topicArn).build());
     }
 }


### PR DESCRIPTION
## What?

- Upgrade SQS and SNS to version 2 of the AWS SDK

## Why?

- Version 2 is the latest and greatest and offers us more features. It also means when we migrate completely away from version 1, we will only be managing one version of the SDK.