### PR TITLE
AUT-740 - Log the govuk_signin_journey_id in Splunk

### DIFF
--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppAuthorizeHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppAuthorizeHandler.java
@@ -37,6 +37,7 @@ import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.g
 import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.CLIENT_ID;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.CLIENT_SESSION_ID;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.GOVUK_SIGNIN_JOURNEY_ID;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachLogFieldToLogs;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachSessionIdToLogs;
 import static uk.gov.di.authentication.shared.helpers.RequestHeaderHelper.getHeaderValueFromHeaders;
@@ -121,6 +122,7 @@ public class DocAppAuthorizeHandler
                             CLIENT_SESSION_ID_HEADER,
                             configurationService.getHeadersCaseInsensitive());
             attachLogFieldToLogs(CLIENT_SESSION_ID, clientSessionId);
+            attachLogFieldToLogs(GOVUK_SIGNIN_JOURNEY_ID, clientSessionId);
             var clientID = new ClientID(configurationService.getDocAppAuthorisationClientId());
             attachLogFieldToLogs(CLIENT_ID, clientID.getValue());
             var clientRegistry =

--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
@@ -38,6 +38,7 @@ import static uk.gov.di.authentication.shared.helpers.ConstructUriHelper.buildUR
 import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.CLIENT_ID;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.CLIENT_SESSION_ID;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.GOVUK_SIGNIN_JOURNEY_ID;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachLogFieldToLogs;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachSessionIdToLogs;
 
@@ -136,6 +137,7 @@ public class DocAppCallbackHandler
                                                 "ClientSession not found");
                                     });
             attachLogFieldToLogs(CLIENT_SESSION_ID, clientSessionId);
+            attachLogFieldToLogs(GOVUK_SIGNIN_JOURNEY_ID, clientSessionId);
 
             var authenticationRequest =
                     AuthenticationRequest.parse(clientSession.getAuthRequestParams());

--- a/doc-checking-app-api/src/main/resources/log4j2.xml
+++ b/doc-checking-app-api/src/main/resources/log4j2.xml
@@ -5,6 +5,7 @@
                 <KeyValuePair key="session-id" value="$${ctx:sessionId:-unknown}"/>
                 <KeyValuePair key="persistent-session-id" value="$${ctx:persistentSessionId:-}"/>
                 <KeyValuePair key="client-session-id" value="$${ctx:clientSessionId:-}"/>
+                <KeyValuePair key="govuk_signin_journey_id" value="$${ctx:govukSigninJourneyId:-}"/>
                 <KeyValuePair key="client-id" value="$${ctx:clientId:-}"/>
                 <KeyValuePair key="aws-request-id" value="$${ctx:awsRequestId:-}"/>
             </JsonLayout>

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -40,7 +40,6 @@ import static uk.gov.di.authentication.shared.domain.RequestHeaders.CLIENT_SESSI
 import static uk.gov.di.authentication.shared.entity.LevelOfConfidence.NONE;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.CLIENT_ID;
-import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.CLIENT_SESSION_ID;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.PERSISTENT_SESSION_ID;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachLogFieldToLogs;
 import static uk.gov.di.authentication.shared.helpers.PersistentIdHelper.extractPersistentIdFromHeaders;
@@ -108,7 +107,6 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                         input.getHeaders(),
                         CLIENT_SESSION_ID_HEADER,
                         configurationService.getHeadersCaseInsensitive());
-        attachLogFieldToLogs(CLIENT_SESSION_ID, clientSessionId);
         attachLogFieldToLogs(
                 PERSISTENT_SESSION_ID, extractPersistentIdFromHeaders(input.getHeaders()));
         attachLogFieldToLogs(

--- a/frontend-api/src/main/resources/log4j2.xml
+++ b/frontend-api/src/main/resources/log4j2.xml
@@ -5,6 +5,7 @@
                 <KeyValuePair key="session-id" value="$${ctx:sessionId:-unknown}"/>
                 <KeyValuePair key="persistent-session-id" value="$${ctx:persistentSessionId:-}"/>
                 <KeyValuePair key="client-session-id" value="$${ctx:clientSessionId:-}"/>
+                <KeyValuePair key="govuk_signin_journey_id" value="$${ctx:govukSigninJourneyId:-}"/>
                 <KeyValuePair key="client-id" value="$${ctx:clientId:-}"/>
                 <KeyValuePair key="aws-request-id" value="$${ctx:awsRequestId:-}"/>
             </JsonLayout>

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -56,6 +56,7 @@ import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.g
 import static uk.gov.di.authentication.shared.helpers.ClientSubjectHelper.getSectorIdentifierForClient;
 import static uk.gov.di.authentication.shared.helpers.ConstructUriHelper.buildURI;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.CLIENT_SESSION_ID;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.GOVUK_SIGNIN_JOURNEY_ID;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.PERSISTENT_SESSION_ID;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachLogFieldToLogs;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachSessionIdToLogs;
@@ -163,6 +164,7 @@ public class IPVCallbackHandler
                 throw new IpvCallbackException("ClientSession not found");
             }
             attachLogFieldToLogs(CLIENT_SESSION_ID, clientSessionId);
+            attachLogFieldToLogs(GOVUK_SIGNIN_JOURNEY_ID, clientSessionId);
             var authRequest = AuthenticationRequest.parse(clientSession.getAuthRequestParams());
 
             var clientId = authRequest.getClientID().getValue();

--- a/ipv-api/src/main/resources/log4j2.xml
+++ b/ipv-api/src/main/resources/log4j2.xml
@@ -4,6 +4,7 @@
             <JsonLayout compact="true" eventEol="true" objectMessageAsJsonObject="true" >
                 <KeyValuePair key="session-id" value="$${ctx:sessionId:-unknown}"/>
                 <KeyValuePair key="persistent-session-id" value="$${ctx:persistentSessionId:-}"/>
+                <KeyValuePair key="govuk_signin_journey_id" value="$${ctx:govukSigninJourneyId:-}"/>
                 <KeyValuePair key="client-session-id" value="$${ctx:clientSessionId:-}"/>
                 <KeyValuePair key="client-id" value="$${ctx:clientId:-}"/>
                 <KeyValuePair key="aws-request-id" value="$${ctx:awsRequestId:-}"/>

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -47,6 +47,7 @@ import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.g
 import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.addAnnotation;
 import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.CLIENT_SESSION_ID;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.GOVUK_SIGNIN_JOURNEY_ID;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachLogFieldToLogs;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachSessionIdToLogs;
 import static uk.gov.di.authentication.shared.helpers.RequestHeaderHelper.getHeaderValueFromHeaders;
@@ -126,6 +127,7 @@ public class AuthCodeHandler
         }
         attachSessionIdToLogs(session);
         attachLogFieldToLogs(CLIENT_SESSION_ID, clientSessionId);
+        attachLogFieldToLogs(GOVUK_SIGNIN_JOURNEY_ID, clientSessionId);
 
         LOG.info("Processing request");
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -250,8 +250,8 @@ public class AuthorisationHandler
 
         session.addClientSession(clientSessionId);
         updateAttachedLogFieldToLogs(CLIENT_SESSION_ID, clientSessionId);
-        updateAttachedLogFieldToLogs(CLIENT_ID, authenticationRequest.getClientID().getValue());
         updateAttachedLogFieldToLogs(GOVUK_SIGNIN_JOURNEY_ID, clientSessionId);
+        updateAttachedLogFieldToLogs(CLIENT_ID, authenticationRequest.getClientID().getValue());
         sessionService.save(session);
         LOG.info("Session saved successfully");
         return redirect(session, clientSessionId, authenticationRequest, persistentSessionId);

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
@@ -36,6 +36,7 @@ import java.util.Optional;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.CLIENT_SESSION_ID;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.GOVUK_SIGNIN_JOURNEY_ID;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachLogFieldToLogs;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachSessionIdToLogs;
 
@@ -139,6 +140,7 @@ public class LogoutHandler
 
         attachSessionIdToLogs(session);
         attachLogFieldToLogs(CLIENT_SESSION_ID, sessionCookieIds.getClientSessionId());
+        attachLogFieldToLogs(GOVUK_SIGNIN_JOURNEY_ID, sessionCookieIds.getClientSessionId());
 
         LOG.info("LogoutHandler processing request");
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
@@ -52,6 +52,7 @@ import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.addA
 import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.CLIENT_ID;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.CLIENT_SESSION_ID;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.GOVUK_SIGNIN_JOURNEY_ID;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachLogFieldToLogs;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.updateAttachedLogFieldToLogs;
 import static uk.gov.di.authentication.shared.helpers.RequestBodyHelper.parseRequestBody;
@@ -205,6 +206,8 @@ public class TokenHandler
                     400, OAuth2Error.INVALID_GRANT.toJSONObject().toJSONString());
         }
         updateAttachedLogFieldToLogs(CLIENT_SESSION_ID, authCodeExchangeData.getClientSessionId());
+        updateAttachedLogFieldToLogs(
+                GOVUK_SIGNIN_JOURNEY_ID, authCodeExchangeData.getClientSessionId());
         ClientSession clientSession = authCodeExchangeData.getClientSession();
         AuthenticationRequest authRequest;
         try {

--- a/oidc-api/src/main/resources/log4j2.xml
+++ b/oidc-api/src/main/resources/log4j2.xml
@@ -5,6 +5,7 @@
                 <KeyValuePair key="session-id" value="$${ctx:sessionId:-unknown}"/>
                 <KeyValuePair key="persistent-session-id" value="$${ctx:persistentSessionId:-}"/>
                 <KeyValuePair key="client-session-id" value="$${ctx:clientSessionId:-}"/>
+                <KeyValuePair key="govuk_signin_journey_id" value="$${ctx:govukSigninJourneyId:-}"/>
                 <KeyValuePair key="client-id" value="$${ctx:clientId:-}"/>
                 <KeyValuePair key="aws-request-id" value="$${ctx:awsRequestId:-}"/>
             </JsonLayout>

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/LogLineHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/LogLineHelper.java
@@ -13,11 +13,11 @@ public class LogLineHelper {
     public enum LogFieldName {
         SESSION_ID("sessionId", true),
         CLIENT_SESSION_ID("clientSessionId", true),
+        GOVUK_SIGNIN_JOURNEY_ID("govuk_signin_journey_id", true),
         PERSISTENT_SESSION_ID("persistentSessionId", true),
         AWS_REQUEST_ID("awsRequestId", false),
         CLIENT_ID("clientId", true),
-        CLIENT_NAME("clientName", false),
-        GOVUK_SIGNIN_JOURNEY_ID("govuk_signin_journey_id", true);
+        CLIENT_NAME("clientName", false);
 
         private final String logFieldName;
         private boolean isBase64;

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/LogLineHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/LogLineHelper.java
@@ -13,7 +13,7 @@ public class LogLineHelper {
     public enum LogFieldName {
         SESSION_ID("sessionId", true),
         CLIENT_SESSION_ID("clientSessionId", true),
-        GOVUK_SIGNIN_JOURNEY_ID("govuk_signin_journey_id", true),
+        GOVUK_SIGNIN_JOURNEY_ID("govukSigninJourneyId", true),
         PERSISTENT_SESSION_ID("persistentSessionId", true),
         AWS_REQUEST_ID("awsRequestId", false),
         CLIENT_ID("clientId", true),

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ClientSessionService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ClientSessionService.java
@@ -15,6 +15,7 @@ import java.util.Optional;
 
 import static uk.gov.di.authentication.shared.domain.RequestHeaders.CLIENT_SESSION_ID_HEADER;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.CLIENT_SESSION_ID;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.GOVUK_SIGNIN_JOURNEY_ID;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachLogFieldToLogs;
 import static uk.gov.di.authentication.shared.helpers.RequestHeaderHelper.getHeaderValueFromHeaders;
 import static uk.gov.di.authentication.shared.helpers.RequestHeaderHelper.headersContainValidHeader;
@@ -75,6 +76,7 @@ public class ClientSessionService {
 
     public Optional<ClientSession> getClientSession(String clientSessionId) {
         attachLogFieldToLogs(CLIENT_SESSION_ID, clientSessionId);
+        attachLogFieldToLogs(GOVUK_SIGNIN_JOURNEY_ID, clientSessionId);
 
         try {
             if (redisConnectionService.keyExists(CLIENT_SESSION_PREFIX.concat(clientSessionId))) {
@@ -95,6 +97,7 @@ public class ClientSessionService {
 
     public void saveClientSession(String clientSessionId, ClientSession clientSession) {
         attachLogFieldToLogs(CLIENT_SESSION_ID, clientSessionId);
+        attachLogFieldToLogs(GOVUK_SIGNIN_JOURNEY_ID, clientSessionId);
 
         try {
             redisConnectionService.saveWithExpiry(


### PR DESCRIPTION
## What?

 - Log the govuk_signin_journey_id in Splunk

## Why?

- Attach the clientSessionId to the govuk_signin_journey_id field in Splunk. The govuk_signin_journey_id is being used in other parts of the journeys IPV etc and there isn't currently a single field which can be searched on in Splunk. This will make debugging journeys easier across all of DI.
- We might want to remove the client_session_id field in from the logs but we can leave it in for now until all journeys in auth have a govuk_signin_journey_id attached for the entire user journey throught auth