### PR TITLE
AUT-663: Add Dynamo Stream on UserProfile table

### DIFF
--- a/ci/terraform/shared/dynamodb.tf
+++ b/ci/terraform/shared/dynamodb.tf
@@ -40,9 +40,11 @@ resource "aws_dynamodb_table" "user_credentials_table" {
 }
 
 resource "aws_dynamodb_table" "user_profile_table" {
-  name         = "${var.environment}-user-profile"
-  billing_mode = var.provision_dynamo ? "PROVISIONED" : "PAY_PER_REQUEST"
-  hash_key     = "Email"
+  name             = "${var.environment}-user-profile"
+  billing_mode     = var.provision_dynamo ? "PROVISIONED" : "PAY_PER_REQUEST"
+  hash_key         = "Email"
+  stream_enabled   = true
+  stream_view_type = "NEW_AND_OLD_IMAGES"
 
   read_capacity  = var.provision_dynamo ? var.dynamo_default_read_capacity : null
   write_capacity = var.provision_dynamo ? var.dynamo_default_write_capacity : null

--- a/ci/terraform/utils/experian_phone_check_dynamo_access.tf
+++ b/ci/terraform/utils/experian_phone_check_dynamo_access.tf
@@ -1,0 +1,24 @@
+data "aws_iam_policy_document" "user_profile_stream_access" {
+  statement {
+    sid    = "AllowAccessToUserProfileDynamoStreamOnly"
+    effect = "Allow"
+
+    actions = [
+      "dynamodb:DescribeStream",
+      "dynamodb:GetRecords",
+      "dynamodb:GetShardIterator",
+      "dynamodb:ListStreams"
+    ]
+
+    resources = [
+      data.aws_dynamodb_table.user_profile.stream_arn,
+    ]
+  }
+}
+
+resource "aws_iam_policy" "user_profile_stream_access" {
+  name_prefix = "dynamo-access-policy"
+  description = "IAM policy for managing stream read permissions to the Dynamo User Profile table"
+
+  policy = data.aws_iam_policy_document.user_profile_stream_access.json
+}

--- a/ci/terraform/utils/experian_phone_check_lambda.tf
+++ b/ci/terraform/utils/experian_phone_check_lambda.tf
@@ -1,0 +1,64 @@
+module "experian_phone_check_lambda_role" {
+  source = "../modules/lambda-role"
+
+  environment = var.environment
+  role_name   = "experian_phone_check_lambda_role"
+
+  policies_to_attach = [
+    aws_iam_policy.user_profile_stream_access.arn,
+  ]
+}
+
+resource "aws_lambda_function" "experian_phone_check_lambda" {
+  function_name = "${var.environment}-experian-phone-check-lambda"
+  role          = module.experian_phone_check_lambda_role.arn
+  handler       = "uk.gov.di.authentication.utils.lambda.ExperianPhoneCheckHandler::handleRequest"
+  timeout       = 900
+  memory_size   = 4096
+  runtime       = "java11"
+  publish       = true
+
+  s3_bucket         = aws_s3_object.utils_release_zip.bucket
+  s3_key            = aws_s3_object.utils_release_zip.key
+  s3_object_version = aws_s3_object.utils_release_zip.version_id
+
+  environment {
+    variables = merge({
+      ENVIRONMENT = var.environment
+    })
+  }
+
+  tags = local.default_tags
+}
+
+resource "aws_lambda_event_source_mapping" "user_profile_stream" {
+  event_source_arn  = data.aws_dynamodb_table.user_profile.stream_arn
+  function_name     = aws_lambda_function.experian_phone_check_lambda.arn
+  starting_position = "LATEST"
+}
+
+resource "aws_cloudwatch_log_group" "experian_phone_check_lambda_log_group" {
+  count = var.use_localstack ? 0 : 1
+
+  name              = "/aws/lambda/${aws_lambda_function.experian_phone_check_lambda.function_name}"
+  kms_key_id        = local.cloudwatch_encryption_key_arn
+  retention_in_days = var.cloudwatch_log_retention
+
+  tags = local.default_tags
+
+  depends_on = [
+    aws_lambda_function.experian_phone_check_lambda
+  ]
+}
+
+resource "aws_cloudwatch_log_subscription_filter" "experian_phone_check_lambda_log_subscription" {
+  count           = length(var.logging_endpoint_arns)
+  name            = "${aws_lambda_function.experian_phone_check_lambda.function_name}-log-subscription-${count.index}"
+  log_group_name  = aws_cloudwatch_log_group.experian_phone_check_lambda_log_group[0].name
+  filter_pattern  = ""
+  destination_arn = var.logging_endpoint_arns[count.index]
+
+  lifecycle {
+    create_before_destroy = false
+  }
+}

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/ExperianPhoneCheckHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/ExperianPhoneCheckHandler.java
@@ -1,0 +1,33 @@
+package uk.gov.di.authentication.utils.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.DynamodbEvent;
+import com.amazonaws.services.lambda.runtime.events.DynamodbEvent.DynamodbStreamRecord;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class ExperianPhoneCheckHandler implements RequestHandler<DynamodbEvent, Void> {
+
+    private static final Logger LOG = LogManager.getLogger(ExperianPhoneCheckHandler.class);
+
+    @Override
+    public Void handleRequest(DynamodbEvent dynamodbEvent, Context context) {
+
+        int recordLength = 0;
+
+        for (DynamodbStreamRecord record : dynamodbEvent.getRecords()) {
+
+            if (record == null) {
+                continue;
+            }
+            recordLength++;
+        }
+
+        LOG.info(
+                "Skeleton Experian phone check lambda has been triggered for {} individual streaming records",
+                recordLength);
+
+        return null;
+    }
+}


### PR DESCRIPTION
## What?

- Add Dynamo Stream on UserProfile table
- Add log-only lambda which consumes this stream
- Add requisite permissions for new lambda to read from stream

## Why?

- Precursor to building out Experian phone number check API call lambda, which will consume changes to DynamoDB table, and - if relevant - call Experian to check that the number is not in some way 'bad'.
