### PR TITLE
AUT-398 - Create custom attribute converter to store booleans as numb…

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/dynamodb/BooleanToIntAttributeConverter.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/dynamodb/BooleanToIntAttributeConverter.java
@@ -1,0 +1,29 @@
+package uk.gov.di.authentication.shared.dynamodb;
+
+import software.amazon.awssdk.enhanced.dynamodb.AttributeConverter;
+import software.amazon.awssdk.enhanced.dynamodb.AttributeValueType;
+import software.amazon.awssdk.enhanced.dynamodb.EnhancedType;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+public class BooleanToIntAttributeConverter implements AttributeConverter<Boolean> {
+
+    @Override
+    public AttributeValue transformFrom(Boolean input) {
+        return AttributeValue.fromN(Boolean.TRUE.equals(input) ? "1" : "0");
+    }
+
+    @Override
+    public Boolean transformTo(AttributeValue input) {
+        return input.n().equals("1");
+    }
+
+    @Override
+    public EnhancedType<Boolean> type() {
+        return EnhancedType.of(Boolean.class);
+    }
+
+    @Override
+    public AttributeValueType attributeValueType() {
+        return AttributeValueType.N;
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/UserProfile.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/UserProfile.java
@@ -2,8 +2,10 @@ package uk.gov.di.authentication.shared.entity;
 
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbAttribute;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbConvertedBy;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSecondaryPartitionKey;
+import uk.gov.di.authentication.shared.dynamodb.BooleanToIntAttributeConverter;
 
 import java.nio.ByteBuffer;
 import java.util.List;
@@ -71,6 +73,7 @@ public class UserProfile {
         return this;
     }
 
+    @DynamoDbConvertedBy(BooleanToIntAttributeConverter.class)
     @DynamoDbAttribute(ATTRIBUTE_EMAIL_VERIFIED)
     public boolean isEmailVerified() {
         return emailVerified;
@@ -99,6 +102,7 @@ public class UserProfile {
         return this;
     }
 
+    @DynamoDbConvertedBy(BooleanToIntAttributeConverter.class)
     @DynamoDbAttribute(ATTRIBUTE_PHONE_NUMBER_VERIFIED)
     public boolean isPhoneNumberVerified() {
         return phoneNumberVerified;


### PR DESCRIPTION
## What?

 - Create custom attribute converter to store booleans as numbers in Dynamo

## Why?
- In Version 1 of the SDK, booleans were stored in Dynamo by default as either 1 or 0. In SDK version 2, they are stored in either true or false. This will make the database inconsistent and we should look to get them the same.
- Create a custom attribute converter to convert booleans to number attribute value so that booleans are stored in Dynamo as either 0 or 1.

