### PR TITLE
AUT-796 - Add internal subject id to specific audit events

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -46,6 +46,7 @@ import static uk.gov.di.authentication.shared.entity.Session.AccountState.EXISTI
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachSessionIdToLogs;
+import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
 
 public class LoginHandler extends BaseFrontendHandler<LoginRequest>
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -155,7 +156,8 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
                         userProfile.getEmail(),
                         IpAddressHelper.extractIpAddress(input),
                         userProfile.getPhoneNumber(),
-                        persistentSessionId);
+                        persistentSessionId,
+                        pair("internalSubjectId", userProfile.getSubjectID()));
 
                 return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1028);
             }
@@ -168,11 +170,12 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
                         userContext.getClientSessionId(),
                         userContext.getSession().getSessionId(),
                         clientId,
-                        AuditService.UNKNOWN,
+                        userProfile.getSubjectID(),
                         request.getEmail(),
                         IpAddressHelper.extractIpAddress(input),
                         AuditService.UNKNOWN,
-                        persistentSessionId);
+                        persistentSessionId,
+                        pair("internalSubjectId", userProfile.getSubjectID()));
 
                 return generateApiGatewayProxyErrorResponse(401, ErrorResponse.ERROR_1008);
             }
@@ -227,7 +230,8 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
                     userProfile.getEmail(),
                     IpAddressHelper.extractIpAddress(input),
                     userProfile.getPhoneNumber(),
-                    persistentSessionId);
+                    persistentSessionId,
+                    pair("internalSubjectId", userProfile.getSubjectID()));
 
             if (!isMfaRequired) {
                 cloudwatchMetricsService.incrementAuthenticationSuccess(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
@@ -41,6 +41,7 @@ import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachLogFieldToLogs;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachSessionIdToLogs;
 import static uk.gov.di.authentication.shared.helpers.PersistentIdHelper.extractPersistentIdFromHeaders;
+import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
 
 public class SignUpHandler extends BaseFrontendHandler<SignupRequest>
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -151,7 +152,8 @@ public class SignUpHandler extends BaseFrontendHandler<SignupRequest>
                     request.getEmail(),
                     IpAddressHelper.extractIpAddress(input),
                     AuditService.UNKNOWN,
-                    PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));
+                    PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
+                    pair("internalSubjectId", user.getUserProfile().getSubjectID()));
 
             LOG.info("Setting internal common subject identifier in user session");
             sessionService.save(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandlerTest.java
@@ -64,6 +64,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.frontendapi.lambda.StartHandlerTest.CLIENT_SESSION_ID_HEADER;
+import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
 import static uk.gov.di.authentication.sharedtest.helper.RequestEventHelper.contextWithSourceIp;
 import static uk.gov.di.authentication.sharedtest.logging.LogEventMatcher.withMessageContaining;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
@@ -187,7 +188,8 @@ class SignUpHandlerTest {
                         EMAIL,
                         "123.123.123.123",
                         AuditService.UNKNOWN,
-                        persistentId);
+                        persistentId,
+                        pair("internalSubjectId", INTERNAL_SUBJECT_ID.getValue()));
 
         verify(sessionService)
                 .save(argThat(session -> session.isNewAccount() == Session.AccountState.NEW));

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -82,6 +82,7 @@ import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.LOW_LE
 import static uk.gov.di.authentication.shared.entity.CredentialTrustLevel.MEDIUM_LEVEL;
 import static uk.gov.di.authentication.shared.entity.Session.AccountState.NEW;
 import static uk.gov.di.authentication.shared.entity.Session.AccountState.UNKNOWN;
+import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
 import static uk.gov.di.authentication.sharedtest.helper.RequestEventHelper.contextWithSourceIp;
 import static uk.gov.di.authentication.sharedtest.logging.LogEventMatcher.withMessageContaining;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
@@ -221,7 +222,8 @@ class AuthCodeHandlerTest {
                         EMAIL,
                         "123.123.123.123",
                         AuditService.UNKNOWN,
-                        PERSISTENT_SESSION_ID);
+                        PERSISTENT_SESSION_ID,
+                        pair("internalSubjectId", SUBJECT.getValue()));
 
         var dimensions =
                 Map.of(


### PR DESCRIPTION
## What?

- Add the internal subject id as an additional pair to the audit events in the login, sign up and auth code lambdas.
- In the auth code lambda, only add the internalSubjectId to all non doc app journeys. This is because doc app journeys don't technically have an internalSubjectId.

## Why?

- This is currently a duplicate of the user id but the user id will soon be changing and it's important that we can still link audit events to an internal subject id. Adding this field to the signUp, login and auth code lambdas will allow for this to happen.
