### PR TITLE
AUT-692: Additional metrics for new and existing sign ins

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -234,6 +234,11 @@ public class AuthCodeHandler
             }
 
             cloudwatchMetricsService.incrementCounter("SignIn", dimensions);
+            cloudwatchMetricsService.incrementSignInByClient(
+                    session.isNewAccount(),
+                    authenticationRequest.getClientID().getValue(),
+                    clientSession.getClientName(),
+                    isTestJourney);
 
             if (!docAppJourney) {
                 sessionService.save(session.setAuthenticated(true).setNewAccount(EXISTING));

--- a/shared/src/main/java/uk/gov/di/authentication/shared/domain/CloudwatchMetrics.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/domain/CloudwatchMetrics.java
@@ -4,7 +4,9 @@ public enum CloudwatchMetrics {
     AUTHENTICATION_SUCCESS("AuthenticationSuccess"),
     AUTHENTICATION_SUCCESS_NEW_ACCOUNT_BY_CLIENT("AuthenticationSuccessNewAccountByClient"),
     AUTHENTICATION_SUCCESS_EXISTING_ACCOUNT_BY_CLIENT(
-            "AuthenticationSuccessExistingAccountByClient");
+            "AuthenticationSuccessExistingAccountByClient"),
+    SIGN_IN_NEW_ACCOUNT_BY_CLIENT("SignInNewAccountByClient"),
+    SIGN_IN_EXISTING_ACCOUNT_BY_CLIENT("SignInExistingAccountByClient");
 
     private String value;
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsService.java
@@ -17,6 +17,8 @@ import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.AUTHENTICATION_SUCCESS;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.AUTHENTICATION_SUCCESS_EXISTING_ACCOUNT_BY_CLIENT;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.AUTHENTICATION_SUCCESS_NEW_ACCOUNT_BY_CLIENT;
+import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.SIGN_IN_EXISTING_ACCOUNT_BY_CLIENT;
+import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.SIGN_IN_NEW_ACCOUNT_BY_CLIENT;
 import static uk.gov.di.authentication.shared.entity.Session.AccountState.EXISTING;
 import static uk.gov.di.authentication.shared.entity.Session.AccountState.NEW;
 import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
@@ -51,6 +53,35 @@ public class CloudwatchMetricsService {
 
     public void incrementCounter(String name, Map<String, String> dimensions) {
         putEmbeddedValue(name, 1, dimensions);
+    }
+
+    public void incrementSignInByClient(
+            Session.AccountState accountState,
+            String clientId,
+            String clientName,
+            boolean isTestJourney) {
+        if (NEW.equals(accountState) && !isTestJourney) {
+            incrementCounter(
+                    SIGN_IN_NEW_ACCOUNT_BY_CLIENT.getValue(),
+                    Map.of(
+                            ENVIRONMENT.getValue(),
+                            configurationService.getEnvironment(),
+                            CLIENT.getValue(),
+                            clientId,
+                            CLIENT_NAME.getValue(),
+                            clientName));
+        }
+        if (EXISTING.equals(accountState) && !isTestJourney) {
+            incrementCounter(
+                    SIGN_IN_EXISTING_ACCOUNT_BY_CLIENT.getValue(),
+                    Map.of(
+                            ENVIRONMENT.getValue(),
+                            configurationService.getEnvironment(),
+                            CLIENT.getValue(),
+                            clientId,
+                            CLIENT_NAME.getValue(),
+                            clientName));
+        }
     }
 
     public void incrementAuthenticationSuccess(


### PR DESCRIPTION
Reduce number of dimensions in the metrics for easier reporting by client.

## What?

Additional metrics for new and existing signins.

This metric is reported from a single lambda so it will give meaningful counts in Grafana which aren't spilt by service.

## Why?

Reduce number of dimensions in the metrics for easier reporting by client.

It's not possible to filter on a single metric (such as client) when reporting on cloudwatch metrics in Grafana, so separate metrics with only the required information are needed instead.

https://stackoverflow.com/questions/48443899/cloudwatch-does-not-aggregate-across-dimensions-for-your-custom-metrics

## Related PRs

#2380 