### PR TITLE
AUT-809 - Add txma audit kms key alias

### DIFF
--- a/ci/terraform/modules/txma-audit-queue/key.tf
+++ b/ci/terraform/modules/txma-audit-queue/key.tf
@@ -9,6 +9,11 @@ resource "aws_kms_key" "txma_audit_queue_encryption_key" {
   tags = var.default_tags
 }
 
+resource "aws_kms_alias" "txma_audit_queue_encryption_key_alias" {
+  name          = "alias/${var.environment}-audit-encryption-key-alias"
+  target_key_id = aws_kms_key.txma_audit_queue_encryption_key.key_id
+}
+
 data "aws_caller_identity" "current" {}
 
 data "aws_iam_policy_document" "txma_audit_queue_encryption_key_access_policy" {


### PR DESCRIPTION
## What?

- Add a aws_kms_alias for the txma audit encryption key. 

## Why?

- This is required so that it can be referenced by a terraform data source for the phone number check.