### PR TITLE
ACI-7: Do not block email when validation code entered incorrectly max times for new account

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/SendNotificationRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/SendNotificationRequest.java
@@ -17,12 +17,20 @@ public class SendNotificationRequest extends BaseFrontendRequest {
     @Expose
     private String phoneNumber;
 
+    @SerializedName("requestNewCode")
+    @Expose
+    private Boolean requestNewCode;
+
     public NotificationType getNotificationType() {
         return notificationType;
     }
 
     public String getPhoneNumber() {
         return phoneNumber;
+    }
+
+    public Boolean isRequestNewCode() {
+        return requestNewCode;
     }
 
     @Override
@@ -35,6 +43,9 @@ public class SendNotificationRequest extends BaseFrontendRequest {
                 + '\''
                 + ", email='"
                 + email
+                + '\''
+                + ", requestNewCode='"
+                + requestNewCode
                 + '\''
                 + '}';
     }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -286,6 +286,7 @@ class VerifyCodeHandlerTest {
         verify(codeStorageService)
                 .saveBlockedForEmail(
                         TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX, BLOCKED_EMAIL_DURATION);
+        verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(TEST_EMAIL_ADDRESS);
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CODE_MAX_RETRIES_REACHED,
@@ -316,7 +317,7 @@ class VerifyCodeHandlerTest {
     }
 
     @Test
-    void shouldUpdateRedisWhenUserHasReachedMaxEmailCodeAttempts() {
+    void shouldNotUpdateRedisWhenUserHasReachedMaxEmailCodeAttempts() {
         when(configurationService.getCodeMaxRetries()).thenReturn(0);
 
         when(configurationService.getBlockedEmailDuration()).thenReturn(BLOCKED_EMAIL_DURATION);
@@ -331,9 +332,10 @@ class VerifyCodeHandlerTest {
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1033));
         assertThat(session.getRetryCount(), equalTo(0));
-        verify(codeStorageService)
+        verify(codeStorageService, never())
                 .saveBlockedForEmail(
                         TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX, BLOCKED_EMAIL_DURATION);
+        verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(TEST_EMAIL_ADDRESS);
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CODE_MAX_RETRIES_REACHED,
@@ -418,6 +420,7 @@ class VerifyCodeHandlerTest {
         verify(codeStorageService)
                 .saveBlockedForEmail(
                         TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX, BLOCKED_EMAIL_DURATION);
+        verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(TEST_EMAIL_ADDRESS);
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CODE_MAX_RETRIES_REACHED,


### PR DESCRIPTION
## What?

Do not block email when validation code entered incorrectly max times for new account.
Do not ask user to re-enter email when they request another code having exceeded the maximum.
Provide flag to send a new code instead of the old one as previously codes were reused for 15 mins.  In this case it makes sense to send a new code.

In 'verify-code' for email notification types, where the code is 1033 meaning that user has exceeded the maximum number of attempts to enter the code correctly, then don't block the email in Redis.


## Why?

No reason to block the account if the account does not already exist, this just means the user has to wait 15 mins before they can create the account.
Make it easier for the user by not asking them to enter their email again.

## Related PRs

https://github.com/alphagov/di-authentication-frontend/pull/787
https://github.com/alphagov/di-authentication-acceptance-tests/pull/149