### PR TITLE
BAU: Add `expiry_time` to access tokens

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
@@ -355,7 +355,9 @@ public class TokenService {
         }
 
         SignedJWT signedJWT = generateSignedJWT(claimSetBuilder.build(), Optional.empty());
-        AccessToken accessToken = new BearerAccessToken(signedJWT.serialize());
+        AccessToken accessToken =
+                new BearerAccessToken(
+                        signedJWT.serialize(), configService.getAccessTokenExpiry(), null);
 
         try {
             redisConnectionService.saveWithExpiry(

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
@@ -635,6 +635,8 @@ public class TokenServiceTest {
 
         var header = (JWSHeader) tokenResponse.getOIDCTokens().getIDToken().getHeader();
 
+        assertThat(tokenResponse.getOIDCTokens().getAccessToken().getLifetime(), is(300L));
+
         assertThat(
                 header.getKeyID(),
                 is("1d504aece298a14d74ee0a02b6740b4372a1fab4206778e486ba72770ff4beb8"));


### PR DESCRIPTION
We were claiming that we published this in the docs, but we actually don't.
