### PR TITLE
AUT-398 - Use custom attribute converter when setting MFA method

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/MFAMethod.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/MFAMethod.java
@@ -2,7 +2,9 @@ package uk.gov.di.authentication.shared.entity;
 
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbAttribute;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbConvertedBy;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import uk.gov.di.authentication.shared.dynamodb.BooleanToIntAttributeConverter;
 
 import java.util.Map;
 import java.util.Objects;
@@ -65,6 +67,7 @@ public class MFAMethod {
         return this;
     }
 
+    @DynamoDbConvertedBy(BooleanToIntAttributeConverter.class)
     @DynamoDbAttribute(ATTRIBUTE_METHOD_VERIFIED)
     public boolean isMethodVerified() {
         return methodVerified;
@@ -79,6 +82,7 @@ public class MFAMethod {
         return this;
     }
 
+    @DynamoDbConvertedBy(BooleanToIntAttributeConverter.class)
     @DynamoDbAttribute(ATTRIBUTE_ENABLED)
     public boolean isEnabled() {
         return enabled;


### PR DESCRIPTION


## What?

 - In Version 1 of the SDK, booleans were stored in Dynamo by default as either 1 or 0. In SDK version 2, they are stored in either true or false. This will make the database inconsistent and we should look to get them the same.
## Why?
- So booleans are still stored as either 0 or 1 to keep it consistent with what we currently have in the DB