### PR TITLE
AUT-829: Shorten test services lambda source bucket name

### DIFF
--- a/ci/terraform/test-services/s3.tf
+++ b/ci/terraform/test-services/s3.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "source_bucket" {
-  bucket_prefix = "${var.environment}-test-services-lambda-source-"
+  bucket_prefix = "${var.environment}-test-services-lam-src"
 }
 
 resource "aws_s3_bucket_versioning" "source_bucket_versioning" {


### PR DESCRIPTION
## What?

Shorten test services lambda source bucket name.

## Why?

In integration the name exceeds the maximum length.

## Related PRs

#2556 