### PR TITLE
AUT-584: Remove TxMA audit feature toggle

### DIFF
--- a/ci/terraform/account-management/authenticate.tf
+++ b/ci/terraform/account-management/authenticate.tf
@@ -22,7 +22,6 @@ module "authenticate" {
     DYNAMO_ENDPOINT         = var.use_localstack ? var.lambda_dynamo_endpoint : null
     LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
     EVENTS_SNS_TOPIC_ARN    = data.aws_sns_topic.events.arn
-    TXMA_AUDIT_ENABLED      = true
     TXMA_AUDIT_QUEUE_URL    = module.account_management_txma_audit.queue_url
     AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name
   }

--- a/ci/terraform/account-management/remove-account.tf
+++ b/ci/terraform/account-management/remove-account.tf
@@ -24,7 +24,6 @@ module "delete_account" {
     LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
     EMAIL_QUEUE_URL         = aws_sqs_queue.email_queue.id
     EVENTS_SNS_TOPIC_ARN    = data.aws_sns_topic.events.arn
-    TXMA_AUDIT_ENABLED      = true
     TXMA_AUDIT_QUEUE_URL    = module.account_management_txma_audit.queue_url
     AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name
   }

--- a/ci/terraform/account-management/send_otp_notification.tf
+++ b/ci/terraform/account-management/send_otp_notification.tf
@@ -27,7 +27,6 @@ module "send_otp_notification" {
     LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
     REDIS_KEY               = local.redis_key
     EVENTS_SNS_TOPIC_ARN    = data.aws_sns_topic.events.arn
-    TXMA_AUDIT_ENABLED      = true
     TXMA_AUDIT_QUEUE_URL    = module.account_management_txma_audit.queue_url
     AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name
   }

--- a/ci/terraform/account-management/update-email.tf
+++ b/ci/terraform/account-management/update-email.tf
@@ -27,7 +27,6 @@ module "update_email" {
     LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
     REDIS_KEY               = local.redis_key
     EVENTS_SNS_TOPIC_ARN    = data.aws_sns_topic.events.arn
-    TXMA_AUDIT_ENABLED      = true
     TXMA_AUDIT_QUEUE_URL    = module.account_management_txma_audit.queue_url
     AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name
   }

--- a/ci/terraform/account-management/update-password.tf
+++ b/ci/terraform/account-management/update-password.tf
@@ -25,7 +25,6 @@ module "update_password" {
     LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
     EMAIL_QUEUE_URL         = aws_sqs_queue.email_queue.id
     EVENTS_SNS_TOPIC_ARN    = data.aws_sns_topic.events.arn
-    TXMA_AUDIT_ENABLED      = true
     TXMA_AUDIT_QUEUE_URL    = module.account_management_txma_audit.queue_url
     AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name
   }

--- a/ci/terraform/account-management/update-phone-number.tf
+++ b/ci/terraform/account-management/update-phone-number.tf
@@ -26,7 +26,6 @@ module "update_phone_number" {
     LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
     REDIS_KEY               = local.redis_key
     EVENTS_SNS_TOPIC_ARN    = data.aws_sns_topic.events.arn
-    TXMA_AUDIT_ENABLED      = true
     TXMA_AUDIT_QUEUE_URL    = module.account_management_txma_audit.queue_url
     AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name
   }

--- a/ci/terraform/oidc/auth-code.tf
+++ b/ci/terraform/oidc/auth-code.tf
@@ -23,7 +23,6 @@ module "auth-code" {
 
   handler_environment_variables = {
     EVENTS_SNS_TOPIC_ARN     = aws_sns_topic.events.arn
-    TXMA_AUDIT_ENABLED       = true
     TXMA_AUDIT_QUEUE_URL     = module.oidc_txma_audit.queue_url
     AUDIT_SIGNING_KEY_ALIAS  = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT      = var.use_localstack ? var.localstack_endpoint : null

--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -29,7 +29,6 @@ module "authorize" {
     DOC_APP_API_ENABLED      = var.doc_app_api_enabled
     DYNAMO_ENDPOINT          = var.use_localstack ? var.lambda_dynamo_endpoint : null
     EVENTS_SNS_TOPIC_ARN     = aws_sns_topic.events.arn
-    TXMA_AUDIT_ENABLED       = true
     TXMA_AUDIT_QUEUE_URL     = module.oidc_txma_audit.queue_url
     ENVIRONMENT              = var.environment
     HEADERS_CASE_INSENSITIVE = var.use_localstack ? "true" : "false"

--- a/ci/terraform/oidc/doc-app-authorize.tf
+++ b/ci/terraform/oidc/doc-app-authorize.tf
@@ -25,7 +25,6 @@ module "doc-app-authorize" {
   handler_environment_variables = {
     ENVIRONMENT                        = var.environment
     EVENTS_SNS_TOPIC_ARN               = aws_sns_topic.events.arn
-    TXMA_AUDIT_ENABLED                 = true
     TXMA_AUDIT_QUEUE_URL               = module.oidc_txma_audit.queue_url
     AUDIT_SIGNING_KEY_ALIAS            = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT                = var.use_localstack ? var.localstack_endpoint : null

--- a/ci/terraform/oidc/doc-app-callback.tf
+++ b/ci/terraform/oidc/doc-app-callback.tf
@@ -26,7 +26,6 @@ module "doc-app-callback" {
   handler_environment_variables = {
     ENVIRONMENT                        = var.environment
     EVENTS_SNS_TOPIC_ARN               = aws_sns_topic.events.arn
-    TXMA_AUDIT_ENABLED                 = true
     TXMA_AUDIT_QUEUE_URL               = module.oidc_txma_audit.queue_url
     AUDIT_SIGNING_KEY_ALIAS            = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT                = var.use_localstack ? var.localstack_endpoint : null

--- a/ci/terraform/oidc/ipv-authorize.tf
+++ b/ci/terraform/oidc/ipv-authorize.tf
@@ -28,7 +28,6 @@ module "ipv-authorize" {
   handler_environment_variables = {
     ENVIRONMENT                    = var.environment
     EVENTS_SNS_TOPIC_ARN           = aws_sns_topic.events.arn
-    TXMA_AUDIT_ENABLED             = true
     TXMA_AUDIT_QUEUE_URL           = module.oidc_txma_audit.queue_url
     AUDIT_SIGNING_KEY_ALIAS        = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT            = var.use_localstack ? var.localstack_endpoint : null

--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -31,7 +31,6 @@ module "ipv-callback" {
     AUDIT_SIGNING_KEY_ALIAS        = local.audit_signing_key_alias_name
     DYNAMO_ENDPOINT                = var.use_localstack ? var.lambda_dynamo_endpoint : null
     EVENTS_SNS_TOPIC_ARN           = aws_sns_topic.events.arn
-    TXMA_AUDIT_ENABLED             = true
     TXMA_AUDIT_QUEUE_URL           = module.oidc_txma_audit.queue_url
     ENVIRONMENT                    = var.environment
     IDENTITY_ENABLED               = var.ipv_api_enabled

--- a/ci/terraform/oidc/ipv-capacity.tf
+++ b/ci/terraform/oidc/ipv-capacity.tf
@@ -23,7 +23,6 @@ module "ipv-capacity" {
   handler_environment_variables = {
     ENVIRONMENT                    = var.environment
     EVENTS_SNS_TOPIC_ARN           = aws_sns_topic.events.arn
-    TXMA_AUDIT_ENABLED             = true
     TXMA_AUDIT_QUEUE_URL           = module.oidc_txma_audit.queue_url
     AUDIT_SIGNING_KEY_ALIAS        = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT            = var.use_localstack ? var.localstack_endpoint : null

--- a/ci/terraform/oidc/login.tf
+++ b/ci/terraform/oidc/login.tf
@@ -28,7 +28,6 @@ module "login" {
   handler_environment_variables = {
     ENVIRONMENT              = var.environment
     EVENTS_SNS_TOPIC_ARN     = aws_sns_topic.events.arn
-    TXMA_AUDIT_ENABLED       = true
     TXMA_AUDIT_QUEUE_URL     = module.oidc_txma_audit.queue_url
     AUDIT_SIGNING_KEY_ALIAS  = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT      = var.use_localstack ? var.localstack_endpoint : null

--- a/ci/terraform/oidc/logout.tf
+++ b/ci/terraform/oidc/logout.tf
@@ -26,7 +26,6 @@ module "logout" {
   handler_environment_variables = {
     DEFAULT_LOGOUT_URI            = "${module.dns.frontend_url}signed-out"
     EVENTS_SNS_TOPIC_ARN          = aws_sns_topic.events.arn
-    TXMA_AUDIT_ENABLED            = true
     TXMA_AUDIT_QUEUE_URL          = module.oidc_txma_audit.queue_url
     AUDIT_SIGNING_KEY_ALIAS       = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT           = var.use_localstack ? var.localstack_endpoint : null

--- a/ci/terraform/oidc/mfa.tf
+++ b/ci/terraform/oidc/mfa.tf
@@ -27,7 +27,6 @@ module "mfa" {
     BLOCKED_EMAIL_DURATION  = var.blocked_email_duration
     EMAIL_QUEUE_URL         = aws_sqs_queue.email_queue.id
     EVENTS_SNS_TOPIC_ARN    = aws_sns_topic.events.arn
-    TXMA_AUDIT_ENABLED      = true
     TXMA_AUDIT_QUEUE_URL    = module.oidc_txma_audit.queue_url
     AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null

--- a/ci/terraform/oidc/processing-identity.tf
+++ b/ci/terraform/oidc/processing-identity.tf
@@ -28,7 +28,6 @@ module "processing-identity" {
     AUDIT_SIGNING_KEY_ALIAS  = local.audit_signing_key_alias_name
     DYNAMO_ENDPOINT          = var.use_localstack ? var.lambda_dynamo_endpoint : null
     EVENTS_SNS_TOPIC_ARN     = aws_sns_topic.events.arn
-    TXMA_AUDIT_ENABLED       = true
     TXMA_AUDIT_QUEUE_URL     = module.oidc_txma_audit.queue_url
     ENVIRONMENT              = var.environment
     HEADERS_CASE_INSENSITIVE = var.use_localstack ? "true" : "false"

--- a/ci/terraform/oidc/register.tf
+++ b/ci/terraform/oidc/register.tf
@@ -25,7 +25,6 @@ module "register" {
     ENVIRONMENT             = var.environment
     DYNAMO_ENDPOINT         = var.use_localstack ? var.lambda_dynamo_endpoint : null
     EVENTS_SNS_TOPIC_ARN    = aws_sns_topic.events.arn
-    TXMA_AUDIT_ENABLED      = true
     TXMA_AUDIT_QUEUE_URL    = module.oidc_txma_audit.queue_url
     AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null

--- a/ci/terraform/oidc/reset-password-request.tf
+++ b/ci/terraform/oidc/reset-password-request.tf
@@ -29,7 +29,6 @@ module "reset-password-request" {
     BLOCKED_EMAIL_DURATION  = var.blocked_email_duration
     SQS_ENDPOINT            = var.use_localstack ? "http://localhost:45678/" : null
     EMAIL_QUEUE_URL         = aws_sqs_queue.email_queue.id
-    TXMA_AUDIT_ENABLED      = true
     TXMA_AUDIT_QUEUE_URL    = module.oidc_txma_audit.queue_url
     EVENTS_SNS_TOPIC_ARN    = aws_sns_topic.events.arn
     AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name

--- a/ci/terraform/oidc/reset_password.tf
+++ b/ci/terraform/oidc/reset_password.tf
@@ -30,7 +30,6 @@ module "reset_password" {
     EMAIL_QUEUE_URL          = aws_sqs_queue.email_queue.id
     ENVIRONMENT              = var.environment
     EVENTS_SNS_TOPIC_ARN     = aws_sns_topic.events.arn
-    TXMA_AUDIT_ENABLED       = true
     TXMA_AUDIT_QUEUE_URL     = module.oidc_txma_audit.queue_url
     AUDIT_SIGNING_KEY_ALIAS  = local.audit_signing_key_alias_name
     REDIS_KEY                = local.redis_key

--- a/ci/terraform/oidc/send_notification.tf
+++ b/ci/terraform/oidc/send_notification.tf
@@ -27,7 +27,6 @@ module "send_notification" {
     BLOCKED_EMAIL_DURATION  = var.blocked_email_duration
     EMAIL_QUEUE_URL         = aws_sqs_queue.email_queue.id
     EVENTS_SNS_TOPIC_ARN    = aws_sns_topic.events.arn
-    TXMA_AUDIT_ENABLED      = true
     TXMA_AUDIT_QUEUE_URL    = module.oidc_txma_audit.queue_url
     AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null

--- a/ci/terraform/oidc/signup.tf
+++ b/ci/terraform/oidc/signup.tf
@@ -27,7 +27,6 @@ module "signup" {
   handler_environment_variables = {
     ENVIRONMENT              = var.environment
     EVENTS_SNS_TOPIC_ARN     = aws_sns_topic.events.arn
-    TXMA_AUDIT_ENABLED       = true
     TXMA_AUDIT_QUEUE_URL     = module.oidc_txma_audit.queue_url
     AUDIT_SIGNING_KEY_ALIAS  = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT      = var.use_localstack ? var.localstack_endpoint : null

--- a/ci/terraform/oidc/spot-response.tf
+++ b/ci/terraform/oidc/spot-response.tf
@@ -95,7 +95,6 @@ resource "aws_lambda_function" "spot_response_lambda" {
       DYNAMO_ENDPOINT         = var.use_localstack ? var.lambda_dynamo_endpoint : null
       ENVIRONMENT             = var.environment
       EVENTS_SNS_TOPIC_ARN    = aws_sns_topic.events.arn
-      TXMA_AUDIT_ENABLED      = true
       TXMA_AUDIT_QUEUE_URL    = module.oidc_txma_audit.queue_url
       FRONTEND_BASE_URL       = module.dns.frontend_url
     })

--- a/ci/terraform/oidc/start.tf
+++ b/ci/terraform/oidc/start.tf
@@ -24,7 +24,6 @@ module "start" {
 
   handler_environment_variables = {
     EVENTS_SNS_TOPIC_ARN     = aws_sns_topic.events.arn
-    TXMA_AUDIT_ENABLED       = true
     TXMA_AUDIT_QUEUE_URL     = module.oidc_txma_audit.queue_url
     AUDIT_SIGNING_KEY_ALIAS  = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT      = var.use_localstack ? var.localstack_endpoint : null

--- a/ci/terraform/oidc/token.tf
+++ b/ci/terraform/oidc/token.tf
@@ -51,7 +51,6 @@ module "token" {
     OIDC_API_BASE_URL         = local.api_base_url
     DYNAMO_ENDPOINT           = var.use_localstack ? var.lambda_dynamo_endpoint : null
     EVENTS_SNS_TOPIC_ARN      = aws_sns_topic.events.arn
-    TXMA_AUDIT_ENABLED        = true
     TXMA_AUDIT_QUEUE_URL      = module.oidc_txma_audit.queue_url
     AUDIT_SIGNING_KEY_ALIAS   = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT       = var.use_localstack ? var.localstack_endpoint : null

--- a/ci/terraform/oidc/update.tf
+++ b/ci/terraform/oidc/update.tf
@@ -26,7 +26,6 @@ module "update" {
   handler_environment_variables = {
     ENVIRONMENT             = var.environment
     DYNAMO_ENDPOINT         = var.use_localstack ? var.lambda_dynamo_endpoint : null
-    TXMA_AUDIT_ENABLED      = true
     TXMA_AUDIT_QUEUE_URL    = module.oidc_txma_audit.queue_url
     EVENTS_SNS_TOPIC_ARN    = aws_sns_topic.events.arn
     AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name

--- a/ci/terraform/oidc/update_profile.tf
+++ b/ci/terraform/oidc/update_profile.tf
@@ -26,7 +26,6 @@ module "update_profile" {
   handler_environment_variables = {
     ENVIRONMENT              = var.environment
     EVENTS_SNS_TOPIC_ARN     = aws_sns_topic.events.arn
-    TXMA_AUDIT_ENABLED       = true
     TXMA_AUDIT_QUEUE_URL     = module.oidc_txma_audit.queue_url
     AUDIT_SIGNING_KEY_ALIAS  = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT      = var.use_localstack ? var.localstack_endpoint : null

--- a/ci/terraform/oidc/userexists.tf
+++ b/ci/terraform/oidc/userexists.tf
@@ -24,7 +24,6 @@ module "userexists" {
 
   handler_environment_variables = {
     ENVIRONMENT              = var.environment
-    TXMA_AUDIT_ENABLED       = true
     TXMA_AUDIT_QUEUE_URL     = module.oidc_txma_audit.queue_url
     EVENTS_SNS_TOPIC_ARN     = aws_sns_topic.events.arn
     AUDIT_SIGNING_KEY_ALIAS  = local.audit_signing_key_alias_name

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -27,7 +27,6 @@ module "userinfo" {
   handler_environment_variables = {
     ENVIRONMENT             = var.environment
     EVENTS_SNS_TOPIC_ARN    = aws_sns_topic.events.arn
-    TXMA_AUDIT_ENABLED      = true
     TXMA_AUDIT_QUEUE_URL    = module.oidc_txma_audit.queue_url
     AUDIT_SIGNING_KEY_ALIAS = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null

--- a/ci/terraform/oidc/verify_code.tf
+++ b/ci/terraform/oidc/verify_code.tf
@@ -27,7 +27,6 @@ module "verify_code" {
     ENVIRONMENT                         = var.environment
     BLOCKED_EMAIL_DURATION              = var.blocked_email_duration
     EVENTS_SNS_TOPIC_ARN                = aws_sns_topic.events.arn
-    TXMA_AUDIT_ENABLED                  = true
     TXMA_AUDIT_QUEUE_URL                = module.oidc_txma_audit.queue_url
     AUDIT_SIGNING_KEY_ALIAS             = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT                 = var.use_localstack ? var.localstack_endpoint : null

--- a/ci/terraform/oidc/verify_mfa_code.tf
+++ b/ci/terraform/oidc/verify_mfa_code.tf
@@ -27,7 +27,6 @@ module "verify_mfa_code" {
     ENVIRONMENT                         = var.environment
     BLOCKED_EMAIL_DURATION              = var.blocked_email_duration
     EVENTS_SNS_TOPIC_ARN                = aws_sns_topic.events.arn
-    TXMA_AUDIT_ENABLED                  = true
     TXMA_AUDIT_QUEUE_URL                = module.oidc_txma_audit.queue_url
     AUDIT_SIGNING_KEY_ALIAS             = local.audit_signing_key_alias_name
     LOCALSTACK_ENDPOINT                 = var.use_localstack ? var.localstack_endpoint : null

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -684,11 +684,6 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         }
 
         @Override
-        public boolean isTxmaAuditEnabled() {
-            return true;
-        }
-
-        @Override
         public String getTxmaAuditQueueUrl() {
             return txmaAuditQueue.getQueueUrl();
         }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppAuthorizeHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppAuthorizeHandlerIntegrationTest.java
@@ -200,11 +200,6 @@ class DocAppAuthorizeHandlerIntegrationTest extends ApiGatewayHandlerIntegration
         }
 
         @Override
-        public boolean isTxmaAuditEnabled() {
-            return true;
-        }
-
-        @Override
         public String getTxmaAuditQueueUrl() {
             return txmaAuditQueue.getQueueUrl();
         }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppCallbackHandlerIntegrationTest.java
@@ -317,11 +317,6 @@ class DocAppCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
         }
 
         @Override
-        public boolean isTxmaAuditEnabled() {
-            return true;
-        }
-
-        @Override
         public String getTxmaAuditQueueUrl() {
             return txmaAuditQueue.getQueueUrl();
         }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVAuthorisationHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVAuthorisationHandlerIntegrationTest.java
@@ -205,11 +205,6 @@ class IPVAuthorisationHandlerIntegrationTest extends ApiGatewayHandlerIntegratio
         }
 
         @Override
-        public boolean isTxmaAuditEnabled() {
-            return true;
-        }
-
-        @Override
         public String getTxmaAuditQueueUrl() {
             return txmaAuditQueue.getQueueUrl();
         }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
@@ -277,11 +277,6 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
         }
 
         @Override
-        public boolean isTxmaAuditEnabled() {
-            return true;
-        }
-
-        @Override
         public String getTxmaAuditQueueUrl() {
             return txmaAuditQueue.getQueueUrl();
         }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCapacityHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCapacityHandlerIntegrationTest.java
@@ -50,10 +50,6 @@ class IPVCapacityHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                 spotQueue,
                 docAppPrivateKeyJwtSigner,
                 configurationParameters) {
-            @Override
-            public boolean isTxmaAuditEnabled() {
-                return true;
-            }
 
             @Override
             public String getTxmaAuditQueueUrl() {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
@@ -233,11 +233,6 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         }
 
         @Override
-        public boolean isTxmaAuditEnabled() {
-            return true;
-        }
-
-        @Override
         public String getTxmaAuditQueueUrl() {
             return txmaAuditQueue.getQueueUrl();
         }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
@@ -101,11 +101,6 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         configurationParameters) {
 
                     @Override
-                    public boolean isTxmaAuditEnabled() {
-                        return true;
-                    }
-
-                    @Override
                     public String getTxmaAuditQueueUrl() {
                         return txmaAuditQueue.getQueueUrl();
                     }
@@ -458,11 +453,6 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         @Override
         public boolean isIdentityEnabled() {
-            return true;
-        }
-
-        @Override
-        public boolean isTxmaAuditEnabled() {
             return true;
         }
 

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
@@ -123,10 +123,6 @@ public abstract class HandlerIntegrationTest<Q, S> {
                     spotQueue,
                     docAppPrivateKeyJwtSigner,
                     configurationParameters) {
-                @Override
-                public boolean isTxmaAuditEnabled() {
-                    return true;
-                }
 
                 @Override
                 public String getTxmaAuditQueueUrl() {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/configuration/AuditPublisherConfiguration.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/configuration/AuditPublisherConfiguration.java
@@ -10,10 +10,6 @@ public interface AuditPublisherConfiguration extends BaseLambdaConfiguration {
         return System.getenv("EVENTS_SNS_TOPIC_ARN");
     }
 
-    default boolean isTxmaAuditEnabled() {
-        return Boolean.parseBoolean(System.getenv("TXMA_AUDIT_ENABLED"));
-    }
-
     default String getTxmaAuditQueueUrl() {
         return System.getenv("TXMA_AUDIT_QUEUE_URL");
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
@@ -31,12 +31,10 @@ public class AuditService {
         this.configurationService = configurationService;
         this.clock = Clock.systemUTC();
         this.txmaQueueClient =
-                configurationService.isTxmaAuditEnabled()
-                        ? new AwsSqsClient(
-                                configurationService.getAwsRegion(),
-                                configurationService.getTxmaAuditQueueUrl(),
-                                configurationService.getLocalstackEndpointUri())
-                        : new AwsSqsClient.NoOpSqsClient();
+                new AwsSqsClient(
+                        configurationService.getAwsRegion(),
+                        configurationService.getTxmaAuditQueueUrl(),
+                        configurationService.getLocalstackEndpointUri());
     }
 
     public void submitAuditEvent(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
@@ -17,20 +17,12 @@ public class AuditService {
     public static final String UNKNOWN = "";
 
     private final Clock clock;
-    private final SnsService snsService;
-    private final KmsConnectionService kmsConnectionService;
     private final ConfigurationService configurationService;
     private final AwsSqsClient txmaQueueClient;
 
     public AuditService(
-            Clock clock,
-            SnsService snsService,
-            KmsConnectionService kmsConnectionService,
-            ConfigurationService configurationService,
-            AwsSqsClient txmaQueueClient) {
+            Clock clock, ConfigurationService configurationService, AwsSqsClient txmaQueueClient) {
         this.clock = clock;
-        this.snsService = snsService;
-        this.kmsConnectionService = kmsConnectionService;
         this.configurationService = configurationService;
         this.txmaQueueClient = txmaQueueClient;
     }
@@ -38,13 +30,6 @@ public class AuditService {
     public AuditService(ConfigurationService configurationService) {
         this.configurationService = configurationService;
         this.clock = Clock.systemUTC();
-        this.snsService = new SnsService(configurationService);
-        this.kmsConnectionService =
-                new KmsConnectionService(
-                        configurationService.getLocalstackEndpointUri(),
-                        configurationService.getAwsRegion(),
-                        configurationService.getAuditSigningKeyAlias());
-
         this.txmaQueueClient =
                 configurationService.isTxmaAuditEnabled()
                         ? new AwsSqsClient(


### PR DESCRIPTION
- AUT-584: Stop initialising KMS/SNS clients in `AuditService`
- AUT-584: Remove conditional SQS setup - this is now default
- AUT-584: Remove `isTxmaAuditEnabled` flag from configuration
- AUT-584: Remove `TXMA_AUDIT_ENABLED` environment variables
