### PR TITLE
AUT-876 - Switch Doc App alerts to Pagerduty

### DIFF
--- a/ci/terraform/oidc/doc-app-alerts.tf
+++ b/ci/terraform/oidc/doc-app-alerts.tf
@@ -45,5 +45,5 @@ resource "aws_cloudwatch_metric_alarm" "doc_app_p1_cloudwatch_alarm" {
   statistic           = "Sum"
   threshold           = var.doc_app_p1_alarm_error_threshold
   alarm_description   = "${var.doc_app_p1_alarm_error_threshold} or more Doc App errors have occurred in ${var.environment}.ACCOUNT: ${data.aws_iam_account_alias.current.account_alias}"
-  alarm_actions       = [var.environment == "production" ? data.aws_sns_topic.slack_events.arn : data.aws_sns_topic.slack_events.arn]
+  alarm_actions       = [var.environment == "production" ? data.aws_sns_topic.pagerduty_p1_alerts[0].arn : data.aws_sns_topic.slack_events.arn]
 }


### PR DESCRIPTION
## What?

- Switch Doc App alerts to Pagerduty

## Why?

- The Doc App will start to run from 8am - 8pm so we need to ensure that our alerting will reach the on-call engineers

