### PR TITLE
AUT-796 - Add internal sector URI to all OIDC Lambdas config

### DIFF
--- a/ci/terraform/oidc/auth-code.tf
+++ b/ci/terraform/oidc/auth-code.tf
@@ -28,6 +28,7 @@ module "auth-code" {
     ENVIRONMENT              = var.environment
     DYNAMO_ENDPOINT          = var.use_localstack ? var.lambda_dynamo_endpoint : null
     HEADERS_CASE_INSENSITIVE = var.use_localstack ? "true" : "false"
+    INTERNAl_SECTOR_URI      = var.internal_sector_uri
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.AuthCodeHandler::handleRequest"
 

--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -36,6 +36,7 @@ module "authorize" {
     REDIS_KEY                = local.redis_key
     TERMS_CONDITIONS_VERSION = var.terms_and_conditions
     SUPPORT_LANGUAGE_CY      = tostring(var.language_cy_enabled)
+    INTERNAl_SECTOR_URI      = var.internal_sector_uri
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.AuthorisationHandler::handleRequest"
   rest_api_id           = aws_api_gateway_rest_api.di_authentication_api.id

--- a/ci/terraform/oidc/build-overrides.tfvars
+++ b/ci/terraform/oidc/build-overrides.tfvars
@@ -9,6 +9,7 @@ doc_app_jwks_endpoint              = "https://build-doc-app-cri-stub.london.clou
 doc_app_encryption_key_id          = "7788bc975abd44e8b4fd7646d08ea9428476e37bff3e4365804b41cc29f8ef21"
 spot_enabled                       = false
 language_cy_enabled                = true
+internal_sector_uri                = "https://identity.build.account.gov.uk"
 
 blocked_email_duration                    = 30
 otp_code_ttl_duration                     = 120

--- a/ci/terraform/oidc/doc-app-authorize.tf
+++ b/ci/terraform/oidc/doc-app-authorize.tf
@@ -34,6 +34,7 @@ module "doc-app-authorize" {
     DOC_APP_JWKS_URL                   = var.doc_app_jwks_endpoint
     DOC_APP_ENCRYPTION_KEY_ID          = var.doc_app_encryption_key_id
     DOC_APP_TOKEN_SIGNING_KEY_ALIAS    = local.doc_app_auth_key_alias_name
+    INTERNAl_SECTOR_URI                = var.internal_sector_uri
   }
   handler_function_name = "uk.gov.di.authentication.app.lambda.DocAppAuthorizeHandler::handleRequest"
 

--- a/ci/terraform/oidc/doc-app-callback.tf
+++ b/ci/terraform/oidc/doc-app-callback.tf
@@ -36,6 +36,7 @@ module "doc-app-callback" {
     DOC_APP_BACKEND_URI                = var.doc_app_backend_uri
     DOC_APP_CRI_DATA_ENDPOINT          = var.doc_app_cri_data_endpoint
     DOC_APP_JWKS_URL                   = var.doc_app_jwks_endpoint
+    INTERNAl_SECTOR_URI                = var.internal_sector_uri
   }
   handler_function_name = "uk.gov.di.authentication.app.lambda.DocAppCallbackHandler::handleRequest"
 

--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -45,6 +45,7 @@ module "ipv-callback" {
     REDIS_KEY                      = local.redis_key
     SPOT_ENABLED                   = tostring(var.spot_enabled)
     SPOT_QUEUE_URL                 = aws_sqs_queue.spot_request_queue.id
+    INTERNAl_SECTOR_URI            = var.internal_sector_uri
   }
   handler_function_name = "uk.gov.di.authentication.ipv.lambda.IPVCallbackHandler::handleRequest"
 

--- a/ci/terraform/oidc/login.tf
+++ b/ci/terraform/oidc/login.tf
@@ -34,6 +34,7 @@ module "login" {
     DYNAMO_ENDPOINT          = var.use_localstack ? var.lambda_dynamo_endpoint : null
     TERMS_CONDITIONS_VERSION = var.terms_and_conditions
     HEADERS_CASE_INSENSITIVE = var.use_localstack ? "true" : "false"
+    INTERNAl_SECTOR_URI      = var.internal_sector_uri
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.LoginHandler::handleRequest"
 

--- a/ci/terraform/oidc/logout.tf
+++ b/ci/terraform/oidc/logout.tf
@@ -33,6 +33,7 @@ module "logout" {
     TOKEN_SIGNING_KEY_ALIAS       = local.id_token_signing_key_alias_name
     LOCALSTACK_ENDPOINT           = var.use_localstack ? var.localstack_endpoint : null
     BACK_CHANNEL_LOGOUT_QUEUE_URI = aws_sqs_queue.back_channel_logout_queue.id
+    INTERNAl_SECTOR_URI           = var.internal_sector_uri
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.LogoutHandler::handleRequest"
 

--- a/ci/terraform/oidc/mfa.tf
+++ b/ci/terraform/oidc/mfa.tf
@@ -33,6 +33,7 @@ module "mfa" {
     REDIS_KEY                              = local.redis_key
     DYNAMO_ENDPOINT                        = var.use_localstack ? var.lambda_dynamo_endpoint : null
     TEST_CLIENTS_ENABLED                   = var.test_clients_enabled
+    INTERNAl_SECTOR_URI                    = var.internal_sector_uri
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.MfaHandler::handleRequest"
 

--- a/ci/terraform/oidc/processing-identity.tf
+++ b/ci/terraform/oidc/processing-identity.tf
@@ -31,6 +31,7 @@ module "processing-identity" {
     HEADERS_CASE_INSENSITIVE = var.use_localstack ? "true" : "false"
     LOCALSTACK_ENDPOINT      = var.use_localstack ? var.localstack_endpoint : null
     REDIS_KEY                = local.redis_key
+    INTERNAl_SECTOR_URI      = var.internal_sector_uri
   }
   handler_function_name = "uk.gov.di.authentication.ipv.lambda.ProcessingIdentityHandler::handleRequest"
 

--- a/ci/terraform/oidc/reset-password-request.tf
+++ b/ci/terraform/oidc/reset-password-request.tf
@@ -33,6 +33,7 @@ module "reset-password-request" {
     LOCALSTACK_ENDPOINT    = var.use_localstack ? var.localstack_endpoint : null
     REDIS_KEY              = local.redis_key
     DYNAMO_ENDPOINT        = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    INTERNAl_SECTOR_URI    = var.internal_sector_uri
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.ResetPasswordRequestHandler::handleRequest"
 

--- a/ci/terraform/oidc/reset_password.tf
+++ b/ci/terraform/oidc/reset_password.tf
@@ -35,6 +35,7 @@ module "reset_password" {
     TERMS_CONDITIONS_VERSION               = var.terms_and_conditions
     DEFAULT_OTP_CODE_EXPIRY                = var.otp_code_ttl_duration
     EMAIL_OTP_ACCOUNT_CREATION_CODE_EXPIRY = var.email_acct_creation_otp_code_ttl_duration
+    INTERNAl_SECTOR_URI                    = var.internal_sector_uri
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.ResetPasswordHandler::handleRequest"
 

--- a/ci/terraform/oidc/send_notification.tf
+++ b/ci/terraform/oidc/send_notification.tf
@@ -32,6 +32,7 @@ module "send_notification" {
     TEST_CLIENTS_ENABLED                   = var.test_clients_enabled
     DEFAULT_OTP_CODE_EXPIRY                = var.otp_code_ttl_duration
     EMAIL_OTP_ACCOUNT_CREATION_CODE_EXPIRY = var.email_acct_creation_otp_code_ttl_duration
+    INTERNAl_SECTOR_URI                    = var.internal_sector_uri
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.SendNotificationHandler::handleRequest"
 

--- a/ci/terraform/oidc/signup.tf
+++ b/ci/terraform/oidc/signup.tf
@@ -31,6 +31,7 @@ module "signup" {
     REDIS_KEY                = local.redis_key
     DYNAMO_ENDPOINT          = var.use_localstack ? var.lambda_dynamo_endpoint : null
     TERMS_CONDITIONS_VERSION = var.terms_and_conditions
+    INTERNAl_SECTOR_URI      = var.internal_sector_uri
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.SignUpHandler::handleRequest"
 

--- a/ci/terraform/oidc/spot-response.tf
+++ b/ci/terraform/oidc/spot-response.tf
@@ -95,6 +95,7 @@ resource "aws_lambda_function" "spot_response_lambda" {
       ENVIRONMENT          = var.environment
       TXMA_AUDIT_QUEUE_URL = module.oidc_txma_audit.queue_url
       FRONTEND_BASE_URL    = module.dns.frontend_url
+      INTERNAl_SECTOR_URI  = var.internal_sector_uri
     })
   }
   kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn

--- a/ci/terraform/oidc/start.tf
+++ b/ci/terraform/oidc/start.tf
@@ -31,6 +31,7 @@ module "start" {
     DYNAMO_ENDPOINT          = var.use_localstack ? var.lambda_dynamo_endpoint : null
     HEADERS_CASE_INSENSITIVE = var.use_localstack ? "true" : "false"
     IDENTITY_ENABLED         = var.ipv_api_enabled
+    INTERNAl_SECTOR_URI      = var.internal_sector_uri
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.StartHandler::handleRequest"
 

--- a/ci/terraform/oidc/token.tf
+++ b/ci/terraform/oidc/token.tf
@@ -57,6 +57,7 @@ module "token" {
     LOCALSTACK_ENDPOINT       = var.use_localstack ? var.localstack_endpoint : null
     HEADERS_CASE_INSENSITIVE  = var.use_localstack ? "true" : "false"
     RESOURCE_ID_SCOPE_ENABLED = var.environment == "integration" ? "true" : false
+    INTERNAl_SECTOR_URI       = var.internal_sector_uri
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.TokenHandler::handleRequest"
 

--- a/ci/terraform/oidc/update_profile.tf
+++ b/ci/terraform/oidc/update_profile.tf
@@ -31,6 +31,7 @@ module "update_profile" {
     DYNAMO_ENDPOINT          = var.use_localstack ? var.lambda_dynamo_endpoint : null
     TERMS_CONDITIONS_VERSION = var.terms_and_conditions
     HEADERS_CASE_INSENSITIVE = var.use_localstack ? "true" : "false"
+    INTERNAl_SECTOR_URI      = var.internal_sector_uri
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.UpdateProfileHandler::handleRequest"
 

--- a/ci/terraform/oidc/userexists.tf
+++ b/ci/terraform/oidc/userexists.tf
@@ -29,7 +29,7 @@ module "userexists" {
     REDIS_KEY                = local.redis_key
     DYNAMO_ENDPOINT          = var.use_localstack ? var.lambda_dynamo_endpoint : null
     HEADERS_CASE_INSENSITIVE = var.use_localstack ? "true" : "false"
-
+    INTERNAl_SECTOR_URI      = var.internal_sector_uri
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.CheckUserExistsHandler::handleRequest"
 

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -32,6 +32,7 @@ module "userinfo" {
     DYNAMO_ENDPOINT         = var.use_localstack ? var.lambda_dynamo_endpoint : null
     TOKEN_SIGNING_KEY_ALIAS = local.id_token_signing_key_alias_name
     IDENTITY_ENABLED        = var.ipv_api_enabled
+    INTERNAl_SECTOR_URI     = var.internal_sector_uri
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.UserInfoHandler::handleRequest"
 

--- a/ci/terraform/oidc/verify_code.tf
+++ b/ci/terraform/oidc/verify_code.tf
@@ -34,6 +34,7 @@ module "verify_code" {
     TEST_CLIENT_VERIFY_EMAIL_OTP        = var.test_client_verify_email_otp
     TEST_CLIENT_VERIFY_PHONE_NUMBER_OTP = var.test_client_verify_phone_number_otp
     TEST_CLIENTS_ENABLED                = var.test_clients_enabled
+    INTERNAl_SECTOR_URI                 = var.internal_sector_uri
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.VerifyCodeHandler::handleRequest"
 

--- a/ci/terraform/oidc/verify_mfa_code.tf
+++ b/ci/terraform/oidc/verify_mfa_code.tf
@@ -34,6 +34,7 @@ module "verify_mfa_code" {
     TEST_CLIENT_VERIFY_EMAIL_OTP        = var.test_client_verify_email_otp
     TEST_CLIENT_VERIFY_PHONE_NUMBER_OTP = var.test_client_verify_phone_number_otp
     TEST_CLIENTS_ENABLED                = var.test_clients_enabled
+    INTERNAl_SECTOR_URI                 = var.internal_sector_uri
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.VerifyMfaCodeHandler::handleRequest"
 


### PR DESCRIPTION
## What?

 - Add internal sector URI to all Lambdas sitting under the OIDC module

## Why?

- So the Lambda have it available when required although for now it is only the IPV lambda using it.
