### PR TITLE
BAU: Minor fixes to utils module

### DIFF
--- a/ci/terraform/utils/sandpit.tfvars
+++ b/ci/terraform/utils/sandpit.tfvars
@@ -1,2 +1,2 @@
 environment         = "sandpit"
-common_state_bucket = "digital-identity-dev-tfstate"
+shared_state_bucket = "digital-identity-dev-tfstate"

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java'
+    id "jacoco"
 }
 
 group 'uk.gov.di.authentication.utils'
@@ -41,3 +42,10 @@ task buildZip(type: Zip) {
 }
 
 build.dependsOn buildZip
+
+jacocoTestReport {
+    reports {
+        xml.enabled true
+    }
+    dependsOn "test"
+}


### PR DESCRIPTION
## What?

- Use correct parameter name for shared state bucket
- Add Jacoco task to Gradle so coverage stats are generated

## Why?

The incorrect parameter name was causing Terraform to prompt during sandpit deploy
The missing Jacoco report means Sonar is reporting 0% coverage on changes to the `utils` module
