### PR TITLE
BAU: Toggle User Profile table streaming on

### DIFF
--- a/ci/terraform/shared/production-sizing.tfvars
+++ b/ci/terraform/shared/production-sizing.tfvars
@@ -1,3 +1,3 @@
 redis_node_size            = "cache.m4.xlarge"
 provision_dynamo           = false
-enable_user_profile_stream = false
+enable_user_profile_stream = true


### PR DESCRIPTION
## What?

-  Toggle User Profile table streaming on

## Why?

To resolve Terraform error that we cannot disable a stream that does not exist (yet)