### PR TITLE
BAU: Additional logging for ui_locales parameter

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -293,14 +293,16 @@ public class AuthorisationHandler
 
         getPrimaryLanguageFromUILocales(authenticationRequest, configurationService)
                 .ifPresent(
-                        primaryLanguage ->
-                                cookies.add(
-                                        CookieHelper.buildCookieString(
-                                                CookieHelper.LANGUAGE_COOKIE_NAME,
-                                                primaryLanguage.getLanguage(),
-                                                configurationService.getLanguageCookieMaxAge(),
-                                                configurationService.getSessionCookieAttributes(),
-                                                configurationService.getDomainName())));
+                        primaryLanguage -> {
+                            LOG.info("Setting primary language: {}", primaryLanguage.getLanguage());
+                            cookies.add(
+                                    CookieHelper.buildCookieString(
+                                            CookieHelper.LANGUAGE_COOKIE_NAME,
+                                            primaryLanguage.getLanguage(),
+                                            configurationService.getLanguageCookieMaxAge(),
+                                            configurationService.getSessionCookieAttributes(),
+                                            configurationService.getDomainName()));
+                        });
 
         return generateApiGatewayProxyResponse(
                 302,

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/LocaleHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/LocaleHelper.java
@@ -49,12 +49,14 @@ public class LocaleHelper {
         if (Objects.isNull(authenticationRequest.getUILocales())) {
             return Optional.empty();
         }
+        LOG.info("ui_locales is present: {}", authenticationRequest.getUILocales());
         for (LangTag langTag : authenticationRequest.getUILocales()) {
-            if (langTag.getPrimaryLanguage().equals(EN.getLanguage())) {
+            if (langTag.getPrimaryLanguage().equalsIgnoreCase(EN.getLanguage())) {
                 return Optional.of(EN);
             }
             if (configurationService.isLanguageEnabled(CY)
-                    && langTag.getPrimaryLanguage().equals(SupportedLanguage.CY.getLanguage())) {
+                    && langTag.getPrimaryLanguage()
+                            .equalsIgnoreCase(SupportedLanguage.CY.getLanguage())) {
                 return Optional.of(CY);
             }
         }


### PR DESCRIPTION
## What?

Additional logging for ui_locales parameter.
Use ignorecase when checking for language tag match.

## Why?

Language is not being set anymore when launching from the stub, need more logging to see what's happening.

