### PR TITLE
AUT-796 - Send back 'public_subject_id' claim to account management

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/UserInfoService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/UserInfoService.java
@@ -66,6 +66,9 @@ public class UserInfoService {
         if (accessTokenInfo.getScopes().contains(CustomScopeValue.GOVUK_ACCOUNT.getValue())) {
             userInfo.setClaim("legacy_subject_id", userProfile.getLegacySubjectID());
         }
+        if (accessTokenInfo.getScopes().contains(CustomScopeValue.ACCOUNT_MANAGEMENT.getValue())) {
+            userInfo.setClaim("public_subject_id", userProfile.getPublicSubjectID());
+        }
         if (configurationService.isIdentityEnabled()
                 && Objects.nonNull(accessTokenInfo.getIdentityClaims())) {
             return populateIdentityInfo(accessTokenInfo, userInfo);


### PR DESCRIPTION
## What?

- Check to see if the scope in the request contains `am` and if so send back public_subject_id to AM as an additional claim.

## Why?

- We will be replacing the sub sent to AM with the common subject identifier but account management still needs the public_subject_id for when it sends requests to the publishing service. This is for when a user changes email or deletes an account
