### PR TITLE
AUT-796 - Use the Internal Sector URI for generating pairwise when cl…

### DIFF
--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -241,7 +241,11 @@ public class IPVCallbackHandler
                 return redirectToFrontendErrorPage();
             }
             var pairwiseSubject =
-                    ClientSubjectHelper.getSubject(userProfile, clientRegistry, dynamoService);
+                    ClientSubjectHelper.getSubject(
+                            userProfile,
+                            clientRegistry,
+                            dynamoService,
+                            configurationService.getInternalSectorUri());
             if (configurationService.isIdentityTraceLoggingEnabled()) {
                 LOG.info(
                         "Sending UserInfo request with accessToken {}",
@@ -295,7 +299,8 @@ public class IPVCallbackHandler
                                     clientSessionId);
                     queueSPOTRequest(
                             logIds,
-                            getSectorIdentifierForClient(clientRegistry),
+                            getSectorIdentifierForClient(
+                                    clientRegistry, configurationService.getInternalSectorUri()),
                             userProfile,
                             pairwiseSubject,
                             userIdentityUserInfo,

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
@@ -83,7 +83,8 @@ public class ProcessingIdentityHandler extends BaseFrontendHandler<ProcessingIde
                     ClientSubjectHelper.getSubject(
                             userContext.getUserProfile().orElseThrow(),
                             userContext.getClient().orElseThrow(),
-                            authenticationService);
+                            authenticationService,
+                            configurationService.getInternalSectorUri());
             int processingAttempts = userContext.getSession().incrementProcessingIdentityAttempts();
             LOG.info(
                     "Attempting to find identity credentials in dynamo. Attempt: {}",

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandlerTest.java
@@ -99,6 +99,7 @@ class IPVCallbackHandlerTest {
     private final AwsSqsClient awsSqsClient = mock(AwsSqsClient.class);
     private static final URI LOGIN_URL = URI.create("https://example.com");
     private static final String OIDC_BASE_URL = "https://base-url.com";
+    private static final String INTERNAL_SECTOR_URI = "https://test.account.gov.uk";
     private static final AuthorizationCode AUTH_CODE = new AuthorizationCode();
     private static final String COOKIE = "Cookie";
     private static final String SESSION_ID = "a-session-id";
@@ -259,7 +260,8 @@ class IPVCallbackHandlerTest {
         var expectedRedirectURI = new URIBuilder(LOGIN_URL).setPath("ipv-callback").build();
         assertThat(response.getHeaders().get("Location"), equalTo(expectedRedirectURI.toString()));
         var expectedPairwiseSub =
-                ClientSubjectHelper.getSubject(userProfile, clientRegistry, dynamoService);
+                ClientSubjectHelper.getSubject(
+                        userProfile, clientRegistry, dynamoService, INTERNAL_SECTOR_URI);
         verify(awsSqsClient)
                 .send(
                         objectMapper.writeValueAsString(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
@@ -376,7 +376,9 @@ public class LogoutHandler
                     .ifPresent(
                             clientRegistry ->
                                     backChannelLogoutService.sendLogoutMessage(
-                                            clientRegistry, session.getEmailAddress()));
+                                            clientRegistry,
+                                            session.getEmailAddress(),
+                                            configurationService.getInternalSectorUri()));
             LOG.info("Deleting Client Session");
             clientSessionService.deleteClientSessionFromRedis(clientSessionId);
         }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
@@ -262,7 +262,12 @@ public class TokenHandler
         } else {
             UserProfile userProfile =
                     dynamoService.getUserProfileByEmail(authCodeExchangeData.getEmail());
-            Subject subject = ClientSubjectHelper.getSubject(userProfile, client, dynamoService);
+            Subject subject =
+                    ClientSubjectHelper.getSubject(
+                            userProfile,
+                            client,
+                            dynamoService,
+                            configurationService.getInternalSectorUri());
             tokenResponse =
                     segmentedFunctionCall(
                             "generateTokenResponse",

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/BackChannelLogoutService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/BackChannelLogoutService.java
@@ -35,7 +35,8 @@ public class BackChannelLogoutService {
         this.authenticationService = authenticationService;
     }
 
-    public void sendLogoutMessage(ClientRegistry clientRegistry, String emailAddress) {
+    public void sendLogoutMessage(
+            ClientRegistry clientRegistry, String emailAddress, String internalSectorUri) {
 
         if (isBlank(clientRegistry.getClientID())
                 || isBlank(clientRegistry.getBackChannelLogoutUri())) {
@@ -54,7 +55,9 @@ public class BackChannelLogoutService {
             return;
         }
 
-        var subjectId = getSubject(user.get(), clientRegistry, authenticationService).getValue();
+        var subjectId =
+                getSubject(user.get(), clientRegistry, authenticationService, internalSectorUri)
+                        .getValue();
 
         var message =
                 new BackChannelLogoutMessage(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/LogoutHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/LogoutHandlerTest.java
@@ -78,6 +78,7 @@ class LogoutHandlerTest {
 
     private static final State STATE = new State();
     private static final String COOKIE = "Cookie";
+    private static final String INTERNAL_SECTOR_URI = "https://test.account.gov.uk";
     private static final String SESSION_ID = IdGenerator.generate();
     private static final String CLIENT_SESSION_ID = IdGenerator.generate();
     private static final String PERSISTENT_SESSION_ID = IdGenerator.generate();
@@ -118,6 +119,7 @@ class LogoutHandlerTest {
                         auditService,
                         backChannelLogoutService);
         when(configurationService.getDefaultLogoutURI()).thenReturn(DEFAULT_LOGOUT_URI);
+        when(configurationService.getInternalSectorUri()).thenReturn(INTERNAL_SECTOR_URI);
         ECKey ecSigningKey =
                 new ECKeyGenerator(Curve.P_256).algorithm(JWSAlgorithm.ES256).generate();
         signedIDToken =
@@ -666,11 +668,14 @@ class LogoutHandlerTest {
         verify(sessionService).deleteSessionFromRedis(SESSION_ID);
 
         verify(backChannelLogoutService)
-                .sendLogoutMessage(argThat(withClientId("client-id")), eq(EMAIL));
+                .sendLogoutMessage(
+                        argThat(withClientId("client-id")), eq(EMAIL), eq(INTERNAL_SECTOR_URI));
         verify(backChannelLogoutService)
-                .sendLogoutMessage(argThat(withClientId("client-id-2")), eq(EMAIL));
+                .sendLogoutMessage(
+                        argThat(withClientId("client-id-2")), eq(EMAIL), eq(INTERNAL_SECTOR_URI));
         verify(backChannelLogoutService)
-                .sendLogoutMessage(argThat(withClientId("client-id-3")), eq(EMAIL));
+                .sendLogoutMessage(
+                        argThat(withClientId("client-id-3")), eq(EMAIL), eq(INTERNAL_SECTOR_URI));
 
         verify(clientSessionService).deleteClientSessionFromRedis(CLIENT_SESSION_ID);
         verify(clientSessionService).deleteClientSessionFromRedis("client-session-id-2");

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/BackChannelLogoutServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/BackChannelLogoutServiceTest.java
@@ -25,6 +25,7 @@ class BackChannelLogoutServiceTest {
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
     private final BackChannelLogoutService service =
             new BackChannelLogoutService(sqs, authenticationService);
+    private static final String INTERNAL_SECTOR_URI = "https://test.account.gov.uk";
 
     @Test
     void shouldPostBackChannelLogoutMessageToSqsForPairwiseClients() {
@@ -40,7 +41,8 @@ class BackChannelLogoutServiceTest {
                         .withSubjectType("pairwise")
                         .withSectorIdentifierUri("https://example.sign-in.service.gov.uk")
                         .withBackChannelLogoutUri("http://localhost:8080/back-channel-logout"),
-                "test@test.com");
+                "test@test.com",
+                INTERNAL_SECTOR_URI);
 
         var captor = ArgumentCaptor.forClass(BackChannelLogoutMessage.class);
 
@@ -62,7 +64,10 @@ class BackChannelLogoutServiceTest {
         var neitherField = new ClientRegistry();
 
         Stream.of(noLogoutUri, noClientId, neitherField)
-                .forEach(clientRegistry -> service.sendLogoutMessage(clientRegistry, null));
+                .forEach(
+                        clientRegistry ->
+                                service.sendLogoutMessage(
+                                        clientRegistry, null, INTERNAL_SECTOR_URI));
 
         verify(sqs, never()).send(anyString());
     }
@@ -76,7 +81,8 @@ class BackChannelLogoutServiceTest {
                 new ClientRegistry()
                         .withClientID("client-id")
                         .withBackChannelLogoutUri("http://localhost:8080/back-channel-logout"),
-                "test@test.com");
+                "test@test.com",
+                INTERNAL_SECTOR_URI);
 
         verify(sqs, never()).send(anyString());
     }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ClientSubjectHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ClientSubjectHelperTest.java
@@ -3,30 +3,33 @@ package uk.gov.di.authentication.shared.helpers;
 import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.shared.entity.ClientConsent;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.ValidScopes;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
+import uk.gov.di.authentication.sharedtest.helper.KeyPairHelper;
 
-import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import java.security.NoSuchAlgorithmException;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Base64;
 import java.util.List;
 import java.util.Set;
 
+import static com.nimbusds.openid.connect.sdk.SubjectType.PAIRWISE;
+import static com.nimbusds.openid.connect.sdk.SubjectType.PUBLIC;
 import static java.util.Collections.singletonList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -35,156 +38,239 @@ class ClientSubjectHelperTest {
     private static final String TEST_EMAIL = "joe.bloggs@digital.cabinet-office.gov.uk";
     private static final String PHONE_NUMBER = "01234567890";
     private static final String REDIRECT_URI = "http://localhost/redirect";
+    private static final String INTERNAL_SECTOR_URI = "https://test.account.gov.uk";
     private static final Subject INTERNAL_SUBJECT = new Subject();
     private static final Subject PUBLIC_SUBJECT = new Subject();
     private static final String CLIENT_ID = "test-id";
     private static final Scope SCOPES =
             new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL, OIDCScopeValue.OFFLINE_ACCESS);
-
+    private KeyPair keyPair;
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
+    private final UserProfile userProfile = generateUserProfile();
+
+    @BeforeEach
+    void setUp() {
+        keyPair = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+        when(authenticationService.getOrGenerateSalt(userProfile))
+                .thenReturn(SaltHelper.generateNewSalt());
+    }
 
     @Test
     void shouldReturnDifferentSubjectIDForMultipleClientsWithDifferentSectors() {
-        stubAuthenticationService();
-        KeyPair keyPair = generateRsaKeyPair();
-        UserProfile userProfile = generateUserProfile();
-
         ClientRegistry clientRegistry1 =
                 generateClientRegistryPairwise(
-                        keyPair, "test-client-id-1", "pairwise", "https://test.com");
+                        keyPair,
+                        "test-client-id-1",
+                        PAIRWISE.toString(),
+                        "https://test.com",
+                        false);
         ClientRegistry clientRegistry2 =
                 generateClientRegistryPairwise(
-                        keyPair, "test-client-id-2", "pairwise", "https://not-test.com");
+                        keyPair,
+                        "test-client-id-2",
+                        PAIRWISE.toString(),
+                        "https://not-test.com",
+                        false);
 
         Subject subject1 =
-                ClientSubjectHelper.getSubject(userProfile, clientRegistry1, authenticationService);
+                ClientSubjectHelper.getSubject(
+                        userProfile, clientRegistry1, authenticationService, INTERNAL_SECTOR_URI);
         Subject subject2 =
-                ClientSubjectHelper.getSubject(userProfile, clientRegistry2, authenticationService);
+                ClientSubjectHelper.getSubject(
+                        userProfile, clientRegistry2, authenticationService, INTERNAL_SECTOR_URI);
 
         assertNotEquals(subject1, subject2);
     }
 
     @Test
     void shouldReturnSameSubjectIDForMultipleClientsWithSameSector() {
-        stubAuthenticationService();
-        KeyPair keyPair = generateRsaKeyPair();
-        UserProfile userProfile = generateUserProfile();
-
-        ClientRegistry clientRegistry1 =
+        var clientRegistry1 =
                 generateClientRegistryPairwise(
-                        keyPair, "test-client-id-1", "pairwise", "https://test.com");
-        ClientRegistry clientRegistry2 =
+                        keyPair,
+                        "test-client-id-1",
+                        PAIRWISE.toString(),
+                        "https://test.com",
+                        false);
+        var clientRegistry2 =
                 generateClientRegistryPairwise(
-                        keyPair, "test-client-id-2", "pairwise", "https://test.com");
+                        keyPair,
+                        "test-client-id-2",
+                        PAIRWISE.toString(),
+                        "https://test.com",
+                        false);
 
-        Subject subject1 =
-                ClientSubjectHelper.getSubject(userProfile, clientRegistry1, authenticationService);
-        Subject subject2 =
-                ClientSubjectHelper.getSubject(userProfile, clientRegistry2, authenticationService);
+        var subject1 =
+                ClientSubjectHelper.getSubject(
+                        userProfile, clientRegistry1, authenticationService, INTERNAL_SECTOR_URI);
+        var subject2 =
+                ClientSubjectHelper.getSubject(
+                        userProfile, clientRegistry2, authenticationService, INTERNAL_SECTOR_URI);
 
         assertEquals(subject1, subject2);
     }
 
     @Test
     void shouldReturnSameSubjectIDForMultipleClientsWithPublicSubjectType() {
-        KeyPair keyPair = generateRsaKeyPair();
-        UserProfile userProfile = generateUserProfile();
-
         ClientRegistry clientRegistry1 =
                 generateClientRegistryPairwise(
-                        keyPair, "test-client-id-1", "public", "https://test.com");
+                        keyPair, "test-client-id-1", PUBLIC.toString(), "https://test.com", false);
         ClientRegistry clientRegistry2 =
                 generateClientRegistryPairwise(
-                        keyPair, "test-client-id-2", "public", "https://test.com");
+                        keyPair, "test-client-id-2", PUBLIC.toString(), "https://test.com", false);
 
         Subject subject1 =
-                ClientSubjectHelper.getSubject(userProfile, clientRegistry1, authenticationService);
+                ClientSubjectHelper.getSubject(
+                        userProfile, clientRegistry1, authenticationService, INTERNAL_SECTOR_URI);
         Subject subject2 =
-                ClientSubjectHelper.getSubject(userProfile, clientRegistry2, authenticationService);
+                ClientSubjectHelper.getSubject(
+                        userProfile, clientRegistry2, authenticationService, INTERNAL_SECTOR_URI);
 
-        assertEquals(subject1, subject2);
+        assertThat(subject1, equalTo(PUBLIC_SUBJECT));
+        assertThat(subject2, equalTo(PUBLIC_SUBJECT));
     }
 
     @Test
-    void shouldReturnSubjectIDAsURIWhenClientTypeIsPairwise() {
-        stubAuthenticationService();
-        var keyPair = generateRsaKeyPair();
-        var userProfile = generateUserProfile();
-
+    void shouldReturnPairwiseSubjectIdWhenClientTypeIsPairwise() {
         var clientRegistry1 =
                 generateClientRegistryPairwise(
-                        keyPair, "test-client-id-1", "pairwise", "https://test.com");
+                        keyPair,
+                        "test-client-id-1",
+                        PAIRWISE.toString(),
+                        "https://test.com",
+                        false);
 
         var subject =
-                ClientSubjectHelper.getSubject(userProfile, clientRegistry1, authenticationService);
+                ClientSubjectHelper.getSubject(
+                        userProfile, clientRegistry1, authenticationService, INTERNAL_SECTOR_URI);
 
         assertTrue(subject.getValue().startsWith("urn:fdc:gov.uk:2022:"));
     }
 
     @Test
-    void shouldNotReturnSubjectIDAsURIWhenClientTypeIsPublic() {
-        stubAuthenticationService();
-        var keyPair = generateRsaKeyPair();
-        var userProfile = generateUserProfile();
-
+    void shouldReturnPairwiseSubjectIdWhenClientTypeIsPairwiseAndIsAOneLoginService() {
         var clientRegistry1 =
                 generateClientRegistryPairwise(
-                        keyPair, "test-client-id-1", "public", "https://test.com");
+                        keyPair, "test-client-id-1", PAIRWISE.toString(), "https://test.com", true);
+        var clientRegistry2 =
+                generateClientRegistryPairwise(
+                        keyPair,
+                        "test-client-id-1",
+                        PAIRWISE.toString(),
+                        "https://test.com",
+                        false);
 
         var subject =
-                ClientSubjectHelper.getSubject(userProfile, clientRegistry1, authenticationService);
+                ClientSubjectHelper.getSubject(
+                        userProfile, clientRegistry1, authenticationService, INTERNAL_SECTOR_URI);
+        var subject2 =
+                ClientSubjectHelper.getSubject(
+                        userProfile, clientRegistry2, authenticationService, INTERNAL_SECTOR_URI);
+
+        assertTrue(subject.getValue().startsWith("urn:fdc:gov.uk:2022:"));
+        assertThat(subject, not(subject2));
+    }
+
+    @Test
+    void shouldNotReturnPairwiseSubjectIdWhenClientTypeIsPublic() {
+        var clientRegistry1 =
+                generateClientRegistryPairwise(
+                        keyPair, "test-client-id-1", PUBLIC.toString(), "https://test.com", false);
+
+        var subject =
+                ClientSubjectHelper.getSubject(
+                        userProfile, clientRegistry1, authenticationService, INTERNAL_SECTOR_URI);
 
         assertFalse(subject.getValue().startsWith("urn:fdc:gov.uk:2022:"));
+        assertThat(subject.getValue(), equalTo(PUBLIC_SUBJECT.getValue()));
     }
 
     @Test
-    void shouldGetHostAsSectorIdentierWhenDefinedByClient() {
-        KeyPair keyPair = generateRsaKeyPair();
-        ClientRegistry clientRegistry1 =
+    void shouldGetHostAsSectorIdentifierWhenDefinedByClient() {
+        var clientRegistry =
                 generateClientRegistryPairwise(
-                        keyPair, "test-client-id-1", "public", "https://test.com");
+                        keyPair, "test-client-id-1", PUBLIC.toString(), "https://test.com", false);
 
-        String sectorId = ClientSubjectHelper.getSectorIdentifierForClient(clientRegistry1);
+        var sectorId =
+                ClientSubjectHelper.getSectorIdentifierForClient(
+                        clientRegistry, INTERNAL_SECTOR_URI);
 
-        assertEquals("test.com", sectorId);
+        assertThat(sectorId, equalTo("test.com"));
     }
 
     @Test
-    void shouldGetRedirectHostWhenSectorIdentierNotDefinedByClient() {
-        KeyPair keyPair = generateRsaKeyPair();
-        ClientRegistry clientRegistry1 =
-                generateClientRegistryPairwise(keyPair, "test-client-id-1", "public", null);
+    void shouldGetHostOfInternalSectorUriWhenClientIsOneLoginService() {
+        var clientRegistry =
+                generateClientRegistryPairwise(
+                        keyPair, "test-client-id-1", PUBLIC.toString(), null, true);
 
-        String sectorId = ClientSubjectHelper.getSectorIdentifierForClient(clientRegistry1);
+        var sectorId =
+                ClientSubjectHelper.getSectorIdentifierForClient(
+                        clientRegistry, INTERNAL_SECTOR_URI);
 
-        assertEquals("localhost", sectorId);
+        assertThat(sectorId, equalTo("test.account.gov.uk"));
+    }
+
+    @Test
+    void shouldUseHostOfInternalSectorUriWhenOneLoginServiceAndClientHasRegisteredSector() {
+        var clientRegistry =
+                generateClientRegistryPairwise(
+                        keyPair, "test-client-id-1", PUBLIC.toString(), "https://test.com", true);
+
+        var sectorId =
+                ClientSubjectHelper.getSectorIdentifierForClient(
+                        clientRegistry, INTERNAL_SECTOR_URI);
+
+        assertThat(sectorId, equalTo("test.account.gov.uk"));
+    }
+
+    @Test
+    void shouldCalculateHostFromRedirectUriWhenSectorUriIsNotDefinedByClient() {
+        var clientRegistry =
+                generateClientRegistryPairwise(
+                        keyPair, "test-client-id-1", PUBLIC.toString(), null, false);
+
+        var sectorId =
+                ClientSubjectHelper.getSectorIdentifierForClient(
+                        clientRegistry, INTERNAL_SECTOR_URI);
+
+        assertThat(sectorId, equalTo("localhost"));
     }
 
     @Test
     void shouldThrowExceptionWhenClientConfigSectorIdInvalid() {
-        KeyPair keyPair = generateRsaKeyPair();
-        ClientRegistry clientRegistry1 =
+        var clientRegistry =
                 generateClientRegistryPairwise(
                         keyPair,
                         "test-client-id-1",
-                        "public",
+                        PUBLIC.toString(),
                         null,
-                        List.of("https://www.test.com", "https://www.test2.com"));
+                        List.of("https://www.test.com", "https://www.test2.com"),
+                        false);
 
         assertThrows(
                 RuntimeException.class,
-                () -> ClientSubjectHelper.getSectorIdentifierForClient(clientRegistry1),
+                () ->
+                        ClientSubjectHelper.getSectorIdentifierForClient(
+                                clientRegistry, INTERNAL_SECTOR_URI),
                 "Expected to throw exception");
     }
 
     @Test
     void shouldReturnHostForValidSectorUri() {
-        assertEquals("test.com", ClientSubjectHelper.returnHost("https://test.com/hello"));
+        assertThat(ClientSubjectHelper.returnHost("https://test.com/hello"), equalTo("test.com"));
+    }
+
+    @Test
+    void shouldReturnHostForInternalSectorUri() {
+        assertThat(
+                ClientSubjectHelper.returnHost(INTERNAL_SECTOR_URI),
+                equalTo("test.account.gov.uk"));
     }
 
     @Test
     void shouldReturnHostForValidSectorUriStartingWWW() {
-        assertEquals("test.com", ClientSubjectHelper.returnHost("https://www.test.com/hello"));
+        assertThat(
+                ClientSubjectHelper.returnHost("https://www.test.com/hello"), equalTo("test.com"));
     }
 
     @Test
@@ -219,80 +305,62 @@ class ClientSubjectHelperTest {
 
     @Test
     void shouldBeValidClientWithoutSectorId() {
-        KeyPair keyPair = generateRsaKeyPair();
-        ClientRegistry clientRegistry1 =
-                generateClientRegistryPairwise(keyPair, "test-client-id-1", "public", null);
+        var clientRegistry =
+                generateClientRegistryPairwise(
+                        keyPair, "test-client-id-1", PUBLIC.toString(), null, false);
 
-        assertTrue(ClientSubjectHelper.hasValidClientConfig(clientRegistry1));
+        assertTrue(ClientSubjectHelper.hasValidClientConfig(clientRegistry));
     }
 
     @Test
     void shouldBeValidClientWithSectorId() {
-        KeyPair keyPair = generateRsaKeyPair();
-        ClientRegistry clientRegistry1 =
+        var clientRegistry =
                 generateClientRegistryPairwise(
-                        keyPair, "test-client-id-1", "public", "https://test.com");
+                        keyPair, "test-client-id-1", PUBLIC.toString(), "https://test.com", false);
 
-        assertTrue(ClientSubjectHelper.hasValidClientConfig(clientRegistry1));
+        assertTrue(ClientSubjectHelper.hasValidClientConfig(clientRegistry));
     }
 
     @Test
     void shouldBeValidClientWithSectorIdAndTwoRedirectHosts() {
-        KeyPair keyPair = generateRsaKeyPair();
-        ClientRegistry clientRegistry1 =
+        var clientRegistry =
                 generateClientRegistryPairwise(
                         keyPair,
                         "test-client-id-1",
-                        "public",
+                        PUBLIC.toString(),
                         "https://test.com",
-                        List.of("https://www.test.com", "https://www.test2.com"));
+                        List.of("https://www.test.com", "https://www.test2.com"),
+                        false);
 
-        assertTrue(ClientSubjectHelper.hasValidClientConfig(clientRegistry1));
+        assertTrue(ClientSubjectHelper.hasValidClientConfig(clientRegistry));
     }
 
     @Test
     void shouldBeInvalidClientWithoutSectorIdAndTwoRedirectHosts() {
-        KeyPair keyPair = generateRsaKeyPair();
-        ClientRegistry clientRegistry1 =
+        var clientRegistry =
                 generateClientRegistryPairwise(
                         keyPair,
                         "test-client-id-1",
-                        "public",
+                        PUBLIC.toString(),
                         null,
-                        List.of("https://www.test.com", "https://www.test2.com"));
+                        List.of("https://www.test.com", "https://www.test2.com"),
+                        false);
 
-        assertFalse(ClientSubjectHelper.hasValidClientConfig(clientRegistry1));
+        assertFalse(ClientSubjectHelper.hasValidClientConfig(clientRegistry));
     }
 
     @Test
     void shouldBeValidClientWithoutSectorIdAndOneRedirectHostsWithTwoRedirectUris() {
-        KeyPair keyPair = generateRsaKeyPair();
-        ClientRegistry clientRegistry1 =
+        var clientRegistry =
                 generateClientRegistryPairwise(
                         keyPair,
                         "test-client-id-1",
-                        "public",
+                        PUBLIC.toString(),
                         null,
-                        List.of("https://www.test.com/1", "https://www.test.com/2"));
+                        List.of("https://www.test.com/1", "https://www.test.com/2"),
+                        false);
 
-        assertTrue(ClientSubjectHelper.hasValidClientConfig(clientRegistry1));
-    }
-
-    private KeyPair generateRsaKeyPair() {
-        KeyPairGenerator kpg;
-        try {
-            kpg = KeyPairGenerator.getInstance("RSA");
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException();
-        }
-        kpg.initialize(2048);
-        return kpg.generateKeyPair();
-    }
-
-    private ClientRegistry generateClientRegistryPairwise(
-            KeyPair keyPair, String clientID, String subjectType, String sector) {
-        return generateClientRegistryPairwise(
-                keyPair, clientID, subjectType, sector, singletonList(REDIRECT_URI));
+        assertTrue(ClientSubjectHelper.hasValidClientConfig(clientRegistry));
     }
 
     private ClientRegistry generateClientRegistryPairwise(
@@ -300,7 +368,23 @@ class ClientSubjectHelperTest {
             String clientID,
             String subjectType,
             String sector,
-            List<String> redirectUrls) {
+            boolean oneLoginService) {
+        return generateClientRegistryPairwise(
+                keyPair,
+                clientID,
+                subjectType,
+                sector,
+                singletonList(REDIRECT_URI),
+                oneLoginService);
+    }
+
+    private ClientRegistry generateClientRegistryPairwise(
+            KeyPair keyPair,
+            String clientID,
+            String subjectType,
+            String sector,
+            List<String> redirectUrls,
+            boolean oneLoginService) {
         return new ClientRegistry()
                 .withClientID(clientID)
                 .withClientName("test-client")
@@ -310,6 +394,7 @@ class ClientSubjectHelperTest {
                 .withPublicKey(
                         Base64.getMimeEncoder().encodeToString(keyPair.getPublic().getEncoded()))
                 .withSectorIdentifierUri(sector)
+                .withOneLoginService(oneLoginService)
                 .withSubjectType(subjectType);
     }
 
@@ -327,10 +412,5 @@ class ClientSubjectHelperTest {
                 .withClientConsent(
                         new ClientConsent(
                                 CLIENT_ID, claims, LocalDateTime.now(ZoneId.of("UTC")).toString()));
-    }
-
-    private void stubAuthenticationService() {
-        when(authenticationService.getOrGenerateSalt(any(UserProfile.class)))
-                .thenReturn("a-test-salt".getBytes(StandardCharsets.UTF_8));
     }
 }


### PR DESCRIPTION
## What?

Use the Internal Sector URI for generating pairwise when client is a one login service

## Why?


- So we only maintain a single config file for the internal sector uri, check to see whether the client is configured as a oneLoginService and if so use the internal sector URI otherwise continue as normal.
