### PR TITLE
ACI-19: Additional logging for reset password required

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -259,6 +259,7 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
         } catch (Exception e) {
             LOG.error("Unable to check if password was a common password");
         }
+        LOG.info("Password reset required: {}", isPasswordChangeRequired);
 
         return isPasswordChangeRequired;
     }


### PR DESCRIPTION
## What?

Additional logging for reset password required.

## Why?

Log whether a user is required to reset their password for debug and reporting purposes.

## Related PRs

#2520 