### PR TITLE
AUT-398 - Add Dynamo SDKv2 dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,7 +100,9 @@ subprojects {
 
         cloudwatch "software.amazon.cloudwatchlogs:aws-embedded-metrics:2.0.0"
 
-        dynamodb "com.amazonaws:aws-java-sdk-dynamodb:${dependencyVersions.aws_sdk_version}"
+        dynamodb "com.amazonaws:aws-java-sdk-dynamodb:${dependencyVersions.aws_sdk_version}",
+                "software.amazon.awssdk:dynamodb:${dependencyVersions.aws_sdk_v2_version}",
+                "software.amazon.awssdk:dynamodb-enhanced:${dependencyVersions.aws_sdk_v2_version}"
 
         glassfish "org.glassfish.jersey.core:jersey-client:${dependencyVersions.glassfish_version}",
                 "org.glassfish.jersey.inject:jersey-hk2:${dependencyVersions.glassfish_version}",

--- a/shared/src/main/java/uk/gov/di/authentication/shared/dynamodb/DynamoClientHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/dynamodb/DynamoClientHelper.java
@@ -1,10 +1,15 @@
 package uk.gov.di.authentication.shared.dynamodb;
 
-import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
+import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperConfig;
-import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperConfig.ConsistentReads;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+import java.net.URI;
 
 import static com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder.standard;
 import static com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperConfig.TableNameOverride.withTableNameReplacement;
@@ -14,7 +19,10 @@ public class DynamoClientHelper {
     public static AmazonDynamoDB createDynamoClient(ConfigurationService configurationService) {
         return configurationService
                 .getDynamoEndpointUri()
-                .map(uri -> new EndpointConfiguration(uri, configurationService.getAwsRegion()))
+                .map(
+                        uri ->
+                                new AwsClientBuilder.EndpointConfiguration(
+                                        uri, configurationService.getAwsRegion()))
                 .map(standard()::withEndpointConfiguration)
                 .orElse(standard().withRegion(configurationService.getAwsRegion()))
                 .build();
@@ -23,7 +31,21 @@ public class DynamoClientHelper {
     public static DynamoDBMapperConfig tableConfig(String tableName) {
         return new DynamoDBMapperConfig.Builder()
                 .withTableNameOverride(withTableNameReplacement(tableName))
-                .withConsistentReads(ConsistentReads.CONSISTENT)
+                .withConsistentReads(DynamoDBMapperConfig.ConsistentReads.CONSISTENT)
                 .build();
+    }
+
+    public static DynamoDbEnhancedClient createDynamoEnhancedClient(
+            ConfigurationService configurationService) {
+        var dynamoDbClientBuilder =
+                DynamoDbClient.builder()
+                        .credentialsProvider(DefaultCredentialsProvider.create())
+                        .region(Region.of(configurationService.getAwsRegion()));
+        configurationService
+                .getDynamoEndpointUri()
+                .ifPresent(
+                        endpoint -> dynamoDbClientBuilder.endpointOverride(URI.create(endpoint)));
+        var dynamoDbClient = dynamoDbClientBuilder.build();
+        return DynamoDbEnhancedClient.builder().dynamoDbClient(dynamoDbClient).build();
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/CommonPassword.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/CommonPassword.java
@@ -1,17 +1,27 @@
 package uk.gov.di.authentication.shared.entity;
 
-import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbAttribute;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
 
+@DynamoDbBean
 public class CommonPassword {
 
     private String password;
 
-    @DynamoDBHashKey(attributeName = "Password")
+    public CommonPassword() {}
+
+    @DynamoDbPartitionKey
+    @DynamoDbAttribute("Password")
     public String getPassword() {
         return password;
     }
 
-    public CommonPassword setPassword(String password) {
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public CommonPassword withPassword(String password) {
         this.password = password;
         return this;
     }


### PR DESCRIPTION
## What?

- Add the DynamoSDK2 dependency and the enhanced client. https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/dynamodb-enhanced-client.html
- Add a method to the dynamo client helper to create an enhanced client
- Uplift CommonPassword to use Dynamo version2 of the SDK
- Update CommonPassword bean with the Dynamo SDKv2 annotations.
- Ensure there is a default setter as if this is missing SDKv2 does not like it and will throw errors similar to `java.lang.IllegalArgumentException: Attempt to execute an operation against an index that requires a partition key without assigning a partition key to that index. Index name: $PRIMARY_INDEX`
- Update `setPassword` to `withPassword` so you can return an inctance of the object when setting attributes. 

## Why?

- So we make use of the latest features and then eventually ditch the SDKv1 library 
- Previously when using the mapper, the library took care of batching the writerequest for us into batches of 25 which is the max dynamo can handle. Unfortunately the version 2 of the client does not handle this for us, so we need to batch it ourselves.

