### PR TITLE
AUT-796 - Add logic to the account management lambdas to ensure a user exists

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthoriseAccessTokenHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/AuthoriseAccessTokenHandler.java
@@ -16,7 +16,6 @@ import uk.gov.di.authentication.shared.entity.CustomScopeValue;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoClientService;
-import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.JwksService;
 import uk.gov.di.authentication.shared.services.KmsConnectionService;
 import uk.gov.di.authentication.shared.services.TokenValidationService;
@@ -34,17 +33,14 @@ public class AuthoriseAccessTokenHandler
 
     private final TokenValidationService tokenValidationService;
     private final ConfigurationService configurationService;
-    private final DynamoService dynamoService;
     private final DynamoClientService clientService;
 
     public AuthoriseAccessTokenHandler(
             TokenValidationService tokenValidationService,
             ConfigurationService configurationService,
-            DynamoService dynamoService,
             DynamoClientService clientService) {
         this.tokenValidationService = tokenValidationService;
         this.configurationService = configurationService;
-        this.dynamoService = dynamoService;
         this.clientService = clientService;
     }
 
@@ -55,7 +51,6 @@ public class AuthoriseAccessTokenHandler
                         new JwksService(
                                 configurationService,
                                 new KmsConnectionService(configurationService)));
-        dynamoService = new DynamoService(configurationService);
         clientService = new DynamoClientService(configurationService);
     }
 
@@ -66,7 +61,6 @@ public class AuthoriseAccessTokenHandler
                         new JwksService(
                                 configurationService,
                                 new KmsConnectionService(configurationService)));
-        dynamoService = new DynamoService(configurationService);
         clientService = new DynamoClientService(configurationService);
     }
 
@@ -121,12 +115,6 @@ public class AuthoriseAccessTokenHandler
             String subject = claimsSet.getSubject();
             if (subject == null) {
                 LOG.warn("Access Token subject is missing");
-                throw new RuntimeException("Unauthorized");
-            }
-            try {
-                dynamoService.getUserProfileFromPublicSubject(subject);
-            } catch (Exception e) {
-                LOG.error("Unable to retrieve UserProfile from Dynamo with given SubjectID");
                 throw new RuntimeException("Unauthorized");
             }
             LOG.info("User found in Dynamo with given SubjectID");

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
@@ -14,7 +14,7 @@ import uk.gov.di.accountmanagement.entity.UpdateEmailRequest;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
-import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.exceptions.UserNotFoundException;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
@@ -120,9 +120,14 @@ public class UpdateEmailHandler
             if (dynamoService.userExists(updateInfoRequest.getReplacementEmailAddress())) {
                 return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1009);
             }
-            UserProfile userProfile =
-                    dynamoService.getUserProfileByEmail(
-                            updateInfoRequest.getExistingEmailAddress());
+            var userProfile =
+                    dynamoService
+                            .getUserProfileByEmailMaybe(updateInfoRequest.getExistingEmailAddress())
+                            .orElseThrow(
+                                    () ->
+                                            new UserNotFoundException(
+                                                    "User not found with given email"));
+
             Map<String, Object> authorizerParams = input.getRequestContext().getAuthorizer();
             RequestBodyHelper.validatePrincipal(
                     new Subject(userProfile.getPublicSubjectID()), authorizerParams);
@@ -150,6 +155,8 @@ public class UpdateEmailHandler
 
             LOG.info("Message successfully added to queue. Generating successful gateway response");
             return generateEmptySuccessApiGatewayResponse();
+        } catch (UserNotFoundException e) {
+            return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1010);
         } catch (JsonException | IllegalArgumentException e) {
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
         }

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/AuthoriseAccessTokenHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/AuthoriseAccessTokenHandlerTest.java
@@ -17,7 +17,6 @@ import uk.gov.di.accountmanagement.entity.TokenAuthorizerContext;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoClientService;
-import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.TokenValidationService;
 import uk.gov.di.authentication.sharedtest.helper.TokenGeneratorHelper;
 
@@ -37,7 +36,6 @@ class AuthoriseAccessTokenHandlerTest {
 
     private final TokenValidationService tokenValidationServicen =
             mock(TokenValidationService.class);
-    private final DynamoService dynamoService = mock(DynamoService.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final DynamoClientService clientService = mock(DynamoClientService.class);
     private AuthoriseAccessTokenHandler handler;
@@ -56,10 +54,7 @@ class AuthoriseAccessTokenHandlerTest {
     public void setUp() {
         handler =
                 new AuthoriseAccessTokenHandler(
-                        tokenValidationServicen,
-                        configurationService,
-                        dynamoService,
-                        clientService);
+                        tokenValidationServicen, configurationService, clientService);
     }
 
     @Test
@@ -104,27 +99,6 @@ class AuthoriseAccessTokenHandlerTest {
                         TOKEN_TYPE, signedAccessToken.toAuthorizationHeader(), METHOD_ARN);
         when(tokenValidationServicen.validateAccessTokenSignature(signedAccessToken))
                 .thenReturn(false);
-
-        RuntimeException exception =
-                assertThrows(
-                        RuntimeException.class,
-                        () -> handler.handleRequest(tokenAuthorizerContext, context),
-                        "Expected to throw exception");
-
-        assertEquals("Unauthorized", exception.getMessage());
-    }
-
-    @Test
-    public void shouldThrowExceptionWhenSubjectIdCannotBeLinkedToAUser() throws JOSEException {
-        BearerAccessToken signedAccessToken =
-                new BearerAccessToken(createSignedAccessToken(SCOPES).serialize());
-        TokenAuthorizerContext tokenAuthorizerContext =
-                new TokenAuthorizerContext(
-                        TOKEN_TYPE, signedAccessToken.toAuthorizationHeader(), METHOD_ARN);
-        when(tokenValidationServicen.validateAccessTokenSignature(signedAccessToken))
-                .thenReturn(true);
-        when(dynamoService.getUserProfileFromSubject(SUBJECT.getValue()))
-                .thenThrow(RuntimeException.class);
 
         RuntimeException exception =
                 assertThrows(

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandlerTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
+import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
@@ -26,16 +27,20 @@ import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.accountmanagement.entity.NotificationType.DELETE_ACCOUNT;
 import static uk.gov.di.authentication.sharedtest.helper.RequestEventHelper.identityWithSourceIp;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 class RemoveAccountHandlerTest {
 
     private static final String EMAIL = "joe.bloggs@digital.cabinet-office.gov.uk";
-    private static final Subject SUBJECT = new Subject();
+    private static final Subject PUBLIC_SUBJECT = new Subject();
+    private static final String PERSISTENT_ID = "some-persistent-session-id";
     private final Json objectMapper = SerializationService.getInstance();
 
     private RemoveAccountHandler handler;
@@ -54,29 +59,18 @@ class RemoveAccountHandlerTest {
 
     @Test
     public void shouldReturn204IfAccountRemovalIsSuccessful() throws Json.JsonException {
-        String persistentIdValue = "some-persistent-session-id";
-        UserProfile userProfile = new UserProfile().withPublicSubjectID(SUBJECT.getValue());
+        var userProfile = new UserProfile().withPublicSubjectID(PUBLIC_SUBJECT.getValue());
         when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
                 .thenReturn(Optional.of(userProfile));
-        APIGatewayProxyRequestEvent.ProxyRequestContext proxyRequestContext =
-                new APIGatewayProxyRequestEvent.ProxyRequestContext();
-        Map<String, Object> authorizerParams = new HashMap<>();
-        authorizerParams.put("principalId", SUBJECT.getValue());
-        proxyRequestContext.setAuthorizer(authorizerParams);
-        proxyRequestContext.setIdentity(identityWithSourceIp("123.123.123.123"));
 
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        event.setRequestContext(proxyRequestContext);
-        event.setBody(format("{ \"email\": \"%s\" }", EMAIL));
-        event.setHeaders(Map.of(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, persistentIdValue));
+        var result = generateRequest();
 
-        when(authenticationService.userExists(EMAIL)).thenReturn(true);
-        APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
+        assertThat(result, hasStatus(204));
         verify(authenticationService).removeAccount(eq(EMAIL));
-        NotifyRequest notifyRequest =
-                new NotifyRequest(EMAIL, DELETE_ACCOUNT, SupportedLanguage.EN);
-        verify(sqsClient).send(objectMapper.writeValueAsString(notifyRequest));
-
+        verify(sqsClient)
+                .send(
+                        objectMapper.writeValueAsString(
+                                new NotifyRequest(EMAIL, DELETE_ACCOUNT, SupportedLanguage.EN)));
         verify(auditService)
                 .submitAuditEvent(
                         AccountManagementAuditableEvent.DELETE_ACCOUNT,
@@ -87,8 +81,33 @@ class RemoveAccountHandlerTest {
                         userProfile.getEmail(),
                         "123.123.123.123",
                         userProfile.getPhoneNumber(),
-                        persistentIdValue);
+                        PERSISTENT_ID);
+    }
 
-        assertThat(result, hasStatus(204));
+    @Test
+    void shouldReturn400IfUserAccountDoesNotExist() {
+        when(authenticationService.getUserProfileByEmailMaybe(EMAIL)).thenReturn(Optional.empty());
+
+        var result = generateRequest();
+
+        verify(authenticationService, never()).removeAccount(EMAIL);
+        verifyNoInteractions(auditService);
+        assertThat(result, hasStatus(400));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1010));
+    }
+
+    private APIGatewayProxyResponseEvent generateRequest() {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        event.setBody(format("{\"email\": \"%s\" }", EMAIL));
+        APIGatewayProxyRequestEvent.ProxyRequestContext proxyRequestContext =
+                new APIGatewayProxyRequestEvent.ProxyRequestContext();
+        Map<String, Object> authorizerParams = new HashMap<>();
+        authorizerParams.put("principalId", PUBLIC_SUBJECT.getValue());
+        proxyRequestContext.setAuthorizer(authorizerParams);
+        proxyRequestContext.setIdentity(identityWithSourceIp("123.123.123.123"));
+        event.setRequestContext(proxyRequestContext);
+        event.setHeaders(Map.of(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, PERSISTENT_ID));
+
+        return handler.handleRequest(event, context);
     }
 }

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandlerTest.java
@@ -22,6 +22,7 @@ import uk.gov.di.authentication.shared.services.SerializationService;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -33,7 +34,6 @@ import static org.mockito.Mockito.when;
 import static uk.gov.di.accountmanagement.entity.NotificationType.PHONE_NUMBER_UPDATED;
 import static uk.gov.di.accountmanagement.entity.NotificationType.VERIFY_PHONE_NUMBER;
 import static uk.gov.di.authentication.sharedtest.helper.RequestEventHelper.identityWithSourceIp;
-import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
@@ -47,16 +47,16 @@ class UpdatePhoneNumberHandlerTest {
     private static final String EMAIL_ADDRESS = "joe.bloggs@digital.cabinet-office.gov.uk";
     private static final String NEW_PHONE_NUMBER = "07755551084";
     private static final String OLD_PHONE_NUMBER = "09876543219";
-    private static final String INVALID_PHONE_NUMBER = "12345";
     private static final String OTP = "123456";
-    private static final Subject SUBJECT = new Subject();
+    private static final Subject PUBLIC_SUBJECT = new Subject();
+    private static final String PERSISTENT_ID = "some-persistent-session-id";
 
     private final Json objectMapper = SerializationService.getInstance();
     private final AuditService auditService = mock(AuditService.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         handler =
                 new UpdatePhoneNumberHandler(
                         dynamoService,
@@ -67,37 +67,27 @@ class UpdatePhoneNumberHandlerTest {
     }
 
     @Test
-    public void shouldReturn204ForValidUpdatePhoneNumberRequest() throws Json.JsonException {
-        String persistentIdValue = "some-persistent-session-id";
-        UserProfile userProfile =
-                new UserProfile()
-                        .withPublicSubjectID(SUBJECT.getValue())
-                        .withPhoneNumber(OLD_PHONE_NUMBER);
-        when(dynamoService.getUserProfileByEmail(EMAIL_ADDRESS)).thenReturn(userProfile);
-        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
-        event.setBody(
-                format(
-                        "{\"email\": \"%s\", \"phoneNumber\": \"%s\", \"otp\": \"%s\"  }",
-                        EMAIL_ADDRESS, NEW_PHONE_NUMBER, OTP));
-        event.setHeaders(Map.of(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, persistentIdValue));
-        APIGatewayProxyRequestEvent.ProxyRequestContext proxyRequestContext =
-                new APIGatewayProxyRequestEvent.ProxyRequestContext();
-        Map<String, Object> authorizerParams = new HashMap<>();
-        authorizerParams.put("principalId", SUBJECT.getValue());
-        proxyRequestContext.setIdentity(identityWithSourceIp("123.123.123.123"));
-        proxyRequestContext.setAuthorizer(authorizerParams);
-        event.setRequestContext(proxyRequestContext);
+    void shouldReturn204ForValidUpdatePhoneNumberRequest() throws Json.JsonException {
         when(codeStorageService.isValidOtpCode(EMAIL_ADDRESS, OTP, VERIFY_PHONE_NUMBER))
                 .thenReturn(true);
+        var userProfile =
+                new UserProfile()
+                        .withPublicSubjectID(PUBLIC_SUBJECT.getValue())
+                        .withPhoneNumber(OLD_PHONE_NUMBER);
+        when(dynamoService.getUserProfileByEmailMaybe(EMAIL_ADDRESS))
+                .thenReturn(Optional.of(userProfile));
 
-        APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
+        var result = generateRequest();
 
         assertThat(result, hasStatus(204));
         verify(dynamoService).updatePhoneNumber(EMAIL_ADDRESS, NEW_PHONE_NUMBER);
-        NotifyRequest notifyRequest =
-                new NotifyRequest(EMAIL_ADDRESS, PHONE_NUMBER_UPDATED, SupportedLanguage.EN);
-        verify(sqsClient).send(objectMapper.writeValueAsString(notifyRequest));
-
+        verify(sqsClient)
+                .send(
+                        objectMapper.writeValueAsString(
+                                new NotifyRequest(
+                                        EMAIL_ADDRESS,
+                                        PHONE_NUMBER_UPDATED,
+                                        SupportedLanguage.EN)));
         verify(auditService)
                 .submitAuditEvent(
                         AccountManagementAuditableEvent.UPDATE_PHONE_NUMBER,
@@ -108,15 +98,15 @@ class UpdatePhoneNumberHandlerTest {
                         userProfile.getEmail(),
                         "123.123.123.123",
                         NEW_PHONE_NUMBER,
-                        persistentIdValue);
+                        PERSISTENT_ID);
     }
 
     @Test
-    public void shouldReturn400WhenRequestIsMissingParameters() {
+    void shouldReturn400WhenRequestIsMissingParameters() {
         APIGatewayProxyRequestEvent.ProxyRequestContext proxyRequestContext =
                 new APIGatewayProxyRequestEvent.ProxyRequestContext();
         Map<String, Object> authorizerParams = new HashMap<>();
-        authorizerParams.put("principalId", SUBJECT.getValue());
+        authorizerParams.put("principalId", PUBLIC_SUBJECT.getValue());
         proxyRequestContext.setAuthorizer(authorizerParams);
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setRequestContext(proxyRequestContext);
@@ -130,30 +120,49 @@ class UpdatePhoneNumberHandlerTest {
     }
 
     @Test
-    public void shouldReturnErrorWhenOtpCodeIsNotValid() throws Json.JsonException {
-        when(dynamoService.getSubjectFromEmail(EMAIL_ADDRESS)).thenReturn(SUBJECT);
+    void shouldReturn400WhenOtpCodeIsNotValid() {
+        when(codeStorageService.isValidOtpCode(EMAIL_ADDRESS, OTP, VERIFY_PHONE_NUMBER))
+                .thenReturn(false);
+
+        var result = generateRequest();
+
+        verify(dynamoService, times(0)).updatePhoneNumber(EMAIL_ADDRESS, NEW_PHONE_NUMBER);
+        verifyNoInteractions(sqsClient);
+        verifyNoInteractions(auditService);
+        assertThat(result, hasStatus(400));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1020));
+    }
+
+    @Test
+    void shouldReturn400IfUserAccountDoesNotExistForCurrentEmail() {
+        when(codeStorageService.isValidOtpCode(EMAIL_ADDRESS, OTP, VERIFY_PHONE_NUMBER))
+                .thenReturn(true);
+        when(dynamoService.getUserProfileByEmailMaybe(EMAIL_ADDRESS)).thenReturn(Optional.empty());
+
+        var result = generateRequest();
+
+        verify(dynamoService, times(0)).updatePhoneNumber(EMAIL_ADDRESS, NEW_PHONE_NUMBER);
+        verifyNoInteractions(sqsClient);
+        verifyNoInteractions(auditService);
+        assertThat(result, hasStatus(400));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1010));
+    }
+
+    private APIGatewayProxyResponseEvent generateRequest() {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setBody(
                 format(
                         "{\"email\": \"%s\", \"phoneNumber\": \"%s\", \"otp\": \"%s\"  }",
-                        EMAIL_ADDRESS, INVALID_PHONE_NUMBER, OTP));
+                        EMAIL_ADDRESS, NEW_PHONE_NUMBER, OTP));
         APIGatewayProxyRequestEvent.ProxyRequestContext proxyRequestContext =
                 new APIGatewayProxyRequestEvent.ProxyRequestContext();
         Map<String, Object> authorizerParams = new HashMap<>();
-        authorizerParams.put("principalId", SUBJECT.getValue());
+        authorizerParams.put("principalId", PUBLIC_SUBJECT.getValue());
         proxyRequestContext.setAuthorizer(authorizerParams);
+        proxyRequestContext.setIdentity(identityWithSourceIp("123.123.123.123"));
         event.setRequestContext(proxyRequestContext);
-        when(codeStorageService.isValidOtpCode(EMAIL_ADDRESS, OTP, VERIFY_PHONE_NUMBER))
-                .thenReturn(false);
-        APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
+        event.setHeaders(Map.of(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, PERSISTENT_ID));
 
-        assertThat(result, hasStatus(400));
-        verify(dynamoService, times(0)).updatePhoneNumber(EMAIL_ADDRESS, INVALID_PHONE_NUMBER);
-        NotifyRequest notifyRequest =
-                new NotifyRequest(INVALID_PHONE_NUMBER, PHONE_NUMBER_UPDATED, SupportedLanguage.EN);
-        verify(sqsClient, times(0)).send(objectMapper.writeValueAsString(notifyRequest));
-        String expectedResponse = objectMapper.writeValueAsString(ErrorResponse.ERROR_1020);
-        assertThat(result, hasBody(expectedResponse));
-        verifyNoInteractions(auditService);
+        return handler.handleRequest(event, context);
     }
 }

--- a/ci/terraform/account-management/authorizer.tf
+++ b/ci/terraform/account-management/authorizer.tf
@@ -6,7 +6,6 @@ module "account_management_api_authorizer_role" {
 
   policies_to_attach = [
     aws_iam_policy.lambda_kms_policy.arn,
-    aws_iam_policy.dynamo_am_user_read_access_policy.arn,
     aws_iam_policy.dynamo_am_client_registry_read_access_policy.arn,
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn
   ]

--- a/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/UserNotFoundException.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/UserNotFoundException.java
@@ -1,0 +1,8 @@
+package uk.gov.di.authentication.shared.exceptions;
+
+public class UserNotFoundException extends Exception {
+
+    public UserNotFoundException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
## What?

- Add logic to the account management lambdas to ensure a user exists 
- Remove logic to check whether a user exists from the account management authorizer.

## Why?

- Previously we were checking whether a user exists by using the subject id in the access token and calling dynamo to see if there was a user account. As we look to change this subject ID from the public subject id to the common subject identifier, we will no longer be able to do this.
- We can do this check instead in the account management lambdas. This allows us to not need to rely on the Subject in the access token and removes a call to dynamo which should reduce latency. 
