### PR TITLE
ACI-115: Use CheckUserExists lambda to return user account status

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/domain/AccountManagementAuditableEvent.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/domain/AccountManagementAuditableEvent.java
@@ -8,9 +8,7 @@ public enum AccountManagementAuditableEvent implements AuditableEvent {
     UPDATE_PHONE_NUMBER,
     ACCOUNT_MANAGEMENT_AUTHENTICATE,
     DELETE_ACCOUNT,
-    SEND_OTP,
-    ACCOUNT_TEMPORARILY_LOCKED,
-    INVALID_CREDENTIALS;
+    SEND_OTP;
 
     public AuditableEvent parseFromName(String name) {
         return valueOf(name);

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandler.java
@@ -16,7 +16,6 @@ import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.serialization.Json.JsonException;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
-import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.SerializationService;
@@ -35,18 +34,11 @@ public class AuthenticateHandler
     private final AuthenticationService authenticationService;
     private final Json objectMapper = SerializationService.getInstance();
     private final AuditService auditService;
-    private final CodeStorageService codeStorageService;
-    private final ConfigurationService configurationService;
 
     public AuthenticateHandler(
-            AuthenticationService authenticationService,
-            AuditService auditService,
-            CodeStorageService codeStorageService,
-            ConfigurationService configurationService) {
+            AuthenticationService authenticationService, AuditService auditService) {
         this.authenticationService = authenticationService;
         this.auditService = auditService;
-        this.codeStorageService = codeStorageService;
-        this.configurationService = configurationService;
     }
 
     public AuthenticateHandler() {
@@ -56,8 +48,6 @@ public class AuthenticateHandler
     public AuthenticateHandler(ConfigurationService configurationService) {
         this.authenticationService = new DynamoService(configurationService);
         this.auditService = new AuditService(configurationService);
-        this.codeStorageService = new CodeStorageService(configurationService);
-        this.configurationService = configurationService;
     }
 
     @Override
@@ -78,26 +68,6 @@ public class AuthenticateHandler
         try {
             AuthenticateRequest loginRequest =
                     objectMapper.readValue(input.getBody(), AuthenticateRequest.class);
-            var persistentSessionId =
-                    PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders());
-            var incorrectPasswordCount =
-                    codeStorageService.getIncorrectPasswordCount(loginRequest.getEmail());
-            if (incorrectPasswordCount >= configurationService.getMaxPasswordRetries()) {
-                LOG.info("User has exceeded max password retries");
-
-                auditService.submitAuditEvent(
-                        AccountManagementAuditableEvent.ACCOUNT_TEMPORARILY_LOCKED,
-                        AuditService.UNKNOWN,
-                        sessionId,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        loginRequest.getEmail(),
-                        IpAddressHelper.extractIpAddress(input),
-                        AuditService.UNKNOWN,
-                        persistentSessionId);
-
-                return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1028);
-            }
             boolean userHasAccount = authenticationService.userExists(loginRequest.getEmail());
             if (!userHasAccount) {
                 return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1010);
@@ -106,11 +76,7 @@ public class AuthenticateHandler
                     authenticationService.login(
                             loginRequest.getEmail(), loginRequest.getPassword());
             if (!hasValidCredentials) {
-                codeStorageService.increaseIncorrectPasswordCount(loginRequest.getEmail());
                 return generateApiGatewayProxyErrorResponse(401, ErrorResponse.ERROR_1008);
-            }
-            if (incorrectPasswordCount != 0) {
-                codeStorageService.deleteIncorrectPasswordCount(loginRequest.getEmail());
             }
             LOG.info("User has successfully Logged in. Generating successful AuthenticateResponse");
 

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/AuthenticateHandlerTest.java
@@ -7,13 +7,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
-import uk.gov.di.authentication.shared.entity.Session;
-import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
-import uk.gov.di.authentication.shared.services.CodeStorageService;
-import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.util.Map;
 import java.util.Optional;
@@ -38,20 +34,10 @@ class AuthenticateHandlerTest {
     private final Context context = mock(Context.class);
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
     private final AuditService auditService = mock(AuditService.class);
-    private final CodeStorageService codeStorageService = mock(CodeStorageService.class);
-    private final ConfigurationService configurationService = mock(ConfigurationService.class);
-    private final Session session = new Session(IdGenerator.generate()).setEmailAddress(EMAIL);
 
     @BeforeEach
     public void setUp() {
-        when(configurationService.getMaxPasswordRetries()).thenReturn(5);
-
-        handler =
-                new AuthenticateHandler(
-                        authenticationService,
-                        auditService,
-                        codeStorageService,
-                        configurationService);
+        handler = new AuthenticateHandler(authenticationService, auditService);
     }
 
     @Test
@@ -123,46 +109,5 @@ class AuthenticateHandlerTest {
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1010));
 
         verifyNoInteractions(auditService);
-    }
-
-    @Test
-    void shouldChangeStateToAccountTemporarilyLockedAfter5UnsuccessfulAttempts() {
-        when(codeStorageService.getIncorrectPasswordCount(EMAIL)).thenReturn(5);
-        when(authenticationService.login(EMAIL, PASSWORD)).thenReturn(false);
-
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        event.setBody(format("{ \"password\": \"%s\", \"email\": \"%s\" }", PASSWORD, EMAIL));
-        APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
-
-        assertThat(result, hasStatus(400));
-
-        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1028));
-    }
-
-    @Test
-    void shouldKeepUserLockedWhenTheyEnterSuccessfulLoginRequestInNewSession() {
-        when(codeStorageService.getIncorrectPasswordCount(EMAIL)).thenReturn(5);
-        when(authenticationService.login(EMAIL, PASSWORD)).thenReturn(false);
-
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        event.setRequestContext(contextWithSourceIp(IP_ADDRESS));
-        event.setHeaders(Map.of("Session-Id", session.getSessionId()));
-        event.setBody(format("{ \"password\": \"%s\", \"email\": \"%s\" }", PASSWORD, EMAIL));
-        APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
-
-        assertThat(result, hasStatus(400));
-        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1028));
-
-        verify(auditService)
-                .submitAuditEvent(
-                        AccountManagementAuditableEvent.ACCOUNT_TEMPORARILY_LOCKED,
-                        AuditService.UNKNOWN,
-                        session.getSessionId(),
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        EMAIL,
-                        IP_ADDRESS,
-                        AuditService.UNKNOWN,
-                        PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE);
     }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -21,6 +21,7 @@ import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
+import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.state.UserContext;
@@ -41,6 +42,8 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
     private static final Logger LOG = LogManager.getLogger(CheckUserExistsHandler.class);
 
     private final AuditService auditService;
+    private final CodeStorageService codeStorageService;
+    private final ConfigurationService configurationService;
 
     public CheckUserExistsHandler(
             ConfigurationService configurationService,
@@ -48,7 +51,8 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
             ClientSessionService clientSessionService,
             ClientService clientService,
             AuthenticationService authenticationService,
-            AuditService auditService) {
+            AuditService auditService,
+            CodeStorageService codeStorageService) {
         super(
                 CheckUserExistsRequest.class,
                 configurationService,
@@ -57,6 +61,8 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
                 clientService,
                 authenticationService);
         this.auditService = auditService;
+        this.codeStorageService = codeStorageService;
+        this.configurationService = configurationService;
     }
 
     public CheckUserExistsHandler() {
@@ -66,6 +72,8 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
     public CheckUserExistsHandler(ConfigurationService configurationService) {
         super(CheckUserExistsRequest.class, configurationService);
         this.auditService = new AuditService(configurationService);
+        this.codeStorageService = new CodeStorageService(configurationService);
+        this.configurationService = configurationService;
     }
 
     @Override
@@ -106,6 +114,26 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
                         persistentSessionId);
                 return generateApiGatewayProxyErrorResponse(400, errorResponse.get());
             }
+
+            var incorrectPasswordCount = codeStorageService.getIncorrectPasswordCount(emailAddress);
+
+            if (incorrectPasswordCount >= configurationService.getMaxPasswordRetries()) {
+                LOG.info("User account is locked");
+
+                auditService.submitAuditEvent(
+                        FrontendAuditableEvent.ACCOUNT_TEMPORARILY_LOCKED,
+                        userContext.getClientSessionId(),
+                        userContext.getSession().getSessionId(),
+                        userContext.getClientId(),
+                        AuditService.UNKNOWN,
+                        emailAddress,
+                        IpAddressHelper.extractIpAddress(input),
+                        AuditService.UNKNOWN,
+                        persistentSessionId);
+
+                return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1045);
+            }
+
             boolean userExists = authenticationService.userExists(emailAddress);
             userContext.getSession().setEmailAddress(emailAddress);
             AuditableEvent auditableEvent;

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -43,7 +43,6 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
 
     private final AuditService auditService;
     private final CodeStorageService codeStorageService;
-    private final ConfigurationService configurationService;
 
     public CheckUserExistsHandler(
             ConfigurationService configurationService,
@@ -62,7 +61,6 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
                 authenticationService);
         this.auditService = auditService;
         this.codeStorageService = codeStorageService;
-        this.configurationService = configurationService;
     }
 
     public CheckUserExistsHandler() {
@@ -73,7 +71,6 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
         super(CheckUserExistsRequest.class, configurationService);
         this.auditService = new AuditService(configurationService);
         this.codeStorageService = new CodeStorageService(configurationService);
-        this.configurationService = configurationService;
     }
 
     @Override

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
@@ -47,6 +47,7 @@ import static uk.gov.di.authentication.frontendapi.lambda.StartHandlerTest.CLIEN
 import static uk.gov.di.authentication.sharedtest.helper.RequestEventHelper.contextWithSourceIp;
 import static uk.gov.di.authentication.sharedtest.logging.LogEventMatcher.withMessageContaining;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 class CheckUserExistsHandlerTest {
 
@@ -242,7 +243,8 @@ class CheckUserExistsHandlerTest {
         event.setRequestContext(contextWithSourceIp("123.123.123.123"));
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
-        assertEquals(400, result.getStatusCode());
+        assertThat(result, hasStatus(400));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1045));
 
         verify(auditService)
                 .submitAuditEvent(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
@@ -18,6 +18,7 @@ import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
+import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.shared.services.SessionService;
@@ -40,6 +41,7 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.ACCOUNT_TEMPORARILY_LOCKED;
 import static uk.gov.di.authentication.frontendapi.lambda.StartHandlerTest.CLIENT_SESSION_ID;
 import static uk.gov.di.authentication.frontendapi.lambda.StartHandlerTest.CLIENT_SESSION_ID_HEADER;
 import static uk.gov.di.authentication.sharedtest.helper.RequestEventHelper.contextWithSourceIp;
@@ -55,6 +57,7 @@ class CheckUserExistsHandlerTest {
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final ClientSessionService clientSessionService = mock(ClientSessionService.class);
     private final ClientService clientService = mock(ClientService.class);
+    private final CodeStorageService codeStorageService = mock(CodeStorageService.class);
 
     private CheckUserExistsHandler handler;
     private static final Json objectMapper = SerializationService.getInstance();
@@ -73,6 +76,7 @@ class CheckUserExistsHandlerTest {
     @BeforeEach
     void setup() {
         when(context.getAwsRequestId()).thenReturn("aws-session-id");
+        when(configurationService.getMaxPasswordRetries()).thenReturn(5);
 
         handler =
                 new CheckUserExistsHandler(
@@ -81,7 +85,8 @@ class CheckUserExistsHandlerTest {
                         clientSessionService,
                         clientService,
                         authenticationService,
-                        auditService);
+                        auditService,
+                        codeStorageService);
         reset(authenticationService);
     }
 
@@ -124,9 +129,10 @@ class CheckUserExistsHandlerTest {
 
     @Test
     void shouldReturn200IfUserDoesNotExist() throws Json.JsonException {
+        String email = "joe.bloggs@digital.cabinet-office.gov.uk";
         usingValidSession();
-        when(authenticationService.userExists(eq("joe.bloggs@digital.cabinet-office.gov.uk")))
-                .thenReturn(false);
+        when(authenticationService.userExists(eq(email))).thenReturn(false);
+        when(codeStorageService.getIncorrectPasswordCount(email)).thenReturn(0);
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setBody("{ \"email\": \"joe.bloggs@digital.cabinet-office.gov.uk\" }");
@@ -143,8 +149,7 @@ class CheckUserExistsHandlerTest {
 
         CheckUserExistsResponse checkUserExistsResponse =
                 objectMapper.readValue(result.getBody(), CheckUserExistsResponse.class);
-        assertEquals(
-                "joe.bloggs@digital.cabinet-office.gov.uk", checkUserExistsResponse.getEmail());
+        assertEquals(email, checkUserExistsResponse.getEmail());
         assertFalse(checkUserExistsResponse.doesUserExist());
 
         verify(auditService)
@@ -154,7 +159,7 @@ class CheckUserExistsHandlerTest {
                         session.getSessionId(),
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
-                        "joe.bloggs@digital.cabinet-office.gov.uk",
+                        email,
                         "123.123.123.123",
                         AuditService.UNKNOWN,
                         PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE);
@@ -214,6 +219,39 @@ class CheckUserExistsHandlerTest {
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         "joe.bloggs",
+                        "123.123.123.123",
+                        AuditService.UNKNOWN,
+                        PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE);
+    }
+
+    @Test
+    void shouldReturn400IfUserAccountIsLocked() throws Json.JsonException {
+        String email = "joe.bloggs@digital.cabinet-office.gov.uk";
+        usingValidSession();
+        when(authenticationService.userExists(eq(email))).thenReturn(false);
+        when(codeStorageService.getIncorrectPasswordCount(email)).thenReturn(5);
+
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        event.setBody("{ \"email\": \"joe.bloggs@digital.cabinet-office.gov.uk\" }");
+        event.setHeaders(
+                Map.of(
+                        "Session-Id",
+                        session.getSessionId(),
+                        CLIENT_SESSION_ID_HEADER,
+                        CLIENT_SESSION_ID));
+        event.setRequestContext(contextWithSourceIp("123.123.123.123"));
+        APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
+
+        assertEquals(400, result.getStatusCode());
+
+        verify(auditService)
+                .submitAuditEvent(
+                        ACCOUNT_TEMPORARILY_LOCKED,
+                        CLIENT_SESSION_ID,
+                        session.getSessionId(),
+                        AuditService.UNKNOWN,
+                        AuditService.UNKNOWN,
+                        email,
                         "123.123.123.123",
                         AuditService.UNKNOWN,
                         PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE);

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
@@ -118,6 +118,10 @@ public class RedisExtension
                 session.getSessionId(), objectMapper.writeValueAsString(session), 3600);
     }
 
+    public void incrementPasswordCount(String email) {
+        codeStorageService.increaseIncorrectPasswordCount(email);
+    }
+
     public void addAuthRequestToSession(
             String clientSessionId,
             String sessionId,

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
@@ -49,7 +49,8 @@ public enum ErrorResponse {
     ERROR_1041(1041, "Auth app secret is invalid"),
     ERROR_1042(1042, "User entered invalid authenticator app verification code too many times"),
     ERROR_1043(1043, "User entered invalid authenticator app code"),
-    ERROR_1044(1044, "New phone number is the same as current phone number");
+    ERROR_1044(1044, "New phone number is the same as current phone number"),
+    ERROR_1045(1045, "User account is temporarily locked from sign in");
 
     private int code;
 


### PR DESCRIPTION
## What?

1. Refactor `CheckUserExistsHandler` to include check for  when user account is locked/unlocked
2. Return a new error code `1045 - User account locked`
3. Revert changes from [PR](https://github.com/alphagov/di-authentication-api/pull/2363) as the changes required applies to global Sign In rather than Account Management module only.

## Why?

This is required in the Sign-In journey when a user tries to enter their password after their account has been locked, the page needs to redirect to a new account locked page detailing why the user cannot sign in

## Related PRs

[Backend changes](https://github.com/alphagov/di-authentication-frontend/pull/826)