### PR TITLE
AUT-621: Add additional dimensions to sign-in metric

### DIFF
--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -220,22 +220,26 @@ class AuthCodeHandlerTest {
                         AuditService.UNKNOWN,
                         PERSISTENT_SESSION_ID);
 
-        verify(cloudwatchMetricsService)
-                .incrementCounter(
-                        "SignIn",
-                        Map.of(
-                                "Account",
-                                "NEW",
-                                "Environment",
-                                "unit-test",
-                                "Client",
-                                CLIENT_ID.getValue(),
-                                "IsTest",
-                                "true",
-                                "MfaMethod",
-                                mfaMethodType.getValue(),
-                                "MfaRequired",
-                                requestedLevel.equals(LOW_LEVEL) ? "No" : "Yes"));
+        var dimensions = new HashMap<String, String>();
+        dimensions.putAll(
+                Map.of(
+                        "Account",
+                        "NEW",
+                        "Environment",
+                        "unit-test",
+                        "Client",
+                        CLIENT_ID.getValue(),
+                        "IsTest",
+                        "true",
+                        "IsDocApp",
+                        Boolean.toString(docAppJourney),
+                        "MfaMethod",
+                        mfaMethodType.getValue()));
+        if (!docAppJourney) {
+            dimensions.put("MfaRequired", requestedLevel.equals(LOW_LEVEL) ? "No" : "Yes");
+            dimensions.put("RequestedLevelOfConfidence", "P0");
+        }
+        verify(cloudwatchMetricsService).incrementCounter("SignIn", dimensions);
     }
 
     @Test


### PR DESCRIPTION
## What?

- Add a `IsDocApp` dimension to indicate whether it is doc app journey
- Add a `RequestedLevelOfConfidence` so we can slice out how many identity journeys are being requested
- Only add the `MfaRequired` and `RequestedLevelOfConfidence` dimension if the journey is not a doc app journey

## Why?

We wish to be identify the different types of journeys succeeding in Grafana dashboards, adding the dimension to the `SignIn` metric allows us to do that.

## Related PRs

#2284 