### PR TITLE
BAU - Log out AccessToken in IpvCallbackHandler in non-prod environments

### DIFF
--- a/ci/terraform/oidc/integration-overrides.tfvars
+++ b/ci/terraform/oidc/integration-overrides.tfvars
@@ -17,6 +17,7 @@ ipv_backend_uri                = "https://api.identity.integration.account.gov.u
 ipv_audience                   = "https://identity.integration.account.gov.uk"
 ipv_sector                     = "https://identity.integration.account.gov.uk"
 spot_enabled                   = true
+identity_trace_logging_enabled = true
 ipv_auth_public_encryption_key = <<-EOT
 -----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzgTML6YZ+XUEPQprWBlW

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -242,6 +242,15 @@ public class IPVCallbackHandler
             }
             var pairwiseSubject =
                     ClientSubjectHelper.getSubject(userProfile, clientRegistry, dynamoService);
+            if (configurationService.isIdentityTraceLoggingEnabled()) {
+                LOG.info(
+                        "Sending UserInfo request with accessToken {}",
+                        tokenResponse
+                                .toSuccessResponse()
+                                .getTokens()
+                                .getBearerAccessToken()
+                                .getValue());
+            }
             var userIdentityUserInfo =
                     ipvTokenService.sendIpvUserIdentityRequest(
                             new UserInfoRequest(


### PR DESCRIPTION
## What?

 - Log out AccessToken in IpvCallbackHandler in non-prod environments

## Why?

- To help debug an issue between Auth and IPV - `Response from user-identity does not indicate success `

