### PR TITLE
AUT-584: Stop writing audit messages to SNS

### DIFF
--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/AuthenticateIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/AuthenticateIntegrationTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import uk.gov.di.accountmanagement.entity.AuthenticateRequest;
 import uk.gov.di.accountmanagement.lambda.AuthenticateHandler;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 
 import java.util.List;
 import java.util.Map;
@@ -13,7 +14,6 @@ import java.util.Optional;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.ACCOUNT_MANAGEMENT_AUTHENTICATE;
 import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertNoAuditEventsReceivedByEitherService;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class AuthenticateIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -52,6 +52,6 @@ public class AuthenticateIntegrationTest extends ApiGatewayHandlerIntegrationTes
 
         assertThat(response, hasStatus(401));
 
-        assertNoAuditEventsReceivedByEitherService(auditTopic, txmaAuditQueue);
+        AuditAssertionsHelper.assertNoTxmaAuditEventsReceived(txmaAuditQueue);
     }
 }

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/AuthenticateIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/AuthenticateIntegrationTest.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.ACCOUNT_MANAGEMENT_AUTHENTICATE;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class AuthenticateIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -36,8 +36,7 @@ public class AuthenticateIntegrationTest extends ApiGatewayHandlerIntegrationTes
 
         assertThat(response, hasStatus(204));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic, txmaAuditQueue, List.of(ACCOUNT_MANAGEMENT_AUTHENTICATE));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(ACCOUNT_MANAGEMENT_AUTHENTICATE));
     }
 
     @Test

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/RemoveAccountIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/RemoveAccountIntegrationTest.java
@@ -18,7 +18,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.DELETE_ACCOUNT;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class RemoveAccountIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -48,7 +48,7 @@ public class RemoveAccountIntegrationTest extends ApiGatewayHandlerIntegrationTe
 
         assertFalse(userStore.userExists(email));
 
-        assertEventTypesReceivedByBothServices(auditTopic, txmaAuditQueue, List.of(DELETE_ACCOUNT));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(DELETE_ACCOUNT));
     }
 
     @Test

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/SendOtpNotificationIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/SendOtpNotificationIntegrationTest.java
@@ -11,6 +11,7 @@ import uk.gov.di.accountmanagement.testsupport.helpers.NotificationAssertionHelp
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 
 import java.util.Collections;
 import java.util.List;
@@ -22,7 +23,6 @@ import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent
 import static uk.gov.di.accountmanagement.entity.NotificationType.VERIFY_EMAIL;
 import static uk.gov.di.accountmanagement.entity.NotificationType.VERIFY_PHONE_NUMBER;
 import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertNoAuditEventsReceivedByEitherService;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
@@ -77,7 +77,7 @@ class SendOtpNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTes
 
         NotificationAssertionHelper.assertNoNotificationsReceived(notificationsQueue);
 
-        assertNoAuditEventsReceivedByEitherService(auditTopic, txmaAuditQueue);
+        AuditAssertionsHelper.assertNoTxmaAuditEventsReceived(txmaAuditQueue);
     }
 
     @Test
@@ -140,7 +140,7 @@ class SendOtpNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTes
 
         NotificationAssertionHelper.assertNoNotificationsReceived(notificationsQueue);
 
-        assertNoAuditEventsReceivedByEitherService(auditTopic, txmaAuditQueue);
+        AuditAssertionsHelper.assertNoTxmaAuditEventsReceived(txmaAuditQueue);
     }
 
     @Test
@@ -162,6 +162,6 @@ class SendOtpNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTes
 
         NotificationAssertionHelper.assertNoNotificationsReceived(notificationsQueue);
 
-        assertNoAuditEventsReceivedByEitherService(auditTopic, txmaAuditQueue);
+        AuditAssertionsHelper.assertNoTxmaAuditEventsReceived(txmaAuditQueue);
     }
 }

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/SendOtpNotificationIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/SendOtpNotificationIntegrationTest.java
@@ -22,7 +22,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.SEND_OTP;
 import static uk.gov.di.accountmanagement.entity.NotificationType.VERIFY_EMAIL;
 import static uk.gov.di.accountmanagement.entity.NotificationType.VERIFY_PHONE_NUMBER;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
@@ -56,7 +56,7 @@ class SendOtpNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTes
         NotificationAssertionHelper.assertNotificationsReceived(
                 notificationsQueue, List.of(new NotifyRequest(TEST_EMAIL, VERIFY_EMAIL)));
 
-        assertEventTypesReceivedByBothServices(auditTopic, txmaAuditQueue, List.of(SEND_OTP));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(SEND_OTP));
     }
 
     @Test
@@ -96,7 +96,7 @@ class SendOtpNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTes
                 notificationsQueue,
                 List.of(new NotifyRequest(TEST_PHONE_NUMBER, VERIFY_PHONE_NUMBER)));
 
-        assertEventTypesReceivedByBothServices(auditTopic, txmaAuditQueue, List.of(SEND_OTP));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(SEND_OTP));
     }
 
     @Test
@@ -119,7 +119,7 @@ class SendOtpNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTes
                 notificationsQueue,
                 List.of(new NotifyRequest(TEST_PHONE_NUMBER, VERIFY_PHONE_NUMBER)));
 
-        assertEventTypesReceivedByBothServices(auditTopic, txmaAuditQueue, List.of(SEND_OTP));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(SEND_OTP));
     }
 
     @Test

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdateEmailIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdateEmailIntegrationTest.java
@@ -23,7 +23,7 @@ import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent
 import static uk.gov.di.accountmanagement.entity.NotificationType.EMAIL_UPDATED;
 import static uk.gov.di.accountmanagement.testsupport.helpers.NotificationAssertionHelper.assertNoNotificationsReceived;
 import static uk.gov.di.accountmanagement.testsupport.helpers.NotificationAssertionHelper.assertNotificationsReceived;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
@@ -59,7 +59,7 @@ class UpdateEmailIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertNotificationsReceived(
                 notificationsQueue, List.of(new NotifyRequest(NEW_EMAIL_ADDRESS, EMAIL_UPDATED)));
 
-        assertEventTypesReceivedByBothServices(auditTopic, txmaAuditQueue, List.of(UPDATE_EMAIL));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(UPDATE_EMAIL));
     }
 
     @Test

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdateEmailIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdateEmailIntegrationTest.java
@@ -9,6 +9,7 @@ import uk.gov.di.accountmanagement.entity.UpdateEmailRequest;
 import uk.gov.di.accountmanagement.lambda.UpdateEmailHandler;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 
 import java.util.Collections;
 import java.util.List;
@@ -23,7 +24,6 @@ import static uk.gov.di.accountmanagement.entity.NotificationType.EMAIL_UPDATED;
 import static uk.gov.di.accountmanagement.testsupport.helpers.NotificationAssertionHelper.assertNoNotificationsReceived;
 import static uk.gov.di.accountmanagement.testsupport.helpers.NotificationAssertionHelper.assertNotificationsReceived;
 import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertNoAuditEventsReceivedByEitherService;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
@@ -83,7 +83,7 @@ class UpdateEmailIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         assertNoNotificationsReceived(notificationsQueue);
 
-        assertNoAuditEventsReceivedByEitherService(auditTopic, txmaAuditQueue);
+        AuditAssertionsHelper.assertNoTxmaAuditEventsReceived(txmaAuditQueue);
     }
 
     @Test
@@ -106,7 +106,7 @@ class UpdateEmailIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         assertNoNotificationsReceived(notificationsQueue);
 
-        assertNoAuditEventsReceivedByEitherService(auditTopic, txmaAuditQueue);
+        AuditAssertionsHelper.assertNoTxmaAuditEventsReceived(txmaAuditQueue);
     }
 
     @Test
@@ -130,7 +130,7 @@ class UpdateEmailIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         assertNoNotificationsReceived(notificationsQueue);
 
-        assertNoAuditEventsReceivedByEitherService(auditTopic, txmaAuditQueue);
+        AuditAssertionsHelper.assertNoTxmaAuditEventsReceived(txmaAuditQueue);
     }
 
     @Test

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdatePasswordIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdatePasswordIntegrationTest.java
@@ -25,7 +25,7 @@ import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent
 import static uk.gov.di.accountmanagement.entity.NotificationType.PASSWORD_UPDATED;
 import static uk.gov.di.accountmanagement.testsupport.helpers.NotificationAssertionHelper.assertNoNotificationsReceived;
 import static uk.gov.di.accountmanagement.testsupport.helpers.NotificationAssertionHelper.assertNotificationsReceived;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
@@ -59,8 +59,7 @@ public class UpdatePasswordIntegrationTest extends ApiGatewayHandlerIntegrationT
         assertNotificationsReceived(
                 notificationsQueue, List.of(new NotifyRequest(TEST_EMAIL, PASSWORD_UPDATED)));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic, txmaAuditQueue, List.of(UPDATE_PASSWORD));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(UPDATE_PASSWORD));
     }
 
     @Test

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdatePasswordIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdatePasswordIntegrationTest.java
@@ -10,6 +10,7 @@ import uk.gov.di.accountmanagement.lambda.UpdatePasswordHandler;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.extensions.CommonPasswordsExtension;
+import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 
 import java.util.Collections;
 import java.util.List;
@@ -25,7 +26,6 @@ import static uk.gov.di.accountmanagement.entity.NotificationType.PASSWORD_UPDAT
 import static uk.gov.di.accountmanagement.testsupport.helpers.NotificationAssertionHelper.assertNoNotificationsReceived;
 import static uk.gov.di.accountmanagement.testsupport.helpers.NotificationAssertionHelper.assertNotificationsReceived;
 import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertNoAuditEventsReceivedByEitherService;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
@@ -80,7 +80,7 @@ public class UpdatePasswordIntegrationTest extends ApiGatewayHandlerIntegrationT
 
         assertNoNotificationsReceived(notificationsQueue);
 
-        assertNoAuditEventsReceivedByEitherService(auditTopic, txmaAuditQueue);
+        AuditAssertionsHelper.assertNoTxmaAuditEventsReceived(txmaAuditQueue);
     }
 
     @Test
@@ -102,7 +102,7 @@ public class UpdatePasswordIntegrationTest extends ApiGatewayHandlerIntegrationT
 
         assertNoNotificationsReceived(notificationsQueue);
 
-        assertNoAuditEventsReceivedByEitherService(auditTopic, txmaAuditQueue);
+        AuditAssertionsHelper.assertNoTxmaAuditEventsReceived(txmaAuditQueue);
     }
 
     @Test

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdatePhoneNumberIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdatePhoneNumberIntegrationTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent.UPDATE_PHONE_NUMBER;
 import static uk.gov.di.accountmanagement.entity.NotificationType.PHONE_NUMBER_UPDATED;
 import static uk.gov.di.accountmanagement.testsupport.helpers.NotificationAssertionHelper.assertNoNotificationsReceived;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
@@ -91,8 +91,7 @@ class UpdatePhoneNumberIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         NotificationAssertionHelper.assertNotificationsReceived(
                 notificationsQueue, List.of(new NotifyRequest(TEST_EMAIL, PHONE_NUMBER_UPDATED)));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic, txmaAuditQueue, List.of(UPDATE_PHONE_NUMBER));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(UPDATE_PHONE_NUMBER));
     }
 
     @Test

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdatePhoneNumberIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdatePhoneNumberIntegrationTest.java
@@ -13,6 +13,7 @@ import uk.gov.di.accountmanagement.lambda.UpdatePhoneNumberHandler;
 import uk.gov.di.accountmanagement.testsupport.helpers.NotificationAssertionHelper;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 
 import java.util.Collections;
 import java.util.List;
@@ -28,7 +29,6 @@ import static uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent
 import static uk.gov.di.accountmanagement.entity.NotificationType.PHONE_NUMBER_UPDATED;
 import static uk.gov.di.accountmanagement.testsupport.helpers.NotificationAssertionHelper.assertNoNotificationsReceived;
 import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertNoAuditEventsReceivedByEitherService;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
@@ -115,7 +115,7 @@ class UpdatePhoneNumberIntegrationTest extends ApiGatewayHandlerIntegrationTest 
 
         assertNoNotificationsReceived(notificationsQueue);
 
-        assertNoAuditEventsReceivedByEitherService(auditTopic, txmaAuditQueue);
+        AuditAssertionsHelper.assertNoTxmaAuditEventsReceived(txmaAuditQueue);
     }
 
     @Test
@@ -139,7 +139,7 @@ class UpdatePhoneNumberIntegrationTest extends ApiGatewayHandlerIntegrationTest 
 
         assertNoNotificationsReceived(notificationsQueue);
 
-        assertNoAuditEventsReceivedByEitherService(auditTopic, txmaAuditQueue);
+        AuditAssertionsHelper.assertNoTxmaAuditEventsReceived(txmaAuditQueue);
     }
 
     @Test

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
@@ -29,7 +29,7 @@ import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.startsWith;
 import static uk.gov.di.authentication.oidc.domain.OidcAuditableEvent.AUTH_CODE_ISSUED;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class AuthCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -71,8 +71,7 @@ public class AuthCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 startsWith(
                         "https://di-auth-stub-relying-party-build.london.cloudapps.digital/?code="));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic, txmaAuditQueue, List.of(AUTH_CODE_ISSUED));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_CODE_ISSUED));
     }
 
     private AuthenticationRequest generateAuthRequest() {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -57,7 +57,7 @@ import static uk.gov.di.authentication.oidc.domain.OidcAuditableEvent.AUTHORISAT
 import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.LOW_LEVEL;
 import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.MEDIUM_LEVEL;
 import static uk.gov.di.authentication.shared.helpers.CookieHelper.getHttpCookieFromMultiValueResponseHeaders;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.helper.JsonArrayHelper.jsonArrayOf;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
@@ -97,10 +97,8 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         .isPresent(),
                 equalTo(true));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic,
-                txmaAuditQueue,
-                List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
+        assertTxmaAuditEventsReceived(
+                txmaAuditQueue, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
     @Test
@@ -120,10 +118,8 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 equalTo(true));
         assertThat(URI.create(redirectUri).getQuery(), equalTo(null));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic,
-                txmaAuditQueue,
-                List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
+        assertTxmaAuditEventsReceived(
+                txmaAuditQueue, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
     @Test
@@ -154,10 +150,8 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(persistentCookie.isPresent(), equalTo(true));
         assertThat(persistentCookie.get().getValue(), equalTo("persistent-id-value"));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic,
-                txmaAuditQueue,
-                List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
+        assertTxmaAuditEventsReceived(
+                txmaAuditQueue, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
     @Test
@@ -192,10 +186,8 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(languageCookie.isPresent(), equalTo(true));
         assertThat(languageCookie.get().getValue(), equalTo("en"));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic,
-                txmaAuditQueue,
-                List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
+        assertTxmaAuditEventsReceived(
+                txmaAuditQueue, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
     @Test
@@ -221,10 +213,8 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         .isPresent(),
                 equalTo(true));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic,
-                txmaAuditQueue,
-                List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
+        assertTxmaAuditEventsReceived(
+                txmaAuditQueue, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
     @Test
@@ -240,8 +230,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(redirectUri, containsString(OAuth2Error.INVALID_SCOPE.getCode()));
         assertThat(redirectUri, startsWith(RP_REDIRECT_URI));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic,
+        assertTxmaAuditEventsReceived(
                 txmaAuditQueue,
                 List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_REQUEST_ERROR));
     }
@@ -268,10 +257,8 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         .isPresent(),
                 equalTo(true));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic,
-                txmaAuditQueue,
-                List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
+        assertTxmaAuditEventsReceived(
+                txmaAuditQueue, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
     @Test
@@ -297,10 +284,8 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         .isPresent(),
                 equalTo(true));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic,
-                txmaAuditQueue,
-                List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
+        assertTxmaAuditEventsReceived(
+                txmaAuditQueue, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
     @Test
@@ -330,10 +315,8 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(cookie.isPresent(), equalTo(true));
         assertThat(cookie.get().getValue(), not(startsWith(sessionId)));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic,
-                txmaAuditQueue,
-                List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
+        assertTxmaAuditEventsReceived(
+                txmaAuditQueue, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
     @Test
@@ -362,10 +345,8 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(cookie.isPresent(), equalTo(true));
         assertThat(cookie.get().getValue(), not(startsWith(sessionId)));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic,
-                txmaAuditQueue,
-                List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
+        assertTxmaAuditEventsReceived(
+                txmaAuditQueue, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
     @Test
@@ -394,10 +375,8 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(cookie.isPresent(), equalTo(true));
         assertThat(cookie.get().getValue(), not(startsWith(sessionId)));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic,
-                txmaAuditQueue,
-                List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
+        assertTxmaAuditEventsReceived(
+                txmaAuditQueue, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
     @Test
@@ -413,10 +392,8 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(redirectUri, startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
         assertThat(URI.create(redirectUri).getQuery(), equalTo(null));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic,
-                txmaAuditQueue,
-                List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
+        assertTxmaAuditEventsReceived(
+                txmaAuditQueue, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
     @Test
@@ -449,10 +426,8 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 getLocationResponseHeader(response),
                 startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic,
-                txmaAuditQueue,
-                List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
+        assertTxmaAuditEventsReceived(
+                txmaAuditQueue, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
     @Test
@@ -485,10 +460,8 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(redirectUri, startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
         assertThat(URI.create(redirectUri).getQuery(), equalTo("prompt=login"));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic,
-                txmaAuditQueue,
-                List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
+        assertTxmaAuditEventsReceived(
+                txmaAuditQueue, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
     @Test
@@ -521,10 +494,8 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         String redirectUri = getLocationResponseHeader(response);
         assertThat(redirectUri, startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic,
-                txmaAuditQueue,
-                List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
+        assertTxmaAuditEventsReceived(
+                txmaAuditQueue, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
     @Test
@@ -557,10 +528,8 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         String redirectUri = getLocationResponseHeader(response);
         assertThat(redirectUri, startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic,
-                txmaAuditQueue,
-                List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
+        assertTxmaAuditEventsReceived(
+                txmaAuditQueue, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
     @Test
@@ -602,10 +571,8 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var clientSession = redis.getClientSession(clientSessionID);
         var authRequest = AuthenticationRequest.parse(clientSession.getAuthRequestParams());
         assertTrue(authRequest.getScope().contains(CustomScopeValue.DOC_CHECKING_APP));
-        assertEventTypesReceivedByBothServices(
-                auditTopic,
-                txmaAuditQueue,
-                List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
+        assertTxmaAuditEventsReceived(
+                txmaAuditQueue, List.of(AUTHORISATION_REQUEST_RECEIVED, AUTHORISATION_INITIATED));
     }
 
     private String givenAnExistingSession(CredentialTrustLevel credentialTrustLevel)

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientRegistrationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ClientRegistrationIntegrationTest.java
@@ -25,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.authentication.clientregistry.domain.ClientRegistryAuditableEvent.REGISTER_CLIENT_REQUEST_RECEIVED;
 import static uk.gov.di.authentication.shared.entity.ServiceType.MANDATORY;
 import static uk.gov.di.authentication.shared.entity.ServiceType.OPTIONAL;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class ClientRegistrationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -94,7 +94,6 @@ public class ClientRegistrationIntegrationTest extends ApiGatewayHandlerIntegrat
         assertThat(clientResponse.getBackChannelLogoutUri(), equalTo(backChannelLogoutUri));
         assertThat(clientResponse.getClientType(), equalTo(ClientType.WEB.getValue()));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic, txmaAuditQueue, List.of(REGISTER_CLIENT_REQUEST_RECEIVED));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(REGISTER_CLIENT_REQUEST_RECEIVED));
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppAuthorizeHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppAuthorizeHandlerIntegrationTest.java
@@ -40,7 +40,7 @@ import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.startsWith;
 import static uk.gov.di.authentication.app.domain.DocAppAuditableEvent.DOC_APP_AUTHORISATION_REQUESTED;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 class DocAppAuthorizeHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -110,8 +110,7 @@ class DocAppAuthorizeHandlerIntegrationTest extends ApiGatewayHandlerIntegration
         assertThat(
                 body.getRedirectUri(),
                 startsWith(configurationService.getDocAppAuthorisationURI().toString()));
-        assertEventTypesReceivedByBothServices(
-                auditTopic, txmaAuditQueue, List.of(DOC_APP_AUTHORISATION_REQUESTED));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(DOC_APP_AUTHORISATION_REQUESTED));
     }
 
     @Test

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppAuthorizeHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppAuthorizeHandlerIntegrationTest.java
@@ -23,6 +23,7 @@ import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.extensions.DocAppJwksExtension;
+import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -40,7 +41,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.startsWith;
 import static uk.gov.di.authentication.app.domain.DocAppAuditableEvent.DOC_APP_AUTHORISATION_REQUESTED;
 import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertNoAuditEventsReceivedByEitherService;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 class DocAppAuthorizeHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -125,7 +125,7 @@ class DocAppAuthorizeHandlerIntegrationTest extends ApiGatewayHandlerIntegration
 
         assertThat(response, hasStatus(400));
 
-        assertNoAuditEventsReceivedByEitherService(auditTopic, txmaAuditQueue);
+        AuditAssertionsHelper.assertNoTxmaAuditEventsReceived(txmaAuditQueue);
     }
 
     private AuthenticationRequest withAuthenticationRequest(String clientId) {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppCallbackHandlerIntegrationTest.java
@@ -54,7 +54,7 @@ import static uk.gov.di.authentication.app.domain.DocAppAuditableEvent.DOC_APP_A
 import static uk.gov.di.authentication.app.domain.DocAppAuditableEvent.DOC_APP_SUCCESSFUL_CREDENTIAL_RESPONSE_RECEIVED;
 import static uk.gov.di.authentication.app.domain.DocAppAuditableEvent.DOC_APP_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED;
 import static uk.gov.di.authentication.app.domain.DocAppAuditableEvent.DOC_APP_UNSUCCESSFUL_CREDENTIAL_RESPONSE_RECEIVED;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 class DocAppCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -138,8 +138,7 @@ class DocAppCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
                 response.getHeaders().get(ResponseHeaders.LOCATION),
                 startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic,
+        assertTxmaAuditEventsReceived(
                 txmaAuditQueue,
                 List.of(
                         DOC_APP_AUTHORISATION_RESPONSE_RECEIVED,
@@ -175,8 +174,7 @@ class DocAppCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
                 startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
         assertThat(response.getHeaders().get(ResponseHeaders.LOCATION), endsWith("error"));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic,
+        assertTxmaAuditEventsReceived(
                 txmaAuditQueue,
                 List.of(
                         DOC_APP_AUTHORISATION_RESPONSE_RECEIVED,
@@ -203,8 +201,7 @@ class DocAppCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
                 startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
         assertThat(response.getHeaders().get(ResponseHeaders.LOCATION), endsWith("error"));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic,
+        assertTxmaAuditEventsReceived(
                 txmaAuditQueue,
                 List.of(
                         DOC_APP_AUTHORISATION_RESPONSE_RECEIVED,
@@ -231,8 +228,7 @@ class DocAppCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
                 startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
         assertThat(response.getHeaders().get(ResponseHeaders.LOCATION), endsWith("error"));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic,
+        assertTxmaAuditEventsReceived(
                 txmaAuditQueue,
                 List.of(
                         DOC_APP_AUTHORISATION_RESPONSE_RECEIVED,

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVAuthorisationHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVAuthorisationHandlerIntegrationTest.java
@@ -19,6 +19,7 @@ import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.extensions.IPVStubExtension;
+import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -36,7 +37,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.startsWith;
 import static uk.gov.di.authentication.ipv.domain.IPVAuditableEvent.IPV_AUTHORISATION_REQUESTED;
 import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertNoAuditEventsReceivedByEitherService;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 class IPVAuthorisationHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -123,7 +123,7 @@ class IPVAuthorisationHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
 
         assertThat(response, hasStatus(400));
 
-        assertNoAuditEventsReceivedByEitherService(auditTopic, txmaAuditQueue);
+        AuditAssertionsHelper.assertNoTxmaAuditEventsReceived(txmaAuditQueue);
     }
 
     private AuthenticationRequest withAuthenticationRequest(String clientId) {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVAuthorisationHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVAuthorisationHandlerIntegrationTest.java
@@ -36,7 +36,7 @@ import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.startsWith;
 import static uk.gov.di.authentication.ipv.domain.IPVAuditableEvent.IPV_AUTHORISATION_REQUESTED;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 class IPVAuthorisationHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -108,8 +108,7 @@ class IPVAuthorisationHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
                 body.getRedirectUri(),
                 startsWith(configurationService.getIPVAuthorisationURI().toString()));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic, txmaAuditQueue, List.of(IPV_AUTHORISATION_REQUESTED));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(IPV_AUTHORISATION_REQUESTED));
     }
 
     @Test

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
@@ -53,7 +53,7 @@ import static uk.gov.di.authentication.ipv.domain.IPVAuditableEvent.IPV_SUCCESSF
 import static uk.gov.di.authentication.shared.entity.IdentityClaims.VOT;
 import static uk.gov.di.authentication.shared.entity.IdentityClaims.VTM;
 import static uk.gov.di.authentication.shared.helpers.ClientSubjectHelper.calculatePairwiseIdentifier;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -120,8 +120,7 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                 response.getHeaders().get(ResponseHeaders.LOCATION),
                 startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic,
+        assertTxmaAuditEventsReceived(
                 txmaAuditQueue,
                 List.of(
                         IPV_AUTHORISATION_RESPONSE_RECEIVED,

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCapacityHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCapacityHandlerIntegrationTest.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.gov.di.authentication.ipv.domain.IPVAuditableEvent.IPV_CAPACITY_REQUESTED;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 class IPVCapacityHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -25,8 +25,7 @@ class IPVCapacityHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
 
         assertThat(response, hasStatus(503));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic, txmaAuditQueue, List.of(IPV_CAPACITY_REQUESTED));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(IPV_CAPACITY_REQUESTED));
     }
 
     @Test
@@ -38,8 +37,7 @@ class IPVCapacityHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
 
         assertThat(response, hasStatus(200));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic, txmaAuditQueue, List.of(IPV_CAPACITY_REQUESTED));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(IPV_CAPACITY_REQUESTED));
     }
 
     public ConfigurationService capacityAwareConfiguration(String value) {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/JwksIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/JwksIntegrationTest.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertNoAuditEventsReceived;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertNoTxmaAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class JwksIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -25,7 +25,7 @@ public class JwksIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(response, hasStatus(200));
         assertThat(JWKSet.parse(response.getBody()).getKeys(), hasSize(1));
 
-        assertNoAuditEventsReceived(auditTopic);
+        assertNoTxmaAuditEventsReceived(txmaAuditQueue);
     }
 
     @Test
@@ -37,7 +37,7 @@ public class JwksIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(response, hasStatus(200));
         assertThat(JWKSet.parse(response.getBody()).getKeys(), hasSize(2));
 
-        assertNoAuditEventsReceived(auditTopic);
+        assertNoTxmaAuditEventsReceived(txmaAuditQueue);
     }
 
     private static class JwksTestConfigurationService extends IntegrationTestConfigurationService {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
@@ -37,7 +37,7 @@ import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.LOW_LE
 import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.MEDIUM_LEVEL;
 import static uk.gov.di.authentication.shared.entity.MFAMethodType.AUTH_APP;
 import static uk.gov.di.authentication.shared.entity.MFAMethodType.SMS;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.helper.JsonArrayHelper.jsonArrayOf;
 import static uk.gov.di.authentication.sharedtest.helper.KeyPairHelper.GENERATE_RSA_KEY_PAIR;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
@@ -128,7 +128,7 @@ public class LoginIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(loginResponse.getMfaMethodType(), equalTo(mfaMethodType));
         assertThat(loginResponse.isMfaMethodVerified(), equalTo(mfaMethodVerified));
 
-        assertEventTypesReceivedByBothServices(auditTopic, txmaAuditQueue, List.of(LOG_IN_SUCCESS));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(LOG_IN_SUCCESS));
     }
 
     private static Stream<Arguments> vectorOfTrust() {
@@ -174,7 +174,6 @@ public class LoginIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 makeRequest(Optional.of(new LoginRequest(email, password)), headers, Map.of());
         assertThat(response, hasStatus(401));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic, txmaAuditQueue, List.of(INVALID_CREDENTIALS));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(INVALID_CREDENTIALS));
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LogoutIntegrationTest.java
@@ -33,7 +33,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.hasEntry;
 import static uk.gov.di.authentication.oidc.domain.OidcAuditableEvent.LOG_OUT_SUCCESS;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.isRedirect;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.isRedirectTo;
 import static uk.gov.di.authentication.sharedtest.matchers.UriMatcher.baseUri;
@@ -79,8 +79,7 @@ public class LogoutIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                                 baseUri(URI.create(REDIRECT_URL)),
                                 redirectQueryParameters(hasEntry("state", STATE)))));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic, txmaAuditQueue, List.of(LOG_OUT_SUCCESS));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(LOG_OUT_SUCCESS));
     }
 
     @Test
@@ -109,8 +108,7 @@ public class LogoutIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                                 baseUri(URI.create(REDIRECT_URL)),
                                 redirectQueryParameters(hasEntry("state", STATE)))));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic, txmaAuditQueue, List.of(LOG_OUT_SUCCESS));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(LOG_OUT_SUCCESS));
     }
 
     @Test
@@ -132,8 +130,7 @@ public class LogoutIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                                 baseUri(TEST_CONFIGURATION_SERVICE.getDefaultLogoutURI()),
                                 redirectQueryParameters(hasEntry("state", STATE)))));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic, txmaAuditQueue, List.of(LOG_OUT_SUCCESS));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(LOG_OUT_SUCCESS));
     }
 
     @Test
@@ -163,8 +160,7 @@ public class LogoutIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                                 redirectQueryParameters(
                                         hasEntry("error_code", "invalid_request")))));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic, txmaAuditQueue, List.of(LOG_OUT_SUCCESS));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(LOG_OUT_SUCCESS));
     }
 
     private SignedJWT setupClientAndSession(String sessionId, String clientSessionId)

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/MfaHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/MfaHandlerIntegrationTest.java
@@ -19,7 +19,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.MFA_CODE_SENT;
 import static uk.gov.di.authentication.shared.entity.NotificationType.MFA_SMS;
 import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_PHONE_NUMBER;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 class MfaHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -51,7 +51,7 @@ class MfaHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Map.of());
 
         assertThat(response, hasStatus(204));
-        assertEventTypesReceivedByBothServices(auditTopic, txmaAuditQueue, List.of(MFA_CODE_SENT));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(MFA_CODE_SENT));
 
         List<NotifyRequest> requests = notificationsQueue.getMessages(NotifyRequest.class);
         assertThat(requests, hasSize(1));
@@ -69,7 +69,7 @@ class MfaHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Map.of());
 
         assertThat(response, hasStatus(204));
-        assertEventTypesReceivedByBothServices(auditTopic, txmaAuditQueue, List.of(MFA_CODE_SENT));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(MFA_CODE_SENT));
 
         List<NotifyRequest> requests = notificationsQueue.getMessages(NotifyRequest.class);
         assertThat(requests, hasSize(1));

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ProcessingIdentityIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ProcessingIdentityIntegrationTest.java
@@ -35,7 +35,7 @@ import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static uk.gov.di.authentication.ipv.domain.IPVAuditableEvent.PROCESSING_IDENTITY_REQUEST;
 import static uk.gov.di.authentication.shared.helpers.ClientSubjectHelper.calculatePairwiseIdentifier;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.helper.IdentityTestData.CORE_IDENTITY_CLAIM;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
@@ -84,8 +84,7 @@ public class ProcessingIdentityIntegrationTest extends ApiGatewayHandlerIntegrat
                 response,
                 hasJsonBody(new ProcessingIdentityResponse(ProcessingIdentityStatus.COMPLETED)));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic, txmaAuditQueue, List.of(PROCESSING_IDENTITY_REQUEST));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(PROCESSING_IDENTITY_REQUEST));
     }
 
     @Test
@@ -118,8 +117,7 @@ public class ProcessingIdentityIntegrationTest extends ApiGatewayHandlerIntegrat
                 response,
                 hasJsonBody(new ProcessingIdentityResponse(ProcessingIdentityStatus.PROCESSING)));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic, txmaAuditQueue, List.of(PROCESSING_IDENTITY_REQUEST));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(PROCESSING_IDENTITY_REQUEST));
     }
 
     @Test
@@ -145,8 +143,7 @@ public class ProcessingIdentityIntegrationTest extends ApiGatewayHandlerIntegrat
                 response,
                 hasJsonBody(new ProcessingIdentityResponse(ProcessingIdentityStatus.ERROR)));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic, txmaAuditQueue, List.of(PROCESSING_IDENTITY_REQUEST));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(PROCESSING_IDENTITY_REQUEST));
     }
 
     @Test
@@ -172,8 +169,7 @@ public class ProcessingIdentityIntegrationTest extends ApiGatewayHandlerIntegrat
                 response,
                 hasJsonBody(new ProcessingIdentityResponse(ProcessingIdentityStatus.NO_ENTRY)));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic, txmaAuditQueue, List.of(PROCESSING_IDENTITY_REQUEST));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(PROCESSING_IDENTITY_REQUEST));
     }
 
     private void setupSession(boolean incrementProcessIdentityAttempts) throws Json.JsonException {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordIntegrationTest.java
@@ -21,7 +21,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.PASSWORD_RESET_SUCCESSFUL;
 import static uk.gov.di.authentication.shared.entity.NotificationType.PASSWORD_RESET_CONFIRMATION;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class ResetPasswordIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -57,8 +57,7 @@ public class ResetPasswordIntegrationTest extends ApiGatewayHandlerIntegrationTe
         assertThat(requests.get(0).getDestination(), equalTo(EMAIL_ADDRESS));
         assertThat(requests.get(0).getNotificationType(), equalTo(PASSWORD_RESET_CONFIRMATION));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic, txmaAuditQueue, List.of(PASSWORD_RESET_SUCCESSFUL));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(PASSWORD_RESET_SUCCESSFUL));
     }
 
     @Test
@@ -82,8 +81,7 @@ public class ResetPasswordIntegrationTest extends ApiGatewayHandlerIntegrationTe
         assertThat(requests.get(0).getDestination(), equalTo(EMAIL_ADDRESS));
         assertThat(requests.get(0).getNotificationType(), equalTo(PASSWORD_RESET_CONFIRMATION));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic, txmaAuditQueue, List.of(PASSWORD_RESET_SUCCESSFUL));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(PASSWORD_RESET_SUCCESSFUL));
     }
 
     @Test

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordRequestIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordRequestIntegrationTest.java
@@ -21,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.*;
 import static uk.gov.di.authentication.shared.entity.NotificationType.RESET_PASSWORD;
 import static uk.gov.di.authentication.shared.entity.NotificationType.RESET_PASSWORD_WITH_CODE;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class ResetPasswordRequestIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -64,8 +64,8 @@ public class ResetPasswordRequestIntegrationTest extends ApiGatewayHandlerIntegr
         assertThat(resetLinkSplit[2], equalTo(sessionId));
         assertThat(resetLinkSplit[3], equalTo(persistentSessionId));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic, txmaAuditQueue, Collections.singletonList(PASSWORD_RESET_REQUESTED));
+        assertTxmaAuditEventsReceived(
+                txmaAuditQueue, Collections.singletonList(PASSWORD_RESET_REQUESTED));
     }
 
     @Test
@@ -95,7 +95,7 @@ public class ResetPasswordRequestIntegrationTest extends ApiGatewayHandlerIntegr
         assertThat(requests.get(0).getNotificationType(), equalTo(RESET_PASSWORD_WITH_CODE));
         assertThat(requests.get(0).getCode(), hasLength(6));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic, txmaAuditQueue, Collections.singletonList(PASSWORD_RESET_REQUESTED));
+        assertTxmaAuditEventsReceived(
+                txmaAuditQueue, Collections.singletonList(PASSWORD_RESET_REQUESTED));
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/SignupIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/SignupIntegrationTest.java
@@ -32,7 +32,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.CREATE_ACCOUNT;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.helper.KeyPairHelper.GENERATE_RSA_KEY_PAIR;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
@@ -107,7 +107,7 @@ public class SignupIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         assertTrue(userStore.userExists("joe.bloggs+5@digital.cabinet-office.gov.uk"));
 
-        assertEventTypesReceivedByBothServices(auditTopic, txmaAuditQueue, List.of(CREATE_ACCOUNT));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(CREATE_ACCOUNT));
     }
 
     @Test

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
@@ -46,7 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.START_INFO_FOUND;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -118,8 +118,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(startResponse.getUser().getGaCrossDomainTrackingId(), equalTo(null));
         assertThat(startResponse.getUser().isAuthenticated(), equalTo(isAuthenticated));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic, txmaAuditQueue, List.of(START_INFO_FOUND));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(START_INFO_FOUND));
     }
 
     @Test
@@ -183,8 +182,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         assertNotNull(clientSession.getDocAppSubjectId());
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic, txmaAuditQueue, List.of(START_INFO_FOUND));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(START_INFO_FOUND));
     }
 
     private void registerClient(KeyPair keyPair, ClientType clientType) {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
@@ -26,6 +26,7 @@ import uk.gov.di.authentication.shared.entity.CustomScopeValue;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 import uk.gov.di.authentication.sharedtest.helper.KeyPairHelper;
 
 import java.net.URI;
@@ -46,7 +47,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.START_INFO_FOUND;
 import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertNoAuditEventsReceivedByEitherService;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -129,7 +129,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var response = makeRequest(Optional.empty(), headers, Map.of());
         assertThat(response, hasStatus(400));
 
-        assertNoAuditEventsReceivedByEitherService(auditTopic, txmaAuditQueue);
+        AuditAssertionsHelper.assertNoTxmaAuditEventsReceived(txmaAuditQueue);
     }
 
     @ParameterizedTest

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
@@ -46,6 +46,7 @@ import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 import uk.gov.di.authentication.sharedtest.helper.JsonArrayHelper;
 import uk.gov.di.authentication.sharedtest.helper.KeyPairHelper;
 
@@ -73,7 +74,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.authentication.shared.entity.IdentityClaims.VOT;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertNoAuditEventsReceivedByEitherService;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
@@ -139,7 +139,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         .getClaim(VOT.getValue()),
                 equalTo(expectedVotClaim));
 
-        assertNoAuditEventsReceivedByEitherService(auditTopic, txmaAuditQueue);
+        AuditAssertionsHelper.assertNoTxmaAuditEventsReceived(txmaAuditQueue);
     }
 
     @Test
@@ -192,7 +192,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         .getSubject(),
                 equalTo(userStore.getPublicSubjectIdForEmail(TEST_EMAIL)));
 
-        assertNoAuditEventsReceivedByEitherService(auditTopic, txmaAuditQueue);
+        AuditAssertionsHelper.assertNoTxmaAuditEventsReceived(txmaAuditQueue);
     }
 
     @Test
@@ -226,7 +226,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         .getSubject(),
                 not(equalTo(userStore.getPublicSubjectIdForEmail(TEST_EMAIL))));
 
-        assertNoAuditEventsReceivedByEitherService(auditTopic, txmaAuditQueue);
+        AuditAssertionsHelper.assertNoTxmaAuditEventsReceived(txmaAuditQueue);
     }
 
     @Test
@@ -271,7 +271,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         assertTrue(jsonarray.contains("nickname"));
         assertTrue(jsonarray.contains("birthdate"));
-        assertNoAuditEventsReceivedByEitherService(auditTopic, txmaAuditQueue);
+        AuditAssertionsHelper.assertNoTxmaAuditEventsReceived(txmaAuditQueue);
     }
 
     @Test
@@ -297,7 +297,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         .getTokens()
                         .getBearerAccessToken());
 
-        assertNoAuditEventsReceivedByEitherService(auditTopic, txmaAuditQueue);
+        AuditAssertionsHelper.assertNoTxmaAuditEventsReceived(txmaAuditQueue);
     }
 
     @Test
@@ -349,7 +349,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         .getTokens()
                         .getBearerAccessToken());
 
-        assertNoAuditEventsReceivedByEitherService(auditTopic, txmaAuditQueue);
+        AuditAssertionsHelper.assertNoTxmaAuditEventsReceived(txmaAuditQueue);
     }
 
     private SignedJWT generateSignedRefreshToken(Scope scope, Subject publicSubject) {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateClientConfigIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateClientConfigIntegrationTest.java
@@ -18,7 +18,7 @@ import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static uk.gov.di.authentication.clientregistry.domain.ClientRegistryAuditableEvent.UPDATE_CLIENT_REQUEST_RECEIVED;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class UpdateClientConfigIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -65,8 +65,7 @@ public class UpdateClientConfigIntegrationTest extends ApiGatewayHandlerIntegrat
         assertThat(clientResponse.getClientName(), equalTo("new-client-name"));
         assertThat(clientResponse.getClientId(), equalTo(CLIENT_ID));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic, txmaAuditQueue, List.of(UPDATE_CLIENT_REQUEST_RECEIVED));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(UPDATE_CLIENT_REQUEST_RECEIVED));
     }
 
     @Test
@@ -86,8 +85,7 @@ public class UpdateClientConfigIntegrationTest extends ApiGatewayHandlerIntegrat
                 response.getBody(),
                 equalTo(OAuth2Error.INVALID_CLIENT.toJSONObject().toJSONString()));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic,
+        assertTxmaAuditEventsReceived(
                 txmaAuditQueue,
                 List.of(UPDATE_CLIENT_REQUEST_RECEIVED, UPDATE_CLIENT_REQUEST_RECEIVED));
     }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateProfileIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateProfileIntegrationTest.java
@@ -38,7 +38,7 @@ import static uk.gov.di.authentication.frontendapi.entity.UpdateProfileType.ADD_
 import static uk.gov.di.authentication.frontendapi.entity.UpdateProfileType.CAPTURE_CONSENT;
 import static uk.gov.di.authentication.frontendapi.entity.UpdateProfileType.REGISTER_AUTH_APP;
 import static uk.gov.di.authentication.frontendapi.entity.UpdateProfileType.UPDATE_TERMS_CONDS;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class UpdateProfileIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -82,8 +82,7 @@ public class UpdateProfileIntegrationTest extends ApiGatewayHandlerIntegrationTe
 
         assertThat(response, hasStatus(204));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic,
+        assertTxmaAuditEventsReceived(
                 txmaAuditQueue,
                 List.of(UPDATE_PROFILE_REQUEST_RECEIVED, UPDATE_PROFILE_REQUEST_RECEIVED));
     }
@@ -115,8 +114,7 @@ public class UpdateProfileIntegrationTest extends ApiGatewayHandlerIntegrationTe
         assertTrue(consent.get().getClaims().containsAll(OIDCScopeValue.OPENID.getClaimNames()));
         assertTrue(consent.get().getClaims().containsAll(OIDCScopeValue.EMAIL.getClaimNames()));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic,
+        assertTxmaAuditEventsReceived(
                 txmaAuditQueue,
                 List.of(UPDATE_PROFILE_REQUEST_RECEIVED, UPDATE_PROFILE_REQUEST_RECEIVED));
     }
@@ -138,8 +136,7 @@ public class UpdateProfileIntegrationTest extends ApiGatewayHandlerIntegrationTe
                         Map.of());
 
         assertThat(response, hasStatus(204));
-        assertEventTypesReceivedByBothServices(
-                auditTopic,
+        assertTxmaAuditEventsReceived(
                 txmaAuditQueue,
                 List.of(UPDATE_PROFILE_REQUEST_RECEIVED, UPDATE_PROFILE_REQUEST_RECEIVED));
     }
@@ -166,8 +163,7 @@ public class UpdateProfileIntegrationTest extends ApiGatewayHandlerIntegrationTe
         assertThat(mfaMethod.get(0).getCredentialValue(), equalTo(authAppSecret));
         assertThat(mfaMethod.get(0).isMethodVerified(), equalTo(false));
         assertThat(mfaMethod.get(0).isEnabled(), equalTo(true));
-        assertEventTypesReceivedByBothServices(
-                auditTopic,
+        assertTxmaAuditEventsReceived(
                 txmaAuditQueue,
                 List.of(UPDATE_PROFILE_REQUEST_RECEIVED, UPDATE_PROFILE_REQUEST_RECEIVED));
     }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserExistsIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserExistsIntegrationTest.java
@@ -19,7 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.CHECK_USER_KNOWN_EMAIL;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.CHECK_USER_NO_ACCOUNT_WITH_EMAIL;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class UserExistsIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -48,8 +48,7 @@ public class UserExistsIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         assertThat(checkUserExistsResponse.getEmail(), equalTo(emailAddress));
         assertTrue(checkUserExistsResponse.doesUserExist());
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic, txmaAuditQueue, List.of(CHECK_USER_KNOWN_EMAIL));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(CHECK_USER_KNOWN_EMAIL));
     }
 
     @Test
@@ -69,7 +68,6 @@ public class UserExistsIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         assertThat(checkUserExistsResponse.getEmail(), equalTo(emailAddress));
         assertFalse(checkUserExistsResponse.doesUserExist());
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic, txmaAuditQueue, List.of(CHECK_USER_NO_ACCOUNT_WITH_EMAIL));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(CHECK_USER_NO_ACCOUNT_WITH_EMAIL));
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
@@ -58,7 +58,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static uk.gov.di.authentication.oidc.domain.OidcAuditableEvent.USER_INFO_RETURNED;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.helper.IdentityTestData.ADDRESS_CLAIM;
 import static uk.gov.di.authentication.sharedtest.helper.IdentityTestData.CORE_IDENTITY_CLAIM;
 import static uk.gov.di.authentication.sharedtest.helper.IdentityTestData.PASSPORT_CLAIM;
@@ -156,8 +156,7 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(userInfoResponse.getSubject(), equalTo(PUBLIC_SUBJECT));
         assertThat(userInfoResponse.toJWTClaimsSet().getClaims().size(), equalTo(5));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic, txmaAuditQueue, singletonList(USER_INFO_RETURNED));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, singletonList(USER_INFO_RETURNED));
     }
 
     @Test
@@ -209,8 +208,7 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 equalTo(signedCredential.serialize()));
         assertThat(userInfoResponse.toJWTClaimsSet().getClaims().size(), equalTo(8));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic, txmaAuditQueue, singletonList(USER_INFO_RETURNED));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, singletonList(USER_INFO_RETURNED));
     }
 
     @Test
@@ -239,8 +237,7 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertNull(userInfoResponse.getClaim(ValidClaims.PASSPORT.getValue()));
         assertNull(userInfoResponse.getClaim(ValidClaims.CORE_IDENTITY_JWT.getValue()));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic, txmaAuditQueue, singletonList(USER_INFO_RETURNED));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, singletonList(USER_INFO_RETURNED));
     }
 
     @Test
@@ -261,8 +258,7 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertNull(userInfoResponse.getClaim(ValidClaims.PASSPORT.getValue()));
         assertNull(userInfoResponse.getClaim(ValidClaims.CORE_IDENTITY_JWT.getValue()));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic, txmaAuditQueue, singletonList(USER_INFO_RETURNED));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, singletonList(USER_INFO_RETURNED));
     }
 
     @Test
@@ -283,8 +279,7 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(userInfoResponse.getSubject(), equalTo(DOC_APP_PUBLIC_SUBJECT));
         assertThat(userInfoResponse.toJWTClaimsSet().getClaims().size(), equalTo(2));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic, txmaAuditQueue, singletonList(USER_INFO_RETURNED));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, singletonList(USER_INFO_RETURNED));
     }
 
     @Test

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
@@ -33,6 +33,7 @@ import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.extensions.DocumentAppCredentialStoreExtension;
 import uk.gov.di.authentication.sharedtest.extensions.IdentityStoreExtension;
+import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 import uk.gov.di.authentication.sharedtest.helper.KeyPairHelper;
 import uk.gov.di.authentication.sharedtest.helper.SignedCredentialHelper;
 
@@ -58,7 +59,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static uk.gov.di.authentication.oidc.domain.OidcAuditableEvent.USER_INFO_RETURNED;
 import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertNoAuditEventsReceivedByEitherService;
 import static uk.gov.di.authentication.sharedtest.helper.IdentityTestData.ADDRESS_CLAIM;
 import static uk.gov.di.authentication.sharedtest.helper.IdentityTestData.CORE_IDENTITY_CLAIM;
 import static uk.gov.di.authentication.sharedtest.helper.IdentityTestData.PASSPORT_CLAIM;
@@ -174,7 +174,7 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                                 .getHeaderMap()
                                 .get("WWW-Authenticate")));
 
-        assertNoAuditEventsReceivedByEitherService(auditTopic, txmaAuditQueue);
+        AuditAssertionsHelper.assertNoTxmaAuditEventsReceived(txmaAuditQueue);
     }
 
     @Test
@@ -299,7 +299,7 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 this::makeDocAppUserinfoRequest,
                 "Expected to throw exception");
 
-        assertNoAuditEventsReceivedByEitherService(auditTopic, txmaAuditQueue);
+        AuditAssertionsHelper.assertNoTxmaAuditEventsReceived(txmaAuditQueue);
     }
 
     @Test
@@ -311,7 +311,7 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 this::makeDocAppUserinfoRequest,
                 "Expected to throw exception");
 
-        assertNoAuditEventsReceivedByEitherService(auditTopic, txmaAuditQueue);
+        AuditAssertionsHelper.assertNoTxmaAuditEventsReceived(txmaAuditQueue);
     }
 
     public static SignedJWT generateSignedJWT(JWTClaimsSet jwtClaimsSet, KeyPair keyPair)

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
@@ -35,7 +35,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.CODE_VERIFIED;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.INVALID_CODE_SENT;
 import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_EMAIL;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
@@ -66,7 +66,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
                         Map.of());
         assertThat(response, hasStatus(204));
 
-        assertEventTypesReceivedByBothServices(auditTopic, txmaAuditQueue, List.of(CODE_VERIFIED));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(CODE_VERIFIED));
     }
 
     @Test
@@ -88,7 +88,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
 
         assertThat(response, hasStatus(204));
         assertThat(redis.getMfaCodeAttemptsCount(EMAIL_ADDRESS), equalTo(0));
-        assertEventTypesReceivedByBothServices(auditTopic, txmaAuditQueue, List.of(CODE_VERIFIED));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(CODE_VERIFIED));
     }
 
     @Test
@@ -111,8 +111,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         assertThat(response, hasStatus(400));
         assertThat(response, hasJsonBody(ErrorResponse.ERROR_1036));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic, txmaAuditQueue, List.of(INVALID_CODE_SENT));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(INVALID_CODE_SENT));
     }
 
     @Test
@@ -140,8 +139,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         assertThat(response2, hasStatus(400));
         assertThat(response2, hasJsonBody(ErrorResponse.ERROR_1036));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic, txmaAuditQueue, List.of(CODE_VERIFIED, INVALID_CODE_SENT));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(CODE_VERIFIED, INVALID_CODE_SENT));
     }
 
     @Test
@@ -165,7 +163,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
                         Map.of());
 
         assertThat(response, hasStatus(204));
-        assertEventTypesReceivedByBothServices(auditTopic, txmaAuditQueue, List.of(CODE_VERIFIED));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(CODE_VERIFIED));
     }
 
     @Test
@@ -194,7 +192,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
 
         assertThat(response, hasStatus(204));
         assertThat(redis.getMfaCodeAttemptsCount(EMAIL_ADDRESS), equalTo(0));
-        assertEventTypesReceivedByBothServices(auditTopic, txmaAuditQueue, List.of(CODE_VERIFIED));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(CODE_VERIFIED));
     }
 
     @Test
@@ -218,8 +216,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         assertThat(response, hasStatus(400));
         assertThat(response, hasJsonBody(ErrorResponse.ERROR_1037));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic, txmaAuditQueue, List.of(INVALID_CODE_SENT));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(INVALID_CODE_SENT));
     }
 
     @Test
@@ -285,7 +282,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
                         Map.of());
 
         assertThat(response, hasStatus(204));
-        assertEventTypesReceivedByBothServices(auditTopic, txmaAuditQueue, List.of(CODE_VERIFIED));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(CODE_VERIFIED));
     }
 
     private void setUpTestWithoutSignUp(String sessionId, Scope scope) throws Json.JsonException {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
@@ -18,6 +18,7 @@ import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.shared.entity.ValidScopes;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 
 import java.net.URI;
 import java.time.LocalDateTime;
@@ -35,7 +36,6 @@ import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.INVALID_CODE_SENT;
 import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_EMAIL;
 import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertNoAuditEventsReceivedByEitherService;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
@@ -238,7 +238,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         assertThat(response, hasStatus(400));
         assertThat(response, hasJsonBody(ErrorResponse.ERROR_1034));
 
-        assertNoAuditEventsReceivedByEitherService(auditTopic, txmaAuditQueue);
+        AuditAssertionsHelper.assertNoTxmaAuditEventsReceived(txmaAuditQueue);
     }
 
     @Test
@@ -256,7 +256,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         assertThat(response, hasStatus(400));
         assertThat(response, hasJsonBody(ErrorResponse.ERROR_1033));
 
-        assertNoAuditEventsReceivedByEitherService(auditTopic, txmaAuditQueue);
+        AuditAssertionsHelper.assertNoTxmaAuditEventsReceived(txmaAuditQueue);
     }
 
     @Test

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.CODE_MAX_RETRIES_REACHED;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.CODE_VERIFIED;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.INVALID_CODE_SENT;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
@@ -76,8 +76,7 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Map.of());
         assertThat(response, hasStatus(204));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic, txmaAuditQueue, singletonList(CODE_VERIFIED));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, singletonList(CODE_VERIFIED));
     }
 
     @Test
@@ -96,8 +95,7 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Map.of());
 
         assertThat(response, hasStatus(204));
-        assertEventTypesReceivedByBothServices(
-                auditTopic, txmaAuditQueue, singletonList(CODE_VERIFIED));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, singletonList(CODE_VERIFIED));
     }
 
     @Test
@@ -116,8 +114,7 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         Map.of());
 
         assertThat(response, hasStatus(400));
-        assertEventTypesReceivedByBothServices(
-                auditTopic, txmaAuditQueue, singletonList(INVALID_CODE_SENT));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, singletonList(INVALID_CODE_SENT));
     }
 
     @Test
@@ -136,8 +133,7 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         assertThat(response, hasStatus(400));
         assertThat(response, hasJsonBody(ErrorResponse.ERROR_1043));
-        assertEventTypesReceivedByBothServices(
-                auditTopic, txmaAuditQueue, singletonList(INVALID_CODE_SENT));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, singletonList(INVALID_CODE_SENT));
     }
 
     @Test
@@ -156,8 +152,7 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         assertThat(response, hasStatus(400));
         assertThat(response, hasJsonBody(ErrorResponse.ERROR_1043));
-        assertEventTypesReceivedByBothServices(
-                auditTopic, txmaAuditQueue, singletonList(INVALID_CODE_SENT));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, singletonList(INVALID_CODE_SENT));
     }
 
     @Test
@@ -195,8 +190,7 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         assertThat(response, hasStatus(400));
         assertThat(response, hasJsonBody(ErrorResponse.ERROR_1042));
-        assertEventTypesReceivedByBothServices(
-                auditTopic, txmaAuditQueue, singletonList(CODE_MAX_RETRIES_REACHED));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, singletonList(CODE_MAX_RETRIES_REACHED));
     }
 
     @Test

--- a/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/SpotResponseIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/SpotResponseIntegrationTest.java
@@ -25,7 +25,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
-import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertEventTypesReceivedByBothServices;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.helper.IdentityTestData.CORE_IDENTITY_CLAIM;
 
 public class SpotResponseIntegrationTest extends HandlerIntegrationTest<SQSEvent, Object> {
@@ -66,8 +66,7 @@ public class SpotResponseIntegrationTest extends HandlerIntegrationTest<SQSEvent
                         .getCoreIdentityJWT(),
                 equalTo(signedCredential));
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic,
+        assertTxmaAuditEventsReceived(
                 txmaAuditQueue,
                 Collections.singletonList(IPVAuditableEvent.IPV_SUCCESSFUL_SPOT_RESPONSE_RECEIVED));
     }
@@ -94,8 +93,7 @@ public class SpotResponseIntegrationTest extends HandlerIntegrationTest<SQSEvent
         assertFalse(
                 identityStore.getIdentityCredentials(pairwiseIdentifier.getValue()).isPresent());
 
-        assertEventTypesReceivedByBothServices(
-                auditTopic,
+        assertTxmaAuditEventsReceived(
                 txmaAuditQueue,
                 Collections.singletonList(
                         IPVAuditableEvent.IPV_UNSUCCESSFUL_SPOT_RESPONSE_RECEIVED));

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuditAssertionsHelper.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuditAssertionsHelper.java
@@ -22,22 +22,6 @@ public class AuditAssertionsHelper {
     private static final int SNS_TIMEOUT = 1;
     public static final int SNS_TIMEOUT_MILLIS = SNS_TIMEOUT * 1000;
 
-    public static void assertNoAuditEventsReceivedByEitherService(
-            AuditSnsTopicExtension auditTopic, SqsQueueExtension txmaAuditQueue) {
-        assertNoAuditEventsReceived(auditTopic);
-        assertNoTxmaAuditEventsReceived(txmaAuditQueue);
-    }
-
-    public static void assertNoAuditEventsReceived(AuditSnsTopicExtension auditTopic) {
-        try {
-            Thread.sleep(SNS_TIMEOUT_MILLIS);
-        } catch (InterruptedException ex) {
-            throw new RuntimeException(ex);
-        }
-
-        assertThat(auditTopic.getCountOfRequests(), equalTo(0));
-    }
-
     public static void assertNoTxmaAuditEventsReceived(SqsQueueExtension txmaAuditQueue) {
         try {
             Thread.sleep(SNS_TIMEOUT_MILLIS);

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuditAssertionsHelper.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuditAssertionsHelper.java
@@ -5,11 +5,12 @@ import uk.gov.di.authentication.shared.domain.AuditableEvent;
 import uk.gov.di.authentication.sharedtest.extensions.SqsQueueExtension;
 import uk.gov.di.authentication.sharedtest.matchers.JsonMatcher;
 
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
@@ -17,16 +18,12 @@ import static org.hamcrest.Matchers.hasItem;
 
 public class AuditAssertionsHelper {
 
-    private static final int SNS_TIMEOUT = 1;
-    public static final int SNS_TIMEOUT_MILLIS = SNS_TIMEOUT * 1000;
+    private static final Duration TIMEOUT = Duration.of(1, ChronoUnit.SECONDS);
 
     public static void assertNoTxmaAuditEventsReceived(SqsQueueExtension txmaAuditQueue) {
-        try {
-            Thread.sleep(SNS_TIMEOUT_MILLIS);
-        } catch (InterruptedException ex) {
-            throw new RuntimeException(ex);
-        }
-        assertThat(txmaAuditQueue.getApproximateMessageCount(), equalTo(0));
+        await().atMost(TIMEOUT)
+                .untilAsserted(
+                        () -> assertThat(txmaAuditQueue.getApproximateMessageCount(), equalTo(0)));
     }
 
     public static void assertTxmaAuditEventsReceived(
@@ -43,7 +40,7 @@ public class AuditAssertionsHelper {
                     "Do not call assertTxmaAuditEventsReceived() with an empty collection of event types; it won't wait to see if anything unexpected was received.  Instead, call Thread.sleep and then check the count of requests.");
         }
 
-        await().atMost(SNS_TIMEOUT, SECONDS)
+        await().atMost(TIMEOUT)
                 .untilAsserted(
                         () ->
                                 assertThat(

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
@@ -1,47 +1,26 @@
 package uk.gov.di.authentication.shared.services;
 
-import com.google.protobuf.InvalidProtocolBufferException;
-import org.hamcrest.CustomTypeSafeMatcher;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.MockitoAnnotations;
-import software.amazon.awssdk.core.SdkBytes;
-import software.amazon.awssdk.services.kms.model.SignRequest;
-import software.amazon.awssdk.services.kms.model.SignResponse;
-import uk.gov.di.audit.AuditPayload.SignedAuditEvent;
 import uk.gov.di.authentication.shared.domain.AuditableEvent;
 
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
-import java.util.Base64;
 import java.util.Optional;
-import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
 import static uk.gov.di.authentication.shared.services.AuditServiceTest.TestEvents.TEST_EVENT_ONE;
-import static uk.gov.di.authentication.sharedtest.matchers.AuditMessageMatcher.hasClientId;
-import static uk.gov.di.authentication.sharedtest.matchers.AuditMessageMatcher.hasEmail;
-import static uk.gov.di.authentication.sharedtest.matchers.AuditMessageMatcher.hasEventName;
-import static uk.gov.di.authentication.sharedtest.matchers.AuditMessageMatcher.hasIpAddress;
-import static uk.gov.di.authentication.sharedtest.matchers.AuditMessageMatcher.hasMetadataPair;
-import static uk.gov.di.authentication.sharedtest.matchers.AuditMessageMatcher.hasPersistentSessionId;
-import static uk.gov.di.authentication.sharedtest.matchers.AuditMessageMatcher.hasPhoneNumber;
-import static uk.gov.di.authentication.sharedtest.matchers.AuditMessageMatcher.hasRequestId;
-import static uk.gov.di.authentication.sharedtest.matchers.AuditMessageMatcher.hasSessionId;
-import static uk.gov.di.authentication.sharedtest.matchers.AuditMessageMatcher.hasSubjectId;
-import static uk.gov.di.authentication.sharedtest.matchers.AuditMessageMatcher.hasTimestamp;
 import static uk.gov.di.authentication.sharedtest.matchers.JsonMatcher.asJson;
 import static uk.gov.di.authentication.sharedtest.matchers.JsonMatcher.hasFieldWithValue;
 import static uk.gov.di.authentication.sharedtest.matchers.JsonMatcher.hasNumericFieldWithValue;
@@ -57,7 +36,6 @@ class AuditServiceTest {
     private final AwsSqsClient awsSqsClient = mock(AwsSqsClient.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
 
-    @Captor private ArgumentCaptor<String> messageCaptor;
     @Captor private ArgumentCaptor<String> txmaMessageCaptor;
 
     enum TestEvents implements AuditableEvent {
@@ -70,18 +48,13 @@ class AuditServiceTest {
 
     @BeforeEach
     void beforeEach() {
-        var signResponse =
-                SignResponse.builder()
-                        .signature(SdkBytes.fromByteArray("signature".getBytes()))
-                        .build();
-        when(kmsConnectionService.sign(any(SignRequest.class))).thenReturn(signResponse);
         when(configurationService.getOidcApiBaseURL()).thenReturn(Optional.of("oidc-base-url"));
         MockitoAnnotations.openMocks(this);
     }
 
     @AfterEach
     void afterEach() {
-        verifyNoMoreInteractions(snsService);
+        verifyNoInteractions(snsService, kmsConnectionService);
     }
 
     @Test
@@ -105,20 +78,6 @@ class AuditServiceTest {
                 "phone-number",
                 "persistent-session-id");
 
-        verify(snsService).publishAuditMessage(messageCaptor.capture());
-        var serialisedAuditMessage = messageCaptor.getValue();
-
-        assertThat(serialisedAuditMessage, hasTimestamp(FIXED_TIMESTAMP));
-        assertThat(serialisedAuditMessage, hasEventName(TEST_EVENT_ONE.toString()));
-        assertThat(serialisedAuditMessage, hasRequestId("request-id"));
-        assertThat(serialisedAuditMessage, hasSessionId("session-id"));
-        assertThat(serialisedAuditMessage, hasPersistentSessionId("persistent-session-id"));
-        assertThat(serialisedAuditMessage, hasClientId("client-id"));
-        assertThat(serialisedAuditMessage, hasSubjectId("subject-id"));
-        assertThat(serialisedAuditMessage, hasEmail("email"));
-        assertThat(serialisedAuditMessage, hasIpAddress("ip-address"));
-        assertThat(serialisedAuditMessage, hasPhoneNumber("phone-number"));
-
         verify(awsSqsClient).send(txmaMessageCaptor.capture());
 
         var txmaMessage = asJson(txmaMessageCaptor.getValue());
@@ -138,41 +97,6 @@ class AuditServiceTest {
         assertThat(userObject, hasFieldWithValue("email", equalTo("email")));
         assertThat(userObject, hasFieldWithValue("phone", equalTo("phone-number")));
         assertThat(userObject, hasFieldWithValue("ip_address", equalTo("ip-address")));
-    }
-
-    @Test
-    void shouldSignAuditEventPayload() throws InvalidProtocolBufferException {
-        var auditService =
-                new AuditService(
-                        FIXED_CLOCK,
-                        snsService,
-                        kmsConnectionService,
-                        configurationService,
-                        awsSqsClient);
-
-        var signingRequestCaptor = ArgumentCaptor.forClass(SignRequest.class);
-
-        auditService.submitAuditEvent(
-                TEST_EVENT_ONE,
-                "request-id",
-                "session-id",
-                "client-id",
-                "subject-id",
-                "email",
-                "ip-address",
-                "persistent-session-id",
-                "phone-number");
-
-        verify(kmsConnectionService).sign(signingRequestCaptor.capture());
-        verify(snsService).publishAuditMessage(messageCaptor.capture());
-
-        SignedAuditEvent event =
-                SignedAuditEvent.parseFrom(Base64.getDecoder().decode(messageCaptor.getValue()));
-
-        assertThat(
-                event.getPayload().toByteArray(),
-                is(signingRequestCaptor.getValue().message().asByteArray()));
-        assertThat(event.getSignature().toByteArray(), is("signature".getBytes()));
     }
 
     @Test
@@ -198,14 +122,6 @@ class AuditServiceTest {
                 pair("key", "value"),
                 pair("key2", "value2"));
 
-        verify(snsService).publishAuditMessage(messageCaptor.capture());
-        var serialisedAuditMessage = messageCaptor.getValue();
-
-        assertThat(serialisedAuditMessage, hasTimestamp(FIXED_TIMESTAMP));
-        assertThat(serialisedAuditMessage, hasEventName(TEST_EVENT_ONE.toString()));
-        assertThat(serialisedAuditMessage, hasMetadataPair(pair("key", "value")));
-        assertThat(serialisedAuditMessage, hasMetadataPair(pair("key2", "value2")));
-
         verify(awsSqsClient).send(txmaMessageCaptor.capture());
         var txmaMessage = asJson(txmaMessageCaptor.getValue());
 
@@ -216,21 +132,5 @@ class AuditServiceTest {
 
         assertThat(extensions, hasFieldWithValue("key", equalTo("value")));
         assertThat(extensions, hasFieldWithValue("key2", equalTo("value2")));
-        assertThat(extensions, hasFieldWithValue("legacy_audit_event_id", isUuid()));
-    }
-
-    private static CustomTypeSafeMatcher<String> isUuid() {
-        return new CustomTypeSafeMatcher<>("Should be a UUID") {
-            @Override
-            @SuppressWarnings("all")
-            protected boolean matchesSafely(String item) {
-                try {
-                    UUID.fromString(item);
-                    return true;
-                } catch (IllegalArgumentException e) {
-                    return false;
-                }
-            }
-        };
     }
 }


### PR DESCRIPTION
This completely decouples the auth services from the old audit service, and will enable the consumers / protobuf to be removed.
