### PR TITLE
BAU: Add REDIS_KEY env variable to AuthenticateHandler

### DIFF
--- a/ci/terraform/account-management/authenticate.tf
+++ b/ci/terraform/account-management/authenticate.tf
@@ -23,6 +23,7 @@ module "authenticate" {
     DYNAMO_ENDPOINT      = var.use_localstack ? var.lambda_dynamo_endpoint : null
     LOCALSTACK_ENDPOINT  = var.use_localstack ? var.localstack_endpoint : null
     TXMA_AUDIT_QUEUE_URL = module.account_management_txma_audit.queue_url
+    REDIS_KEY            = local.redis_key
   }
   handler_function_name = "uk.gov.di.accountmanagement.lambda.AuthenticateHandler::handleRequest"
 


### PR DESCRIPTION
## What?

- Add REDIS_KEY env variable to AuthenticateHandler

## Why?

As the handler now needs to access Redis it needs to know the key of Redis connection parameters to get from SSM

## Related PRs

#2370 
#2363 