### PR TITLE
AUT-796 - Send SubjectID to audit payload in auth code

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthCodeIntegrationTest.java
@@ -1,9 +1,16 @@
 package uk.gov.di.authentication.api;
 
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import com.nimbusds.oauth2.sdk.id.State;
+import com.nimbusds.oauth2.sdk.id.Subject;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import com.nimbusds.openid.connect.sdk.Nonce;
 import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
@@ -11,14 +18,19 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.oidc.entity.AuthCodeResponse;
 import uk.gov.di.authentication.oidc.lambda.AuthCodeHandler;
+import uk.gov.di.authentication.shared.entity.ClientSession;
+import uk.gov.di.authentication.shared.entity.CustomScopeValue;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.ServiceType;
+import uk.gov.di.authentication.shared.entity.VectorOfTrust;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.helper.KeyPairHelper;
 
 import java.net.URI;
 import java.security.KeyPair;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
@@ -28,6 +40,8 @@ import java.util.Optional;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.startsWith;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.authentication.oidc.domain.OidcAuditableEvent.AUTH_CODE_ISSUED;
 import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
@@ -37,6 +51,10 @@ public class AuthCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     private static final URI REDIRECT_URI =
             URI.create(System.getenv("STUB_RELYING_PARTY_REDIRECT_URI"));
     private static final ClientID CLIENT_ID = new ClientID("test-client");
+    private static final String CLIENT_NAME = "some-client-name";
+    private final KeyPair keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+    private static final State STATE = new State();
+    private static final Nonce NONCE = new Nonce();
 
     @BeforeEach
     void setup() {
@@ -45,18 +63,17 @@ public class AuthCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     }
 
     @Test
-    void shouldReturn302WithSuccessfulAuthorisationResponse() throws Json.JsonException {
-        String sessionId = "some-session-id";
-        String clientSessionId = "some-client-session-id";
-        String clientName = "some-client-name";
-        KeyPair keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
-        redis.createSession(sessionId);
-        redis.setVerifiedMfaMethodType(sessionId, MFAMethodType.AUTH_APP);
+    void shouldReturn200WithSuccessfulAuthResponse() throws Json.JsonException {
+        var clientSessionId = "some-client-session-id";
+        var sessionID = redis.createSession();
+        redis.addEmailToSession(sessionID, EMAIL);
+        redis.setVerifiedMfaMethodType(sessionID, MFAMethodType.AUTH_APP);
         redis.addAuthRequestToSession(
-                clientSessionId, sessionId, generateAuthRequest().toParameters(), clientName);
-        setUpDynamo(keyPair);
+                clientSessionId, sessionID, generateAuthRequest().toParameters(), CLIENT_NAME);
+        userStore.signUp(EMAIL, "password");
+        registerClient(new Scope(OIDCScopeValue.OPENID));
         Map<String, String> headers = new HashMap<>();
-        headers.put("Session-Id", sessionId);
+        headers.put("Session-Id", sessionID);
         headers.put("X-API-Key", FRONTEND_API_KEY);
         headers.put("Client-Session-Id", clientSessionId);
 
@@ -64,36 +81,94 @@ public class AuthCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         assertThat(response, hasStatus(200));
 
-        AuthCodeResponse authCodeResponse =
-                objectMapper.readValue(response.getBody(), AuthCodeResponse.class);
-
+        var authCodeResponse = objectMapper.readValue(response.getBody(), AuthCodeResponse.class);
         assertThat(
                 authCodeResponse.getLocation(),
                 startsWith(
                         "https://di-auth-stub-relying-party-build.london.cloudapps.digital/?code="));
 
+        assertTrue(redis.getSession(sessionID).isAuthenticated());
+        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_CODE_ISSUED));
+    }
+
+    @Test
+    void shouldReturn200WithSuccessfulAuthResponseForDocAppJourney()
+            throws Json.JsonException, JOSEException {
+        var clientSessionId = "some-client-session-id";
+        var sessionID = redis.createSession();
+        Map<String, List<String>> authRequestParams = generateDocAppAuthRequest().toParameters();
+        var clientSession =
+                new ClientSession(
+                        authRequestParams,
+                        LocalDateTime.now(ZoneId.of("UTC")),
+                        VectorOfTrust.getDefaults(),
+                        CLIENT_NAME);
+        clientSession.setDocAppSubjectId(new Subject());
+        redis.addAuthRequestToSession(clientSessionId, sessionID, authRequestParams, CLIENT_NAME);
+        redis.createClientSession(clientSessionId, clientSession);
+        registerClient(new Scope(OIDCScopeValue.OPENID, CustomScopeValue.DOC_CHECKING_APP));
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Session-Id", sessionID);
+        headers.put("X-API-Key", FRONTEND_API_KEY);
+        headers.put("Client-Session-Id", clientSessionId);
+
+        var response = makeRequest(Optional.empty(), headers, Map.of());
+
+        assertThat(response, hasStatus(200));
+
+        var authCodeResponse = objectMapper.readValue(response.getBody(), AuthCodeResponse.class);
+        assertThat(
+                authCodeResponse.getLocation(),
+                startsWith(
+                        "https://di-auth-stub-relying-party-build.london.cloudapps.digital/?code="));
+
+        assertFalse(redis.getSession(sessionID).isAuthenticated());
         assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(AUTH_CODE_ISSUED));
     }
 
     private AuthenticationRequest generateAuthRequest() {
-        ResponseType responseType = new ResponseType(ResponseType.Value.CODE);
-        State state = new State();
-        Scope scope = new Scope();
-        Nonce nonce = new Nonce();
-        scope.add(OIDCScopeValue.OPENID);
+        var responseType = new ResponseType(ResponseType.Value.CODE);
+        var scope = new Scope(OIDCScopeValue.OPENID);
         return new AuthenticationRequest.Builder(responseType, scope, CLIENT_ID, REDIRECT_URI)
-                .state(state)
-                .nonce(nonce)
+                .state(STATE)
+                .nonce(NONCE)
                 .build();
     }
 
-    private void setUpDynamo(KeyPair keyPair) {
+    private AuthenticationRequest generateDocAppAuthRequest() throws JOSEException {
+        var jwtClaimsSetBuilder =
+                new JWTClaimsSet.Builder()
+                        .audience("http://localhost/authorize")
+                        .claim("redirect_uri", REDIRECT_URI)
+                        .claim("response_type", ResponseType.CODE.toString())
+                        .claim(
+                                "scope",
+                                new Scope(OIDCScopeValue.OPENID, CustomScopeValue.DOC_CHECKING_APP)
+                                        .toString())
+                        .claim("nonce", new Nonce().getValue())
+                        .claim("client_id", CLIENT_ID)
+                        .claim("state", new State().getValue())
+                        .issuer(CLIENT_ID.getValue());
+        var jwsHeader = new JWSHeader(JWSAlgorithm.RS256);
+        var signedJWT = new SignedJWT(jwsHeader, jwtClaimsSetBuilder.build());
+        var signer = new RSASSASigner(keyPair.getPrivate());
+        signedJWT.sign(signer);
+        var scope = new Scope(OIDCScopeValue.OPENID, CustomScopeValue.DOC_CHECKING_APP);
+        return new AuthenticationRequest.Builder(ResponseType.CODE, scope, CLIENT_ID, REDIRECT_URI)
+                .state(STATE)
+                .nonce(NONCE)
+                .requestObject(signedJWT)
+                .build();
+    }
+
+    private void registerClient(Scope scope) {
         clientStore.registerClient(
                 CLIENT_ID.getValue(),
-                "test-client",
+                CLIENT_NAME,
                 singletonList(REDIRECT_URI.toString()),
                 singletonList(EMAIL),
-                singletonList("openid"),
+                scope.toStringList(),
                 Base64.getMimeEncoder().encodeToString(keyPair.getPublic().getEncoded()),
                 singletonList("http://localhost/post-redirect-logout"),
                 "http://example.com",

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
@@ -244,7 +244,6 @@ public class TokenHandler
         final OIDCClaimsRequest finalClaimsRequest = claimsRequest;
         OIDCTokenResponse tokenResponse;
         if (isDocCheckingAppUserWithSubjectId(clientSession)) {
-            LOG.info("Doc Checking App User with SubjectId: true");
             tokenResponse =
                     segmentedFunctionCall(
                             "generateTokenResponse",

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthorizationService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthorizationService.java
@@ -68,6 +68,7 @@ public class AuthorizationService {
             URI redirectUri,
             State state) {
 
+        LOG.info("Generating Successful Auth Response");
         return new AuthenticationSuccessResponse(
                 redirectUri,
                 authorizationCode,
@@ -182,6 +183,7 @@ public class AuthorizationService {
 
     public AuthenticationErrorResponse generateAuthenticationErrorResponse(
             URI redirectUri, State state, ResponseMode responseMode, ErrorObject errorObject) {
+        LOG.info("Generating Authentication Error Response");
         return new AuthenticationErrorResponse(redirectUri, errorObject, state, responseMode);
     }
 
@@ -232,6 +234,8 @@ public class AuthorizationService {
     }
 
     public boolean isTestJourney(ClientID clientID, String emailAddress) {
-        return dynamoClientService.isTestJourney(clientID.toString(), emailAddress);
+        var isTestJourney = dynamoClientService.isTestJourney(clientID.toString(), emailAddress);
+        LOG.info("Is journey a test journey: {}", isTestJourney);
+        return isTestJourney;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/conditions/DocAppUserHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/conditions/DocAppUserHelper.java
@@ -36,8 +36,11 @@ public class DocAppUserHelper {
     }
 
     public static boolean isDocCheckingAppUserWithSubjectId(ClientSession clientSession) {
-        return clientSession.getDocAppSubjectId() != null
-                && hasDocCheckingScope(clientSession.getAuthRequestParams());
+        boolean isDocCheckingUser =
+                clientSession.getDocAppSubjectId() != null
+                        && hasDocCheckingScope(clientSession.getAuthRequestParams());
+        LOG.info("User is Doc Checking App user: {}", isDocCheckingUser);
+        return isDocCheckingUser;
     }
 
     private static boolean hasDocCheckingScope(Map<String, List<String>> authRequestParams) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthorisationCodeService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthorisationCodeService.java
@@ -41,6 +41,7 @@ public class AuthorisationCodeService {
 
     public AuthorizationCode generateAuthorisationCode(
             String clientSessionId, String email, ClientSession clientSession) {
+        LOG.info("Generating and saving AuthorisationCode");
         AuthorizationCode authorizationCode = new AuthorizationCode();
         try {
             redisConnectionService.saveWithExpiry(


### PR DESCRIPTION
## What?

 - Send SubjectID to audit payload in auth code
- Add additional logging in the auth code handler
- Add additional test coverage for doc app journeys
- Tidy up some of the if conditions in the auth code lambda


## Why?

- We were previously not sending the subjectId to the audit payload in the auth code lambda. This change ensures the subject id is sent to audit for both normal journeys and doc app journeys.
- This will also make the change to send the common subject identifier to audit easier. 