### PR TITLE
BAU: Allow requests without user agents

### DIFF
--- a/ci/terraform/oidc/api-gateway.tf
+++ b/ci/terraform/oidc/api-gateway.tf
@@ -335,6 +335,11 @@ resource "aws_wafv2_web_acl" "wafregional_web_acl_oidc_api" {
         excluded_rule {
           name = "GenericRFI_BODY"
         }
+
+        excluded_rule {
+          name = "NoUserAgent_HEADER"
+        }
+
         dynamic "excluded_rule" {
           for_each = var.environment != "production" ? ["1"] : []
           content {


### PR DESCRIPTION
Some off-the-shelf OIDC providers or SaaS solutions choose not to send user agent data, and this is blocking some integrations

