### PR TITLE
AUT-830/828 - Add ok_actions to P1 cloudwatch alarms

### DIFF
--- a/ci/terraform/oidc/doc-app-alerts.tf
+++ b/ci/terraform/oidc/doc-app-alerts.tf
@@ -46,4 +46,5 @@ resource "aws_cloudwatch_metric_alarm" "doc_app_p1_cloudwatch_alarm" {
   threshold           = var.doc_app_p1_alarm_error_threshold
   alarm_description   = "${var.doc_app_p1_alarm_error_threshold} or more Doc App errors have occurred in ${var.environment}.ACCOUNT: ${data.aws_iam_account_alias.current.account_alias}"
   alarm_actions       = [var.environment == "production" ? data.aws_sns_topic.slack_events.arn : data.aws_sns_topic.slack_events.arn]
+  ok_actions          = [var.environment == "production" ? data.aws_sns_topic.slack_events.arn : data.aws_sns_topic.slack_events.arn]
 }

--- a/ci/terraform/oidc/ipv-handback-alerts.tf
+++ b/ci/terraform/oidc/ipv-handback-alerts.tf
@@ -64,4 +64,5 @@ resource "aws_cloudwatch_metric_alarm" "ipv_handback_p1_cloudwatch_alarm" {
   threshold           = var.ipv_p1_alarm_error_threshold
   alarm_description   = "${var.ipv_p1_alarm_error_threshold} or more IPV handback errors have occurred in ${var.environment}.ACCOUNT: ${data.aws_iam_account_alias.current.account_alias}"
   alarm_actions       = [var.environment == "production" ? data.aws_sns_topic.slack_events.arn : data.aws_sns_topic.slack_events.arn]
+  ok_actions          = [var.environment == "production" ? data.aws_sns_topic.slack_events.arn : data.aws_sns_topic.slack_events.arn]
 }

--- a/ci/terraform/oidc/ipv-handoff-alerts.tf
+++ b/ci/terraform/oidc/ipv-handoff-alerts.tf
@@ -28,4 +28,5 @@ resource "aws_cloudwatch_metric_alarm" "ipv_handoff_p1_cloudwatch_alarm" {
   threshold           = var.ipv_p1_alarm_error_threshold
   alarm_description   = "${var.ipv_p1_alarm_error_threshold} or more IPV handoff errors have occurred in ${var.environment}.ACCOUNT: ${data.aws_iam_account_alias.current.account_alias}"
   alarm_actions       = [var.environment == "production" ? data.aws_sns_topic.slack_events.arn : data.aws_sns_topic.slack_events.arn]
+  ok_actions          = [var.environment == "production" ? data.aws_sns_topic.slack_events.arn : data.aws_sns_topic.slack_events.arn]
 }


### PR DESCRIPTION
## What?

- Add ok_actions to P1 cloudwatch alarms.

## Why?

- These are currently all set to the slack message sns but when we switch the alarms to pagerduty sns, we will also need to update the ok_actions to pagerduty. This will ensure that the pagerduty incident will be auto resolved.