### PR TITLE
AUT-804: Add testUser flags to DB

### DIFF
--- a/ci/terraform/shared/dynamodb.tf
+++ b/ci/terraform/shared/dynamodb.tf
@@ -16,10 +16,24 @@ resource "aws_dynamodb_table" "user_credentials_table" {
     type = "S"
   }
 
+  attribute {
+    name = "testUser"
+    type = "N"
+  }
+
   global_secondary_index {
     name            = "SubjectIDIndex"
     hash_key        = "SubjectID"
     projection_type = "ALL"
+    read_capacity   = var.provision_dynamo ? var.dynamo_default_read_capacity : null
+    write_capacity  = var.provision_dynamo ? var.dynamo_default_write_capacity : null
+  }
+
+  global_secondary_index {
+    name            = "TestUserIndex"
+    hash_key        = "SubjectID"
+    range_key       = "testUser"
+    projection_type = "KEYS_ONLY"
     read_capacity   = var.provision_dynamo ? var.dynamo_default_read_capacity : null
     write_capacity  = var.provision_dynamo ? var.dynamo_default_write_capacity : null
   }
@@ -69,6 +83,11 @@ resource "aws_dynamodb_table" "user_profile_table" {
     type = "N"
   }
 
+  attribute {
+    name = "testUser"
+    type = "N"
+  }
+
   global_secondary_index {
     name            = "SubjectIDIndex"
     hash_key        = "SubjectID"
@@ -89,6 +108,15 @@ resource "aws_dynamodb_table" "user_profile_table" {
     name            = "VerifiedAccountIndex"
     hash_key        = "SubjectID"
     range_key       = "accountVerified"
+    projection_type = "KEYS_ONLY"
+    read_capacity   = var.provision_dynamo ? var.dynamo_default_read_capacity : null
+    write_capacity  = var.provision_dynamo ? var.dynamo_default_write_capacity : null
+  }
+
+  global_secondary_index {
+    name            = "TestUserIndex"
+    hash_key        = "SubjectID"
+    range_key       = "testUser"
     projection_type = "KEYS_ONLY"
     read_capacity   = var.provision_dynamo ? var.dynamo_default_read_capacity : null
     write_capacity  = var.provision_dynamo ? var.dynamo_default_write_capacity : null

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/UserCredentials.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/UserCredentials.java
@@ -17,6 +17,7 @@ public class UserCredentials {
     public static final String ATTRIBUTE_UPDATED = "Updated";
     public static final String ATTRIBUTE_MIGRATED_PASSWORD = "MigratedPassword";
     public static final String ATTRIBUTE_MFA_METHODS = "MfaMethods";
+    public static final String ATTRIBUTE_TEST_USER = "testUser";
 
     private String email;
     private String subjectID;
@@ -25,6 +26,7 @@ public class UserCredentials {
     private String updated;
     private String migratedPassword;
     private List<MFAMethod> mfaMethods;
+    private int testUser;
 
     public UserCredentials() {}
 
@@ -136,5 +138,14 @@ public class UserCredentials {
             this.mfaMethods.add(mfaMethod);
         }
         return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_TEST_USER)
+    public int getTestUser() {
+        return testUser;
+    }
+
+    public void setTestUser(int isTestUser) {
+        this.testUser = isTestUser;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/UserProfile.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/UserProfile.java
@@ -26,6 +26,7 @@ public class UserProfile {
     public static final String ATTRIBUTE_LEGACY_SUBJECT_ID = "LegacySubjectID";
     public static final String ATTRIBUTE_SALT = "salt";
     public static final String ATTRIBUTE_ACCOUNT_VERIFIED = "accountVerified";
+    public static final String ATTRIBUTE_TEST_USER = "testUser";
 
     private String email;
     private String subjectID;
@@ -40,6 +41,7 @@ public class UserProfile {
     private String legacySubjectID;
     private ByteBuffer salt;
     private int accountVerified;
+    private int testUser;
 
     public UserProfile() {}
 
@@ -237,5 +239,14 @@ public class UserProfile {
     public UserProfile withAccountVerified(int accountVerified) {
         this.accountVerified = accountVerified;
         return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_TEST_USER)
+    public int getTestUser() {
+        return testUser;
+    }
+
+    public void setTestUser(int isTestUser) {
+        this.testUser = isTestUser;
     }
 }


### PR DESCRIPTION
## What?

- Add testUser flag to `UserProfile` and `UserCredential` objects
- Add global secondary indices to these Dynamo tables to allow faster finding and safe deletion
- Int used over boolean for consistency with accountVerified flag

## Why?
- Will enable bulk upload and deletion of test users