### PR TITLE
FIREBREAK: Pre-commit hooks for Terraform

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,3 +20,9 @@ repos:
         entry: hashicorp/terraform:1.0.4 fmt -recursive
         files: ^.*(.tf|.tfvars)$
         pass_filenames: false
+      - id: terraform-validate
+        name: Run Terraform Validate
+        language: script
+        entry: ci/terraform/precommit-validate.sh
+        files: ^.*(.tf|.tfvars)$
+        pass_filenames: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,3 +14,9 @@ repos:
         entry: ./gradlew spotlessApply
         files: ^.*(gradle|java)$
         pass_filenames: false
+      - id: terraform-format
+        name: Run Terraform Format
+        language: docker_image
+        entry: hashicorp/terraform:1.0.4 fmt -recursive
+        files: ^.*(.tf|.tfvars)$
+        pass_filenames: false

--- a/ci/terraform/precommit-validate.sh
+++ b/ci/terraform/precommit-validate.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -eu
+DIR="$(git rev-parse --show-toplevel)"
+pushd "${DIR}" > /dev/null
+export DOCKER_DEFAULT_PLATFORM=linux/amd64
+TERRAFORM_VERSION=$(cat ci/terraform/.terraform-version)
+
+function runTerraformValidate() {
+  echo "Running Terraform Validate in ${1}..."
+  export DATA_DIR="build/precommit/${1}"
+  export TF_DATA_DIR="/src/${DATA_DIR}"
+  mkdir -p "${DIR}/${DATA_DIR}"
+  rm -rf "${DIR}/${DATA_DIR}/*"
+  export TF_IN_AUTOMATION=1
+  docker run \
+    -v "${DIR}:/src" \
+    -e TF_DATA_DIR \
+    -e TF_IN_AUTOMATION \
+    "hashicorp/terraform:${TERRAFORM_VERSION}" \
+    -chdir="/src/${1}" \
+    init -backend=false
+
+  docker run \
+    -v "${DIR}:/src" \
+    -e TF_DATA_DIR \
+    -e TF_IN_AUTOMATION \
+    "hashicorp/terraform:${TERRAFORM_VERSION}" \
+    -chdir="/src/${1}" \
+    validate
+}
+
+DIRECTORIES=($(for dir in $(dirname "$@"); do
+  echo ${dir}
+done | sort -u))
+
+for TERRAFORM_DIR in "${DIRECTORIES[@]}"; do
+  runTerraformValidate "${TERRAFORM_DIR}"
+done
+
+popd > /dev/null


### PR DESCRIPTION
## What?

- Run `terrraform fmt` on all Terraform files when Terraform files have changed (`.tf` or  `.tfvars`)
- Add a pre-commit hook to run a script to validate Terraform.
- Use a Docker image for Terraform rather than rely on local, working, installation
- Script should take in list of changed files and determine distinct Terraform directories, only running validate once per directory

## Why?

Ensure that commits are validated to be, syntactically, correct and are formatted consistently.
(the validate rule takes about 20-30 seconds to run, so longer than you'd normally expect for a pre-commit hook, but not unusable).
