### PR TITLE
AUT-708-part-2: Add client session id to audit payloads

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
@@ -195,7 +195,7 @@ public class SendOtpNotificationHandler
 
         auditService.submitAuditEvent(
                 AccountManagementAuditableEvent.SEND_OTP,
-                context.getAwsRequestId(),
+                AuditService.UNKNOWN,
                 AuditService.UNKNOWN,
                 AuditService.UNKNOWN,
                 AuditService.UNKNOWN,

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
@@ -152,7 +152,7 @@ public class UpdateEmailHandler
 
                                 auditService.submitAuditEvent(
                                         AccountManagementAuditableEvent.UPDATE_EMAIL,
-                                        context.getAwsRequestId(),
+                                        AuditService.UNKNOWN,
                                         sessionId,
                                         AuditService.UNKNOWN,
                                         userProfile.getSubjectID(),

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandler.java
@@ -165,7 +165,7 @@ public class UpdatePasswordHandler
 
                                 auditService.submitAuditEvent(
                                         AccountManagementAuditableEvent.UPDATE_PASSWORD,
-                                        context.getAwsRequestId(),
+                                        AuditService.UNKNOWN,
                                         sessionId,
                                         AuditService.UNKNOWN,
                                         userProfile.getSubjectID(),

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandler.java
@@ -137,7 +137,7 @@ public class UpdatePhoneNumberHandler
 
                                 auditService.submitAuditEvent(
                                         AccountManagementAuditableEvent.UPDATE_PHONE_NUMBER,
-                                        context.getAwsRequestId(),
+                                        AuditService.UNKNOWN,
                                         sessionId,
                                         AuditService.UNKNOWN,
                                         userProfile.getSubjectID(),

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandlerTest.java
@@ -106,7 +106,7 @@ class SendOtpNotificationHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         AccountManagementAuditableEvent.SEND_OTP,
-                        context.getAwsRequestId(),
+                        AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
@@ -150,7 +150,7 @@ class SendOtpNotificationHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         AccountManagementAuditableEvent.SEND_OTP,
-                        context.getAwsRequestId(),
+                        AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandlerTest.java
@@ -98,7 +98,7 @@ class UpdateEmailHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         AccountManagementAuditableEvent.UPDATE_EMAIL,
-                        context.getAwsRequestId(),
+                        AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         userProfile.getSubjectID(),

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandlerTest.java
@@ -107,7 +107,7 @@ class UpdatePasswordHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         AccountManagementAuditableEvent.UPDATE_PASSWORD,
-                        context.getAwsRequestId(),
+                        AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         userProfile.getSubjectID(),

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandlerTest.java
@@ -101,7 +101,7 @@ class UpdatePhoneNumberHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         AccountManagementAuditableEvent.UPDATE_PHONE_NUMBER,
-                        context.getAwsRequestId(),
+                        AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         userProfile.getSubjectID(),

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandler.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandler.java
@@ -75,7 +75,7 @@ public class UpdateClientConfigHandler
                             String ipAddress = IpAddressHelper.extractIpAddress(input);
                             auditService.submitAuditEvent(
                                     UPDATE_CLIENT_REQUEST_RECEIVED,
-                                    context.getAwsRequestId(),
+                                    AuditService.UNKNOWN,
                                     AuditService.UNKNOWN,
                                     AuditService.UNKNOWN,
                                     AuditService.UNKNOWN,
@@ -96,7 +96,7 @@ public class UpdateClientConfigHandler
                                 if (!clientService.isValidClient(clientId)) {
                                     auditService.submitAuditEvent(
                                             UPDATE_CLIENT_REQUEST_ERROR,
-                                            context.getAwsRequestId(),
+                                            AuditService.UNKNOWN,
                                             AuditService.UNKNOWN,
                                             clientId,
                                             AuditService.UNKNOWN,
@@ -121,7 +121,7 @@ public class UpdateClientConfigHandler
                                             errorResponse.get().getDescription());
                                     auditService.submitAuditEvent(
                                             UPDATE_CLIENT_REQUEST_ERROR,
-                                            context.getAwsRequestId(),
+                                            AuditService.UNKNOWN,
                                             AuditService.UNKNOWN,
                                             clientId,
                                             AuditService.UNKNOWN,
@@ -155,7 +155,7 @@ public class UpdateClientConfigHandler
                             } catch (JsonException | NullPointerException e) {
                                 auditService.submitAuditEvent(
                                         UPDATE_CLIENT_REQUEST_ERROR,
-                                        context.getAwsRequestId(),
+                                        AuditService.UNKNOWN,
                                         AuditService.UNKNOWN,
                                         AuditService.UNKNOWN,
                                         AuditService.UNKNOWN,

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandlerTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandlerTest.java
@@ -111,8 +111,7 @@ class UpdateClientConfigHandlerTest {
         assertThat(result, hasBody(OAuth2Error.INVALID_REQUEST.toJSONObject().toJSONString()));
 
         verify(auditService)
-                .submitAuditEvent(
-                        UPDATE_CLIENT_REQUEST_ERROR, "request-id", "", "", "", "", "", "", "");
+                .submitAuditEvent(UPDATE_CLIENT_REQUEST_ERROR, "", "", "", "", "", "", "", "");
     }
 
     @Test
@@ -125,8 +124,7 @@ class UpdateClientConfigHandlerTest {
         assertThat(result, hasBody(OAuth2Error.INVALID_REQUEST.toJSONObject().toJSONString()));
 
         verify(auditService)
-                .submitAuditEvent(
-                        UPDATE_CLIENT_REQUEST_ERROR, "request-id", "", "", "", "", "", "", "");
+                .submitAuditEvent(UPDATE_CLIENT_REQUEST_ERROR, "", "", "", "", "", "", "", "");
     }
 
     @Test
@@ -142,15 +140,7 @@ class UpdateClientConfigHandlerTest {
 
         verify(auditService)
                 .submitAuditEvent(
-                        UPDATE_CLIENT_REQUEST_ERROR,
-                        "request-id",
-                        "",
-                        CLIENT_ID,
-                        "",
-                        "",
-                        "",
-                        "",
-                        "");
+                        UPDATE_CLIENT_REQUEST_ERROR, "", "", CLIENT_ID, "", "", "", "", "");
     }
 
     @Test
@@ -173,15 +163,7 @@ class UpdateClientConfigHandlerTest {
 
         verify(auditService)
                 .submitAuditEvent(
-                        UPDATE_CLIENT_REQUEST_ERROR,
-                        "request-id",
-                        "",
-                        CLIENT_ID,
-                        "",
-                        "",
-                        "",
-                        "",
-                        "");
+                        UPDATE_CLIENT_REQUEST_ERROR, "", "", CLIENT_ID, "", "", "", "", "");
     }
 
     @Test
@@ -201,15 +183,7 @@ class UpdateClientConfigHandlerTest {
 
         verify(auditService)
                 .submitAuditEvent(
-                        UPDATE_CLIENT_REQUEST_ERROR,
-                        "request-id",
-                        "",
-                        CLIENT_ID,
-                        "",
-                        "",
-                        "",
-                        "",
-                        "");
+                        UPDATE_CLIENT_REQUEST_ERROR, "", "", CLIENT_ID, "", "", "", "", "");
     }
 
     private ClientRegistry createClientRegistry() {
@@ -230,8 +204,7 @@ class UpdateClientConfigHandlerTest {
         var response = handler.handleRequest(event, context);
 
         verify(auditService)
-                .submitAuditEvent(
-                        UPDATE_CLIENT_REQUEST_RECEIVED, "request-id", "", "", "", "", "", "", "");
+                .submitAuditEvent(UPDATE_CLIENT_REQUEST_RECEIVED, "", "", "", "", "", "", "", "");
 
         return response;
     }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
@@ -107,7 +107,7 @@ public class SignUpHandler extends BaseFrontendHandler<SignupRequest>
 
                 auditService.submitAuditEvent(
                         FrontendAuditableEvent.CREATE_ACCOUNT_EMAIL_ALREADY_EXISTS,
-                        context.getAwsRequestId(),
+                        AuditService.UNKNOWN,
                         userContext.getSession().getSessionId(),
                         userContext
                                 .getClient()
@@ -132,7 +132,7 @@ public class SignUpHandler extends BaseFrontendHandler<SignupRequest>
 
             auditService.submitAuditEvent(
                     FrontendAuditableEvent.CREATE_ACCOUNT,
-                    context.getAwsRequestId(),
+                    AuditService.UNKNOWN,
                     userContext.getSession().getSessionId(),
                     userContext
                             .getClient()

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -121,18 +121,17 @@ public class StartHandler
                                                 cookieConsent,
                                                 gaTrackingId,
                                                 configurationService.isIdentityEnabled());
+                                var clientSessionId =
+                                        getHeaderValueFromHeaders(
+                                                input.getHeaders(),
+                                                CLIENT_SESSION_ID_HEADER,
+                                                configurationService.getHeadersCaseInsensitive());
                                 if (userStartInfo.isDocCheckingAppUser()) {
                                     var docAppSubjectId =
                                             ClientSubjectHelper.calculatePairwiseIdentifier(
                                                     new Subject().getValue(),
                                                     configurationService.getDocAppDomain(),
                                                     SaltHelper.generateNewSalt());
-                                    var clientSessionId =
-                                            getHeaderValueFromHeaders(
-                                                    input.getHeaders(),
-                                                    CLIENT_SESSION_ID_HEADER,
-                                                    configurationService
-                                                            .getHeadersCaseInsensitive());
                                     clientSessionService.saveClientSession(
                                             clientSessionId,
                                             clientSession
@@ -148,7 +147,7 @@ public class StartHandler
 
                                 auditService.submitAuditEvent(
                                         FrontendAuditableEvent.START_INFO_FOUND,
-                                        context.getAwsRequestId(),
+                                        clientSessionId,
                                         session.get().getSessionId(),
                                         userContext.getClient().get().getClientID(),
                                         AuditService.UNKNOWN,

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -121,17 +121,18 @@ public class StartHandler
                                                 cookieConsent,
                                                 gaTrackingId,
                                                 configurationService.isIdentityEnabled());
-                                var clientSessionId =
-                                        getHeaderValueFromHeaders(
-                                                input.getHeaders(),
-                                                CLIENT_SESSION_ID_HEADER,
-                                                configurationService.getHeadersCaseInsensitive());
                                 if (userStartInfo.isDocCheckingAppUser()) {
                                     var docAppSubjectId =
                                             ClientSubjectHelper.calculatePairwiseIdentifier(
                                                     new Subject().getValue(),
                                                     configurationService.getDocAppDomain(),
                                                     SaltHelper.generateNewSalt());
+                                    var clientSessionId =
+                                            getHeaderValueFromHeaders(
+                                                    input.getHeaders(),
+                                                    CLIENT_SESSION_ID_HEADER,
+                                                    configurationService
+                                                            .getHeadersCaseInsensitive());
                                     clientSessionService.saveClientSession(
                                             clientSessionId,
                                             clientSession
@@ -147,7 +148,7 @@ public class StartHandler
 
                                 auditService.submitAuditEvent(
                                         FrontendAuditableEvent.START_INFO_FOUND,
-                                        clientSessionId,
+                                        AuditService.UNKNOWN,
                                         session.get().getSessionId(),
                                         userContext.getClient().get().getClientID(),
                                         AuditService.UNKNOWN,

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
@@ -90,7 +90,7 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
     public void onRequestReceived(Context context) {
         auditService.submitAuditEvent(
                 UPDATE_PROFILE_REQUEST_RECEIVED,
-                context.getAwsRequestId(),
+                AuditService.UNKNOWN,
                 AuditService.UNKNOWN,
                 AuditService.UNKNOWN,
                 AuditService.UNKNOWN,
@@ -104,7 +104,7 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
     public void onRequestValidationError(Context context) {
         auditService.submitAuditEvent(
                 UPDATE_PROFILE_REQUEST_ERROR,
-                context.getAwsRequestId(),
+                AuditService.UNKNOWN,
                 AuditService.UNKNOWN,
                 AuditService.UNKNOWN,
                 AuditService.UNKNOWN,
@@ -275,7 +275,7 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
         }
         auditService.submitAuditEvent(
                 auditableEvent,
-                context.getAwsRequestId(),
+                AuditService.UNKNOWN,
                 session.getSessionId(),
                 auditableClientId,
                 userContext
@@ -334,7 +334,7 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
             String persistentSessionId) {
         auditService.submitAuditEvent(
                 UPDATE_PROFILE_REQUEST_ERROR,
-                context.getAwsRequestId(),
+                AuditService.UNKNOWN,
                 sessionId,
                 clientId,
                 AuditService.UNKNOWN,

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -265,7 +265,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
         codeStorageService.deleteOtpCode(session.getEmailAddress(), notificationType);
         auditService.submitAuditEvent(
                 FrontendAuditableEvent.CODE_VERIFIED,
-                context.getAwsRequestId(),
+                clientSessionId,
                 session.getSessionId(),
                 userContext
                         .getClient()
@@ -310,7 +310,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
         }
         auditService.submitAuditEvent(
                 auditableEvent,
-                context.getAwsRequestId(),
+                AuditService.UNKNOWN,
                 session.getSessionId(),
                 userContext
                         .getClient()

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -141,9 +141,9 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                     session,
                     mfaMethodType,
                     input,
-                    context,
                     userContext,
-                    isRegistration);
+                    isRegistration,
+                    clientSessionId);
 
             sessionService.save(session);
 
@@ -208,9 +208,9 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
             Session session,
             MFAMethodType mfaMethodType,
             APIGatewayProxyRequestEvent input,
-            Context context,
             UserContext userContext,
-            boolean isRegistration) {
+            boolean isRegistration,
+            String clientSessionId) {
 
         var auditableEvent = errorResponseAsFrontendAuditableEvent(errorResponse);
 
@@ -226,7 +226,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
 
         auditService.submitAuditEvent(
                 auditableEvent,
-                context.getAwsRequestId(),
+                clientSessionId,
                 session.getSessionId(),
                 userContext
                         .getClient()

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandlerTest.java
@@ -168,7 +168,7 @@ class SignUpHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CREATE_ACCOUNT,
-                        context.getAwsRequestId(),
+                        AuditService.UNKNOWN,
                         session.getSessionId(),
                         CLIENT_ID.getValue(),
                         AuditService.UNKNOWN,
@@ -238,7 +238,7 @@ class SignUpHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CREATE_ACCOUNT_EMAIL_ALREADY_EXISTS,
-                        context.getAwsRequestId(),
+                        AuditService.UNKNOWN,
                         session.getSessionId(),
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -61,7 +61,7 @@ class StartHandlerTest {
 
     public static final String TEST_CLIENT_ID = "test_client_id";
     public static final String TEST_CLIENT_NAME = "test_client_name";
-    public static final String CLIENT_SESSION_ID_HEADER = "client-session-id";
+    public static final String CLIENT_SESSION_ID_HEADER = "Client-Session-Id";
     public static final String SESSION_ID_HEADER = "Session-Id";
     public static final String CLIENT_SESSION_ID = "known-client-session-id";
     public static final String SESSION_ID = "some-session-id";
@@ -160,7 +160,7 @@ class StartHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.START_INFO_FOUND,
-                        CLIENT_SESSION_ID,
+                        AuditService.UNKNOWN,
                         SESSION_ID,
                         TEST_CLIENT_ID,
                         AuditService.UNKNOWN,
@@ -224,7 +224,7 @@ class StartHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.START_INFO_FOUND,
-                        CLIENT_SESSION_ID,
+                        AuditService.UNKNOWN,
                         SESSION_ID,
                         TEST_CLIENT_ID,
                         AuditService.UNKNOWN,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -61,7 +61,7 @@ class StartHandlerTest {
 
     public static final String TEST_CLIENT_ID = "test_client_id";
     public static final String TEST_CLIENT_NAME = "test_client_name";
-    public static final String CLIENT_SESSION_ID_HEADER = "Client-Session-Id";
+    public static final String CLIENT_SESSION_ID_HEADER = "client-session-id";
     public static final String SESSION_ID_HEADER = "Session-Id";
     public static final String CLIENT_SESSION_ID = "known-client-session-id";
     public static final String SESSION_ID = "some-session-id";
@@ -160,7 +160,7 @@ class StartHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.START_INFO_FOUND,
-                        "aws-session-id",
+                        CLIENT_SESSION_ID,
                         SESSION_ID,
                         TEST_CLIENT_ID,
                         AuditService.UNKNOWN,
@@ -224,7 +224,7 @@ class StartHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.START_INFO_FOUND,
-                        "aws-session-id",
+                        CLIENT_SESSION_ID,
                         SESSION_ID,
                         TEST_CLIENT_ID,
                         AuditService.UNKNOWN,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandlerTest.java
@@ -152,7 +152,7 @@ class UpdateProfileHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         UPDATE_PROFILE_PHONE_NUMBER,
-                        "request-id",
+                        "",
                         session.getSessionId(),
                         "",
                         "",
@@ -191,7 +191,7 @@ class UpdateProfileHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         UPDATE_PROFILE_REQUEST_ERROR,
-                        "request-id",
+                        "",
                         SESSION_ID,
                         CLIENT_ID.getValue(),
                         "",
@@ -226,7 +226,7 @@ class UpdateProfileHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         UPDATE_PROFILE_TERMS_CONDS_ACCEPTANCE,
-                        "request-id",
+                        "",
                         session.getSessionId(),
                         CLIENT_ID.getValue(),
                         INTERNAL_SUBJECT,
@@ -265,7 +265,7 @@ class UpdateProfileHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         UPDATE_PROFILE_CONSENT_UPDATED,
-                        "request-id",
+                        "",
                         session.getSessionId(),
                         CLIENT_ID.getValue(),
                         INTERNAL_SUBJECT,
@@ -292,8 +292,7 @@ class UpdateProfileHandlerTest {
         verify(authenticationService, never())
                 .updatePhoneNumber(eq(TEST_EMAIL_ADDRESS), eq(PHONE_NUMBER));
         verify(auditService)
-                .submitAuditEvent(
-                        UPDATE_PROFILE_REQUEST_ERROR, "request-id", "", "", "", "", "", "", "");
+                .submitAuditEvent(UPDATE_PROFILE_REQUEST_ERROR, "", "", "", "", "", "", "", "");
     }
 
     @Test
@@ -320,7 +319,7 @@ class UpdateProfileHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         UPDATE_PROFILE_AUTH_APP,
-                        "request-id",
+                        "",
                         session.getSessionId(),
                         CLIENT_ID.getValue(),
                         INTERNAL_SUBJECT,
@@ -360,7 +359,7 @@ class UpdateProfileHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         UPDATE_PROFILE_REQUEST_ERROR,
-                        "request-id",
+                        "",
                         SESSION_ID,
                         CLIENT_ID.getValue(),
                         "",
@@ -396,8 +395,7 @@ class UpdateProfileHandlerTest {
         var response = handler.handleRequest(event, context);
 
         verify(auditService)
-                .submitAuditEvent(
-                        UPDATE_PROFILE_REQUEST_RECEIVED, "request-id", "", "", "", "", "", "", "");
+                .submitAuditEvent(UPDATE_PROFILE_REQUEST_RECEIVED, "", "", "", "", "", "", "", "");
 
         return response;
     }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -48,7 +48,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.authentication.frontendapi.lambda.StartHandlerTest.CLIENT_SESSION_ID_HEADER;
 import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.MEDIUM_LEVEL;
 import static uk.gov.di.authentication.shared.entity.NotificationType.MFA_SMS;
 import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_EMAIL;
@@ -66,6 +65,7 @@ class VerifyCodeHandlerTest {
     private static final String CODE = "123456";
     private static final String INVALID_CODE = "6543221";
     private static final String CLIENT_ID = "client-id";
+    private static final String CLIENT_SESSION_ID = "client-session-id";
     private static final String TEST_CLIENT_ID = "test-client-id";
     private static final String TEST_CLIENT_CODE = "654321";
     private static final String TEST_CLIENT_EMAIL =
@@ -158,7 +158,7 @@ class VerifyCodeHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CODE_VERIFIED,
-                        CLIENT_SESSION_ID_HEADER,
+                        CLIENT_SESSION_ID,
                         session.getSessionId(),
                         CLIENT_ID,
                         "test-subject-id",
@@ -190,7 +190,7 @@ class VerifyCodeHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CODE_VERIFIED,
-                        CLIENT_SESSION_ID_HEADER,
+                        CLIENT_SESSION_ID,
                         session.getSessionId(),
                         CLIENT_ID,
                         "test-subject-id",
@@ -371,7 +371,7 @@ class VerifyCodeHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CODE_VERIFIED,
-                        CLIENT_SESSION_ID_HEADER,
+                        CLIENT_SESSION_ID,
                         session.getSessionId(),
                         CLIENT_ID,
                         "test-subject-id",

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -48,6 +48,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.frontendapi.lambda.StartHandlerTest.CLIENT_SESSION_ID_HEADER;
 import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.MEDIUM_LEVEL;
 import static uk.gov.di.authentication.shared.entity.NotificationType.MFA_SMS;
 import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_EMAIL;
@@ -157,7 +158,7 @@ class VerifyCodeHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CODE_VERIFIED,
-                        context.getAwsRequestId(),
+                        CLIENT_SESSION_ID_HEADER,
                         session.getSessionId(),
                         CLIENT_ID,
                         "test-subject-id",
@@ -189,7 +190,7 @@ class VerifyCodeHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CODE_VERIFIED,
-                        context.getAwsRequestId(),
+                        CLIENT_SESSION_ID_HEADER,
                         session.getSessionId(),
                         CLIENT_ID,
                         "test-subject-id",
@@ -284,7 +285,7 @@ class VerifyCodeHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CODE_MAX_RETRIES_REACHED,
-                        context.getAwsRequestId(),
+                        AuditService.UNKNOWN,
                         session.getSessionId(),
                         CLIENT_ID,
                         "test-subject-id",
@@ -332,7 +333,7 @@ class VerifyCodeHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CODE_MAX_RETRIES_REACHED,
-                        context.getAwsRequestId(),
+                        AuditService.UNKNOWN,
                         session.getSessionId(),
                         CLIENT_ID,
                         "test-subject-id",
@@ -370,7 +371,7 @@ class VerifyCodeHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CODE_VERIFIED,
-                        context.getAwsRequestId(),
+                        CLIENT_SESSION_ID_HEADER,
                         session.getSessionId(),
                         CLIENT_ID,
                         "test-subject-id",
@@ -416,7 +417,7 @@ class VerifyCodeHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CODE_MAX_RETRIES_REACHED,
-                        context.getAwsRequestId(),
+                        AuditService.UNKNOWN,
                         session.getSessionId(),
                         CLIENT_ID,
                         "test-subject-id",

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -160,7 +160,7 @@ class VerifyMfaCodeHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CODE_VERIFIED,
-                        context.getAwsRequestId(),
+                        CLIENT_SESSION_ID,
                         session.getSessionId(),
                         CLIENT_ID,
                         SUBJECT_ID,
@@ -195,7 +195,7 @@ class VerifyMfaCodeHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CODE_VERIFIED,
-                        context.getAwsRequestId(),
+                        CLIENT_SESSION_ID,
                         session.getSessionId(),
                         CLIENT_ID,
                         SUBJECT_ID,
@@ -256,7 +256,7 @@ class VerifyMfaCodeHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CODE_MAX_RETRIES_REACHED,
-                        context.getAwsRequestId(),
+                        CLIENT_SESSION_ID,
                         session.getSessionId(),
                         CLIENT_ID,
                         SUBJECT_ID,
@@ -291,7 +291,7 @@ class VerifyMfaCodeHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.INVALID_CODE_SENT,
-                        context.getAwsRequestId(),
+                        CLIENT_SESSION_ID,
                         session.getSessionId(),
                         CLIENT_ID,
                         SUBJECT_ID,

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandler.java
@@ -64,8 +64,7 @@ public class SPOTResponseHandler implements RequestHandler<SQSEvent, Object> {
                             spotResponse.getStatus());
                     submitAuditEvent(
                             IPVAuditableEvent.IPV_SUCCESSFUL_SPOT_RESPONSE_RECEIVED,
-                            spotResponse.getLogIds(),
-                            context.getAwsRequestId());
+                            spotResponse.getLogIds());
                     dynamoIdentityService.addCoreIdentityJWT(
                             spotResponse.getSub(),
                             spotResponse.getClaims().values().stream()
@@ -80,8 +79,7 @@ public class SPOTResponseHandler implements RequestHandler<SQSEvent, Object> {
                             spotResponse.getReason());
                     submitAuditEvent(
                             IPVAuditableEvent.IPV_UNSUCCESSFUL_SPOT_RESPONSE_RECEIVED,
-                            spotResponse.getLogIds(),
-                            context.getAwsRequestId());
+                            spotResponse.getLogIds());
                     dynamoIdentityService.deleteIdentityCredentials(spotResponse.getSub());
                     return null;
                 }
@@ -96,11 +94,10 @@ public class SPOTResponseHandler implements RequestHandler<SQSEvent, Object> {
         return null;
     }
 
-    private void submitAuditEvent(
-            AuditableEvent auditableEvent, LogIds logIds, String awsRequestId) {
+    private void submitAuditEvent(AuditableEvent auditableEvent, LogIds logIds) {
         auditService.submitAuditEvent(
                 auditableEvent,
-                awsRequestId,
+                AuditService.UNKNOWN,
                 logIds.getSessionId(),
                 logIds.getClientId(),
                 AuditService.UNKNOWN,

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandlerTest.java
@@ -53,7 +53,7 @@ class SPOTResponseHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         IPVAuditableEvent.IPV_SUCCESSFUL_SPOT_RESPONSE_RECEIVED,
-                        REQUEST_ID,
+                        AuditService.UNKNOWN,
                         SESSION_ID,
                         CLIENT_ID.getValue(),
                         AuditService.UNKNOWN,
@@ -88,7 +88,7 @@ class SPOTResponseHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         IPVAuditableEvent.IPV_UNSUCCESSFUL_SPOT_RESPONSE_RECEIVED,
-                        REQUEST_ID,
+                        AuditService.UNKNOWN,
                         SESSION_ID,
                         CLIENT_ID.getValue(),
                         AuditService.UNKNOWN,

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandler.java
@@ -130,7 +130,7 @@ public class UserInfoHandler
 
                             auditService.submitAuditEvent(
                                     OidcAuditableEvent.USER_INFO_RETURNED,
-                                    context.getAwsRequestId(),
+                                    AuditService.UNKNOWN,
                                     AuditService.UNKNOWN,
                                     accessTokenInfo.getClientID(),
                                     accessTokenInfo.getSubject(),

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandlerTest.java
@@ -87,7 +87,7 @@ public class UserInfoHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         OidcAuditableEvent.USER_INFO_RETURNED,
-                        "aws-request-id",
+                        "",
                         "",
                         "client-id",
                         SUBJECT.getValue(),


### PR DESCRIPTION
## What?

Add client session id to audit payloads and implement across all lambdas which have access to client session id.

## Why?

We pass this value (client session id) up to IPV Core and the Document Checking App but don’t publish it to our own audit log.

## Related PRs

[Initial Change](https://github.com/alphagov/di-authentication-api/pull/2326)
[Part 1](https://github.com/alphagov/di-authentication-api/pull/2332)