### PR TITLE
FIREBREAK: Pre commit hooks for Cloudformation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,13 @@ repos:
       - id: end-of-file-fixer
       - id: check-added-large-files
 
+  - repo: https://github.com/awslabs/cfn-python-lint
+    rev: v0.72.2
+    hooks:
+      - id: cfn-python-lint
+        exclude: ^(ci|.github)/.*|docker-compose.*|.pre-commit-config.yaml$
+        files: ^.*\.(json|yml|yaml)$
+
   - repo: local
     hooks:
       - id: spotless-check

--- a/shared/client-dynamo-tables.yaml
+++ b/shared/client-dynamo-tables.yaml
@@ -17,6 +17,7 @@ Resources:
   ClientRegistry:
     # checkov:skip=CKV_AWS_119: "Ensure DynamoDB Tables are encrypted using a KMS Customer Managed CMK"
     DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Type: "AWS::DynamoDB::Table"
     Properties:
       AttributeDefinitions:

--- a/shared/common-password-dynamo-table.yaml
+++ b/shared/common-password-dynamo-table.yaml
@@ -17,6 +17,7 @@ Resources:
   CommonPassword:
     # checkov:skip=CKV_AWS_119: "Ensure DynamoDB Tables are encrypted using a KMS Customer Managed CMK"
     DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Type: "AWS::DynamoDB::Table"
     Properties:
       AttributeDefinitions:

--- a/shared/kms.yaml
+++ b/shared/kms.yaml
@@ -53,6 +53,7 @@ Resources:
   IdTokenSigningKey:
     Type: AWS::KMS::Key
     DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       Description: KMS signing key for ID tokens
       Enabled: true
@@ -78,6 +79,7 @@ Resources:
   IdTokenSigningKeyAlias:
     Type: AWS::KMS::Alias
     DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       AliasName: !Sub "alias/${Environment}-id-token-signing-key-alias"
       TargetKeyId: !Ref IdTokenSigningKey
@@ -85,6 +87,7 @@ Resources:
   IpvAuthSigningKey:
     Type: AWS::KMS::Key
     DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       Description: KMS signing key for authentication to the IPV token endpoint
       Enabled: true
@@ -110,6 +113,7 @@ Resources:
   IpvAuthSigningKeyAlias:
     Type: AWS::KMS::Alias
     DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       AliasName: !Sub "alias/${Environment}-ipv-token-auth-kms-key-alias"
       TargetKeyId: !Ref IpvAuthSigningKey
@@ -117,6 +121,7 @@ Resources:
   DocAppAuthSigningKey:
     Type: AWS::KMS::Key
     DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       Description: KMS signing key for authentication to the Doc Checking App
       Enabled: true
@@ -142,6 +147,7 @@ Resources:
   DocAppAuthSigningKeyAlias:
     Type: AWS::KMS::Alias
     DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       AliasName: !Sub "alias/${Environment}-doc-app-auth-kms-key-alias"
       TargetKeyId: !Ref DocAppAuthSigningKey
@@ -149,6 +155,7 @@ Resources:
   CloudWatchLogEncryptionKey:
     Type: AWS::KMS::Key
     DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       Description: KMS key for Cloudwatch logs
       Enabled: true
@@ -186,6 +193,7 @@ Resources:
   LambdaEnvironmentVariableEncryptionKey:
     Type: AWS::KMS::Key
     DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       Description: KMS encryption key for lambda environment variables
       Enabled: true
@@ -211,6 +219,7 @@ Resources:
   LambdaEnvironmentVariableEncryptionKeyAlias:
     Type: AWS::KMS::Alias
     DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Properties:
       AliasName: !Sub "alias/${Environment}-lambda-env-vars-encryption-key-alias"
       TargetKeyId: !Ref LambdaEnvironmentVariableEncryptionKey

--- a/shared/user-dynamo-tables.yaml
+++ b/shared/user-dynamo-tables.yaml
@@ -17,6 +17,7 @@ Resources:
   UserCredentials:
     # checkov:skip=CKV_AWS_119: "Ensure DynamoDB Tables are encrypted using a KMS Customer Managed CMK"
     DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Type: "AWS::DynamoDB::Table"
     Properties:
       AttributeDefinitions:
@@ -49,6 +50,7 @@ Resources:
   UserProfile:
     # checkov:skip=CKV_AWS_119: "Ensure DynamoDB Tables are encrypted using a KMS Customer Managed CMK"
     DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Type: "AWS::DynamoDB::Table"
     Properties:
       AttributeDefinitions:
@@ -109,6 +111,7 @@ Resources:
   IdentityCredentials:
     # checkov:skip=CKV_AWS_119: "Ensure DynamoDB Tables are encrypted using a KMS Customer Managed CMK"
     DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Type: "AWS::DynamoDB::Table"
     Properties:
       AttributeDefinitions:
@@ -135,6 +138,7 @@ Resources:
   DocAppCredentials:
     # checkov:skip=CKV_AWS_119: "Ensure DynamoDB Tables are encrypted using a KMS Customer Managed CMK"
     DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
     Type: "AWS::DynamoDB::Table"
     Properties:
       AttributeDefinitions:


### PR DESCRIPTION
## What?

- Use `cfn-python-lint` to lint cloudformation files. Assume that all YAML files are potentially Cloudformation files except those in the exclusion list (we may want to refactor this later).
- Add a `UpdateReplacePolicy` where-ever we have a `DeletionPolicy`

## Why?

To give us confidence that Cloudformation we're committing it sensible.

N.B. the first commit adds the functionality, the second commit makes existing files compliant with the linter rules.
