### PR TITLE
AUT-644: Dynamo table CloudFormation templates

### DIFF
--- a/shared/client-dynamo-tables.yaml
+++ b/shared/client-dynamo-tables.yaml
@@ -1,0 +1,47 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Authentication DynamoDB tables for Client Data Storage
+
+Parameters:
+  Environment:
+    Type: String
+    Default: sandpit
+    AllowedValues:
+      - sandpit
+      - build
+      - integration
+      - staging
+      - production
+    Description: The logical name for this deployment environment
+
+Resources:
+  ClientRegistry:
+    # checkov:skip=CKV_AWS_119: "Ensure DynamoDB Tables are encrypted using a KMS Customer Managed CMK"
+    DeletionPolicy: Retain
+    Type: "AWS::DynamoDB::Table"
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: ClientID
+          AttributeType: S
+        - AttributeName: ClientName
+          AttributeType: S
+      BillingMode: PAY_PER_REQUEST
+      GlobalSecondaryIndexes:
+        - IndexName: ClientNameIndex
+          KeySchema:
+            - AttributeName: ClientName
+              KeyType: HASH
+          Projection:
+            ProjectionType: ALL
+      KeySchema:
+        - AttributeName: ClientID
+          KeyType: HASH
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
+      SSESpecification:
+        SSEEnabled: true
+      TableName: !Sub "${Environment}-client-registry"
+      Tags:
+        - Key: environment
+          Value: !Ref Environment
+        - Key: application
+          Value: shared

--- a/shared/common-password-dynamo-table.yaml
+++ b/shared/common-password-dynamo-table.yaml
@@ -1,0 +1,38 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Authentication DynamoDB tables for Common Password Storage
+
+Parameters:
+  Environment:
+    Type: String
+    Default: sandpit
+    AllowedValues:
+      - sandpit
+      - build
+      - integration
+      - staging
+      - production
+    Description: The logical name for this deployment environment
+
+Resources:
+  CommonPassword:
+    # checkov:skip=CKV_AWS_119: "Ensure DynamoDB Tables are encrypted using a KMS Customer Managed CMK"
+    DeletionPolicy: Retain
+    Type: "AWS::DynamoDB::Table"
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: Password
+          AttributeType: S
+      BillingMode: PAY_PER_REQUEST
+      KeySchema:
+        - AttributeName: Password
+          KeyType: HASH
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
+      SSESpecification:
+        SSEEnabled: true
+      TableName: !Sub "${Environment}-common-passwords"
+      Tags:
+        - Key: environment
+          Value: !Ref Environment
+        - Key: application
+          Value: shared

--- a/shared/user-dynamo-tables.yaml
+++ b/shared/user-dynamo-tables.yaml
@@ -1,0 +1,149 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Authentication DynamoDB tables for User Data Storage
+
+Parameters:
+  Environment:
+    Type: String
+    Default: sandpit
+    AllowedValues:
+      - sandpit
+      - build
+      - integration
+      - staging
+      - production
+    Description: The logical name for this deployment environment
+
+Resources:
+  UserCredentials:
+    # checkov:skip=CKV_AWS_119: "Ensure DynamoDB Tables are encrypted using a KMS Customer Managed CMK"
+    DeletionPolicy: Retain
+    Type: "AWS::DynamoDB::Table"
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: Email
+          AttributeType: S
+        - AttributeName: SubjectID
+          AttributeType: S
+      BillingMode: PAY_PER_REQUEST
+      GlobalSecondaryIndexes:
+        - IndexName: SubjectIDIndex
+          KeySchema:
+            - AttributeName: SubjectID
+              KeyType: HASH
+          Projection:
+            ProjectionType: ALL
+      KeySchema:
+        - AttributeName: Email
+          KeyType: HASH
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
+      SSESpecification:
+        SSEEnabled: true
+      TableName: !Sub "${Environment}-user-credentials"
+      Tags:
+        - Key: environment
+          Value: !Ref Environment
+        - Key: application
+          Value: shared
+
+  UserProfile:
+    # checkov:skip=CKV_AWS_119: "Ensure DynamoDB Tables are encrypted using a KMS Customer Managed CMK"
+    DeletionPolicy: Retain
+    Type: "AWS::DynamoDB::Table"
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: Email
+          AttributeType: S
+        - AttributeName: SubjectID
+          AttributeType: S
+        - AttributeName: PublicSubjectID
+          AttributeType: S
+        - AttributeName: accountVerified
+          AttributeType: N
+      BillingMode: PAY_PER_REQUEST
+      GlobalSecondaryIndexes:
+        - IndexName: SubjectIDIndex
+          KeySchema:
+            - AttributeName: SubjectID
+              KeyType: HASH
+          Projection:
+            ProjectionType: ALL
+        - IndexName: PublicSubjectIDIndex
+          KeySchema:
+            - AttributeName: PublicSubjectID
+              KeyType: HASH
+          Projection:
+            ProjectionType: ALL
+        - IndexName: VerifiedAccountIndex
+          KeySchema:
+            - AttributeName: SubjectID
+              KeyType: HASH
+            - AttributeName: accountVerified
+              KeyType: RANGE
+          Projection:
+            ProjectionType: KEYS_ONLY
+      KeySchema:
+        - AttributeName: Email
+          KeyType: HASH
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
+      SSESpecification:
+        SSEEnabled: true
+      TableName: !Sub "${Environment}-user-profile"
+      Tags:
+        - Key: environment
+          Value: !Ref Environment
+        - Key: application
+          Value: shared
+
+  IdentityCredentials:
+    # checkov:skip=CKV_AWS_119: "Ensure DynamoDB Tables are encrypted using a KMS Customer Managed CMK"
+    DeletionPolicy: Retain
+    Type: "AWS::DynamoDB::Table"
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: SubjectID
+          AttributeType: S
+      BillingMode: PAY_PER_REQUEST
+      KeySchema:
+        - AttributeName: SubjectID
+          KeyType: HASH
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
+      SSESpecification:
+        SSEEnabled: true
+      TableName: !Sub "${Environment}-identity-credentials"
+      TimeToLiveSpecification:
+        AttributeName: TimeToExist
+        Enabled: true
+      Tags:
+        - Key: environment
+          Value: !Ref Environment
+        - Key: application
+          Value: shared
+
+  DocAppCredentials:
+    # checkov:skip=CKV_AWS_119: "Ensure DynamoDB Tables are encrypted using a KMS Customer Managed CMK"
+    DeletionPolicy: Retain
+    Type: "AWS::DynamoDB::Table"
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: SubjectID
+          AttributeType: S
+      BillingMode: PAY_PER_REQUEST
+      KeySchema:
+        - AttributeName: SubjectID
+          KeyType: HASH
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
+      SSESpecification:
+        SSEEnabled: true
+      TableName: !Sub "${Environment}-doc-app-credential"
+      TimeToLiveSpecification:
+        AttributeName: TimeToExist
+        Enabled: true
+      Tags:
+        - Key: environment
+          Value: !Ref Environment
+        - Key: application
+          Value: shared


### PR DESCRIPTION
## What?

- Add stack template for user tables
- Add stack template for client registry tables
- Add stack template for common password tables
- Ignore checkov rule `CKV_AWS_119` for the moment, this is scheduled as separate story.

## Why?

We are migrating to the devplatform which means deploying resources with Cloudformation instead of Terraform. These templates have designed to import existing tables and have been tested and proved to produce no "drift" from current resources.
