### PR TITLE
AUT-802 - Return the MfaMethodType from the StartResponse

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/UserStartInfo.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/UserStartInfo.java
@@ -2,6 +2,7 @@ package uk.gov.di.authentication.frontendapi.entity;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.validation.Required;
 
 public class UserStartInfo {
@@ -38,6 +39,10 @@ public class UserStartInfo {
     @Expose
     private boolean docCheckingAppUser;
 
+    @SerializedName("mfaMethodType")
+    @Expose
+    private MFAMethodType mfaMethodType;
+
     public UserStartInfo() {}
 
     public UserStartInfo(
@@ -47,7 +52,8 @@ public class UserStartInfo {
             boolean authenticated,
             String cookieConsent,
             String gaCrossDomainTrackingId,
-            boolean docCheckingAppUser) {
+            boolean docCheckingAppUser,
+            MFAMethodType mfaMethodType) {
         this.consentRequired = consentRequired;
         this.upliftRequired = upliftRequired;
         this.identityRequired = identityRequired;
@@ -55,6 +61,7 @@ public class UserStartInfo {
         this.cookieConsent = cookieConsent;
         this.gaCrossDomainTrackingId = gaCrossDomainTrackingId;
         this.docCheckingAppUser = docCheckingAppUser;
+        this.mfaMethodType = mfaMethodType;
     }
 
     public boolean isConsentRequired() {
@@ -83,5 +90,9 @@ public class UserStartInfo {
 
     public boolean isDocCheckingAppUser() {
         return docCheckingAppUser;
+    }
+
+    public MFAMethodType getMfaMethodType() {
+        return mfaMethodType;
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -174,7 +174,7 @@ class StartHandlerTest {
     void shouldReturn200WhenDocCheckingAppUserIsPresent()
             throws ParseException, Json.JsonException {
         when(configurationService.getDocAppDomain()).thenReturn(URI.create("https://doc-app"));
-        var userStartInfo = new UserStartInfo(false, false, false, false, null, null, true);
+        var userStartInfo = new UserStartInfo(false, false, false, false, null, null, true, null);
         when(startService.buildUserContext(session, clientSession)).thenReturn(userContext);
         var scope = new Scope(OIDCScopeValue.OPENID, CustomScopeValue.DOC_CHECKING_APP);
         when(startService.buildClientStartInfo(userContext))
@@ -338,6 +338,6 @@ class StartHandlerTest {
 
     private UserStartInfo getUserStartInfo(String cookieConsent, String gaCrossDomainTrackingId) {
         return new UserStartInfo(
-                true, false, false, true, cookieConsent, gaCrossDomainTrackingId, false);
+                true, false, false, true, cookieConsent, gaCrossDomainTrackingId, false, null);
     }
 }


### PR DESCRIPTION
## What?

- Return the MfaMethodType from the StartResponse

## Why?

- The frontend uplift journey depends on what MFA type the user is configured with. The frontend does not currently know this so we need to return this information from start.
- Currently the frontend directs the user to the /uplift path when a user is configured with the Auth App MFA method, this is incorrect