### PR TITLE
AUT-389-backend-changes: Return password max retries error code

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/domain/AccountManagementAuditableEvent.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/domain/AccountManagementAuditableEvent.java
@@ -8,7 +8,9 @@ public enum AccountManagementAuditableEvent implements AuditableEvent {
     UPDATE_PHONE_NUMBER,
     ACCOUNT_MANAGEMENT_AUTHENTICATE,
     DELETE_ACCOUNT,
-    SEND_OTP;
+    SEND_OTP,
+    ACCOUNT_TEMPORARILY_LOCKED,
+    INVALID_CREDENTIALS;
 
     public AuditableEvent parseFromName(String name) {
         return valueOf(name);

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandler.java
@@ -16,6 +16,7 @@ import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.serialization.Json.JsonException;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
+import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.SerializationService;
@@ -34,11 +35,18 @@ public class AuthenticateHandler
     private final AuthenticationService authenticationService;
     private final Json objectMapper = SerializationService.getInstance();
     private final AuditService auditService;
+    private final CodeStorageService codeStorageService;
+    private final ConfigurationService configurationService;
 
     public AuthenticateHandler(
-            AuthenticationService authenticationService, AuditService auditService) {
+            AuthenticationService authenticationService,
+            AuditService auditService,
+            CodeStorageService codeStorageService,
+            ConfigurationService configurationService) {
         this.authenticationService = authenticationService;
         this.auditService = auditService;
+        this.codeStorageService = codeStorageService;
+        this.configurationService = configurationService;
     }
 
     public AuthenticateHandler() {
@@ -48,6 +56,8 @@ public class AuthenticateHandler
     public AuthenticateHandler(ConfigurationService configurationService) {
         this.authenticationService = new DynamoService(configurationService);
         this.auditService = new AuditService(configurationService);
+        this.codeStorageService = new CodeStorageService(configurationService);
+        this.configurationService = configurationService;
     }
 
     @Override
@@ -68,6 +78,26 @@ public class AuthenticateHandler
         try {
             AuthenticateRequest loginRequest =
                     objectMapper.readValue(input.getBody(), AuthenticateRequest.class);
+            var persistentSessionId =
+                    PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders());
+            var incorrectPasswordCount =
+                    codeStorageService.getIncorrectPasswordCount(loginRequest.getEmail());
+            if (incorrectPasswordCount >= configurationService.getMaxPasswordRetries()) {
+                LOG.info("User has exceeded max password retries");
+
+                auditService.submitAuditEvent(
+                        AccountManagementAuditableEvent.ACCOUNT_TEMPORARILY_LOCKED,
+                        AuditService.UNKNOWN,
+                        sessionId,
+                        AuditService.UNKNOWN,
+                        AuditService.UNKNOWN,
+                        loginRequest.getEmail(),
+                        IpAddressHelper.extractIpAddress(input),
+                        AuditService.UNKNOWN,
+                        persistentSessionId);
+
+                return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1028);
+            }
             boolean userHasAccount = authenticationService.userExists(loginRequest.getEmail());
             if (!userHasAccount) {
                 return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1010);
@@ -76,7 +106,11 @@ public class AuthenticateHandler
                     authenticationService.login(
                             loginRequest.getEmail(), loginRequest.getPassword());
             if (!hasValidCredentials) {
+                codeStorageService.increaseIncorrectPasswordCount(loginRequest.getEmail());
                 return generateApiGatewayProxyErrorResponse(401, ErrorResponse.ERROR_1008);
+            }
+            if (incorrectPasswordCount != 0) {
+                codeStorageService.deleteIncorrectPasswordCount(loginRequest.getEmail());
             }
             LOG.info("User has successfully Logged in. Generating successful AuthenticateResponse");
 


### PR DESCRIPTION
## What?

- Add password max retries to account management during authentication
- Return error code 1028 when account is temporarily locked after 5 unsuccessful attempts

## Why?

- Currently users are able to retry sign in even when their account is locked
- Users should be redirected to a `/account-locked` page instead of login page when they try to sign in again