### PR TITLE
AUT-398 - Update client registry to Dynamo SDK v2

### DIFF
--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandlerTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandlerTest.java
@@ -213,18 +213,17 @@ class UpdateClientConfigHandlerTest {
     }
 
     private ClientRegistry createClientRegistry() {
-        ClientRegistry clientRegistry = new ClientRegistry();
-        clientRegistry.setClientName(CLIENT_NAME);
-        clientRegistry.setClientID(CLIENT_ID);
-        clientRegistry.setPublicKey("public-key");
-        clientRegistry.setScopes(SCOPES);
-        clientRegistry.setSubjectType("Public");
-        clientRegistry.setRedirectUrls(singletonList("http://localhost/redirect"));
-        clientRegistry.setContacts(singletonList("contant-name"));
-        clientRegistry.setPostLogoutRedirectUrls(singletonList("localhost/logout"));
-        clientRegistry.setServiceType(SERVICE_TYPE);
-        clientRegistry.setClientType(ClientType.WEB.getValue());
-        return clientRegistry;
+        return new ClientRegistry()
+                .withClientName(CLIENT_NAME)
+                .withClientID(CLIENT_ID)
+                .withPublicKey("public-key")
+                .withScopes(SCOPES)
+                .withSubjectType("Public")
+                .withRedirectUrls(singletonList("http://localhost/redirect"))
+                .withContacts(singletonList("contant-name"))
+                .withPostLogoutRedirectUrls(singletonList("localhost/logout"))
+                .withServiceType(SERVICE_TYPE)
+                .withClientType(ClientType.WEB.getValue());
     }
 
     private APIGatewayProxyResponseEvent makeHandlerRequest(APIGatewayProxyRequestEvent event) {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
@@ -620,11 +620,11 @@ class LoginHandlerTest {
 
     private ClientRegistry generateClientRegistry() {
         return new ClientRegistry()
-                .setClientID(CLIENT_ID.getValue())
-                .setConsentRequired(false)
-                .setClientName("test-client")
-                .setSectorIdentifierUri("https://test.com")
-                .setSubjectType("public");
+                .withClientID(CLIENT_ID.getValue())
+                .withConsentRequired(false)
+                .withClientName("test-client")
+                .withSectorIdentifierUri("https://test.com")
+                .withSubjectType("public");
     }
 
     private void usingDefaultVectorOfTrust() {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
@@ -89,9 +89,9 @@ public class MfaHandlerTest {
     private final Session session = new Session("a-session-id").setEmailAddress(TEST_EMAIL_ADDRESS);
     private final ClientRegistry testClientRegistry =
             new ClientRegistry()
-                    .setTestClient(true)
-                    .setClientID(TEST_CLIENT_ID)
-                    .setTestClientEmailAllowlist(
+                    .withTestClient(true)
+                    .withClientID(TEST_CLIENT_ID)
+                    .withTestClientEmailAllowlist(
                             List.of(
                                     "joe.bloggs@digital.cabinet-office.gov.uk",
                                     TEST_EMAIL_ADDRESS,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
@@ -86,12 +86,12 @@ class SendNotificationHandlerTest {
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
     private final ClientSession clientSession = mock(ClientSession.class);
     private final ClientRegistry clientRegistry =
-            new ClientRegistry().setTestClient(false).setClientID(CLIENT_ID);
+            new ClientRegistry().withTestClient(false).withClientID(CLIENT_ID);
     private final ClientRegistry testClientRegistry =
             new ClientRegistry()
-                    .setTestClient(true)
-                    .setClientID(TEST_CLIENT_ID)
-                    .setTestClientEmailAllowlist(
+                    .withTestClient(true)
+                    .withClientID(TEST_CLIENT_ID)
+                    .withTestClientEmailAllowlist(
                             List.of(
                                     "joe.bloggs@digital.cabinet-office.gov.uk",
                                     "jb2@digital.cabinet-office.gov.uk"));

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandlerTest.java
@@ -274,10 +274,10 @@ class SignUpHandlerTest {
 
     private ClientRegistry generateClientRegistry(boolean consentRequired) {
         return new ClientRegistry()
-                .setClientID(CLIENT_ID.getValue())
-                .setConsentRequired(consentRequired)
-                .setClientName("test-client")
-                .setSectorIdentifierUri("https://test.com")
-                .setSubjectType("public");
+                .withClientID(CLIENT_ID.getValue())
+                .withConsentRequired(consentRequired)
+                .withClientName("test-client")
+                .withSectorIdentifierUri("https://test.com")
+                .withSubjectType("public");
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -90,12 +90,12 @@ class VerifyCodeHandlerTest {
             mock(CloudwatchMetricsService.class);
 
     private final ClientRegistry clientRegistry =
-            new ClientRegistry().setTestClient(false).setClientID(CLIENT_ID);
+            new ClientRegistry().withTestClient(false).withClientID(CLIENT_ID);
     private final ClientRegistry testClientRegistry =
             new ClientRegistry()
-                    .setTestClient(true)
-                    .setClientID(TEST_CLIENT_ID)
-                    .setTestClientEmailAllowlist(
+                    .withTestClient(true)
+                    .withClientID(TEST_CLIENT_ID)
+                    .withTestClientEmailAllowlist(
                             List.of("testclient.user1@digital.cabinet-office.gov.uk"));
 
     private VerifyCodeHandler handler;

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
@@ -339,12 +339,12 @@ class StartServiceTest {
     private ClientRegistry generateClientRegistry(
             String redirectURI, String clientID, boolean cookieConsentShared) {
         return new ClientRegistry()
-                .setRedirectUrls(singletonList(redirectURI))
-                .setClientID(clientID)
-                .setContacts(singletonList("joe.bloggs@digital.cabinet-office.gov.uk"))
-                .setPublicKey(null)
-                .setScopes(singletonList("openid"))
-                .setCookieConsentShared(cookieConsentShared);
+                .withRedirectUrls(singletonList(redirectURI))
+                .withClientID(clientID)
+                .withContacts(singletonList("joe.bloggs@digital.cabinet-office.gov.uk"))
+                .withPublicKey(null)
+                .withScopes(singletonList("openid"))
+                .withCookieConsentShared(cookieConsentShared);
     }
 
     private UserContext buildUserContext(
@@ -388,12 +388,12 @@ class StartServiceTest {
                         authRequest.toParameters(), LocalDateTime.now(), clientSessionVTR);
         var clientRegistry =
                 new ClientRegistry()
-                        .setClientID(CLIENT_ID.getValue())
-                        .setClientName(CLIENT_NAME)
-                        .setConsentRequired(consentRequired)
-                        .setCookieConsentShared(cookieConsentShared)
-                        .setClientType(clientType.getValue())
-                        .setIdentityVerificationSupported(identityVerificationSupport);
+                        .withClientID(CLIENT_ID.getValue())
+                        .withClientName(CLIENT_NAME)
+                        .withConsentRequired(consentRequired)
+                        .withCookieConsentShared(cookieConsentShared)
+                        .withClientType(clientType.getValue())
+                        .withIdentityVerificationSupported(identityVerificationSupport);
         return UserContext.builder(SESSION.setAuthenticated(isAuthenticated))
                 .withClientSession(clientSession)
                 .withClient(clientRegistry)

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateClientConfigIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateClientConfigIntegrationTest.java
@@ -64,6 +64,7 @@ public class UpdateClientConfigIntegrationTest extends ApiGatewayHandlerIntegrat
                 objectMapper.readValue(response.getBody(), ClientRegistrationResponse.class);
         assertThat(clientResponse.getClientName(), equalTo("new-client-name"));
         assertThat(clientResponse.getClientId(), equalTo(CLIENT_ID));
+        assertThat(clientResponse.getScopes(), equalTo(singletonList("openid")));
 
         assertEventTypesReceivedByBothServices(
                 auditTopic, txmaAuditQueue, List.of(UPDATE_CLIENT_REQUEST_RECEIVED));

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandlerTest.java
@@ -253,14 +253,14 @@ public class IPVAuthorisationHandlerTest {
 
     private ClientRegistry generateClientRegistry() {
         return new ClientRegistry()
-                .setRedirectUrls(singletonList(REDIRECT_URI.toString()))
-                .setClientID(CLIENT_ID)
-                .setContacts(singletonList("joe.bloggs@digital.cabinet-office.gov.uk"))
-                .setPublicKey(null)
-                .setSectorIdentifierUri("http://sector-identifier")
-                .setScopes(singletonList("openid"))
-                .setCookieConsentShared(true)
-                .setSubjectType("pairwise");
+                .withRedirectUrls(singletonList(REDIRECT_URI.toString()))
+                .withClientID(CLIENT_ID)
+                .withContacts(singletonList("joe.bloggs@digital.cabinet-office.gov.uk"))
+                .withPublicKey(null)
+                .withSectorIdentifierUri("http://sector-identifier")
+                .withScopes(singletonList("openid"))
+                .withCookieConsentShared(true)
+                .withSubjectType("pairwise");
     }
 
     private UserProfile generateUserProfile() {

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -554,12 +554,12 @@ class IPVCallbackHandlerTest {
 
     private ClientRegistry generateClientRegistry() {
         return new ClientRegistry()
-                .setClientID(CLIENT_ID.getValue())
-                .setConsentRequired(false)
-                .setClientName("test-client")
-                .setRedirectUrls(singletonList(REDIRECT_URI.toString()))
-                .setSectorIdentifierUri("https://test.com")
-                .setSubjectType("pairwise");
+                .withClientID(CLIENT_ID.getValue())
+                .withConsentRequired(false)
+                .withClientName("test-client")
+                .withRedirectUrls(singletonList(REDIRECT_URI.toString()))
+                .withSectorIdentifierUri("https://test.com")
+                .withSubjectType("pairwise");
     }
 
     public static AuthenticationRequest generateAuthRequest() {

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandlerTest.java
@@ -269,14 +269,14 @@ class ProcessingIdentityHandlerTest {
 
     private ClientRegistry generateClientRegistry() {
         return new ClientRegistry()
-                .setRedirectUrls(singletonList(REDIRECT_URI.toString()))
-                .setClientID(CLIENT_ID)
-                .setContacts(singletonList("joe.bloggs@digital.cabinet-office.gov.uk"))
-                .setPublicKey(null)
-                .setSectorIdentifierUri("http://sector-identifier")
-                .setScopes(singletonList("openid"))
-                .setCookieConsentShared(true)
-                .setSubjectType("pairwise");
+                .withRedirectUrls(singletonList(REDIRECT_URI.toString()))
+                .withClientID(CLIENT_ID)
+                .withContacts(singletonList("joe.bloggs@digital.cabinet-office.gov.uk"))
+                .withPublicKey(null)
+                .withSectorIdentifierUri("http://sector-identifier")
+                .withScopes(singletonList("openid"))
+                .withCookieConsentShared(true)
+                .withSubjectType("pairwise");
     }
 
     private UserProfile generateUserProfile() {

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -712,10 +712,10 @@ class AuthorisationHandlerTest {
 
     private ClientRegistry generateClientRegistry() {
         return new ClientRegistry()
-                .setClientID(new ClientID().getValue())
-                .setConsentRequired(false)
-                .setClientName("test-client")
-                .setSectorIdentifierUri("https://test.com")
-                .setSubjectType("public");
+                .withClientID(new ClientID().getValue())
+                .withConsentRequired(false)
+                .withClientName("test-client")
+                .withSectorIdentifierUri("https://test.com")
+                .withSubjectType("public");
     }
 }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/LogoutHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/LogoutHandlerTest.java
@@ -609,13 +609,13 @@ class LogoutHandlerTest {
 
     private ClientRegistry createClientRegistry() {
         return new ClientRegistry()
-                .setClientID("client-id")
-                .setClientName("client-one")
-                .setPublicKey("public-key")
-                .setContacts(singletonList("contact-1"))
-                .setPostLogoutRedirectUrls(singletonList(CLIENT_LOGOUT_URI.toString()))
-                .setScopes(singletonList("openid"))
-                .setRedirectUrls(singletonList("http://localhost/redirect"));
+                .withClientID("client-id")
+                .withClientName("client-one")
+                .withPublicKey("public-key")
+                .withContacts(singletonList("contact-1"))
+                .withPostLogoutRedirectUrls(singletonList(CLIENT_LOGOUT_URI.toString()))
+                .withScopes(singletonList("openid"))
+                .withRedirectUrls(singletonList("http://localhost/redirect"));
     }
 
     private static String buildCookieString(String clientSessionId) {
@@ -657,7 +657,7 @@ class LogoutHandlerTest {
                                         LocalDateTime.now(),
                                         VectorOfTrust.getDefaults())));
         when(dynamoClientService.getClient(clientId))
-                .thenReturn(Optional.of(new ClientRegistry().setClientID(clientId)));
+                .thenReturn(Optional.of(new ClientRegistry().withClientID(clientId)));
     }
 
     private void verifySessions() {

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
@@ -500,16 +500,16 @@ public class TokenHandlerTest {
 
     private ClientRegistry generateClientRegistry(KeyPair keyPair, boolean consentRequired) {
         return new ClientRegistry()
-                .setClientID(CLIENT_ID)
-                .setConsentRequired(consentRequired)
-                .setClientName("test-client")
-                .setRedirectUrls(singletonList(REDIRECT_URI))
-                .setScopes(SCOPES.toStringList())
-                .setContacts(singletonList(TEST_EMAIL))
-                .setPublicKey(
+                .withClientID(CLIENT_ID)
+                .withConsentRequired(consentRequired)
+                .withClientName("test-client")
+                .withRedirectUrls(singletonList(REDIRECT_URI))
+                .withScopes(SCOPES.toStringList())
+                .withContacts(singletonList(TEST_EMAIL))
+                .withPublicKey(
                         Base64.getMimeEncoder().encodeToString(keyPair.getPublic().getEncoded()))
-                .setSectorIdentifierUri("https://test.com")
-                .setSubjectType("public");
+                .withSectorIdentifierUri("https://test.com")
+                .withSubjectType("public");
     }
 
     private APIGatewayProxyResponseEvent generateApiGatewayRequest(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AccessTokenServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AccessTokenServiceTest.java
@@ -326,12 +326,12 @@ class AccessTokenServiceTest {
 
     private ClientRegistry generateClientRegistry(List<String> scopes, boolean identitySupported) {
         return new ClientRegistry()
-                .setRedirectUrls(singletonList("http://localhost/redirect"))
-                .setClientID(CLIENT_ID)
-                .setContacts(singletonList("joe.bloggs@digital.cabinet-office.gov.uk"))
-                .setPublicKey(null)
-                .setIdentityVerificationSupported(identitySupported)
-                .setScopes(scopes);
+                .withRedirectUrls(singletonList("http://localhost/redirect"))
+                .withClientID(CLIENT_ID)
+                .withContacts(singletonList("joe.bloggs@digital.cabinet-office.gov.uk"))
+                .withPublicKey(null)
+                .withIdentityVerificationSupported(identitySupported)
+                .withScopes(scopes);
     }
 
     private AccessToken createSignedAccessToken(OIDCClaimsRequest identityClaims, boolean expired) {

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AuthorizationServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AuthorizationServiceTest.java
@@ -200,10 +200,10 @@ class AuthorizationServiceTest {
         var scope = new Scope(OIDCScopeValue.OPENID);
         var clientRegistry =
                 new ClientRegistry()
-                        .setRedirectUrls(singletonList(REDIRECT_URI.toString()))
-                        .setClientID(CLIENT_ID.toString())
-                        .setScopes(scope.toStringList())
-                        .setClaims(
+                        .withRedirectUrls(singletonList(REDIRECT_URI.toString()))
+                        .withClientID(CLIENT_ID.toString())
+                        .withScopes(scope.toStringList())
+                        .withClaims(
                                 List.of(
                                         ValidClaims.ADDRESS.getValue(),
                                         ValidClaims.CORE_IDENTITY_JWT.getValue()));
@@ -569,6 +569,9 @@ class AuthorizationServiceTest {
         assertThat(
                 authorizationService.isTestJourney(CLIENT_ID, "test@test.com"),
                 equalTo(dynamoClientServiceReturns));
+        assertThat(
+                authorizationService.isTestJourney(CLIENT_ID, "test@test.com"),
+                equalTo(dynamoClientServiceReturns));
     }
 
     private ClientRegistry generateClientRegistry(String redirectURI, String clientID) {
@@ -583,12 +586,12 @@ class AuthorizationServiceTest {
     private ClientRegistry generateClientRegistry(
             String redirectURI, String clientID, List<String> scopes, boolean testClient) {
         return new ClientRegistry()
-                .setRedirectUrls(singletonList(redirectURI))
-                .setClientID(clientID)
-                .setContacts(singletonList("joe.bloggs@digital.cabinet-office.gov.uk"))
-                .setPublicKey(null)
-                .setTestClient(testClient)
-                .setScopes(scopes);
+                .withRedirectUrls(singletonList(redirectURI))
+                .withClientID(clientID)
+                .withContacts(singletonList("joe.bloggs@digital.cabinet-office.gov.uk"))
+                .withPublicKey(null)
+                .withTestClient(testClient)
+                .withScopes(scopes);
     }
 
     private AuthenticationRequest generateAuthRequest(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/BackChannelLogoutServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/BackChannelLogoutServiceTest.java
@@ -36,10 +36,10 @@ class BackChannelLogoutServiceTest {
 
         service.sendLogoutMessage(
                 new ClientRegistry()
-                        .setClientID("client-id")
-                        .setSubjectType("pairwise")
-                        .setSectorIdentifierUri("https://example.sign-in.service.gov.uk")
-                        .setBackChannelLogoutUri("http://localhost:8080/back-channel-logout"),
+                        .withClientID("client-id")
+                        .withSubjectType("pairwise")
+                        .withSectorIdentifierUri("https://example.sign-in.service.gov.uk")
+                        .withBackChannelLogoutUri("http://localhost:8080/back-channel-logout"),
                 "test@test.com");
 
         var captor = ArgumentCaptor.forClass(BackChannelLogoutMessage.class);
@@ -57,8 +57,8 @@ class BackChannelLogoutServiceTest {
 
     @Test
     void shouldNotPostMessageToSqsWhenRequiredFieldsAreNotPresent() {
-        var noLogoutUri = new ClientRegistry().setClientID("client-id");
-        var noClientId = new ClientRegistry().setBackChannelLogoutUri("http://localhost:8080/");
+        var noLogoutUri = new ClientRegistry().withClientID("client-id");
+        var noClientId = new ClientRegistry().withBackChannelLogoutUri("http://localhost:8080/");
         var neitherField = new ClientRegistry();
 
         Stream.of(noLogoutUri, noClientId, neitherField)
@@ -74,8 +74,8 @@ class BackChannelLogoutServiceTest {
 
         service.sendLogoutMessage(
                 new ClientRegistry()
-                        .setClientID("client-id")
-                        .setBackChannelLogoutUri("http://localhost:8080/back-channel-logout"),
+                        .withClientID("client-id")
+                        .withBackChannelLogoutUri("http://localhost:8080/back-channel-logout"),
                 "test@test.com");
 
         verify(sqs, never()).send(anyString());

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RequestObjectServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RequestObjectServiceTest.java
@@ -520,16 +520,16 @@ class RequestObjectServiceTest {
 
     private ClientRegistry generateClientRegistry(String clientType, Scope scope) {
         return new ClientRegistry()
-                .setClientID(CLIENT_ID.getValue())
-                .setPublicKey(
+                .withClientID(CLIENT_ID.getValue())
+                .withPublicKey(
                         Base64.getMimeEncoder().encodeToString(keyPair.getPublic().getEncoded()))
-                .setConsentRequired(false)
-                .setClientName("test-client")
-                .setScopes(scope.toStringList())
-                .setRedirectUrls(singletonList(REDIRECT_URI))
-                .setSectorIdentifierUri("https://test.com")
-                .setSubjectType("pairwise")
-                .setClientType(clientType);
+                .withConsentRequired(false)
+                .withClientName("test-client")
+                .withScopes(scope.toStringList())
+                .withRedirectUrls(singletonList(REDIRECT_URI))
+                .withSectorIdentifierUri("https://test.com")
+                .withSubjectType("pairwise")
+                .withClientType(clientType);
     }
 
     private AuthenticationRequest generateAuthRequest(SignedJWT signedJWT) {

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
@@ -334,11 +334,11 @@ class UserInfoServiceTest {
 
     private ClientRegistry generateClientRegistry() {
         return new ClientRegistry()
-                .setClientID(CLIENT_ID)
-                .setConsentRequired(false)
-                .setClientName("test-client")
-                .setSectorIdentifierUri("https://test.com")
-                .setSubjectType("public");
+                .withClientID(CLIENT_ID)
+                .withConsentRequired(false)
+                .withClientName("test-client")
+                .withSectorIdentifierUri("https://test.com")
+                .withSubjectType("public");
     }
 
     private void assertClaimMetricPublished(String v3) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ClientRegistry.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ClientRegistry.java
@@ -1,12 +1,14 @@
 package uk.gov.di.authentication.shared.entity;
 
-import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBAttribute;
-import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
-import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBIndexHashKey;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbAttribute;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSecondaryPartitionKey;
 
 import java.util.ArrayList;
 import java.util.List;
 
+@DynamoDbBean
 public class ClientRegistry {
 
     private String clientID;
@@ -28,184 +30,258 @@ public class ClientRegistry {
     private String clientType;
     private boolean identityVerificationSupported = false;
 
-    @DynamoDBHashKey(attributeName = "ClientID")
+    public ClientRegistry() {}
+
+    @DynamoDbPartitionKey
+    @DynamoDbAttribute("ClientID")
     public String getClientID() {
         return clientID;
     }
 
-    public ClientRegistry setClientID(String clientID) {
+    public void setClientID(String clientID) {
+        this.clientID = clientID;
+    }
+
+    public ClientRegistry withClientID(String clientID) {
         this.clientID = clientID;
         return this;
     }
 
-    @DynamoDBIndexHashKey(
-            globalSecondaryIndexName = "ClientNameIndex",
-            attributeName = "ClientName")
+    @DynamoDbSecondaryPartitionKey(indexNames = {"ClientNameIndex"})
+    @DynamoDbAttribute("ClientName")
     public String getClientName() {
         return clientName;
     }
 
-    public ClientRegistry setClientName(String clientName) {
+    public void setClientName(String clientName) {
+        this.clientName = clientName;
+    }
+
+    public ClientRegistry withClientName(String clientName) {
         this.clientName = clientName;
         return this;
     }
 
-    @DynamoDBAttribute(attributeName = "PublicKey")
+    @DynamoDbAttribute("PublicKey")
     public String getPublicKey() {
         return publicKey;
     }
 
-    public ClientRegistry setPublicKey(String publicKey) {
+    public void setPublicKey(String publicKey) {
+        this.publicKey = publicKey;
+    }
+
+    public ClientRegistry withPublicKey(String publicKey) {
         this.publicKey = publicKey;
         return this;
     }
 
-    @DynamoDBAttribute(attributeName = "Scopes")
+    @DynamoDbAttribute("Scopes")
     public List<String> getScopes() {
         return scopes;
     }
 
-    public ClientRegistry setScopes(List<String> scopes) {
+    public void setScopes(List<String> scopes) {
+        this.scopes = scopes;
+    }
+
+    public ClientRegistry withScopes(List<String> scopes) {
         this.scopes = scopes;
         return this;
     }
 
-    @DynamoDBAttribute(attributeName = "RedirectUrls")
+    @DynamoDbAttribute("RedirectUrls")
     public List<String> getRedirectUrls() {
         return redirectUrls;
     }
 
-    public ClientRegistry setRedirectUrls(List<String> redirectUrls) {
+    public void setRedirectUrls(List<String> redirectUrls) {
+        this.redirectUrls = redirectUrls;
+    }
+
+    public ClientRegistry withRedirectUrls(List<String> redirectUrls) {
         this.redirectUrls = redirectUrls;
         return this;
     }
 
-    @DynamoDBAttribute(attributeName = "Contacts")
+    @DynamoDbAttribute("Contacts")
     public List<String> getContacts() {
         return contacts;
     }
 
-    public ClientRegistry setContacts(List<String> contacts) {
+    public void setContacts(List<String> contacts) {
+        this.contacts = contacts;
+    }
+
+    public ClientRegistry withContacts(List<String> contacts) {
         this.contacts = contacts;
         return this;
     }
 
-    @DynamoDBAttribute(attributeName = "PostLogoutRedirectUrls")
+    @DynamoDbAttribute("PostLogoutRedirectUrls")
     public List<String> getPostLogoutRedirectUrls() {
         return postLogoutRedirectUrls;
     }
 
-    public ClientRegistry setPostLogoutRedirectUrls(List<String> postLogoutRedirectUrls) {
+    public void setPostLogoutRedirectUrls(List<String> postLogoutRedirectUrls) {
+        this.postLogoutRedirectUrls = postLogoutRedirectUrls;
+    }
+
+    public ClientRegistry withPostLogoutRedirectUrls(List<String> postLogoutRedirectUrls) {
         this.postLogoutRedirectUrls = postLogoutRedirectUrls;
         return this;
     }
 
-    @DynamoDBAttribute(attributeName = "BackChannelLogoutUri")
+    @DynamoDbAttribute("BackChannelLogoutUri")
     public String getBackChannelLogoutUri() {
         return backChannelLogoutUri;
     }
 
-    public ClientRegistry setBackChannelLogoutUri(String backChannelLogoutUri) {
+    public void setBackChannelLogoutUri(String backChannelLogoutUri) {
+        this.backChannelLogoutUri = backChannelLogoutUri;
+    }
+
+    public ClientRegistry withBackChannelLogoutUri(String backChannelLogoutUri) {
         this.backChannelLogoutUri = backChannelLogoutUri;
         return this;
     }
 
-    @DynamoDBAttribute(attributeName = "ServiceType")
+    @DynamoDbAttribute("ServiceType")
     public String getServiceType() {
         return serviceType;
     }
 
-    public ClientRegistry setServiceType(String serviceType) {
+    public void setServiceType(String serviceType) {
+        this.serviceType = serviceType;
+    }
+
+    public ClientRegistry withServiceType(String serviceType) {
         this.serviceType = serviceType;
         return this;
     }
 
-    @DynamoDBAttribute(attributeName = "SectorIdentifierUri")
+    @DynamoDbAttribute("SectorIdentifierUri")
     public String getSectorIdentifierUri() {
         return sectorIdentifierUri;
     }
 
-    public ClientRegistry setSectorIdentifierUri(String sectorIdentifierUri) {
+    public void setSectorIdentifierUri(String sectorIdentifierUri) {
+        this.sectorIdentifierUri = sectorIdentifierUri;
+    }
+
+    public ClientRegistry withSectorIdentifierUri(String sectorIdentifierUri) {
         this.sectorIdentifierUri = sectorIdentifierUri;
         return this;
     }
 
-    @DynamoDBAttribute(attributeName = "SubjectType")
+    @DynamoDbAttribute("SubjectType")
     public String getSubjectType() {
         return subjectType;
     }
 
-    public ClientRegistry setSubjectType(String subjectType) {
+    public void setSubjectType(String subjectType) {
+        this.subjectType = subjectType;
+    }
+
+    public ClientRegistry withSubjectType(String subjectType) {
         this.subjectType = subjectType;
         return this;
     }
 
-    @DynamoDBAttribute(attributeName = "CookieConsentShared")
+    @DynamoDbAttribute("CookieConsentShared")
     public boolean isCookieConsentShared() {
         return cookieConsentShared;
     }
 
-    public ClientRegistry setCookieConsentShared(boolean cookieConsent) {
+    public void setCookieConsentShared(boolean cookieConsentShared) {
+        this.cookieConsentShared = cookieConsentShared;
+    }
+
+    public ClientRegistry withCookieConsentShared(boolean cookieConsent) {
         this.cookieConsentShared = cookieConsent;
         return this;
     }
 
-    @DynamoDBAttribute(attributeName = "TestClient")
+    @DynamoDbAttribute("TestClient")
     public boolean isTestClient() {
         return testClient;
     }
 
-    public ClientRegistry setTestClient(boolean testClient) {
+    public void setTestClient(boolean testClient) {
+        this.testClient = testClient;
+    }
+
+    public ClientRegistry withTestClient(boolean testClient) {
         this.testClient = testClient;
         return this;
     }
 
-    @DynamoDBAttribute(attributeName = "TestClientEmailAllowlist")
+    @DynamoDbAttribute("TestClientEmailAllowlist")
     public List<String> getTestClientEmailAllowlist() {
         return testClientEmailAllowlist;
     }
 
-    public ClientRegistry setTestClientEmailAllowlist(List<String> testClientEmailAllowlist) {
+    public void setTestClientEmailAllowlist(List<String> testClientEmailAllowlist) {
+        this.testClientEmailAllowlist = testClientEmailAllowlist;
+    }
+
+    public ClientRegistry withTestClientEmailAllowlist(List<String> testClientEmailAllowlist) {
         this.testClientEmailAllowlist = testClientEmailAllowlist;
         return this;
     }
 
-    @DynamoDBAttribute(attributeName = "ConsentRequired")
+    @DynamoDbAttribute("ConsentRequired")
     public boolean isConsentRequired() {
         return consentRequired;
     }
 
-    public ClientRegistry setConsentRequired(boolean consentRequired) {
+    public void setConsentRequired(boolean consentRequired) {
+        this.consentRequired = consentRequired;
+    }
+
+    public ClientRegistry withConsentRequired(boolean consentRequired) {
         this.consentRequired = consentRequired;
         return this;
     }
 
-    @DynamoDBAttribute(attributeName = "Claims")
+    @DynamoDbAttribute("Claims")
     public List<String> getClaims() {
         return claims;
     }
 
-    public ClientRegistry setClaims(List<String> claims) {
+    public void setClaims(List<String> claims) {
+        this.claims = claims;
+    }
+
+    public ClientRegistry withClaims(List<String> claims) {
         this.claims = claims;
         return this;
     }
 
-    @DynamoDBAttribute(attributeName = "ClientType")
+    @DynamoDbAttribute("ClientType")
     public String getClientType() {
         return clientType;
     }
 
-    public ClientRegistry setClientType(String clientType) {
+    public void setClientType(String clientType) {
+        this.clientType = clientType;
+    }
+
+    public ClientRegistry withClientType(String clientType) {
         this.clientType = clientType;
         return this;
     }
 
-    @DynamoDBAttribute(attributeName = "IdentityVerificationSupported")
+    @DynamoDbAttribute("IdentityVerificationSupported")
     public boolean isIdentityVerificationSupported() {
         return identityVerificationSupported;
     }
 
-    public ClientRegistry setIdentityVerificationSupported(boolean identityVerificationSupported) {
+    public void setIdentityVerificationSupported(boolean identityVerificationSupported) {
+        this.identityVerificationSupported = identityVerificationSupported;
+    }
+
+    public ClientRegistry withIdentityVerificationSupported(boolean identityVerificationSupported) {
         this.identityVerificationSupported = identityVerificationSupported;
         return this;
     }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/conditions/DocAppUserHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/conditions/DocAppUserHelperTest.java
@@ -180,11 +180,11 @@ class DocAppUserHelperTest {
         subject.ifPresent(clientSession::setDocAppSubjectId);
         var clientRegistry =
                 new ClientRegistry()
-                        .setClientID(CLIENT_ID.getValue())
-                        .setClientName(CLIENT_NAME)
-                        .setConsentRequired(false)
-                        .setCookieConsentShared(false)
-                        .setClientType(clientType.getValue());
+                        .withClientID(CLIENT_ID.getValue())
+                        .withClientName(CLIENT_NAME)
+                        .withConsentRequired(false)
+                        .withCookieConsentShared(false)
+                        .withClientType(clientType.getValue());
         return UserContext.builder(SESSION)
                 .withClientSession(clientSession)
                 .withClient(clientRegistry)

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ClientSubjectHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ClientSubjectHelperTest.java
@@ -302,15 +302,15 @@ class ClientSubjectHelperTest {
             String sector,
             List<String> redirectUrls) {
         return new ClientRegistry()
-                .setClientID(clientID)
-                .setClientName("test-client")
-                .setRedirectUrls(redirectUrls)
-                .setScopes(SCOPES.toStringList())
-                .setContacts(singletonList(TEST_EMAIL))
-                .setPublicKey(
+                .withClientID(clientID)
+                .withClientName("test-client")
+                .withRedirectUrls(redirectUrls)
+                .withScopes(SCOPES.toStringList())
+                .withContacts(singletonList(TEST_EMAIL))
+                .withPublicKey(
                         Base64.getMimeEncoder().encodeToString(keyPair.getPublic().getEncoded()))
-                .setSectorIdentifierUri(sector)
-                .setSubjectType(subjectType);
+                .withSectorIdentifierUri(sector)
+                .withSubjectType(subjectType);
     }
 
     private UserProfile generateUserProfile() {

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/DynamoClientServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/DynamoClientServiceTest.java
@@ -1,9 +1,9 @@
 package uk.gov.di.authentication.shared.services;
 
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 
 import java.util.List;
@@ -20,21 +20,23 @@ class DynamoClientServiceTest {
     private static final ClientID CLIENT_ID = new ClientID();
 
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
-    private final AmazonDynamoDB dynamoDB = mock(AmazonDynamoDB.class);
+    private final DynamoDbEnhancedClient dynamoDbEnhancedClient =
+            mock(DynamoDbEnhancedClient.class);
     private DynamoClientService dynamoClientService;
 
     @BeforeEach
     void setup() {
         when(configurationService.getAwsRegion()).thenReturn("eu-west-2");
-        dynamoClientService = spy(new DynamoClientService(configurationService, dynamoDB));
+        dynamoClientService =
+                spy(new DynamoClientService(configurationService, dynamoDbEnhancedClient));
     }
 
     @Test
     void shouldIdentifyATestUserJourney() {
         var client =
                 generateClientRegistry(CLIENT_ID.toString())
-                        .setTestClient(true)
-                        .setTestClientEmailAllowlist(List.of("test@test.com"));
+                        .withTestClient(true)
+                        .withTestClientEmailAllowlist(List.of("test@test.com"));
 
         doReturn(Optional.of(client)).when(dynamoClientService).getClient(CLIENT_ID.toString());
 
@@ -45,8 +47,8 @@ class DynamoClientServiceTest {
     void shouldIdentifyATestUserJourney_UserNotOnAllowList() {
         var client =
                 generateClientRegistry(CLIENT_ID.toString())
-                        .setTestClient(true)
-                        .setTestClientEmailAllowlist(List.of("different-test@test.com"));
+                        .withTestClient(true)
+                        .withTestClientEmailAllowlist(List.of("different-test@test.com"));
 
         doReturn(Optional.of(client)).when(dynamoClientService).getClient(CLIENT_ID.toString());
 
@@ -55,7 +57,7 @@ class DynamoClientServiceTest {
 
     @Test
     void shouldIdentifyATestUserJourney_NoAllowlist() {
-        var client = generateClientRegistry(CLIENT_ID.toString()).setTestClient(true);
+        var client = generateClientRegistry(CLIENT_ID.toString()).withTestClient(true);
 
         doReturn(Optional.of(client)).when(dynamoClientService).getClient(CLIENT_ID.toString());
 
@@ -70,6 +72,6 @@ class DynamoClientServiceTest {
     }
 
     private ClientRegistry generateClientRegistry(String clientId) {
-        return new ClientRegistry().setClientID(clientId);
+        return new ClientRegistry().withClientID(clientId);
     }
 }


### PR DESCRIPTION
## What?

- Update client registry to Dynamo SDK v2

## Why?

- So we can move away from AWS SDK v1 and take advantage of the new features in v2