### PR TITLE
BAU - Remove aws-java-sdk-lambda from shared and shared-test

### DIFF
--- a/shared-test/build.gradle
+++ b/shared-test/build.gradle
@@ -18,7 +18,6 @@ dependencies {
             configurations.ssm,
             configurations.cloudwatch,
             "org.eclipse.jetty:jetty-server:11.0.11",
-            "com.amazonaws:aws-java-sdk-lambda:1.12.286",
             "com.google.protobuf:protobuf-java:3.21.5",
             "com.google.code.gson:gson:2.9.1"
 

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -23,7 +23,6 @@ dependencies {
             configurations.xray,
             configurations.cloudwatch,
             configurations.gson,
-            "com.amazonaws:aws-java-sdk-lambda:1.12.286",
             "com.google.protobuf:protobuf-java:3.21.5"
 
     testImplementation configurations.tests,


### PR DESCRIPTION
## What?

 - Remove aws-java-sdk-lambda from shared and shared-test
 - The only other place the aws-java-sdk-lambda is used is in the lambda-warmer module. This will soon be deleted and therefore avoids the need to update the lambda sdk to version 2.

## Why?

- It is not used so we can remove it.

