### PR TITLE
BAU - Increase the dependabot PR limit to 100

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
     schedule:
       interval: daily
       time: "03:00"
+    open-pull-requests-limit: 100
     target-branch: main
     labels:
       - dependabot
@@ -13,6 +14,7 @@ updates:
     schedule:
       interval: daily
       time: "03:00"
+    open-pull-requests-limit: 100
     target-branch: main
     labels:
     - dependabot


### PR DESCRIPTION


## What?

 - Increase the dependabot PR limit to 100

## Why?

- By default the limit is 5. We want to see all dependabot PRs which are raised

