### PR TITLE
BAU: Remove deprecated logging endpoint from apps

### DIFF
--- a/ci/terraform/account-management/build-overrides.tfvars
+++ b/ci/terraform/account-management/build-overrides.tfvars
@@ -5,7 +5,6 @@ endpoint_memory_size   = 1024
 scaling_trigger        = 0.6
 
 logging_endpoint_arns = [
-  "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod",
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]
 

--- a/ci/terraform/account-management/integration-overrides.tfvars
+++ b/ci/terraform/account-management/integration-overrides.tfvars
@@ -5,6 +5,5 @@ endpoint_memory_size   = 1024
 scaling_trigger        = 0.6
 
 logging_endpoint_arns = [
-  "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod",
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]

--- a/ci/terraform/account-management/production-overrides.tfvars
+++ b/ci/terraform/account-management/production-overrides.tfvars
@@ -25,6 +25,5 @@ endpoint_memory_size   = 1024
 scaling_trigger        = 0.6
 
 logging_endpoint_arns = [
-  "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod",
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]

--- a/ci/terraform/account-management/staging-overrides.tfvars
+++ b/ci/terraform/account-management/staging-overrides.tfvars
@@ -5,6 +5,5 @@ endpoint_memory_size   = 1024
 scaling_trigger        = 0.6
 
 logging_endpoint_arns = [
-  "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod",
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]

--- a/ci/terraform/audit-processors/build-overrides.tfvars
+++ b/ci/terraform/audit-processors/build-overrides.tfvars
@@ -1,4 +1,3 @@
 logging_endpoint_arns = [
-  "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod",
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]

--- a/ci/terraform/audit-processors/integration-overrides.tfvars
+++ b/ci/terraform/audit-processors/integration-overrides.tfvars
@@ -1,4 +1,3 @@
 logging_endpoint_arns = [
-  "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod",
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]

--- a/ci/terraform/audit-processors/production-overrides.tfvars
+++ b/ci/terraform/audit-processors/production-overrides.tfvars
@@ -1,4 +1,3 @@
 logging_endpoint_arns = [
-  "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod",
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]

--- a/ci/terraform/audit-processors/staging-overrides.tfvars
+++ b/ci/terraform/audit-processors/staging-overrides.tfvars
@@ -1,4 +1,3 @@
 logging_endpoint_arns = [
-  "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod",
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]

--- a/ci/terraform/delivery-receipts/integration-overrides.tfvars
+++ b/ci/terraform/delivery-receipts/integration-overrides.tfvars
@@ -1,4 +1,3 @@
 logging_endpoint_arns = [
-  "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod",
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]

--- a/ci/terraform/delivery-receipts/production-overrides.tfvars
+++ b/ci/terraform/delivery-receipts/production-overrides.tfvars
@@ -16,6 +16,5 @@ notify_template_map = {
 }
 
 logging_endpoint_arns = [
-  "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod",
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]

--- a/ci/terraform/delivery-receipts/staging-overrides.tfvars
+++ b/ci/terraform/delivery-receipts/staging-overrides.tfvars
@@ -1,4 +1,3 @@
 logging_endpoint_arns = [
-  "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod",
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]

--- a/ci/terraform/oidc/build-overrides.tfvars
+++ b/ci/terraform/oidc/build-overrides.tfvars
@@ -15,7 +15,6 @@ otp_code_ttl_duration                     = 120
 email_acct_creation_otp_code_ttl_duration = 60
 
 logging_endpoint_arns = [
-  "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod",
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]
 

--- a/ci/terraform/oidc/integration-overrides.tfvars
+++ b/ci/terraform/oidc/integration-overrides.tfvars
@@ -30,7 +30,6 @@ NQIDAQAB
 -----END PUBLIC KEY-----
 EOT
 logging_endpoint_arns = [
-  "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod",
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]
 

--- a/ci/terraform/oidc/production-overrides.tfvars
+++ b/ci/terraform/oidc/production-overrides.tfvars
@@ -77,6 +77,5 @@ endpoint_memory_size   = 1024
 scaling_trigger        = 0.6
 
 logging_endpoint_arns = [
-  "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod",
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]

--- a/ci/terraform/oidc/staging-overrides.tfvars
+++ b/ci/terraform/oidc/staging-overrides.tfvars
@@ -52,6 +52,5 @@ endpoint_memory_size   = 1024
 scaling_trigger        = 0.6
 
 logging_endpoint_arns = [
-  "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod",
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]

--- a/ci/terraform/utils/build-overrides.tfvars
+++ b/ci/terraform/utils/build-overrides.tfvars
@@ -1,4 +1,3 @@
 logging_endpoint_arns = [
-  "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod",
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]

--- a/ci/terraform/utils/integration-overrides.tfvars
+++ b/ci/terraform/utils/integration-overrides.tfvars
@@ -1,4 +1,3 @@
 logging_endpoint_arns = [
-  "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod",
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]

--- a/ci/terraform/utils/production-overrides.tfvars
+++ b/ci/terraform/utils/production-overrides.tfvars
@@ -1,6 +1,5 @@
 cloudwatch_log_retention = 5
 
 logging_endpoint_arns = [
-  "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod",
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]

--- a/ci/terraform/utils/staging-overrides.tfvars
+++ b/ci/terraform/utils/staging-overrides.tfvars
@@ -1,4 +1,3 @@
 logging_endpoint_arns = [
-  "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod",
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]


### PR DESCRIPTION
The new endpoint has superseded the old one
