### PR TITLE
AUT-830 - Add P1 doc app alerts and include account alias in cloudwatch alarm

### DIFF
--- a/ci/terraform/modules/endpoint-module/account.tf
+++ b/ci/terraform/modules/endpoint-module/account.tf
@@ -1,0 +1,1 @@
+data "aws_iam_account_alias" "current" {}

--- a/ci/terraform/modules/endpoint-module/alerts.tf
+++ b/ci/terraform/modules/endpoint-module/alerts.tf
@@ -21,7 +21,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda_error_cloudwatch_alarm" {
   period              = "3600"
   statistic           = "Sum"
   threshold           = var.lambda_log_alarm_threshold
-  alarm_description   = "${var.lambda_log_alarm_threshold} or more errors have occurred in the ${var.environment} ${var.endpoint_name} lambda"
+  alarm_description   = "${var.lambda_log_alarm_threshold} or more errors have occurred in the ${var.environment} ${var.endpoint_name} lambda.ACCOUNT: ${data.aws_iam_account_alias.current.account_alias}"
   alarm_actions       = [data.aws_sns_topic.slack_events.arn]
 }
 

--- a/ci/terraform/oidc/account.tf
+++ b/ci/terraform/oidc/account.tf
@@ -1,0 +1,1 @@
+data "aws_iam_account_alias" "current" {}

--- a/ci/terraform/oidc/alerts.tf
+++ b/ci/terraform/oidc/alerts.tf
@@ -12,7 +12,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs_deadletter_cloudwatch_alarm" {
   dimensions = {
     QueueName = aws_sqs_queue.email_dead_letter_queue.name
   }
-  alarm_description = "${var.dlq_alarm_threshold} or more messages have appeared on the ${aws_sqs_queue.email_dead_letter_queue.name}"
+  alarm_description = "${var.dlq_alarm_threshold} or more messages have appeared on the ${aws_sqs_queue.email_dead_letter_queue.name}.ACCOUNT: ${data.aws_iam_account_alias.current.account_alias}"
   alarm_actions     = [data.aws_sns_topic.slack_events.arn]
 }
 
@@ -30,7 +30,7 @@ resource "aws_cloudwatch_metric_alarm" "spot_request_sqs_dlq_cloudwatch_alarm" {
   dimensions = {
     QueueName = aws_sqs_queue.spot_request_dead_letter_queue.name
   }
-  alarm_description = "${var.dlq_alarm_threshold} or more messages have appeared on the ${aws_sqs_queue.spot_request_dead_letter_queue.name}"
+  alarm_description = "${var.dlq_alarm_threshold} or more messages have appeared on the ${aws_sqs_queue.spot_request_dead_letter_queue.name}.ACCOUNT: ${data.aws_iam_account_alias.current.account_alias}"
   alarm_actions     = [data.aws_sns_topic.slack_events.arn]
 }
 

--- a/ci/terraform/oidc/doc-app-alerts.tf
+++ b/ci/terraform/oidc/doc-app-alerts.tf
@@ -1,0 +1,49 @@
+data "aws_cloudwatch_log_group" "doc_app_callback_lambda_log_group" {
+  count = var.use_localstack ? 0 : 1
+  name  = replace("/aws/lambda/${var.environment}-doc-app-callback-lambda", ".", "")
+}
+
+data "aws_cloudwatch_log_group" "doc_app_authorize_lambda_log_group" {
+  count = var.use_localstack ? 0 : 1
+  name  = replace("/aws/lambda/${var.environment}-doc-app-authorize-lambda", ".", "")
+}
+
+resource "aws_cloudwatch_log_metric_filter" "doc_app_callback_metric_filter" {
+  count          = var.use_localstack ? 0 : 1
+  name           = replace("${var.environment}-doc-app-callback-p1-errors", ".", "")
+  pattern        = "{($.level = \"ERROR\")}"
+  log_group_name = data.aws_cloudwatch_log_group.doc_app_callback_lambda_log_group[0].name
+
+  metric_transformation {
+    name      = replace("${var.environment}-doc-app-error-count", ".", "")
+    namespace = "LambdaErrorsNamespace"
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "doc_app_authorize_metric_filter" {
+  count          = var.use_localstack ? 0 : 1
+  name           = replace("${var.environment}-doc-app-authorize-p1-errors", ".", "")
+  pattern        = "{($.level = \"ERROR\")}"
+  log_group_name = data.aws_cloudwatch_log_group.doc_app_authorize_lambda_log_group[0].name
+
+  metric_transformation {
+    name      = replace("${var.environment}-doc-app-error-count", ".", "")
+    namespace = "LambdaErrorsNamespace"
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "doc_app_p1_cloudwatch_alarm" {
+  count               = var.use_localstack ? 0 : 1
+  alarm_name          = replace("${var.environment}-P1-doc-app-alarm", ".", "")
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = aws_cloudwatch_log_metric_filter.doc_app_authorize_metric_filter[0].metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.doc_app_authorize_metric_filter[0].metric_transformation[0].namespace
+  period              = var.doc_app_p1_alarm_error_time_period
+  statistic           = "Sum"
+  threshold           = var.doc_app_p1_alarm_error_threshold
+  alarm_description   = "${var.doc_app_p1_alarm_error_threshold} or more Doc App errors have occurred in ${var.environment}.ACCOUNT: ${data.aws_iam_account_alias.current.account_alias}"
+  alarm_actions       = [var.environment == "production" ? data.aws_sns_topic.slack_events.arn : data.aws_sns_topic.slack_events.arn]
+}

--- a/ci/terraform/oidc/ipv-handback-alerts.tf
+++ b/ci/terraform/oidc/ipv-handback-alerts.tf
@@ -62,6 +62,6 @@ resource "aws_cloudwatch_metric_alarm" "ipv_handback_p1_cloudwatch_alarm" {
   period              = var.ipv_p1_alarm_error_time_period
   statistic           = "Sum"
   threshold           = var.ipv_p1_alarm_error_threshold
-  alarm_description   = "${var.ipv_p1_alarm_error_threshold} or more errors have occurred during the IPV handback for ${var.environment}"
+  alarm_description   = "${var.ipv_p1_alarm_error_threshold} or more IPV handback errors have occurred in ${var.environment}.ACCOUNT: ${data.aws_iam_account_alias.current.account_alias}"
   alarm_actions       = [var.environment == "production" ? data.aws_sns_topic.slack_events.arn : data.aws_sns_topic.slack_events.arn]
 }

--- a/ci/terraform/oidc/ipv-handoff-alerts.tf
+++ b/ci/terraform/oidc/ipv-handoff-alerts.tf
@@ -26,6 +26,6 @@ resource "aws_cloudwatch_metric_alarm" "ipv_handoff_p1_cloudwatch_alarm" {
   period              = var.ipv_p1_alarm_error_time_period
   statistic           = "Sum"
   threshold           = var.ipv_p1_alarm_error_threshold
-  alarm_description   = "${var.ipv_p1_alarm_error_threshold} or more errors have occurred during the IPV handoff for ${var.environment}"
+  alarm_description   = "${var.ipv_p1_alarm_error_threshold} or more IPV handoff errors have occurred in ${var.environment}.ACCOUNT: ${data.aws_iam_account_alias.current.account_alias}"
   alarm_actions       = [var.environment == "production" ? data.aws_sns_topic.slack_events.arn : data.aws_sns_topic.slack_events.arn]
 }

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -46,6 +46,18 @@ variable "ipv_p1_alarm_error_time_period" {
   default     = 600
 }
 
+variable "doc_app_p1_alarm_error_threshold" {
+  type        = number
+  description = "The number of Doc App errors raised before generating a Cloudwatch alarm"
+  default     = 20
+}
+
+variable "doc_app_p1_alarm_error_time_period" {
+  type        = number
+  description = "The time period in seconds for when the Doc App errors need to occur"
+  default     = 600
+}
+
 variable "deployer_role_arn" {
   default     = ""
   description = "The name of the AWS role to assume, leave blank when running locally"


### PR DESCRIPTION
## What?

 - Include account alias in cloudwatch alarm descriptions
 - Add P1 alerts for DocApp errors

## Why?

- Add the account alias to the cloudwatch alarm descripton. The account will then be cut from the alarmDescription in the alerts.js lambda and set as it's own field. This will make it easier for those actioning the alert to identify what AWS account the alert impacts.
- Create a cloudwatch alarm which monitors both the DocAppAuthoize and DocAppCallback lambda's for any errors that occur. The alarm will be triggered when there has been 20 errors in 10 minutes. This can be tweaked as required.
- For now, we will use the slack SNS topic so that these alerts will only generate slack messages to the #di-2nd-line channel. When required, we can switch the SNS topic for production to use pagerduty so that we have monitoring 24/7.