### PR TITLE
AUT-77: Add client ID to Doc App authorize

### DIFF
--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppAuthorizeHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppAuthorizeHandler.java
@@ -147,7 +147,7 @@ public class DocAppAuthorizeHandler
                     DocAppAuditableEvent.DOC_APP_AUTHORISATION_REQUESTED,
                     clientSessionId,
                     session.getSessionId(),
-                    AuditService.UNKNOWN,
+                    clientID.getValue(),
                     clientSession.getDocAppSubjectId().toString(),
                     AuditService.UNKNOWN,
                     IpAddressHelper.extractIpAddress(input),

--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppAuthorizeHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppAuthorizeHandler.java
@@ -147,7 +147,7 @@ public class DocAppAuthorizeHandler
                     DocAppAuditableEvent.DOC_APP_AUTHORISATION_REQUESTED,
                     clientSessionId,
                     session.getSessionId(),
-                    clientID.getValue(),
+                    clientRegistry.getClientID(),
                     clientSession.getDocAppSubjectId().toString(),
                     AuditService.UNKNOWN,
                     IpAddressHelper.extractIpAddress(input),

--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppAuthorizeHandlerTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppAuthorizeHandlerTest.java
@@ -146,7 +146,7 @@ class DocAppAuthorizeHandlerTest {
                         DocAppAuditableEvent.DOC_APP_AUTHORISATION_REQUESTED,
                         CLIENT_SESSION_ID,
                         SESSION_ID,
-                        AuditService.UNKNOWN,
+                        DOC_APP_CLIENT_ID,
                         DOC_APP_SUBJECT_ID.getValue(),
                         AuditService.UNKNOWN,
                         "123.123.123.123",

--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppAuthorizeHandlerTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppAuthorizeHandlerTest.java
@@ -83,7 +83,7 @@ class DocAppAuthorizeHandlerTest {
     private static final Subject DOC_APP_SUBJECT_ID = new Subject();
     private static final Json objectMapper = SerializationService.getInstance();
 
-    private static final String CLIENT_ID = "test-client";
+    private static final ClientID CLIENT_ID = new ClientID("test-client");
 
     private final Context context = mock(Context.class);
     private final SessionService sessionService = mock(SessionService.class);
@@ -93,7 +93,7 @@ class DocAppAuthorizeHandlerTest {
             mock(DocAppAuthorisationService.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final AuditService auditService = mock(AuditService.class);
-
+    private final ClientRegistry clientRegistry = mock(ClientRegistry.class);
     private final ClientService clientService = mock(ClientService.class);
 
     private DocAppAuthorizeHandler handler;
@@ -127,7 +127,8 @@ class DocAppAuthorizeHandlerTest {
                         any(ClientRegistry.class),
                         anyString()))
                 .thenReturn(encryptedJWT);
-        when(clientService.getClient(CLIENT_ID)).thenReturn(Optional.of(new ClientRegistry()));
+        when(clientRegistry.getClientID()).thenReturn(CLIENT_ID.getValue());
+        when(clientService.getClient(CLIENT_ID.getValue())).thenReturn(Optional.of(clientRegistry));
         when(clientSession.getAuthRequestParams()).thenReturn(generateAuthRequest().toParameters());
         usingValidSession();
         usingValidClientSession();
@@ -146,7 +147,7 @@ class DocAppAuthorizeHandlerTest {
                         DocAppAuditableEvent.DOC_APP_AUTHORISATION_REQUESTED,
                         CLIENT_SESSION_ID,
                         SESSION_ID,
-                        DOC_APP_CLIENT_ID,
+                        CLIENT_ID.getValue(),
                         DOC_APP_SUBJECT_ID.getValue(),
                         AuditService.UNKNOWN,
                         "123.123.123.123",


### PR DESCRIPTION
## What?

Add `clientID` for DCMAW events to be audited

## Why?

Needed for grouping and analysis 