### PR TITLE
ACI-121: Add OneLoginService flag to client start info

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/ClientStartInfo.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/ClientStartInfo.java
@@ -33,6 +33,10 @@ public class ClientStartInfo {
     @Expose
     private State state;
 
+    @SerializedName("isOneLoginService")
+    @Expose
+    private boolean oneLoginService;
+
     public ClientStartInfo() {}
 
     public ClientStartInfo(
@@ -41,13 +45,15 @@ public class ClientStartInfo {
             String serviceType,
             boolean cookieConsentShared,
             URI redirectUri,
-            State state) {
+            State state,
+            boolean oneLoginService) {
         this.clientName = clientName;
         this.scopes = scopes;
         this.serviceType = serviceType;
         this.cookieConsentShared = cookieConsentShared;
         this.redirectUri = redirectUri;
         this.state = state;
+        this.oneLoginService = oneLoginService;
     }
 
     public String getClientName() {
@@ -72,5 +78,9 @@ public class ClientStartInfo {
 
     public State getState() {
         return state;
+    }
+
+    public boolean isOneLoginService() {
+        return oneLoginService;
     }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
@@ -111,7 +111,8 @@ public class StartService {
                         clientRegistry.getServiceType(),
                         clientRegistry.isCookieConsentShared(),
                         redirectURI,
-                        state);
+                        state,
+                        clientRegistry.isOneLoginService());
         LOG.info(
                 "Found ClientStartInfo for ClientName: {} Scopes: {} ServiceType: {}",
                 clientRegistry.getClientName(),

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -147,6 +147,7 @@ class StartHandlerTest {
                 response.getClient().getCookieConsentShared(),
                 equalTo(getClientStartInfo().getCookieConsentShared()));
         assertThat(response.getClient().getRedirectUri(), equalTo(REDIRECT_URL));
+        assertFalse(response.getClient().isOneLoginService());
         assertThat(
                 response.getUser().isConsentRequired(), equalTo(userStartInfo.isConsentRequired()));
         assertThat(
@@ -185,7 +186,8 @@ class StartHandlerTest {
                                 "MANDATORY",
                                 false,
                                 REDIRECT_URL,
-                                STATE));
+                                STATE,
+                                false));
         when(startService.getGATrackingId(anyMap())).thenReturn(null);
         when(startService.getCookieConsentValue(anyMap(), anyString())).thenReturn(null);
         when(startService.buildUserStartInfo(userContext, null, null, true))
@@ -333,7 +335,13 @@ class StartHandlerTest {
         Scope scope = new Scope(OIDCScopeValue.OPENID.getValue());
 
         return new ClientStartInfo(
-                TEST_CLIENT_NAME, scope.toStringList(), "MANDATORY", false, REDIRECT_URL, STATE);
+                TEST_CLIENT_NAME,
+                scope.toStringList(),
+                "MANDATORY",
+                false,
+                REDIRECT_URL,
+                STATE,
+                false);
     }
 
     private UserStartInfo getUserStartInfo(String cookieConsent, String gaCrossDomainTrackingId) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ClientRegistry.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ClientRegistry.java
@@ -30,6 +30,8 @@ public class ClientRegistry {
     private String clientType;
     private boolean identityVerificationSupported = false;
 
+    private boolean oneLoginService = false;
+
     public ClientRegistry() {}
 
     @DynamoDbPartitionKey
@@ -283,6 +285,20 @@ public class ClientRegistry {
 
     public ClientRegistry withIdentityVerificationSupported(boolean identityVerificationSupported) {
         this.identityVerificationSupported = identityVerificationSupported;
+        return this;
+    }
+
+    @DynamoDbAttribute("OneLoginService")
+    public boolean isOneLoginService() {
+        return oneLoginService;
+    }
+
+    public void setOneLoginService(boolean oneLoginService) {
+        this.oneLoginService = oneLoginService;
+    }
+
+    public ClientRegistry withOneLoginService(boolean oneLoginService) {
+        this.oneLoginService = oneLoginService;
         return this;
     }
 }


### PR DESCRIPTION
## What?

- Add the new flag to the `ClientRegistry` class
- Default value should be `false`
- Add `oneLoginService` flag to `ClientStartInfo` class
- Set this value from the value that is returned from the client registry

## Why?

We need to make the frontend aware of whether the RP is an internal One Login service so that we can display different content where necessary.

There is no corresponding Client Registry change to this as we will manually manage the flags for the relevant clients.

## Related PRs

https://github.com/alphagov/di-authentication-frontend/pull/832