### PR TITLE
AUT-708-part-2: Add client session id to audit payloads

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -93,7 +93,7 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
             if (errorResponse.isPresent()) {
                 auditService.submitAuditEvent(
                         FrontendAuditableEvent.CHECK_USER_INVALID_EMAIL,
-                        context.getAwsRequestId(),
+                        userContext.getClientSessionId(),
                         userContext.getSession().getSessionId(),
                         userContext
                                 .getClient()
@@ -116,7 +116,7 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
             }
             auditService.submitAuditEvent(
                     auditableEvent,
-                    context.getAwsRequestId(),
+                    userContext.getClientSessionId(),
                     userContext.getSession().getSessionId(),
                     userContext
                             .getClient()

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -117,7 +117,7 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
 
                 auditService.submitAuditEvent(
                         FrontendAuditableEvent.NO_ACCOUNT_WITH_EMAIL,
-                        context.getAwsRequestId(),
+                        userContext.getClientSessionId(),
                         userContext.getSession().getSessionId(),
                         clientId,
                         AuditService.UNKNOWN,
@@ -140,7 +140,7 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
 
                 auditService.submitAuditEvent(
                         FrontendAuditableEvent.ACCOUNT_TEMPORARILY_LOCKED,
-                        context.getAwsRequestId(),
+                        userContext.getClientSessionId(),
                         userContext.getSession().getSessionId(),
                         clientId,
                         userProfile.getSubjectID(),
@@ -157,7 +157,7 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
 
                 auditService.submitAuditEvent(
                         FrontendAuditableEvent.INVALID_CREDENTIALS,
-                        context.getAwsRequestId(),
+                        userContext.getClientSessionId(),
                         userContext.getSession().getSessionId(),
                         clientId,
                         AuditService.UNKNOWN,
@@ -203,7 +203,7 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
 
             auditService.submitAuditEvent(
                     LOG_IN_SUCCESS,
-                    context.getAwsRequestId(),
+                    userContext.getClientSessionId(),
                     userContext.getSession().getSessionId(),
                     clientId,
                     userProfile.getSubjectID(),

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
@@ -128,7 +128,7 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
             if (codeRequestValid.isPresent()) {
                 auditService.submitAuditEvent(
                         FrontendAuditableEvent.MFA_INVALID_CODE_REQUEST,
-                        context.getAwsRequestId(),
+                        userContext.getClientSessionId(),
                         userContext.getSession().getSessionId(),
                         userContext
                                 .getClient()
@@ -148,7 +148,7 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
 
                 auditService.submitAuditEvent(
                         FrontendAuditableEvent.MFA_MISMATCHED_EMAIL,
-                        context.getAwsRequestId(),
+                        userContext.getClientSessionId(),
                         userContext.getSession().getSessionId(),
                         userContext
                                 .getClient()
@@ -167,7 +167,7 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
             if (phoneNumber == null) {
                 auditService.submitAuditEvent(
                         FrontendAuditableEvent.MFA_MISSING_PHONE_NUMBER,
-                        context.getAwsRequestId(),
+                        userContext.getClientSessionId(),
                         userContext.getSession().getSessionId(),
                         userContext
                                 .getClient()
@@ -212,7 +212,7 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
             }
             auditService.submitAuditEvent(
                     auditableEvent,
-                    context.getAwsRequestId(),
+                    userContext.getClientSessionId(),
                     userContext.getSession().getSessionId(),
                     userContext
                             .getClient()

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
@@ -150,7 +150,7 @@ public class ResetPasswordHandler extends BaseFrontendHandler<ResetPasswordCompl
             sqsClient.send(serialiseRequest(notifyRequest));
             auditService.submitAuditEvent(
                     FrontendAuditableEvent.PASSWORD_RESET_SUCCESSFUL,
-                    context.getAwsRequestId(),
+                    userContext.getClientSessionId(),
                     userContext.getSession().getSessionId(),
                     userContext
                             .getClient()

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
@@ -110,7 +110,7 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
                     PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders());
             auditService.submitAuditEvent(
                     FrontendAuditableEvent.PASSWORD_RESET_REQUESTED,
-                    context.getAwsRequestId(),
+                    userContext.getClientSessionId(),
                     userContext.getSession().getSessionId(),
                     userContext
                             .getClient()

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
@@ -107,7 +107,7 @@ public class SignUpHandler extends BaseFrontendHandler<SignupRequest>
 
                 auditService.submitAuditEvent(
                         FrontendAuditableEvent.CREATE_ACCOUNT_EMAIL_ALREADY_EXISTS,
-                        context.getAwsRequestId(),
+                        userContext.getClientSessionId(),
                         userContext.getSession().getSessionId(),
                         userContext
                                 .getClient()
@@ -132,7 +132,7 @@ public class SignUpHandler extends BaseFrontendHandler<SignupRequest>
 
             auditService.submitAuditEvent(
                     FrontendAuditableEvent.CREATE_ACCOUNT,
-                    context.getAwsRequestId(),
+                    userContext.getClientSessionId(),
                     userContext.getSession().getSessionId(),
                     userContext
                             .getClient()

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -121,18 +121,17 @@ public class StartHandler
                                                 cookieConsent,
                                                 gaTrackingId,
                                                 configurationService.isIdentityEnabled());
+                                var clientSessionId =
+                                        getHeaderValueFromHeaders(
+                                                input.getHeaders(),
+                                                CLIENT_SESSION_ID_HEADER,
+                                                configurationService.getHeadersCaseInsensitive());
                                 if (userStartInfo.isDocCheckingAppUser()) {
                                     var docAppSubjectId =
                                             ClientSubjectHelper.calculatePairwiseIdentifier(
                                                     new Subject().getValue(),
                                                     configurationService.getDocAppDomain(),
                                                     SaltHelper.generateNewSalt());
-                                    var clientSessionId =
-                                            getHeaderValueFromHeaders(
-                                                    input.getHeaders(),
-                                                    CLIENT_SESSION_ID_HEADER,
-                                                    configurationService
-                                                            .getHeadersCaseInsensitive());
                                     clientSessionService.saveClientSession(
                                             clientSessionId,
                                             clientSession
@@ -148,7 +147,7 @@ public class StartHandler
 
                                 auditService.submitAuditEvent(
                                         FrontendAuditableEvent.START_INFO_FOUND,
-                                        context.getAwsRequestId(),
+                                        clientSessionId,
                                         session.get().getSessionId(),
                                         userContext.getClient().get().getClientID(),
                                         AuditService.UNKNOWN,

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
@@ -87,10 +87,10 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
     }
 
     @Override
-    public void onRequestReceived(Context context) {
+    public void onRequestReceived(String clientSessionId) {
         auditService.submitAuditEvent(
                 UPDATE_PROFILE_REQUEST_RECEIVED,
-                context.getAwsRequestId(),
+                clientSessionId,
                 AuditService.UNKNOWN,
                 AuditService.UNKNOWN,
                 AuditService.UNKNOWN,
@@ -101,10 +101,10 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
     }
 
     @Override
-    public void onRequestValidationError(Context context) {
+    public void onRequestValidationError(String clientSessionId) {
         auditService.submitAuditEvent(
                 UPDATE_PROFILE_REQUEST_ERROR,
-                context.getAwsRequestId(),
+                clientSessionId,
                 AuditService.UNKNOWN,
                 AuditService.UNKNOWN,
                 AuditService.UNKNOWN,
@@ -137,7 +137,7 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
             LOG.info("Invalid session");
             return generateErrorResponse(
                     ErrorResponse.ERROR_1000,
-                    context,
+                    userContext.getClientSessionId(),
                     AuditService.UNKNOWN,
                     AuditService.UNKNOWN,
                     AuditService.UNKNOWN,
@@ -167,7 +167,7 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
                     if (errorResponse.isPresent()) {
                         return generateErrorResponse(
                                 errorResponse.get(),
-                                context,
+                                userContext.getClientSessionId(),
                                 session.getSessionId(),
                                 auditableClientId,
                                 request.getEmail(),
@@ -188,7 +188,7 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
                     if (clientSession == null) {
                         return generateErrorResponse(
                                 ErrorResponse.ERROR_1018,
-                                context,
+                                userContext.getClientSessionId(),
                                 session.getSessionId(),
                                 auditableClientId,
                                 request.getEmail(),
@@ -201,7 +201,7 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
                     } catch (ParseException e) {
                         return generateErrorResponse(
                                 ErrorResponse.ERROR_1038,
-                                context,
+                                userContext.getClientSessionId(),
                                 session.getSessionId(),
                                 auditableClientId,
                                 request.getEmail(),
@@ -245,7 +245,7 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
                     if (!base32.isInAlphabet(request.getProfileInformation())) {
                         return generateErrorResponse(
                                 ErrorResponse.ERROR_1041,
-                                context,
+                                userContext.getClientSessionId(),
                                 session.getSessionId(),
                                 auditableClientId,
                                 request.getEmail(),
@@ -267,7 +267,7 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
                         session.getSessionId());
                 return generateErrorResponse(
                         ErrorResponse.ERROR_1013,
-                        context,
+                        userContext.getClientSessionId(),
                         session.getSessionId(),
                         auditableClientId,
                         request.getEmail(),
@@ -275,7 +275,7 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
         }
         auditService.submitAuditEvent(
                 auditableEvent,
-                context.getAwsRequestId(),
+                userContext.getClientSessionId(),
                 session.getSessionId(),
                 auditableClientId,
                 userContext
@@ -327,14 +327,14 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
 
     private APIGatewayProxyResponseEvent generateErrorResponse(
             ErrorResponse errorResponse,
-            Context context,
+            String clientSessionId,
             String sessionId,
             String clientId,
             String email,
             String persistentSessionId) {
         auditService.submitAuditEvent(
                 UPDATE_PROFILE_REQUEST_ERROR,
-                context.getAwsRequestId(),
+                clientSessionId,
                 sessionId,
                 clientId,
                 AuditService.UNKNOWN,

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -141,9 +141,9 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                     session,
                     mfaMethodType,
                     input,
-                    context,
                     userContext,
-                    isRegistration);
+                    isRegistration,
+                    clientSessionId);
 
             sessionService.save(session);
 
@@ -208,9 +208,9 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
             Session session,
             MFAMethodType mfaMethodType,
             APIGatewayProxyRequestEvent input,
-            Context context,
             UserContext userContext,
-            boolean isRegistration) {
+            boolean isRegistration,
+            String clientSessionId) {
 
         var auditableEvent = errorResponseAsFrontendAuditableEvent(errorResponse);
 
@@ -226,7 +226,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
 
         auditService.submitAuditEvent(
                 auditableEvent,
-                context.getAwsRequestId(),
+                clientSessionId,
                 session.getSessionId(),
                 userContext
                         .getClient()

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -137,13 +137,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
             var errorResponse = mfaCodeValidator.validateCode(codeRequest.getCode());
 
             processCodeSession(
-                    errorResponse,
-                    session,
-                    mfaMethodType,
-                    input,
-                    userContext,
-                    isRegistration,
-                    clientSessionId);
+                    errorResponse, session, mfaMethodType, input, userContext, isRegistration);
 
             sessionService.save(session);
 
@@ -209,8 +203,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
             MFAMethodType mfaMethodType,
             APIGatewayProxyRequestEvent input,
             UserContext userContext,
-            boolean isRegistration,
-            String clientSessionId) {
+            boolean isRegistration) {
 
         var auditableEvent = errorResponseAsFrontendAuditableEvent(errorResponse);
 
@@ -226,7 +219,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
 
         auditService.submitAuditEvent(
                 auditableEvent,
-                clientSessionId,
+                userContext.getClientSessionId(),
                 session.getSessionId(),
                 userContext
                         .getClient()

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
@@ -41,6 +41,8 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.frontendapi.lambda.StartHandlerTest.CLIENT_SESSION_ID;
+import static uk.gov.di.authentication.frontendapi.lambda.StartHandlerTest.CLIENT_SESSION_ID_HEADER;
 import static uk.gov.di.authentication.sharedtest.helper.RequestEventHelper.contextWithSourceIp;
 import static uk.gov.di.authentication.sharedtest.logging.LogEventMatcher.withMessageContaining;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
@@ -91,6 +93,7 @@ class CheckUserExistsHandlerTest {
         Map<String, String> headers = new HashMap<>();
         headers.put(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, persistentId);
         headers.put("Session-Id", session.getSessionId());
+        headers.put(CLIENT_SESSION_ID_HEADER, CLIENT_SESSION_ID);
         when(authenticationService.userExists(eq("joe.bloggs@digital.cabinet-office.gov.uk")))
                 .thenReturn(true);
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
@@ -110,7 +113,7 @@ class CheckUserExistsHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CHECK_USER_KNOWN_EMAIL,
-                        "aws-session-id",
+                        CLIENT_SESSION_ID,
                         session.getSessionId(),
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
@@ -128,7 +131,12 @@ class CheckUserExistsHandlerTest {
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setBody("{ \"email\": \"joe.bloggs@digital.cabinet-office.gov.uk\" }");
-        event.setHeaders(Map.of("Session-Id", session.getSessionId()));
+        event.setHeaders(
+                Map.of(
+                        "Session-Id",
+                        session.getSessionId(),
+                        CLIENT_SESSION_ID_HEADER,
+                        CLIENT_SESSION_ID));
         event.setRequestContext(contextWithSourceIp("123.123.123.123"));
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
@@ -143,7 +151,7 @@ class CheckUserExistsHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CHECK_USER_NO_ACCOUNT_WITH_EMAIL,
-                        "aws-session-id",
+                        CLIENT_SESSION_ID,
                         session.getSessionId(),
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
@@ -187,7 +195,12 @@ class CheckUserExistsHandlerTest {
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setBody("{ \"email\": \"joe.bloggs\" }");
-        event.setHeaders(Map.of("Session-Id", session.getSessionId()));
+        event.setHeaders(
+                Map.of(
+                        "Session-Id",
+                        session.getSessionId(),
+                        CLIENT_SESSION_ID_HEADER,
+                        CLIENT_SESSION_ID));
         event.setRequestContext(contextWithSourceIp("123.123.123.123"));
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
@@ -197,7 +210,7 @@ class CheckUserExistsHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CHECK_USER_INVALID_EMAIL,
-                        "aws-session-id",
+                        CLIENT_SESSION_ID,
                         session.getSessionId(),
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
@@ -69,6 +69,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.frontendapi.lambda.StartHandlerTest.CLIENT_SESSION_ID;
+import static uk.gov.di.authentication.frontendapi.lambda.StartHandlerTest.CLIENT_SESSION_ID_HEADER;
 import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.LOW_LEVEL;
 import static uk.gov.di.authentication.shared.entity.MFAMethodType.SMS;
 import static uk.gov.di.authentication.sharedtest.helper.JsonArrayHelper.jsonArrayOf;
@@ -151,6 +153,7 @@ class LoginHandlerTest {
         Map<String, String> headers = new HashMap<>();
         headers.put(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, persistentId);
         headers.put("Session-Id", session.getSessionId());
+        headers.put(CLIENT_SESSION_ID_HEADER, CLIENT_SESSION_ID);
         UserProfile userProfile = generateUserProfile(null);
         when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
                 .thenReturn(Optional.of(userProfile));
@@ -185,7 +188,7 @@ class LoginHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.LOG_IN_SUCCESS,
-                        "aws-session-id",
+                        CLIENT_SESSION_ID,
                         session.getSessionId(),
                         CLIENT_ID.getValue(),
                         userProfile.getSubjectID(),
@@ -206,6 +209,7 @@ class LoginHandlerTest {
         Map<String, String> headers = new HashMap<>();
         headers.put(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, persistentId);
         headers.put("Session-Id", session.getSessionId());
+        headers.put(CLIENT_SESSION_ID_HEADER, CLIENT_SESSION_ID);
         UserProfile userProfile = generateUserProfile(null);
         when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
                 .thenReturn(Optional.of(userProfile));
@@ -235,7 +239,7 @@ class LoginHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.LOG_IN_SUCCESS,
-                        "aws-session-id",
+                        CLIENT_SESSION_ID,
                         session.getSessionId(),
                         CLIENT_ID.getValue(),
                         userProfile.getSubjectID(),
@@ -256,6 +260,7 @@ class LoginHandlerTest {
         Map<String, String> headers = new HashMap<>();
         headers.put(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, persistentId);
         headers.put("Session-Id", session.getSessionId());
+        headers.put(CLIENT_SESSION_ID_HEADER, CLIENT_SESSION_ID);
         UserProfile userProfile = generateUserProfile(null);
         when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
                 .thenReturn(Optional.of(userProfile));
@@ -285,7 +290,7 @@ class LoginHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.LOG_IN_SUCCESS,
-                        "aws-session-id",
+                        CLIENT_SESSION_ID,
                         session.getSessionId(),
                         CLIENT_ID.getValue(),
                         userProfile.getSubjectID(),
@@ -400,7 +405,12 @@ class LoginHandlerTest {
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setRequestContext(contextWithSourceIp("123.123.123.123"));
-        event.setHeaders(Map.of("Session-Id", session.getSessionId()));
+        event.setHeaders(
+                Map.of(
+                        "Session-Id",
+                        session.getSessionId(),
+                        CLIENT_SESSION_ID_HEADER,
+                        CLIENT_SESSION_ID));
         event.setBody(format("{ \"password\": \"%s\", \"email\": \"%s\" }", PASSWORD, EMAIL));
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
@@ -410,7 +420,7 @@ class LoginHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.ACCOUNT_TEMPORARILY_LOCKED,
-                        "aws-session-id",
+                        CLIENT_SESSION_ID,
                         session.getSessionId(),
                         "",
                         userProfile.getSubjectID(),
@@ -457,7 +467,12 @@ class LoginHandlerTest {
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setRequestContext(contextWithSourceIp("123.123.123.123"));
-        event.setHeaders(Map.of("Session-Id", session.getSessionId()));
+        event.setHeaders(
+                Map.of(
+                        "Session-Id",
+                        session.getSessionId(),
+                        CLIENT_SESSION_ID_HEADER,
+                        CLIENT_SESSION_ID));
         event.setBody(format("{ \"password\": \"%s\", \"email\": \"%s\" }", PASSWORD, EMAIL));
 
         usingValidSession();
@@ -468,7 +483,7 @@ class LoginHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.INVALID_CREDENTIALS,
-                        "aws-session-id",
+                        CLIENT_SESSION_ID,
                         session.getSessionId(),
                         "",
                         "",
@@ -494,7 +509,12 @@ class LoginHandlerTest {
         when(userMigrationService.processMigratedUser(applicableUserCredentials, PASSWORD))
                 .thenReturn(false);
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        event.setHeaders(Map.of("Session-Id", session.getSessionId()));
+        event.setHeaders(
+                Map.of(
+                        "Session-Id",
+                        session.getSessionId(),
+                        CLIENT_SESSION_ID_HEADER,
+                        CLIENT_SESSION_ID));
         event.setBody(format("{ \"password\": \"%s\", \"email\": \"%s\" }", PASSWORD, EMAIL));
         usingValidSession();
         usingDefaultVectorOfTrust();
@@ -508,7 +528,12 @@ class LoginHandlerTest {
     @Test
     void shouldReturn400IfAnyRequestParametersAreMissing() {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        event.setHeaders(Map.of("Session-Id", session.getSessionId()));
+        event.setHeaders(
+                Map.of(
+                        "Session-Id",
+                        session.getSessionId(),
+                        CLIENT_SESSION_ID_HEADER,
+                        CLIENT_SESSION_ID));
         event.setBody(format("{ \"password\": \"%s\"}", PASSWORD));
 
         usingValidSession();
@@ -522,7 +547,12 @@ class LoginHandlerTest {
     @Test
     void shouldReturn400IfSessionIdIsInvalid() {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        event.setHeaders(Map.of("Session-Id", session.getSessionId()));
+        event.setHeaders(
+                Map.of(
+                        "Session-Id",
+                        session.getSessionId(),
+                        CLIENT_SESSION_ID_HEADER,
+                        CLIENT_SESSION_ID));
         event.setBody(format("{ \"password\": \"%s\"}", PASSWORD));
 
         when(sessionService.getSessionFromRequestHeaders(event.getHeaders()))
@@ -539,7 +569,12 @@ class LoginHandlerTest {
         when(authenticationService.getUserProfileByEmailMaybe(EMAIL)).thenReturn(Optional.empty());
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setRequestContext(contextWithSourceIp("123.123.123.123"));
-        event.setHeaders(Map.of("Session-Id", session.getSessionId()));
+        event.setHeaders(
+                Map.of(
+                        "Session-Id",
+                        session.getSessionId(),
+                        CLIENT_SESSION_ID_HEADER,
+                        CLIENT_SESSION_ID));
         event.setBody(format("{ \"password\": \"%s\", \"email\": \"%s\" }", PASSWORD, EMAIL));
         usingValidSession();
         usingDefaultVectorOfTrust();
@@ -549,7 +584,7 @@ class LoginHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.NO_ACCOUNT_WITH_EMAIL,
-                        "aws-session-id",
+                        CLIENT_SESSION_ID,
                         session.getSessionId(),
                         "",
                         "",

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
@@ -55,6 +55,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.frontendapi.lambda.StartHandlerTest.CLIENT_SESSION_ID;
+import static uk.gov.di.authentication.frontendapi.lambda.StartHandlerTest.CLIENT_SESSION_ID_HEADER;
 import static uk.gov.di.authentication.shared.entity.NotificationType.MFA_SMS;
 import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_PHONE_NUMBER;
 import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_BLOCKED_KEY_PREFIX;
@@ -133,6 +135,7 @@ public class MfaHandlerTest {
         Map<String, String> headers = new HashMap<>();
         headers.put(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, persistentId);
         headers.put("Session-Id", session.getSessionId());
+        headers.put(CLIENT_SESSION_ID_HEADER, CLIENT_SESSION_ID);
         when(authenticationService.getPhoneNumber(TEST_EMAIL_ADDRESS))
                 .thenReturn(Optional.of(PHONE_NUMBER));
         when(codeGeneratorService.sixDigitCode()).thenReturn(CODE);
@@ -152,7 +155,7 @@ public class MfaHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.MFA_CODE_SENT,
-                        "aws-session-id",
+                        CLIENT_SESSION_ID,
                         session.getSessionId(),
                         "",
                         AuditService.UNKNOWN,
@@ -169,6 +172,7 @@ public class MfaHandlerTest {
         Map<String, String> headers = new HashMap<>();
         headers.put(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, persistentId);
         headers.put("Session-Id", session.getSessionId());
+        headers.put(CLIENT_SESSION_ID_HEADER, CLIENT_SESSION_ID);
         when(authenticationService.getPhoneNumber(TEST_EMAIL_ADDRESS))
                 .thenReturn(Optional.of(PHONE_NUMBER));
         when(codeStorageService.getOtpCode(TEST_EMAIL_ADDRESS, VERIFY_PHONE_NUMBER))
@@ -198,7 +202,7 @@ public class MfaHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.MFA_CODE_SENT,
-                        "aws-session-id",
+                        CLIENT_SESSION_ID,
                         session.getSessionId(),
                         "",
                         AuditService.UNKNOWN,
@@ -218,7 +222,12 @@ public class MfaHandlerTest {
         NotifyRequest notifyRequest =
                 new NotifyRequest(PHONE_NUMBER, MFA_SMS, CODE, SupportedLanguage.EN);
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        event.setHeaders(Map.of("Session-Id", session.getSessionId()));
+        event.setHeaders(
+                Map.of(
+                        "Session-Id",
+                        session.getSessionId(),
+                        CLIENT_SESSION_ID_HEADER,
+                        CLIENT_SESSION_ID));
         event.setBody(format("{ \"email\": \"%s\"}", TEST_EMAIL_ADDRESS));
         event.setRequestContext(contextWithSourceIp("123.123.123.123"));
 
@@ -231,7 +240,7 @@ public class MfaHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.MFA_CODE_SENT,
-                        "aws-session-id",
+                        CLIENT_SESSION_ID,
                         session.getSessionId(),
                         "",
                         AuditService.UNKNOWN,
@@ -262,7 +271,12 @@ public class MfaHandlerTest {
                 .thenReturn(Optional.of(PHONE_NUMBER));
         when(codeGeneratorService.sixDigitCode()).thenReturn(CODE);
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        event.setHeaders(Map.of("Session-Id", session.getSessionId()));
+        event.setHeaders(
+                Map.of(
+                        "Session-Id",
+                        session.getSessionId(),
+                        CLIENT_SESSION_ID_HEADER,
+                        CLIENT_SESSION_ID));
         event.setBody(format("{ \"email\": \"%s\"}", "wrong.email@gov.uk"));
         event.setRequestContext(contextWithSourceIp("123.123.123.123"));
 
@@ -273,7 +287,7 @@ public class MfaHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.MFA_MISMATCHED_EMAIL,
-                        "aws-session-id",
+                        CLIENT_SESSION_ID,
                         session.getSessionId(),
                         "",
                         AuditService.UNKNOWN,
@@ -288,7 +302,12 @@ public class MfaHandlerTest {
         usingValidSession();
         when(authenticationService.getPhoneNumber(TEST_EMAIL_ADDRESS)).thenReturn(Optional.empty());
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        event.setHeaders(Map.of("Session-Id", session.getSessionId()));
+        event.setHeaders(
+                Map.of(
+                        "Session-Id",
+                        session.getSessionId(),
+                        CLIENT_SESSION_ID_HEADER,
+                        CLIENT_SESSION_ID));
         event.setBody(format("{ \"email\": \"%s\"}", TEST_EMAIL_ADDRESS));
         event.setRequestContext(contextWithSourceIp("123.123.123.123"));
 
@@ -300,7 +319,7 @@ public class MfaHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.MFA_MISSING_PHONE_NUMBER,
-                        "aws-session-id",
+                        CLIENT_SESSION_ID,
                         session.getSessionId(),
                         "",
                         AuditService.UNKNOWN,
@@ -321,7 +340,12 @@ public class MfaHandlerTest {
         session.incrementCodeRequestCount();
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        event.setHeaders(Map.of("Session-Id", session.getSessionId()));
+        event.setHeaders(
+                Map.of(
+                        "Session-Id",
+                        session.getSessionId(),
+                        CLIENT_SESSION_ID_HEADER,
+                        CLIENT_SESSION_ID));
         event.setBody(format("{ \"email\": \"%s\"}", TEST_EMAIL_ADDRESS));
         event.setRequestContext(contextWithSourceIp("123.123.123.123"));
 
@@ -339,7 +363,7 @@ public class MfaHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.MFA_INVALID_CODE_REQUEST,
-                        "aws-session-id",
+                        CLIENT_SESSION_ID,
                         session.getSessionId(),
                         "",
                         AuditService.UNKNOWN,
@@ -357,7 +381,12 @@ public class MfaHandlerTest {
                 .thenReturn(true);
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        event.setHeaders(Map.of("Session-Id", session.getSessionId()));
+        event.setHeaders(
+                Map.of(
+                        "Session-Id",
+                        session.getSessionId(),
+                        CLIENT_SESSION_ID_HEADER,
+                        CLIENT_SESSION_ID));
         event.setBody(format("{ \"email\": \"%s\"}", TEST_EMAIL_ADDRESS));
         event.setRequestContext(contextWithSourceIp("123.123.123.123"));
 
@@ -369,7 +398,7 @@ public class MfaHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.MFA_INVALID_CODE_REQUEST,
-                        "aws-session-id",
+                        CLIENT_SESSION_ID,
                         session.getSessionId(),
                         "",
                         AuditService.UNKNOWN,
@@ -386,7 +415,12 @@ public class MfaHandlerTest {
                 .thenReturn(true);
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        event.setHeaders(Map.of("Session-Id", session.getSessionId()));
+        event.setHeaders(
+                Map.of(
+                        "Session-Id",
+                        session.getSessionId(),
+                        CLIENT_SESSION_ID_HEADER,
+                        CLIENT_SESSION_ID));
         event.setBody(format("{ \"email\": \"%s\"}", TEST_EMAIL_ADDRESS));
         event.setRequestContext(contextWithSourceIp("123.123.123.123"));
 
@@ -398,7 +432,7 @@ public class MfaHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.MFA_INVALID_CODE_REQUEST,
-                        "aws-session-id",
+                        CLIENT_SESSION_ID,
                         session.getSessionId(),
                         "",
                         AuditService.UNKNOWN,
@@ -420,7 +454,12 @@ public class MfaHandlerTest {
         NotifyRequest notifyRequest =
                 new NotifyRequest(PHONE_NUMBER, MFA_SMS, CODE, SupportedLanguage.EN);
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        event.setHeaders(Map.of("Session-Id", session.getSessionId()));
+        event.setHeaders(
+                Map.of(
+                        "Session-Id",
+                        session.getSessionId(),
+                        CLIENT_SESSION_ID_HEADER,
+                        CLIENT_SESSION_ID));
         event.setBody(format("{ \"email\": \"%s\"}", TEST_EMAIL_ADDRESS));
         event.setRequestContext(contextWithSourceIp("123.123.123.123"));
 
@@ -433,7 +472,7 @@ public class MfaHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.MFA_CODE_SENT_FOR_TEST_CLIENT,
-                        "aws-session-id",
+                        CLIENT_SESSION_ID,
                         session.getSessionId(),
                         TEST_CLIENT_ID,
                         AuditService.UNKNOWN,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandlerTest.java
@@ -42,6 +42,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.frontendapi.lambda.StartHandlerTest.CLIENT_SESSION_ID;
+import static uk.gov.di.authentication.frontendapi.lambda.StartHandlerTest.CLIENT_SESSION_ID_HEADER;
 import static uk.gov.di.authentication.sharedtest.helper.RequestEventHelper.contextWithSourceIp;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
@@ -103,6 +105,7 @@ class ResetPasswordHandlerTest {
         Map<String, String> headers = new HashMap<>();
         headers.put(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, PERSISTENT_ID);
         headers.put("Session-Id", session.getSessionId());
+        headers.put(CLIENT_SESSION_ID_HEADER, CLIENT_SESSION_ID);
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setHeaders(headers);
         event.setBody(format("{ \"code\": \"%s\", \"password\": \"%s\"}", CODE, NEW_PASSWORD));
@@ -117,7 +120,7 @@ class ResetPasswordHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.PASSWORD_RESET_SUCCESSFUL,
-                        context.getAwsRequestId(),
+                        CLIENT_SESSION_ID,
                         session.getSessionId(),
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
@@ -139,6 +142,7 @@ class ResetPasswordHandlerTest {
         Map<String, String> headers = new HashMap<>();
         headers.put(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, PERSISTENT_ID);
         headers.put("Session-Id", session.getSessionId());
+        headers.put(CLIENT_SESSION_ID_HEADER, CLIENT_SESSION_ID);
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setHeaders(headers);
         event.setBody(format("{ \"password\": \"%s\"}", NEW_PASSWORD));
@@ -152,7 +156,7 @@ class ResetPasswordHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.PASSWORD_RESET_SUCCESSFUL,
-                        context.getAwsRequestId(),
+                        CLIENT_SESSION_ID,
                         session.getSessionId(),
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
@@ -175,6 +179,7 @@ class ResetPasswordHandlerTest {
         Map<String, String> headers = new HashMap<>();
         headers.put(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, PERSISTENT_ID);
         headers.put("Session-Id", session.getSessionId());
+        headers.put(CLIENT_SESSION_ID_HEADER, CLIENT_SESSION_ID);
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setBody(format("{ \"code\": \"%s\", \"password\": \"%s\"}", CODE, NEW_PASSWORD));
         event.setHeaders(headers);
@@ -189,7 +194,7 @@ class ResetPasswordHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.PASSWORD_RESET_SUCCESSFUL,
-                        context.getAwsRequestId(),
+                        CLIENT_SESSION_ID,
                         session.getSessionId(),
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
@@ -277,6 +282,7 @@ class ResetPasswordHandlerTest {
         Map<String, String> headers = new HashMap<>();
         headers.put(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, PERSISTENT_ID);
         headers.put("Session-Id", session.getSessionId());
+        headers.put(CLIENT_SESSION_ID_HEADER, CLIENT_SESSION_ID);
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setBody(format("{ \"code\": \"%s\", \"password\": \"%s\"}", CODE, NEW_PASSWORD));
         event.setHeaders(headers);
@@ -290,7 +296,7 @@ class ResetPasswordHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.PASSWORD_RESET_SUCCESSFUL,
-                        context.getAwsRequestId(),
+                        CLIENT_SESSION_ID,
                         session.getSessionId(),
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
@@ -52,6 +52,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.frontendapi.lambda.StartHandlerTest.CLIENT_SESSION_ID;
+import static uk.gov.di.authentication.frontendapi.lambda.StartHandlerTest.CLIENT_SESSION_ID_HEADER;
 import static uk.gov.di.authentication.shared.entity.NotificationType.RESET_PASSWORD;
 import static uk.gov.di.authentication.shared.entity.NotificationType.RESET_PASSWORD_WITH_CODE;
 import static uk.gov.di.authentication.shared.services.CodeStorageService.PASSWORD_RESET_BLOCKED_KEY_PREFIX;
@@ -123,6 +125,7 @@ class ResetPasswordRequestHandlerTest {
         Map<String, String> headers = new HashMap<>();
         headers.put(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, persistentId);
         headers.put("Session-Id", session.getSessionId());
+        headers.put(CLIENT_SESSION_ID_HEADER, CLIENT_SESSION_ID);
         Subject subject = new Subject("subject_1");
         when(authenticationService.getSubjectFromEmail(TEST_EMAIL_ADDRESS)).thenReturn(subject);
         when(resetPasswordService.buildResetPasswordLink(
@@ -154,7 +157,7 @@ class ResetPasswordRequestHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.PASSWORD_RESET_REQUESTED,
-                        context.getAwsRequestId(),
+                        CLIENT_SESSION_ID,
                         session.getSessionId(),
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
@@ -170,6 +173,7 @@ class ResetPasswordRequestHandlerTest {
         Map<String, String> headers = new HashMap<>();
         headers.put(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, persistentId);
         headers.put("Session-Id", session.getSessionId());
+        headers.put(CLIENT_SESSION_ID_HEADER, CLIENT_SESSION_ID);
         Subject subject = new Subject("subject_1");
         when(authenticationService.getSubjectFromEmail(TEST_EMAIL_ADDRESS)).thenReturn(subject);
         NotifyRequest notifyRequest =
@@ -201,7 +205,7 @@ class ResetPasswordRequestHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.PASSWORD_RESET_REQUESTED,
-                        context.getAwsRequestId(),
+                        CLIENT_SESSION_ID,
                         session.getSessionId(),
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -160,7 +160,7 @@ class StartHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.START_INFO_FOUND,
-                        "aws-session-id",
+                        CLIENT_SESSION_ID,
                         SESSION_ID,
                         TEST_CLIENT_ID,
                         AuditService.UNKNOWN,
@@ -224,7 +224,7 @@ class StartHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.START_INFO_FOUND,
-                        "aws-session-id",
+                        CLIENT_SESSION_ID,
                         SESSION_ID,
                         TEST_CLIENT_ID,
                         AuditService.UNKNOWN,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandlerTest.java
@@ -62,6 +62,7 @@ import static uk.gov.di.authentication.frontendapi.entity.UpdateProfileType.ADD_
 import static uk.gov.di.authentication.frontendapi.entity.UpdateProfileType.CAPTURE_CONSENT;
 import static uk.gov.di.authentication.frontendapi.entity.UpdateProfileType.REGISTER_AUTH_APP;
 import static uk.gov.di.authentication.frontendapi.entity.UpdateProfileType.UPDATE_TERMS_CONDS;
+import static uk.gov.di.authentication.frontendapi.lambda.StartHandlerTest.CLIENT_SESSION_ID_HEADER;
 import static uk.gov.di.authentication.shared.entity.MFAMethodType.AUTH_APP;
 import static uk.gov.di.authentication.shared.helpers.CookieHelper.buildCookieString;
 import static uk.gov.di.authentication.sharedtest.logging.LogEventMatcher.withMessageContaining;
@@ -137,6 +138,7 @@ class UpdateProfileHandlerTest {
         Map<String, String> headers = new HashMap<>();
         headers.put(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, persistentId);
         headers.put("Session-Id", session.getSessionId());
+        headers.put(CLIENT_SESSION_ID_HEADER, CLIENT_SESSION_ID);
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setHeaders(headers);
         event.setBody(
@@ -152,7 +154,7 @@ class UpdateProfileHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         UPDATE_PROFILE_PHONE_NUMBER,
-                        "request-id",
+                        CLIENT_SESSION_ID,
                         session.getSessionId(),
                         "",
                         "",
@@ -174,6 +176,7 @@ class UpdateProfileHandlerTest {
         Map<String, String> headers = new HashMap<>();
         headers.put(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, PERSISTENT_SESSION_ID);
         headers.put("Session-Id", session.getSessionId());
+        headers.put(CLIENT_SESSION_ID_HEADER, CLIENT_SESSION_ID);
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setHeaders(headers);
         event.setBody(
@@ -191,7 +194,7 @@ class UpdateProfileHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         UPDATE_PROFILE_REQUEST_ERROR,
-                        "request-id",
+                        CLIENT_SESSION_ID,
                         SESSION_ID,
                         CLIENT_ID.getValue(),
                         "",
@@ -211,7 +214,12 @@ class UpdateProfileHandlerTest {
         when(clientRegistry.getClientID()).thenReturn(CLIENT_ID.getValue());
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        event.setHeaders(Map.of("Session-Id", session.getSessionId()));
+        event.setHeaders(
+                Map.of(
+                        "Session-Id",
+                        session.getSessionId(),
+                        CLIENT_SESSION_ID_HEADER,
+                        CLIENT_SESSION_ID));
         event.setBody(
                 format(
                         "{ \"email\": \"%s\", \"updateProfileType\": \"%s\", \"profileInformation\": \"%s\" }",
@@ -226,7 +234,7 @@ class UpdateProfileHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         UPDATE_PROFILE_TERMS_CONDS_ACCEPTANCE,
-                        "request-id",
+                        CLIENT_SESSION_ID,
                         session.getSessionId(),
                         CLIENT_ID.getValue(),
                         INTERNAL_SUBJECT,
@@ -252,7 +260,9 @@ class UpdateProfileHandlerTest {
                                 SESSION_ID + "." + CLIENT_SESSION_ID,
                                 3600,
                                 "Secure; HttpOnly;",
-                                "domain")));
+                                "domain"),
+                        CLIENT_SESSION_ID_HEADER,
+                        CLIENT_SESSION_ID));
         event.setBody(
                 format(
                         "{ \"email\": \"%s\", \"updateProfileType\": \"%s\", \"profileInformation\": \"%s\" }",
@@ -265,7 +275,7 @@ class UpdateProfileHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         UPDATE_PROFILE_CONSENT_UPDATED,
-                        "request-id",
+                        CLIENT_SESSION_ID,
                         session.getSessionId(),
                         CLIENT_ID.getValue(),
                         INTERNAL_SUBJECT,
@@ -280,7 +290,12 @@ class UpdateProfileHandlerTest {
         usingValidSession();
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        event.setHeaders(Map.of("Session-Id", session.getSessionId()));
+        event.setHeaders(
+                Map.of(
+                        "Session-Id",
+                        session.getSessionId(),
+                        CLIENT_SESSION_ID_HEADER,
+                        CLIENT_SESSION_ID));
         event.setBody(
                 format(
                         "{ \"email\": \"%s\", \"updateProfileType\": \"%s\"}",
@@ -293,7 +308,15 @@ class UpdateProfileHandlerTest {
                 .updatePhoneNumber(eq(TEST_EMAIL_ADDRESS), eq(PHONE_NUMBER));
         verify(auditService)
                 .submitAuditEvent(
-                        UPDATE_PROFILE_REQUEST_ERROR, "request-id", "", "", "", "", "", "", "");
+                        UPDATE_PROFILE_REQUEST_ERROR,
+                        CLIENT_SESSION_ID,
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
+                        "");
     }
 
     @Test
@@ -307,7 +330,12 @@ class UpdateProfileHandlerTest {
 
         var authAppSecret = "JZ5PYIOWNZDAOBA65S5T77FEEKYCCIT2VE4RQDAJD7SO73T3LODA";
         var event = new APIGatewayProxyRequestEvent();
-        event.setHeaders(Map.of("Session-Id", session.getSessionId()));
+        event.setHeaders(
+                Map.of(
+                        "Session-Id",
+                        session.getSessionId(),
+                        CLIENT_SESSION_ID_HEADER,
+                        CLIENT_SESSION_ID));
         event.setBody(
                 format(
                         "{ \"email\": \"%s\", \"updateProfileType\": \"%s\", \"profileInformation\": \"%s\" }",
@@ -320,7 +348,7 @@ class UpdateProfileHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         UPDATE_PROFILE_AUTH_APP,
-                        "request-id",
+                        CLIENT_SESSION_ID,
                         session.getSessionId(),
                         CLIENT_ID.getValue(),
                         INTERNAL_SUBJECT,
@@ -346,7 +374,9 @@ class UpdateProfileHandlerTest {
                         "Session-Id",
                         session.getSessionId(),
                         PersistentIdHelper.PERSISTENT_ID_HEADER_NAME,
-                        PERSISTENT_SESSION_ID));
+                        PERSISTENT_SESSION_ID,
+                        CLIENT_SESSION_ID_HEADER,
+                        CLIENT_SESSION_ID));
         event.setBody(
                 format(
                         "{ \"email\": \"%s\", \"updateProfileType\": \"%s\", \"profileInformation\": \"%s\" }",
@@ -360,7 +390,7 @@ class UpdateProfileHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         UPDATE_PROFILE_REQUEST_ERROR,
-                        "request-id",
+                        CLIENT_SESSION_ID,
                         SESSION_ID,
                         CLIENT_ID.getValue(),
                         "",
@@ -397,7 +427,15 @@ class UpdateProfileHandlerTest {
 
         verify(auditService)
                 .submitAuditEvent(
-                        UPDATE_PROFILE_REQUEST_RECEIVED, "request-id", "", "", "", "", "", "", "");
+                        UPDATE_PROFILE_REQUEST_RECEIVED,
+                        CLIENT_SESSION_ID,
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
+                        "",
+                        "");
 
         return response;
     }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -48,6 +48,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.frontendapi.lambda.StartHandlerTest.CLIENT_SESSION_ID;
 import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.MEDIUM_LEVEL;
 import static uk.gov.di.authentication.shared.entity.NotificationType.MFA_SMS;
 import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_EMAIL;
@@ -157,7 +158,7 @@ class VerifyCodeHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CODE_VERIFIED,
-                        context.getAwsRequestId(),
+                        CLIENT_SESSION_ID,
                         session.getSessionId(),
                         CLIENT_ID,
                         "test-subject-id",
@@ -189,7 +190,7 @@ class VerifyCodeHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CODE_VERIFIED,
-                        context.getAwsRequestId(),
+                        CLIENT_SESSION_ID,
                         session.getSessionId(),
                         CLIENT_ID,
                         "test-subject-id",
@@ -284,7 +285,7 @@ class VerifyCodeHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CODE_MAX_RETRIES_REACHED,
-                        context.getAwsRequestId(),
+                        CLIENT_SESSION_ID,
                         session.getSessionId(),
                         CLIENT_ID,
                         "test-subject-id",
@@ -332,7 +333,7 @@ class VerifyCodeHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CODE_MAX_RETRIES_REACHED,
-                        context.getAwsRequestId(),
+                        CLIENT_SESSION_ID,
                         session.getSessionId(),
                         CLIENT_ID,
                         "test-subject-id",
@@ -370,7 +371,7 @@ class VerifyCodeHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CODE_VERIFIED,
-                        context.getAwsRequestId(),
+                        CLIENT_SESSION_ID,
                         session.getSessionId(),
                         CLIENT_ID,
                         "test-subject-id",
@@ -416,7 +417,7 @@ class VerifyCodeHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CODE_MAX_RETRIES_REACHED,
-                        context.getAwsRequestId(),
+                        CLIENT_SESSION_ID,
                         session.getSessionId(),
                         CLIENT_ID,
                         "test-subject-id",
@@ -473,7 +474,7 @@ class VerifyCodeHandlerTest {
                         "Session-Id",
                         session.map(Session::getSessionId).orElse("invalid-session-id"),
                         "Client-Session-Id",
-                        "client-session-id"));
+                        CLIENT_SESSION_ID));
         event.setBody(
                 format(
                         "{ \"code\": \"%s\", \"notificationType\": \"%s\" }",
@@ -487,7 +488,7 @@ class VerifyCodeHandlerTest {
         when(clientService.getClient(TEST_CLIENT_ID)).thenReturn(Optional.of(testClientRegistry));
         when(clientSessionService.getClientSessionFromRequestHeaders(event.getHeaders()))
                 .thenReturn(Optional.of(clientSession));
-        when(clientSessionService.getClientSession("client-session-id"))
+        when(clientSessionService.getClientSession(CLIENT_SESSION_ID))
                 .thenReturn(Optional.of(clientSession));
         when(clientSession.getEffectiveVectorOfTrust()).thenReturn(VectorOfTrust.getDefaults());
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -160,7 +160,7 @@ class VerifyMfaCodeHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CODE_VERIFIED,
-                        context.getAwsRequestId(),
+                        CLIENT_SESSION_ID,
                         session.getSessionId(),
                         CLIENT_ID,
                         SUBJECT_ID,
@@ -195,7 +195,7 @@ class VerifyMfaCodeHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CODE_VERIFIED,
-                        context.getAwsRequestId(),
+                        CLIENT_SESSION_ID,
                         session.getSessionId(),
                         CLIENT_ID,
                         SUBJECT_ID,
@@ -256,7 +256,7 @@ class VerifyMfaCodeHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CODE_MAX_RETRIES_REACHED,
-                        context.getAwsRequestId(),
+                        CLIENT_SESSION_ID,
                         session.getSessionId(),
                         CLIENT_ID,
                         SUBJECT_ID,
@@ -291,7 +291,7 @@ class VerifyMfaCodeHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.INVALID_CODE_SENT,
-                        context.getAwsRequestId(),
+                        CLIENT_SESSION_ID,
                         session.getSessionId(),
                         CLIENT_ID,
                         SUBJECT_ID,

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
@@ -110,7 +110,7 @@ public class ProcessingIdentityHandler extends BaseFrontendHandler<ProcessingIde
                             processingStatus.toString()));
             auditService.submitAuditEvent(
                     IPVAuditableEvent.PROCESSING_IDENTITY_REQUEST,
-                    context.getAwsRequestId(),
+                    userContext.getClientSessionId(),
                     userContext.getSession().getSessionId(),
                     userContext.getClient().get().getClientID(),
                     AuditService.UNKNOWN,

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandler.java
@@ -64,8 +64,7 @@ public class SPOTResponseHandler implements RequestHandler<SQSEvent, Object> {
                             spotResponse.getStatus());
                     submitAuditEvent(
                             IPVAuditableEvent.IPV_SUCCESSFUL_SPOT_RESPONSE_RECEIVED,
-                            spotResponse.getLogIds(),
-                            context.getAwsRequestId());
+                            spotResponse.getLogIds());
                     dynamoIdentityService.addCoreIdentityJWT(
                             spotResponse.getSub(),
                             spotResponse.getClaims().values().stream()
@@ -80,8 +79,7 @@ public class SPOTResponseHandler implements RequestHandler<SQSEvent, Object> {
                             spotResponse.getReason());
                     submitAuditEvent(
                             IPVAuditableEvent.IPV_UNSUCCESSFUL_SPOT_RESPONSE_RECEIVED,
-                            spotResponse.getLogIds(),
-                            context.getAwsRequestId());
+                            spotResponse.getLogIds());
                     dynamoIdentityService.deleteIdentityCredentials(spotResponse.getSub());
                     return null;
                 }
@@ -96,11 +94,10 @@ public class SPOTResponseHandler implements RequestHandler<SQSEvent, Object> {
         return null;
     }
 
-    private void submitAuditEvent(
-            AuditableEvent auditableEvent, LogIds logIds, String awsRequestId) {
+    private void submitAuditEvent(AuditableEvent auditableEvent, LogIds logIds) {
         auditService.submitAuditEvent(
                 auditableEvent,
-                awsRequestId,
+                logIds.getClientSessionId(),
                 logIds.getSessionId(),
                 logIds.getClientId(),
                 AuditService.UNKNOWN,

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandlerTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.ipv.lambda.ProcessingIdentityHandlerTest.CLIENT_SESSION_ID;
 
 class SPOTResponseHandlerTest {
 
@@ -40,8 +41,13 @@ class SPOTResponseHandlerTest {
         var json =
                 format(
                         "{\"sub\":\"urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6\",\"status\":\"ACCEPTED\","
-                                + "\"claims\":{\"http://something/v1/verifiableIdentityJWT\":\"random-searalized-credential\"}, \"log_ids\":{\"session_id\":\"%s\",\"persistent_session_id\":\"%s\",\"request_id\":\"%s\",\"client_id\":\"%s\"}}",
-                        SESSION_ID, PERSISTENT_SESSION_ID, REQUEST_ID, CLIENT_ID);
+                                + "\"claims\":{\"http://something/v1/verifiableIdentityJWT\":\"random-searalized-credential\"}, "
+                                + "\"log_ids\":{\"session_id\":\"%s\",\"persistent_session_id\":\"%s\",\"request_id\":\"%s\",\"client_id\":\"%s\",\"client_session_id\":\"%s\"}}",
+                        SESSION_ID,
+                        PERSISTENT_SESSION_ID,
+                        REQUEST_ID,
+                        CLIENT_ID,
+                        CLIENT_SESSION_ID);
 
         handler.handleRequest(generateSQSEvent(json), context);
 
@@ -53,7 +59,7 @@ class SPOTResponseHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         IPVAuditableEvent.IPV_SUCCESSFUL_SPOT_RESPONSE_RECEIVED,
-                        REQUEST_ID,
+                        CLIENT_SESSION_ID,
                         SESSION_ID,
                         CLIENT_ID.getValue(),
                         AuditService.UNKNOWN,
@@ -77,8 +83,12 @@ class SPOTResponseHandlerTest {
         var json =
                 format(
                         "{\"sub\":\"urn:uuid:f81d4fae-7dec-11d0-a765-00a0c91e6bf6\",\"status\":\"REJECTED\","
-                                + "\"log_ids\":{\"session_id\":\"%s\",\"persistent_session_id\":\"%s\",\"request_id\":\"%s\",\"client_id\":\"%s\"}}",
-                        SESSION_ID, PERSISTENT_SESSION_ID, REQUEST_ID, CLIENT_ID);
+                                + "\"log_ids\":{\"session_id\":\"%s\",\"persistent_session_id\":\"%s\",\"request_id\":\"%s\",\"client_id\":\"%s\",\"client_session_id\":\"%s\"}}",
+                        SESSION_ID,
+                        PERSISTENT_SESSION_ID,
+                        REQUEST_ID,
+                        CLIENT_ID,
+                        CLIENT_SESSION_ID);
 
         handler.handleRequest(generateSQSEvent(json), context);
 
@@ -88,7 +98,7 @@ class SPOTResponseHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         IPVAuditableEvent.IPV_UNSUCCESSFUL_SPOT_RESPONSE_RECEIVED,
-                        REQUEST_ID,
+                        CLIENT_SESSION_ID,
                         SESSION_ID,
                         CLIENT_ID.getValue(),
                         AuditService.UNKNOWN,

--- a/shared/src/main/java/uk/gov/di/authentication/shared/state/UserContext.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/state/UserContext.java
@@ -17,6 +17,7 @@ public class UserContext {
     private final Optional<ClientRegistry> client;
     private final ClientSession clientSession;
     private final SupportedLanguage userLanguage;
+    private final String clientSessionId;
 
     protected UserContext(
             Session session,
@@ -25,7 +26,8 @@ public class UserContext {
             boolean userAuthenticated,
             Optional<ClientRegistry> client,
             ClientSession clientSession,
-            SupportedLanguage userLanguage) {
+            SupportedLanguage userLanguage,
+            String clientSessionId) {
         this.session = session;
         this.userProfile = userProfile;
         this.userCredentials = userCredentials;
@@ -33,6 +35,7 @@ public class UserContext {
         this.client = client;
         this.clientSession = clientSession;
         this.userLanguage = userLanguage;
+        this.clientSessionId = clientSessionId;
     }
 
     public Session getSession() {
@@ -63,6 +66,10 @@ public class UserContext {
         return userLanguage;
     }
 
+    public String getClientSessionId() {
+        return clientSessionId;
+    }
+
     public static Builder builder(Session session) {
         return new Builder(session);
     }
@@ -75,6 +82,7 @@ public class UserContext {
         private Optional<ClientRegistry> client = Optional.empty();
         private ClientSession clientSession = null;
         private SupportedLanguage userLanguage;
+        private String clientSessionId;
 
         protected Builder(Session session) {
             this.session = session;
@@ -118,6 +126,11 @@ public class UserContext {
             return this;
         }
 
+        public Builder withClientSessionId(String clientSessionId) {
+            this.clientSessionId = clientSessionId;
+            return this;
+        }
+
         public UserContext build() {
             return new UserContext(
                     session,
@@ -126,7 +139,8 @@ public class UserContext {
                     userAuthenticated,
                     client,
                     clientSession,
-                    userLanguage);
+                    userLanguage,
+                    clientSessionId);
         }
     }
 }


### PR DESCRIPTION
## What?

Add client session id to audit payloads for lambdas in frontend-api

- Add `clientSessionId` to `UserContext` which is used in majority of the handlers
- Refactor `BaseFrontendHandler` to set the client session id in the user context in order for all handlers to have access to the `clientSessionId`

## Why?

We pass this value (client session id) up to IPV Core and the Document Checking App but don’t publish it to our own audit log.

## Related PRs

[Part 1](https://github.com/alphagov/di-authentication-api/pull/2336)
[Authorise Handler](https://github.com/alphagov/di-authentication-api/pull/2338)