### PR TITLE
ACI-123 - Upgrade GH actions to not use Node.js 12

### DIFF
--- a/.github/workflows/pre-merge-checks-terraform.yml
+++ b/.github/workflows/pre-merge-checks-terraform.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Get Terraform version
         id: getterraformversion

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '11'
           distribution: 'adopt'
@@ -26,15 +26,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '11'
           distribution: 'adopt'
           cache: 'gradle'
       - name: Build Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             .gradle/
@@ -51,15 +51,15 @@ jobs:
       - build
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '11'
           distribution: 'adopt'
           cache: 'gradle'
       - name: Build Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             .gradle/
@@ -84,7 +84,7 @@ jobs:
 
           retention-days: 5
       - name: Cache Unit Test Reports
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           key: ${{ runner.os }}-unit-test-reports-${{ github.sha }}
           path: |
@@ -136,15 +136,15 @@ jobs:
           - 8000:8000
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '11'
           distribution: 'adopt'
           cache: 'gradle'
       - name: Build Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             .gradle/
@@ -183,7 +183,7 @@ jobs:
           path: delivery-receipts-integration-tests/build/reports/tests/test/
           retention-days: 5
       - name: Cache Test Reports
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           key: ${{ runner.os }}-integration-test-reports-${{ github.sha }}
           path: |
@@ -201,15 +201,15 @@ jobs:
       - run-integration-tests
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '11'
           distribution: 'adopt'
           cache: 'gradle'
       - name: Build Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             .gradle/
@@ -218,7 +218,7 @@ jobs:
             !*/build/jacoco
           key: ${{ runner.os }}-build-${{ github.sha }}
       - name: Cache Unit Test Reports
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           key: ${{ runner.os }}-unit-test-reports-${{ github.sha }}
           path: |
@@ -231,7 +231,7 @@ jobs:
             !delivery-receipts-integration-tests/build/jacoco/
             !delivery-receipts-integration-tests/build/reports/
       - name: Cache Test Reports
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           key: ${{ runner.os }}-integration-test-reports-${{ github.sha }}
           path: |

--- a/.github/workflows/sonar-analysis-on-merge.yml
+++ b/.github/workflows/sonar-analysis-on-merge.yml
@@ -9,16 +9,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '11'
           distribution: 'adopt'
 
       - name: Cache Gradle packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches


### PR DESCRIPTION
## What?

 - Upgrade GH actions to not use Node.js 12

## Why?

- Node12 is out of support and any github versions running on Node will need to be upgrade - https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
- We are currently seeing messages such as `Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/setup-java@v2, actions/cache@v2`
