### PR TITLE
AUT-769: Add ui_locales claim to request object

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/helpers/RequestObjectToAuthRequestHelper.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/helpers/RequestObjectToAuthRequestHelper.java
@@ -1,6 +1,7 @@
 package uk.gov.di.authentication.oidc.helpers;
 
 import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.langtag.LangTagUtils;
 import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.id.ClientID;
@@ -41,6 +42,16 @@ public class RequestObjectToAuthRequestHelper {
 
             if (Objects.nonNull(jwtClaimsSet.getClaim("vtr"))) {
                 builder.customParameter("vtr", (String) jwtClaimsSet.getClaim("vtr"));
+            }
+            if (Objects.nonNull(jwtClaimsSet.getClaim("ui_locales"))) {
+                try {
+                    String uiLocales = (String) jwtClaimsSet.getClaim("ui_locales");
+                    if (!uiLocales.isBlank()) {
+                        builder.uiLocales(LangTagUtils.parseLangTagList(uiLocales.split(" ")));
+                    }
+                } catch (ClassCastException e) {
+                    LOG.error("Unable to read ui_locales claim: {}", e.getMessage());
+                }
             }
             return builder.build();
         } catch (ParseException | com.nimbusds.oauth2.sdk.ParseException e) {

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RequestObjectServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RequestObjectServiceTest.java
@@ -518,6 +518,28 @@ class RequestObjectServiceTest {
         assertThat(requestObjectError.get().getRedirectURI().toString(), equalTo(REDIRECT_URI));
     }
 
+    @Test
+    void shouldReturnErrorForInvalidUILocales() throws JOSEException {
+        var jwtClaimsSet =
+                new JWTClaimsSet.Builder()
+                        .audience(AUDIENCE)
+                        .claim("redirect_uri", REDIRECT_URI)
+                        .claim("response_type", ResponseType.CODE.toString())
+                        .claim("scope", SCOPE)
+                        .claim("nonce", NONCE.getValue())
+                        .claim("state", STATE.toString())
+                        .issuer(CLIENT_ID.getValue())
+                        .claim("client_id", CLIENT_ID.getValue())
+                        .claim("ui_locales", "123456")
+                        .build();
+        var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet, keyPair));
+        var requestObjectError = service.validateRequestObject(authRequest);
+
+        assertTrue(requestObjectError.isPresent());
+        assertThat(requestObjectError.get().getErrorObject(), equalTo(OAuth2Error.INVALID_REQUEST));
+        assertThat(requestObjectError.get().getRedirectURI().toString(), equalTo(REDIRECT_URI));
+    }
+
     private ClientRegistry generateClientRegistry(String clientType, Scope scope) {
         return new ClientRegistry()
                 .withClientID(CLIENT_ID.getValue())


### PR DESCRIPTION
## What?

Add ui_locales claim to request object.

- Validates are reads the ui_locales claim if it is present.
- Follows the same behaviour as for the ui_locales query parameter: the cookie will only be set on authorisation if a language preference is specified, and the requested language is available, otherwise frontend (and user preferences) will be respected.
- Will be used initially be the doc app journey.

## Why?

Support language preferences for services using the request object, who will be able to specify en or cy when Welsh is switched-on.

## Related PRs

#2292 