### PR TITLE
AUT-708-part-1: Add client session id to audit payloads

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandler.java
@@ -94,7 +94,7 @@ public class AuthenticateHandler
                                 auditService.submitAuditEvent(
                                         AccountManagementAuditableEvent
                                                 .ACCOUNT_MANAGEMENT_AUTHENTICATE,
-                                        context.getAwsRequestId(),
+                                        AuditService.UNKNOWN,
                                         sessionId,
                                         AuditService.UNKNOWN,
                                         AuditService.UNKNOWN,

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandler.java
@@ -131,7 +131,7 @@ public class RemoveAccountHandler
                                         "Remove account message successfully added to queue. Generating successful gateway response");
                                 auditService.submitAuditEvent(
                                         AccountManagementAuditableEvent.DELETE_ACCOUNT,
-                                        context.getAwsRequestId(),
+                                        AuditService.UNKNOWN,
                                         sessionId,
                                         AuditService.UNKNOWN,
                                         userProfile.getSubjectID(),

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
@@ -195,7 +195,7 @@ public class SendOtpNotificationHandler
 
         auditService.submitAuditEvent(
                 AccountManagementAuditableEvent.SEND_OTP,
-                context.getAwsRequestId(),
+                AuditService.UNKNOWN,
                 AuditService.UNKNOWN,
                 AuditService.UNKNOWN,
                 AuditService.UNKNOWN,

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
@@ -152,7 +152,7 @@ public class UpdateEmailHandler
 
                                 auditService.submitAuditEvent(
                                         AccountManagementAuditableEvent.UPDATE_EMAIL,
-                                        context.getAwsRequestId(),
+                                        AuditService.UNKNOWN,
                                         sessionId,
                                         AuditService.UNKNOWN,
                                         userProfile.getSubjectID(),

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandler.java
@@ -165,7 +165,7 @@ public class UpdatePasswordHandler
 
                                 auditService.submitAuditEvent(
                                         AccountManagementAuditableEvent.UPDATE_PASSWORD,
-                                        context.getAwsRequestId(),
+                                        AuditService.UNKNOWN,
                                         sessionId,
                                         AuditService.UNKNOWN,
                                         userProfile.getSubjectID(),

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandler.java
@@ -137,7 +137,7 @@ public class UpdatePhoneNumberHandler
 
                                 auditService.submitAuditEvent(
                                         AccountManagementAuditableEvent.UPDATE_PHONE_NUMBER,
-                                        context.getAwsRequestId(),
+                                        AuditService.UNKNOWN,
                                         sessionId,
                                         AuditService.UNKNOWN,
                                         userProfile.getSubjectID(),

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandlerTest.java
@@ -56,7 +56,7 @@ class AuthenticateHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         AccountManagementAuditableEvent.ACCOUNT_MANAGEMENT_AUTHENTICATE,
-                        context.getAwsRequestId(),
+                        AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandlerTest.java
@@ -80,7 +80,7 @@ class RemoveAccountHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         AccountManagementAuditableEvent.DELETE_ACCOUNT,
-                        context.getAwsRequestId(),
+                        AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         userProfile.getSubjectID(),

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandlerTest.java
@@ -106,7 +106,7 @@ class SendOtpNotificationHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         AccountManagementAuditableEvent.SEND_OTP,
-                        context.getAwsRequestId(),
+                        AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
@@ -150,7 +150,7 @@ class SendOtpNotificationHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         AccountManagementAuditableEvent.SEND_OTP,
-                        context.getAwsRequestId(),
+                        AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandlerTest.java
@@ -98,7 +98,7 @@ class UpdateEmailHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         AccountManagementAuditableEvent.UPDATE_EMAIL,
-                        context.getAwsRequestId(),
+                        AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         userProfile.getSubjectID(),

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandlerTest.java
@@ -107,7 +107,7 @@ class UpdatePasswordHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         AccountManagementAuditableEvent.UPDATE_PASSWORD,
-                        context.getAwsRequestId(),
+                        AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         userProfile.getSubjectID(),

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandlerTest.java
@@ -101,7 +101,7 @@ class UpdatePhoneNumberHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         AccountManagementAuditableEvent.UPDATE_PHONE_NUMBER,
-                        context.getAwsRequestId(),
+                        AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         userProfile.getSubjectID(),

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandler.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandler.java
@@ -154,7 +154,7 @@ public class ClientRegistrationHandler
                                         "Invalid Client registration request. Missing parameters from request");
                                 auditService.submitAuditEvent(
                                         REGISTER_CLIENT_REQUEST_ERROR,
-                                        context.getAwsRequestId(),
+                                        AuditService.UNKNOWN,
                                         AuditService.UNKNOWN,
                                         AuditService.UNKNOWN,
                                         AuditService.UNKNOWN,

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandler.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandler.java
@@ -75,7 +75,7 @@ public class UpdateClientConfigHandler
                             String ipAddress = IpAddressHelper.extractIpAddress(input);
                             auditService.submitAuditEvent(
                                     UPDATE_CLIENT_REQUEST_RECEIVED,
-                                    context.getAwsRequestId(),
+                                    AuditService.UNKNOWN,
                                     AuditService.UNKNOWN,
                                     AuditService.UNKNOWN,
                                     AuditService.UNKNOWN,
@@ -96,7 +96,7 @@ public class UpdateClientConfigHandler
                                 if (!clientService.isValidClient(clientId)) {
                                     auditService.submitAuditEvent(
                                             UPDATE_CLIENT_REQUEST_ERROR,
-                                            context.getAwsRequestId(),
+                                            AuditService.UNKNOWN,
                                             AuditService.UNKNOWN,
                                             clientId,
                                             AuditService.UNKNOWN,
@@ -121,7 +121,7 @@ public class UpdateClientConfigHandler
                                             errorResponse.get().getDescription());
                                     auditService.submitAuditEvent(
                                             UPDATE_CLIENT_REQUEST_ERROR,
-                                            context.getAwsRequestId(),
+                                            AuditService.UNKNOWN,
                                             AuditService.UNKNOWN,
                                             clientId,
                                             AuditService.UNKNOWN,
@@ -155,7 +155,7 @@ public class UpdateClientConfigHandler
                             } catch (JsonException | NullPointerException e) {
                                 auditService.submitAuditEvent(
                                         UPDATE_CLIENT_REQUEST_ERROR,
-                                        context.getAwsRequestId(),
+                                        AuditService.UNKNOWN,
                                         AuditService.UNKNOWN,
                                         AuditService.UNKNOWN,
                                         AuditService.UNKNOWN,

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandlerTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandlerTest.java
@@ -206,8 +206,7 @@ class ClientRegistrationHandlerTest {
         assertThat(result, hasBody(OAuth2Error.INVALID_REQUEST.toJSONObject().toJSONString()));
 
         verify(auditService)
-                .submitAuditEvent(
-                        REGISTER_CLIENT_REQUEST_ERROR, "request-id", "", "", "", "", "", "", "");
+                .submitAuditEvent(REGISTER_CLIENT_REQUEST_ERROR, "", "", "", "", "", "", "", "");
     }
 
     @Test

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandlerTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandlerTest.java
@@ -111,8 +111,7 @@ class UpdateClientConfigHandlerTest {
         assertThat(result, hasBody(OAuth2Error.INVALID_REQUEST.toJSONObject().toJSONString()));
 
         verify(auditService)
-                .submitAuditEvent(
-                        UPDATE_CLIENT_REQUEST_ERROR, "request-id", "", "", "", "", "", "", "");
+                .submitAuditEvent(UPDATE_CLIENT_REQUEST_ERROR, "", "", "", "", "", "", "", "");
     }
 
     @Test
@@ -125,8 +124,7 @@ class UpdateClientConfigHandlerTest {
         assertThat(result, hasBody(OAuth2Error.INVALID_REQUEST.toJSONObject().toJSONString()));
 
         verify(auditService)
-                .submitAuditEvent(
-                        UPDATE_CLIENT_REQUEST_ERROR, "request-id", "", "", "", "", "", "", "");
+                .submitAuditEvent(UPDATE_CLIENT_REQUEST_ERROR, "", "", "", "", "", "", "", "");
     }
 
     @Test
@@ -142,15 +140,7 @@ class UpdateClientConfigHandlerTest {
 
         verify(auditService)
                 .submitAuditEvent(
-                        UPDATE_CLIENT_REQUEST_ERROR,
-                        "request-id",
-                        "",
-                        CLIENT_ID,
-                        "",
-                        "",
-                        "",
-                        "",
-                        "");
+                        UPDATE_CLIENT_REQUEST_ERROR, "", "", CLIENT_ID, "", "", "", "", "");
     }
 
     @Test
@@ -173,15 +163,7 @@ class UpdateClientConfigHandlerTest {
 
         verify(auditService)
                 .submitAuditEvent(
-                        UPDATE_CLIENT_REQUEST_ERROR,
-                        "request-id",
-                        "",
-                        CLIENT_ID,
-                        "",
-                        "",
-                        "",
-                        "",
-                        "");
+                        UPDATE_CLIENT_REQUEST_ERROR, "", "", CLIENT_ID, "", "", "", "", "");
     }
 
     @Test
@@ -201,15 +183,7 @@ class UpdateClientConfigHandlerTest {
 
         verify(auditService)
                 .submitAuditEvent(
-                        UPDATE_CLIENT_REQUEST_ERROR,
-                        "request-id",
-                        "",
-                        CLIENT_ID,
-                        "",
-                        "",
-                        "",
-                        "",
-                        "");
+                        UPDATE_CLIENT_REQUEST_ERROR, "", "", CLIENT_ID, "", "", "", "", "");
     }
 
     private ClientRegistry createClientRegistry() {
@@ -230,8 +204,7 @@ class UpdateClientConfigHandlerTest {
         var response = handler.handleRequest(event, context);
 
         verify(auditService)
-                .submitAuditEvent(
-                        UPDATE_CLIENT_REQUEST_RECEIVED, "request-id", "", "", "", "", "", "", "");
+                .submitAuditEvent(UPDATE_CLIENT_REQUEST_RECEIVED, "", "", "", "", "", "", "", "");
 
         return response;
     }


### PR DESCRIPTION
## What?

Set `govuk_signin_journey_id` in AuditService to empty string `""` for lambdas with no access to client session id. Mainly account management and client registry lambdas

## Why?

We pass this value (client session id) up to IPV Core and the Document Checking App but don’t publish it to our own audit log.

## Related PRs

[Change for IPV/CRI/DocApp lambdas](https://github.com/alphagov/di-authentication-api/pull/2326)