### PR TITLE
BAU - Add user-profile data resource to account_metrics_lambda

### DIFF
--- a/.github/workflows/pre-merge-checks-terraform.yml
+++ b/.github/workflows/pre-merge-checks-terraform.yml
@@ -38,3 +38,9 @@ jobs:
         run: |
           terraform init -input=false -backend=false
           terraform validate
+
+      - name: Terraform Validate (utils)
+        working-directory: ci/terraform/utils
+        run: |
+          terraform init -input=false -backend=false
+          terraform validate

--- a/ci/terraform/utils/account_metrics_lambda.tf
+++ b/ci/terraform/utils/account_metrics_lambda.tf
@@ -13,6 +13,10 @@ data "aws_iam_policy_document" "account_metrics_dynamo_access" {
   }
 }
 
+data "aws_dynamodb_table" "user_profile" {
+  name = "${var.environment}-user-profile"
+}
+
 resource "aws_iam_policy" "account_metrics_dynamo_access" {
   name_prefix = "account-metrics-dynamo-access-policy"
   description = "IAM policy for managing permissions to the Dynamo User Profile table"


### PR DESCRIPTION
## What?

- Add user-profile data resource to account_metrics_lambda
- Add validation to the terraform utils module

## Why?

- Previously it was using the data resource from the verified_account_update_lambda.tf which has since been deleted
- The terraform issue did not get picked up until the pipeline. Adding a github actions will ensure we can capture any issues earlier
