### PR TITLE
AUT-828 - Only use SNS topic in Production

### DIFF
--- a/ci/terraform/oidc/sns.tf
+++ b/ci/terraform/oidc/sns.tf
@@ -1,5 +1,6 @@
 data "aws_sns_topic" "pagerduty_p1_alerts" {
-  name = "${var.environment}-pagerduty-p1-alerts"
+  count = var.environment == "production" ? 1 : 0
+  name  = "${var.environment}-pagerduty-p1-alerts"
 }
 
 data "aws_sns_topic" "slack_events" {


### PR DESCRIPTION
## What?

- Only use pagerduty SNS topic in Production

## Why?

- The Pagerduty sns topic is only created in production. Therefore we should only reference to it in production.

