### PR TITLE
AUT-621: Publish auth success metrics

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsService.java
@@ -3,6 +3,7 @@ package uk.gov.di.authentication.shared.services;
 import software.amazon.cloudwatchlogs.emf.logger.MetricsLogger;
 import software.amazon.cloudwatchlogs.emf.model.DimensionSet;
 import software.amazon.cloudwatchlogs.emf.model.Unit;
+import uk.gov.di.authentication.shared.entity.Session;
 
 import java.util.Map;
 
@@ -10,7 +11,15 @@ import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segm
 
 public class CloudwatchMetricsService {
 
-    public CloudwatchMetricsService() {}
+    private final ConfigurationService configurationService;
+
+    public CloudwatchMetricsService() {
+        configurationService = ConfigurationService.getInstance();
+    }
+
+    public CloudwatchMetricsService(ConfigurationService configurationService) {
+        this.configurationService = configurationService;
+    }
 
     public void putEmbeddedValue(String name, double value, Map<String, String> dimensions) {
         segmentedFunctionCall(
@@ -30,5 +39,28 @@ public class CloudwatchMetricsService {
 
     public void incrementCounter(String name, Map<String, String> dimensions) {
         putEmbeddedValue(name, 1, dimensions);
+    }
+
+    public void incrementAuthenticationSuccess(
+            Session.AccountState accountState,
+            String clientId,
+            String requestedLevelOfConfidence,
+            boolean isTestJourney,
+            boolean mfaRequired) {
+        incrementCounter(
+                "AuthenticationSuccess",
+                Map.of(
+                        "Account",
+                        accountState.name(),
+                        "Environment",
+                        configurationService.getEnvironment(),
+                        "Client",
+                        clientId,
+                        "IsTest",
+                        Boolean.toString(isTestJourney),
+                        "RequestedLevelOfConfidence",
+                        requestedLevelOfConfidence,
+                        "MfaRequired",
+                        Boolean.toString(mfaRequired)));
     }
 }


### PR DESCRIPTION
## What?

- Add a new metric to the `CloudwatchMetricsService` to output a new `AuthenticationSuccess` metric with common dimensions
- Add code to the `LoginHandler` to increment the `AuthenticationSuccess` metric if login succeeds and no MFA is required.
- Add code to the `VerifyCodeHandler` to increment the `AuthenticationSuccess` metric if phone verification or SMS MFA
succeeds
- Add code to the `VerifyMfaCodeHandler` to increment the `AuthenticationSuccess` metric if auth app code verification succeeds in either a registration or sign-in context

## Why?

This metric, combined with the `SignIn` metric, should help identify how many journeys are abandoned after successful login. For example, not hitting the button to return to service, or abandoning during the longer identity journey.
