### PR TITLE
AUT-590: Support ui_locales in /authorize

### DIFF
--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -38,6 +38,7 @@ module "authorize" {
     OIDC_API_BASE_URL        = local.api_base_url
     REDIS_KEY                = local.redis_key
     TERMS_CONDITIONS_VERSION = var.terms_and_conditions
+    SUPPORT_LANGUAGE_CY      = tostring(var.language_cy_enabled)
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.AuthorisationHandler::handleRequest"
   rest_api_id           = aws_api_gateway_rest_api.di_authentication_api.id

--- a/ci/terraform/oidc/staging-overrides.tfvars
+++ b/ci/terraform/oidc/staging-overrides.tfvars
@@ -17,6 +17,7 @@ ipv_backend_uri                    = "https://api.identity.staging.account.gov.u
 ipv_sector                         = "https://identity.staging.account.gov.uk"
 spot_enabled                       = true
 identity_trace_logging_enabled     = true
+language_cy_enabled                = true
 ipv_auth_public_encryption_key     = <<-EOT
 -----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyB5V0Tc9KEV5/zGUHLu0

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -386,6 +386,11 @@ variable "txma_account_id" {
   type    = string
 }
 
+variable "language_cy_enabled" {
+  default = false
+  type    = bool
+}
+
 locals {
   default_performance_parameters = {
     memory          = var.endpoint_memory_size

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/CookieHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/CookieHelper.java
@@ -21,6 +21,8 @@ public class CookieHelper {
     public static final String PERSISTENT_COOKIE_NAME = "di-persistent-session-id";
     public static final String SESSION_COOKIE_NAME = "gs";
 
+    public static final String LANGUAGE_COOKIE_NAME = "lng";
+
     public static Optional<HttpCookie> getHttpCookieFromRequestHeaders(
             Map<String, String> headers, String cookieName) {
         return getHttpCookieFromHeaders(headers, cookieName, REQUEST_COOKIE_HEADER);

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/LocaleHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/LocaleHelper.java
@@ -1,0 +1,47 @@
+package uk.gov.di.authentication.shared.helpers;
+
+import com.nimbusds.langtag.LangTag;
+import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage.CY;
+import static uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage.EN;
+
+public class LocaleHelper {
+
+    public enum SupportedLanguage {
+        EN("en"),
+        CY("cy");
+        private String language;
+
+        SupportedLanguage(String language) {
+            this.language = language;
+        }
+
+        public String getLanguage() {
+            return language;
+        }
+    }
+
+    public static Optional<SupportedLanguage> getPrimaryLanguageFromUILocales(
+            AuthenticationRequest authenticationRequest,
+            ConfigurationService configurationService) {
+
+        if (Objects.isNull(authenticationRequest.getUILocales())) {
+            return Optional.empty();
+        }
+        for (LangTag langTag : authenticationRequest.getUILocales()) {
+            if (langTag.getPrimaryLanguage().equals(EN.getLanguage())) {
+                return Optional.of(EN);
+            }
+            if (configurationService.isLanguageEnabled(CY)
+                    && langTag.getPrimaryLanguage().equals(SupportedLanguage.CY.getLanguage())) {
+                return Optional.of(CY);
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -13,6 +13,7 @@ import software.amazon.awssdk.services.ssm.model.ParameterNotFoundException;
 import uk.gov.di.authentication.shared.configuration.AuditPublisherConfiguration;
 import uk.gov.di.authentication.shared.configuration.BaseLambdaConfiguration;
 import uk.gov.di.authentication.shared.entity.DeliveryReceiptsNotificationType;
+import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 
 import java.net.URI;
 import java.util.Arrays;
@@ -178,6 +179,16 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
                 .equals("true");
     }
 
+    public boolean isLanguageEnabled(SupportedLanguage supportedLanguage) {
+        if (supportedLanguage.equals(SupportedLanguage.EN)) {
+            return true;
+        } else if (supportedLanguage.equals(SupportedLanguage.CY)) {
+            return System.getenv().getOrDefault("SUPPORT_LANGUAGE_CY", "false").equals("true");
+        } else {
+            return false;
+        }
+    }
+
     public long getIDTokenExpiry() {
         return Long.parseLong(System.getenv().getOrDefault("ID_TOKEN_EXPIRY", "120"));
     }
@@ -321,6 +332,11 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
     public int getPersistentCookieMaxAge() {
         return Integer.parseInt(
                 System.getenv().getOrDefault("PERSISTENT_COOKIE_MAX_AGE", "34190000"));
+    }
+
+    public int getLanguageCookieMaxAge() {
+        return Integer.parseInt(
+                System.getenv().getOrDefault("LANGUAGE_COOKIE_MAX_AGE", "31536000"));
     }
 
     public long getSessionExpiry() {

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/LocaleHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/LocaleHelperTest.java
@@ -1,0 +1,139 @@
+package uk.gov.di.authentication.shared.helpers;
+
+import com.nimbusds.langtag.LangTag;
+import com.nimbusds.langtag.LangTagException;
+import com.nimbusds.oauth2.sdk.ResponseType;
+import com.nimbusds.oauth2.sdk.Scope;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.id.State;
+import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+import com.nimbusds.openid.connect.sdk.Nonce;
+import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
+
+class LocaleHelperTest {
+
+    private static Optional<SupportedLanguage> PRIMARY_LANGUAGE_EN =
+            Optional.of(SupportedLanguage.EN);
+    private static Optional<SupportedLanguage> PRIMARY_LANGUAGE_CY =
+            Optional.of(SupportedLanguage.CY);
+
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+
+    private static Stream<Arguments> uiLocalesAndPrimaryLanguageCYEnabled()
+            throws LangTagException {
+        return Stream.of(
+                Arguments.of(List.of(LangTag.parse("en")), PRIMARY_LANGUAGE_EN),
+                Arguments.of(
+                        List.of(LangTag.parse("en"), LangTag.parse("cy")), PRIMARY_LANGUAGE_EN),
+                Arguments.of(
+                        List.of(LangTag.parse("es"), LangTag.parse("en"), LangTag.parse("cy")),
+                        PRIMARY_LANGUAGE_EN),
+                Arguments.of(
+                        List.of(LangTag.parse("es"), LangTag.parse("cy"), LangTag.parse("en")),
+                        PRIMARY_LANGUAGE_CY),
+                Arguments.of(List.of(LangTag.parse("cy")), PRIMARY_LANGUAGE_CY),
+                Arguments.of(
+                        List.of(LangTag.parse("cy"), LangTag.parse("en")), PRIMARY_LANGUAGE_CY),
+                Arguments.of(List.of(), Optional.empty()),
+                Arguments.of(
+                        List.of(LangTag.parse("es"), LangTag.parse("fr"), LangTag.parse("ja")),
+                        Optional.empty()),
+                Arguments.of(
+                        List.of(LangTag.parse("cy-AR"), LangTag.parse("en")), PRIMARY_LANGUAGE_CY),
+                Arguments.of(
+                        List.of(LangTag.parse("de-DE"), LangTag.parse("cy"), LangTag.parse("en")),
+                        PRIMARY_LANGUAGE_CY),
+                Arguments.of(
+                        List.of(
+                                LangTag.parse("zh-cmn-Hans-CN"),
+                                LangTag.parse("en-US"),
+                                LangTag.parse("cy")),
+                        PRIMARY_LANGUAGE_EN));
+    }
+
+    private static Stream<Arguments> uiLocalesAndPrimaryLanguageCYNotEnabled()
+            throws LangTagException {
+        return Stream.of(
+                Arguments.of(List.of(LangTag.parse("en")), PRIMARY_LANGUAGE_EN),
+                Arguments.of(
+                        List.of(LangTag.parse("en"), LangTag.parse("cy")), PRIMARY_LANGUAGE_EN),
+                Arguments.of(
+                        List.of(LangTag.parse("es"), LangTag.parse("en"), LangTag.parse("cy")),
+                        PRIMARY_LANGUAGE_EN),
+                Arguments.of(
+                        List.of(LangTag.parse("es"), LangTag.parse("cy"), LangTag.parse("en")),
+                        PRIMARY_LANGUAGE_EN),
+                Arguments.of(List.of(LangTag.parse("cy")), Optional.empty()),
+                Arguments.of(
+                        List.of(LangTag.parse("cy"), LangTag.parse("en")), PRIMARY_LANGUAGE_EN),
+                Arguments.of(List.of(), Optional.empty()),
+                Arguments.of(
+                        List.of(LangTag.parse("es"), LangTag.parse("fr"), LangTag.parse("ja")),
+                        Optional.empty()),
+                Arguments.of(
+                        List.of(LangTag.parse("cy-AR"), LangTag.parse("en")), PRIMARY_LANGUAGE_EN),
+                Arguments.of(
+                        List.of(LangTag.parse("de-DE"), LangTag.parse("cy"), LangTag.parse("en")),
+                        PRIMARY_LANGUAGE_EN),
+                Arguments.of(
+                        List.of(
+                                LangTag.parse("zh-cmn-Hans-CN"),
+                                LangTag.parse("en-US"),
+                                LangTag.parse("cy")),
+                        PRIMARY_LANGUAGE_EN));
+    }
+
+    @ParameterizedTest
+    @MethodSource("uiLocalesAndPrimaryLanguageCYEnabled")
+    void shouldReturnLanguageBasedOnUILocalesCYEnabled(
+            List<LangTag> uiLocales, Optional<SupportedLanguage> primaryLanguage)
+            throws LangTagException {
+        when(configurationService.isLanguageEnabled(SupportedLanguage.CY)).thenReturn(true);
+        assertThat(
+                LocaleHelper.getPrimaryLanguageFromUILocales(
+                        generateAuthRequest(uiLocales), configurationService),
+                equalTo(primaryLanguage));
+    }
+
+    @ParameterizedTest
+    @MethodSource("uiLocalesAndPrimaryLanguageCYNotEnabled")
+    void shouldReturnLanguageBasedOnUILocalesCYNotEnabled(
+            List<LangTag> uiLocales, Optional<SupportedLanguage> primaryLanguage)
+            throws LangTagException {
+        when(configurationService.isLanguageEnabled(SupportedLanguage.CY)).thenReturn(false);
+        assertThat(
+                LocaleHelper.getPrimaryLanguageFromUILocales(
+                        generateAuthRequest(uiLocales), configurationService),
+                equalTo(primaryLanguage));
+    }
+
+    private AuthenticationRequest generateAuthRequest(List<LangTag> uiLocales) {
+        Scope scope = new Scope();
+        scope.add(OIDCScopeValue.OPENID);
+        AuthenticationRequest.Builder builder =
+                new AuthenticationRequest.Builder(
+                                ResponseType.CODE,
+                                scope,
+                                new ClientID(),
+                                URI.create("http://localhost/redirect"))
+                        .state(new State())
+                        .nonce(new Nonce());
+        builder.uiLocales(uiLocales);
+        return builder.build();
+    }
+}


### PR DESCRIPTION
## What?

Support ui_locales in /authorize

- Check for the presence of the ui_locales paramater and set the 'lng' cookie if any of the supported languages are present.
- Creates two supported languages: English and Welsh.
- Only the primary languages part is processed and all other subtags are ignored, so 'en-US' will just map to 'en' and 'cy-AR' to 'cy'.
- If either of the supported languages en or cy are passed in ui_locales then the language cookie will be set to switch to the correct language.  
- If the parameter is missing, or no supported languages are provided then the cookie will not be set, and frontend user choices will continue to be respected.
- Adds a switch for the Welsh lanugage.  Welsh will only be set in the cookie if the switch is on.
- This PR switches Welsh on in Staging but leaves behaviour unchanged in other environments (where there is only one language).

There is an outstanding issue to be resolved to do with the language cookie domain to make sure that backend cookie sets are respected by frontend apps, which may follow in a separate PR.

## Why?

Apps should be availabe in Welsh.

## Related PRs

https://github.com/alphagov/digital-identity-architecture/pull/227
https://github.com/alphagov/di-auth-stub-relying-party/pull/161