### PR TITLE
AUT-661: New lambda to publish account metrics

### DIFF
--- a/ci/terraform/utils/account_metrics_lambda.tf
+++ b/ci/terraform/utils/account_metrics_lambda.tf
@@ -1,0 +1,96 @@
+data "aws_iam_policy_document" "account_metrics_dynamo_access" {
+  statement {
+    sid    = "AllowAccessToDescribeUserProfileTable"
+    effect = "Allow"
+
+    actions = [
+      "dynamodb:DescribeTable",
+    ]
+
+    resources = [
+      data.aws_dynamodb_table.user_profile.arn,
+    ]
+  }
+}
+
+resource "aws_iam_policy" "account_metrics_dynamo_access" {
+  name_prefix = "account-metrics-dynamo-access-policy"
+  description = "IAM policy for managing permissions to the Dynamo User Profile table"
+
+  policy = data.aws_iam_policy_document.account_metrics_dynamo_access.json
+}
+
+module "account_metrics_update_lambda_role" {
+  source = "../modules/lambda-role"
+
+  environment = var.environment
+  role_name   = "account-metrics-lambda-role"
+
+  policies_to_attach = [
+    aws_iam_policy.account_metrics_dynamo_access.arn,
+  ]
+}
+
+resource "aws_lambda_function" "account_metrics_lambda" {
+  function_name = "${var.environment}-account-metrics-publish-lambda"
+  role          = module.account_metrics_update_lambda_role.arn
+  handler       = "uk.gov.di.authentication.utils.lambda.AccountMetricPublishHandler::handleRequest"
+  timeout       = 900
+  memory_size   = 4096
+  runtime       = "java11"
+  publish       = true
+
+  s3_bucket         = aws_s3_object.utils_release_zip.bucket
+  s3_key            = aws_s3_object.utils_release_zip.key
+  s3_object_version = aws_s3_object.utils_release_zip.version_id
+
+  environment {
+    variables = merge({
+      ENVIRONMENT = var.environment
+    })
+  }
+
+  tags = local.default_tags
+}
+
+
+resource "aws_cloudwatch_log_group" "account_metrics_lambda_log_group" {
+  count = var.use_localstack ? 0 : 1
+
+  name              = "/aws/lambda/${aws_lambda_function.account_metrics_lambda.function_name}"
+  kms_key_id        = local.cloudwatch_encryption_key_arn
+  retention_in_days = var.cloudwatch_log_retention
+
+  tags = local.default_tags
+}
+
+resource "aws_cloudwatch_log_subscription_filter" "account_metrics_log_subscription" {
+  count           = length(var.logging_endpoint_arns)
+  name            = "${aws_lambda_function.account_metrics_lambda.function_name}-log-subscription-${count.index}"
+  log_group_name  = aws_cloudwatch_log_group.account_metrics_lambda_log_group[0].name
+  filter_pattern  = ""
+  destination_arn = var.logging_endpoint_arns[count.index]
+
+  lifecycle {
+    create_before_destroy = false
+  }
+}
+
+resource "aws_cloudwatch_event_rule" "account_metrics_schedule" {
+  name                = "${var.environment}-account-metrics-publish-schedule"
+  schedule_expression = "rate(1 hour)"
+}
+
+resource "aws_cloudwatch_event_target" "account_metrics_schedule_target" {
+  arn       = aws_lambda_function.account_metrics_lambda.arn
+  rule      = aws_cloudwatch_event_rule.account_metrics_schedule.name
+  target_id = aws_lambda_function.account_metrics_lambda.version
+}
+
+resource "aws_lambda_permission" "allow_cloudwatch_to_call_account_metrics_lambda" {
+  statement_id  = "AllowExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.account_metrics_lambda.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.account_metrics_schedule.arn
+}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
@@ -51,6 +51,7 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     private static final Logger LOG = LogManager.getLogger(SendNotificationHandler.class);
+    private static final CloudwatchMetricsService METRICS = new CloudwatchMetricsService();
 
     private final AwsSqsClient sqsClient;
     private final CodeGeneratorService codeGeneratorService;
@@ -180,7 +181,7 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
         if (notTestClientWithValidTestEmail(userContext, notificationType)) {
 
             if (notificationType == VERIFY_PHONE_NUMBER) {
-                CloudwatchMetricsService.putEmbeddedValue(
+                METRICS.putEmbeddedValue(
                         "SendingSms",
                         1,
                         Map.of(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/HttpRequestService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/HttpRequestService.java
@@ -3,6 +3,7 @@ package uk.gov.di.authentication.oidc.services;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.ObjectMessage;
+import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 
 import java.io.IOException;
 import java.net.URI;
@@ -12,11 +13,11 @@ import java.util.Map;
 
 import static java.net.http.HttpClient.newHttpClient;
 import static java.net.http.HttpRequest.BodyPublishers.ofString;
-import static uk.gov.di.authentication.shared.services.CloudwatchMetricsService.putEmbeddedValue;
 
 public class HttpRequestService {
 
     private static final Logger LOG = LogManager.getLogger(HttpRequestService.class);
+    private static final CloudwatchMetricsService METRICS = new CloudwatchMetricsService();
 
     public void post(URI uri, String body) {
 
@@ -39,7 +40,7 @@ public class HttpRequestService {
 
             LOG.info(new ObjectMessage(logMessage));
 
-            putEmbeddedValue(
+            METRICS.putEmbeddedValue(
                     "BackChannelLogoutRequest",
                     1,
                     Map.of("StatusCode", Integer.toString(response.statusCode())));

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsService.java
@@ -12,7 +12,7 @@ public class CloudwatchMetricsService {
 
     public CloudwatchMetricsService() {}
 
-    public static void putEmbeddedValue(String name, double value, Map<String, String> dimensions) {
+    public void putEmbeddedValue(String name, double value, Map<String, String> dimensions) {
         segmentedFunctionCall(
                 "Metrics::EMF",
                 () -> {

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/AccountMetricPublishHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/AccountMetricPublishHandler.java
@@ -1,0 +1,55 @@
+package uk.gov.di.authentication.utils.lambda;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.ScheduledEvent;
+import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+import java.util.Map;
+
+import static java.text.MessageFormat.format;
+import static uk.gov.di.authentication.shared.dynamodb.DynamoClientHelper.createDynamoClient;
+
+public class AccountMetricPublishHandler implements RequestHandler<ScheduledEvent, Long> {
+
+    private final ConfigurationService configurationService;
+    private final AmazonDynamoDB client;
+    private final CloudwatchMetricsService cloudwatchMetricsService;
+
+    public AccountMetricPublishHandler(
+            ConfigurationService configurationService,
+            AmazonDynamoDB client,
+            CloudwatchMetricsService cloudwatchMetricsService) {
+        this.configurationService = configurationService;
+        this.client = client;
+        this.cloudwatchMetricsService = cloudwatchMetricsService;
+    }
+
+    public AccountMetricPublishHandler() {
+        this.configurationService = ConfigurationService.getInstance();
+        client = createDynamoClient(configurationService);
+        cloudwatchMetricsService = new CloudwatchMetricsService();
+    }
+
+    @Override
+    public Long handleRequest(ScheduledEvent input, Context context) {
+        var result =
+                client.describeTable(
+                        format("{0}-user-profile", configurationService.getEnvironment()));
+        var numberOfAccounts = result.getTable().getItemCount();
+        var numberOfVerifiedAccounts =
+                result.getTable().getGlobalSecondaryIndexes().stream()
+                        .filter(i -> i.getIndexName().equals("VerifiedAccountIndex"))
+                        .findFirst()
+                        .orElseThrow()
+                        .getItemCount();
+
+        cloudwatchMetricsService.putEmbeddedValue("NumberOfAccounts", numberOfAccounts, Map.of());
+        cloudwatchMetricsService.putEmbeddedValue(
+                "NumberOfVerifiedAccounts", numberOfVerifiedAccounts, Map.of());
+
+        return numberOfVerifiedAccounts;
+    }
+}

--- a/utils/src/test/java/uk/gov/di/authentication/utils/lambda/AccountMetricPublishHandlerTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/lambda/AccountMetricPublishHandlerTest.java
@@ -1,0 +1,81 @@
+package uk.gov.di.authentication.utils.lambda;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.model.DescribeTableResult;
+import com.amazonaws.services.dynamodbv2.model.GlobalSecondaryIndexDescription;
+import com.amazonaws.services.dynamodbv2.model.TableDescription;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.ScheduledEvent;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class AccountMetricPublishHandlerTest {
+
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private final CloudwatchMetricsService cloudwatchMetricsService =
+            mock(CloudwatchMetricsService.class);
+    private final AmazonDynamoDB client = mock(AmazonDynamoDB.class);
+
+    private final AccountMetricPublishHandler handler =
+            new AccountMetricPublishHandler(configurationService, client, cloudwatchMetricsService);
+
+    @Test
+    void shouldPublishMetrics() {
+        when(configurationService.getEnvironment()).thenReturn("test");
+        when(client.describeTable("test-user-profile"))
+                .thenReturn(
+                        new DescribeTableResult()
+                                .withTable(
+                                        new TableDescription()
+                                                .withGlobalSecondaryIndexes(
+                                                        new GlobalSecondaryIndexDescription()
+                                                                .withIndexName(
+                                                                        "VerifiedAccountIndex")
+                                                                .withItemCount(5000l),
+                                                        new GlobalSecondaryIndexDescription()
+                                                                .withIndexName("AnotherIndex")
+                                                                .withItemCount(3000l))
+                                                .withItemCount(5100l)));
+
+        handler.handleRequest(mock(ScheduledEvent.class), mock(Context.class));
+
+        verify(cloudwatchMetricsService, times(1))
+                .putEmbeddedValue("NumberOfAccounts", 5100, Map.of());
+        verify(cloudwatchMetricsService, times(1))
+                .putEmbeddedValue("NumberOfVerifiedAccounts", 5000, Map.of());
+    }
+
+    @Test
+    void shouldNotPublishMetricsIfIndexNotFound() {
+        when(configurationService.getEnvironment()).thenReturn("test");
+        when(client.describeTable("test-user-profile"))
+                .thenReturn(
+                        new DescribeTableResult()
+                                .withTable(
+                                        new TableDescription()
+                                                .withGlobalSecondaryIndexes(
+                                                        new GlobalSecondaryIndexDescription()
+                                                                .withIndexName("AnotherIndex")
+                                                                .withItemCount(3000l))
+                                                .withItemCount(5100l)));
+
+        assertThrows(
+                NoSuchElementException.class,
+                () -> handler.handleRequest(mock(ScheduledEvent.class), mock(Context.class)));
+
+        verify(cloudwatchMetricsService, never()).putEmbeddedValue(any(), anyDouble(), any());
+    }
+}


### PR DESCRIPTION
## What?

- Refactor of CloudwatchMetricService
- Add a lambda, that will run on a schedule, to publish the total number of accounts and the number of verified accounts to Cloudwatch metrics.
- Create lambda with permission to describe the UserProfile table
- Schedule the lambda to run every hour

## Why?

We want to show this metric in a Grafana dashboard.

## Related PRs

#2271 
#2232 
#2233 