### PR TITLE
BAU - Change elasticcache maitenance window

### DIFF
--- a/ci/terraform/account-management/redis.tf
+++ b/ci/terraform/account-management/redis.tf
@@ -33,7 +33,7 @@ resource "aws_elasticache_replication_group" "account_management_sessions_store"
   engine_version                = "6.x"
   parameter_group_name          = "default.redis6.x"
   port                          = local.redis_port_number
-  maintenance_window            = "mon:02:00-mon:03:00"
+  maintenance_window            = "tue:22:00-tue:23:00"
   notification_topic_arn        = data.aws_sns_topic.slack_events.arn
 
   multi_az_enabled = true

--- a/ci/terraform/shared/redis.tf
+++ b/ci/terraform/shared/redis.tf
@@ -33,7 +33,7 @@ resource "aws_elasticache_replication_group" "sessions_store" {
   parameter_group_name          = "default.redis6.x"
   port                          = local.redis_port_number
   multi_az_enabled              = true
-  maintenance_window            = "thu:02:00-thu:03:00"
+  maintenance_window            = "wed:22:00-wed:23:00"
   notification_topic_arn        = aws_sns_topic.slack_events.arn
 
   at_rest_encryption_enabled = true


### PR DESCRIPTION
## What?

- Change elasticcache maitenance window

## Why?

- Make the maintenance window earlier so that it still avoids high periods of traffic but so that it is not in the middle of the night should elasticcache maintenance caus e an incident.


