### PR TITLE
BAU: Add the parameter policy to the authenticate role

### DIFF
--- a/ci/terraform/account-management/authenticate.tf
+++ b/ci/terraform/account-management/authenticate.tf
@@ -7,6 +7,7 @@ module "account_management_api_authenticate_role" {
   policies_to_attach = [
     aws_iam_policy.dynamo_am_user_read_access_policy.arn,
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    aws_iam_policy.parameter_policy.arn,
     module.account_management_txma_audit.access_policy_arn
   ]
 }


### PR DESCRIPTION
## What?

- The `AuthenticateHandler` now uses `CodeStorageService` which needs to get Redis connection parameters from SSM. Add the required policy to the execution role.

## Why?

The `AuthenticateHandler` is failing to start and as such provisioned concurrency is failing to deploy.

## Related PRs

#2363 