### PR TITLE
ACI-19: Add isPasswordResetRequired info to login handler response

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/LoginResponse.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/LoginResponse.java
@@ -36,6 +36,11 @@ public class LoginResponse {
     @Required
     private boolean consentRequired;
 
+    @SerializedName(value = "passwordChangeRequired")
+    @Expose
+    @Required
+    private boolean passwordChangeRequired;
+
     public LoginResponse() {}
 
     public LoginResponse(
@@ -44,13 +49,15 @@ public class LoginResponse {
             boolean latestTermsAndConditionsAccepted,
             boolean consentRequired,
             MFAMethodType mfaMethodType,
-            boolean mfaMethodVerified) {
+            boolean mfaMethodVerified,
+            boolean passwordChangeRequired) {
         this.redactedPhoneNumber = redactedPhoneNumber;
         this.mfaRequired = mfaRequired;
         this.latestTermsAndConditionsAccepted = latestTermsAndConditionsAccepted;
         this.consentRequired = consentRequired;
         this.mfaMethodType = mfaMethodType;
         this.mfaMethodVerified = mfaMethodVerified;
+        this.passwordChangeRequired = passwordChangeRequired;
     }
 
     public String getRedactedPhoneNumber() {
@@ -75,5 +82,9 @@ public class LoginResponse {
 
     public boolean isMfaMethodVerified() {
         return mfaMethodVerified;
+    }
+
+    public boolean isPasswordChangeRequired() {
+        return passwordChangeRequired;
     }
 }


### PR DESCRIPTION
## What?

- Add isPasswordResetRequired info to login handler response
- If true, then the frontend can route to the password reset page

## Why?

- Pre-requisite for front end changes to allow user to be prompted to reset password when their existing password is detected as a common password.
- If this PR is approved I intend to use the new field in the frontend [here](https://github.com/alphagov/di-authentication-frontend/blob/66e206c80ee8b4d74530b3bc6d87082caa172d05/src/components/enter-password/enter-password-controller.ts#L92) by adding it to the state machine context, and from there saying that the next page if `resetPasswordRequired` is `true` on a `USER_JOURNEY_EVENTS.CREDENTIALS_VALIDATED` event should be to send the user to the normal Reset Password page, from where they would follow the state flow exactly as if they had manually clicked through from 'I've forgotten my password' to get a reset.
