### PR TITLE
BAU: Sign tokens with RSA if client requests and environment enabled

### DIFF
--- a/ci/terraform/oidc/token.tf
+++ b/ci/terraform/oidc/token.tf
@@ -25,7 +25,8 @@ data "aws_iam_policy_document" "kms_signing_policy_document" {
       "kms:GetPublicKey",
     ]
     resources = [
-      local.id_token_signing_key_arn
+      local.id_token_signing_key_arn,
+      aws_kms_key.id_token_signing_key_rsa.arn
     ]
   }
 }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/WellknownHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/WellknownHandler.java
@@ -85,7 +85,10 @@ public class WellknownHandler
                             "email_verified",
                             "phone_number",
                             "phone_number_verified"));
-            providerMetadata.setIDTokenJWSAlgs(List.of(JWSAlgorithm.ES256));
+            providerMetadata.setIDTokenJWSAlgs(
+                    configService.isRsaSigningAvailable()
+                            ? List.of(JWSAlgorithm.ES256, JWSAlgorithm.RS256)
+                            : List.of(JWSAlgorithm.ES256));
             providerMetadata.setTokenEndpointJWSAlgs(
                     List.of(
                             JWSAlgorithm.RS256,

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/TokenGeneratorHelper.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/TokenGeneratorHelper.java
@@ -127,7 +127,13 @@ public class TokenGeneratorHelper {
                             .collect(Collectors.toList()));
         }
 
-        JWSHeader jwsHeader = new JWSHeader.Builder(JWSAlgorithm.ES256).keyID(keyId).build();
+        JWSHeader jwsHeader =
+                new JWSHeader.Builder(
+                                signer instanceof RSASSASigner
+                                        ? JWSAlgorithm.RS256
+                                        : JWSAlgorithm.ES256)
+                        .keyID(keyId)
+                        .build();
 
         var signedJWT = new SignedJWT(jwsHeader, claimsBuilder.build());
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ClientRegistry.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ClientRegistry.java
@@ -31,6 +31,7 @@ public class ClientRegistry {
     private boolean identityVerificationSupported = false;
 
     private boolean oneLoginService = false;
+    private String idTokenSigningAlgorithm = "ES256";
 
     public ClientRegistry() {}
 
@@ -299,6 +300,20 @@ public class ClientRegistry {
 
     public ClientRegistry withOneLoginService(boolean oneLoginService) {
         this.oneLoginService = oneLoginService;
+        return this;
+    }
+
+    @DynamoDbAttribute("IdTokenSigningAlgorithm")
+    public String getIdTokenSigningAlgorithm() {
+        return idTokenSigningAlgorithm;
+    }
+
+    public void setIdTokenSigningAlgorithm(String algorithm) {
+        this.idTokenSigningAlgorithm = algorithm;
+    }
+
+    public ClientRegistry withIdTokenSigningAlgorithm(String algorithm) {
+        this.idTokenSigningAlgorithm = algorithm;
         return this;
     }
 }


### PR DESCRIPTION
- BAU: Add `IdTokenSigningAlgorithm` capability to `ClientRegistry`
- BAU: Grant token lambda access to RSA signing key
- BAU: Use RSA if client has chosen it and environment is RSA-enabled
