### PR TITLE
AUT-796 - Save Internal Common Subject ID in user session

### DIFF
--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -61,6 +61,7 @@ test {
     environment "IDENTITY_ENABLED", "false"
     environment "SPOT_ENABLED", "true"
     environment "TRACING_ENABLED", "false"
+    environment "INTERNAl_SECTOR_URI", "https://test.account.gov.uk"
 
     doLast {
         tasks.getByName("jacocoTestReport").sourceDirectories.from(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
@@ -35,6 +35,8 @@ public class Session {
 
     @Expose private MFAMethodType verifiedMfaMethodType;
 
+    @Expose private String internalCommonSubjectIdentifier;
+
     public Session(String sessionId) {
         this.sessionId = sessionId;
         this.clientSessions = new ArrayList<>();
@@ -157,6 +159,15 @@ public class Session {
 
     public Session setVerifiedMfaMethodType(MFAMethodType verifiedMfaMethodType) {
         this.verifiedMfaMethodType = verifiedMfaMethodType;
+        return this;
+    }
+
+    public String getInternalCommonSubjectIdentifier() {
+        return internalCommonSubjectIdentifier;
+    }
+
+    public Session setInternalCommonSubjectIdentifier(String internalCommonSubjectIdentifier) {
+        this.internalCommonSubjectIdentifier = internalCommonSubjectIdentifier;
         return this;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/User.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/User.java
@@ -1,0 +1,20 @@
+package uk.gov.di.authentication.shared.entity;
+
+public class User {
+
+    private final UserProfile userProfile;
+    private final UserCredentials userCredentials;
+
+    public User(UserProfile userProfile, UserCredentials userCredentials) {
+        this.userProfile = userProfile;
+        this.userCredentials = userCredentials;
+    }
+
+    public UserProfile getUserProfile() {
+        return userProfile;
+    }
+
+    public UserCredentials getUserCredentials() {
+        return userCredentials;
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthenticationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthenticationService.java
@@ -4,6 +4,7 @@ import com.nimbusds.oauth2.sdk.id.Subject;
 import uk.gov.di.authentication.shared.entity.ClientConsent;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.TermsAndConditions;
+import uk.gov.di.authentication.shared.entity.User;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 
@@ -14,7 +15,7 @@ import java.util.Optional;
 public interface AuthenticationService {
     boolean userExists(String email);
 
-    void signUp(
+    User signUp(
             String email, String password, Subject subject, TermsAndConditions termsAndConditions);
 
     boolean login(String email, String password);

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
@@ -85,6 +85,7 @@ public class DynamoService implements AuthenticationService {
                         .withPublicSubjectID((new Subject()).toString())
                         .withTermsAndConditions(termsAndConditions)
                         .withLegacySubjectID(null);
+        userProfile.setSalt(SaltHelper.generateNewSalt());
         dynamoUserCredentialsTable.putItem(userCredentials);
         dynamoUserProfileTable.putItem(userProfile);
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
@@ -15,6 +15,7 @@ import uk.gov.di.authentication.shared.entity.ClientConsent;
 import uk.gov.di.authentication.shared.entity.MFAMethod;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.TermsAndConditions;
+import uk.gov.di.authentication.shared.entity.User;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.Argon2EncoderHelper;
@@ -63,7 +64,7 @@ public class DynamoService implements AuthenticationService {
     }
 
     @Override
-    public void signUp(
+    public User signUp(
             String email, String password, Subject subject, TermsAndConditions termsAndConditions) {
         var dateTime = LocalDateTime.now().toString();
         var hashedPassword = hashPassword(password);
@@ -88,6 +89,7 @@ public class DynamoService implements AuthenticationService {
         userProfile.setSalt(SaltHelper.generateNewSalt());
         dynamoUserCredentialsTable.putItem(userCredentials);
         dynamoUserProfileTable.putItem(userProfile);
+        return new User(userProfile, userCredentials);
     }
 
     @Override


### PR DESCRIPTION
## What?

- Save common internal subject ID in session within signup and login lambdas, for users who successfully logged in or signed up.
- Generate and store the Salt to the userprofile when the user signs up 

## Why?

- To avoid having to generate the common internal subject ID in every lambda, we can save this in the session within the login and signup lambas. We know all users who require the common subject ID will need to either login or sign up, so this should capture them all. For users who login to one service and then login into another using SSO, the common subject ID will already be in the session when the user gets to auth code so we don't have to generate it again. 
-  We were previously only generating the Salt as and when we needed it. As we will be using it more for generating the common internal subject ID, we should generate this when we create a users account. This will reduce the amount of calls to Dynamo required.
- We will eventually start to send this common subject id to TXMA, so this is an interim step to get there