### PR TITLE
AUT-692: Ship client name to the AUTHORISATION_INITIATED event

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -215,17 +215,6 @@ public class AuthorisationHandler
         var session = existingSession.orElseGet(sessionService::createSession);
         attachSessionIdToLogs(session);
 
-        auditService.submitAuditEvent(
-                OidcAuditableEvent.AUTHORISATION_INITIATED,
-                clientSessionId,
-                session.getSessionId(),
-                authenticationRequest.getClientID().getValue(),
-                AuditService.UNKNOWN,
-                AuditService.UNKNOWN,
-                ipAddress,
-                AuditService.UNKNOWN,
-                persistentSessionId);
-
         if (existingSession.isEmpty()) {
             updateAttachedSessionIdToLogs(session.getSessionId());
             LOG.info("Created session");
@@ -240,6 +229,17 @@ public class AuthorisationHandler
                         .getClient(authenticationRequest.getClientID().getValue())
                         .map(ClientRegistry::getClientName)
                         .orElse("");
+        auditService.submitAuditEvent(
+                OidcAuditableEvent.AUTHORISATION_INITIATED,
+                clientSessionId,
+                session.getSessionId(),
+                authenticationRequest.getClientID().getValue(),
+                AuditService.UNKNOWN,
+                AuditService.UNKNOWN,
+                ipAddress,
+                AuditService.UNKNOWN,
+                persistentSessionId,
+                pair("client-name", clientName));
         var clientSession =
                 clientSessionService.generateClientSession(
                         authenticationRequest.toParameters(),

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -182,7 +182,8 @@ class AuthorisationHandlerTest {
                         AuditService.UNKNOWN,
                         "123.123.123.123",
                         AuditService.UNKNOWN,
-                        PERSISTENT_SESSION_ID);
+                        PERSISTENT_SESSION_ID,
+                        pair("client-name", "client-name"));
     }
 
     @ParameterizedTest
@@ -250,7 +251,8 @@ class AuthorisationHandlerTest {
                         AuditService.UNKNOWN,
                         "123.123.123.123",
                         AuditService.UNKNOWN,
-                        PERSISTENT_SESSION_ID);
+                        PERSISTENT_SESSION_ID,
+                        pair("client-name", "client-name"));
     }
 
     @Test
@@ -291,7 +293,8 @@ class AuthorisationHandlerTest {
                         AuditService.UNKNOWN,
                         "123.123.123.123",
                         AuditService.UNKNOWN,
-                        PERSISTENT_SESSION_ID);
+                        PERSISTENT_SESSION_ID,
+                        pair("client-name", "client-name"));
     }
 
     @Test
@@ -333,7 +336,8 @@ class AuthorisationHandlerTest {
                         AuditService.UNKNOWN,
                         "123.123.123.123",
                         AuditService.UNKNOWN,
-                        PERSISTENT_SESSION_ID);
+                        PERSISTENT_SESSION_ID,
+                        pair("client-name", "client-name"));
     }
 
     @Test
@@ -374,7 +378,8 @@ class AuthorisationHandlerTest {
                         AuditService.UNKNOWN,
                         "123.123.123.123",
                         AuditService.UNKNOWN,
-                        PERSISTENT_SESSION_ID);
+                        PERSISTENT_SESSION_ID,
+                        pair("client-name", "client-name"));
     }
 
     @Test
@@ -613,7 +618,8 @@ class AuthorisationHandlerTest {
                         AuditService.UNKNOWN,
                         "123.123.123.123",
                         AuditService.UNKNOWN,
-                        PERSISTENT_SESSION_ID);
+                        PERSISTENT_SESSION_ID,
+                        pair("client-name", "client-name"));
     }
 
     private static Stream<Arguments> invalidPromptValues() {


### PR DESCRIPTION

## What?

Ship client name to the AUTHORISATION_INITIATED event.

## Why?

The client name will eventually be added to all audit events.  As this is a fair amount of work which is not covered by 
 AUT-692 it will be done under a separate ticket.

Starting with the most important one so that transactions can be associated with the client name if needed.

