### PR TITLE
BAU: Switch on Welsh in build in the backend

### DIFF
--- a/ci/terraform/oidc/build-overrides.tfvars
+++ b/ci/terraform/oidc/build-overrides.tfvars
@@ -8,6 +8,7 @@ doc_app_authorisation_uri          = "https://build-doc-app-cri-stub.london.clou
 doc_app_jwks_endpoint              = "https://build-doc-app-cri-stub.london.cloudapps.digital/.well-known/jwks.json"
 doc_app_encryption_key_id          = "7788bc975abd44e8b4fd7646d08ea9428476e37bff3e4365804b41cc29f8ef21"
 spot_enabled                       = false
+language_cy_enabled                = true
 
 blocked_email_duration = 30
 


### PR DESCRIPTION
## What?

Switch on Welsh in build in the backend.

## Why?

So /authorize reads ui_locales.
Without this Sign In ignores any languages passed in ui_locales and defaults to en.
