### PR TITLE
BAU: Create RSA (4096) signing key for ID tokens

### DIFF
--- a/ci/terraform/oidc/rsa-signing-key.tf
+++ b/ci/terraform/oidc/rsa-signing-key.tf
@@ -1,0 +1,13 @@
+resource "aws_kms_key" "id_token_signing_key_rsa" {
+  description              = "KMS signing key (RSA) for ID tokens"
+  deletion_window_in_days  = 30
+  key_usage                = "SIGN_VERIFY"
+  customer_master_key_spec = "RSA_4096"
+
+  tags = local.default_tags
+}
+
+resource "aws_kms_alias" "id_token_signing_key_alias" {
+  name          = "alias/${var.environment}-id-token-signing-key-rsa-alias"
+  target_key_id = aws_kms_key.id_token_signing_key_rsa.key_id
+}


### PR DESCRIPTION
Part 1 to supporting RSA in addition to EC for id token signing.

This PR creates the key in KMS and an alias for it.
