### PR TITLE
AUT-664: Turn on Dynamo Stream for User Profile table in production

### DIFF
--- a/ci/terraform/shared/production-sizing.tfvars
+++ b/ci/terraform/shared/production-sizing.tfvars
@@ -1,3 +1,2 @@
-redis_node_size            = "cache.m4.xlarge"
-provision_dynamo           = false
-enable_user_profile_stream = false
+redis_node_size  = "cache.m4.xlarge"
+provision_dynamo = false


### PR DESCRIPTION
## What?
- Turn on Dynamo Stream for User Profile table in production
- The default is for this to be true, hence removing the 'false' from .tfvars


## Why?
- Prerequisite for phone check lambda to work (under discovery implementation in Oct 2022 => full implementation expected to be different)