### PR TITLE
AUT-708: Add client session id to audit payloads 

### DIFF
--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppAuthorizeHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppAuthorizeHandler.java
@@ -163,7 +163,7 @@ public class DocAppAuthorizeHandler
                                 authorisationService.storeState(session.getSessionId(), state);
                                 auditService.submitAuditEvent(
                                         DocAppAuditableEvent.DOC_APP_AUTHORISATION_REQUESTED,
-                                        context.getAwsRequestId(),
+                                        clientSessionId,
                                         session.getSessionId(),
                                         AuditService.UNKNOWN,
                                         clientSession.getDocAppSubjectId().toString(),

--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
@@ -132,17 +132,16 @@ public class DocAppCallbackHandler
                                                                     "Session not found");
                                                         });
                                 attachSessionIdToLogs(session);
+                                var clientSessionId = sessionCookiesIds.getClientSessionId();
                                 var clientSession =
                                         clientSessionService
-                                                .getClientSession(
-                                                        sessionCookiesIds.getClientSessionId())
+                                                .getClientSession(clientSessionId)
                                                 .orElseThrow(
                                                         () -> {
                                                             throw new DocAppCallbackException(
                                                                     "ClientSession not found");
                                                         });
-                                attachLogFieldToLogs(
-                                        CLIENT_SESSION_ID, sessionCookiesIds.getClientSessionId());
+                                attachLogFieldToLogs(CLIENT_SESSION_ID, clientSessionId);
 
                                 var authenticationRequest =
                                         AuthenticationRequest.parse(
@@ -164,7 +163,7 @@ public class DocAppCallbackHandler
                                 auditService.submitAuditEvent(
                                         DocAppAuditableEvent
                                                 .DOC_APP_AUTHORISATION_RESPONSE_RECEIVED,
-                                        context.getAwsRequestId(),
+                                        clientSessionId,
                                         session.getSessionId(),
                                         clientId,
                                         clientSession.getDocAppSubjectId().getValue(),
@@ -182,7 +181,7 @@ public class DocAppCallbackHandler
                                     auditService.submitAuditEvent(
                                             DocAppAuditableEvent
                                                     .DOC_APP_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
-                                            context.getAwsRequestId(),
+                                            clientSessionId,
                                             session.getSessionId(),
                                             clientId,
                                             clientSession.getDocAppSubjectId().getValue(),
@@ -197,7 +196,7 @@ public class DocAppCallbackHandler
                                     auditService.submitAuditEvent(
                                             DocAppAuditableEvent
                                                     .DOC_APP_UNSUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
-                                            context.getAwsRequestId(),
+                                            clientSessionId,
                                             session.getSessionId(),
                                             clientId,
                                             clientSession.getDocAppSubjectId().getValue(),
@@ -231,7 +230,7 @@ public class DocAppCallbackHandler
                                     auditService.submitAuditEvent(
                                             DocAppAuditableEvent
                                                     .DOC_APP_SUCCESSFUL_CREDENTIAL_RESPONSE_RECEIVED,
-                                            context.getAwsRequestId(),
+                                            clientSessionId,
                                             session.getSessionId(),
                                             clientId,
                                             clientSession.getDocAppSubjectId().getValue(),
@@ -261,7 +260,7 @@ public class DocAppCallbackHandler
                                     auditService.submitAuditEvent(
                                             DocAppAuditableEvent
                                                     .DOC_APP_UNSUCCESSFUL_CREDENTIAL_RESPONSE_RECEIVED,
-                                            context.getAwsRequestId(),
+                                            clientSessionId,
                                             session.getSessionId(),
                                             clientId,
                                             clientSession.getDocAppSubjectId().getValue(),

--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppAuthorizeHandlerTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppAuthorizeHandlerTest.java
@@ -144,7 +144,7 @@ class DocAppAuthorizeHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         DocAppAuditableEvent.DOC_APP_AUTHORISATION_REQUESTED,
-                        context.getAwsRequestId(),
+                        CLIENT_SESSION_ID,
                         SESSION_ID,
                         AuditService.UNKNOWN,
                         DOC_APP_SUBJECT_ID.getValue(),

--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
@@ -338,7 +338,7 @@ class DocAppCallbackHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         docAppAuditableEvent,
-                        REQUEST_ID,
+                        CLIENT_SESSION_ID,
                         SESSION_ID,
                         CLIENT_ID.getValue(),
                         PAIRWISE_SUBJECT_ID.getValue(),

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandler.java
@@ -142,7 +142,7 @@ public class IPVAuthorisationHandler extends BaseFrontendHandler<IPVAuthorisatio
             authorisationService.storeState(userContext.getSession().getSessionId(), state);
             auditService.submitAuditEvent(
                     IPVAuditableEvent.IPV_AUTHORISATION_REQUESTED,
-                    context.getAwsRequestId(),
+                    clientSessionId,
                     userContext.getSession().getSessionId(),
                     clientId.orElse(AuditService.UNKNOWN),
                     AuditService.UNKNOWN,

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -165,16 +165,15 @@ public class IPVCallbackHandler
                                         PersistentIdHelper.extractPersistentIdFromCookieHeader(
                                                 input.getHeaders());
                                 attachLogFieldToLogs(PERSISTENT_SESSION_ID, persistentId);
+                                var clientSessionId = sessionCookiesIds.getClientSessionId();
                                 var clientSession =
                                         clientSessionService
-                                                .getClientSession(
-                                                        sessionCookiesIds.getClientSessionId())
+                                                .getClientSession(clientSessionId)
                                                 .orElse(null);
                                 if (Objects.isNull(clientSession)) {
                                     throw new IpvCallbackException("ClientSession not found");
                                 }
-                                attachLogFieldToLogs(
-                                        CLIENT_SESSION_ID, sessionCookiesIds.getClientSessionId());
+                                attachLogFieldToLogs(CLIENT_SESSION_ID, clientSessionId);
                                 var authRequest =
                                         AuthenticationRequest.parse(
                                                 clientSession.getAuthRequestParams());
@@ -223,7 +222,7 @@ public class IPVCallbackHandler
 
                                 auditService.submitAuditEvent(
                                         IPVAuditableEvent.IPV_AUTHORISATION_RESPONSE_RECEIVED,
-                                        context.getAwsRequestId(),
+                                        clientSessionId,
                                         session.getSessionId(),
                                         clientId,
                                         userProfile.getSubjectID(),
@@ -240,7 +239,7 @@ public class IPVCallbackHandler
                                     auditService.submitAuditEvent(
                                             IPVAuditableEvent
                                                     .IPV_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
-                                            context.getAwsRequestId(),
+                                            clientSessionId,
                                             session.getSessionId(),
                                             clientId,
                                             userProfile.getSubjectID(),
@@ -255,7 +254,7 @@ public class IPVCallbackHandler
                                     auditService.submitAuditEvent(
                                             IPVAuditableEvent
                                                     .IPV_UNSUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
-                                            context.getAwsRequestId(),
+                                            clientSessionId,
                                             session.getSessionId(),
                                             clientId,
                                             userProfile.getSubjectID(),
@@ -292,7 +291,7 @@ public class IPVCallbackHandler
                                 }
                                 auditService.submitAuditEvent(
                                         IPVAuditableEvent.IPV_SUCCESSFUL_IDENTITY_RESPONSE_RECEIVED,
-                                        context.getAwsRequestId(),
+                                        clientSessionId,
                                         session.getSessionId(),
                                         clientId,
                                         userProfile.getSubjectID(),
@@ -312,7 +311,7 @@ public class IPVCallbackHandler
                                                         persistentId,
                                                         context.getAwsRequestId(),
                                                         clientId,
-                                                        sessionCookiesIds.getClientSessionId());
+                                                        clientSessionId);
                                         queueSPOTRequest(
                                                 logIds,
                                                 getSectorIdentifierForClient(clientRegistry),
@@ -323,7 +322,7 @@ public class IPVCallbackHandler
 
                                         auditService.submitAuditEvent(
                                                 IPVAuditableEvent.IPV_SPOT_REQUESTED,
-                                                context.getAwsRequestId(),
+                                                clientSessionId,
                                                 session.getSessionId(),
                                                 clientId,
                                                 userProfile.getSubjectID(),

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCapacityHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCapacityHandler.java
@@ -50,7 +50,7 @@ public class IPVCapacityHandler
                             LOG.info("Request received to IPVCapacityHandler");
                             auditService.submitAuditEvent(
                                     IPVAuditableEvent.IPV_CAPACITY_REQUESTED,
-                                    context.getAwsRequestId(),
+                                    AuditService.UNKNOWN,
                                     AuditService.UNKNOWN,
                                     AuditService.UNKNOWN,
                                     AuditService.UNKNOWN,

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandlerTest.java
@@ -188,7 +188,7 @@ public class IPVAuthorisationHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         IPVAuditableEvent.IPV_AUTHORISATION_REQUESTED,
-                        context.getAwsRequestId(),
+                        CLIENT_SESSION_ID,
                         SESSION_ID,
                         CLIENT_ID,
                         AuditService.UNKNOWN,

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -493,7 +493,7 @@ class IPVCallbackHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         IPVAuditableEvent.IPV_AUTHORISATION_RESPONSE_RECEIVED,
-                        REQUEST_ID,
+                        CLIENT_SESSION_ID,
                         SESSION_ID,
                         CLIENT_ID.getValue(),
                         userProfile.getSubjectID(),
@@ -505,7 +505,7 @@ class IPVCallbackHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         IPVAuditableEvent.IPV_UNSUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
-                        REQUEST_ID,
+                        CLIENT_SESSION_ID,
                         SESSION_ID,
                         CLIENT_ID.getValue(),
                         userProfile.getSubjectID(),
@@ -579,7 +579,7 @@ class IPVCallbackHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         auditableEvent,
-                        REQUEST_ID,
+                        CLIENT_SESSION_ID,
                         SESSION_ID,
                         CLIENT_ID.getValue(),
                         userProfile.getSubjectID(),

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
@@ -39,7 +39,7 @@ public class AuditService {
 
     public void submitAuditEvent(
             AuditableEvent event,
-            String requestId,
+            String clientSessionId,
             String sessionId,
             String clientId,
             String subjectId,
@@ -56,7 +56,8 @@ public class AuditService {
                         .withEmail(email)
                         .withIpAddress(ipAddress)
                         .withSessionId(sessionId)
-                        .withPersistentSessionId(persistentSessionId);
+                        .withPersistentSessionId(persistentSessionId)
+                        .withGovukSigninJourneyId(clientSessionId);
 
         var txmaAuditEvent =
                 auditEventWithTime(event, () -> Date.from(clock.instant()))


### PR DESCRIPTION
## What?

Add client session id to audit payloads and implement across all lambdas which have access to client session id.

## Why?

We pass this value (client session id) up to IPV Core and the Document Checking App but don’t publish it to our own audit log.