### PR TITLE
AUT-708: Update remaining OIDC handlers

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -274,7 +274,7 @@ public class AuthCodeHandler
 
                                 auditService.submitAuditEvent(
                                         OidcAuditableEvent.AUTH_CODE_ISSUED,
-                                        context.getAwsRequestId(),
+                                        clientSessionId,
                                         session.getSessionId(),
                                         authenticationRequest.getClientID().getValue(),
                                         AuditService.UNKNOWN,

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
@@ -367,7 +367,7 @@ public class LogoutHandler
         }
         auditService.submitAuditEvent(
                 OidcAuditableEvent.LOG_OUT_SUCCESS,
-                context.getAwsRequestId(),
+                AuditService.UNKNOWN,
                 sessionId.orElse(AuditService.UNKNOWN),
                 clientId.orElse(AuditService.UNKNOWN),
                 AuditService.UNKNOWN,

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandler.java
@@ -130,7 +130,7 @@ public class UserInfoHandler
 
                             auditService.submitAuditEvent(
                                     OidcAuditableEvent.USER_INFO_RETURNED,
-                                    context.getAwsRequestId(),
+                                    AuditService.UNKNOWN,
                                     AuditService.UNKNOWN,
                                     accessTokenInfo.getClientID(),
                                     accessTokenInfo.getSubject(),

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -211,7 +211,7 @@ class AuthCodeHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         OidcAuditableEvent.AUTH_CODE_ISSUED,
-                        "aws-session-id",
+                        CLIENT_SESSION_ID,
                         SESSION_ID,
                         CLIENT_ID.getValue(),
                         AuditService.UNKNOWN,

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/LogoutHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/LogoutHandlerTest.java
@@ -152,7 +152,7 @@ class LogoutHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         OidcAuditableEvent.LOG_OUT_SUCCESS,
-                        "aws-session-id",
+                        AuditService.UNKNOWN,
                         SESSION_ID,
                         "client-id",
                         AuditService.UNKNOWN,
@@ -188,7 +188,7 @@ class LogoutHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         OidcAuditableEvent.LOG_OUT_SUCCESS,
-                        "aws-session-id",
+                        AuditService.UNKNOWN,
                         SESSION_ID,
                         "client-id",
                         AuditService.UNKNOWN,
@@ -220,7 +220,7 @@ class LogoutHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         OidcAuditableEvent.LOG_OUT_SUCCESS,
-                        "aws-session-id",
+                        AuditService.UNKNOWN,
                         SESSION_ID,
                         "client-id",
                         AuditService.UNKNOWN,
@@ -253,7 +253,7 @@ class LogoutHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         OidcAuditableEvent.LOG_OUT_SUCCESS,
-                        "aws-session-id",
+                        AuditService.UNKNOWN,
                         SESSION_ID,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
@@ -284,7 +284,7 @@ class LogoutHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         OidcAuditableEvent.LOG_OUT_SUCCESS,
-                        "aws-session-id",
+                        AuditService.UNKNOWN,
                         SESSION_ID,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
@@ -319,7 +319,7 @@ class LogoutHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         OidcAuditableEvent.LOG_OUT_SUCCESS,
-                        "aws-session-id",
+                        AuditService.UNKNOWN,
                         SESSION_ID,
                         "client-id",
                         AuditService.UNKNOWN,
@@ -350,7 +350,7 @@ class LogoutHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         OidcAuditableEvent.LOG_OUT_SUCCESS,
-                        "aws-session-id",
+                        AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
@@ -391,7 +391,7 @@ class LogoutHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         OidcAuditableEvent.LOG_OUT_SUCCESS,
-                        "aws-session-id",
+                        AuditService.UNKNOWN,
                         SESSION_ID,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
@@ -428,7 +428,7 @@ class LogoutHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         OidcAuditableEvent.LOG_OUT_SUCCESS,
-                        "aws-session-id",
+                        AuditService.UNKNOWN,
                         SESSION_ID,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
@@ -474,7 +474,7 @@ class LogoutHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         OidcAuditableEvent.LOG_OUT_SUCCESS,
-                        "aws-session-id",
+                        AuditService.UNKNOWN,
                         SESSION_ID,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
@@ -521,7 +521,7 @@ class LogoutHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         OidcAuditableEvent.LOG_OUT_SUCCESS,
-                        "aws-session-id",
+                        AuditService.UNKNOWN,
                         SESSION_ID,
                         "invalid-client-id",
                         AuditService.UNKNOWN,
@@ -568,7 +568,7 @@ class LogoutHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         OidcAuditableEvent.LOG_OUT_SUCCESS,
-                        "aws-session-id",
+                        AuditService.UNKNOWN,
                         SESSION_ID,
                         "client-id",
                         AuditService.UNKNOWN,

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandlerTest.java
@@ -87,7 +87,7 @@ public class UserInfoHandlerTest {
         verify(auditService)
                 .submitAuditEvent(
                         OidcAuditableEvent.USER_INFO_RETURNED,
-                        "aws-request-id",
+                        AuditService.UNKNOWN,
                         "",
                         "client-id",
                         SUBJECT.getValue(),


### PR DESCRIPTION
## What?

- Send clientSessionId from `AuthCodeHandler`
- Send `AuditService.UNKNOWN` from `LogoutHandler` and `UserInfoHandler` as these are not client session aware (currently)

## Why?

We wish to use clientSessionId to track journeys across the entire estate.

## Related PRs

#2336 
#2337 
#2338 