### PR TITLE
AUT-844 - Switch IPV production P1 alerts to output to pagerduty

### DIFF
--- a/ci/terraform/oidc/ipv-handback-alerts.tf
+++ b/ci/terraform/oidc/ipv-handback-alerts.tf
@@ -63,5 +63,5 @@ resource "aws_cloudwatch_metric_alarm" "ipv_handback_p1_cloudwatch_alarm" {
   statistic           = "Sum"
   threshold           = var.ipv_p1_alarm_error_threshold
   alarm_description   = "${var.ipv_p1_alarm_error_threshold} or more IPV handback errors have occurred in ${var.environment}.ACCOUNT: ${data.aws_iam_account_alias.current.account_alias}"
-  alarm_actions       = [var.environment == "production" ? data.aws_sns_topic.slack_events.arn : data.aws_sns_topic.slack_events.arn]
+  alarm_actions       = [var.environment == "production" ? data.aws_sns_topic.pagerduty_p1_alerts[0].arn : data.aws_sns_topic.slack_events.arn]
 }

--- a/ci/terraform/oidc/ipv-handoff-alerts.tf
+++ b/ci/terraform/oidc/ipv-handoff-alerts.tf
@@ -27,5 +27,5 @@ resource "aws_cloudwatch_metric_alarm" "ipv_handoff_p1_cloudwatch_alarm" {
   statistic           = "Sum"
   threshold           = var.ipv_p1_alarm_error_threshold
   alarm_description   = "${var.ipv_p1_alarm_error_threshold} or more IPV handoff errors have occurred in ${var.environment}.ACCOUNT: ${data.aws_iam_account_alias.current.account_alias}"
-  alarm_actions       = [var.environment == "production" ? data.aws_sns_topic.slack_events.arn : data.aws_sns_topic.slack_events.arn]
+  alarm_actions       = [var.environment == "production" ? data.aws_sns_topic.pagerduty_p1_alerts[0].arn : data.aws_sns_topic.slack_events.arn]
 }


### PR DESCRIPTION
## What?

- Switch IPV production P1 alerts to output to pagerduty

## Why?

- IPV now runs 24/7 so we need to be alerted if there is an issue