### PR TITLE
AUT-621: Add MfaRequired dimension to metric

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -17,6 +17,7 @@ import uk.gov.di.authentication.oidc.domain.OidcAuditableEvent;
 import uk.gov.di.authentication.oidc.entity.AuthCodeResponse;
 import uk.gov.di.authentication.oidc.services.AuthorizationService;
 import uk.gov.di.authentication.shared.entity.ClientSession;
+import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.VectorOfTrust;
@@ -231,6 +232,15 @@ public class AuthCodeHandler
                                 } else {
                                     LOG.info(
                                             "No mfa method to set. User is either authenticated or signing in from a low level service");
+                                }
+
+                                if (clientSession
+                                        .getEffectiveVectorOfTrust()
+                                        .getCredentialTrustLevel()
+                                        .equals(CredentialTrustLevel.LOW_LEVEL)) {
+                                    dimensions.put("MfaRequired", "No");
+                                } else {
+                                    dimensions.put("MfaRequired", "Yes");
                                 }
 
                                 cloudwatchMetricsService.incrementCounter("SignIn", dimensions);

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -233,7 +233,9 @@ class AuthCodeHandlerTest {
                                 "IsTest",
                                 "true",
                                 "MfaMethod",
-                                mfaMethodType.getValue()));
+                                mfaMethodType.getValue(),
+                                "MfaRequired",
+                                requestedLevel.equals(LOW_LEVEL) ? "No" : "Yes"));
     }
 
     @Test


### PR DESCRIPTION
## What?

- Record the requested credential trust level as new dimension to the `SignIn` metric.

## Why?

We want to collate metrics based on whether the journey required an MFA check (i.e. low level of credential trust).