### PR TITLE
AUT-771: Allow VTR components in any order

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/VectorOfTrust.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/VectorOfTrust.java
@@ -88,14 +88,16 @@ public class VectorOfTrust {
                             .filter(a -> a.startsWith("P"))
                             .map(LevelOfConfidence::retrieveLevelOfConfidence)
                             .collect(Collectors.toList());
+            var ctl =
+                    CredentialTrustLevel.retrieveCredentialTrustLevel(
+                            Arrays.stream(splitVtr)
+                                    .filter(a -> a.startsWith("C"))
+                                    .sorted()
+                                    .collect(Collectors.joining(".")));
             if (levelOfConfidence.isEmpty()) {
-                var ctl = CredentialTrustLevel.retrieveCredentialTrustLevel(vtr);
                 vectorOfTrusts.add(new VectorOfTrust(ctl));
             } else {
                 var loc = levelOfConfidence.get(0);
-                var ctl =
-                        CredentialTrustLevel.retrieveCredentialTrustLevel(
-                                vtr.substring(vtr.indexOf(".") + 1));
                 vectorOfTrusts.add(new VectorOfTrust(ctl, loc));
             }
         }
@@ -131,5 +133,19 @@ public class VectorOfTrust {
                 + ", levelOfConfidence="
                 + levelOfConfidence
                 + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        VectorOfTrust that = (VectorOfTrust) o;
+        return credentialTrustLevel == that.credentialTrustLevel
+                && levelOfConfidence == that.levelOfConfidence;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(credentialTrustLevel, levelOfConfidence);
     }
 }


### PR DESCRIPTION
## What?

- Allow the Identity Proofing `P` component to appear anywhere in the string.
- Allow the Credential Confidence `C` components to appear in anywhere and in any order (so, `Cl.Cm`, `Cm.Cl` and `Cm.P2.Cl` all resolve to medium level (`Cl.Cm`) level of credential confidence.
- Add `equals()` method to `VectorOfTrust` to facilitate testing.

## Why?

We are currently not fully compliant with the spec as we expect the `P` component to be specified first, if supplied.