### PR TITLE
ACI-19: Add common passwords dynamo read access to login

### DIFF
--- a/ci/terraform/oidc/login.tf
+++ b/ci/terraform/oidc/login.tf
@@ -12,6 +12,7 @@ module "frontend_api_login_role" {
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.pepper_parameter_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
+    aws_iam_policy.dynamo_common_passwords_read_access_policy.arn,
     module.oidc_txma_audit.access_policy_arn
   ]
 }


### PR DESCRIPTION
## What?

Add common passwords dynamo read access to login.

## Why?

Lambda cannot start due to missing access rights.

build-login-lambda is not authorized to perform: dynamodb:DescribeTable on resource: arn:aws:dynamodb:eu-west-2::table/ because no identity-based policy allows the dynamodb:DescribeTable action (Service: DynamoDb, Status Code: 400, Request ID: 

## Related PRs

#2520 