### PR TITLE
AUT-488: Support EC key signing

### DIFF
--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/AuthoriseAccessTokenIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/AuthoriseAccessTokenIntegrationTest.java
@@ -136,7 +136,7 @@ class AuthoriseAccessTokenIntegrationTest
     }
 
     private void setUpClient(List<String> scopes) {
-        var keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        var keyPair = KeyPairHelper.generateRsaKeyPair();
         clientStore.registerClient(
                 CLIENT_ID.getValue(),
                 "test-client",

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationService.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationService.java
@@ -141,17 +141,15 @@ public class ClientConfigValidationService {
     private boolean isPublicKeyValid(String publicKey) {
         byte[] decodedKey = Base64.getMimeDecoder().decode(publicKey);
         X509EncodedKeySpec x509publicKey = new X509EncodedKeySpec(decodedKey);
-        KeyFactory rsaKeyFactory;
-        KeyFactory ecKeyFactory;
 
         try {
-            rsaKeyFactory = KeyFactory.getInstance("RSA");
+            KeyFactory rsaKeyFactory = KeyFactory.getInstance("RSA");
             rsaKeyFactory.generatePublic(x509publicKey);
             LOG.info("Valid RSA key found");
             return true;
         } catch (Exception e) {
             try {
-                ecKeyFactory = KeyFactory.getInstance("EC");
+                KeyFactory ecKeyFactory = KeyFactory.getInstance("EC");
                 ecKeyFactory.generatePublic(x509publicKey);
             } catch (Exception ex) {
                 LOG.info("Valid key not found (checked RSA and EC)");

--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationService.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationService.java
@@ -139,10 +139,12 @@ public class ClientConfigValidationService {
     }
 
     private boolean isPublicKeyValid(String publicKey) {
-        byte[] decodedKey = Base64.getMimeDecoder().decode(publicKey);
-        X509EncodedKeySpec x509publicKey = new X509EncodedKeySpec(decodedKey);
+        byte[] decodedKey;
+        X509EncodedKeySpec x509publicKey = null;
 
         try {
+            decodedKey = Base64.getMimeDecoder().decode(publicKey);
+            x509publicKey = new X509EncodedKeySpec(decodedKey);
             KeyFactory rsaKeyFactory = KeyFactory.getInstance("RSA");
             rsaKeyFactory.generatePublic(x509publicKey);
             LOG.info("Valid RSA key found");

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationServiceTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationServiceTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import uk.gov.di.authentication.clientregistry.entity.ClientRegistrationRequest;
 import uk.gov.di.authentication.shared.entity.ClientType;
 import uk.gov.di.authentication.shared.entity.UpdateClientConfigRequest;
@@ -263,13 +264,14 @@ class ClientConfigValidationServiceTest {
                 Arguments.of("PAIRWISE", Optional.of(INVALID_SUBJECT_TYPE)));
     }
 
-    @Test
-    void shouldPassValidationForValidUpdateRequest() {
+    @ParameterizedTest
+    @ValueSource(strings = {VALID_RSA_PUBLIC_CERT, VALID_ECDSA_PUBLIC_CERT})
+    void shouldPassValidationForValidUpdateRequest(String publicCert) {
         Optional<ErrorObject> errorResponse =
                 validationService.validateClientUpdateConfig(
                         generateClientUpdateRequest(
                                 singletonList("http://localhost:1000/redirect"),
-                                VALID_RSA_PUBLIC_CERT,
+                                publicCert,
                                 singletonList("openid"),
                                 singletonList("http://localhost/post-redirect-logout"),
                                 String.valueOf(MANDATORY),

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationServiceTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/services/ClientConfigValidationServiceTest.java
@@ -32,8 +32,11 @@ class ClientConfigValidationServiceTest {
 
     private final ClientConfigValidationService validationService =
             new ClientConfigValidationService();
-    private static final String VALID_PUBLIC_CERT =
+    private static final String VALID_RSA_PUBLIC_CERT =
             "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxt91w8GsMDdklOpS8ZXAsIM1ztQZd5QT/bRCQahZJeS1a6Os4hbuKwzHlz52zfTNp7BL4RB/KOcRIPhOQLgqeyM+bVngRa1EIfTkugJHS2/gu2Xv0aelwvXj8FZgAPRPD+ps2wiV4tUehrFIsRyHZM3yOp9g6qapCcxF7l0E1PlVkKPcPNmxn2oFiqnP6ZThGbE+N2avdXHcySIqt/v6Hbmk8cDHzSExazW7j/XvA+xnp0nQ5m2GisCZul5If5edCTXD0tKzx/I/gtEG4gkv9kENWOt4grP8/0zjNAl2ac6kpRny3tY5RkKBKCOB1VHwq2lUTSNKs32O1BsA5ByyYQIDAQAB";
+    private static final String VALID_ECDSA_PUBLIC_CERT =
+            "MFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAESfEEiC4jDdrcsfLiCe3ltPxh048GyM9G\n"
+                    + "lsCeif85XpaqfJos/MfZX6wh8CmTfOl7UrjbWTwX2MNxpm8TVwA9sA==";
 
     private static Stream<Arguments> registrationRequestParams() {
         return Stream.of(
@@ -60,7 +63,7 @@ class ClientConfigValidationServiceTest {
 
     @ParameterizedTest
     @MethodSource("registrationRequestParams")
-    void shouldPassValidationForValidRegistrationRequest(
+    void shouldPassValidationForValidRegistrationRequestWithRsaAlgorithm(
             List<String> postlogoutUris,
             String backChannelLogoutUri,
             List<String> claims,
@@ -70,7 +73,31 @@ class ClientConfigValidationServiceTest {
                 validationService.validateClientRegistrationConfig(
                         generateClientRegRequest(
                                 singletonList("http://localhost:1000/redirect"),
-                                VALID_PUBLIC_CERT,
+                                VALID_RSA_PUBLIC_CERT,
+                                singletonList("openid"),
+                                postlogoutUris,
+                                backChannelLogoutUri,
+                                serviceType,
+                                "http://test.com",
+                                "public",
+                                claims,
+                                clientType));
+        assertThat(errorResponse, equalTo(Optional.empty()));
+    }
+
+    @ParameterizedTest
+    @MethodSource("registrationRequestParams")
+    void shouldPassValidationForValidRegistrationRequestWithEcAlgorithm(
+            List<String> postlogoutUris,
+            String backChannelLogoutUri,
+            List<String> claims,
+            String serviceType,
+            String clientType) {
+        Optional<ErrorObject> errorResponse =
+                validationService.validateClientRegistrationConfig(
+                        generateClientRegRequest(
+                                singletonList("http://localhost:1000/redirect"),
+                                VALID_ECDSA_PUBLIC_CERT,
                                 singletonList("openid"),
                                 postlogoutUris,
                                 backChannelLogoutUri,
@@ -88,7 +115,7 @@ class ClientConfigValidationServiceTest {
                 validationService.validateClientRegistrationConfig(
                         generateClientRegRequest(
                                 singletonList("http://localhost:1000/redirect"),
-                                VALID_PUBLIC_CERT,
+                                VALID_RSA_PUBLIC_CERT,
                                 singletonList("openid"),
                                 singletonList("invalid-logout-uri"),
                                 "http://example.com",
@@ -106,7 +133,7 @@ class ClientConfigValidationServiceTest {
                 validationService.validateClientRegistrationConfig(
                         generateClientRegRequest(
                                 singletonList("invalid-redirect-uri"),
-                                VALID_PUBLIC_CERT,
+                                VALID_RSA_PUBLIC_CERT,
                                 singletonList("openid"),
                                 singletonList("http://localhost/post-redirect-logout"),
                                 "http://example.com",
@@ -142,7 +169,7 @@ class ClientConfigValidationServiceTest {
                 validationService.validateClientRegistrationConfig(
                         generateClientRegRequest(
                                 singletonList("http://localhost:1000/redirect"),
-                                VALID_PUBLIC_CERT,
+                                VALID_RSA_PUBLIC_CERT,
                                 List.of("openid", "email", "fax"),
                                 singletonList("http://localhost/post-redirect-logout"),
                                 "http://example.com",
@@ -160,7 +187,7 @@ class ClientConfigValidationServiceTest {
                 validationService.validateClientRegistrationConfig(
                         generateClientRegRequest(
                                 singletonList("http://localhost:1000/redirect"),
-                                VALID_PUBLIC_CERT,
+                                VALID_RSA_PUBLIC_CERT,
                                 List.of("openid", "am"),
                                 singletonList("http://localhost/post-redirect-logout"),
                                 "http://example.com",
@@ -178,7 +205,7 @@ class ClientConfigValidationServiceTest {
                 validationService.validateClientRegistrationConfig(
                         generateClientRegRequest(
                                 singletonList("http://localhost:1000/redirect"),
-                                VALID_PUBLIC_CERT,
+                                VALID_RSA_PUBLIC_CERT,
                                 singletonList("openid"),
                                 singletonList("http://localhost/post-redirect-logout"),
                                 "http://example.com",
@@ -196,7 +223,7 @@ class ClientConfigValidationServiceTest {
                 validationService.validateClientRegistrationConfig(
                         generateClientRegRequest(
                                 singletonList("http://localhost:1000/redirect"),
-                                VALID_PUBLIC_CERT,
+                                VALID_RSA_PUBLIC_CERT,
                                 singletonList("openid"),
                                 singletonList("http://localhost/post-redirect-logout"),
                                 "http://example.com",
@@ -216,7 +243,7 @@ class ClientConfigValidationServiceTest {
                 validationService.validateClientRegistrationConfig(
                         generateClientRegRequest(
                                 singletonList("http://localhost:1000/redirect"),
-                                VALID_PUBLIC_CERT,
+                                VALID_RSA_PUBLIC_CERT,
                                 singletonList("openid"),
                                 singletonList("http://localhost/post-redirect-logout"),
                                 "http://example.com",
@@ -242,7 +269,7 @@ class ClientConfigValidationServiceTest {
                 validationService.validateClientUpdateConfig(
                         generateClientUpdateRequest(
                                 singletonList("http://localhost:1000/redirect"),
-                                VALID_PUBLIC_CERT,
+                                VALID_RSA_PUBLIC_CERT,
                                 singletonList("openid"),
                                 singletonList("http://localhost/post-redirect-logout"),
                                 String.valueOf(MANDATORY),
@@ -264,7 +291,7 @@ class ClientConfigValidationServiceTest {
                 validationService.validateClientUpdateConfig(
                         generateClientUpdateRequest(
                                 singletonList("http://localhost:1000/redirect"),
-                                VALID_PUBLIC_CERT,
+                                VALID_RSA_PUBLIC_CERT,
                                 singletonList("openid"),
                                 singletonList("invalid-logout-uri"),
                                 String.valueOf(MANDATORY),
@@ -279,7 +306,7 @@ class ClientConfigValidationServiceTest {
                 validationService.validateClientUpdateConfig(
                         generateClientUpdateRequest(
                                 singletonList("invalid-redirect-uri"),
-                                VALID_PUBLIC_CERT,
+                                VALID_RSA_PUBLIC_CERT,
                                 singletonList("openid"),
                                 singletonList("http://localhost/post-redirect-logout"),
                                 String.valueOf(MANDATORY),
@@ -309,7 +336,7 @@ class ClientConfigValidationServiceTest {
                 validationService.validateClientUpdateConfig(
                         generateClientUpdateRequest(
                                 singletonList("http://localhost:1000/redirect"),
-                                VALID_PUBLIC_CERT,
+                                VALID_RSA_PUBLIC_CERT,
                                 List.of("openid", "email", "fax"),
                                 singletonList("http://localhost/post-redirect-logout"),
                                 String.valueOf(MANDATORY),
@@ -324,7 +351,7 @@ class ClientConfigValidationServiceTest {
                 validationService.validateClientUpdateConfig(
                         generateClientUpdateRequest(
                                 singletonList("http://localhost:1000/redirect"),
-                                VALID_PUBLIC_CERT,
+                                VALID_RSA_PUBLIC_CERT,
                                 List.of("openid", "email"),
                                 singletonList("http://localhost/post-redirect-logout"),
                                 String.valueOf(MANDATORY),

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
@@ -48,7 +48,7 @@ public class AuthCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     void shouldReturn302WithSuccessfulAuthorisationResponse() throws Json.JsonException {
         String sessionId = "some-session-id";
         String clientSessionId = "some-client-session-id";
-        KeyPair keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        KeyPair keyPair = KeyPairHelper.generateRsaKeyPair();
         redis.createSession(sessionId);
         redis.setVerifiedMfaMethodType(sessionId, MFAMethodType.AUTH_APP);
         redis.addAuthRequestToSession(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -68,7 +68,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     private static final String AM_CLIENT_ID = "am-test-client";
     private static final String TEST_EMAIL_ADDRESS = "joe.bloggs@digital.cabinet-office.gov.uk";
     private static final String TEST_PASSWORD = "password";
-    private static final KeyPair KEY_PAIR = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+    private static final KeyPair KEY_PAIR = KeyPairHelper.generateRsaKeyPair();
     public static final String DUMMY_CLIENT_SESSION_ID = "456";
 
     protected static final ConfigurationService configurationService =

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/LoginIntegrationTest.java
@@ -39,7 +39,7 @@ import static uk.gov.di.authentication.shared.entity.MFAMethodType.AUTH_APP;
 import static uk.gov.di.authentication.shared.entity.MFAMethodType.SMS;
 import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.helper.JsonArrayHelper.jsonArrayOf;
-import static uk.gov.di.authentication.sharedtest.helper.KeyPairHelper.GENERATE_RSA_KEY_PAIR;
+import static uk.gov.di.authentication.sharedtest.helper.KeyPairHelper.generateRsaKeyPair;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class LoginIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -100,7 +100,7 @@ public class LoginIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 singletonList("test-client@test.com"),
                 singletonList(scope.toString()),
                 Base64.getMimeEncoder()
-                        .encodeToString(GENERATE_RSA_KEY_PAIR().getPublic().getEncoded()),
+                        .encodeToString(generateRsaKeyPair().getPublic().getEncoded()),
                 singletonList("http://localhost/post-redirect-logout"),
                 "http://example.com",
                 String.valueOf(ServiceType.MANDATORY),

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/SignupIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/SignupIntegrationTest.java
@@ -33,7 +33,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.CREATE_ACCOUNT;
 import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
-import static uk.gov.di.authentication.sharedtest.helper.KeyPairHelper.GENERATE_RSA_KEY_PAIR;
+import static uk.gov.di.authentication.sharedtest.helper.KeyPairHelper.generateRsaKeyPair;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class SignupIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -83,7 +83,7 @@ public class SignupIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 singletonList("test-client@test.com"),
                 singletonList(scope.toString()),
                 Base64.getMimeEncoder()
-                        .encodeToString(GENERATE_RSA_KEY_PAIR().getPublic().getEncoded()),
+                        .encodeToString(generateRsaKeyPair().getPublic().getEncoded()),
                 singletonList("http://localhost/post-redirect-logout"),
                 "http://example.com",
                 String.valueOf(ServiceType.MANDATORY),
@@ -141,7 +141,7 @@ public class SignupIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 singletonList("test-client@test.com"),
                 singletonList(scope.toString()),
                 Base64.getMimeEncoder()
-                        .encodeToString(GENERATE_RSA_KEY_PAIR().getPublic().getEncoded()),
+                        .encodeToString(generateRsaKeyPair().getPublic().getEncoded()),
                 singletonList("http://localhost/post-redirect-logout"),
                 "http://example.com",
                 String.valueOf(ServiceType.MANDATORY),

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
@@ -92,7 +92,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         redis.createClientSession(CLIENT_SESSION_ID, authRequest.toParameters());
 
-        registerClient(KeyPairHelper.GENERATE_RSA_KEY_PAIR(), ClientType.WEB);
+        registerClient(KeyPairHelper.generateRsaKeyPair(), ClientType.WEB);
 
         Map<String, String> headers = new HashMap<>();
         headers.put("Session-Id", sessionId);
@@ -135,7 +135,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     @ValueSource(booleans = {true, false})
     void shouldReturn200WhenUserIsADocCheckingAppUser(boolean isAuthenticated)
             throws JOSEException, Json.JsonException {
-        var keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        var keyPair = KeyPairHelper.generateRsaKeyPair();
         var state = new State();
         var sessionId = redis.createSession(isAuthenticated);
         var scope = new Scope(OIDCScopeValue.OPENID, CustomScopeValue.DOC_CHECKING_APP);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
@@ -111,7 +111,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     void shouldCallTokenResourceAndReturnAccessAndRefreshToken(
             Optional<String> vtr, String expectedVotClaim, Optional<String> clientId)
             throws Exception {
-        KeyPair keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        KeyPair keyPair = KeyPairHelper.generateRsaKeyPair();
         Scope scope =
                 new Scope(
                         OIDCScopeValue.OPENID.getValue(), OIDCScopeValue.OFFLINE_ACCESS.getValue());
@@ -144,7 +144,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @Test
     void shouldCallTokenResourceAndReturn400WhenClientIdParameterDoesNotMatch() throws Exception {
-        KeyPair keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        KeyPair keyPair = KeyPairHelper.generateRsaKeyPair();
         Scope scope =
                 new Scope(
                         OIDCScopeValue.OPENID.getValue(), OIDCScopeValue.OFFLINE_ACCESS.getValue());
@@ -163,7 +163,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @Test
     void shouldReturnIdTokenWithPublicSubjectId() throws Exception {
-        KeyPair keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        KeyPair keyPair = KeyPairHelper.generateRsaKeyPair();
         Scope scope =
                 new Scope(
                         OIDCScopeValue.OPENID.getValue(), OIDCScopeValue.OFFLINE_ACCESS.getValue());
@@ -197,7 +197,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @Test
     void shouldReturnIdTokenWithPairwiseSubjectId() throws Exception {
-        KeyPair keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        KeyPair keyPair = KeyPairHelper.generateRsaKeyPair();
         Scope scope =
                 new Scope(
                         OIDCScopeValue.OPENID.getValue(), OIDCScopeValue.OFFLINE_ACCESS.getValue());
@@ -231,7 +231,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @Test
     void shouldCallTokenResourceAndReturnIdentityClaims() throws Exception {
-        KeyPair keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        KeyPair keyPair = KeyPairHelper.generateRsaKeyPair();
         Scope scope = new Scope(OIDCScopeValue.OPENID.getValue());
         var claimsSetRequest = new ClaimsSetRequest().add("nickname").add("birthdate");
         var oidcClaimsRequest = new OIDCClaimsRequest().withUserInfoClaimsRequest(claimsSetRequest);
@@ -277,7 +277,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     @Test
     void shouldCallTokenResourceAndOnlyReturnAccessTokenWithoutOfflineAccessScope()
             throws Exception {
-        KeyPair keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        KeyPair keyPair = KeyPairHelper.generateRsaKeyPair();
         Scope scope = new Scope(OIDCScopeValue.OPENID.getValue());
         setUpDynamo(keyPair, scope, new Subject());
         var response =
@@ -307,7 +307,7 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL, OIDCScopeValue.OFFLINE_ACCESS);
         Subject publicSubject = new Subject();
         Subject internalSubject = new Subject();
-        KeyPair keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        KeyPair keyPair = KeyPairHelper.generateRsaKeyPair();
         setUpDynamo(keyPair, scope, internalSubject);
         SignedJWT signedJWT = generateSignedRefreshToken(scope, publicSubject);
         RefreshToken refreshToken = new RefreshToken(signedJWT.serialize());

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
@@ -401,7 +401,7 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         userStore.signUp(TEST_EMAIL_ADDRESS, TEST_PASSWORD, INTERNAL_SUBJECT);
         userStore.addPhoneNumber(TEST_EMAIL_ADDRESS, TEST_PHONE_NUMBER);
         userStore.setPhoneNumberVerified(TEST_EMAIL_ADDRESS, true);
-        KeyPair keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        KeyPair keyPair = KeyPairHelper.generateRsaKeyPair();
         clientStore.registerClient(
                 CLIENT_ID,
                 "test-client",
@@ -420,7 +420,7 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     }
 
     private void setUpAppClientInDynamo() {
-        KeyPair keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        KeyPair keyPair = KeyPairHelper.generateRsaKeyPair();
         clientStore.registerClient(
                 APP_CLIENT_ID,
                 "app-test-client",

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/WellknownHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/WellknownHandler.java
@@ -103,7 +103,10 @@ public class WellknownHandler
                                                 JWSAlgorithm.RS512,
                                                 JWSAlgorithm.PS256,
                                                 JWSAlgorithm.PS384,
-                                                JWSAlgorithm.PS512));
+                                                JWSAlgorithm.PS512,
+                                                JWSAlgorithm.ES256,
+                                                JWSAlgorithm.ES384,
+                                                JWSAlgorithm.ES512));
                                 providerMetadata.setServiceDocsURI(
                                         new URI("https://docs.sign-in.service.gov.uk/"));
                                 providerMetadata.setEndSessionEndpointURI(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/helper/RequestObjectTestHelper.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/helper/RequestObjectTestHelper.java
@@ -3,20 +3,36 @@ package uk.gov.di.authentication.oidc.helper;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.ECDSASigner;
 import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.Curve;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 
 import java.security.KeyPair;
 
+import static uk.gov.di.authentication.sharedtest.helper.SupportedAlgorithmsTestHelper.getAlgorithmFamilyName;
+
 public class RequestObjectTestHelper {
+
+    public static SignedJWT generateSignedJWT(
+            JWTClaimsSet jwtClaimsSet, KeyPair keyPair, JWSAlgorithm algorithm)
+            throws JOSEException {
+        String algorithmFamily = getAlgorithmFamilyName(algorithm);
+        var jwsHeader = new JWSHeader(algorithm);
+        var signedJWT = new SignedJWT(jwsHeader, jwtClaimsSet);
+        var signer =
+                (algorithmFamily.equals("EC"))
+                        ? new ECDSASigner(
+                                keyPair.getPrivate(),
+                                Curve.forJWSAlgorithm(algorithm).iterator().next())
+                        : new RSASSASigner(keyPair.getPrivate());
+        signedJWT.sign(signer);
+        return signedJWT;
+    }
 
     public static SignedJWT generateSignedJWT(JWTClaimsSet jwtClaimsSet, KeyPair keyPair)
             throws JOSEException {
-        var jwsHeader = new JWSHeader(JWSAlgorithm.RS256);
-        var signedJWT = new SignedJWT(jwsHeader, jwtClaimsSet);
-        var signer = new RSASSASigner(keyPair.getPrivate());
-        signedJWT.sign(signer);
-        return signedJWT;
+        return generateSignedJWT(jwtClaimsSet, keyPair, JWSAlgorithm.RS256);
     }
 }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/helpers/RequestObjectToAuthRequestHelperTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/helpers/RequestObjectToAuthRequestHelperTest.java
@@ -33,7 +33,7 @@ class RequestObjectToAuthRequestHelperTest {
 
     @Test
     void shouldConvertRequestObjectToAuthRequest() throws JOSEException {
-        var keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        var keyPair = KeyPairHelper.generateRsaKeyPair();
         var scope = new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL);
         var jwtClaimsSet =
                 new JWTClaimsSet.Builder()
@@ -69,7 +69,7 @@ class RequestObjectToAuthRequestHelperTest {
 
     @Test
     void shouldConvertRequestObjectToAuthRequestWhenVTRClaimIsPresent() throws JOSEException {
-        var keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        var keyPair = KeyPairHelper.generateRsaKeyPair();
         var scope = new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL);
         var jwtClaimsSet =
                 new JWTClaimsSet.Builder()

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -409,7 +409,7 @@ class AuthCodeHandlerTest {
     }
 
     private static AuthenticationRequest generateRequestObjectAuthRequest() throws JOSEException {
-        var keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        var keyPair = KeyPairHelper.generateRsaKeyPair();
         var jwtClaimsSet =
                 new JWTClaimsSet.Builder()
                         .audience(AUDIENCE)

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -552,7 +552,7 @@ class AuthorisationHandlerTest {
 
     @Test
     void shouldRedirectToLoginWhenRequestObjectIsValid() throws JOSEException {
-        var keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        var keyPair = KeyPairHelper.generateRsaKeyPair();
         when(configService.isDocAppApiEnabled()).thenReturn(true);
         when(requestObjectService.validateRequestObject(any(AuthenticationRequest.class)))
                 .thenReturn(Optional.empty());

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
@@ -593,7 +593,7 @@ public class TokenHandlerTest {
     }
 
     private static AuthenticationRequest generateRequestObjectAuthRequest() throws JOSEException {
-        var keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        var keyPair = KeyPairHelper.generateRsaKeyPair();
         Scope scope = new Scope(DOC_CHECKING_APP, OIDCScopeValue.OPENID);
         var jwtClaimsSet =
                 new JWTClaimsSet.Builder()

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/KeyPairHelper.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/KeyPairHelper.java
@@ -1,10 +1,15 @@
 package uk.gov.di.authentication.sharedtest.helper;
 
+import com.nimbusds.jose.JWSAlgorithm;
+
+import java.security.InvalidAlgorithmParameterException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 
 import static java.util.Objects.isNull;
+import static uk.gov.di.authentication.sharedtest.helper.SupportedAlgorithmsTestHelper.getAlgorithmFamilyName;
+import static uk.gov.di.authentication.sharedtest.helper.SupportedAlgorithmsTestHelper.getKeyGenParameterSpec;
 
 public class KeyPairHelper {
 
@@ -12,7 +17,7 @@ public class KeyPairHelper {
 
     private static KeyPair cachedKeyPair = null;
 
-    public static final KeyPair GENERATE_RSA_KEY_PAIR() {
+    public static KeyPair generateRsaKeyPair() {
         if (isNull(KeyPairHelper.cachedKeyPair)) {
             KeyPairGenerator kpg;
             try {
@@ -24,5 +29,23 @@ public class KeyPairHelper {
             KeyPairHelper.cachedKeyPair = kpg.generateKeyPair();
         }
         return KeyPairHelper.cachedKeyPair;
+    }
+
+    public static KeyPair generateRsaOrEcKeyPair(JWSAlgorithm algorithm) {
+        KeyPairGenerator kpg;
+        String algorithmFamily = getAlgorithmFamilyName(algorithm);
+        try {
+            kpg = KeyPairGenerator.getInstance(algorithmFamily);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+
+        var keySpec = getKeyGenParameterSpec(algorithm);
+        try {
+            kpg.initialize(keySpec);
+        } catch (InvalidAlgorithmParameterException e) {
+            throw new RuntimeException(e);
+        }
+        return kpg.generateKeyPair();
     }
 }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/SupportedAlgorithmsTestHelper.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/SupportedAlgorithmsTestHelper.java
@@ -8,6 +8,8 @@ import java.security.spec.RSAKeyGenParameterSpec;
 import java.util.Map;
 
 public class SupportedAlgorithmsTestHelper {
+    private SupportedAlgorithmsTestHelper() {}
+
     private static final Map<JWSAlgorithm, AlgorithmParameterSpec> algorithmKeySpec =
             Map.ofEntries(
                     Map.entry(

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/SupportedAlgorithmsTestHelper.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/SupportedAlgorithmsTestHelper.java
@@ -1,0 +1,42 @@
+package uk.gov.di.authentication.sharedtest.helper;
+
+import com.nimbusds.jose.JWSAlgorithm;
+
+import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.ECGenParameterSpec;
+import java.security.spec.RSAKeyGenParameterSpec;
+import java.util.Map;
+
+public class SupportedAlgorithmsTestHelper {
+    private static final Map<JWSAlgorithm, AlgorithmParameterSpec> algorithmKeySpec =
+            Map.ofEntries(
+                    Map.entry(
+                            JWSAlgorithm.RS256,
+                            new RSAKeyGenParameterSpec(2048, RSAKeyGenParameterSpec.F4)),
+                    Map.entry(
+                            JWSAlgorithm.RS384,
+                            new RSAKeyGenParameterSpec(2048, RSAKeyGenParameterSpec.F4)),
+                    Map.entry(
+                            JWSAlgorithm.RS512,
+                            new RSAKeyGenParameterSpec(2048, RSAKeyGenParameterSpec.F4)),
+                    Map.entry(
+                            JWSAlgorithm.PS256,
+                            new RSAKeyGenParameterSpec(2048, RSAKeyGenParameterSpec.F4)),
+                    Map.entry(
+                            JWSAlgorithm.PS384,
+                            new RSAKeyGenParameterSpec(2048, RSAKeyGenParameterSpec.F4)),
+                    Map.entry(
+                            JWSAlgorithm.PS512,
+                            new RSAKeyGenParameterSpec(2048, RSAKeyGenParameterSpec.F4)),
+                    Map.entry(JWSAlgorithm.ES256, new ECGenParameterSpec("secp256r1")),
+                    Map.entry(JWSAlgorithm.ES384, new ECGenParameterSpec("secp384r1")),
+                    Map.entry(JWSAlgorithm.ES512, new ECGenParameterSpec("secp521r1")));
+
+    public static String getAlgorithmFamilyName(JWSAlgorithm algorithmName) {
+        return algorithmKeySpec.get(algorithmName) instanceof ECGenParameterSpec ? "EC" : "RSA";
+    }
+
+    public static AlgorithmParameterSpec getKeyGenParameterSpec(JWSAlgorithm algorithmName) {
+        return algorithmKeySpec.get(algorithmName);
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/SupportedAlgorithmsHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/SupportedAlgorithmsHelper.java
@@ -1,0 +1,23 @@
+package uk.gov.di.authentication.shared.helpers;
+
+import com.nimbusds.jose.JWSAlgorithm;
+
+import java.util.Map;
+
+public class SupportedAlgorithmsHelper {
+    private static final Map<JWSAlgorithm, String> algorithmKeySpec =
+            Map.ofEntries(
+                    Map.entry(JWSAlgorithm.RS256, "RSA"),
+                    Map.entry(JWSAlgorithm.RS384, "RSA"),
+                    Map.entry(JWSAlgorithm.RS512, "RSA"),
+                    Map.entry(JWSAlgorithm.PS256, "RSA"),
+                    Map.entry(JWSAlgorithm.PS384, "RSA"),
+                    Map.entry(JWSAlgorithm.PS512, "RSA"),
+                    Map.entry(JWSAlgorithm.ES256, "EC"),
+                    Map.entry(JWSAlgorithm.ES384, "EC"),
+                    Map.entry(JWSAlgorithm.ES512, "EC"));
+
+    public static String getAlgorithmFamilyName(JWSAlgorithm algorithmName) {
+        return algorithmKeySpec.get(algorithmName);
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/SupportedAlgorithmsHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/SupportedAlgorithmsHelper.java
@@ -5,6 +5,8 @@ import com.nimbusds.jose.JWSAlgorithm;
 import java.util.Map;
 
 public class SupportedAlgorithmsHelper {
+    private SupportedAlgorithmsHelper() {}
+
     private static final Map<JWSAlgorithm, String> algorithmKeySpec =
             Map.ofEntries(
                     Map.entry(JWSAlgorithm.RS256, "RSA"),

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
@@ -73,6 +73,7 @@ import java.util.stream.Collectors;
 import static uk.gov.di.authentication.shared.helpers.ConstructUriHelper.buildURI;
 import static uk.gov.di.authentication.shared.helpers.HashHelper.hashSha256String;
 import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
+import static uk.gov.di.authentication.shared.helpers.SupportedAlgorithmsHelper.getAlgorithmFamilyName;
 
 public class TokenService {
 
@@ -479,10 +480,11 @@ public class TokenService {
                     boolean forceRefresh,
                     com.nimbusds.oauth2.sdk.auth.verifier.Context context) {
 
+                var algorithmFamilyName = getAlgorithmFamilyName(jwsHeader.getAlgorithm());
                 byte[] decodedKey = Base64.getMimeDecoder().decode(publicKey);
                 try {
                     X509EncodedKeySpec x509publicKey = new X509EncodedKeySpec(decodedKey);
-                    KeyFactory kf = KeyFactory.getInstance("RSA");
+                    KeyFactory kf = KeyFactory.getInstance(algorithmFamilyName);
                     return Collections.singletonList(kf.generatePublic(x509publicKey));
                 } catch (InvalidKeySpecException | NoSuchAlgorithmException e) {
                     LOG.warn("Exception when selecting public key", e);


### PR DESCRIPTION
## What?

- Allow RPs to use algorithms other than RSA to sign JWTs using elliptic-curve cryptography.

Note: Although it appears that many files have changed, quite a few of these were a single refactoring of `KeyPairHelper.GENERATE_RSA_KEY_PAIR()` method name to use more conventional camel-case.

## Why?

- Aligns to ADR: https://github.com/alphagov/digital-identity-architecture/blob/e023ab11812afabb68f7cf5d524db9b50c33cc7f/adr/0030-kms-key-selection.md
