### PR TITLE
BAU: Use stock localstack image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,7 @@ version: '3.8'
 
 services:
   aws:
-    build:
-      context: docker
-      dockerfile: localstack.Dockerfile
+    image: localstack/localstack:0.12.20@sha256:ae2c8cbf90ec8dace5d34ff5690b049f030021a0c1a2f8e49bcb8cd6986fae52
     environment:
       SERVICES: iam, ec2, sqs, s3, sts, kms, sns, ssm, cloudwatch
       EDGE_PORT: "45678"
@@ -20,15 +18,6 @@ services:
       - di-authentication-api-net
     ports:
       - 45678:45678
-    healthcheck:
-      test:
-        - CMD
-        - bash
-        - -c
-        - awslocal s3 ls terraform-state
-      interval: 5s
-      timeout: 10s
-      start_period: 10s
 
   redis:
     image: redis:6.0.5-alpine

--- a/docker/localstack.Dockerfile
+++ b/docker/localstack.Dockerfile
@@ -1,9 +1,0 @@
-# localstack Dockerfile
-#
-# Container used to run tasks requiring Localstack in the build pipeline.
-
-FROM localstack/localstack:0.12.20@sha256:ae2c8cbf90ec8dace5d34ff5690b049f030021a0c1a2f8e49bcb8cd6986fae52
-
-COPY localstack/*.sh /docker-entrypoint-initaws.d/
-
-RUN apk add argon2 argon2-dev

--- a/docker/localstack/01_create_buckets.sh
+++ b/docker/localstack/01_create_buckets.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-awslocal s3 mb --region eu-west-2 s3://terraform-state


### PR DESCRIPTION
## What?

- Remove custom localstack `Dockerfile`
- Use stock image in `docker-compose.yml`

## Why?

We no longer use localstack in a way that requires the custom image (we don't Terraform to it nor do we run lambda that require the argon2 dependency).
