### PR TITLE
ACI-84 - Remove AWS sdk v1 dependency

### DIFF
--- a/account-management-integration-tests/build.gradle
+++ b/account-management-integration-tests/build.gradle
@@ -8,6 +8,7 @@ version "unspecified"
 
 dependencies {
     testImplementation configurations.bouncycastle,
+            configurations.apache,
             configurations.nimbus,
             configurations.glassfish,
             configurations.gson,

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,6 @@ apply plugin: "idea"
 
 ext {
     dependencyVersions = [
-        aws_sdk_version: "1.12.286",
         aws_sdk_v2_version: "2.17.261",
         aws_lambda_core_version: "1.2.1",
         aws_lambda_events_version: "3.11.0",
@@ -64,6 +63,7 @@ subprojects {
     }
 
     configurations {
+        apache
         bouncycastle
         cloudwatch
         dynamodb
@@ -95,12 +95,14 @@ subprojects {
     }
 
     dependencies {
+        apache "commons-codec:commons-codec:1.15",
+                "org.apache.httpcomponents:httpclient:4.5.13"
+
         bouncycastle "org.bouncycastle:bcpkix-jdk15on:1.70"
 
         cloudwatch "software.amazon.cloudwatchlogs:aws-embedded-metrics:2.0.0"
 
-        dynamodb "com.amazonaws:aws-java-sdk-dynamodb:${dependencyVersions.aws_sdk_version}",
-                "software.amazon.awssdk:dynamodb:${dependencyVersions.aws_sdk_v2_version}",
+        dynamodb "software.amazon.awssdk:dynamodb:${dependencyVersions.aws_sdk_v2_version}",
                 "software.amazon.awssdk:dynamodb-enhanced:${dependencyVersions.aws_sdk_v2_version}"
 
         glassfish "org.glassfish.jersey.core:jersey-client:${dependencyVersions.glassfish_version}",

--- a/doc-checking-app-api/build.gradle
+++ b/doc-checking-app-api/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     runtimeOnly configurations.logging_runtime
 
     testImplementation configurations.tests,
+            configurations.apache,
             configurations.lambda_tests,
             project(":shared-test"),
             configurations.lambda,

--- a/frontend-api/build.gradle
+++ b/frontend-api/build.gradle
@@ -16,6 +16,7 @@ dependencies {
             configurations.dynamodb
 
     implementation configurations.govuk_notify,
+            configurations.apache,
             configurations.gson,
             configurations.nimbus,
             configurations.cloudwatch,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
@@ -3,7 +3,6 @@ package uk.gov.di.authentication.frontendapi.lambda;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -87,7 +86,7 @@ class CheckUserExistsHandlerTest {
     }
 
     @Test
-    void shouldReturn200IfUserExists() throws JsonProcessingException, Json.JsonException {
+    void shouldReturn200IfUserExists() throws Json.JsonException {
         usingValidSession();
         String persistentId = "some-persistent-id-value";
         Map<String, String> headers = new HashMap<>();
@@ -124,7 +123,7 @@ class CheckUserExistsHandlerTest {
     }
 
     @Test
-    void shouldReturn200IfUserDoesNotExist() throws JsonProcessingException, Json.JsonException {
+    void shouldReturn200IfUserDoesNotExist() throws Json.JsonException {
         usingValidSession();
         when(authenticationService.userExists(eq("joe.bloggs@digital.cabinet-office.gov.uk")))
                 .thenReturn(false);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandlerTest.java
@@ -3,7 +3,6 @@ package uk.gov.di.authentication.frontendapi.lambda;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.id.ClientID;
@@ -120,8 +119,7 @@ class SignUpHandlerTest {
 
     @ParameterizedTest
     @MethodSource("consentValues")
-    void shouldReturn200IfSignUpIsSuccessful(boolean consentRequired)
-            throws JsonProcessingException, Json.JsonException {
+    void shouldReturn200IfSignUpIsSuccessful(boolean consentRequired) throws Json.JsonException {
         String email = "joe.bloggs@test.com";
         String password = "computer-1";
         String persistentId = "some-persistent-id-value";

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -9,6 +9,7 @@ version "unspecified"
 dependencies {
     testImplementation configurations.tests,
             configurations.glassfish,
+            configurations.apache,
             configurations.gson,
             configurations.nimbus,
             configurations.bouncycastle,

--- a/ipv-api/build.gradle
+++ b/ipv-api/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     runtimeOnly configurations.logging_runtime
 
     testImplementation configurations.tests,
+            configurations.apache,
             configurations.lambda_tests,
             project(":shared-test"),
             configurations.lambda,

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCapacityHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCapacityHandlerTest.java
@@ -3,7 +3,6 @@ package uk.gov.di.authentication.ipv.lambda;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.ipv.services.IPVCapacityService;
@@ -29,7 +28,7 @@ public class IPVCapacityHandlerTest {
     }
 
     @Test
-    void shouldReturn200WhenIPVCapacityAvailable() throws JsonProcessingException {
+    void shouldReturn200WhenIPVCapacityAvailable() {
         when(ipvCapacityService.isIPVCapacityAvailable()).thenReturn(true);
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
@@ -39,7 +38,7 @@ public class IPVCapacityHandlerTest {
     }
 
     @Test
-    void shouldReturn503WhenIPVCapacityUnavailable() throws JsonProcessingException {
+    void shouldReturn503WhenIPVCapacityUnavailable() {
         when(ipvCapacityService.isIPVCapacityAvailable()).thenReturn(false);
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TrustMarkHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TrustMarkHandlerTest.java
@@ -3,7 +3,6 @@ package uk.gov.di.authentication.oidc.lambda;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.oidc.entity.TrustMarkResponse;
@@ -38,8 +37,7 @@ class TrustMarkHandlerTest {
     }
 
     @Test
-    public void shouldReturn200WhenRequestIsSuccessful()
-            throws JsonProcessingException, Json.JsonException {
+    public void shouldReturn200WhenRequestIsSuccessful() throws Json.JsonException {
         TrustMarkResponse trustMarkResponse =
                 new TrustMarkResponse(
                         configurationService.getOidcApiBaseURL().orElseThrow(),

--- a/shared-test/build.gradle
+++ b/shared-test/build.gradle
@@ -8,6 +8,7 @@ version "unspecified"
 dependencies {
     implementation configurations.tests,
             configurations.lambda,
+            configurations.apache,
             configurations.glassfish,
             configurations.nimbus,
             configurations.lettuce,


### PR DESCRIPTION
## What?

- Remove AWS sdk v1 dependency
- Add apache dependency

## Why?

- Now that we have uplifted everything to v2 of the AWS sdk dependency, we can remove the version1.
- Verson1 had a transitive dependency on apache that we were using in places (mainly tests) so explictly add the apache dependency.