### PR TITLE
AUT-584: Turn off auth's audit service by removing SNS subscription

### DIFF
--- a/ci/terraform/audit-processors/counter_fraud.tf
+++ b/ci/terraform/audit-processors/counter_fraud.tf
@@ -166,12 +166,6 @@ resource "aws_lambda_function" "fraud_realtime_logging_lambda" {
   tags = local.default_tags
 }
 
-resource "aws_sns_topic_subscription" "fraud_realtime_logging_lambda_subscription" {
-  topic_arn = data.aws_sns_topic.event_stream.arn
-  protocol  = "lambda"
-  endpoint  = aws_lambda_function.fraud_realtime_logging_lambda.arn
-}
-
 resource "aws_lambda_permission" "sns_can_execute_subscriber_fraud_realtime_logging_lambda" {
   statement_id  = "AllowExecutionFromSNS"
   action        = "lambda:InvokeFunction"

--- a/ci/terraform/audit-processors/storage.tf
+++ b/ci/terraform/audit-processors/storage.tf
@@ -162,12 +162,6 @@ resource "aws_sqs_queue" "storage_batch_dead_letter_queue" {
   tags = local.default_tags
 }
 
-resource "aws_sns_topic_subscription" "event_stream_subscription" {
-  topic_arn = data.aws_sns_topic.event_stream.arn
-  protocol  = "sqs"
-  endpoint  = aws_sqs_queue.storage_batch.arn
-}
-
 resource "aws_lambda_event_source_mapping" "audit_storage_batch_queue_subscription" {
   event_source_arn = aws_sqs_queue.storage_batch.arn
   function_name    = aws_lambda_function.audit_processor_lambda.arn


### PR DESCRIPTION
This is the first step in decommissioning Auth's internal audit service in favour of the TxMA-supported audit service.

The lambdas will continue firing messages to SNS but they won't get consumed by either the logging lambda or the long-term storage queue.

Once this has landed, we can start dismantling the infrastructure.
