### PR TITLE
AUT-708-part-1: Add client session id to audit payloads

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandler.java
@@ -94,7 +94,7 @@ public class AuthenticateHandler
                                 auditService.submitAuditEvent(
                                         AccountManagementAuditableEvent
                                                 .ACCOUNT_MANAGEMENT_AUTHENTICATE,
-                                        context.getAwsRequestId(),
+                                        AuditService.UNKNOWN,
                                         sessionId,
                                         AuditService.UNKNOWN,
                                         AuditService.UNKNOWN,

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandler.java
@@ -131,7 +131,7 @@ public class RemoveAccountHandler
                                         "Remove account message successfully added to queue. Generating successful gateway response");
                                 auditService.submitAuditEvent(
                                         AccountManagementAuditableEvent.DELETE_ACCOUNT,
-                                        context.getAwsRequestId(),
+                                        AuditService.UNKNOWN,
                                         sessionId,
                                         AuditService.UNKNOWN,
                                         userProfile.getSubjectID(),

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandlerTest.java
@@ -56,7 +56,7 @@ class AuthenticateHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         AccountManagementAuditableEvent.ACCOUNT_MANAGEMENT_AUTHENTICATE,
-                        context.getAwsRequestId(),
+                        AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandlerTest.java
@@ -80,7 +80,7 @@ class RemoveAccountHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         AccountManagementAuditableEvent.DELETE_ACCOUNT,
-                        context.getAwsRequestId(),
+                        AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         userProfile.getSubjectID(),

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandler.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandler.java
@@ -154,7 +154,7 @@ public class ClientRegistrationHandler
                                         "Invalid Client registration request. Missing parameters from request");
                                 auditService.submitAuditEvent(
                                         REGISTER_CLIENT_REQUEST_ERROR,
-                                        context.getAwsRequestId(),
+                                        AuditService.UNKNOWN,
                                         AuditService.UNKNOWN,
                                         AuditService.UNKNOWN,
                                         AuditService.UNKNOWN,

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandlerTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandlerTest.java
@@ -206,8 +206,7 @@ class ClientRegistrationHandlerTest {
         assertThat(result, hasBody(OAuth2Error.INVALID_REQUEST.toJSONObject().toJSONString()));
 
         verify(auditService)
-                .submitAuditEvent(
-                        REGISTER_CLIENT_REQUEST_ERROR, "request-id", "", "", "", "", "", "", "");
+                .submitAuditEvent(REGISTER_CLIENT_REQUEST_ERROR, "", "", "", "", "", "", "", "");
     }
 
     @Test

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -93,7 +93,7 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
             if (errorResponse.isPresent()) {
                 auditService.submitAuditEvent(
                         FrontendAuditableEvent.CHECK_USER_INVALID_EMAIL,
-                        context.getAwsRequestId(),
+                        AuditService.UNKNOWN,
                         userContext.getSession().getSessionId(),
                         userContext
                                 .getClient()
@@ -116,7 +116,7 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
             }
             auditService.submitAuditEvent(
                     auditableEvent,
-                    context.getAwsRequestId(),
+                    AuditService.UNKNOWN,
                     userContext.getSession().getSessionId(),
                     userContext
                             .getClient()

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -117,7 +117,7 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
 
                 auditService.submitAuditEvent(
                         FrontendAuditableEvent.NO_ACCOUNT_WITH_EMAIL,
-                        context.getAwsRequestId(),
+                        AuditService.UNKNOWN,
                         userContext.getSession().getSessionId(),
                         clientId,
                         AuditService.UNKNOWN,
@@ -140,7 +140,7 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
 
                 auditService.submitAuditEvent(
                         FrontendAuditableEvent.ACCOUNT_TEMPORARILY_LOCKED,
-                        context.getAwsRequestId(),
+                        AuditService.UNKNOWN,
                         userContext.getSession().getSessionId(),
                         clientId,
                         userProfile.getSubjectID(),
@@ -157,7 +157,7 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
 
                 auditService.submitAuditEvent(
                         FrontendAuditableEvent.INVALID_CREDENTIALS,
-                        context.getAwsRequestId(),
+                        AuditService.UNKNOWN,
                         userContext.getSession().getSessionId(),
                         clientId,
                         AuditService.UNKNOWN,
@@ -203,7 +203,7 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
 
             auditService.submitAuditEvent(
                     LOG_IN_SUCCESS,
-                    context.getAwsRequestId(),
+                    AuditService.UNKNOWN,
                     userContext.getSession().getSessionId(),
                     clientId,
                     userProfile.getSubjectID(),

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
@@ -128,7 +128,7 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
             if (codeRequestValid.isPresent()) {
                 auditService.submitAuditEvent(
                         FrontendAuditableEvent.MFA_INVALID_CODE_REQUEST,
-                        context.getAwsRequestId(),
+                        AuditService.UNKNOWN,
                         userContext.getSession().getSessionId(),
                         userContext
                                 .getClient()
@@ -148,7 +148,7 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
 
                 auditService.submitAuditEvent(
                         FrontendAuditableEvent.MFA_MISMATCHED_EMAIL,
-                        context.getAwsRequestId(),
+                        AuditService.UNKNOWN,
                         userContext.getSession().getSessionId(),
                         userContext
                                 .getClient()
@@ -167,7 +167,7 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
             if (phoneNumber == null) {
                 auditService.submitAuditEvent(
                         FrontendAuditableEvent.MFA_MISSING_PHONE_NUMBER,
-                        context.getAwsRequestId(),
+                        AuditService.UNKNOWN,
                         userContext.getSession().getSessionId(),
                         userContext
                                 .getClient()
@@ -212,7 +212,7 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
             }
             auditService.submitAuditEvent(
                     auditableEvent,
-                    context.getAwsRequestId(),
+                    AuditService.UNKNOWN,
                     userContext.getSession().getSessionId(),
                     userContext
                             .getClient()

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
@@ -150,7 +150,7 @@ public class ResetPasswordHandler extends BaseFrontendHandler<ResetPasswordCompl
             sqsClient.send(serialiseRequest(notifyRequest));
             auditService.submitAuditEvent(
                     FrontendAuditableEvent.PASSWORD_RESET_SUCCESSFUL,
-                    context.getAwsRequestId(),
+                    AuditService.UNKNOWN,
                     userContext.getSession().getSessionId(),
                     userContext
                             .getClient()

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
@@ -110,7 +110,7 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
                     PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders());
             auditService.submitAuditEvent(
                     FrontendAuditableEvent.PASSWORD_RESET_REQUESTED,
-                    context.getAwsRequestId(),
+                    AuditService.UNKNOWN,
                     userContext.getSession().getSessionId(),
                     userContext
                             .getClient()

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
@@ -110,7 +110,7 @@ class CheckUserExistsHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CHECK_USER_KNOWN_EMAIL,
-                        "aws-session-id",
+                        AuditService.UNKNOWN,
                         session.getSessionId(),
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
@@ -143,7 +143,7 @@ class CheckUserExistsHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CHECK_USER_NO_ACCOUNT_WITH_EMAIL,
-                        "aws-session-id",
+                        AuditService.UNKNOWN,
                         session.getSessionId(),
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
@@ -197,7 +197,7 @@ class CheckUserExistsHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CHECK_USER_INVALID_EMAIL,
-                        "aws-session-id",
+                        AuditService.UNKNOWN,
                         session.getSessionId(),
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
@@ -185,7 +185,7 @@ class LoginHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.LOG_IN_SUCCESS,
-                        "aws-session-id",
+                        "",
                         session.getSessionId(),
                         CLIENT_ID.getValue(),
                         userProfile.getSubjectID(),
@@ -235,7 +235,7 @@ class LoginHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.LOG_IN_SUCCESS,
-                        "aws-session-id",
+                        "",
                         session.getSessionId(),
                         CLIENT_ID.getValue(),
                         userProfile.getSubjectID(),
@@ -285,7 +285,7 @@ class LoginHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.LOG_IN_SUCCESS,
-                        "aws-session-id",
+                        "",
                         session.getSessionId(),
                         CLIENT_ID.getValue(),
                         userProfile.getSubjectID(),
@@ -410,7 +410,7 @@ class LoginHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.ACCOUNT_TEMPORARILY_LOCKED,
-                        "aws-session-id",
+                        "",
                         session.getSessionId(),
                         "",
                         userProfile.getSubjectID(),
@@ -468,7 +468,7 @@ class LoginHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.INVALID_CREDENTIALS,
-                        "aws-session-id",
+                        "",
                         session.getSessionId(),
                         "",
                         "",
@@ -549,7 +549,7 @@ class LoginHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.NO_ACCOUNT_WITH_EMAIL,
-                        "aws-session-id",
+                        "",
                         session.getSessionId(),
                         "",
                         "",

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
@@ -109,7 +109,7 @@ public class MfaHandlerTest {
 
     @BeforeEach
     void setUp() {
-        when(context.getAwsRequestId()).thenReturn("aws-session-id");
+        when(context.getAwsRequestId()).thenReturn("");
         when(configurationService.getCodeExpiry()).thenReturn(CODE_EXPIRY_TIME);
         when(configurationService.getCodeMaxRetries()).thenReturn(5);
         handler =
@@ -152,7 +152,7 @@ public class MfaHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.MFA_CODE_SENT,
-                        "aws-session-id",
+                        "",
                         session.getSessionId(),
                         "",
                         AuditService.UNKNOWN,
@@ -198,7 +198,7 @@ public class MfaHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.MFA_CODE_SENT,
-                        "aws-session-id",
+                        "",
                         session.getSessionId(),
                         "",
                         AuditService.UNKNOWN,
@@ -231,7 +231,7 @@ public class MfaHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.MFA_CODE_SENT,
-                        "aws-session-id",
+                        "",
                         session.getSessionId(),
                         "",
                         AuditService.UNKNOWN,
@@ -273,7 +273,7 @@ public class MfaHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.MFA_MISMATCHED_EMAIL,
-                        "aws-session-id",
+                        "",
                         session.getSessionId(),
                         "",
                         AuditService.UNKNOWN,
@@ -300,7 +300,7 @@ public class MfaHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.MFA_MISSING_PHONE_NUMBER,
-                        "aws-session-id",
+                        "",
                         session.getSessionId(),
                         "",
                         AuditService.UNKNOWN,
@@ -339,7 +339,7 @@ public class MfaHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.MFA_INVALID_CODE_REQUEST,
-                        "aws-session-id",
+                        "",
                         session.getSessionId(),
                         "",
                         AuditService.UNKNOWN,
@@ -369,7 +369,7 @@ public class MfaHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.MFA_INVALID_CODE_REQUEST,
-                        "aws-session-id",
+                        "",
                         session.getSessionId(),
                         "",
                         AuditService.UNKNOWN,
@@ -398,7 +398,7 @@ public class MfaHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.MFA_INVALID_CODE_REQUEST,
-                        "aws-session-id",
+                        "",
                         session.getSessionId(),
                         "",
                         AuditService.UNKNOWN,
@@ -433,7 +433,7 @@ public class MfaHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.MFA_CODE_SENT_FOR_TEST_CLIENT,
-                        "aws-session-id",
+                        "",
                         session.getSessionId(),
                         TEST_CLIENT_ID,
                         AuditService.UNKNOWN,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandlerTest.java
@@ -117,7 +117,7 @@ class ResetPasswordHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.PASSWORD_RESET_SUCCESSFUL,
-                        context.getAwsRequestId(),
+                        AuditService.UNKNOWN,
                         session.getSessionId(),
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
@@ -152,7 +152,7 @@ class ResetPasswordHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.PASSWORD_RESET_SUCCESSFUL,
-                        context.getAwsRequestId(),
+                        AuditService.UNKNOWN,
                         session.getSessionId(),
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
@@ -189,7 +189,7 @@ class ResetPasswordHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.PASSWORD_RESET_SUCCESSFUL,
-                        context.getAwsRequestId(),
+                        AuditService.UNKNOWN,
                         session.getSessionId(),
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
@@ -290,7 +290,7 @@ class ResetPasswordHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.PASSWORD_RESET_SUCCESSFUL,
-                        context.getAwsRequestId(),
+                        AuditService.UNKNOWN,
                         session.getSessionId(),
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
@@ -154,7 +154,7 @@ class ResetPasswordRequestHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.PASSWORD_RESET_REQUESTED,
-                        context.getAwsRequestId(),
+                        AuditService.UNKNOWN,
                         session.getSessionId(),
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
@@ -201,7 +201,7 @@ class ResetPasswordRequestHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.PASSWORD_RESET_REQUESTED,
-                        context.getAwsRequestId(),
+                        AuditService.UNKNOWN,
                         session.getSessionId(),
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
@@ -110,7 +110,7 @@ public class ProcessingIdentityHandler extends BaseFrontendHandler<ProcessingIde
                             processingStatus.toString()));
             auditService.submitAuditEvent(
                     IPVAuditableEvent.PROCESSING_IDENTITY_REQUEST,
-                    context.getAwsRequestId(),
+                    AuditService.UNKNOWN,
                     userContext.getSession().getSessionId(),
                     userContext.getClient().get().getClientID(),
                     AuditService.UNKNOWN,

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -274,7 +274,7 @@ public class AuthCodeHandler
 
                                 auditService.submitAuditEvent(
                                         OidcAuditableEvent.AUTH_CODE_ISSUED,
-                                        context.getAwsRequestId(),
+                                        clientSessionId,
                                         session.getSessionId(),
                                         authenticationRequest.getClientID().getValue(),
                                         AuditService.UNKNOWN,

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
@@ -367,7 +367,7 @@ public class LogoutHandler
         }
         auditService.submitAuditEvent(
                 OidcAuditableEvent.LOG_OUT_SUCCESS,
-                context.getAwsRequestId(),
+                AuditService.UNKNOWN,
                 sessionId.orElse(AuditService.UNKNOWN),
                 clientId.orElse(AuditService.UNKNOWN),
                 AuditService.UNKNOWN,

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -211,7 +211,7 @@ class AuthCodeHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         OidcAuditableEvent.AUTH_CODE_ISSUED,
-                        "aws-session-id",
+                        CLIENT_SESSION_ID,
                         SESSION_ID,
                         CLIENT_ID.getValue(),
                         AuditService.UNKNOWN,

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -93,7 +93,6 @@ class AuthorisationHandlerTest {
             "lng=en; Max-Age=31536000; Domain=auth.ida.digital.cabinet-office.gov.uk; Secure; HttpOnly;";
     private static final URI LOGIN_URL = URI.create("https://example.com");
     private static final String PERSISTENT_SESSION_ID = "a-persistent-session-id";
-    private static final String AWS_REQUEST_ID = "aws-request-id";
     private static final ClientID CLIENT_ID = new ClientID("test-id");
     private static final String REDIRECT_URI = "https://localhost:8080";
     private static final String SCOPE = "email,openid,profile";
@@ -121,7 +120,7 @@ class AuthorisationHandlerTest {
         when(authorizationService.getExistingOrCreateNewPersistentSessionId(any()))
                 .thenReturn(PERSISTENT_SESSION_ID);
         when(userContext.getClient()).thenReturn(Optional.of(generateClientRegistry()));
-        when(context.getAwsRequestId()).thenReturn(AWS_REQUEST_ID);
+        when(context.getAwsRequestId()).thenReturn("");
         handler =
                 new AuthorisationHandler(
                         configService,
@@ -168,7 +167,7 @@ class AuthorisationHandlerTest {
         inOrder.verify(auditService)
                 .submitAuditEvent(
                         OidcAuditableEvent.AUTHORISATION_INITIATED,
-                        context.getAwsRequestId(),
+                        CLIENT_SESSION_ID,
                         session.getSessionId(),
                         CLIENT_ID.getValue(),
                         AuditService.UNKNOWN,
@@ -236,7 +235,7 @@ class AuthorisationHandlerTest {
         inOrder.verify(auditService)
                 .submitAuditEvent(
                         OidcAuditableEvent.AUTHORISATION_INITIATED,
-                        context.getAwsRequestId(),
+                        CLIENT_SESSION_ID,
                         session.getSessionId(),
                         CLIENT_ID.getValue(),
                         AuditService.UNKNOWN,
@@ -278,7 +277,7 @@ class AuthorisationHandlerTest {
         inOrder.verify(auditService)
                 .submitAuditEvent(
                         OidcAuditableEvent.AUTHORISATION_INITIATED,
-                        context.getAwsRequestId(),
+                        CLIENT_SESSION_ID,
                         session.getSessionId(),
                         CLIENT_ID.getValue(),
                         AuditService.UNKNOWN,
@@ -321,7 +320,7 @@ class AuthorisationHandlerTest {
         inOrder.verify(auditService)
                 .submitAuditEvent(
                         OidcAuditableEvent.AUTHORISATION_INITIATED,
-                        context.getAwsRequestId(),
+                        CLIENT_SESSION_ID,
                         session.getSessionId(),
                         CLIENT_ID.getValue(),
                         AuditService.UNKNOWN,
@@ -363,7 +362,7 @@ class AuthorisationHandlerTest {
         inOrder.verify(auditService)
                 .submitAuditEvent(
                         OidcAuditableEvent.AUTHORISATION_INITIATED,
-                        context.getAwsRequestId(),
+                        CLIENT_SESSION_ID,
                         session.getSessionId(),
                         CLIENT_ID.getValue(),
                         AuditService.UNKNOWN,
@@ -403,7 +402,7 @@ class AuthorisationHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         AUTHORISATION_REQUEST_ERROR,
-                        AWS_REQUEST_ID,
+                        "",
                         "",
                         "",
                         "",
@@ -443,7 +442,7 @@ class AuthorisationHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         AUTHORISATION_REQUEST_ERROR,
-                        AWS_REQUEST_ID,
+                        "",
                         "",
                         CLIENT_ID.getValue(),
                         "",
@@ -485,7 +484,7 @@ class AuthorisationHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         AUTHORISATION_REQUEST_ERROR,
-                        AWS_REQUEST_ID,
+                        "",
                         "",
                         "",
                         "",
@@ -539,7 +538,7 @@ class AuthorisationHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         AUTHORISATION_REQUEST_ERROR,
-                        AWS_REQUEST_ID,
+                        "",
                         "",
                         CLIENT_ID.getValue(),
                         "",
@@ -603,7 +602,7 @@ class AuthorisationHandlerTest {
         inOrder.verify(auditService)
                 .submitAuditEvent(
                         OidcAuditableEvent.AUTHORISATION_INITIATED,
-                        context.getAwsRequestId(),
+                        CLIENT_SESSION_ID,
                         session.getSessionId(),
                         CLIENT_ID.getValue(),
                         AuditService.UNKNOWN,
@@ -635,7 +634,7 @@ class AuthorisationHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         AUTHORISATION_REQUEST_ERROR,
-                        AWS_REQUEST_ID,
+                        "",
                         "",
                         CLIENT_ID.getValue(),
                         "",
@@ -652,7 +651,7 @@ class AuthorisationHandlerTest {
         inOrder.verify(auditService)
                 .submitAuditEvent(
                         OidcAuditableEvent.AUTHORISATION_REQUEST_RECEIVED,
-                        AWS_REQUEST_ID,
+                        "",
                         "",
                         "",
                         "",
@@ -664,7 +663,7 @@ class AuthorisationHandlerTest {
         LogEvent logEvent = logging.events().get(0);
 
         assertThat(logEvent, hasContextData("persistentSessionId", PERSISTENT_SESSION_ID));
-        assertThat(logEvent, hasContextData("awsRequestId", AWS_REQUEST_ID));
+        assertThat(logEvent, hasContextData("awsRequestId", ""));
 
         return response;
     }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/LogoutHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/LogoutHandlerTest.java
@@ -124,7 +124,7 @@ class LogoutHandlerTest {
                 TokenGeneratorHelper.generateIDToken(
                         "client-id", SUBJECT, "http://localhost-rp", ecSigningKey);
         session = generateSession().setEmailAddress(EMAIL);
-        when(context.getAwsRequestId()).thenReturn("aws-session-id");
+        when(context.getAwsRequestId()).thenReturn("");
     }
 
     @Test
@@ -152,7 +152,7 @@ class LogoutHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         OidcAuditableEvent.LOG_OUT_SUCCESS,
-                        "aws-session-id",
+                        "",
                         SESSION_ID,
                         "client-id",
                         AuditService.UNKNOWN,
@@ -188,7 +188,7 @@ class LogoutHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         OidcAuditableEvent.LOG_OUT_SUCCESS,
-                        "aws-session-id",
+                        "",
                         SESSION_ID,
                         "client-id",
                         AuditService.UNKNOWN,
@@ -220,7 +220,7 @@ class LogoutHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         OidcAuditableEvent.LOG_OUT_SUCCESS,
-                        "aws-session-id",
+                        "",
                         SESSION_ID,
                         "client-id",
                         AuditService.UNKNOWN,
@@ -253,7 +253,7 @@ class LogoutHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         OidcAuditableEvent.LOG_OUT_SUCCESS,
-                        "aws-session-id",
+                        "",
                         SESSION_ID,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
@@ -284,7 +284,7 @@ class LogoutHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         OidcAuditableEvent.LOG_OUT_SUCCESS,
-                        "aws-session-id",
+                        "",
                         SESSION_ID,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
@@ -319,7 +319,7 @@ class LogoutHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         OidcAuditableEvent.LOG_OUT_SUCCESS,
-                        "aws-session-id",
+                        "",
                         SESSION_ID,
                         "client-id",
                         AuditService.UNKNOWN,
@@ -350,7 +350,7 @@ class LogoutHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         OidcAuditableEvent.LOG_OUT_SUCCESS,
-                        "aws-session-id",
+                        "",
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
@@ -391,7 +391,7 @@ class LogoutHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         OidcAuditableEvent.LOG_OUT_SUCCESS,
-                        "aws-session-id",
+                        "",
                         SESSION_ID,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
@@ -428,7 +428,7 @@ class LogoutHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         OidcAuditableEvent.LOG_OUT_SUCCESS,
-                        "aws-session-id",
+                        "",
                         SESSION_ID,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
@@ -474,7 +474,7 @@ class LogoutHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         OidcAuditableEvent.LOG_OUT_SUCCESS,
-                        "aws-session-id",
+                        "",
                         SESSION_ID,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
@@ -521,7 +521,7 @@ class LogoutHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         OidcAuditableEvent.LOG_OUT_SUCCESS,
-                        "aws-session-id",
+                        "",
                         SESSION_ID,
                         "invalid-client-id",
                         AuditService.UNKNOWN,
@@ -568,7 +568,7 @@ class LogoutHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         OidcAuditableEvent.LOG_OUT_SUCCESS,
-                        "aws-session-id",
+                        "",
                         SESSION_ID,
                         "client-id",
                         AuditService.UNKNOWN,


### PR DESCRIPTION
## What?

Add client session id to audit payloads and implement across all lambdas which have access to client session id.

## Why?

We pass this value (client session id) up to IPV Core and the Document Checking App but don’t publish it to our own audit log.

## Related PRs

[AUT-708 initial change](https://github.com/alphagov/di-authentication-api/pull/2326)