### PR TITLE
AUT-796 - Validate principalId in AM lambdas against internal subject pairwise id

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/exceptions/InvalidPrincipalException.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/exceptions/InvalidPrincipalException.java
@@ -1,0 +1,8 @@
+package uk.gov.di.accountmanagement.exceptions;
+
+public class InvalidPrincipalException extends RuntimeException {
+
+    public InvalidPrincipalException(String message) {
+        super(message);
+    }
+}

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/helpers/PrincipalValidationHelper.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/helpers/PrincipalValidationHelper.java
@@ -1,0 +1,42 @@
+package uk.gov.di.accountmanagement.helpers;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
+import uk.gov.di.authentication.shared.services.AuthenticationService;
+
+import java.util.Map;
+import java.util.Objects;
+
+public class PrincipalValidationHelper {
+
+    private static final Logger LOG = LogManager.getLogger(PrincipalValidationHelper.class);
+    private static final String PRINCIPAL_ID_KEY = "principalId";
+
+    private PrincipalValidationHelper() {}
+
+    public static boolean principleIsInvalid(
+            UserProfile userProfile,
+            String internalSectorUri,
+            AuthenticationService authenticationService,
+            Map<String, Object> authorizerParams) {
+        if (!authorizerParams.containsKey(PRINCIPAL_ID_KEY)) {
+            LOG.warn("principalId is missing");
+            return true;
+        } else if (Objects.nonNull(userProfile.getPublicSubjectID())
+                && userProfile
+                        .getPublicSubjectID()
+                        .equals(authorizerParams.get(PRINCIPAL_ID_KEY))) {
+            LOG.info("principalId contains publicSubjectID");
+            return false;
+        } else {
+            LOG.info(
+                    "principalId does not contain publicSubjectID. Validating principalId against internal pairwise subject id");
+            var internalSubjectId =
+                    ClientSubjectHelper.getSubjectWithSectorIdentifier(
+                            userProfile, internalSectorUri, authenticationService);
+            return !internalSubjectId.getValue().equals(authorizerParams.get(PRINCIPAL_ID_KEY));
+        }
+    }
+}

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdateEmailHandler.java
@@ -4,13 +4,14 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.nimbusds.oauth2.sdk.id.Subject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent;
 import uk.gov.di.accountmanagement.entity.NotificationType;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.accountmanagement.entity.UpdateEmailRequest;
+import uk.gov.di.accountmanagement.exceptions.InvalidPrincipalException;
+import uk.gov.di.accountmanagement.helpers.PrincipalValidationHelper;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
@@ -18,7 +19,6 @@ import uk.gov.di.authentication.shared.exceptions.UserNotFoundException;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
-import uk.gov.di.authentication.shared.helpers.RequestBodyHelper;
 import uk.gov.di.authentication.shared.helpers.RequestHeaderHelper;
 import uk.gov.di.authentication.shared.helpers.ValidationHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
@@ -129,8 +129,13 @@ public class UpdateEmailHandler
                                                     "User not found with given email"));
 
             Map<String, Object> authorizerParams = input.getRequestContext().getAuthorizer();
-            RequestBodyHelper.validatePrincipal(
-                    new Subject(userProfile.getPublicSubjectID()), authorizerParams);
+            if (PrincipalValidationHelper.principleIsInvalid(
+                    userProfile,
+                    configurationService.getInternalSectorUri(),
+                    dynamoService,
+                    authorizerParams)) {
+                throw new InvalidPrincipalException("Invalid Principal in request");
+            }
             dynamoService.updateEmail(
                     updateInfoRequest.getExistingEmailAddress(),
                     updateInfoRequest.getReplacementEmailAddress());

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePasswordHandler.java
@@ -4,13 +4,14 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.nimbusds.oauth2.sdk.id.Subject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent;
 import uk.gov.di.accountmanagement.entity.NotificationType;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.accountmanagement.entity.UpdatePasswordRequest;
+import uk.gov.di.accountmanagement.exceptions.InvalidPrincipalException;
+import uk.gov.di.accountmanagement.helpers.PrincipalValidationHelper;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.exceptions.UserNotFoundException;
@@ -18,7 +19,6 @@ import uk.gov.di.authentication.shared.helpers.Argon2MatcherHelper;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
-import uk.gov.di.authentication.shared.helpers.RequestBodyHelper;
 import uk.gov.di.authentication.shared.helpers.RequestHeaderHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.serialization.Json.JsonException;
@@ -125,8 +125,13 @@ public class UpdatePasswordHandler
 
             Map<String, Object> authorizerParams = input.getRequestContext().getAuthorizer();
 
-            RequestBodyHelper.validatePrincipal(
-                    new Subject(userProfile.getPublicSubjectID()), authorizerParams);
+            if (PrincipalValidationHelper.principleIsInvalid(
+                    userProfile,
+                    configurationService.getInternalSectorUri(),
+                    dynamoService,
+                    authorizerParams)) {
+                throw new InvalidPrincipalException("Invalid Principal in request");
+            }
 
             String currentPassword =
                     dynamoService

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandler.java
@@ -4,13 +4,14 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.nimbusds.oauth2.sdk.id.Subject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent;
 import uk.gov.di.accountmanagement.entity.NotificationType;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.accountmanagement.entity.UpdatePhoneNumberRequest;
+import uk.gov.di.accountmanagement.exceptions.InvalidPrincipalException;
+import uk.gov.di.accountmanagement.helpers.PrincipalValidationHelper;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.accountmanagement.services.CodeStorageService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
@@ -18,7 +19,6 @@ import uk.gov.di.authentication.shared.exceptions.UserNotFoundException;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
-import uk.gov.di.authentication.shared.helpers.RequestBodyHelper;
 import uk.gov.di.authentication.shared.helpers.RequestHeaderHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.serialization.Json.JsonException;
@@ -117,8 +117,13 @@ public class UpdatePhoneNumberHandler
                                                     "User not found with given email"));
 
             Map<String, Object> authorizerParams = input.getRequestContext().getAuthorizer();
-            RequestBodyHelper.validatePrincipal(
-                    new Subject(userProfile.getPublicSubjectID()), authorizerParams);
+            if (PrincipalValidationHelper.principleIsInvalid(
+                    userProfile,
+                    configurationService.getInternalSectorUri(),
+                    dynamoService,
+                    authorizerParams)) {
+                throw new InvalidPrincipalException("Invalid Principal in request");
+            }
             dynamoService.updatePhoneNumber(
                     updatePhoneNumberRequest.getEmail(), updatePhoneNumberRequest.getPhoneNumber());
             LOG.info("Phone Number has successfully been updated. Adding message to SQS queue");

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/helpers/PrincipalValidationHelperTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/helpers/PrincipalValidationHelperTest.java
@@ -1,0 +1,78 @@
+package uk.gov.di.accountmanagement.helpers;
+
+import com.nimbusds.oauth2.sdk.id.Subject;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
+import uk.gov.di.authentication.shared.helpers.SaltHelper;
+import uk.gov.di.authentication.shared.services.AuthenticationService;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class PrincipalValidationHelperTest {
+
+    private final AuthenticationService authenticationService = mock(AuthenticationService.class);
+    private static final String INTERNAL_SECTOR_URI = "https://test.account.gov.uk";
+    private final Map<String, Object> authorizerParams = new HashMap<>();
+
+    @Test
+    void shouldReturnTrueWhenNoPrincipalIdIsPresent() {
+        assertTrue(
+                PrincipalValidationHelper.principleIsInvalid(
+                        new UserProfile(),
+                        INTERNAL_SECTOR_URI,
+                        authenticationService,
+                        authorizerParams));
+    }
+
+    @Test
+    void shouldReturnFalseWhenPublicSubjectIdEqualsPrinciple() {
+        var publicSubject = new Subject();
+        var userProfile = new UserProfile().withPublicSubjectID(publicSubject.getValue());
+        authorizerParams.put("principalId", publicSubject.getValue());
+
+        assertFalse(
+                PrincipalValidationHelper.principleIsInvalid(
+                        userProfile, INTERNAL_SECTOR_URI, authenticationService, authorizerParams));
+    }
+
+    @Test
+    void shouldReturnFalseWhenPrincipalDoesNotMatchPublicSubjectIdButMatchesPairwiseSubjectId() {
+        var internalSubject = new Subject();
+        var salt = SaltHelper.generateNewSalt();
+        var userProfile = new UserProfile().withSubjectID(internalSubject.getValue());
+        var internalPairwiseIdentifier =
+                ClientSubjectHelper.calculatePairwiseIdentifier(
+                        internalSubject.getValue(), "test.account.gov.uk", salt);
+        when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(salt);
+        authorizerParams.put("principalId", internalPairwiseIdentifier);
+
+        assertFalse(
+                PrincipalValidationHelper.principleIsInvalid(
+                        userProfile, INTERNAL_SECTOR_URI, authenticationService, authorizerParams));
+    }
+
+    @Test
+    void shouldReturnTrueWhenPrincipalDoesNotMatchPublicSubjectIdOrPairwiseSubjectId() {
+        var salt = SaltHelper.generateNewSalt();
+        var userProfile =
+                new UserProfile()
+                        .withSubjectID(new Subject().getValue())
+                        .withPublicSubjectID(new Subject().getValue());
+        var internalPairwiseIdentifier =
+                ClientSubjectHelper.calculatePairwiseIdentifier(
+                        new Subject().getValue(), "test.account.gov.uk", salt);
+        when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(salt);
+        authorizerParams.put("principalId", internalPairwiseIdentifier);
+
+        assertTrue(
+                PrincipalValidationHelper.principleIsInvalid(
+                        userProfile, INTERNAL_SECTOR_URI, authenticationService, authorizerParams));
+    }
+}

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandlerTest.java
@@ -2,17 +2,19 @@ package uk.gov.di.accountmanagement.lambda;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
-import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
+import uk.gov.di.accountmanagement.exceptions.InvalidPrincipalException;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
+import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
@@ -25,6 +27,8 @@ import java.util.Optional;
 
 import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -55,15 +59,18 @@ class RemoveAccountHandlerTest {
         handler =
                 new RemoveAccountHandler(
                         authenticationService, sqsClient, auditService, configurationService);
+        when(configurationService.getInternalSectorUri()).thenReturn("https://test.account.gov.uk");
     }
 
     @Test
-    public void shouldReturn204IfAccountRemovalIsSuccessful() throws Json.JsonException {
+    void shouldReturn204IfAccountRemovalIsSuccessfulAndPrincipalContainsPublicSubjectId()
+            throws Json.JsonException {
         var userProfile = new UserProfile().withPublicSubjectID(PUBLIC_SUBJECT.getValue());
         when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
                 .thenReturn(Optional.of(userProfile));
 
-        var result = generateRequest();
+        var event = generateApiGatewayEvent(PUBLIC_SUBJECT.getValue());
+        var result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(204));
         verify(authenticationService).removeAccount(eq(EMAIL));
@@ -85,10 +92,73 @@ class RemoveAccountHandlerTest {
     }
 
     @Test
+    void shouldReturn204IfAccountRemovalIsSuccessfulAndPrincipalContainsInternalPairwiseSubjectId()
+            throws Json.JsonException {
+        var internalSubject = new Subject();
+        var salt = SaltHelper.generateNewSalt();
+        var userProfile =
+                new UserProfile()
+                        .withPublicSubjectID(PUBLIC_SUBJECT.getValue())
+                        .withSubjectID(internalSubject.getValue());
+        var internalPairwiseIdentifier =
+                ClientSubjectHelper.calculatePairwiseIdentifier(
+                        internalSubject.getValue(), "test.account.gov.uk", salt);
+        when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
+                .thenReturn(Optional.of(userProfile));
+        when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(salt);
+
+        var event = generateApiGatewayEvent(internalPairwiseIdentifier);
+        var result = handler.handleRequest(event, context);
+
+        assertThat(result, hasStatus(204));
+        verify(authenticationService).removeAccount(EMAIL);
+        verify(sqsClient)
+                .send(
+                        objectMapper.writeValueAsString(
+                                new NotifyRequest(EMAIL, DELETE_ACCOUNT, SupportedLanguage.EN)));
+        verify(auditService)
+                .submitAuditEvent(
+                        AccountManagementAuditableEvent.DELETE_ACCOUNT,
+                        AuditService.UNKNOWN,
+                        AuditService.UNKNOWN,
+                        AuditService.UNKNOWN,
+                        userProfile.getSubjectID(),
+                        userProfile.getEmail(),
+                        "123.123.123.123",
+                        userProfile.getPhoneNumber(),
+                        PERSISTENT_ID);
+    }
+
+    @Test
+    void shouldThrowIfPrincipalIdIsInvalid() {
+        var userProfile =
+                new UserProfile()
+                        .withPublicSubjectID(new Subject().getValue())
+                        .withSubjectID(new Subject().getValue());
+        when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
+                .thenReturn(Optional.of(userProfile));
+        when(authenticationService.getOrGenerateSalt(userProfile))
+                .thenReturn(SaltHelper.generateNewSalt());
+
+        var event = generateApiGatewayEvent(PUBLIC_SUBJECT.getValue());
+
+        var expectedException =
+                assertThrows(
+                        InvalidPrincipalException.class,
+                        () -> handler.handleRequest(event, context),
+                        "Expected to throw exception");
+
+        assertThat(expectedException.getMessage(), equalTo("Invalid Principal in request"));
+        verifyNoInteractions(sqsClient);
+        verifyNoInteractions(auditService);
+    }
+
+    @Test
     void shouldReturn400IfUserAccountDoesNotExist() {
         when(authenticationService.getUserProfileByEmailMaybe(EMAIL)).thenReturn(Optional.empty());
 
-        var result = generateRequest();
+        var event = generateApiGatewayEvent(PUBLIC_SUBJECT.getValue());
+        var result = handler.handleRequest(event, context);
 
         verify(authenticationService, never()).removeAccount(EMAIL);
         verifyNoInteractions(auditService);
@@ -96,18 +166,18 @@ class RemoveAccountHandlerTest {
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1010));
     }
 
-    private APIGatewayProxyResponseEvent generateRequest() {
+    private APIGatewayProxyRequestEvent generateApiGatewayEvent(String principalId) {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setBody(format("{\"email\": \"%s\" }", EMAIL));
         APIGatewayProxyRequestEvent.ProxyRequestContext proxyRequestContext =
                 new APIGatewayProxyRequestEvent.ProxyRequestContext();
         Map<String, Object> authorizerParams = new HashMap<>();
-        authorizerParams.put("principalId", PUBLIC_SUBJECT.getValue());
+        authorizerParams.put("principalId", principalId);
         proxyRequestContext.setAuthorizer(authorizerParams);
         proxyRequestContext.setIdentity(identityWithSourceIp("123.123.123.123"));
         event.setRequestContext(proxyRequestContext);
         event.setHeaders(Map.of(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, PERSISTENT_ID));
 
-        return handler.handleRequest(event, context);
+        return event;
     }
 }

--- a/account-management-integration-tests/build.gradle
+++ b/account-management-integration-tests/build.gradle
@@ -44,6 +44,7 @@ test {
     environment "REDIS_KEY", "account-management"
     environment "SQS_ENDPOINT", "http://localhost:45678"
     environment "TRACING_ENABLED", "false"
+    environment "INTERNAl_SECTOR_URI", "https://test.account.gov.uk"
 
     testLogging {
         showStandardStreams = false

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/RemoveAccountIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/RemoveAccountIntegrationTest.java
@@ -80,7 +80,7 @@ public class RemoveAccountIntegrationTest extends ApiGatewayHandlerIntegrationTe
                                         Collections.emptyMap(),
                                         Map.of("principalId", subjectId1)));
 
-        assertThat(ex.getMessage(), is("Subject ID does not match principalId"));
+        assertThat(ex.getMessage(), is("Invalid Principal in request"));
     }
 
     @Test

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdateEmailIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdateEmailIntegrationTest.java
@@ -158,7 +158,7 @@ class UpdateEmailIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                                         Collections.emptyMap(),
                                         Map.of("principalId", otherSubjectID)));
 
-        assertThat(ex.getMessage(), is("Subject ID does not match principalId"));
+        assertThat(ex.getMessage(), is("Invalid Principal in request"));
     }
 
     @Test
@@ -179,6 +179,6 @@ class UpdateEmailIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                                         Collections.emptyMap(),
                                         Collections.emptyMap()));
 
-        assertThat(ex.getMessage(), is("principalId is missing"));
+        assertThat(ex.getMessage(), is("Invalid Principal in request"));
     }
 }

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdatePasswordIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdatePasswordIntegrationTest.java
@@ -127,7 +127,7 @@ public class UpdatePasswordIntegrationTest extends ApiGatewayHandlerIntegrationT
                                         Collections.emptyMap(),
                                         Map.of("principalId", otherSubjectID)));
 
-        assertThat(ex.getMessage(), is("Subject ID does not match principalId"));
+        assertThat(ex.getMessage(), is("Invalid Principal in request"));
     }
 
     @Test
@@ -145,6 +145,6 @@ public class UpdatePasswordIntegrationTest extends ApiGatewayHandlerIntegrationT
                                         Collections.emptyMap(),
                                         Collections.emptyMap()));
 
-        assertThat(ex.getMessage(), is("principalId is missing"));
+        assertThat(ex.getMessage(), is("Invalid Principal in request"));
     }
 }

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdatePhoneNumberIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/UpdatePhoneNumberIntegrationTest.java
@@ -140,7 +140,7 @@ class UpdatePhoneNumberIntegrationTest extends ApiGatewayHandlerIntegrationTest 
                                         Collections.emptyMap(),
                                         Map.of("principalId", otherSubjectID)));
 
-        assertThat(ex.getMessage(), is("Subject ID does not match principalId"));
+        assertThat(ex.getMessage(), is("Invalid Principal in request"));
     }
 
     @Test
@@ -159,6 +159,6 @@ class UpdatePhoneNumberIntegrationTest extends ApiGatewayHandlerIntegrationTest 
                                         Collections.emptyMap(),
                                         Collections.emptyMap()));
 
-        assertThat(ex.getMessage(), is("principalId is missing"));
+        assertThat(ex.getMessage(), is("Invalid Principal in request"));
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/RequestBodyHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/RequestBodyHelper.java
@@ -1,6 +1,5 @@
 package uk.gov.di.authentication.shared.helpers;
 
-import com.nimbusds.oauth2.sdk.id.Subject;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
 import org.apache.logging.log4j.LogManager;
@@ -15,6 +14,7 @@ public class RequestBodyHelper {
     private static final Logger LOG = LogManager.getLogger(RequestBodyHelper.class);
 
     public static Map<String, String> parseRequestBody(String body) {
+        LOG.info("Parsing request body");
         Map<String, String> query_pairs = new HashMap<>();
 
         for (NameValuePair pair : URLEncodedUtils.parse(body, Charset.defaultCharset())) {
@@ -22,19 +22,5 @@ public class RequestBodyHelper {
         }
 
         return query_pairs;
-    }
-
-    public static void validatePrincipal(
-            Subject subjectFromEmail, Map<String, Object> authorizerParams) {
-        if (!authorizerParams.containsKey("principalId")) {
-            LOG.warn("principalId is missing");
-            throw new RuntimeException("principalId is missing");
-        } else if (!subjectFromEmail.getValue().equals(authorizerParams.get("principalId"))) {
-            LOG.warn(
-                    "Subject ID: {} does not match principalId: {}",
-                    subjectFromEmail,
-                    authorizerParams.get("principalId"));
-            throw new RuntimeException("Subject ID does not match principalId");
-        }
     }
 }


### PR DESCRIPTION
## What?

- Validate the principalId against the Internal subject pairwise ID if the validation against the publicSubjectId fails
- Create a new PrincipalValidationHelper to soley focus on the principal validation and add unit tests
 - Add extra unit tests so we cover both scenarios of when the principalId contains the publicSubjectId and when it contains the internal subject pairwise id

## Why?

- We want to move from using the PublicSubjectId to the Internal Subject Identifier. This will help with this transition and ensures that no users will be impacted
