### PR TITLE
AUT-823: Return error if vector of trust is equivalent of `Cl.P2`

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/TokenIntegrationTest.java
@@ -97,12 +97,10 @@ public class TokenIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 Arguments.of(Optional.of("Cl.Cm"), "Cl.Cm", Optional.of(CLIENT_ID)),
                 Arguments.of(Optional.of("Cl"), "Cl", Optional.of(CLIENT_ID)),
                 Arguments.of(Optional.of("P2.Cl.Cm"), "Cl.Cm", Optional.of(CLIENT_ID)),
-                Arguments.of(Optional.of("P2.Cl"), "Cl", Optional.of(CLIENT_ID)),
                 Arguments.of(Optional.empty(), "Cl.Cm", Optional.of(CLIENT_ID)),
                 Arguments.of(Optional.of("Cl.Cm"), "Cl.Cm", Optional.empty()),
                 Arguments.of(Optional.of("Cl"), "Cl", Optional.empty()),
                 Arguments.of(Optional.of("P2.Cl.Cm"), "Cl.Cm", Optional.empty()),
-                Arguments.of(Optional.of("P2.Cl"), "Cl", Optional.empty()),
                 Arguments.of(Optional.empty(), "Cl.Cm", Optional.empty()));
     }
 

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
@@ -151,19 +151,15 @@ public class TokenHandlerTest {
                 Arguments.of("Cl.Cm", true, true, true),
                 Arguments.of("Cl", true, true, true),
                 Arguments.of("P2.Cl.Cm", true, false, true),
-                Arguments.of("P2.Cl", true, false, true),
                 Arguments.of("Cl.Cm", false, false, true),
                 Arguments.of("Cl", false, false, true),
                 Arguments.of("P2.Cl.Cm", false, false, true),
-                Arguments.of("P2.Cl", false, false, false),
                 Arguments.of("Cl.Cm", true, true, false),
                 Arguments.of("Cl", true, true, false),
                 Arguments.of("P2.Cl.Cm", true, false, false),
-                Arguments.of("P2.Cl", true, false, false),
                 Arguments.of("Cl.Cm", false, false, false),
                 Arguments.of("Cl", false, false, false),
-                Arguments.of("P2.Cl.Cm", false, false, false),
-                Arguments.of("P2.Cl", false, false, false));
+                Arguments.of("P2.Cl.Cm", false, false, false));
     }
 
     @ParameterizedTest

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AuthorizationServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AuthorizationServiceTest.java
@@ -143,7 +143,7 @@ class AuthorizationServiceTest {
                         REDIRECT_URI.toString(),
                         responseType,
                         scope,
-                        jsonArrayOf("P2.Cl.Cm", "P2.Cl"),
+                        jsonArrayOf("P2.Cl.Cm"),
                         Optional.empty());
         var errorObject = authorizationService.validateAuthRequest(authRequest);
 


### PR DESCRIPTION
## What?

- Add `isValid()` method to `VectorOfTrust` to determine validity of combination.
- Throw `IllegalArgumentException` when parsing the provided the `vtr` parameter if the result `VectorOfTrust` is invalid.

## Why?

To stop clients requesting an invalid VTR as we require at least `Cl.Cm` for identity proofing (`P2`) journeys. An invalid request now results in the user being returned to the RP with the appropriate error message.
