### PR TITLE
AUT-621: Refactor `isTestJourney()` so available in all APIs

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthorizationService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthorizationService.java
@@ -28,7 +28,6 @@ import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static java.lang.String.format;
@@ -232,17 +231,7 @@ public class AuthorizationService {
         return PersistentIdHelper.getExistingOrCreateNewPersistentSessionId(headers);
     }
 
-    public boolean isTestJourney(ClientID clientID, String emailAddress)
-            throws ClientNotFoundException {
-        var client =
-                dynamoClientService
-                        .getClient(clientID.toString())
-                        .orElseThrow(() -> new ClientNotFoundException(clientID.toString()));
-
-        return Optional.ofNullable(client)
-                .map(ClientRegistry::getTestClientEmailAllowlist)
-                .filter(Predicate.not(List::isEmpty))
-                .map(list -> list.contains(emailAddress))
-                .orElse(false);
+    public boolean isTestJourney(ClientID clientID, String emailAddress) {
+        return dynamoClientService.isTestJourney(clientID.toString(), emailAddress);
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ClientService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ClientService.java
@@ -33,4 +33,6 @@ public interface ClientService {
     ClientID generateClientID();
 
     ClientRegistry updateClient(String clientId, UpdateClientConfigRequest updateRequest);
+
+    boolean isTestJourney(String clientID, String emailAddress);
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/DynamoClientServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/DynamoClientServiceTest.java
@@ -1,0 +1,75 @@
+package uk.gov.di.authentication.shared.services;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.entity.ClientRegistry;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+class DynamoClientServiceTest {
+    private static final ClientID CLIENT_ID = new ClientID();
+
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private final AmazonDynamoDB dynamoDB = mock(AmazonDynamoDB.class);
+    private DynamoClientService dynamoClientService;
+
+    @BeforeEach
+    void setup() {
+        when(configurationService.getAwsRegion()).thenReturn("eu-west-2");
+        dynamoClientService = spy(new DynamoClientService(configurationService, dynamoDB));
+    }
+
+    @Test
+    void shouldIdentifyATestUserJourney() {
+        var client =
+                generateClientRegistry(CLIENT_ID.toString())
+                        .setTestClient(true)
+                        .setTestClientEmailAllowlist(List.of("test@test.com"));
+
+        doReturn(Optional.of(client)).when(dynamoClientService).getClient(CLIENT_ID.toString());
+
+        assertTrue(dynamoClientService.isTestJourney(CLIENT_ID.toString(), "test@test.com"));
+    }
+
+    @Test
+    void shouldIdentifyATestUserJourney_UserNotOnAllowList() {
+        var client =
+                generateClientRegistry(CLIENT_ID.toString())
+                        .setTestClient(true)
+                        .setTestClientEmailAllowlist(List.of("different-test@test.com"));
+
+        doReturn(Optional.of(client)).when(dynamoClientService).getClient(CLIENT_ID.toString());
+
+        assertFalse(dynamoClientService.isTestJourney(CLIENT_ID.toString(), "test@test.com"));
+    }
+
+    @Test
+    void shouldIdentifyATestUserJourney_NoAllowlist() {
+        var client = generateClientRegistry(CLIENT_ID.toString()).setTestClient(true);
+
+        doReturn(Optional.of(client)).when(dynamoClientService).getClient(CLIENT_ID.toString());
+
+        assertFalse(dynamoClientService.isTestJourney(CLIENT_ID.toString(), "test@test.com"));
+    }
+
+    @Test
+    void shouldIdentifyATestUserJourney_MissingClient() {
+        doReturn(Optional.empty()).when(dynamoClientService).getClient(CLIENT_ID.toString());
+
+        assertFalse(dynamoClientService.isTestJourney(CLIENT_ID.toString(), "test@test.com"));
+    }
+
+    private ClientRegistry generateClientRegistry(String clientId) {
+        return new ClientRegistry().setClientID(clientId);
+    }
+}


### PR DESCRIPTION
## What?

- Move the `isTestJourney()` method from the `AuthorizationService` (in the `oidc-api` module) to the `ClientService` (in the `shared` module)

## Why?

We will be using this method in the `frontend-api` when publishing additional metrics (PR to follow).
