### PR TITLE
AUT-663/turn on user profile streaming

### DIFF
--- a/ci/terraform/shared/dynamodb.tf
+++ b/ci/terraform/shared/dynamodb.tf
@@ -43,6 +43,8 @@ resource "aws_dynamodb_table" "user_profile_table" {
   name         = "${var.environment}-user-profile"
   billing_mode = var.provision_dynamo ? "PROVISIONED" : "PAY_PER_REQUEST"
   hash_key     = "Email"
+  stream_enabled   = true
+  stream_view_type = "NEW_AND_OLD_IMAGES"
 
   read_capacity  = var.provision_dynamo ? var.dynamo_default_read_capacity : null
   write_capacity = var.provision_dynamo ? var.dynamo_default_write_capacity : null

--- a/ci/terraform/shared/dynamodb.tf
+++ b/ci/terraform/shared/dynamodb.tf
@@ -40,10 +40,10 @@ resource "aws_dynamodb_table" "user_credentials_table" {
 }
 
 resource "aws_dynamodb_table" "user_profile_table" {
-  name         = "${var.environment}-user-profile"
-  billing_mode = var.provision_dynamo ? "PROVISIONED" : "PAY_PER_REQUEST"
-  hash_key     = "Email"
-  stream_enabled   = true
+  name             = "${var.environment}-user-profile"
+  billing_mode     = var.provision_dynamo ? "PROVISIONED" : "PAY_PER_REQUEST"
+  hash_key         = "Email"
+  stream_enabled   = var.enable_user_profile_stream
   stream_view_type = "NEW_AND_OLD_IMAGES"
 
   read_capacity  = var.provision_dynamo ? var.dynamo_default_read_capacity : null

--- a/ci/terraform/shared/production-sizing.tfvars
+++ b/ci/terraform/shared/production-sizing.tfvars
@@ -1,3 +1,3 @@
-redis_node_size  = "cache.m4.xlarge"
-provision_dynamo = false
-
+redis_node_size            = "cache.m4.xlarge"
+provision_dynamo           = false
+enable_user_profile_stream = false

--- a/ci/terraform/shared/variables.tf
+++ b/ci/terraform/shared/variables.tf
@@ -158,3 +158,9 @@ variable "enforce_code_signing" {
   default     = true
   description = "Whether the code signing policy will reject unsigned code. (only set to false in sandpit environments)"
 }
+
+variable "enable_user_profile_stream" {
+  default     = true
+  type        = bool
+  description = "Whether the User Profile DynamoDB table should have streaming turned on (this is consumed by Experian Phone Check lambda in a separate repo)"
+}


### PR DESCRIPTION
## What?

- Add streaming to UserProfile DynamoDB table
- On by default but off for production

## Why?

- Streaming events will be consumed by the Experian phone check lambda
- To keep costs down, the stream (and lambda subscription) will be conditional - as the lambda could be invoked unnecessarily in production before it is ready otherwise
