### PR TITLE
ACI-76: Decouple email OTP validity from SMS OTP validity

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
@@ -168,13 +168,14 @@ public class SendOtpNotificationHandler
             throws JsonException {
 
         String code = codeGeneratorService.sixDigitCode();
+        var notificationType = sendNotificationRequest.getNotificationType();
+
         NotifyRequest notifyRequest =
-                new NotifyRequest(
-                        destination, sendNotificationRequest.getNotificationType(), code, language);
+                new NotifyRequest(destination, notificationType, code, language);
         codeStorageService.saveOtpCode(
                 sendNotificationRequest.getEmail(),
                 code,
-                configurationService.getSmsOtpCodeExpiry(),
+                configurationService.getDefaultOtpCodeExpiry(),
                 sendNotificationRequest.getNotificationType());
         LOG.info(
                 "Sending message to SQS queue for notificationType: {}",

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
@@ -174,7 +174,7 @@ public class SendOtpNotificationHandler
         codeStorageService.saveOtpCode(
                 sendNotificationRequest.getEmail(),
                 code,
-                configurationService.getCodeExpiry(),
+                configurationService.getSmsOtpCodeExpiry(),
                 sendNotificationRequest.getNotificationType());
         LOG.info(
                 "Sending message to SQS queue for notificationType: {}",

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandlerTest.java
@@ -72,7 +72,7 @@ class SendOtpNotificationHandlerTest {
 
     @BeforeEach
     void setup() {
-        when(configurationService.getCodeExpiry()).thenReturn(CODE_EXPIRY_TIME);
+        when(configurationService.getSmsOtpCodeExpiry()).thenReturn(CODE_EXPIRY_TIME);
         when(codeGeneratorService.sixDigitCode()).thenReturn(TEST_SIX_DIGIT_CODE);
     }
 

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandlerTest.java
@@ -72,7 +72,7 @@ class SendOtpNotificationHandlerTest {
 
     @BeforeEach
     void setup() {
-        when(configurationService.getSmsOtpCodeExpiry()).thenReturn(CODE_EXPIRY_TIME);
+        when(configurationService.getDefaultOtpCodeExpiry()).thenReturn(CODE_EXPIRY_TIME);
         when(codeGeneratorService.sixDigitCode()).thenReturn(TEST_SIX_DIGIT_CODE);
     }
 

--- a/ci/terraform/account-management/build-overrides.tfvars
+++ b/ci/terraform/account-management/build-overrides.tfvars
@@ -8,3 +8,7 @@ logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod",
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]
+
+blocked_email_duration                    = 30
+otp_code_ttl_duration                     = 120
+email_acct_creation_otp_code_ttl_duration = 60

--- a/ci/terraform/account-management/sandpit.tfvars
+++ b/ci/terraform/account-management/sandpit.tfvars
@@ -12,3 +12,7 @@ keep_lambdas_warm      = false
 endpoint_memory_size   = 1024
 lambda_max_concurrency = 0
 lambda_min_concurrency = 0
+
+blocked_email_duration                    = 30
+otp_code_ttl_duration                     = 120
+email_acct_creation_otp_code_ttl_duration = 60

--- a/ci/terraform/account-management/send_otp_notification.tf
+++ b/ci/terraform/account-management/send_otp_notification.tf
@@ -21,12 +21,15 @@ module "send_otp_notification" {
   environment     = var.environment
 
   handler_environment_variables = {
-    ENVIRONMENT          = var.environment
-    EMAIL_QUEUE_URL      = aws_sqs_queue.email_queue.id
-    DYNAMO_ENDPOINT      = var.use_localstack ? var.lambda_dynamo_endpoint : null
-    LOCALSTACK_ENDPOINT  = var.use_localstack ? var.localstack_endpoint : null
-    REDIS_KEY            = local.redis_key
-    TXMA_AUDIT_QUEUE_URL = module.account_management_txma_audit.queue_url
+    ENVIRONMENT                            = var.environment
+    EMAIL_QUEUE_URL                        = aws_sqs_queue.email_queue.id
+    DYNAMO_ENDPOINT                        = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    LOCALSTACK_ENDPOINT                    = var.use_localstack ? var.localstack_endpoint : null
+    REDIS_KEY                              = local.redis_key
+    TXMA_AUDIT_QUEUE_URL                   = module.account_management_txma_audit.queue_url
+    BLOCKED_EMAIL_DURATION                 = var.blocked_email_duration
+    DEFAULT_OTP_CODE_EXPIRY                = var.otp_code_ttl_duration
+    EMAIL_OTP_ACCOUNT_CREATION_CODE_EXPIRY = var.email_acct_creation_otp_code_ttl_duration
   }
   handler_function_name = "uk.gov.di.accountmanagement.lambda.SendOtpNotificationHandler::handleRequest"
 

--- a/ci/terraform/account-management/variables.tf
+++ b/ci/terraform/account-management/variables.tf
@@ -215,6 +215,21 @@ variable "txma_account_id" {
   type    = string
 }
 
+variable "blocked_email_duration" {
+  type    = number
+  default = 900
+}
+
+variable "otp_code_ttl_duration" {
+  type    = number
+  default = 900
+}
+
+variable "email_acct_creation_otp_code_ttl_duration" {
+  type    = number
+  default = 7200
+}
+
 locals {
   default_performance_parameters = {
     memory          = var.endpoint_memory_size

--- a/ci/terraform/oidc/build-overrides.tfvars
+++ b/ci/terraform/oidc/build-overrides.tfvars
@@ -10,7 +10,9 @@ doc_app_encryption_key_id          = "7788bc975abd44e8b4fd7646d08ea9428476e37bff
 spot_enabled                       = false
 language_cy_enabled                = true
 
-blocked_email_duration = 30
+blocked_email_duration                    = 30
+otp_code_ttl_duration                     = 120
+email_acct_creation_otp_code_ttl_duration = 60
 
 logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod",

--- a/ci/terraform/oidc/mfa.tf
+++ b/ci/terraform/oidc/mfa.tf
@@ -23,14 +23,16 @@ module "mfa" {
   environment     = var.environment
 
   handler_environment_variables = {
-    ENVIRONMENT            = var.environment
-    BLOCKED_EMAIL_DURATION = var.blocked_email_duration
-    EMAIL_QUEUE_URL        = aws_sqs_queue.email_queue.id
-    TXMA_AUDIT_QUEUE_URL   = module.oidc_txma_audit.queue_url
-    LOCALSTACK_ENDPOINT    = var.use_localstack ? var.localstack_endpoint : null
-    REDIS_KEY              = local.redis_key
-    DYNAMO_ENDPOINT        = var.use_localstack ? var.lambda_dynamo_endpoint : null
-    TEST_CLIENTS_ENABLED   = var.test_clients_enabled
+    ENVIRONMENT                            = var.environment
+    BLOCKED_EMAIL_DURATION                 = var.blocked_email_duration
+    DEFAULT_OTP_CODE_EXPIRY                = var.otp_code_ttl_duration
+    EMAIL_OTP_ACCOUNT_CREATION_CODE_EXPIRY = var.email_acct_creation_otp_code_ttl_duration
+    EMAIL_QUEUE_URL                        = aws_sqs_queue.email_queue.id
+    TXMA_AUDIT_QUEUE_URL                   = module.oidc_txma_audit.queue_url
+    LOCALSTACK_ENDPOINT                    = var.use_localstack ? var.localstack_endpoint : null
+    REDIS_KEY                              = local.redis_key
+    DYNAMO_ENDPOINT                        = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    TEST_CLIENTS_ENABLED                   = var.test_clients_enabled
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.MfaHandler::handleRequest"
 

--- a/ci/terraform/oidc/reset_password.tf
+++ b/ci/terraform/oidc/reset_password.tf
@@ -25,14 +25,16 @@ module "reset_password" {
   environment     = var.environment
 
   handler_environment_variables = {
-    DYNAMO_ENDPOINT          = var.use_localstack ? var.lambda_dynamo_endpoint : null
-    LOCALSTACK_ENDPOINT      = var.use_localstack ? var.localstack_endpoint : null
-    EMAIL_QUEUE_URL          = aws_sqs_queue.email_queue.id
-    ENVIRONMENT              = var.environment
-    TXMA_AUDIT_QUEUE_URL     = module.oidc_txma_audit.queue_url
-    REDIS_KEY                = local.redis_key
-    SQS_ENDPOINT             = var.use_localstack ? "http://localhost:45678/" : null
-    TERMS_CONDITIONS_VERSION = var.terms_and_conditions
+    DYNAMO_ENDPOINT                        = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    LOCALSTACK_ENDPOINT                    = var.use_localstack ? var.localstack_endpoint : null
+    EMAIL_QUEUE_URL                        = aws_sqs_queue.email_queue.id
+    ENVIRONMENT                            = var.environment
+    TXMA_AUDIT_QUEUE_URL                   = module.oidc_txma_audit.queue_url
+    REDIS_KEY                              = local.redis_key
+    SQS_ENDPOINT                           = var.use_localstack ? "http://localhost:45678/" : null
+    TERMS_CONDITIONS_VERSION               = var.terms_and_conditions
+    DEFAULT_OTP_CODE_EXPIRY                = var.otp_code_ttl_duration
+    EMAIL_OTP_ACCOUNT_CREATION_CODE_EXPIRY = var.email_acct_creation_otp_code_ttl_duration
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.ResetPasswordHandler::handleRequest"
 

--- a/ci/terraform/oidc/sandpit.tfvars
+++ b/ci/terraform/oidc/sandpit.tfvars
@@ -19,4 +19,6 @@ lambda_min_concurrency = 0
 keep_lambdas_warm      = false
 endpoint_memory_size   = 1024
 
-blocked_email_duration = 30
+blocked_email_duration                    = 30
+otp_code_ttl_duration                     = 120
+email_acct_creation_otp_code_ttl_duration = 60

--- a/ci/terraform/oidc/send_notification.tf
+++ b/ci/terraform/oidc/send_notification.tf
@@ -23,13 +23,15 @@ module "send_notification" {
   environment     = var.environment
 
   handler_environment_variables = {
-    ENVIRONMENT            = var.environment
-    BLOCKED_EMAIL_DURATION = var.blocked_email_duration
-    EMAIL_QUEUE_URL        = aws_sqs_queue.email_queue.id
-    TXMA_AUDIT_QUEUE_URL   = module.oidc_txma_audit.queue_url
-    LOCALSTACK_ENDPOINT    = var.use_localstack ? var.localstack_endpoint : null
-    REDIS_KEY              = local.redis_key
-    TEST_CLIENTS_ENABLED   = var.test_clients_enabled
+    ENVIRONMENT                            = var.environment
+    BLOCKED_EMAIL_DURATION                 = var.blocked_email_duration
+    EMAIL_QUEUE_URL                        = aws_sqs_queue.email_queue.id
+    TXMA_AUDIT_QUEUE_URL                   = module.oidc_txma_audit.queue_url
+    LOCALSTACK_ENDPOINT                    = var.use_localstack ? var.localstack_endpoint : null
+    REDIS_KEY                              = local.redis_key
+    TEST_CLIENTS_ENABLED                   = var.test_clients_enabled
+    DEFAULT_OTP_CODE_EXPIRY                = var.otp_code_ttl_duration
+    EMAIL_OTP_ACCOUNT_CREATION_CODE_EXPIRY = var.email_acct_creation_otp_code_ttl_duration
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.SendNotificationHandler::handleRequest"
 

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -170,6 +170,16 @@ variable "blocked_email_duration" {
   default = 900
 }
 
+variable "otp_code_ttl_duration" {
+  type    = number
+  default = 900
+}
+
+variable "email_acct_creation_otp_code_ttl_duration" {
+  type    = number
+  default = 7200
+}
+
 variable "contact_us_link_route" {
   type    = string
   default = "contact-us"

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
@@ -194,7 +194,7 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
                                         codeStorageService.saveOtpCode(
                                                 email,
                                                 newCode,
-                                                configurationService.getSmsOtpCodeExpiry(),
+                                                configurationService.getDefaultOtpCodeExpiry(),
                                                 notificationType);
                                         return newCode;
                                     });

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
@@ -194,7 +194,7 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
                                         codeStorageService.saveOtpCode(
                                                 email,
                                                 newCode,
-                                                configurationService.getCodeExpiry(),
+                                                configurationService.getSmsOtpCodeExpiry(),
                                                 notificationType);
                                         return newCode;
                                     });

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
@@ -161,7 +161,7 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
                                         codeStorageService.saveOtpCode(
                                                 resetPasswordRequest.getEmail(),
                                                 newCode,
-                                                configurationService.getSmsOtpCodeExpiry(),
+                                                configurationService.getDefaultOtpCodeExpiry(),
                                                 notificationType);
                                         return newCode;
                                     });
@@ -175,7 +175,10 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
                             code, userContext.getSession().getSessionId(), persistentSessionId);
             notificationType = RESET_PASSWORD;
             codeStorageService.savePasswordResetCode(
-                    subjectId, code, configurationService.getSmsOtpCodeExpiry(), notificationType);
+                    subjectId,
+                    code,
+                    configurationService.getDefaultOtpCodeExpiry(),
+                    notificationType);
         }
         NotifyRequest notifyRequest =
                 new NotifyRequest(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
@@ -161,7 +161,7 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
                                         codeStorageService.saveOtpCode(
                                                 resetPasswordRequest.getEmail(),
                                                 newCode,
-                                                configurationService.getCodeExpiry(),
+                                                configurationService.getSmsOtpCodeExpiry(),
                                                 notificationType);
                                         return newCode;
                                     });
@@ -175,7 +175,7 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
                             code, userContext.getSession().getSessionId(), persistentSessionId);
             notificationType = RESET_PASSWORD;
             codeStorageService.savePasswordResetCode(
-                    subjectId, code, configurationService.getCodeExpiry(), notificationType);
+                    subjectId, code, configurationService.getSmsOtpCodeExpiry(), notificationType);
         }
         NotifyRequest notifyRequest =
                 new NotifyRequest(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
@@ -205,7 +205,12 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
     private String generateAndSaveNewCode(String email, NotificationType notificationType) {
         String newCode = codeGeneratorService.sixDigitCode();
         codeStorageService.saveOtpCode(
-                email, newCode, configurationService.getCodeExpiry(), notificationType);
+                email,
+                newCode,
+                notificationType.equals(VERIFY_PHONE_NUMBER)
+                        ? configurationService.getSmsOtpCodeExpiry()
+                        : configurationService.getEmailOtpCodeExpiry(),
+                notificationType);
         return newCode;
     }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
@@ -208,8 +208,8 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
                 email,
                 newCode,
                 notificationType.equals(VERIFY_PHONE_NUMBER)
-                        ? configurationService.getSmsOtpCodeExpiry()
-                        : configurationService.getEmailOtpCodeExpiry(),
+                        ? configurationService.getDefaultOtpCodeExpiry()
+                        : configurationService.getEmailAccountCreationOtpCodeExpiry(),
                 notificationType);
         return newCode;
     }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/ResetPasswordService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/ResetPasswordService.java
@@ -19,7 +19,7 @@ public class ResetPasswordService {
     public String buildResetPasswordLink(
             String code, String sessionID, String persistentSessionId) {
         Date expiryDate =
-                NowHelper.nowPlus(configurationService.getCodeExpiry(), ChronoUnit.SECONDS);
+                NowHelper.nowPlus(configurationService.getSmsOtpCodeExpiry(), ChronoUnit.SECONDS);
         return buildURI(
                         configurationService.getFrontendBaseUrl(),
                         configurationService.getResetPasswordRoute()

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/ResetPasswordService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/ResetPasswordService.java
@@ -19,7 +19,8 @@ public class ResetPasswordService {
     public String buildResetPasswordLink(
             String code, String sessionID, String persistentSessionId) {
         Date expiryDate =
-                NowHelper.nowPlus(configurationService.getSmsOtpCodeExpiry(), ChronoUnit.SECONDS);
+                NowHelper.nowPlus(
+                        configurationService.getDefaultOtpCodeExpiry(), ChronoUnit.SECONDS);
         return buildURI(
                         configurationService.getFrontendBaseUrl(),
                         configurationService.getResetPasswordRoute()

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
@@ -112,7 +112,7 @@ public class MfaHandlerTest {
     @BeforeEach
     void setUp() {
         when(context.getAwsRequestId()).thenReturn("aws-session-id");
-        when(configurationService.getCodeExpiry()).thenReturn(CODE_EXPIRY_TIME);
+        when(configurationService.getSmsOtpCodeExpiry()).thenReturn(CODE_EXPIRY_TIME);
         when(configurationService.getCodeMaxRetries()).thenReturn(5);
         handler =
                 new MfaHandler(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
@@ -112,7 +112,7 @@ public class MfaHandlerTest {
     @BeforeEach
     void setUp() {
         when(context.getAwsRequestId()).thenReturn("aws-session-id");
-        when(configurationService.getSmsOtpCodeExpiry()).thenReturn(CODE_EXPIRY_TIME);
+        when(configurationService.getDefaultOtpCodeExpiry()).thenReturn(CODE_EXPIRY_TIME);
         when(configurationService.getCodeMaxRetries()).thenReturn(5);
         handler =
                 new MfaHandler(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
@@ -113,7 +113,7 @@ class ResetPasswordRequestHandlerTest {
 
     @BeforeEach
     void setup() {
-        when(configurationService.getSmsOtpCodeExpiry()).thenReturn(CODE_EXPIRY_TIME);
+        when(configurationService.getDefaultOtpCodeExpiry()).thenReturn(CODE_EXPIRY_TIME);
         when(codeGeneratorService.twentyByteEncodedRandomCode()).thenReturn(TEST_SIX_DIGIT_CODE);
         when(codeGeneratorService.sixDigitCode()).thenReturn(TEST_SIX_DIGIT_CODE);
         when(configurationService.getCodeMaxRetries()).thenReturn(5);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
@@ -113,7 +113,7 @@ class ResetPasswordRequestHandlerTest {
 
     @BeforeEach
     void setup() {
-        when(configurationService.getCodeExpiry()).thenReturn(CODE_EXPIRY_TIME);
+        when(configurationService.getSmsOtpCodeExpiry()).thenReturn(CODE_EXPIRY_TIME);
         when(codeGeneratorService.twentyByteEncodedRandomCode()).thenReturn(TEST_SIX_DIGIT_CODE);
         when(codeGeneratorService.sixDigitCode()).thenReturn(TEST_SIX_DIGIT_CODE);
         when(configurationService.getCodeMaxRetries()).thenReturn(5);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
@@ -133,8 +133,9 @@ class SendNotificationHandlerTest {
 
     @BeforeEach
     void setup() {
-        when(configurationService.getSmsOtpCodeExpiry()).thenReturn(CODE_EXPIRY_TIME);
-        when(configurationService.getEmailOtpCodeExpiry()).thenReturn(CODE_EXPIRY_TIME);
+        when(configurationService.getDefaultOtpCodeExpiry()).thenReturn(CODE_EXPIRY_TIME);
+        when(configurationService.getEmailAccountCreationOtpCodeExpiry())
+                .thenReturn(CODE_EXPIRY_TIME);
         when(configurationService.getBlockedEmailDuration()).thenReturn(BLOCKED_EMAIL_DURATION);
         when(codeGeneratorService.sixDigitCode()).thenReturn(TEST_SIX_DIGIT_CODE);
         when(configurationService.getCodeMaxRetries()).thenReturn(5);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
@@ -133,7 +133,8 @@ class SendNotificationHandlerTest {
 
     @BeforeEach
     void setup() {
-        when(configurationService.getCodeExpiry()).thenReturn(CODE_EXPIRY_TIME);
+        when(configurationService.getSmsOtpCodeExpiry()).thenReturn(CODE_EXPIRY_TIME);
+        when(configurationService.getEmailOtpCodeExpiry()).thenReturn(CODE_EXPIRY_TIME);
         when(configurationService.getBlockedEmailDuration()).thenReturn(BLOCKED_EMAIL_DURATION);
         when(codeGeneratorService.sixDigitCode()).thenReturn(TEST_SIX_DIGIT_CODE);
         when(configurationService.getCodeMaxRetries()).thenReturn(5);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -141,7 +141,7 @@ class VerifyCodeHandlerTest {
         when(authenticationService.getUserProfileFromEmail(TEST_CLIENT_EMAIL))
                 .thenReturn(Optional.of(userProfile));
 
-        when(configurationService.getCodeExpiry()).thenReturn(CODE_EXPIRY_TIME);
+        when(configurationService.getSmsOtpCodeExpiry()).thenReturn(CODE_EXPIRY_TIME);
 
         when(userProfile.getSubjectID()).thenReturn("test-subject-id");
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -141,7 +141,7 @@ class VerifyCodeHandlerTest {
         when(authenticationService.getUserProfileFromEmail(TEST_CLIENT_EMAIL))
                 .thenReturn(Optional.of(userProfile));
 
-        when(configurationService.getSmsOtpCodeExpiry()).thenReturn(CODE_EXPIRY_TIME);
+        when(configurationService.getDefaultOtpCodeExpiry()).thenReturn(CODE_EXPIRY_TIME);
 
         when(userProfile.getSubjectID()).thenReturn("test-subject-id");
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/ResetPasswordServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/ResetPasswordServiceTest.java
@@ -25,7 +25,7 @@ class ResetPasswordServiceTest {
 
     @BeforeEach
     void setup() {
-        when(configurationService.getSmsOtpCodeExpiry()).thenReturn(CODE_EXPIRY_TIME);
+        when(configurationService.getDefaultOtpCodeExpiry()).thenReturn(CODE_EXPIRY_TIME);
         when(configurationService.getFrontendBaseUrl()).thenReturn(FRONTEND_BASE_URL);
         when(configurationService.getResetPasswordRoute()).thenReturn(RESET_PASSWORD_PATH);
     }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/ResetPasswordServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/ResetPasswordServiceTest.java
@@ -25,7 +25,7 @@ class ResetPasswordServiceTest {
 
     @BeforeEach
     void setup() {
-        when(configurationService.getCodeExpiry()).thenReturn(CODE_EXPIRY_TIME);
+        when(configurationService.getSmsOtpCodeExpiry()).thenReturn(CODE_EXPIRY_TIME);
         when(configurationService.getFrontendBaseUrl()).thenReturn(FRONTEND_BASE_URL);
         when(configurationService.getResetPasswordRoute()).thenReturn(RESET_PASSWORD_PATH);
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -64,12 +64,13 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return Long.parseLong(System.getenv().getOrDefault("BLOCKED_EMAIL_DURATION", "900"));
     }
 
-    public long getSmsOtpCodeExpiry() {
-        return Long.parseLong(System.getenv().getOrDefault("SMS_OTP_CODE_EXPIRY", "900"));
+    public long getDefaultOtpCodeExpiry() {
+        return Long.parseLong(System.getenv().getOrDefault("DEFAULT_OTP_CODE_EXPIRY", "900"));
     }
 
-    public long getEmailOtpCodeExpiry() {
-        return Long.parseLong(System.getenv().getOrDefault("EMAIL_OTP_CODE_EXPIRY", "7200"));
+    public long getEmailAccountCreationOtpCodeExpiry() {
+        return Long.parseLong(
+                System.getenv().getOrDefault("EMAIL_OTP_ACCOUNT_CREATION_CODE_EXPIRY", "7200"));
     }
 
     public int getCodeMaxRetries() {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -64,8 +64,12 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return Long.parseLong(System.getenv().getOrDefault("BLOCKED_EMAIL_DURATION", "900"));
     }
 
-    public long getCodeExpiry() {
-        return Long.parseLong(System.getenv().getOrDefault("CODE_EXPIRY", "900"));
+    public long getSmsOtpCodeExpiry() {
+        return Long.parseLong(System.getenv().getOrDefault("SMS_OTP_CODE_EXPIRY", "900"));
+    }
+
+    public long getEmailOtpCodeExpiry() {
+        return Long.parseLong(System.getenv().getOrDefault("EMAIL_OTP_CODE_EXPIRY", "7200"));
     }
 
     public int getCodeMaxRetries() {


### PR DESCRIPTION
## What?

- Decouple email OTP validity from SMS OTP validity (when signing up but NOT for reset password and NOT in account management as ticket suggests only sign-up non-reset should be affected)
- Increase email OTP default value to 2 hours (7200 seconds) - this is not currently overridden in any environment so is the active value being used in production
- This is greater than the 'other' OTP default (SMS OTPs and Email OTPs for Account Management), left at 15 minutes (900 seconds) - this is also not currently overridden in any environment
- Add variables to make all of this separately configurable in environments by passing a value as an environment variable (so 'default' in code should not in fact ever be the deciding factor as there is also a default in Terraform that will populate the environment variables)
- All other changes are auto-refactoring of names to make the default vs Email Sign Up distinction clear

## Why?

- We're seeing a lot of error and support request relating to expired email confirmation codes. 
- One hypothesis is that this is at least partly because the codes are expiring too quickly for the users to use them