### PR TITLE
AUT-644: Templates for ECS Fargate Cluster and Slack Alerting SNS

### DIFF
--- a/shared/fargate-cluster.yaml
+++ b/shared/fargate-cluster.yaml
@@ -1,0 +1,30 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Fargate Cluster for running ECS tasks
+Parameters:
+  Environment:
+    Type: String
+    Default: sandpit
+    AllowedValues:
+      - dev
+      - sandpit
+      - build
+      - integration
+      - staging
+      - production
+    Description: The logical name for this deployment environment
+Outputs:
+  FargateCluster:
+    Value: !Ref FargateCluster
+    Export:
+      Name: FargateCluster
+Resources:
+  FargateCluster:
+    Type: AWS::ECS::Cluster
+    Properties:
+      CapacityProviders:
+        - FARGATE
+      ClusterName: !Sub "${Environment}-fargate-cluster"
+      ClusterSettings:
+        - Name: containerInsights
+          Value: enabled
+

--- a/shared/sns.yaml
+++ b/shared/sns.yaml
@@ -1,0 +1,75 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: SNS topic for sending slack notifications
+Parameters:
+  Environment:
+    Type: String
+    Default: sandpit
+    AllowedValues:
+      - dev
+      - sandpit
+      - build
+      - integration
+      - staging
+      - production
+    Description: The logical name for this deployment environment
+
+Outputs:
+  SlackNotificationsTopic:
+    Value: !Ref SlackNotificationsTopic
+    Export:
+      Name: SlackNotificationsTopic
+  SlackNotificationPublisherPolicy:
+    Value: !Ref SlackNotificationPublisherPolicy
+    Export:
+      Name: SlackNotificationPublisherPolicy
+
+Resources:
+  SlackNotificationsTopicEncryptionKey:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: KMS key for Slack Alerts SNS topic
+      Enabled: true
+      KeySpec: SYMMETRIC_DEFAULT
+      KeyPolicy:
+        Version: 2012-10-17
+        Id: key-policy-sns
+        Statement:
+          - Sid: Enable IAM User Permissions for root user
+            Effect: Allow
+            Principal:
+              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+            Action: 'kms:*'
+            Resource: '*'
+      KeyUsage: ENCRYPT_DECRYPT
+      PendingWindowInDays: 30
+      EnableKeyRotation: true
+
+  SlackNotificationsTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      DisplayName: !Sub "Slack Alerts for ${Environment}"
+      FifoTopic: false
+      KmsMasterKeyId: !Ref SlackNotificationsTopicEncryptionKey
+      TopicName: !Sub "${Environment}-alerts-to-slack"
+
+  SlackNotificationPublisherPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: !Sub "${Environment}-slack-notifications-publisher"
+      Description: Gives access to publish messages the Slack alerts SNS topic
+      Path: !Sub "/${Environment}/sns/"
+      PolicyDocument:
+        Version: 2012-10-17
+        Id: publisher-policy
+        Statement:
+          - Sid: KmsPermissions
+            Effect: Allow
+            Action:
+              - "kms:Decrypt"
+              - "kms:GenerateDataKey"
+            Resource: !GetAtt SlackNotificationsTopicEncryptionKey.Arn
+          - Sid: SnsPermissions
+            Effect: Allow
+            Action:
+              - "sns:Publish"
+            Resource: !Ref SlackNotificationsTopic


### PR DESCRIPTION
## What?

- Add a Cloudformation stack for an ECS fargate cluster
- Add a central SNS topic for slack alerts. This differs slightly from current configuration as it is encrypted (as recommended by Checkov)
- Create a managed policy for event publisher
- Add key for topic encryption (the key policy will change later once required permissions for deployments have been fully established)

## Why?

These are shared resources that will be used by multiple deployments when we migrate to Cloudformation/Codepipeline. These resources will not be imported in production, just created fresh, so its OK that the config differs slightly from our current Terraform.