### PR TITLE
AUT-692: Additional metrics for new and existing authentications

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/domain/CloudwatchMetricDimensions.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/domain/CloudwatchMetricDimensions.java
@@ -1,0 +1,21 @@
+package uk.gov.di.authentication.shared.domain;
+
+public enum CloudwatchMetricDimensions {
+    ACCOUNT("Account"),
+    ENVIRONMENT("Environment"),
+    CLIENT("Client"),
+    IS_TEST("IsTest"),
+    REQUESTED_LEVEL_OF_CONFIDENCE("RequestedLevelOfConfidence"),
+    MFA_REQUIRED("MfaRequired"),
+    CLIENT_NAME("ClientName");
+
+    private String value;
+
+    CloudwatchMetricDimensions(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/domain/CloudwatchMetrics.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/domain/CloudwatchMetrics.java
@@ -1,0 +1,18 @@
+package uk.gov.di.authentication.shared.domain;
+
+public enum CloudwatchMetrics {
+    AUTHENTICATION_SUCCESS("AuthenticationSuccess"),
+    AUTHENTICATION_SUCCESS_NEW_ACCOUNT_BY_CLIENT("AuthenticationSuccessNewAccountByClient"),
+    AUTHENTICATION_SUCCESS_EXISTING_ACCOUNT_BY_CLIENT(
+            "AuthenticationSuccessExistingAccountByClient");
+
+    private String value;
+
+    CloudwatchMetrics(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}


### PR DESCRIPTION
## What?

Additional metrics for new and existing authentications.

## Why?

Reduce number of dimensions in the metrics for easier reporting by client.

It's not possible to filter on a single metric (such as client) when reporting on cloudwatch metrics in Grafana, so separate metrics with only the required information are needed instead.

https://stackoverflow.com/questions/48443899/cloudwatch-does-not-aggregate-across-dimensions-for-your-custom-metrics
