### PR TITLE
AUT-692: Ship client name in metrics to Grafana

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -14,7 +14,6 @@ import uk.gov.di.authentication.frontendapi.services.UserMigrationService;
 import uk.gov.di.authentication.shared.conditions.ConsentHelper;
 import uk.gov.di.authentication.shared.conditions.MfaHelper;
 import uk.gov.di.authentication.shared.conditions.TermsAndConditionsHelper;
-import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.MFAMethod;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
@@ -106,11 +105,7 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
         try {
             var persistentSessionId =
                     PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders());
-            var clientId =
-                    userContext
-                            .getClient()
-                            .map(ClientRegistry::getClientID)
-                            .orElse(AuditService.UNKNOWN);
+            var clientId = userContext.getClientId();
             Optional<UserProfile> userProfileMaybe =
                     authenticationService.getUserProfileByEmailMaybe(request.getEmail());
             if (userProfileMaybe.isEmpty() || userContext.getUserCredentials().isEmpty()) {
@@ -216,6 +211,7 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
                 cloudwatchMetricsService.incrementAuthenticationSuccess(
                         EXISTING,
                         clientId,
+                        userContext.getClientName(),
                         "P0",
                         clientService.isTestJourney(clientId, userProfile.getEmail()),
                         false);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -225,6 +225,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
             cloudwatchMetricsService.incrementAuthenticationSuccess(
                     session.isNewAccount(),
                     clientId,
+                    userContext.getClientName(),
                     levelOfConfidence.getValue(),
                     clientService.isTestJourney(clientId, session.getEmailAddress()),
                     clientSession
@@ -245,6 +246,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
             cloudwatchMetricsService.incrementAuthenticationSuccess(
                     session.isNewAccount(),
                     clientId,
+                    userContext.getClientName(),
                     levelOfConfidence.getValue(),
                     clientService.isTestJourney(clientId, session.getEmailAddress()),
                     true);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -165,6 +165,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                                 cloudwatchMetricsService.incrementAuthenticationSuccess(
                                         session.isNewAccount(),
                                         clientId,
+                                        userContext.getClientName(),
                                         levelOfConfidence.getValue(),
                                         clientService.isTestJourney(
                                                 clientId, session.getEmailAddress()),

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
@@ -93,6 +93,7 @@ class LoginHandlerTest {
                     .setMfaMethod(AUTH_APP_MFA_METHOD);
     private static final String PHONE_NUMBER = "01234567890";
     private static final ClientID CLIENT_ID = new ClientID();
+    private static final String CLIENT_NAME = "client-name";
     private static final MFAMethod AUTH_APP_MFA_METHOD =
             new MFAMethod()
                     .setMfaMethodType(MFAMethodType.AUTH_APP.getValue())
@@ -198,7 +199,12 @@ class LoginHandlerTest {
                         persistentId);
         verify(cloudwatchMetricsService)
                 .incrementAuthenticationSuccess(
-                        Session.AccountState.EXISTING, CLIENT_ID.getValue(), "P0", false, false);
+                        Session.AccountState.EXISTING,
+                        CLIENT_ID.getValue(),
+                        CLIENT_NAME,
+                        "P0",
+                        false,
+                        false);
     }
 
     @ParameterizedTest
@@ -248,7 +254,8 @@ class LoginHandlerTest {
                         userProfile.getPhoneNumber(),
                         persistentId);
         verify(cloudwatchMetricsService, never())
-                .incrementAuthenticationSuccess(any(), any(), any(), anyBoolean(), anyBoolean());
+                .incrementAuthenticationSuccess(
+                        any(), any(), any(), any(), anyBoolean(), anyBoolean());
     }
 
     @ParameterizedTest
@@ -302,7 +309,8 @@ class LoginHandlerTest {
         verify(sessionService)
                 .save(argThat(session -> session.isNewAccount() == Session.AccountState.EXISTING));
         verify(cloudwatchMetricsService, never())
-                .incrementAuthenticationSuccess(any(), any(), any(), anyBoolean(), anyBoolean());
+                .incrementAuthenticationSuccess(
+                        any(), any(), any(), any(), anyBoolean(), anyBoolean());
     }
 
     @ParameterizedTest
@@ -657,7 +665,7 @@ class LoginHandlerTest {
         return new ClientRegistry()
                 .withClientID(CLIENT_ID.getValue())
                 .withConsentRequired(false)
-                .withClientName("test-client")
+                .withClientName(CLIENT_NAME)
                 .withSectorIdentifierUri("https://test.com")
                 .withSubjectType("public");
     }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -66,6 +66,7 @@ class VerifyCodeHandlerTest {
     private static final String CODE = "123456";
     private static final String INVALID_CODE = "6543221";
     private static final String CLIENT_ID = "client-id";
+    private static final String CLIENT_NAME = "client-name";
     private static final String TEST_CLIENT_ID = "test-client-id";
     private static final String TEST_CLIENT_CODE = "654321";
     private static final String TEST_CLIENT_EMAIL =
@@ -91,7 +92,10 @@ class VerifyCodeHandlerTest {
             mock(CloudwatchMetricsService.class);
 
     private final ClientRegistry clientRegistry =
-            new ClientRegistry().withTestClient(false).withClientID(CLIENT_ID);
+            new ClientRegistry()
+                    .withTestClient(false)
+                    .withClientID(CLIENT_ID)
+                    .withClientName(CLIENT_NAME);
     private final ClientRegistry testClientRegistry =
             new ClientRegistry()
                     .withTestClient(true)
@@ -202,7 +206,7 @@ class VerifyCodeHandlerTest {
                         pair("mfa-type", MFAMethodType.SMS.getValue()));
         verify(cloudwatchMetricsService)
                 .incrementAuthenticationSuccess(
-                        Session.AccountState.NEW, CLIENT_ID, "P0", false, false);
+                        Session.AccountState.NEW, CLIENT_ID, CLIENT_NAME, "P0", false, false);
     }
 
     @Test
@@ -383,7 +387,7 @@ class VerifyCodeHandlerTest {
                         pair("mfa-type", MFAMethodType.SMS.getValue()));
         verify(cloudwatchMetricsService)
                 .incrementAuthenticationSuccess(
-                        Session.AccountState.EXISTING, CLIENT_ID, "P0", false, true);
+                        Session.AccountState.EXISTING, CLIENT_ID, CLIENT_NAME, "P0", false, true);
     }
 
     @Test

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -69,6 +69,7 @@ class VerifyMfaCodeHandlerTest {
     private static final String TEST_EMAIL_ADDRESS = "test@test.com";
     private static final String CODE = "123456";
     private static final String CLIENT_ID = "client-id";
+    private static final String CLIENT_NAME = "client-name";
     private static final String TEST_CLIENT_CODE = "654321";
     private static final String CLIENT_SESSION_ID = "client-session-id";
     private static final String SUBJECT_ID = "test-subject-id";
@@ -103,6 +104,8 @@ class VerifyMfaCodeHandlerTest {
                 .thenReturn(Optional.of(userProfile));
         when(clientService.getClient(CLIENT_ID)).thenReturn(Optional.of(clientRegistry));
         when(clientRegistry.getClientID()).thenReturn(CLIENT_ID);
+        when(clientRegistry.getClientName()).thenReturn(CLIENT_NAME);
+
         when(clientSession.getAuthRequestParams())
                 .thenReturn(withAuthenticationRequest().toParameters());
 
@@ -171,7 +174,7 @@ class VerifyMfaCodeHandlerTest {
                         pair("mfa-type", MFAMethodType.AUTH_APP.getValue()));
         verify(cloudwatchMetricsService)
                 .incrementAuthenticationSuccess(
-                        Session.AccountState.NEW, CLIENT_ID, "P0", false, true);
+                        Session.AccountState.NEW, CLIENT_ID, CLIENT_NAME, "P0", false, true);
     }
 
     @Test
@@ -206,7 +209,7 @@ class VerifyMfaCodeHandlerTest {
                         pair("mfa-type", MFAMethodType.AUTH_APP.getValue()));
         verify(cloudwatchMetricsService)
                 .incrementAuthenticationSuccess(
-                        Session.AccountState.EXISTING, CLIENT_ID, "P0", false, true);
+                        Session.AccountState.EXISTING, CLIENT_ID, CLIENT_NAME, "P0", false, true);
     }
 
     @Test

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsService.java
@@ -44,6 +44,7 @@ public class CloudwatchMetricsService {
     public void incrementAuthenticationSuccess(
             Session.AccountState accountState,
             String clientId,
+            String clientName,
             String requestedLevelOfConfidence,
             boolean isTestJourney,
             boolean mfaRequired) {
@@ -61,6 +62,8 @@ public class CloudwatchMetricsService {
                         "RequestedLevelOfConfidence",
                         requestedLevelOfConfidence,
                         "MfaRequired",
-                        Boolean.toString(mfaRequired)));
+                        Boolean.toString(mfaRequired),
+                        "ClientName",
+                        clientName));
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/state/UserContext.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/state/UserContext.java
@@ -58,6 +58,14 @@ public class UserContext {
         return client;
     }
 
+    public String getClientId() {
+        return getClient().map(ClientRegistry::getClientID).orElse("");
+    }
+
+    public String getClientName() {
+        return getClient().map(ClientRegistry::getClientName).orElse("");
+    }
+
     public ClientSession getClientSession() {
         return clientSession;
     }


### PR DESCRIPTION
## What?

Ship client name in metrics to Grafana.

## Why?

To be able to show a friendly readable name when grouping metrics by client in Grafana dashboards.