### PR TITLE
AUT-796 - Add the Internal Sector URI to AM lambda config

### DIFF
--- a/ci/terraform/account-management/authenticate.tf
+++ b/ci/terraform/account-management/authenticate.tf
@@ -21,6 +21,7 @@ module "authenticate" {
   handler_environment_variables = {
     ENVIRONMENT          = var.environment
     DYNAMO_ENDPOINT      = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    INTERNAl_SECTOR_URI  = var.internal_sector_uri
     LOCALSTACK_ENDPOINT  = var.use_localstack ? var.localstack_endpoint : null
     TXMA_AUDIT_QUEUE_URL = module.account_management_txma_audit.queue_url
     REDIS_KEY            = local.redis_key

--- a/ci/terraform/account-management/build-overrides.tfvars
+++ b/ci/terraform/account-management/build-overrides.tfvars
@@ -1,3 +1,5 @@
+internal_sector_uri = "https://identity.build.account.gov.uk"
+
 lambda_max_concurrency = 0
 lambda_min_concurrency = 1
 keep_lambdas_warm      = false

--- a/ci/terraform/account-management/integration-overrides.tfvars
+++ b/ci/terraform/account-management/integration-overrides.tfvars
@@ -1,3 +1,5 @@
+internal_sector_uri = "https://identity.integration.account.gov.uk"
+
 lambda_max_concurrency = 0
 lambda_min_concurrency = 1
 keep_lambdas_warm      = false

--- a/ci/terraform/account-management/production-overrides.tfvars
+++ b/ci/terraform/account-management/production-overrides.tfvars
@@ -1,3 +1,5 @@
+internal_sector_uri = "https://identity.account.gov.uk"
+
 notify_template_map = {
   VERIFY_EMAIL_TEMPLATE_ID         = "bda5cfb3-3d91-407e-90cc-b690c1fa8bf9"
   VERIFY_PHONE_NUMBER_TEMPLATE_ID  = "4bbc0a5c-833a-490e-89c6-5e286a030ac6"

--- a/ci/terraform/account-management/remove-account.tf
+++ b/ci/terraform/account-management/remove-account.tf
@@ -24,6 +24,7 @@ module "delete_account" {
     LOCALSTACK_ENDPOINT  = var.use_localstack ? var.localstack_endpoint : null
     EMAIL_QUEUE_URL      = aws_sqs_queue.email_queue.id
     TXMA_AUDIT_QUEUE_URL = module.account_management_txma_audit.queue_url
+    INTERNAl_SECTOR_URI  = var.internal_sector_uri
   }
   handler_function_name = "uk.gov.di.accountmanagement.lambda.RemoveAccountHandler::handleRequest"
 

--- a/ci/terraform/account-management/send_otp_notification.tf
+++ b/ci/terraform/account-management/send_otp_notification.tf
@@ -30,6 +30,7 @@ module "send_otp_notification" {
     BLOCKED_EMAIL_DURATION                 = var.blocked_email_duration
     DEFAULT_OTP_CODE_EXPIRY                = var.otp_code_ttl_duration
     EMAIL_OTP_ACCOUNT_CREATION_CODE_EXPIRY = var.email_acct_creation_otp_code_ttl_duration
+    INTERNAl_SECTOR_URI                    = var.internal_sector_uri
   }
   handler_function_name = "uk.gov.di.accountmanagement.lambda.SendOtpNotificationHandler::handleRequest"
 

--- a/ci/terraform/account-management/staging-sizing.tfvars
+++ b/ci/terraform/account-management/staging-sizing.tfvars
@@ -1,1 +1,3 @@
+internal_sector_uri = "https://identity.staging.account.gov.uk"
+
 redis_node_size = "cache.t2.small"

--- a/ci/terraform/account-management/update-email.tf
+++ b/ci/terraform/account-management/update-email.tf
@@ -27,6 +27,7 @@ module "update_email" {
     LOCALSTACK_ENDPOINT  = var.use_localstack ? var.localstack_endpoint : null
     REDIS_KEY            = local.redis_key
     TXMA_AUDIT_QUEUE_URL = module.account_management_txma_audit.queue_url
+    INTERNAl_SECTOR_URI  = var.internal_sector_uri
   }
   handler_function_name = "uk.gov.di.accountmanagement.lambda.UpdateEmailHandler::handleRequest"
 

--- a/ci/terraform/account-management/update-password.tf
+++ b/ci/terraform/account-management/update-password.tf
@@ -25,6 +25,7 @@ module "update_password" {
     LOCALSTACK_ENDPOINT  = var.use_localstack ? var.localstack_endpoint : null
     EMAIL_QUEUE_URL      = aws_sqs_queue.email_queue.id
     TXMA_AUDIT_QUEUE_URL = module.account_management_txma_audit.queue_url
+    INTERNAl_SECTOR_URI  = var.internal_sector_uri
   }
   handler_function_name = "uk.gov.di.accountmanagement.lambda.UpdatePasswordHandler::handleRequest"
 

--- a/ci/terraform/account-management/update-phone-number.tf
+++ b/ci/terraform/account-management/update-phone-number.tf
@@ -26,6 +26,7 @@ module "update_phone_number" {
     LOCALSTACK_ENDPOINT  = var.use_localstack ? var.localstack_endpoint : null
     REDIS_KEY            = local.redis_key
     TXMA_AUDIT_QUEUE_URL = module.account_management_txma_audit.queue_url
+    INTERNAl_SECTOR_URI  = var.internal_sector_uri
   }
   handler_function_name = "uk.gov.di.accountmanagement.lambda.UpdatePhoneNumberHandler::handleRequest"
 

--- a/ci/terraform/account-management/variables.tf
+++ b/ci/terraform/account-management/variables.tf
@@ -191,6 +191,11 @@ variable "endpoint_memory_size" {
   type    = number
 }
 
+variable "internal_sector_uri" {
+  type    = string
+  default = "undefined"
+}
+
 variable "performance_tuning" {
   type = map(object({
     memory : number,


### PR DESCRIPTION
## What?

- Make the InternalSectorUri available to all Account Management backend lambdas
- We will not use it until we're ready to switch over all lambdas 

## Why?

- This is required to calculate the subjectID that we send to TXMA

