### PR TITLE
AUT-829: Prune and rename test-services dynamo policies

### DIFF
--- a/ci/terraform/test-services/dynamo-policies.tf
+++ b/ci/terraform/test-services/dynamo-policies.tf
@@ -6,37 +6,14 @@ data "aws_dynamodb_table" "user_profile_table" {
   name = "${var.environment}-user-profile"
 }
 
-data "aws_iam_policy_document" "dynamo_user_write_policy_document" {
-  statement {
-    sid    = "AllowAccessToDynamoTables"
-    effect = "Allow"
-
-    actions = [
-      "dynamodb:BatchWriteItem",
-      "dynamodb:UpdateItem",
-      "dynamodb:PutItem",
-    ]
-    resources = [
-      data.aws_dynamodb_table.user_credentials_table.arn,
-      data.aws_dynamodb_table.user_profile_table.arn,
-      "${data.aws_dynamodb_table.user_profile_table.arn}/index/*",
-      "${data.aws_dynamodb_table.user_credentials_table.arn}/index/*",
-    ]
-  }
-}
-
 data "aws_iam_policy_document" "dynamo_user_read_policy_document" {
   statement {
     sid    = "AllowAccessToDynamoTables"
     effect = "Allow"
 
     actions = [
-      "dynamodb:BatchGetItem",
-      "dynamodb:DescribeStream",
       "dynamodb:DescribeTable",
-      "dynamodb:Get*",
-      "dynamodb:Query",
-      "dynamodb:Scan",
+      "dynamodb:GetItem",
     ]
     resources = [
       data.aws_dynamodb_table.user_credentials_table.arn,
@@ -65,25 +42,17 @@ data "aws_iam_policy_document" "dynamo_user_delete_policy_document" {
 }
 
 resource "aws_iam_policy" "dynamo_test_services_user_read_access_policy" {
-  name_prefix = "dynamo-account-management-user-read-policy"
-  path        = "/${var.environment}/am-shared/"
+  name_prefix = "dynamo-test-services-user-read-policy"
+  path        = "/${var.environment}/test-services/"
   description = "IAM policy for managing read permissions to the Dynamo User tables"
 
   policy = data.aws_iam_policy_document.dynamo_user_read_policy_document.json
 }
 
 resource "aws_iam_policy" "dynamo_test_services_user_delete_access_policy" {
-  name_prefix = "dynamo-account-management-user-delete-policy"
-  path        = "/${var.environment}/am-shared/"
+  name_prefix = "dynamo-test-services-user-delete-policy"
+  path        = "/${var.environment}/test-services/"
   description = "IAM policy for managing delete permissions to the Dynamo User tables"
 
   policy = data.aws_iam_policy_document.dynamo_user_delete_policy_document.json
-}
-
-resource "aws_iam_policy" "dynamo_test_services_user_write_access_policy" {
-  name_prefix = "dynamo-account-management-user-write-policy"
-  path        = "/${var.environment}/am-shared/"
-  description = "IAM policy for managing write permissions to the Dynamo User tables"
-
-  policy = data.aws_iam_policy_document.dynamo_user_write_policy_document.json
 }


### PR DESCRIPTION
## What?

Prune and rename test-services dynamo policies.

- Remove dynamo access rights not required by the handler.
- Rename some policies.

## Why?

Read access had rights that were not needed.
Update some copy and pasted policy names.