### PR TITLE
AUT-827 - Fix auth app uplift bug

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -9,6 +9,7 @@ import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.VerifyMfaCodeRequest;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
+import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.Session;
@@ -161,7 +162,9 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                                         MFAMethodType.AUTH_APP.getValue(),
                                         codeRequest.isRegistration());
                                 sessionService.save(
-                                        session.setVerifiedMfaMethodType(MFAMethodType.AUTH_APP));
+                                        session.setCurrentCredentialStrength(
+                                                        CredentialTrustLevel.MEDIUM_LEVEL)
+                                                .setVerifiedMfaMethodType(MFAMethodType.AUTH_APP));
                                 cloudwatchMetricsService.incrementAuthenticationSuccess(
                                         session.isNewAccount(),
                                         clientId,


### PR DESCRIPTION
## What?

- Ensure that whenever a user successfully enters a auth app OTP, there credential trust level is set to Medium.
- Add extra checks in the auth app mfa unit tests to verify this
- Although it is not impacted by this, add additional checks to the verify code unit tests 

## Why?

- When a user creates an account from a low level service, then they should be authenticated to a medium level. This is because all account creation journeys require MFA.
- Previously when a user created an account from a low level service, they were only authenticated to a low level so when they switched to a medium level service they were asked to enter the auth app OTP. This is not expected and is all different to the behaviour of a user creating an account via sms.
