### PR TITLE
AUT-809 - Concat the serviceName to the audit kms key alias

### DIFF
--- a/ci/terraform/modules/txma-audit-queue/key.tf
+++ b/ci/terraform/modules/txma-audit-queue/key.tf
@@ -10,7 +10,7 @@ resource "aws_kms_key" "txma_audit_queue_encryption_key" {
 }
 
 resource "aws_kms_alias" "txma_audit_queue_encryption_key_alias" {
-  name          = "alias/${var.environment}-audit-encryption-key-alias"
+  name          = "alias/${var.environment}-${var.service_name}-audit-kms-alias"
   target_key_id = aws_kms_key.txma_audit_queue_encryption_key.key_id
 }
 


### PR DESCRIPTION
## What?

 - Concat the serviceName to the audit kms key alias
 
## Why?

- Each module will create a KMS key alias so we can't have them all called the same. Therefore, concat the service name to each alias.