### PR TITLE
AUT-766: Switch off per language Notify templates

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/NotificationType.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/NotificationType.java
@@ -46,7 +46,9 @@ public enum NotificationType implements TemplateAware {
     public String getTemplateId(
             SupportedLanguage language, ConfigurationService configurationService) {
         String templateId = configurationService.getNotifyTemplateId(getTemplateName(language));
-        if (templateId == null || templateId.length() == 0) {
+        if (!configurationService.isNotifyTemplatePerLanguage()
+                || templateId == null
+                || templateId.length() == 0) {
             return configurationService.getNotifyTemplateId(templateName);
         } else {
             return templateId;

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/entity/NotificationTypeTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/entity/NotificationTypeTest.java
@@ -1,4 +1,4 @@
-package uk.gov.di.authentication.shared.entity;
+package uk.gov.di.accountmanagement.entity;
 
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
@@ -8,39 +8,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_EMAIL;
+import static uk.gov.di.accountmanagement.entity.NotificationType.DELETE_ACCOUNT;
+import static uk.gov.di.accountmanagement.entity.NotificationType.VERIFY_EMAIL;
 
 class NotificationTypeTest {
 
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
-
-    @Test
-    void shouldReturnDefaultTemplateForVerifyEmailWithLanguageEN() {
-        assertThat(
-                VERIFY_EMAIL.getTemplateName(SupportedLanguage.EN),
-                equalTo("VERIFY_EMAIL_TEMPLATE_ID"));
-    }
-
-    @Test
-    void shouldReturnWelshTemplateForVerifyEmailWithLanguageCY() {
-        assertThat(
-                VERIFY_EMAIL.getTemplateName(SupportedLanguage.CY),
-                equalTo("VERIFY_EMAIL_TEMPLATE_ID_CY"));
-    }
-
-    @Test
-    void shouldReturnDefaultTemplateForVerifyPhoneNumberWithLanguageEN() {
-        assertThat(
-                NotificationType.VERIFY_PHONE_NUMBER.getTemplateName(SupportedLanguage.EN),
-                equalTo("VERIFY_PHONE_NUMBER_TEMPLATE_ID"));
-    }
-
-    @Test
-    void shouldReturnWelshTemplateForVerifyPhoneNumberWithLanguageCY() {
-        assertThat(
-                NotificationType.VERIFY_PHONE_NUMBER.getTemplateName(SupportedLanguage.CY),
-                equalTo("VERIFY_PHONE_NUMBER_TEMPLATE_ID_CY"));
-    }
 
     @Test
     void shouldReturnDefaultTemplateForVerifyEmailWhenLanguageEN() {
@@ -54,7 +27,7 @@ class NotificationTypeTest {
     }
 
     @Test
-    void shouldReturnCYTemplateForVerifyEmailWhenLanguageCYAndSingleTemplatePerLanguage() {
+    void shouldReturnDefaultTemplateForVerifyEmailWhenLanguageCYAndSingleTemplatePerLanguage() {
         when(configurationService.getNotifyTemplateId("VERIFY_EMAIL_TEMPLATE_ID_CY"))
                 .thenReturn("67890");
         when(configurationService.getNotifyTemplateId("VERIFY_EMAIL_TEMPLATE_ID"))
@@ -66,7 +39,7 @@ class NotificationTypeTest {
     }
 
     @Test
-    void shouldReturnENTemplateForVerifyEmailWhenLanguageCYAndNotSingleTemplatePerLanguage() {
+    void shouldReturnDefaultTemplateForVerifyEmailWhenLanguageCYAndNotSingleTemplatePerLanguage() {
         when(configurationService.getNotifyTemplateId("VERIFY_EMAIL_TEMPLATE_ID_CY"))
                 .thenReturn("67890");
         when(configurationService.getNotifyTemplateId("VERIFY_EMAIL_TEMPLATE_ID"))
@@ -74,6 +47,31 @@ class NotificationTypeTest {
         when(configurationService.isNotifyTemplatePerLanguage()).thenReturn(false);
         assertThat(
                 VERIFY_EMAIL.getTemplateId(SupportedLanguage.CY, configurationService),
+                equalTo("12345"));
+    }
+
+    @Test
+    void shouldReturnCYTemplateForDeleteAccountWhenLanguageCYAndSingleTemplatePerLanguage() {
+        when(configurationService.getNotifyTemplateId("DELETE_ACCOUNT_TEMPLATE_ID_CY"))
+                .thenReturn("67890");
+        when(configurationService.getNotifyTemplateId("DELETE_ACCOUNT_TEMPLATE_ID"))
+                .thenReturn("12345");
+        when(configurationService.isNotifyTemplatePerLanguage()).thenReturn(true);
+        assertThat(
+                DELETE_ACCOUNT.getTemplateId(SupportedLanguage.CY, configurationService),
+                equalTo("67890"));
+    }
+
+    @Test
+    void
+            shouldReturnDefaultTemplateForDeleteAccountWhenLanguageCYAndNotSingleTemplatePerLanguage() {
+        when(configurationService.getNotifyTemplateId("DELETE_ACCOUNT_TEMPLATE_ID_CY"))
+                .thenReturn("67890");
+        when(configurationService.getNotifyTemplateId("DELETE_ACCOUNT_TEMPLATE_ID"))
+                .thenReturn("12345");
+        when(configurationService.isNotifyTemplatePerLanguage()).thenReturn(false);
+        assertThat(
+                DELETE_ACCOUNT.getTemplateId(SupportedLanguage.CY, configurationService),
                 equalTo("12345"));
     }
 

--- a/ci/terraform/account-management/sqs.tf
+++ b/ci/terraform/account-management/sqs.tf
@@ -179,11 +179,12 @@ resource "aws_lambda_function" "email_sqs_lambda" {
   }
   environment {
     variables = merge(var.notify_template_map, {
-      FRONTEND_BASE_URL     = module.dns.frontend_url
-      CONTACT_US_LINK_ROUTE = var.contact_us_link_route
-      NOTIFY_API_KEY        = var.notify_api_key
-      NOTIFY_URL            = var.notify_url
-      JAVA_TOOL_OPTIONS     = "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
+      FRONTEND_BASE_URL            = module.dns.frontend_url
+      CONTACT_US_LINK_ROUTE        = var.contact_us_link_route
+      NOTIFY_API_KEY               = var.notify_api_key
+      NOTIFY_URL                   = var.notify_url
+      NOTIFY_TEMPLATE_PER_LANGUAGE = var.notify_template_per_language
+      JAVA_TOOL_OPTIONS            = "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
     })
   }
   kms_key_arn = data.terraform_remote_state.shared.outputs.lambda_env_vars_encryption_kms_key_arn

--- a/ci/terraform/account-management/variables.tf
+++ b/ci/terraform/account-management/variables.tf
@@ -14,6 +14,11 @@ variable "notify_url" {
   default = null
 }
 
+variable "notify_template_per_language" {
+  default = false
+  type    = bool
+}
+
 variable "notify_template_map" {
   type = map(string)
   default = {

--- a/ci/terraform/oidc/sqs.tf
+++ b/ci/terraform/oidc/sqs.tf
@@ -168,16 +168,17 @@ resource "aws_lambda_function" "email_sqs_lambda" {
   }
   environment {
     variables = merge(var.notify_template_map, {
-      FRONTEND_BASE_URL         = module.dns.frontend_url
-      ACCOUNT_MANAGEMENT_URI    = module.dns.account_management_url
-      RESET_PASSWORD_ROUTE      = var.reset_password_route
-      CONTACT_US_LINK_ROUTE     = var.contact_us_link_route
-      GOV_UK_ACCOUNTS_URL       = var.gov_uk_accounts_url
-      NOTIFY_API_KEY            = var.notify_api_key
-      NOTIFY_URL                = var.notify_url
-      NOTIFY_TEST_DESTINATIONS  = var.notify_test_destinations
-      SMOKETEST_SMS_BUCKET_NAME = local.sms_bucket_name
-      JAVA_TOOL_OPTIONS         = "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
+      FRONTEND_BASE_URL            = module.dns.frontend_url
+      ACCOUNT_MANAGEMENT_URI       = module.dns.account_management_url
+      RESET_PASSWORD_ROUTE         = var.reset_password_route
+      CONTACT_US_LINK_ROUTE        = var.contact_us_link_route
+      GOV_UK_ACCOUNTS_URL          = var.gov_uk_accounts_url
+      NOTIFY_API_KEY               = var.notify_api_key
+      NOTIFY_URL                   = var.notify_url
+      NOTIFY_TEST_DESTINATIONS     = var.notify_test_destinations
+      NOTIFY_TEMPLATE_PER_LANGUAGE = var.notify_template_per_language
+      SMOKETEST_SMS_BUCKET_NAME    = local.sms_bucket_name
+      JAVA_TOOL_OPTIONS            = "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
     })
   }
   kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -399,6 +399,11 @@ variable "language_cy_enabled" {
   type    = bool
 }
 
+variable "notify_template_per_language" {
+  default = false
+  type    = bool
+}
+
 locals {
   default_performance_parameters = {
     memory          = var.endpoint_memory_size

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/NotificationType.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/NotificationType.java
@@ -44,7 +44,9 @@ public enum NotificationType implements TemplateAware {
     public String getTemplateId(
             SupportedLanguage language, ConfigurationService configurationService) {
         String templateId = configurationService.getNotifyTemplateId(getTemplateName(language));
-        if (templateId == null || templateId.length() == 0) {
+        if (!configurationService.isNotifyTemplatePerLanguage()
+                || templateId == null
+                || templateId.length() == 0) {
             return configurationService.getNotifyTemplateId(templateName);
         } else {
             return templateId;

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -189,6 +189,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         }
     }
 
+    public boolean isNotifyTemplatePerLanguage() {
+        return System.getenv().getOrDefault("NOTIFY_TEMPLATE_PER_LANGUAGE", "false").equals("true");
+    }
+
     public long getIDTokenExpiry() {
         return Long.parseLong(System.getenv().getOrDefault("ID_TOKEN_EXPIRY", "120"));
     }


### PR DESCRIPTION
## What?

Switch off per language Notify templates

Create a switch to toggle this feature.
Switch it off: the default template will be used in all cases regardless of the user language.

## Why?

We are switching to bilingual templates so the default can be used in all cases.