### PR TITLE
Update dynamodb.tf

### DIFF
--- a/ci/terraform/shared/dynamodb.tf
+++ b/ci/terraform/shared/dynamodb.tf
@@ -44,7 +44,7 @@ resource "aws_dynamodb_table" "user_profile_table" {
   billing_mode     = var.provision_dynamo ? "PROVISIONED" : "PAY_PER_REQUEST"
   hash_key         = "Email"
   stream_enabled   = var.enable_user_profile_stream
-  stream_view_type = "NEW_AND_OLD_IMAGES"
+  stream_view_type = var.enable_user_profile_stream ? "NEW_AND_OLD_IMAGES" : null
 
   read_capacity  = var.provision_dynamo ? var.dynamo_default_read_capacity : null
   write_capacity = var.provision_dynamo ? var.dynamo_default_write_capacity : null


### PR DESCRIPTION
## What?

- Turn off stream view type alongside streams for UserProfile DynamoDB table

## Why?

- Otherwise, streams eventually disappear in AWS and Terraform attempts to operate on the table because it finds a change (stream view type becoming null) 
- In attempting to operate, Terraform finds an error because the stream does not exist