### PR TITLE
AUT-398 - Upgrade aws kms sdk to version 2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,7 @@ subprojects {
         govuk_notify
         gson
         hamcrest
+        kms
         lambda
         lambda_tests
         lettuce
@@ -111,6 +112,8 @@ subprojects {
         gson "com.google.code.gson:gson:${dependencyVersions.gson}"
 
         hamcrest "org.hamcrest:hamcrest:2.2"
+
+        kms "software.amazon.awssdk:kms:${dependencyVersions.aws_sdk_v2_version}"
 
         lambda "com.amazonaws:aws-lambda-java-core:${dependencyVersions.aws_lambda_core_version}",
                 "com.amazonaws:aws-lambda-java-events:${dependencyVersions.aws_lambda_events_version}",

--- a/doc-checking-app-api/build.gradle
+++ b/doc-checking-app-api/build.gradle
@@ -9,7 +9,8 @@ version "unspecified"
 dependencies {
     compileOnly configurations.lambda,
             configurations.dynamodb,
-            configurations.sns
+            configurations.sns,
+            configurations.kms
 
     implementation configurations.gson,
             configurations.nimbus,
@@ -24,6 +25,7 @@ dependencies {
             project(":shared-test"),
             configurations.lambda,
             configurations.sqs,
+            configurations.kms,
             configurations.dynamodb
 
     testRuntimeOnly configurations.test_runtime

--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/services/DocAppAuthorisationService.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/services/DocAppAuthorisationService.java
@@ -1,8 +1,5 @@
 package uk.gov.di.authentication.app.services;
 
-import com.amazonaws.services.kms.model.GetPublicKeyRequest;
-import com.amazonaws.services.kms.model.SignRequest;
-import com.amazonaws.services.kms.model.SigningAlgorithmSpec;
 import com.nimbusds.jose.EncryptionMethod;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWEAlgorithm;
@@ -25,6 +22,10 @@ import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.kms.model.GetPublicKeyRequest;
+import software.amazon.awssdk.services.kms.model.SignRequest;
+import software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
@@ -37,7 +38,6 @@ import uk.gov.di.authentication.shared.services.RedisConnectionService;
 import uk.gov.di.authentication.shared.services.SerializationService;
 
 import java.net.MalformedURLException;
-import java.nio.ByteBuffer;
 import java.security.interfaces.RSAPublicKey;
 import java.text.ParseException;
 import java.time.temporal.ChronoUnit;
@@ -148,8 +148,10 @@ public class DocAppAuthorisationService {
         var signingKeyId =
                 kmsConnectionService
                         .getPublicKey(
-                                new GetPublicKeyRequest().withKeyId(docAppTokenSigningKeyAlias))
-                        .getKeyId();
+                                GetPublicKeyRequest.builder()
+                                        .keyId(docAppTokenSigningKeyAlias)
+                                        .build())
+                        .keyId();
         var jwsHeader =
                 new JWSHeader.Builder(SIGNING_ALGORITHM)
                         .keyID(hashSha256String(signingKeyId))
@@ -181,18 +183,20 @@ public class DocAppAuthorisationService {
         var encodedHeader = jwsHeader.toBase64URL();
         var encodedClaims = Base64URL.encode(claimsBuilder.build().toString());
         var message = encodedHeader + "." + encodedClaims;
-        var signRequest = new SignRequest();
-        signRequest.setMessage(ByteBuffer.wrap(message.getBytes()));
-        signRequest.setKeyId(docAppTokenSigningKeyAlias);
-        signRequest.setSigningAlgorithm(SigningAlgorithmSpec.ECDSA_SHA_256.toString());
+        var signRequest =
+                SignRequest.builder()
+                        .message(SdkBytes.fromByteArray(message.getBytes()))
+                        .keyId(docAppTokenSigningKeyAlias)
+                        .signingAlgorithm(SigningAlgorithmSpec.ECDSA_SHA_256)
+                        .build();
         try {
             LOG.info("Signing request JWT");
-            var signResult = kmsConnectionService.sign(signRequest);
+            var signResponse = kmsConnectionService.sign(signRequest);
             LOG.info("Request JWT has been signed successfully");
             var signature =
                     Base64URL.encode(
                                     ECDSA.transcodeSignatureToConcat(
-                                            signResult.getSignature().array(),
+                                            signResponse.signature().asByteArray(),
                                             ECDSA.getSignatureByteArrayLength(SIGNING_ALGORITHM)))
                             .toString();
             var signedJWT = SignedJWT.parse(message + "." + signature);

--- a/frontend-api/build.gradle
+++ b/frontend-api/build.gradle
@@ -31,6 +31,7 @@ dependencies {
             configurations.lambda,
             configurations.sqs,
             configurations.s3,
+            configurations.kms,
             configurations.dynamodb
 
     testRuntimeOnly configurations.test_runtime

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -13,6 +13,7 @@ dependencies {
             configurations.nimbus,
             configurations.bouncycastle,
             configurations.sqs,
+            configurations.kms,
             configurations.s3,
             configurations.cloudwatch,
             configurations.dynamodb,

--- a/ipv-api/build.gradle
+++ b/ipv-api/build.gradle
@@ -11,6 +11,7 @@ dependencies {
             configurations.sqs,
             configurations.ssm,
             configurations.sns,
+            configurations.kms,
             configurations.dynamodb
 
     implementation configurations.gson,
@@ -25,6 +26,7 @@ dependencies {
             project(":shared-test"),
             configurations.lambda,
             configurations.sqs,
+            configurations.kms,
             configurations.dynamodb
 
     testRuntimeOnly configurations.test_runtime

--- a/shared-test/build.gradle
+++ b/shared-test/build.gradle
@@ -12,6 +12,7 @@ dependencies {
             configurations.nimbus,
             configurations.lettuce,
             configurations.dynamodb,
+            configurations.kms,
             configurations.sns,
             configurations.s3,
             configurations.sqs,

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
@@ -1,9 +1,9 @@
 package uk.gov.di.authentication.sharedtest.basetest;
 
-import com.amazonaws.services.kms.model.KeyUsageType;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import software.amazon.awssdk.services.kms.model.KeyUsageType;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SerializationService;

--- a/shared/build.gradle
+++ b/shared/build.gradle
@@ -13,6 +13,7 @@ dependencies {
             configurations.bouncycastle,
             configurations.govuk_notify,
             configurations.dynamodb,
+            configurations.kms,
             configurations.lettuce,
             configurations.libphonenumber,
             configurations.hamcrest,


### PR DESCRIPTION
## What?

- Upgrade aws kms sdk to version 2
## Why?

- Previously kms was brought in by the dynamo dependency. Add KMS as its own dependency and set it to version 2 of the AWS sdk. This reduces the impact of uplifting both dynamo and KMS to version 2 at the same time.
