### PR TITLE
AUT-639: Groundwork to choose Notify templates by language

### DIFF
--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/queuehandlers/NotificationHandlerIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/queuehandlers/NotificationHandlerIntegrationTest.java
@@ -4,6 +4,7 @@ import com.amazonaws.services.lambda.runtime.Context;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.accountmanagement.lambda.NotificationHandler;
 import uk.gov.di.authentication.shared.entity.NotifyRequest;
+import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.sharedtest.basetest.NotifyIntegrationTest;
 
@@ -29,7 +30,8 @@ public class NotificationHandlerIntegrationTest extends NotifyIntegrationTest {
 
     @Test
     void shouldCallNotifyWhenValidEmailRequestIsAddedToQueue() throws Json.JsonException {
-        NotifyRequest notifyRequest = new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL, CODE);
+        NotifyRequest notifyRequest =
+                new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL, CODE, SupportedLanguage.EN);
 
         handler.handleRequest(createSqsEvent(notifyRequest), mock(Context.class));
 
@@ -52,7 +54,8 @@ public class NotificationHandlerIntegrationTest extends NotifyIntegrationTest {
     @Test
     void shouldCallNotifyWhenValidPhoneNumberRequestIsAddedToQueue() throws Json.JsonException {
         NotifyRequest notifyRequest =
-                new NotifyRequest(TEST_PHONE_NUMBER, VERIFY_PHONE_NUMBER, CODE);
+                new NotifyRequest(
+                        TEST_PHONE_NUMBER, VERIFY_PHONE_NUMBER, CODE, SupportedLanguage.EN);
 
         handler.handleRequest(createSqsEvent(notifyRequest), mock(Context.class));
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
@@ -200,7 +200,9 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
                                     });
 
             sessionService.save(userContext.getSession().incrementCodeRequestCount());
-            NotifyRequest notifyRequest = new NotifyRequest(phoneNumber, notificationType, code);
+            NotifyRequest notifyRequest =
+                    new NotifyRequest(
+                            phoneNumber, notificationType, code, userContext.getUserLanguage());
             AuditableEvent auditableEvent;
             if (!isTestClientAndAllowedEmail(userContext, notificationType)) {
                 sqsClient.send(objectMapper.writeValueAsString(notifyRequest));

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandler.java
@@ -95,7 +95,8 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                             notificationService.sendEmail(
                                     notifyRequest.getDestination(),
                                     notifyPersonalisation,
-                                    ACCOUNT_CREATED_CONFIRMATION);
+                                    ACCOUNT_CREATED_CONFIRMATION,
+                                    notifyRequest.getLanguage());
                             break;
                         case VERIFY_EMAIL:
                             notifyPersonalisation.put("validation-code", notifyRequest.getCode());
@@ -107,19 +108,24 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                             notificationService.sendEmail(
                                     notifyRequest.getDestination(),
                                     notifyPersonalisation,
-                                    VERIFY_EMAIL);
+                                    VERIFY_EMAIL,
+                                    notifyRequest.getLanguage());
                             break;
                         case VERIFY_PHONE_NUMBER:
                             notifyPersonalisation.put("validation-code", notifyRequest.getCode());
                             notificationService.sendText(
                                     notifyRequest.getDestination(),
                                     notifyPersonalisation,
-                                    VERIFY_PHONE_NUMBER);
+                                    VERIFY_PHONE_NUMBER,
+                                    notifyRequest.getLanguage());
                             break;
                         case MFA_SMS:
                             notifyPersonalisation.put("validation-code", notifyRequest.getCode());
                             notificationService.sendText(
-                                    notifyRequest.getDestination(), notifyPersonalisation, MFA_SMS);
+                                    notifyRequest.getDestination(),
+                                    notifyPersonalisation,
+                                    MFA_SMS,
+                                    notifyRequest.getLanguage());
                             break;
                         case RESET_PASSWORD:
                             notifyPersonalisation.put(
@@ -130,7 +136,8 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                             notificationService.sendEmail(
                                     notifyRequest.getDestination(),
                                     notifyPersonalisation,
-                                    RESET_PASSWORD);
+                                    RESET_PASSWORD,
+                                    notifyRequest.getLanguage());
                             break;
                         case PASSWORD_RESET_CONFIRMATION:
                             Map<String, Object> passwordResetConfirmationPersonalisation =
@@ -141,7 +148,8 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                             notificationService.sendEmail(
                                     notifyRequest.getDestination(),
                                     passwordResetConfirmationPersonalisation,
-                                    PASSWORD_RESET_CONFIRMATION);
+                                    PASSWORD_RESET_CONFIRMATION,
+                                    notifyRequest.getLanguage());
                             break;
                         case RESET_PASSWORD_WITH_CODE:
                             notifyPersonalisation.put("validation-code", notifyRequest.getCode());
@@ -153,7 +161,8 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                             notificationService.sendEmail(
                                     notifyRequest.getDestination(),
                                     notifyPersonalisation,
-                                    RESET_PASSWORD_WITH_CODE);
+                                    RESET_PASSWORD_WITH_CODE,
+                                    notifyRequest.getLanguage());
                             break;
                     }
                     writeTestClientOtpToS3(notifyRequest.getCode(), notifyRequest.getDestination());

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
@@ -144,7 +144,8 @@ public class ResetPasswordHandler extends BaseFrontendHandler<ResetPasswordCompl
             NotifyRequest notifyRequest =
                     new NotifyRequest(
                             userCredentials.getEmail(),
-                            NotificationType.PASSWORD_RESET_CONFIRMATION);
+                            NotificationType.PASSWORD_RESET_CONFIRMATION,
+                            userContext.getUserLanguage());
             LOG.info("Placing message on queue");
             sqsClient.send(serialiseRequest(notifyRequest));
             auditService.submitAuditEvent(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
@@ -178,7 +178,11 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
                     subjectId, code, configurationService.getCodeExpiry(), notificationType);
         }
         NotifyRequest notifyRequest =
-                new NotifyRequest(resetPasswordRequest.getEmail(), notificationType, notifyText);
+                new NotifyRequest(
+                        resetPasswordRequest.getEmail(),
+                        notificationType,
+                        notifyText,
+                        userContext.getUserLanguage());
         sessionService.save(userContext.getSession().incrementPasswordResetCount());
         sqsClient.send(serialiseRequest(notifyRequest));
         LOG.info("Successfully processed request");

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
@@ -110,7 +110,10 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
             if (request.getNotificationType().equals(ACCOUNT_CREATED_CONFIRMATION)) {
                 LOG.info("Placing message on queue for AccountCreatedConfirmation");
                 NotifyRequest notifyRequest =
-                        new NotifyRequest(request.getEmail(), ACCOUNT_CREATED_CONFIRMATION);
+                        new NotifyRequest(
+                                request.getEmail(),
+                                ACCOUNT_CREATED_CONFIRMATION,
+                                userContext.getUserLanguage());
                 if (notTestClientWithValidTestEmail(userContext, ACCOUNT_CREATED_CONFIRMATION)) {
                     sqsClient.send(objectMapper.writeValueAsString((notifyRequest)));
                     LOG.info("AccountCreatedConfirmation email placed on queue");
@@ -175,7 +178,9 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
                                     return newCode;
                                 });
 
-        var notifyRequest = new NotifyRequest(destination, notificationType, code);
+        var notifyRequest =
+                new NotifyRequest(
+                        destination, notificationType, code, userContext.getUserLanguage());
 
         sessionService.save(session.incrementCodeRequestCount());
         if (notTestClientWithValidTestEmail(userContext, notificationType)) {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
@@ -21,6 +21,7 @@ import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.NotifyRequest;
 import uk.gov.di.authentication.shared.entity.Session;
+import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
@@ -135,7 +136,8 @@ public class MfaHandlerTest {
         when(authenticationService.getPhoneNumber(TEST_EMAIL_ADDRESS))
                 .thenReturn(Optional.of(PHONE_NUMBER));
         when(codeGeneratorService.sixDigitCode()).thenReturn(CODE);
-        NotifyRequest notifyRequest = new NotifyRequest(PHONE_NUMBER, MFA_SMS, CODE);
+        NotifyRequest notifyRequest =
+                new NotifyRequest(PHONE_NUMBER, MFA_SMS, CODE, SupportedLanguage.EN);
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setHeaders(headers);
         event.setBody(format("{ \"email\": \"%s\"}", TEST_EMAIL_ADDRESS));
@@ -171,7 +173,8 @@ public class MfaHandlerTest {
                 .thenReturn(Optional.of(PHONE_NUMBER));
         when(codeStorageService.getOtpCode(TEST_EMAIL_ADDRESS, VERIFY_PHONE_NUMBER))
                 .thenReturn(Optional.of(CODE));
-        NotifyRequest notifyRequest = new NotifyRequest(PHONE_NUMBER, VERIFY_PHONE_NUMBER, CODE);
+        NotifyRequest notifyRequest =
+                new NotifyRequest(PHONE_NUMBER, VERIFY_PHONE_NUMBER, CODE, SupportedLanguage.EN);
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setHeaders(headers);
         event.setBody(
@@ -212,7 +215,8 @@ public class MfaHandlerTest {
         when(authenticationService.getPhoneNumber(TEST_EMAIL_ADDRESS))
                 .thenReturn(Optional.of(PHONE_NUMBER));
         when(codeGeneratorService.sixDigitCode()).thenReturn(CODE);
-        NotifyRequest notifyRequest = new NotifyRequest(PHONE_NUMBER, MFA_SMS, CODE);
+        NotifyRequest notifyRequest =
+                new NotifyRequest(PHONE_NUMBER, MFA_SMS, CODE, SupportedLanguage.EN);
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setHeaders(Map.of("Session-Id", session.getSessionId()));
         event.setBody(format("{ \"email\": \"%s\"}", TEST_EMAIL_ADDRESS));
@@ -413,7 +417,8 @@ public class MfaHandlerTest {
         when(authenticationService.getPhoneNumber(TEST_EMAIL_ADDRESS))
                 .thenReturn(Optional.of(PHONE_NUMBER));
         when(codeGeneratorService.sixDigitCode()).thenReturn(CODE);
-        NotifyRequest notifyRequest = new NotifyRequest(PHONE_NUMBER, MFA_SMS, CODE);
+        NotifyRequest notifyRequest =
+                new NotifyRequest(PHONE_NUMBER, MFA_SMS, CODE, SupportedLanguage.EN);
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setHeaders(Map.of("Session-Id", session.getSessionId()));
         event.setBody(format("{ \"email\": \"%s\"}", TEST_EMAIL_ADDRESS));
@@ -455,7 +460,8 @@ public class MfaHandlerTest {
 
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
-        NotifyRequest notifyRequest = new NotifyRequest(PHONE_NUMBER, MFA_SMS, CODE);
+        NotifyRequest notifyRequest =
+                new NotifyRequest(PHONE_NUMBER, MFA_SMS, CODE, SupportedLanguage.EN);
         String serialisedRequest = objectMapper.writeValueAsString(notifyRequest);
 
         verify(codeGeneratorService, never()).sixDigitCode();
@@ -488,7 +494,8 @@ public class MfaHandlerTest {
 
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
-        NotifyRequest notifyRequest = new NotifyRequest(PHONE_NUMBER, MFA_SMS, CODE);
+        NotifyRequest notifyRequest =
+                new NotifyRequest(PHONE_NUMBER, MFA_SMS, CODE, SupportedLanguage.EN);
         String serialisedRequest = objectMapper.writeValueAsString(notifyRequest);
 
         verify(codeGeneratorService).sixDigitCode();

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandlerTest.java
@@ -10,6 +10,7 @@ import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import uk.gov.di.authentication.shared.entity.NotifyRequest;
+import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.NotificationService;
@@ -67,7 +68,8 @@ public class NotificationHandlerTest {
     void shouldSuccessfullyProcessEmailMessageFromSQSQueue()
             throws Json.JsonException, NotificationClientException {
 
-        NotifyRequest notifyRequest = new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL, "654321");
+        NotifyRequest notifyRequest =
+                new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL, "654321", SupportedLanguage.EN);
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
         var contactUsLinkUrl =
@@ -80,14 +82,16 @@ public class NotificationHandlerTest {
         personalisation.put("email-address", notifyRequest.getDestination());
         personalisation.put("contact-us-link", contactUsLinkUrl);
 
-        verify(notificationService).sendEmail(TEST_EMAIL_ADDRESS, personalisation, VERIFY_EMAIL);
+        verify(notificationService)
+                .sendEmail(TEST_EMAIL_ADDRESS, personalisation, VERIFY_EMAIL, SupportedLanguage.EN);
     }
 
     @Test
     void shouldSuccessfullyProcessResetPasswordConfirmationFromSQSQueue()
             throws Json.JsonException, NotificationClientException {
         NotifyRequest notifyRequest =
-                new NotifyRequest(TEST_EMAIL_ADDRESS, PASSWORD_RESET_CONFIRMATION);
+                new NotifyRequest(
+                        TEST_EMAIL_ADDRESS, PASSWORD_RESET_CONFIRMATION, SupportedLanguage.EN);
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
         var contactUsLinkUrl =
@@ -99,14 +103,22 @@ public class NotificationHandlerTest {
         personalisation.put("contact-us-link", contactUsLinkUrl);
 
         verify(notificationService)
-                .sendEmail(TEST_EMAIL_ADDRESS, personalisation, PASSWORD_RESET_CONFIRMATION);
+                .sendEmail(
+                        TEST_EMAIL_ADDRESS,
+                        personalisation,
+                        PASSWORD_RESET_CONFIRMATION,
+                        SupportedLanguage.EN);
     }
 
     @Test
     void shouldSuccessfullyProcessResetPasswordEmailFromSQSQueue()
             throws Json.JsonException, NotificationClientException {
         NotifyRequest notifyRequest =
-                new NotifyRequest(TEST_EMAIL_ADDRESS, RESET_PASSWORD, TEST_RESET_PASSWORD_LINK);
+                new NotifyRequest(
+                        TEST_EMAIL_ADDRESS,
+                        RESET_PASSWORD,
+                        TEST_RESET_PASSWORD_LINK,
+                        SupportedLanguage.EN);
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
         var contactUsLinkUrl =
@@ -118,7 +130,9 @@ public class NotificationHandlerTest {
         personalisation.put("reset-password-link", TEST_RESET_PASSWORD_LINK);
         personalisation.put("contact-us-link", contactUsLinkUrl);
 
-        verify(notificationService).sendEmail(TEST_EMAIL_ADDRESS, personalisation, RESET_PASSWORD);
+        verify(notificationService)
+                .sendEmail(
+                        TEST_EMAIL_ADDRESS, personalisation, RESET_PASSWORD, SupportedLanguage.EN);
     }
 
     @Test
@@ -132,7 +146,8 @@ public class NotificationHandlerTest {
         when(configService.getGovUKAccountsURL()).thenReturn(govUKAccountsUrl);
 
         NotifyRequest notifyRequest =
-                new NotifyRequest(TEST_EMAIL_ADDRESS, ACCOUNT_CREATED_CONFIRMATION);
+                new NotifyRequest(
+                        TEST_EMAIL_ADDRESS, ACCOUNT_CREATED_CONFIRMATION, SupportedLanguage.EN);
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
 
@@ -143,14 +158,19 @@ public class NotificationHandlerTest {
         personalisation.put("gov-uk-accounts-url", govUKAccountsUrl.toString());
 
         verify(notificationService)
-                .sendEmail(TEST_EMAIL_ADDRESS, personalisation, ACCOUNT_CREATED_CONFIRMATION);
+                .sendEmail(
+                        TEST_EMAIL_ADDRESS,
+                        personalisation,
+                        ACCOUNT_CREATED_CONFIRMATION,
+                        SupportedLanguage.EN);
     }
 
     @Test
     void shouldSuccessfullyProcessPhoneMessageFromSQSQueue()
             throws Json.JsonException, NotificationClientException {
         NotifyRequest notifyRequest =
-                new NotifyRequest(TEST_PHONE_NUMBER, VERIFY_PHONE_NUMBER, "654321");
+                new NotifyRequest(
+                        TEST_PHONE_NUMBER, VERIFY_PHONE_NUMBER, "654321", SupportedLanguage.EN);
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
 
@@ -160,7 +180,11 @@ public class NotificationHandlerTest {
         personalisation.put("validation-code", "654321");
 
         verify(notificationService)
-                .sendText(notifyRequest.getDestination(), personalisation, VERIFY_PHONE_NUMBER);
+                .sendText(
+                        notifyRequest.getDestination(),
+                        personalisation,
+                        VERIFY_PHONE_NUMBER,
+                        SupportedLanguage.EN);
     }
 
     @Test
@@ -180,7 +204,8 @@ public class NotificationHandlerTest {
     @Test
     void shouldThrowExceptionIfNotifyIsUnableToSendEmail()
             throws Json.JsonException, NotificationClientException {
-        NotifyRequest notifyRequest = new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL, "654321");
+        NotifyRequest notifyRequest =
+                new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL, "654321", SupportedLanguage.EN);
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
         var contactUsLinkUrl =
@@ -192,7 +217,7 @@ public class NotificationHandlerTest {
         personalisation.put("contact-us-link", contactUsLinkUrl);
         Mockito.doThrow(NotificationClientException.class)
                 .when(notificationService)
-                .sendEmail(TEST_EMAIL_ADDRESS, personalisation, VERIFY_EMAIL);
+                .sendEmail(TEST_EMAIL_ADDRESS, personalisation, VERIFY_EMAIL, SupportedLanguage.EN);
 
         RuntimeException exception =
                 assertThrows(
@@ -209,7 +234,8 @@ public class NotificationHandlerTest {
     void shouldThrowExceptionIfNotifyIsUnableToSendText()
             throws Json.JsonException, NotificationClientException {
         NotifyRequest notifyRequest =
-                new NotifyRequest(TEST_PHONE_NUMBER, VERIFY_PHONE_NUMBER, "654321");
+                new NotifyRequest(
+                        TEST_PHONE_NUMBER, VERIFY_PHONE_NUMBER, "654321", SupportedLanguage.EN);
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
 
@@ -217,7 +243,11 @@ public class NotificationHandlerTest {
         personalisation.put("validation-code", "654321");
         Mockito.doThrow(NotificationClientException.class)
                 .when(notificationService)
-                .sendText(TEST_PHONE_NUMBER, personalisation, VERIFY_PHONE_NUMBER);
+                .sendText(
+                        TEST_PHONE_NUMBER,
+                        personalisation,
+                        VERIFY_PHONE_NUMBER,
+                        SupportedLanguage.EN);
 
         RuntimeException exception =
                 assertThrows(
@@ -234,7 +264,8 @@ public class NotificationHandlerTest {
     void shouldSuccessfullyProcessPhoneMessageFromSQSQueueAndWriteToS3WhenTestClient()
             throws Json.JsonException, NotificationClientException {
         NotifyRequest notifyRequest =
-                new NotifyRequest(NOTIFY_PHONE_NUMBER, VERIFY_PHONE_NUMBER, "654321");
+                new NotifyRequest(
+                        NOTIFY_PHONE_NUMBER, VERIFY_PHONE_NUMBER, "654321", SupportedLanguage.EN);
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
 
@@ -244,7 +275,11 @@ public class NotificationHandlerTest {
         personalisation.put("validation-code", "654321");
 
         verify(notificationService)
-                .sendText(notifyRequest.getDestination(), personalisation, VERIFY_PHONE_NUMBER);
+                .sendText(
+                        notifyRequest.getDestination(),
+                        personalisation,
+                        VERIFY_PHONE_NUMBER,
+                        SupportedLanguage.EN);
         var putObjectRequest =
                 PutObjectRequest.builder().bucket(BUCKET_NAME).key(NOTIFY_PHONE_NUMBER).build();
         verify(s3Client).putObject(eq(putObjectRequest), any(RequestBody.class));
@@ -253,7 +288,8 @@ public class NotificationHandlerTest {
     @Test
     void shouldSuccessfullyProcessMfaMessageFromSQSQueue()
             throws Json.JsonException, NotificationClientException {
-        NotifyRequest notifyRequest = new NotifyRequest(TEST_PHONE_NUMBER, MFA_SMS, "654321");
+        NotifyRequest notifyRequest =
+                new NotifyRequest(TEST_PHONE_NUMBER, MFA_SMS, "654321", SupportedLanguage.EN);
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
 
@@ -263,13 +299,18 @@ public class NotificationHandlerTest {
         personalisation.put("validation-code", "654321");
 
         verify(notificationService)
-                .sendText(notifyRequest.getDestination(), personalisation, MFA_SMS);
+                .sendText(
+                        notifyRequest.getDestination(),
+                        personalisation,
+                        MFA_SMS,
+                        SupportedLanguage.EN);
     }
 
     @Test
     void shouldSuccessfullyProcessMfaMessageFromSQSQueueAndWriteToS3WhenTestClient()
             throws Json.JsonException, NotificationClientException {
-        NotifyRequest notifyRequest = new NotifyRequest(NOTIFY_PHONE_NUMBER, MFA_SMS, "654321");
+        NotifyRequest notifyRequest =
+                new NotifyRequest(NOTIFY_PHONE_NUMBER, MFA_SMS, "654321", SupportedLanguage.EN);
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
 
@@ -279,7 +320,11 @@ public class NotificationHandlerTest {
         personalisation.put("validation-code", "654321");
 
         verify(notificationService)
-                .sendText(notifyRequest.getDestination(), personalisation, MFA_SMS);
+                .sendText(
+                        notifyRequest.getDestination(),
+                        personalisation,
+                        MFA_SMS,
+                        SupportedLanguage.EN);
         var putObjectRequest =
                 PutObjectRequest.builder().bucket(BUCKET_NAME).key(NOTIFY_PHONE_NUMBER).build();
         verify(s3Client).putObject(eq(putObjectRequest), any(RequestBody.class));
@@ -289,7 +334,11 @@ public class NotificationHandlerTest {
     void shouldSuccessfullyProcessPasswordResetWithCodeMessageFromSQSQueue()
             throws Json.JsonException, NotificationClientException {
         NotifyRequest notifyRequest =
-                new NotifyRequest(TEST_EMAIL_ADDRESS, RESET_PASSWORD_WITH_CODE, "654321");
+                new NotifyRequest(
+                        TEST_EMAIL_ADDRESS,
+                        RESET_PASSWORD_WITH_CODE,
+                        "654321",
+                        SupportedLanguage.EN);
         String notifyRequestString = objectMapper.writeValueAsString(notifyRequest);
         SQSEvent sqsEvent = generateSQSEvent(notifyRequestString);
         var contactUsLinkUrl =
@@ -303,7 +352,11 @@ public class NotificationHandlerTest {
         personalisation.put("contact-us-link", contactUsLinkUrl);
 
         verify(notificationService)
-                .sendEmail(TEST_EMAIL_ADDRESS, personalisation, RESET_PASSWORD_WITH_CODE);
+                .sendEmail(
+                        TEST_EMAIL_ADDRESS,
+                        personalisation,
+                        RESET_PASSWORD_WITH_CODE,
+                        SupportedLanguage.EN);
     }
 
     private SQSEvent generateSQSEvent(String messageBody) {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandlerTest.java
@@ -13,6 +13,7 @@ import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.helpers.Argon2EncoderHelper;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
+import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
@@ -97,7 +98,8 @@ class ResetPasswordHandlerTest {
                 .thenReturn(generateUserCredentials());
         usingValidSession();
         NotifyRequest notifyRequest =
-                new NotifyRequest(EMAIL, NotificationType.PASSWORD_RESET_CONFIRMATION);
+                new NotifyRequest(
+                        EMAIL, NotificationType.PASSWORD_RESET_CONFIRMATION, SupportedLanguage.EN);
         Map<String, String> headers = new HashMap<>();
         headers.put(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, PERSISTENT_ID);
         headers.put("Session-Id", session.getSessionId());
@@ -132,7 +134,8 @@ class ResetPasswordHandlerTest {
                 .thenReturn(generateUserCredentials());
         usingValidSession();
         NotifyRequest notifyRequest =
-                new NotifyRequest(EMAIL, NotificationType.PASSWORD_RESET_CONFIRMATION);
+                new NotifyRequest(
+                        EMAIL, NotificationType.PASSWORD_RESET_CONFIRMATION, SupportedLanguage.EN);
         Map<String, String> headers = new HashMap<>();
         headers.put(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, PERSISTENT_ID);
         headers.put("Session-Id", session.getSessionId());
@@ -167,7 +170,8 @@ class ResetPasswordHandlerTest {
                 .thenReturn(generateMigratedUserCredentials());
         usingValidSession();
         NotifyRequest notifyRequest =
-                new NotifyRequest(EMAIL, NotificationType.PASSWORD_RESET_CONFIRMATION);
+                new NotifyRequest(
+                        EMAIL, NotificationType.PASSWORD_RESET_CONFIRMATION, SupportedLanguage.EN);
         Map<String, String> headers = new HashMap<>();
         headers.put(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, PERSISTENT_ID);
         headers.put("Session-Id", session.getSessionId());
@@ -231,7 +235,8 @@ class ResetPasswordHandlerTest {
         when(authenticationService.getUserCredentialsFromSubject(SUBJECT))
                 .thenReturn(generateUserCredentials(Argon2EncoderHelper.argon2Hash(NEW_PASSWORD)));
         NotifyRequest notifyRequest =
-                new NotifyRequest(EMAIL, NotificationType.PASSWORD_RESET_CONFIRMATION);
+                new NotifyRequest(
+                        EMAIL, NotificationType.PASSWORD_RESET_CONFIRMATION, SupportedLanguage.EN);
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setBody(format("{ \"code\": \"%s\", \"password\": \"%s\"}", CODE, NEW_PASSWORD));
         event.setHeaders(Map.of("Session-Id", session.getSessionId()));

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
@@ -17,6 +17,7 @@ import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.NotifyRequest;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
+import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
@@ -128,7 +129,11 @@ class ResetPasswordRequestHandlerTest {
                         TEST_SIX_DIGIT_CODE, session.getSessionId(), persistentId))
                 .thenReturn(TEST_RESET_PASSWORD_LINK);
         NotifyRequest notifyRequest =
-                new NotifyRequest(TEST_EMAIL_ADDRESS, RESET_PASSWORD, TEST_RESET_PASSWORD_LINK);
+                new NotifyRequest(
+                        TEST_EMAIL_ADDRESS,
+                        RESET_PASSWORD,
+                        TEST_RESET_PASSWORD_LINK,
+                        SupportedLanguage.EN);
         String serialisedRequest = objectMapper.writeValueAsString(notifyRequest);
 
         usingValidSession();
@@ -169,7 +174,10 @@ class ResetPasswordRequestHandlerTest {
         when(authenticationService.getSubjectFromEmail(TEST_EMAIL_ADDRESS)).thenReturn(subject);
         NotifyRequest notifyRequest =
                 new NotifyRequest(
-                        TEST_EMAIL_ADDRESS, RESET_PASSWORD_WITH_CODE, TEST_SIX_DIGIT_CODE);
+                        TEST_EMAIL_ADDRESS,
+                        RESET_PASSWORD_WITH_CODE,
+                        TEST_SIX_DIGIT_CODE,
+                        SupportedLanguage.EN);
         String serialisedRequest = objectMapper.writeValueAsString(notifyRequest);
 
         usingValidSession();
@@ -223,7 +231,10 @@ class ResetPasswordRequestHandlerTest {
 
         NotifyRequest notifyRequest =
                 new NotifyRequest(
-                        TEST_EMAIL_ADDRESS, RESET_PASSWORD_WITH_CODE, TEST_SIX_DIGIT_CODE);
+                        TEST_EMAIL_ADDRESS,
+                        RESET_PASSWORD_WITH_CODE,
+                        TEST_SIX_DIGIT_CODE,
+                        SupportedLanguage.EN);
         String serialisedRequest = objectMapper.writeValueAsString(notifyRequest);
 
         verify(codeGeneratorService, never()).sixDigitCode();
@@ -272,7 +283,11 @@ class ResetPasswordRequestHandlerTest {
                         TEST_SIX_DIGIT_CODE, session.getSessionId(), persistentId))
                 .thenReturn(TEST_RESET_PASSWORD_LINK);
         NotifyRequest notifyRequest =
-                new NotifyRequest(TEST_EMAIL_ADDRESS, RESET_PASSWORD, TEST_RESET_PASSWORD_LINK);
+                new NotifyRequest(
+                        TEST_EMAIL_ADDRESS,
+                        RESET_PASSWORD,
+                        TEST_RESET_PASSWORD_LINK,
+                        SupportedLanguage.EN);
         String serialisedRequest = objectMapper.writeValueAsString(notifyRequest);
         Mockito.doThrow(SdkClientException.class).when(awsSqsClient).send(eq(serialisedRequest));
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
@@ -23,6 +23,7 @@ import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.NotifyRequest;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
+import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.AwsSqsClient;
@@ -147,7 +148,11 @@ class SendNotificationHandlerTest {
     void shouldReturn204AndPutMessageOnQueueForAValidVerifyEmailRequest()
             throws Json.JsonException {
         NotifyRequest notifyRequest =
-                new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL, TEST_SIX_DIGIT_CODE);
+                new NotifyRequest(
+                        TEST_EMAIL_ADDRESS,
+                        VERIFY_EMAIL,
+                        TEST_SIX_DIGIT_CODE,
+                        SupportedLanguage.EN);
         String serialisedRequest = objectMapper.writeValueAsString(notifyRequest);
 
         usingValidSession();
@@ -185,7 +190,11 @@ class SendNotificationHandlerTest {
                         TEST_EMAIL_ADDRESS, VERIFY_PHONE_NUMBER, TEST_PHONE_NUMBER));
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
         var notifyRequest =
-                new NotifyRequest(TEST_PHONE_NUMBER, VERIFY_PHONE_NUMBER, TEST_SIX_DIGIT_CODE);
+                new NotifyRequest(
+                        TEST_PHONE_NUMBER,
+                        VERIFY_PHONE_NUMBER,
+                        TEST_SIX_DIGIT_CODE,
+                        SupportedLanguage.EN);
         verify(awsSqsClient).send(objectMapper.writeValueAsString(notifyRequest));
         String serialisedRequest = objectMapper.writeValueAsString(notifyRequest);
 
@@ -205,7 +214,11 @@ class SendNotificationHandlerTest {
             throws Json.JsonException {
         when(configurationService.isTestClientsEnabled()).thenReturn(true);
         NotifyRequest notifyRequest =
-                new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL, TEST_SIX_DIGIT_CODE);
+                new NotifyRequest(
+                        TEST_EMAIL_ADDRESS,
+                        VERIFY_EMAIL,
+                        TEST_SIX_DIGIT_CODE,
+                        SupportedLanguage.EN);
         String serialisedRequest = objectMapper.writeValueAsString(notifyRequest);
 
         usingValidSession();
@@ -259,7 +272,11 @@ class SendNotificationHandlerTest {
     @Test
     void shouldReturn500IfMessageCannotBeSentToQueue() throws Json.JsonException {
         NotifyRequest notifyRequest =
-                new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL, TEST_SIX_DIGIT_CODE);
+                new NotifyRequest(
+                        TEST_EMAIL_ADDRESS,
+                        VERIFY_EMAIL,
+                        TEST_SIX_DIGIT_CODE,
+                        SupportedLanguage.EN);
         String serialisedRequest = objectMapper.writeValueAsString(notifyRequest);
         Mockito.doThrow(SdkClientException.class).when(awsSqsClient).send(eq(serialisedRequest));
 
@@ -451,7 +468,8 @@ class SendNotificationHandlerTest {
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         NotifyRequest notifyRequest =
-                new NotifyRequest(TEST_EMAIL_ADDRESS, ACCOUNT_CREATED_CONFIRMATION);
+                new NotifyRequest(
+                        TEST_EMAIL_ADDRESS, ACCOUNT_CREATED_CONFIRMATION, SupportedLanguage.EN);
         verify(awsSqsClient).send(objectMapper.writeValueAsString(notifyRequest));
 
         assertEquals(204, result.getStatusCode());
@@ -472,7 +490,8 @@ class SendNotificationHandlerTest {
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         NotifyRequest notifyRequest =
-                new NotifyRequest(TEST_EMAIL_ADDRESS, ACCOUNT_CREATED_CONFIRMATION);
+                new NotifyRequest(
+                        TEST_EMAIL_ADDRESS, ACCOUNT_CREATED_CONFIRMATION, SupportedLanguage.EN);
         verify(awsSqsClient, never()).send(objectMapper.writeValueAsString(notifyRequest));
 
         assertEquals(204, result.getStatusCode());

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/NotificationServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/NotificationServiceTest.java
@@ -2,6 +2,7 @@ package uk.gov.di.authentication.frontendapi.services;
 
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.shared.entity.TemplateAware;
+import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 import uk.gov.di.authentication.shared.services.NotificationService;
 import uk.gov.service.notify.NotificationClient;
 import uk.gov.service.notify.NotificationClientException;
@@ -30,7 +31,7 @@ class NotificationServiceTest {
             return name();
         }
 
-        public String getTemplateId(String language) {
+        public String getTemplateId(SupportedLanguage language) {
             return name();
         }
     }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/NotificationServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/NotificationServiceTest.java
@@ -29,6 +29,10 @@ class NotificationServiceTest {
         public String getTemplateId() {
             return name();
         }
+
+        public String getTemplateId(String language) {
+            return name();
+        }
     }
 
     @Test

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/NotificationServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/NotificationServiceTest.java
@@ -42,7 +42,8 @@ class NotificationServiceTest {
         emailPersonalisation.put("validation-code", "some-code");
         emailPersonalisation.put("email-address", TEST_EMAIL);
 
-        notificationService.sendEmail(TEST_EMAIL, emailPersonalisation, FAKE_EMAIL);
+        notificationService.sendEmail(
+                TEST_EMAIL, emailPersonalisation, FAKE_EMAIL, SupportedLanguage.EN);
 
         verify(notificationClient).sendEmail("FAKE_EMAIL", TEST_EMAIL, emailPersonalisation, "");
     }
@@ -51,7 +52,8 @@ class NotificationServiceTest {
     public void shouldCallNotifyClientToSendText() throws NotificationClientException {
         Map<String, Object> phonePersonalisation = new HashMap<>();
         phonePersonalisation.put("validation-code", "some-code");
-        notificationService.sendText(TEST_PHONE_NUMBER, phonePersonalisation, FAKE_SMS);
+        notificationService.sendText(
+                TEST_PHONE_NUMBER, phonePersonalisation, FAKE_SMS, SupportedLanguage.EN);
 
         verify(notificationClient).sendSms("FAKE_SMS", TEST_PHONE_NUMBER, phonePersonalisation, "");
     }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/NotificationServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/NotificationServiceTest.java
@@ -3,6 +3,7 @@ package uk.gov.di.authentication.frontendapi.services;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.shared.entity.TemplateAware;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.NotificationService;
 import uk.gov.service.notify.NotificationClient;
 import uk.gov.service.notify.NotificationClientException;
@@ -31,7 +32,8 @@ class NotificationServiceTest {
             return name();
         }
 
-        public String getTemplateId(SupportedLanguage language) {
+        public String getTemplateId(
+                SupportedLanguage language, ConfigurationService configurationService) {
             return name();
         }
     }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/NotificationHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/NotificationHandlerIntegrationTest.java
@@ -4,6 +4,7 @@ import com.amazonaws.services.lambda.runtime.Context;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.frontendapi.lambda.NotificationHandler;
 import uk.gov.di.authentication.shared.entity.NotifyRequest;
+import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.CodeGeneratorService;
 import uk.gov.di.authentication.sharedtest.basetest.NotifyIntegrationTest;
@@ -38,7 +39,9 @@ public class NotificationHandlerIntegrationTest extends NotifyIntegrationTest {
     void shouldCallNotifyWhenValidEmailRequestIsAddedToQueue() throws Json.JsonException {
 
         handler.handleRequest(
-                createSqsEvent(new NotifyRequest(TEST_EMAIL_ADDRESS, VERIFY_EMAIL, CODE)),
+                createSqsEvent(
+                        new NotifyRequest(
+                                TEST_EMAIL_ADDRESS, VERIFY_EMAIL, CODE, SupportedLanguage.EN)),
                 mock(Context.class));
 
         var request = notifyStub.waitForRequest(60);
@@ -59,7 +62,12 @@ public class NotificationHandlerIntegrationTest extends NotifyIntegrationTest {
     @Test
     void shouldCallNotifyWhenValidPhoneNumberRequestIsAddedToQueue() throws Json.JsonException {
         handler.handleRequest(
-                createSqsEvent(new NotifyRequest(TEST_PHONE_NUMBER, VERIFY_PHONE_NUMBER, CODE)),
+                createSqsEvent(
+                        new NotifyRequest(
+                                TEST_PHONE_NUMBER,
+                                VERIFY_PHONE_NUMBER,
+                                CODE,
+                                SupportedLanguage.EN)),
                 mock(Context.class));
 
         var request = notifyStub.waitForRequest(60);
@@ -77,7 +85,8 @@ public class NotificationHandlerIntegrationTest extends NotifyIntegrationTest {
     @Test
     void shouldCallNotifyWhenValidMfaRequestIsAddedToQueue() throws Json.JsonException {
         handler.handleRequest(
-                createSqsEvent(new NotifyRequest(TEST_PHONE_NUMBER, MFA_SMS, CODE)),
+                createSqsEvent(
+                        new NotifyRequest(TEST_PHONE_NUMBER, MFA_SMS, CODE, SupportedLanguage.EN)),
                 mock(Context.class));
 
         var request = notifyStub.waitForRequest(60);
@@ -99,7 +108,11 @@ public class NotificationHandlerIntegrationTest extends NotifyIntegrationTest {
 
         handler.handleRequest(
                 createSqsEvent(
-                        new NotifyRequest(TEST_EMAIL_ADDRESS, RESET_PASSWORD, resetPasswordLink)),
+                        new NotifyRequest(
+                                TEST_EMAIL_ADDRESS,
+                                RESET_PASSWORD,
+                                resetPasswordLink,
+                                SupportedLanguage.EN)),
                 mock(Context.class));
 
         var request = notifyStub.waitForRequest(60);
@@ -117,7 +130,11 @@ public class NotificationHandlerIntegrationTest extends NotifyIntegrationTest {
     @Test
     void shouldCallNotifyWhenValidAccountCreatedRequestIsAddedToQueue() throws Json.JsonException {
         handler.handleRequest(
-                createSqsEvent(new NotifyRequest(TEST_EMAIL_ADDRESS, ACCOUNT_CREATED_CONFIRMATION)),
+                createSqsEvent(
+                        new NotifyRequest(
+                                TEST_EMAIL_ADDRESS,
+                                ACCOUNT_CREATED_CONFIRMATION,
+                                SupportedLanguage.EN)),
                 mock(Context.class));
 
         var request = notifyStub.waitForRequest(60);

--- a/shared/src/main/java/uk/gov/di/authentication/shared/domain/RequestHeaders.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/domain/RequestHeaders.java
@@ -5,6 +5,7 @@ public final class RequestHeaders {
     public static final String SESSION_ID_HEADER = "Session-Id";
     public static final String CLIENT_SESSION_ID_HEADER = "Client-Session-Id";
     public static final String AUTHORIZATION_HEADER = "Authorization";
+    public static final String USER_LANGUAGE_HEADER = "User-Language";
 
     private RequestHeaders() {}
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/DeliveryReceiptsNotificationType.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/DeliveryReceiptsNotificationType.java
@@ -32,6 +32,11 @@ public enum DeliveryReceiptsNotificationType implements TemplateAware {
         return System.getenv(templateName);
     }
 
+    @Override
+    public String getTemplateId(String language) {
+        return null;
+    }
+
     public String getTemplateAlias() {
         return templateAlias;
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/DeliveryReceiptsNotificationType.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/DeliveryReceiptsNotificationType.java
@@ -1,6 +1,7 @@
 package uk.gov.di.authentication.shared.entity;
 
 import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 public enum DeliveryReceiptsNotificationType implements TemplateAware {
     VERIFY_EMAIL("VERIFY_EMAIL", "VERIFY_EMAIL_TEMPLATE_ID"),
@@ -35,7 +36,8 @@ public enum DeliveryReceiptsNotificationType implements TemplateAware {
     }
 
     @Override
-    public String getTemplateId(SupportedLanguage language) {
+    public String getTemplateId(
+            SupportedLanguage language, ConfigurationService configurationService) {
         return null;
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/DeliveryReceiptsNotificationType.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/DeliveryReceiptsNotificationType.java
@@ -1,5 +1,7 @@
 package uk.gov.di.authentication.shared.entity;
 
+import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
+
 public enum DeliveryReceiptsNotificationType implements TemplateAware {
     VERIFY_EMAIL("VERIFY_EMAIL", "VERIFY_EMAIL_TEMPLATE_ID"),
     RESET_PASSWORD("RESET_PASSWORD_EMAIL", "RESET_PASSWORD_TEMPLATE_ID"),
@@ -33,7 +35,7 @@ public enum DeliveryReceiptsNotificationType implements TemplateAware {
     }
 
     @Override
-    public String getTemplateId(String language) {
+    public String getTemplateId(SupportedLanguage language) {
         return null;
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/NotificationType.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/NotificationType.java
@@ -1,32 +1,43 @@
 package uk.gov.di.authentication.shared.entity;
 
+import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
 
 public enum NotificationType implements TemplateAware {
     VERIFY_EMAIL(
             "VERIFY_EMAIL_TEMPLATE_ID",
-            Map.of(Locale.forLanguageTag("cy"), "VERIFY_EMAIL_TEMPLATE_ID_CY")),
-    VERIFY_PHONE_NUMBER("VERIFY_PHONE_NUMBER_TEMPLATE_ID"),
-    MFA_SMS("MFA_SMS_TEMPLATE_ID"),
-    RESET_PASSWORD("RESET_PASSWORD_TEMPLATE_ID"),
-    PASSWORD_RESET_CONFIRMATION("PASSWORD_RESET_CONFIRMATION_TEMPLATE_ID"),
-    ACCOUNT_CREATED_CONFIRMATION("ACCOUNT_CREATED_CONFIRMATION_TEMPLATE_ID"),
-    RESET_PASSWORD_WITH_CODE("RESET_PASSWORD_WITH_CODE_TEMPLATE_ID");
+            Map.of(SupportedLanguage.CY, "VERIFY_EMAIL_TEMPLATE_ID_CY")),
+    VERIFY_PHONE_NUMBER(
+            "VERIFY_PHONE_NUMBER_TEMPLATE_ID",
+            Map.of(SupportedLanguage.CY, "VERIFY_PHONE_NUMBER_TEMPLATE_ID_CY")),
+    MFA_SMS("MFA_SMS_TEMPLATE_ID", Map.of(SupportedLanguage.CY, "MFA_SMS_TEMPLATE_ID_CY")),
+    RESET_PASSWORD(
+            "RESET_PASSWORD_TEMPLATE_ID",
+            Map.of(SupportedLanguage.CY, "RESET_PASSWORD_TEMPLATE_ID_CY")),
+    PASSWORD_RESET_CONFIRMATION(
+            "PASSWORD_RESET_CONFIRMATION_TEMPLATE_ID",
+            Map.of(SupportedLanguage.CY, "PASSWORD_RESET_CONFIRMATION_TEMPLATE_ID_CY")),
+    ACCOUNT_CREATED_CONFIRMATION(
+            "ACCOUNT_CREATED_CONFIRMATION_TEMPLATE_ID",
+            Map.of(SupportedLanguage.CY, "ACCOUNT_CREATED_CONFIRMATION_TEMPLATE_ID_CY")),
+    RESET_PASSWORD_WITH_CODE(
+            "RESET_PASSWORD_WITH_CODE_TEMPLATE_ID",
+            Map.of(SupportedLanguage.CY, "RESET_PASSWORD_WITH_CODE_TEMPLATE_ID_CY"));
 
     private final String templateName;
 
     private static final ConfigurationService configurationService = new ConfigurationService();
-    private Map<Locale, String> languageSpecificTemplates = new HashMap<>();
+    private Map<SupportedLanguage, String> languageSpecificTemplates = new HashMap<>();
 
     private NotificationType(String templateName) {
         this.templateName = templateName;
     }
 
-    private NotificationType(String templateName, Map<Locale, String> languageSpecificTemplates) {
+    private NotificationType(
+            String templateName, Map<SupportedLanguage, String> languageSpecificTemplates) {
         this(templateName);
         this.languageSpecificTemplates = languageSpecificTemplates;
     }
@@ -35,14 +46,13 @@ public enum NotificationType implements TemplateAware {
         return System.getenv(templateName);
     }
 
-    public String getTemplateId(String language) {
+    public String getTemplateId(SupportedLanguage language) {
         return configurationService.getNotifyTemplateId(getTemplateName(language));
     }
 
-    String getTemplateName(String language) {
-        Locale locale = Locale.forLanguageTag(language);
-        if (languageSpecificTemplates.containsKey(locale)) {
-            return languageSpecificTemplates.get(locale);
+    String getTemplateName(SupportedLanguage language) {
+        if (languageSpecificTemplates.containsKey(language)) {
+            return languageSpecificTemplates.get(language);
         } else {
             return templateName;
         }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/NotificationType.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/NotificationType.java
@@ -1,7 +1,15 @@
 package uk.gov.di.authentication.shared.entity;
 
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
 public enum NotificationType implements TemplateAware {
-    VERIFY_EMAIL("VERIFY_EMAIL_TEMPLATE_ID"),
+    VERIFY_EMAIL(
+            "VERIFY_EMAIL_TEMPLATE_ID",
+            Map.of(Locale.forLanguageTag("cy"), "VERIFY_EMAIL_TEMPLATE_ID_CY")),
     VERIFY_PHONE_NUMBER("VERIFY_PHONE_NUMBER_TEMPLATE_ID"),
     MFA_SMS("MFA_SMS_TEMPLATE_ID"),
     RESET_PASSWORD("RESET_PASSWORD_TEMPLATE_ID"),
@@ -11,11 +19,32 @@ public enum NotificationType implements TemplateAware {
 
     private final String templateName;
 
-    NotificationType(String templateName) {
+    private static final ConfigurationService configurationService = new ConfigurationService();
+    private Map<Locale, String> languageSpecificTemplates = new HashMap<>();
+
+    private NotificationType(String templateName) {
         this.templateName = templateName;
+    }
+
+    private NotificationType(String templateName, Map<Locale, String> languageSpecificTemplates) {
+        this(templateName);
+        this.languageSpecificTemplates = languageSpecificTemplates;
     }
 
     public String getTemplateId() {
         return System.getenv(templateName);
+    }
+
+    public String getTemplateId(String language) {
+        return configurationService.getNotifyTemplateId(getTemplateName(language));
+    }
+
+    String getTemplateName(String language) {
+        Locale locale = Locale.forLanguageTag(language);
+        if (languageSpecificTemplates.containsKey(locale)) {
+            return languageSpecificTemplates.get(locale);
+        } else {
+            return templateName;
+        }
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/NotificationType.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/NotificationType.java
@@ -29,7 +29,6 @@ public enum NotificationType implements TemplateAware {
 
     private final String templateName;
 
-    private static final ConfigurationService configurationService = new ConfigurationService();
     private Map<SupportedLanguage, String> languageSpecificTemplates = new HashMap<>();
 
     private NotificationType(String templateName) {
@@ -46,8 +45,14 @@ public enum NotificationType implements TemplateAware {
         return System.getenv(templateName);
     }
 
-    public String getTemplateId(SupportedLanguage language) {
-        return configurationService.getNotifyTemplateId(getTemplateName(language));
+    public String getTemplateId(
+            SupportedLanguage language, ConfigurationService configurationService) {
+        String templateId = configurationService.getNotifyTemplateId(getTemplateName(language));
+        if (templateId == null || templateId.length() == 0) {
+            return configurationService.getNotifyTemplateId(templateName);
+        } else {
+            return templateId;
+        }
     }
 
     String getTemplateName(SupportedLanguage language) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/NotifyRequest.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/NotifyRequest.java
@@ -15,6 +15,8 @@ public class NotifyRequest {
 
     @Expose private String code;
 
+    @Expose private String language;
+
     public NotifyRequest() {}
 
     public NotifyRequest(String destination, NotificationType notificationType, String code) {
@@ -27,6 +29,12 @@ public class NotifyRequest {
         this(destination, notificationType, null);
     }
 
+    public NotifyRequest(
+            NotificationType notificationType, String destination, String code, String language) {
+        this(destination, notificationType, code);
+        this.language = language;
+    }
+
     public NotificationType getNotificationType() {
         return notificationType;
     }
@@ -37,5 +45,9 @@ public class NotifyRequest {
 
     public String getCode() {
         return code;
+    }
+
+    public String getLanguage() {
+        return language;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/NotifyRequest.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/NotifyRequest.java
@@ -2,6 +2,7 @@ package uk.gov.di.authentication.shared.entity;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 import uk.gov.di.authentication.shared.validation.Required;
 
 public class NotifyRequest {
@@ -15,24 +16,24 @@ public class NotifyRequest {
 
     @Expose private String code;
 
-    @Expose private String language;
+    @Expose private SupportedLanguage language;
 
     public NotifyRequest() {}
 
-    public NotifyRequest(String destination, NotificationType notificationType, String code) {
+    public NotifyRequest(
+            String destination,
+            NotificationType notificationType,
+            String code,
+            SupportedLanguage language) {
         this.destination = destination;
         this.notificationType = notificationType;
         this.code = code;
-    }
-
-    public NotifyRequest(String destination, NotificationType notificationType) {
-        this(destination, notificationType, null);
+        this.language = language;
     }
 
     public NotifyRequest(
-            NotificationType notificationType, String destination, String code, String language) {
-        this(destination, notificationType, code);
-        this.language = language;
+            String destination, NotificationType notificationType, SupportedLanguage language) {
+        this(destination, notificationType, null, language);
     }
 
     public NotificationType getNotificationType() {
@@ -47,7 +48,7 @@ public class NotifyRequest {
         return code;
     }
 
-    public String getLanguage() {
+    public SupportedLanguage getLanguage() {
         return language;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/TemplateAware.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/TemplateAware.java
@@ -1,7 +1,9 @@
 package uk.gov.di.authentication.shared.entity;
 
+import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
+
 public interface TemplateAware {
     String getTemplateId();
 
-    String getTemplateId(String language);
+    String getTemplateId(SupportedLanguage language);
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/TemplateAware.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/TemplateAware.java
@@ -2,4 +2,6 @@ package uk.gov.di.authentication.shared.entity;
 
 public interface TemplateAware {
     String getTemplateId();
+
+    String getTemplateId(String language);
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/TemplateAware.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/TemplateAware.java
@@ -1,9 +1,10 @@
 package uk.gov.di.authentication.shared.entity;
 
 import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 public interface TemplateAware {
     String getTemplateId();
 
-    String getTemplateId(SupportedLanguage language);
+    String getTemplateId(SupportedLanguage language, ConfigurationService configurationService);
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/LocaleHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/LocaleHelper.java
@@ -2,19 +2,30 @@ package uk.gov.di.authentication.shared.helpers;
 
 import com.nimbusds.langtag.LangTag;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
+import static uk.gov.di.authentication.shared.domain.RequestHeaders.USER_LANGUAGE_HEADER;
+import static uk.gov.di.authentication.shared.helpers.InputSanitiser.sanitiseBase64;
 import static uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage.CY;
 import static uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage.EN;
+import static uk.gov.di.authentication.shared.helpers.RequestHeaderHelper.getHeaderValueFromHeaders;
+import static uk.gov.di.authentication.shared.helpers.RequestHeaderHelper.headersContainValidHeader;
 
 public class LocaleHelper {
 
+    private static final Logger LOG = LogManager.getLogger(LocaleHelper.class);
+
     public enum SupportedLanguage {
         EN("en"),
+
         CY("cy");
+
         private String language;
 
         SupportedLanguage(String language) {
@@ -22,6 +33,11 @@ public class LocaleHelper {
         }
 
         public String getLanguage() {
+            return language;
+        }
+
+        @Override
+        public String toString() {
             return language;
         }
     }
@@ -43,5 +59,36 @@ public class LocaleHelper {
             }
         }
         return Optional.empty();
+    }
+
+    public static SupportedLanguage matchSupportedLanguage(Optional<String> language) {
+        return language.map(
+                        lng -> {
+                            if (lng.equalsIgnoreCase(SupportedLanguage.CY.getLanguage())) {
+                                return SupportedLanguage.CY;
+                            } else {
+                                return SupportedLanguage.EN;
+                            }
+                        })
+                .orElseGet(() -> SupportedLanguage.EN);
+    }
+
+    public static Optional<String> getUserLanguageFromRequestHeaders(
+            Map<String, String> headers, ConfigurationService configurationService) {
+        if (!headersContainValidHeader(
+                headers, USER_LANGUAGE_HEADER, configurationService.getHeadersCaseInsensitive())) {
+            LOG.warn("Headers are missing User-Language header");
+            return Optional.empty();
+        }
+        String language =
+                getHeaderValueFromHeaders(
+                        headers,
+                        USER_LANGUAGE_HEADER,
+                        configurationService.getHeadersCaseInsensitive());
+        if (language == null) {
+            LOG.warn("Value not found for User-Language header");
+            return Optional.empty();
+        }
+        return sanitiseBase64(language);
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/lambda/BaseFrontendHandler.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/lambda/BaseFrontendHandler.java
@@ -27,6 +27,8 @@ import java.util.Optional;
 
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
+import static uk.gov.di.authentication.shared.helpers.LocaleHelper.getUserLanguageFromRequestHeaders;
+import static uk.gov.di.authentication.shared.helpers.LocaleHelper.matchSupportedLanguage;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachSessionIdToLogs;
 import static uk.gov.di.authentication.shared.helpers.WarmerHelper.isWarming;
 
@@ -124,6 +126,8 @@ public abstract class BaseFrontendHandler<T>
         } else {
             attachSessionIdToLogs(session.get());
         }
+        Optional<String> userLanguage =
+                getUserLanguageFromRequestHeaders(input.getHeaders(), configurationService);
         final T request;
         try {
             request = objectMapper.readValue(input.getBody(), clazz);
@@ -169,6 +173,8 @@ public abstract class BaseFrontendHandler<T>
                                     userContextBuilder.withUserCredentials(
                                             Optional.of(userCredentials)));
         }
+
+        userContextBuilder.withUserLanguage(matchSupportedLanguage(userLanguage));
 
         return handleRequestWithUserContext(input, context, request, userContextBuilder.build());
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -461,4 +461,8 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
     public String getBackChannelLogoutQueueUri() {
         return System.getenv("BACK_CHANNEL_LOGOUT_QUEUE_URI");
     }
+
+    public String getNotifyTemplateId(String templateName) {
+        return System.getenv(templateName);
+    }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/NotificationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/NotificationService.java
@@ -1,5 +1,7 @@
 package uk.gov.di.authentication.shared.services;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.entity.TemplateAware;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 import uk.gov.service.notify.NotificationClient;
@@ -9,29 +11,31 @@ import java.util.Map;
 
 public class NotificationService {
 
+    private static final Logger LOG = LogManager.getLogger(NotificationService.class);
+
     private final NotificationClient notifyClient;
 
     public NotificationService(NotificationClient notifyClient) {
         this.notifyClient = notifyClient;
     }
 
-    public void sendEmail(String email, Map<String, Object> personalisation, TemplateAware type)
-            throws NotificationClientException {
-        notifyClient.sendEmail(type.getTemplateId(), email, personalisation, "");
-    }
-
     public void sendEmail(
             String email,
             Map<String, Object> personalisation,
             TemplateAware type,
-            SupportedLanguage language)
+            SupportedLanguage userLanguage)
             throws NotificationClientException {
-        notifyClient.sendEmail(type.getTemplateId(language), email, personalisation, "");
+        LOG.info("sendEmail language {}", userLanguage);
+        notifyClient.sendEmail(type.getTemplateId(), email, personalisation, "");
     }
 
     public void sendText(
-            String phoneNumber, Map<String, Object> personalisation, TemplateAware type)
+            String phoneNumber,
+            Map<String, Object> personalisation,
+            TemplateAware type,
+            SupportedLanguage userLanguage)
             throws NotificationClientException {
+        LOG.info("sendText language {}", userLanguage);
         notifyClient.sendSms(type.getTemplateId(), phoneNumber, personalisation, "");
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/NotificationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/NotificationService.java
@@ -19,6 +19,12 @@ public class NotificationService {
         notifyClient.sendEmail(type.getTemplateId(), email, personalisation, "");
     }
 
+    public void sendEmail(
+            String email, Map<String, Object> personalisation, TemplateAware type, String language)
+            throws NotificationClientException {
+        notifyClient.sendEmail(type.getTemplateId(language), email, personalisation, "");
+    }
+
     public void sendText(
             String phoneNumber, Map<String, Object> personalisation, TemplateAware type)
             throws NotificationClientException {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/NotificationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/NotificationService.java
@@ -1,6 +1,7 @@
 package uk.gov.di.authentication.shared.services;
 
 import uk.gov.di.authentication.shared.entity.TemplateAware;
+import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 import uk.gov.service.notify.NotificationClient;
 import uk.gov.service.notify.NotificationClientException;
 
@@ -20,7 +21,10 @@ public class NotificationService {
     }
 
     public void sendEmail(
-            String email, Map<String, Object> personalisation, TemplateAware type, String language)
+            String email,
+            Map<String, Object> personalisation,
+            TemplateAware type,
+            SupportedLanguage language)
             throws NotificationClientException {
         notifyClient.sendEmail(type.getTemplateId(language), email, personalisation, "");
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/state/UserContext.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/state/UserContext.java
@@ -5,17 +5,18 @@ import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 
 import java.util.Optional;
 
 public class UserContext {
     private final Session session;
     private final Optional<UserProfile> userProfile;
-
     private final Optional<UserCredentials> userCredentials;
     private final boolean userAuthenticated;
     private final Optional<ClientRegistry> client;
     private final ClientSession clientSession;
+    private final SupportedLanguage userLanguage;
 
     protected UserContext(
             Session session,
@@ -23,13 +24,15 @@ public class UserContext {
             Optional<UserCredentials> userCredentials,
             boolean userAuthenticated,
             Optional<ClientRegistry> client,
-            ClientSession clientSession) {
+            ClientSession clientSession,
+            SupportedLanguage userLanguage) {
         this.session = session;
         this.userProfile = userProfile;
         this.userCredentials = userCredentials;
         this.userAuthenticated = userAuthenticated;
         this.client = client;
         this.clientSession = clientSession;
+        this.userLanguage = userLanguage;
     }
 
     public Session getSession() {
@@ -56,6 +59,10 @@ public class UserContext {
         return clientSession;
     }
 
+    public SupportedLanguage getUserLanguage() {
+        return userLanguage;
+    }
+
     public static Builder builder(Session session) {
         return new Builder(session);
     }
@@ -67,6 +74,7 @@ public class UserContext {
         private boolean userAuthenticated = false;
         private Optional<ClientRegistry> client = Optional.empty();
         private ClientSession clientSession = null;
+        private SupportedLanguage userLanguage;
 
         protected Builder(Session session) {
             this.session = session;
@@ -105,6 +113,11 @@ public class UserContext {
             return this;
         }
 
+        public Builder withUserLanguage(SupportedLanguage userLanguage) {
+            this.userLanguage = userLanguage;
+            return this;
+        }
+
         public UserContext build() {
             return new UserContext(
                     session,
@@ -112,7 +125,8 @@ public class UserContext {
                     userCredentials,
                     userAuthenticated,
                     client,
-                    clientSession);
+                    clientSession,
+                    userLanguage);
         }
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/NotificationTypeTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/NotificationTypeTest.java
@@ -1,6 +1,7 @@
 package uk.gov.di.authentication.shared.entity;
 
 import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -10,37 +11,28 @@ class NotificationTypeTest {
     @Test
     void shouldReturnDefaultTemplateForVerifyEmailWithLanguageEN() {
         assertThat(
-                NotificationType.VERIFY_EMAIL.getTemplateName("en"),
+                NotificationType.VERIFY_EMAIL.getTemplateName(SupportedLanguage.EN),
                 equalTo("VERIFY_EMAIL_TEMPLATE_ID"));
     }
 
     @Test
-    void shouldReturnDefaultTemplateForVerifyEmailWithLanguageCY() {
+    void shouldReturnWelshTemplateForVerifyEmailWithLanguageCY() {
         assertThat(
-                NotificationType.VERIFY_EMAIL.getTemplateName("cy"),
-                equalTo("VERIFY_EMAIL_TEMPLATE_ID_CY"));
-    }
-
-    /*
-       TODO: This case is required but is not currently built
-    */
-    void shouldReturnDefaultTemplateForVerifyEmailWithLanguageCY_AR() {
-        assertThat(
-                NotificationType.VERIFY_EMAIL.getTemplateName("cy_AR"),
+                NotificationType.VERIFY_EMAIL.getTemplateName(SupportedLanguage.CY),
                 equalTo("VERIFY_EMAIL_TEMPLATE_ID_CY"));
     }
 
     @Test
     void shouldReturnDefaultTemplateForVerifyPhoneNumberWithLanguageEN() {
         assertThat(
-                NotificationType.VERIFY_PHONE_NUMBER.getTemplateName("en"),
+                NotificationType.VERIFY_PHONE_NUMBER.getTemplateName(SupportedLanguage.EN),
                 equalTo("VERIFY_PHONE_NUMBER_TEMPLATE_ID"));
     }
 
     @Test
-    void shouldReturnDefaultTemplateForVerifyPhoneNumberWithLanguageCY() {
+    void shouldReturnWelshTemplateForVerifyPhoneNumberWithLanguageCY() {
         assertThat(
-                NotificationType.VERIFY_PHONE_NUMBER.getTemplateName("cy"),
-                equalTo("VERIFY_PHONE_NUMBER_TEMPLATE_ID"));
+                NotificationType.VERIFY_PHONE_NUMBER.getTemplateName(SupportedLanguage.CY),
+                equalTo("VERIFY_PHONE_NUMBER_TEMPLATE_ID_CY"));
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/NotificationTypeTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/NotificationTypeTest.java
@@ -2,23 +2,29 @@ package uk.gov.di.authentication.shared.entity;
 
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_EMAIL;
 
 class NotificationTypeTest {
+
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
 
     @Test
     void shouldReturnDefaultTemplateForVerifyEmailWithLanguageEN() {
         assertThat(
-                NotificationType.VERIFY_EMAIL.getTemplateName(SupportedLanguage.EN),
+                VERIFY_EMAIL.getTemplateName(SupportedLanguage.EN),
                 equalTo("VERIFY_EMAIL_TEMPLATE_ID"));
     }
 
     @Test
     void shouldReturnWelshTemplateForVerifyEmailWithLanguageCY() {
         assertThat(
-                NotificationType.VERIFY_EMAIL.getTemplateName(SupportedLanguage.CY),
+                VERIFY_EMAIL.getTemplateName(SupportedLanguage.CY),
                 equalTo("VERIFY_EMAIL_TEMPLATE_ID_CY"));
     }
 
@@ -34,5 +40,38 @@ class NotificationTypeTest {
         assertThat(
                 NotificationType.VERIFY_PHONE_NUMBER.getTemplateName(SupportedLanguage.CY),
                 equalTo("VERIFY_PHONE_NUMBER_TEMPLATE_ID_CY"));
+    }
+
+    @Test
+    void shouldReturnDefaultTemplateForVerifyEmailWhenLanguageEN() {
+        when(configurationService.getNotifyTemplateId("VERIFY_EMAIL_TEMPLATE_ID_CY"))
+                .thenReturn("67890");
+        when(configurationService.getNotifyTemplateId("VERIFY_EMAIL_TEMPLATE_ID"))
+                .thenReturn("12345");
+        assertThat(
+                VERIFY_EMAIL.getTemplateId(SupportedLanguage.EN, configurationService),
+                equalTo("12345"));
+    }
+
+    @Test
+    void shouldReturnCYTemplateForVerifyEmailWhenLanguageCY() {
+        when(configurationService.getNotifyTemplateId("VERIFY_EMAIL_TEMPLATE_ID_CY"))
+                .thenReturn("67890");
+        when(configurationService.getNotifyTemplateId("VERIFY_EMAIL_TEMPLATE_ID"))
+                .thenReturn("12345");
+        assertThat(
+                VERIFY_EMAIL.getTemplateId(SupportedLanguage.CY, configurationService),
+                equalTo("67890"));
+    }
+
+    @Test
+    void shouldReturnDefaultTemplateForVerifyEmailWhenLanguageCYButTemplateMissing() {
+        when(configurationService.getNotifyTemplateId("VERIFY_EMAIL_TEMPLATE_ID_CY"))
+                .thenReturn("");
+        when(configurationService.getNotifyTemplateId("VERIFY_EMAIL_TEMPLATE_ID"))
+                .thenReturn("12345");
+        assertThat(
+                VERIFY_EMAIL.getTemplateId(SupportedLanguage.CY, configurationService),
+                equalTo("12345"));
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/NotificationTypeTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/NotificationTypeTest.java
@@ -1,0 +1,46 @@
+package uk.gov.di.authentication.shared.entity;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class NotificationTypeTest {
+
+    @Test
+    void shouldReturnDefaultTemplateForVerifyEmailWithLanguageEN() {
+        assertThat(
+                NotificationType.VERIFY_EMAIL.getTemplateName("en"),
+                equalTo("VERIFY_EMAIL_TEMPLATE_ID"));
+    }
+
+    @Test
+    void shouldReturnDefaultTemplateForVerifyEmailWithLanguageCY() {
+        assertThat(
+                NotificationType.VERIFY_EMAIL.getTemplateName("cy"),
+                equalTo("VERIFY_EMAIL_TEMPLATE_ID_CY"));
+    }
+
+    /*
+       TODO: This case is required but is not currently built
+    */
+    void shouldReturnDefaultTemplateForVerifyEmailWithLanguageCY_AR() {
+        assertThat(
+                NotificationType.VERIFY_EMAIL.getTemplateName("cy_AR"),
+                equalTo("VERIFY_EMAIL_TEMPLATE_ID_CY"));
+    }
+
+    @Test
+    void shouldReturnDefaultTemplateForVerifyPhoneNumberWithLanguageEN() {
+        assertThat(
+                NotificationType.VERIFY_PHONE_NUMBER.getTemplateName("en"),
+                equalTo("VERIFY_PHONE_NUMBER_TEMPLATE_ID"));
+    }
+
+    @Test
+    void shouldReturnDefaultTemplateForVerifyPhoneNumberWithLanguageCY() {
+        assertThat(
+                NotificationType.VERIFY_PHONE_NUMBER.getTemplateName("cy"),
+                equalTo("VERIFY_PHONE_NUMBER_TEMPLATE_ID"));
+    }
+}

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/LocaleHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/LocaleHelperTest.java
@@ -16,6 +16,7 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -120,6 +121,42 @@ class LocaleHelperTest {
                 LocaleHelper.getPrimaryLanguageFromUILocales(
                         generateAuthRequest(uiLocales), configurationService),
                 equalTo(primaryLanguage));
+    }
+
+    private static Stream<Arguments> shouldMatchSupportedLanguageSource() {
+        return Stream.of(
+                Arguments.of(Optional.of("en"), SupportedLanguage.EN),
+                Arguments.of(Optional.of("cy"), SupportedLanguage.CY),
+                Arguments.of(Optional.of("EN"), SupportedLanguage.EN),
+                Arguments.of(Optional.of("CY"), SupportedLanguage.CY),
+                Arguments.of(Optional.of("fr"), SupportedLanguage.EN),
+                Arguments.of(Optional.of(""), SupportedLanguage.EN),
+                Arguments.of(Optional.of("123456789"), SupportedLanguage.EN),
+                Arguments.of(Optional.empty(), SupportedLanguage.EN));
+    }
+
+    @ParameterizedTest
+    @MethodSource("shouldMatchSupportedLanguageSource")
+    void shouldMatchSupportedLanguage(Optional<String> language, SupportedLanguage result) {
+        assertThat(LocaleHelper.matchSupportedLanguage(language), equalTo(result));
+    }
+
+    private static Stream<Arguments> shouldGetUserLanguageFromRequestHeadersSource() {
+        return Stream.of(
+                Arguments.of(Map.of("User-Language", "en"), Optional.of("en")),
+                Arguments.of(Map.of(), Optional.empty()),
+                Arguments.of(Map.of("User-Language", "cy"), Optional.of("cy")),
+                Arguments.of(Map.of("User-Language", "fr"), Optional.of("fr")));
+    }
+
+    @ParameterizedTest
+    @MethodSource("shouldGetUserLanguageFromRequestHeadersSource")
+    void shouldGetUserLanguageFromRequestHeaders(
+            Map<String, String> headers, Optional<String> result) {
+        when(configurationService.getHeadersCaseInsensitive()).thenReturn(false);
+        assertThat(
+                LocaleHelper.getUserLanguageFromRequestHeaders(headers, configurationService),
+                equalTo(result));
     }
 
     private AuthenticationRequest generateAuthRequest(List<LangTag> uiLocales) {


### PR DESCRIPTION
## What?

Groundwork to choose Notify templates by language.

Put in place the infrastructure to be able to choose which Notify template to use by language, but do not make use of it.  Able to demonstrate that the new functionilty will work, and that the existing functionality is unchanged.
A subsequent PR will add the Welsh template ids to the right environment variables, and tweak the code to vary the template by language.

- Expect a new header in the frontend api endpoints containing the user language called 'User-Language'.
- Read the value of this new header in 'BaseFrontendHandler' to make it available in the UserContext, so available to all endpoints that use the base class.
- English is set to the default in all cases where the header is not 'cy' or 'CY', including when the header is missing.
- The header needs to be added to the frontend api calls which trigger notifications.  In the meantime no behaviour changes.
- Add a 'userLanguage' field to 'NotifyRequest', which is the message put on the notify queue that triggers a message send to Notify.
- Update all tests to populate and check for this field in the message.
- In the 'NotificationHandler' and 'NotificationService' that reads messages off the queue and sends them to Notify, only log the value in the 'userLanguage' but do not change the existing behaviour.  Only the existing English templates will be used.

## Why?

Notify messages should be sent either in English or Welsh depending on the user language.
The backend apis do not receive cookies from the frontend, so the language needs to be added as a header in the apis.  This will be done in subsequent frontend PRs.
The user can potentially change their language at any point after the session has been created, so we always need to transmit the current value of the client lng cookie when making api calls that will send Notify messages.  This means the language cannot just be set once when a session is created, and why we can't rely on getting the user language from the session.

## Related PRs

#2292 
