### PR TITLE
AUT-771: Refactoring and VTR parsing fix

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/VectorOfTrust.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/VectorOfTrust.java
@@ -87,6 +87,17 @@ public class VectorOfTrust {
                     Arrays.stream(splitVtr)
                             .filter(a -> a.startsWith("P"))
                             .map(LevelOfConfidence::retrieveLevelOfConfidence)
+                            .collect(
+                                    Collectors.collectingAndThen(
+                                            Collectors.toList(),
+                                            list -> {
+                                                if (list.size() > 1) {
+                                                    throw new IllegalArgumentException(
+                                                            "VTR must contain either 0 or 1 identity proofing components");
+                                                }
+                                                return list;
+                                            }))
+                            .stream()
                             .findFirst();
 
             var credentialTrustLevel =

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/VectorOfTrust.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/VectorOfTrust.java
@@ -11,6 +11,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static net.minidev.json.parser.JSONParser.DEFAULT_PERMISSIVE_MODE;
@@ -25,15 +26,14 @@ public class VectorOfTrust {
     @Expose private LevelOfConfidence levelOfConfidence;
 
     private VectorOfTrust(CredentialTrustLevel credentialTrustLevel) {
-        this(credentialTrustLevel, null);
+        this(credentialTrustLevel, Optional.empty());
     }
 
-    public VectorOfTrust() {}
-
     private VectorOfTrust(
-            CredentialTrustLevel credentialTrustLevel, LevelOfConfidence levelOfConfidence) {
+            CredentialTrustLevel credentialTrustLevel,
+            Optional<LevelOfConfidence> levelOfConfidence) {
         this.credentialTrustLevel = credentialTrustLevel;
-        this.levelOfConfidence = levelOfConfidence;
+        this.levelOfConfidence = levelOfConfidence.orElse(null);
     }
 
     public CredentialTrustLevel getCredentialTrustLevel() {
@@ -83,23 +83,19 @@ public class VectorOfTrust {
             String vtr = (String) obj;
             var splitVtr = vtr.split("\\.");
 
-            List<LevelOfConfidence> levelOfConfidence =
+            var levelOfConfidence =
                     Arrays.stream(splitVtr)
                             .filter(a -> a.startsWith("P"))
                             .map(LevelOfConfidence::retrieveLevelOfConfidence)
-                            .collect(Collectors.toList());
-            var ctl =
+                            .findFirst();
+
+            var credentialTrustLevel =
                     CredentialTrustLevel.retrieveCredentialTrustLevel(
                             Arrays.stream(splitVtr)
                                     .filter(a -> a.startsWith("C"))
                                     .sorted()
                                     .collect(Collectors.joining(".")));
-            if (levelOfConfidence.isEmpty()) {
-                vectorOfTrusts.add(new VectorOfTrust(ctl));
-            } else {
-                var loc = levelOfConfidence.get(0);
-                vectorOfTrusts.add(new VectorOfTrust(ctl, loc));
-            }
+            vectorOfTrusts.add(new VectorOfTrust(credentialTrustLevel, levelOfConfidence));
         }
 
         return vectorOfTrusts.stream()


### PR DESCRIPTION
## What?

- Simplify the creation of `VectorOfTrust` class while parsing.
- Check that the vectors only contain ones identity proofing (`P`) component (previous test that checked this was only succeeding because invalid `P` values were used).
- Turn the all the `shouldThrow...` tests into a single, parameterised test (as per suggestion from Sonar)
- Add parameters to test the multiple, valid, `P` value scenario.

## Why?

Simplifies code and ensures we only allow one `P` value in the vectors (as per [RFC](https://www.rfc-editor.org/rfc/rfc8485.html#section-2.4))

## Related PRs

#2454 