### PR TITLE
AUT-828 - Add 2 cloudwatch alarms to cover IPV handoff and IPV handback process

### DIFF
--- a/ci/terraform/modules/endpoint-module/alerts.tf
+++ b/ci/terraform/modules/endpoint-module/alerts.tf
@@ -1,7 +1,7 @@
 resource "aws_cloudwatch_log_metric_filter" "lambda_error_metric_filter" {
   count          = var.use_localstack ? 0 : 1
   name           = replace("${var.environment}-${var.endpoint_name}-errors", ".", "")
-  pattern        = "{($.level = \"ERROR\") && ($.message != \"Session attempted invalid transition from*\")}"
+  pattern        = "ERROR"
   log_group_name = aws_cloudwatch_log_group.lambda_log_group[0].name
 
   metric_transformation {

--- a/ci/terraform/oidc/alerts.tf
+++ b/ci/terraform/oidc/alerts.tf
@@ -78,7 +78,3 @@ resource "aws_cloudwatch_metric_alarm" "spot_request_sqs_dlq_cloudwatch_alarm" {
 #  alarm_description = "${var.waf_alarm_blocked_reqeuest_threshold} or more blocked requests have been received by the ${aws_wafv2_web_acl.wafregional_web_acl_frontend_api[count.index].name} in the last 5 minutes"
 #  alarm_actions     = [data.aws_sns_topic.slack_events.arn]
 #}
-
-data "aws_sns_topic" "slack_events" {
-  name = "${var.environment}-slack-events"
-}

--- a/ci/terraform/oidc/ipv-handback-alerts.tf
+++ b/ci/terraform/oidc/ipv-handback-alerts.tf
@@ -1,0 +1,67 @@
+data "aws_cloudwatch_log_group" "ipv_callback_lambda_log_group" {
+  count = var.use_localstack ? 0 : 1
+  name  = replace("/aws/lambda/${var.environment}-ipv-callback-lambda", ".", "")
+}
+
+data "aws_cloudwatch_log_group" "spot_response_lambda_log_group" {
+  count = var.use_localstack ? 0 : 1
+  name  = replace("/aws/lambda/${var.environment}-spot-response-lambda", ".", "")
+}
+
+data "aws_cloudwatch_log_group" "processing_identity_lambda_log_group" {
+  count = var.use_localstack ? 0 : 1
+  name  = replace("/aws/lambda/${var.environment}-processing-identity-lambda", ".", "")
+}
+
+resource "aws_cloudwatch_log_metric_filter" "ipv_callback_metric_filter" {
+  count          = var.use_localstack ? 0 : 1
+  name           = replace("${var.environment}-ipv-callback-p1-errors", ".", "")
+  pattern        = "ERROR"
+  log_group_name = data.aws_cloudwatch_log_group.ipv_callback_lambda_log_group[0].name
+
+  metric_transformation {
+    name      = replace("${var.environment}-ipv-handback-error-count", ".", "")
+    namespace = "LambdaErrorsNamespace"
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "spot_response_metric_filter" {
+  count          = var.use_localstack ? 0 : 1
+  name           = replace("${var.environment}-spot-response-p1-errors", ".", "")
+  pattern        = "ERROR"
+  log_group_name = data.aws_cloudwatch_log_group.spot_response_lambda_log_group[0].name
+
+  metric_transformation {
+    name      = replace("${var.environment}-ipv-handback-error-count", ".", "")
+    namespace = "LambdaErrorsNamespace"
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "processing_identity_metric_filter" {
+  count          = var.use_localstack ? 0 : 1
+  name           = replace("${var.environment}-processing-identity-p1-errors", ".", "")
+  pattern        = "ERROR"
+  log_group_name = data.aws_cloudwatch_log_group.processing_identity_lambda_log_group[0].name
+
+  metric_transformation {
+    name      = replace("${var.environment}-ipv-handback-error-count", ".", "")
+    namespace = "LambdaErrorsNamespace"
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "ipv_handback_p1_cloudwatch_alarm" {
+  count               = var.use_localstack ? 0 : 1
+  alarm_name          = replace("${var.environment}-P1-ipv-handback-alarm", ".", "")
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = aws_cloudwatch_log_metric_filter.processing_identity_metric_filter[0].metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.processing_identity_metric_filter[0].metric_transformation[0].namespace
+  period              = var.ipv_p1_alarm_error_time_period
+  statistic           = "Sum"
+  threshold           = var.ipv_p1_alarm_error_threshold
+  alarm_description   = "${var.ipv_p1_alarm_error_threshold} or more errors have occurred during the IPV handback for ${var.environment}"
+  alarm_actions       = [var.environment == "production" ? data.aws_sns_topic.slack_events.arn : data.aws_sns_topic.slack_events.arn]
+}

--- a/ci/terraform/oidc/ipv-handoff-alerts.tf
+++ b/ci/terraform/oidc/ipv-handoff-alerts.tf
@@ -1,0 +1,31 @@
+data "aws_cloudwatch_log_group" "ipv_authorize_lambda_log_group" {
+  count = var.use_localstack ? 0 : 1
+  name  = replace("/aws/lambda/${var.environment}-ipv-authorize-lambda", ".", "")
+}
+
+resource "aws_cloudwatch_log_metric_filter" "ipv_authorize_metric_filter" {
+  count          = var.use_localstack ? 0 : 1
+  name           = replace("${var.environment}-ipv-handoff-p1-errors", ".", "")
+  pattern        = "ERROR"
+  log_group_name = data.aws_cloudwatch_log_group.ipv_authorize_lambda_log_group[0].name
+
+  metric_transformation {
+    name      = replace("${var.environment}-ipv-handoff-error-count", ".", "")
+    namespace = "LambdaErrorsNamespace"
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "ipv_handoff_p1_cloudwatch_alarm" {
+  count               = var.use_localstack ? 0 : 1
+  alarm_name          = replace("${var.environment}-P1-ipv-handoff-alarm", ".", "")
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = aws_cloudwatch_log_metric_filter.ipv_authorize_metric_filter[0].metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.ipv_authorize_metric_filter[0].metric_transformation[0].namespace
+  period              = var.ipv_p1_alarm_error_time_period
+  statistic           = "Sum"
+  threshold           = var.ipv_p1_alarm_error_threshold
+  alarm_description   = "${var.ipv_p1_alarm_error_threshold} or more errors have occurred during the IPV handoff for ${var.environment}"
+  alarm_actions       = [var.environment == "production" ? data.aws_sns_topic.slack_events.arn : data.aws_sns_topic.slack_events.arn]
+}

--- a/ci/terraform/oidc/sns.tf
+++ b/ci/terraform/oidc/sns.tf
@@ -1,0 +1,7 @@
+data "aws_sns_topic" "pagerduty_p1_alerts" {
+  name = "${var.environment}-pagerduty-p1-alerts"
+}
+
+data "aws_sns_topic" "slack_events" {
+  name = "${var.environment}-slack-events"
+}

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -34,6 +34,18 @@ variable "lambda_warmer_zip_file" {
   type        = string
 }
 
+variable "ipv_p1_alarm_error_threshold" {
+  type        = number
+  description = "The number of IPV errors raised before generating a Cloudwatch alarm"
+  default     = 20
+}
+
+variable "ipv_p1_alarm_error_time_period" {
+  type        = number
+  description = "The time period in seconds for when the IPV errors need to occur"
+  default     = 600
+}
+
 variable "deployer_role_arn" {
   default     = ""
   description = "The name of the AWS role to assume, leave blank when running locally"


### PR DESCRIPTION
## What?

- Update pattern for existing metric filter as we no longer perform state transitions in the backend
- The IPV handoff covers the IPVAuthorisation lambda
- The IPV handback covers the IPVCallback, SpotResponse and ProcessingIdentity lambda's
- The alarms are currently set to trigger when 20 errors have occured within a 10 minute period. This time period may need adjusting as needs be
- The alarms are currently set to generate a slack alert, however this is just to help us gauge how they behave over the next week or so before switching production over to use pagerduty p1 alerts.
 - When we are happy with the alarms we can switch over the alarm_actions for production to use the pagerduty sns topic rather than the slack sns topic

## Why?
- The alarms will give us out of hours alerting of any issues occuring in the IPV section of Orchestration


## TODO

- Test with the pagerduty SNS topic
- Add a ticket to switch from slack to pagerduty sns topic for production when we are happy