### PR TITLE
Firebreak 🔥  - Add classes to validate client_secret_basic and client_secret_post 

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ClientRegistry.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ClientRegistry.java
@@ -29,6 +29,8 @@ public class ClientRegistry {
     private List<String> claims = new ArrayList<>();
     private String clientType;
     private boolean identityVerificationSupported = false;
+    private String tokenAuthMethod;
+    private String clientSecret;
 
     private boolean oneLoginService = false;
     private String idTokenSigningAlgorithm = "ES256";
@@ -314,6 +316,34 @@ public class ClientRegistry {
 
     public ClientRegistry withIdTokenSigningAlgorithm(String algorithm) {
         this.idTokenSigningAlgorithm = algorithm;
+        return this;
+    }
+
+    @DynamoDbAttribute("TokenAuthMethod")
+    public String getTokenAuthMethod() {
+        return tokenAuthMethod;
+    }
+
+    public void setTokenAuthMethod(String tokenAuthMethod) {
+        this.tokenAuthMethod = tokenAuthMethod;
+    }
+
+    public ClientRegistry withTokenAuthMethod(String tokenAuthMethod) {
+        this.tokenAuthMethod = tokenAuthMethod;
+        return this;
+    }
+
+    @DynamoDbAttribute("ClientSecret")
+    public String getClientSecret() {
+        return clientSecret;
+    }
+
+    public void setClientSecret(String clientSecret) {
+        this.clientSecret = clientSecret;
+    }
+
+    public ClientRegistry withClientSecret(String clientSecret) {
+        this.clientSecret = clientSecret;
         return this;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/TokenAuthInvalidException.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/TokenAuthInvalidException.java
@@ -1,0 +1,34 @@
+package uk.gov.di.authentication.shared.exceptions;
+
+import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod;
+
+import static java.lang.String.format;
+
+public class TokenAuthInvalidException extends Exception {
+
+    private final ErrorObject errorObject;
+    private final String clientId;
+
+    public TokenAuthInvalidException(
+            ErrorObject errorObject,
+            ClientAuthenticationMethod clientAuthenticationMethod,
+            String clientID) {
+        super(
+                format(
+                        "Issue when validating %s for clientID: %s. Reason: %s",
+                        clientAuthenticationMethod.getValue(),
+                        clientID,
+                        errorObject.getDescription()));
+        this.errorObject = errorObject;
+        this.clientId = clientID;
+    }
+
+    public ErrorObject getErrorObject() {
+        return errorObject;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -175,6 +175,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return System.getenv().getOrDefault("HEADERS_CASE_INSENSITIVE", "false").equals("true");
     }
 
+    public boolean isClientSecretSupported() {
+        return List.of("build", "staging", "local").contains(getEnvironment());
+    }
+
     public boolean isIdentityEnabled() {
         return System.getenv().getOrDefault("IDENTITY_ENABLED", "false").equals("true");
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/validation/ClientSecretBasicClientAuthValidator.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/validation/ClientSecretBasicClientAuthValidator.java
@@ -1,0 +1,97 @@
+package uk.gov.di.authentication.shared.validation;
+
+import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.OAuth2Error;
+import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod;
+import com.nimbusds.oauth2.sdk.auth.ClientSecretBasic;
+import com.nimbusds.oauth2.sdk.auth.verifier.InvalidClientException;
+import uk.gov.di.authentication.shared.entity.ClientRegistry;
+import uk.gov.di.authentication.shared.exceptions.TokenAuthInvalidException;
+import uk.gov.di.authentication.shared.helpers.Argon2MatcherHelper;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.DynamoClientService;
+
+import java.util.Map;
+import java.util.Objects;
+
+import static uk.gov.di.authentication.shared.domain.RequestHeaders.AUTHORIZATION_HEADER;
+import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.addAnnotation;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.CLIENT_ID;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachLogFieldToLogs;
+import static uk.gov.di.authentication.shared.helpers.RequestHeaderHelper.getHeaderValueFromHeaders;
+
+public class ClientSecretBasicClientAuthValidator extends TokenClientAuthValidator {
+
+    private final ConfigurationService configurationService;
+
+    public ClientSecretBasicClientAuthValidator(
+            DynamoClientService dynamoClientService, ConfigurationService configurationService) {
+        super(dynamoClientService);
+        this.configurationService = configurationService;
+    }
+
+    @Override
+    public ClientRegistry validateTokenAuthAndReturnClientRegistryIfValid(
+            String requestBody, Map<String, String> requestHeaders)
+            throws TokenAuthInvalidException {
+        try {
+            LOG.info("Validating client_secret_basic");
+            var authorizationHeader =
+                    getHeaderValueFromHeaders(
+                            requestHeaders,
+                            AUTHORIZATION_HEADER,
+                            configurationService.getHeadersCaseInsensitive());
+            var clientSecretBasic = ClientSecretBasic.parse(authorizationHeader);
+            attachLogFieldToLogs(CLIENT_ID, clientSecretBasic.getClientID().getValue());
+            addAnnotation("client_id", clientSecretBasic.getClientID().getValue());
+            var clientRegistry = getClientRegistryFromTokenAuth(clientSecretBasic.getClientID());
+
+            if (Objects.isNull(clientRegistry.getTokenAuthMethod())
+                    || !clientRegistry
+                            .getTokenAuthMethod()
+                            .equals(ClientAuthenticationMethod.CLIENT_SECRET_BASIC.getValue())) {
+                LOG.warn("Client is not registered to use client_secret_basic");
+                throw new TokenAuthInvalidException(
+                        new ErrorObject(
+                                OAuth2Error.INVALID_CLIENT_CODE,
+                                "Client is not registered to use client_secret_basic"),
+                        ClientAuthenticationMethod.CLIENT_SECRET_BASIC,
+                        clientRegistry.getClientID());
+            }
+            if (Objects.isNull(clientRegistry.getClientSecret())) {
+                LOG.warn("No client secret registered for this client");
+                throw new TokenAuthInvalidException(
+                        new ErrorObject(
+                                OAuth2Error.INVALID_CLIENT_CODE, "No client secret registered"),
+                        ClientAuthenticationMethod.CLIENT_SECRET_BASIC,
+                        clientRegistry.getClientID());
+            }
+            var validSecret =
+                    Argon2MatcherHelper.matchRawStringWithEncoded(
+                            clientSecretBasic.getClientSecret().getValue(),
+                            clientRegistry.getClientSecret());
+            if (!validSecret) {
+                LOG.warn("Invalid Client Secret when validating for client_secret_basic");
+                throw new TokenAuthInvalidException(
+                        new ErrorObject(OAuth2Error.INVALID_CLIENT_CODE, "Invalid client secret"),
+                        ClientAuthenticationMethod.CLIENT_SECRET_BASIC,
+                        clientRegistry.getClientID());
+            }
+            LOG.info("client_secret_basic is valid");
+            return clientRegistry;
+        } catch (ParseException e) {
+            LOG.warn("Could not parse client_secret_basic");
+            throw new TokenAuthInvalidException(
+                    OAuth2Error.INVALID_REQUEST,
+                    ClientAuthenticationMethod.CLIENT_SECRET_BASIC,
+                    "unknown");
+        } catch (InvalidClientException e) {
+            LOG.warn("Invalid client_id in client_secret_basic");
+            throw new TokenAuthInvalidException(
+                    OAuth2Error.INVALID_CLIENT,
+                    ClientAuthenticationMethod.CLIENT_SECRET_BASIC,
+                    "unknown");
+        }
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/validation/ClientSecretPostClientAuthValidator.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/validation/ClientSecretPostClientAuthValidator.java
@@ -1,0 +1,84 @@
+package uk.gov.di.authentication.shared.validation;
+
+import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.OAuth2Error;
+import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod;
+import com.nimbusds.oauth2.sdk.auth.ClientSecretPost;
+import com.nimbusds.oauth2.sdk.auth.verifier.InvalidClientException;
+import uk.gov.di.authentication.shared.entity.ClientRegistry;
+import uk.gov.di.authentication.shared.exceptions.TokenAuthInvalidException;
+import uk.gov.di.authentication.shared.helpers.Argon2MatcherHelper;
+import uk.gov.di.authentication.shared.services.DynamoClientService;
+
+import java.util.Map;
+import java.util.Objects;
+
+import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.addAnnotation;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.CLIENT_ID;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachLogFieldToLogs;
+
+public class ClientSecretPostClientAuthValidator extends TokenClientAuthValidator {
+
+    public ClientSecretPostClientAuthValidator(DynamoClientService dynamoClientService) {
+        super(dynamoClientService);
+    }
+
+    @Override
+    public ClientRegistry validateTokenAuthAndReturnClientRegistryIfValid(
+            String requestBody, Map<String, String> requestHeaders)
+            throws TokenAuthInvalidException {
+        try {
+            LOG.info("Validating client_secret_post");
+            var clientSecretPost = ClientSecretPost.parse(requestBody);
+            attachLogFieldToLogs(CLIENT_ID, clientSecretPost.getClientID().getValue());
+            addAnnotation("client_id", clientSecretPost.getClientID().getValue());
+            var clientRegistry = getClientRegistryFromTokenAuth(clientSecretPost.getClientID());
+            if (Objects.isNull(clientRegistry.getTokenAuthMethod())
+                    || !clientRegistry
+                            .getTokenAuthMethod()
+                            .equals(ClientAuthenticationMethod.CLIENT_SECRET_POST.getValue())) {
+                LOG.warn("Client is not registered to use client_secret_post");
+                throw new TokenAuthInvalidException(
+                        new ErrorObject(
+                                OAuth2Error.INVALID_CLIENT_CODE,
+                                "Client is not registered to use client_secret_post"),
+                        ClientAuthenticationMethod.CLIENT_SECRET_POST,
+                        clientRegistry.getClientID());
+            }
+            if (Objects.isNull(clientRegistry.getClientSecret())) {
+                LOG.warn("No client secret registered for this client");
+                throw new TokenAuthInvalidException(
+                        new ErrorObject(
+                                OAuth2Error.INVALID_CLIENT_CODE, "No client secret registered"),
+                        ClientAuthenticationMethod.CLIENT_SECRET_POST,
+                        clientRegistry.getClientID());
+            }
+            var validSecret =
+                    Argon2MatcherHelper.matchRawStringWithEncoded(
+                            clientSecretPost.getClientSecret().getValue(),
+                            clientRegistry.getClientSecret());
+            if (!validSecret) {
+                LOG.warn("Invalid Client Secret when validating for client_secret_post");
+                throw new TokenAuthInvalidException(
+                        new ErrorObject(OAuth2Error.INVALID_CLIENT_CODE, "Invalid client secret"),
+                        ClientAuthenticationMethod.CLIENT_SECRET_POST,
+                        clientRegistry.getClientID());
+            }
+            LOG.info("client_secret_post is valid");
+            return clientRegistry;
+        } catch (InvalidClientException e) {
+            LOG.warn("Invalid Client when validating client_secret_post", e);
+            throw new TokenAuthInvalidException(
+                    OAuth2Error.INVALID_CLIENT,
+                    ClientAuthenticationMethod.CLIENT_SECRET_POST,
+                    "unknown");
+        } catch (ParseException e) {
+            LOG.warn("Could not parse client_secret_post");
+            throw new TokenAuthInvalidException(
+                    new ErrorObject(OAuth2Error.INVALID_REQUEST_CODE, "Invalid client secret"),
+                    ClientAuthenticationMethod.CLIENT_SECRET_POST,
+                    "unknown");
+        }
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/validation/PrivateKeyJwtClientAuthValidator.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/validation/PrivateKeyJwtClientAuthValidator.java
@@ -1,0 +1,169 @@
+package uk.gov.di.authentication.shared.validation;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.jwk.KeyType;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.jwt.util.DateUtils;
+import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.OAuth2Error;
+import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod;
+import com.nimbusds.oauth2.sdk.auth.PrivateKeyJWT;
+import com.nimbusds.oauth2.sdk.auth.Secret;
+import com.nimbusds.oauth2.sdk.auth.verifier.ClientAuthenticationVerifier;
+import com.nimbusds.oauth2.sdk.auth.verifier.ClientCredentialsSelector;
+import com.nimbusds.oauth2.sdk.auth.verifier.InvalidClientException;
+import com.nimbusds.oauth2.sdk.id.Audience;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import uk.gov.di.authentication.shared.entity.ClientRegistry;
+import uk.gov.di.authentication.shared.exceptions.TokenAuthInvalidException;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.DynamoClientService;
+
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static uk.gov.di.authentication.shared.helpers.ConstructUriHelper.buildURI;
+import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.addAnnotation;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.CLIENT_ID;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachLogFieldToLogs;
+
+public class PrivateKeyJwtClientAuthValidator extends TokenClientAuthValidator {
+
+    private final ConfigurationService configurationService;
+    private static final String TOKEN_PATH = "token";
+    private static final String UNKNOWN_CLIENT_ID = "unknown";
+
+    public PrivateKeyJwtClientAuthValidator(
+            DynamoClientService dynamoClientService, ConfigurationService configurationService) {
+        super(dynamoClientService);
+        this.configurationService = configurationService;
+    }
+
+    @Override
+    public ClientRegistry validateTokenAuthAndReturnClientRegistryIfValid(
+            String requestBody, Map<String, String> requestHeaders)
+            throws TokenAuthInvalidException {
+        try {
+            LOG.info("Validating private_key_jwt");
+            var privateKeyJWT = PrivateKeyJWT.parse(requestBody);
+            if (Objects.isNull(privateKeyJWT.getClientID())) {
+                LOG.warn("Invalid ClientID in PrivateKeyJWT");
+                throw new InvalidClientException("ClientID missing from PrivateKeyJWT");
+            }
+            var clientRegistry = getClientRegistryFromTokenAuth(privateKeyJWT.getClientID());
+            attachLogFieldToLogs(CLIENT_ID, clientRegistry.getClientID());
+            addAnnotation("client_id", clientRegistry.getClientID());
+            var tokenUrl =
+                    buildURI(configurationService.getOidcApiBaseURL().orElseThrow(), TOKEN_PATH)
+                            .toString();
+            if (Objects.nonNull(clientRegistry.getTokenAuthMethod())
+                    && !clientRegistry
+                            .getTokenAuthMethod()
+                            .equals(ClientAuthenticationMethod.PRIVATE_KEY_JWT.getValue())) {
+                LOG.warn("Client is not registered to use private_key_jwt");
+                throw new TokenAuthInvalidException(
+                        new ErrorObject(
+                                OAuth2Error.INVALID_CLIENT_CODE,
+                                "Client is not registered to use private_key_jwt"),
+                        ClientAuthenticationMethod.PRIVATE_KEY_JWT,
+                        clientRegistry.getClientID());
+            }
+            if (hasPrivateKeyJwtExpired(privateKeyJWT.getClientAssertion())) {
+                LOG.warn("private_key_jwt has expired");
+                throw new TokenAuthInvalidException(
+                        new ErrorObject(
+                                OAuth2Error.INVALID_GRANT_CODE, "private_key_jwt has expired"),
+                        ClientAuthenticationMethod.PRIVATE_KEY_JWT,
+                        clientRegistry.getClientID());
+            }
+            ClientAuthenticationVerifier<?> authenticationVerifier =
+                    new ClientAuthenticationVerifier<>(
+                            generateClientCredentialsSelector(clientRegistry.getPublicKey()),
+                            Collections.singleton(new Audience(tokenUrl)));
+            authenticationVerifier.verify(privateKeyJWT, null, null);
+            return clientRegistry;
+        } catch (InvalidClientException e) {
+            LOG.warn("Invalid client in private_kew_jwt", e);
+            throw new TokenAuthInvalidException(
+                    OAuth2Error.INVALID_CLIENT,
+                    ClientAuthenticationMethod.PRIVATE_KEY_JWT,
+                    UNKNOWN_CLIENT_ID);
+        } catch (JOSEException e) {
+            LOG.warn("Could not verify signature of private_key_jwt", e);
+            throw new TokenAuthInvalidException(
+                    new ErrorObject(
+                            OAuth2Error.INVALID_CLIENT_CODE,
+                            "Invalid signature in private_key_jwt"),
+                    ClientAuthenticationMethod.PRIVATE_KEY_JWT,
+                    UNKNOWN_CLIENT_ID);
+        } catch (ParseException e) {
+            LOG.warn("Unable to parse private_kew_jwt", e);
+            throw new TokenAuthInvalidException(
+                    new ErrorObject(OAuth2Error.INVALID_REQUEST_CODE, "Invalid private_key_jwt"),
+                    ClientAuthenticationMethod.PRIVATE_KEY_JWT,
+                    UNKNOWN_CLIENT_ID);
+        }
+    }
+
+    private boolean hasPrivateKeyJwtExpired(SignedJWT signedJWT) {
+        try {
+            JWTClaimsSet claimsSet = signedJWT.getJWTClaimsSet();
+            Date currentDateTime = NowHelper.now();
+            if (DateUtils.isBefore(claimsSet.getExpirationTime(), currentDateTime, 30)) {
+                LOG.warn(
+                        "private_key_jwt has expired. Expiration time: {}. Current time: {}",
+                        claimsSet.getExpirationTime(),
+                        currentDateTime);
+                return true;
+            }
+        } catch (java.text.ParseException e) {
+            LOG.warn("Unable to parse private_key_jwt when checking if expired", e);
+            return true;
+        }
+        return false;
+    }
+
+    private ClientCredentialsSelector<?> generateClientCredentialsSelector(String publicKey) {
+        return new ClientCredentialsSelector<>() {
+            @Override
+            public List<Secret> selectClientSecrets(
+                    ClientID claimedClientID,
+                    ClientAuthenticationMethod authMethod,
+                    com.nimbusds.oauth2.sdk.auth.verifier.Context context) {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public List<PublicKey> selectPublicKeys(
+                    ClientID claimedClientID,
+                    ClientAuthenticationMethod authMethod,
+                    JWSHeader jwsHeader,
+                    boolean forceRefresh,
+                    com.nimbusds.oauth2.sdk.auth.verifier.Context context) {
+
+                byte[] decodedKey = Base64.getMimeDecoder().decode(publicKey);
+                try {
+                    X509EncodedKeySpec x509publicKey = new X509EncodedKeySpec(decodedKey);
+                    KeyFactory kf = KeyFactory.getInstance(KeyType.RSA.getValue());
+                    return Collections.singletonList(kf.generatePublic(x509publicKey));
+                } catch (InvalidKeySpecException | NoSuchAlgorithmException e) {
+                    LOG.error("Exception when selecting public key", e);
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/validation/TokenClientAuthValidator.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/validation/TokenClientAuthValidator.java
@@ -1,0 +1,35 @@
+package uk.gov.di.authentication.shared.validation;
+
+import com.nimbusds.oauth2.sdk.auth.verifier.InvalidClientException;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.shared.entity.ClientRegistry;
+import uk.gov.di.authentication.shared.exceptions.TokenAuthInvalidException;
+import uk.gov.di.authentication.shared.services.DynamoClientService;
+
+import java.util.Map;
+
+public abstract class TokenClientAuthValidator {
+
+    protected final Logger LOG = LogManager.getLogger(this.getClass());
+    protected final DynamoClientService dynamoClientService;
+
+    protected TokenClientAuthValidator(DynamoClientService dynamoClientService) {
+        this.dynamoClientService = dynamoClientService;
+    }
+
+    public abstract ClientRegistry validateTokenAuthAndReturnClientRegistryIfValid(
+            String requestBody, Map<String, String> requestHeaders)
+            throws TokenAuthInvalidException;
+
+    protected ClientRegistry getClientRegistryFromTokenAuth(ClientID clientID)
+            throws InvalidClientException {
+        return dynamoClientService
+                .getClient(clientID.getValue())
+                .orElseThrow(
+                        () ->
+                                new InvalidClientException(
+                                        "Invalid ClientID: " + clientID.getValue()));
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/validation/TokenClientAuthValidatorFactory.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/validation/TokenClientAuthValidatorFactory.java
@@ -1,0 +1,61 @@
+package uk.gov.di.authentication.shared.validation;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.DynamoClientService;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import static uk.gov.di.authentication.shared.domain.RequestHeaders.AUTHORIZATION_HEADER;
+import static uk.gov.di.authentication.shared.helpers.RequestBodyHelper.parseRequestBody;
+import static uk.gov.di.authentication.shared.helpers.RequestHeaderHelper.getHeaderValueFromHeaders;
+
+public class TokenClientAuthValidatorFactory {
+
+    private final ConfigurationService configurationService;
+    private final DynamoClientService dynamoClientService;
+    private static final Logger LOG = LogManager.getLogger(TokenClientAuthValidatorFactory.class);
+
+    public TokenClientAuthValidatorFactory(
+            ConfigurationService configurationService, DynamoClientService dynamoClientService) {
+        this.configurationService = configurationService;
+        this.dynamoClientService = dynamoClientService;
+    }
+
+    public Optional<TokenClientAuthValidator> getTokenAuthenticationValidator(
+            String inputBody, Map<String, String> requestHeaders) {
+        LOG.info("Getting ClientAuthenticationMethod from request");
+        LOG.info("ClientSecretSupport: {}", configurationService.isClientSecretSupported());
+        var requestBody = parseRequestBody(inputBody);
+        if (requestBody.containsKey("client_assertion")
+                && requestBody.containsKey("client_assertion_type")) {
+            LOG.info("Client auth method is: private_key_jwt");
+            return Optional.of(
+                    new PrivateKeyJwtClientAuthValidator(
+                            dynamoClientService, configurationService));
+        }
+        if (requestBody.containsKey("client_secret")
+                && requestBody.containsKey("client_id")
+                && configurationService.isClientSecretSupported()) {
+            LOG.info("Client auth method is: client_secret_post");
+            return Optional.of(new ClientSecretPostClientAuthValidator(dynamoClientService));
+        }
+        var authorizationHeader =
+                getHeaderValueFromHeaders(
+                        requestHeaders,
+                        AUTHORIZATION_HEADER,
+                        configurationService.getHeadersCaseInsensitive());
+        if (Objects.nonNull(authorizationHeader)
+                && authorizationHeader.startsWith("Basic")
+                && configurationService.isClientSecretSupported()) {
+            LOG.info("Client auth method is: client_secret_basic");
+            return Optional.of(
+                    new ClientSecretBasicClientAuthValidator(
+                            dynamoClientService, configurationService));
+        }
+        return Optional.empty();
+    }
+}

--- a/shared/src/test/java/uk/gov/di/authentication/shared/validation/ClientSecretBasicClientAuthValidatorTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/validation/ClientSecretBasicClientAuthValidatorTest.java
@@ -1,0 +1,210 @@
+package uk.gov.di.authentication.shared.validation;
+
+import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.OAuth2Error;
+import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod;
+import com.nimbusds.oauth2.sdk.auth.ClientSecretBasic;
+import com.nimbusds.oauth2.sdk.auth.Secret;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.entity.ClientRegistry;
+import uk.gov.di.authentication.shared.exceptions.TokenAuthInvalidException;
+import uk.gov.di.authentication.shared.helpers.Argon2EncoderHelper;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.DynamoClientService;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.util.Collections.singletonList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ClientSecretBasicClientAuthValidatorTest {
+
+    private final DynamoClientService dynamoClientService = mock(DynamoClientService.class);
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private ClientSecretBasicClientAuthValidator clientSecretBasicClientAuthValidator;
+
+    private static final ClientID CLIENT_ID = new ClientID();
+    private static final Secret CLIENT_SECRET = new Secret();
+
+    @BeforeEach
+    void setUp() {
+        when(configurationService.getHeadersCaseInsensitive()).thenReturn(true);
+        clientSecretBasicClientAuthValidator =
+                new ClientSecretBasicClientAuthValidator(dynamoClientService, configurationService);
+    }
+
+    @Test
+    void shouldSuccessfullyValidateClientSecretBasicAndReturnClientRegistry()
+            throws TokenAuthInvalidException {
+        var expectedClientRegistry =
+                generateClientRegistry(
+                        ClientAuthenticationMethod.CLIENT_SECRET_BASIC.getValue(),
+                        Argon2EncoderHelper.argon2Hash(CLIENT_SECRET.getValue()));
+        when(dynamoClientService.getClient(CLIENT_ID.getValue()))
+                .thenReturn(Optional.of(expectedClientRegistry));
+        var clientSecretBasic = new ClientSecretBasic(CLIENT_ID, CLIENT_SECRET);
+
+        var clientRegistryOutput =
+                clientSecretBasicClientAuthValidator
+                        .validateTokenAuthAndReturnClientRegistryIfValid(
+                                null,
+                                Map.of(
+                                        "Authorization",
+                                        clientSecretBasic.toHTTPAuthorizationHeader()));
+
+        assertTrue(Objects.nonNull(clientRegistryOutput));
+        assertThat(
+                clientRegistryOutput.getClientID(), equalTo(expectedClientRegistry.getClientID()));
+    }
+
+    @Test
+    void shouldThrowIfClientIsNotFoundInClientRegistry() {
+        var clientSecretBasic = new ClientSecretBasic(CLIENT_ID, CLIENT_SECRET);
+
+        TokenAuthInvalidException tokenAuthInvalidException =
+                assertThrows(
+                        TokenAuthInvalidException.class,
+                        () ->
+                                clientSecretBasicClientAuthValidator
+                                        .validateTokenAuthAndReturnClientRegistryIfValid(
+                                                null,
+                                                Map.of(
+                                                        "Authorization",
+                                                        clientSecretBasic
+                                                                .toHTTPAuthorizationHeader())),
+                        "Expected to throw exception");
+
+        assertThat(tokenAuthInvalidException.getClientId(), equalTo("unknown"));
+        assertThat(tokenAuthInvalidException.getErrorObject(), equalTo(OAuth2Error.INVALID_CLIENT));
+    }
+
+    @Test
+    void shouldThrowIfClientRegistryDoesNotSupportClientSecretBasic() {
+        var expectedClientRegistry =
+                generateClientRegistry(
+                        null, Argon2EncoderHelper.argon2Hash(CLIENT_SECRET.getValue()));
+        when(dynamoClientService.getClient(CLIENT_ID.getValue()))
+                .thenReturn(Optional.of(expectedClientRegistry));
+        var clientSecretBasic = new ClientSecretBasic(CLIENT_ID, CLIENT_SECRET);
+
+        var tokenAuthInvalidException =
+                assertThrows(
+                        TokenAuthInvalidException.class,
+                        () ->
+                                clientSecretBasicClientAuthValidator
+                                        .validateTokenAuthAndReturnClientRegistryIfValid(
+                                                null,
+                                                Map.of(
+                                                        "Authorization",
+                                                        clientSecretBasic
+                                                                .toHTTPAuthorizationHeader())),
+                        "Expected to throw exception");
+
+        assertThat(tokenAuthInvalidException.getClientId(), equalTo(CLIENT_ID.getValue()));
+        assertThat(
+                tokenAuthInvalidException.getErrorObject(),
+                equalTo(
+                        new ErrorObject(
+                                OAuth2Error.INVALID_CLIENT_CODE,
+                                "Client is not registered to use client_secret_basic")));
+    }
+
+    @Test
+    void shouldThrowIfNoClientSecretIsRegisteredWhenValidatingClientSecretBasic() {
+        var expectedClientRegistry =
+                generateClientRegistry(
+                        ClientAuthenticationMethod.CLIENT_SECRET_BASIC.getValue(), null);
+        when(dynamoClientService.getClient(CLIENT_ID.getValue()))
+                .thenReturn(Optional.of(expectedClientRegistry));
+        var clientSecretBasic = new ClientSecretBasic(CLIENT_ID, CLIENT_SECRET);
+
+        var tokenAuthInvalidException =
+                assertThrows(
+                        TokenAuthInvalidException.class,
+                        () ->
+                                clientSecretBasicClientAuthValidator
+                                        .validateTokenAuthAndReturnClientRegistryIfValid(
+                                                null,
+                                                Map.of(
+                                                        "Authorization",
+                                                        clientSecretBasic
+                                                                .toHTTPAuthorizationHeader())),
+                        "Expected to throw exception");
+
+        assertThat(tokenAuthInvalidException.getClientId(), equalTo(CLIENT_ID.getValue()));
+        assertThat(
+                tokenAuthInvalidException.getErrorObject(),
+                equalTo(
+                        new ErrorObject(
+                                OAuth2Error.INVALID_CLIENT_CODE, "No client secret registered")));
+    }
+
+    @Test
+    void shouldThrowIfClientSecretIsInvalidWhenValidatingClientSecretBasic() {
+        var expectedClientRegistry =
+                generateClientRegistry(
+                        ClientAuthenticationMethod.CLIENT_SECRET_BASIC.getValue(),
+                        Argon2EncoderHelper.argon2Hash(new Secret().getValue()));
+        when(dynamoClientService.getClient(CLIENT_ID.getValue()))
+                .thenReturn(Optional.of(expectedClientRegistry));
+        var clientSecretBasic = new ClientSecretBasic(CLIENT_ID, CLIENT_SECRET);
+
+        var tokenAuthInvalidException =
+                assertThrows(
+                        TokenAuthInvalidException.class,
+                        () ->
+                                clientSecretBasicClientAuthValidator
+                                        .validateTokenAuthAndReturnClientRegistryIfValid(
+                                                null,
+                                                Map.of(
+                                                        "Authorization",
+                                                        clientSecretBasic
+                                                                .toHTTPAuthorizationHeader())),
+                        "Expected to throw exception");
+
+        assertThat(tokenAuthInvalidException.getClientId(), equalTo(CLIENT_ID.getValue()));
+        assertThat(
+                tokenAuthInvalidException.getErrorObject(),
+                equalTo(new ErrorObject(OAuth2Error.INVALID_CLIENT_CODE, "Invalid client secret")));
+    }
+
+    @Test
+    void shouldThrowWhenUnableToParseClientSecretBasic() {
+        var tokenAuthInvalidException =
+                assertThrows(
+                        TokenAuthInvalidException.class,
+                        () ->
+                                clientSecretBasicClientAuthValidator
+                                        .validateTokenAuthAndReturnClientRegistryIfValid(
+                                                null,
+                                                Map.of(
+                                                        "Authorization",
+                                                        "rubbish-client-secret-basic")),
+                        "Expected to throw exception");
+
+        assertThat(tokenAuthInvalidException.getClientId(), equalTo("unknown"));
+        assertThat(
+                tokenAuthInvalidException.getErrorObject(), equalTo(OAuth2Error.INVALID_REQUEST));
+    }
+
+    private ClientRegistry generateClientRegistry(String tokenAuthMethod, String clientSecret) {
+        return new ClientRegistry()
+                .withRedirectUrls(singletonList("https://localhost:8080"))
+                .withClientID(CLIENT_ID.getValue())
+                .withContacts(singletonList("joe.bloggs@digital.cabinet-office.gov.uk"))
+                .withPublicKey(null)
+                .withScopes(singletonList("openid"))
+                .withCookieConsentShared(true)
+                .withTokenAuthMethod(tokenAuthMethod)
+                .withClientSecret(clientSecret);
+    }
+}

--- a/shared/src/test/java/uk/gov/di/authentication/shared/validation/ClientSecretPostClientAuthValidatorTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/validation/ClientSecretPostClientAuthValidatorTest.java
@@ -1,0 +1,190 @@
+package uk.gov.di.authentication.shared.validation;
+
+import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.OAuth2Error;
+import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod;
+import com.nimbusds.oauth2.sdk.auth.ClientSecretPost;
+import com.nimbusds.oauth2.sdk.auth.Secret;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.util.URLUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.entity.ClientRegistry;
+import uk.gov.di.authentication.shared.exceptions.TokenAuthInvalidException;
+import uk.gov.di.authentication.shared.helpers.Argon2EncoderHelper;
+import uk.gov.di.authentication.shared.services.DynamoClientService;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ClientSecretPostClientAuthValidatorTest {
+
+    private final DynamoClientService dynamoClientService = mock(DynamoClientService.class);
+    private ClientSecretPostClientAuthValidator clientSecretPostClientAuthValidator;
+
+    private static final ClientID CLIENT_ID = new ClientID();
+    private static final Secret CLIENT_SECRET = new Secret();
+
+    @BeforeEach
+    void setUp() {
+        clientSecretPostClientAuthValidator =
+                new ClientSecretPostClientAuthValidator(dynamoClientService);
+    }
+
+    @Test
+    void shouldSuccessfullyValidateClientSecretPostAndReturnClientRegistry()
+            throws TokenAuthInvalidException {
+        var expectedClientRegistry =
+                generateClientRegistry(
+                        ClientAuthenticationMethod.CLIENT_SECRET_POST.getValue(),
+                        Argon2EncoderHelper.argon2Hash(CLIENT_SECRET.getValue()));
+        when(dynamoClientService.getClient(CLIENT_ID.getValue()))
+                .thenReturn(Optional.of(expectedClientRegistry));
+        var clientSecretPost = new ClientSecretPost(CLIENT_ID, CLIENT_SECRET);
+        var requestString = URLUtils.serializeParameters(clientSecretPost.toParameters());
+
+        var clientRegistryOutput =
+                clientSecretPostClientAuthValidator.validateTokenAuthAndReturnClientRegistryIfValid(
+                        requestString, emptyMap());
+
+        assertTrue(Objects.nonNull(clientRegistryOutput));
+        assertThat(
+                clientRegistryOutput.getClientID(), equalTo(expectedClientRegistry.getClientID()));
+    }
+
+    @Test
+    void shouldThrowIfClientIsNotFoundInClientRegistry() {
+        var clientSecretPost = new ClientSecretPost(CLIENT_ID, CLIENT_SECRET);
+        var requestString = URLUtils.serializeParameters(clientSecretPost.toParameters());
+
+        TokenAuthInvalidException tokenAuthInvalidException =
+                assertThrows(
+                        TokenAuthInvalidException.class,
+                        () ->
+                                clientSecretPostClientAuthValidator
+                                        .validateTokenAuthAndReturnClientRegistryIfValid(
+                                                requestString, emptyMap()),
+                        "Expected to throw exception");
+
+        assertThat(tokenAuthInvalidException.getClientId(), equalTo("unknown"));
+        assertThat(tokenAuthInvalidException.getErrorObject(), equalTo(OAuth2Error.INVALID_CLIENT));
+    }
+
+    @Test
+    void shouldThrowIfClientRegistryDoesNotSupportClientSecretPost() {
+        var expectedClientRegistry =
+                generateClientRegistry(
+                        null, Argon2EncoderHelper.argon2Hash(CLIENT_SECRET.getValue()));
+        when(dynamoClientService.getClient(CLIENT_ID.getValue()))
+                .thenReturn(Optional.of(expectedClientRegistry));
+        var clientSecretPost = new ClientSecretPost(CLIENT_ID, CLIENT_SECRET);
+        var requestString = URLUtils.serializeParameters(clientSecretPost.toParameters());
+
+        var tokenAuthInvalidException =
+                assertThrows(
+                        TokenAuthInvalidException.class,
+                        () ->
+                                clientSecretPostClientAuthValidator
+                                        .validateTokenAuthAndReturnClientRegistryIfValid(
+                                                requestString, emptyMap()),
+                        "Expected to throw exception");
+
+        assertThat(tokenAuthInvalidException.getClientId(), equalTo(CLIENT_ID.getValue()));
+        assertThat(
+                tokenAuthInvalidException.getErrorObject(),
+                equalTo(
+                        new ErrorObject(
+                                OAuth2Error.INVALID_CLIENT_CODE,
+                                "Client is not registered to use client_secret_basic")));
+    }
+
+    @Test
+    void shouldThrowIfNoClientSecretIsRegisteredWhenValidatingClientSecretPost() {
+        var expectedClientRegistry =
+                generateClientRegistry(
+                        ClientAuthenticationMethod.CLIENT_SECRET_POST.getValue(), null);
+        when(dynamoClientService.getClient(CLIENT_ID.getValue()))
+                .thenReturn(Optional.of(expectedClientRegistry));
+        var clientSecretPost = new ClientSecretPost(CLIENT_ID, CLIENT_SECRET);
+        var requestString = URLUtils.serializeParameters(clientSecretPost.toParameters());
+
+        var tokenAuthInvalidException =
+                assertThrows(
+                        TokenAuthInvalidException.class,
+                        () ->
+                                clientSecretPostClientAuthValidator
+                                        .validateTokenAuthAndReturnClientRegistryIfValid(
+                                                requestString, emptyMap()),
+                        "Expected to throw exception");
+
+        assertThat(tokenAuthInvalidException.getClientId(), equalTo(CLIENT_ID.getValue()));
+        assertThat(
+                tokenAuthInvalidException.getErrorObject(),
+                equalTo(
+                        new ErrorObject(
+                                OAuth2Error.INVALID_CLIENT_CODE, "No client secret registered")));
+    }
+
+    @Test
+    void shouldThrowIfClientSecretIsInvalidWhenValidatingClientSecretPost() {
+        var expectedClientRegistry =
+                generateClientRegistry(
+                        ClientAuthenticationMethod.CLIENT_SECRET_POST.getValue(),
+                        Argon2EncoderHelper.argon2Hash(new Secret().getValue()));
+        when(dynamoClientService.getClient(CLIENT_ID.getValue()))
+                .thenReturn(Optional.of(expectedClientRegistry));
+        var clientSecretPost = new ClientSecretPost(CLIENT_ID, CLIENT_SECRET);
+        var requestString = URLUtils.serializeParameters(clientSecretPost.toParameters());
+
+        var tokenAuthInvalidException =
+                assertThrows(
+                        TokenAuthInvalidException.class,
+                        () ->
+                                clientSecretPostClientAuthValidator
+                                        .validateTokenAuthAndReturnClientRegistryIfValid(
+                                                requestString, emptyMap()),
+                        "Expected to throw exception");
+
+        assertThat(tokenAuthInvalidException.getClientId(), equalTo(CLIENT_ID.getValue()));
+        assertThat(
+                tokenAuthInvalidException.getErrorObject(),
+                equalTo(new ErrorObject(OAuth2Error.INVALID_CLIENT_CODE, "Invalid client secret")));
+    }
+
+    @Test
+    void shouldThrowWhenUnableToParseClientSecretPost() {
+        var tokenAuthInvalidException =
+                assertThrows(
+                        TokenAuthInvalidException.class,
+                        () ->
+                                clientSecretPostClientAuthValidator
+                                        .validateTokenAuthAndReturnClientRegistryIfValid(
+                                                "rubbish-client-secret-post", emptyMap()),
+                        "Expected to throw exception");
+
+        assertThat(tokenAuthInvalidException.getClientId(), equalTo("unknown"));
+        assertThat(
+                tokenAuthInvalidException.getErrorObject(), equalTo(OAuth2Error.INVALID_REQUEST));
+    }
+
+    private ClientRegistry generateClientRegistry(String tokenAuthMethod, String clientSecret) {
+        return new ClientRegistry()
+                .withRedirectUrls(singletonList("https://localhost:8080"))
+                .withClientID(CLIENT_ID.getValue())
+                .withContacts(singletonList("joe.bloggs@digital.cabinet-office.gov.uk"))
+                .withPublicKey(null)
+                .withScopes(singletonList("openid"))
+                .withCookieConsentShared(true)
+                .withTokenAuthMethod(tokenAuthMethod)
+                .withClientSecret(clientSecret);
+    }
+}

--- a/shared/src/test/java/uk/gov/di/authentication/shared/validation/PrivateKeyJwtClientAuthValidatorTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/validation/PrivateKeyJwtClientAuthValidatorTest.java
@@ -1,0 +1,231 @@
+package uk.gov.di.authentication.shared.validation;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.OAuth2Error;
+import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod;
+import com.nimbusds.oauth2.sdk.auth.JWTAuthenticationClaimsSet;
+import com.nimbusds.oauth2.sdk.auth.PrivateKeyJWT;
+import com.nimbusds.oauth2.sdk.id.Audience;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.util.URLUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import uk.gov.di.authentication.shared.entity.ClientRegistry;
+import uk.gov.di.authentication.shared.exceptions.TokenAuthInvalidException;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.DynamoClientService;
+import uk.gov.di.authentication.sharedtest.helper.KeyPairHelper;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.time.temporal.ChronoUnit;
+import java.util.Base64;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.shared.helpers.ConstructUriHelper.buildURI;
+
+class PrivateKeyJwtClientAuthValidatorTest {
+
+    private final DynamoClientService dynamoClientService = mock(DynamoClientService.class);
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private static final String OIDC_BASE_URL = "https://example.com";
+    private static final ClientID CLIENT_ID = new ClientID();
+    private static final KeyPair RSA_KEY_PAIR = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
+    private PrivateKeyJwtClientAuthValidator privateKeyJwtClientAuthValidator;
+
+    @BeforeEach
+    void setUp() {
+        privateKeyJwtClientAuthValidator =
+                new PrivateKeyJwtClientAuthValidator(dynamoClientService, configurationService);
+        when(configurationService.getOidcApiBaseURL()).thenReturn(Optional.of(OIDC_BASE_URL));
+    }
+
+    private static Stream<JWSAlgorithm> supportedAlgorithms() {
+        return Stream.of(
+                JWSAlgorithm.RS256,
+                JWSAlgorithm.RS384,
+                JWSAlgorithm.RS512,
+                JWSAlgorithm.PS256,
+                JWSAlgorithm.PS384,
+                JWSAlgorithm.PS512);
+    }
+
+    @ParameterizedTest
+    @MethodSource("supportedAlgorithms")
+    void shouldSuccessfullyValidatePrivateKeyJWT(JWSAlgorithm algorithm)
+            throws JOSEException, TokenAuthInvalidException {
+        var publicKey =
+                Base64.getMimeEncoder().encodeToString(RSA_KEY_PAIR.getPublic().getEncoded());
+        var expiryDate = NowHelper.nowPlus(5, ChronoUnit.MINUTES);
+        var expectedClientRegistry =
+                generateClientRegistry(
+                        publicKey, ClientAuthenticationMethod.PRIVATE_KEY_JWT.getValue());
+        var requestString = generateSerialisedPrivateKeyJWT(algorithm, expiryDate.getTime());
+        when(dynamoClientService.getClient(CLIENT_ID.getValue()))
+                .thenReturn(Optional.of(expectedClientRegistry));
+
+        var clientRegistryOutput =
+                privateKeyJwtClientAuthValidator.validateTokenAuthAndReturnClientRegistryIfValid(
+                        requestString, emptyMap());
+
+        assertThat(
+                clientRegistryOutput.getClientID(), equalTo(expectedClientRegistry.getClientID()));
+    }
+
+    @Test
+    void shouldSuccessfullyValidatePrivateKeyJWTWhenAuthenticationIsNotRegisteredInClientRegistry()
+            throws JOSEException, TokenAuthInvalidException {
+        var publicKey =
+                Base64.getMimeEncoder().encodeToString(RSA_KEY_PAIR.getPublic().getEncoded());
+        var expiryDate = NowHelper.nowPlus(5, ChronoUnit.MINUTES);
+        var expectedClientRegistry = generateClientRegistry(publicKey, null);
+        var requestString =
+                generateSerialisedPrivateKeyJWT(JWSAlgorithm.RS256, expiryDate.getTime());
+        when(dynamoClientService.getClient(CLIENT_ID.getValue()))
+                .thenReturn(Optional.of(expectedClientRegistry));
+
+        var clientRegistryOutput =
+                privateKeyJwtClientAuthValidator.validateTokenAuthAndReturnClientRegistryIfValid(
+                        requestString, emptyMap());
+
+        assertThat(
+                clientRegistryOutput.getClientID(), equalTo(expectedClientRegistry.getClientID()));
+    }
+
+    @Test
+    void shouldThrowClientsAuthenticationMethodIsClientSecretPost() throws JOSEException {
+        var publicKey =
+                Base64.getMimeEncoder().encodeToString(RSA_KEY_PAIR.getPublic().getEncoded());
+        var expectedClientRegistry =
+                generateClientRegistry(
+                        publicKey, ClientAuthenticationMethod.CLIENT_SECRET_POST.getValue());
+        when(dynamoClientService.getClient(CLIENT_ID.getValue()))
+                .thenReturn(Optional.of(expectedClientRegistry));
+        var requestString =
+                generateSerialisedPrivateKeyJWT(
+                        JWSAlgorithm.RS256, NowHelper.nowMinus(2, ChronoUnit.MINUTES).getTime());
+
+        TokenAuthInvalidException tokenAuthInvalidException =
+                assertThrows(
+                        TokenAuthInvalidException.class,
+                        () ->
+                                privateKeyJwtClientAuthValidator
+                                        .validateTokenAuthAndReturnClientRegistryIfValid(
+                                                requestString, emptyMap()),
+                        "Expected to throw exception");
+
+        assertThat(tokenAuthInvalidException.getClientId(), equalTo(CLIENT_ID.getValue()));
+        assertThat(
+                tokenAuthInvalidException.getErrorObject(),
+                equalTo(
+                        new ErrorObject(
+                                OAuth2Error.INVALID_CLIENT_CODE,
+                                "Client is not registered to use private_key_jwt")));
+    }
+
+    @Test
+    void shouldThrowWhenUnableToValidatePrivateKeyJWTIfExpired() throws JOSEException {
+        var publicKey =
+                Base64.getMimeEncoder().encodeToString(RSA_KEY_PAIR.getPublic().getEncoded());
+        var expectedClientRegistry = generateClientRegistry(publicKey, null);
+        when(dynamoClientService.getClient(CLIENT_ID.getValue()))
+                .thenReturn(Optional.of(expectedClientRegistry));
+        var requestString =
+                generateSerialisedPrivateKeyJWT(
+                        JWSAlgorithm.RS256, NowHelper.nowMinus(2, ChronoUnit.MINUTES).getTime());
+
+        TokenAuthInvalidException tokenAuthInvalidException =
+                assertThrows(
+                        TokenAuthInvalidException.class,
+                        () ->
+                                privateKeyJwtClientAuthValidator
+                                        .validateTokenAuthAndReturnClientRegistryIfValid(
+                                                requestString, emptyMap()),
+                        "Expected to throw exception");
+
+        assertThat(tokenAuthInvalidException.getClientId(), equalTo(CLIENT_ID.getValue()));
+        assertThat(
+                tokenAuthInvalidException.getErrorObject(),
+                equalTo(
+                        new ErrorObject(
+                                OAuth2Error.INVALID_GRANT_CODE, "private_key_jwt has expired")));
+    }
+
+    @Test
+    void shouldThrowIfUnableToValidatePrivateKeyJWTSignature() throws JOSEException {
+        var invalidKeyPair = generateRsaKeyPair();
+        var publicKey =
+                Base64.getMimeEncoder().encodeToString(invalidKeyPair.getPublic().getEncoded());
+        var expectedClientRegistry = generateClientRegistry(publicKey, null);
+        when(dynamoClientService.getClient(CLIENT_ID.getValue()))
+                .thenReturn(Optional.of(expectedClientRegistry));
+        var requestString =
+                generateSerialisedPrivateKeyJWT(
+                        JWSAlgorithm.RS256, NowHelper.nowPlus(5, ChronoUnit.MINUTES).getTime());
+
+        TokenAuthInvalidException tokenAuthInvalidException =
+                assertThrows(
+                        TokenAuthInvalidException.class,
+                        () ->
+                                privateKeyJwtClientAuthValidator
+                                        .validateTokenAuthAndReturnClientRegistryIfValid(
+                                                requestString, emptyMap()),
+                        "Expected to throw exception");
+
+        assertThat(tokenAuthInvalidException.getClientId(), equalTo("unknown"));
+        assertThat(
+                tokenAuthInvalidException.getErrorObject(),
+                equalTo(
+                        new ErrorObject(
+                                OAuth2Error.INVALID_CLIENT_CODE,
+                                "Invalid signature in private_key_jwt")));
+    }
+
+    private ClientRegistry generateClientRegistry(String publicKey, String authenticationMethod) {
+        return new ClientRegistry()
+                .withRedirectUrls(singletonList("https://localhost:8080"))
+                .withClientID(CLIENT_ID.getValue())
+                .withContacts(singletonList("joe.bloggs@digital.cabinet-office.gov.uk"))
+                .withPublicKey(publicKey)
+                .withScopes(singletonList("openid"))
+                .withCookieConsentShared(true)
+                .withTokenAuthMethod(authenticationMethod);
+    }
+
+    private String generateSerialisedPrivateKeyJWT(JWSAlgorithm algorithm, long expiryTime)
+            throws JOSEException {
+        var claimsSet =
+                new JWTAuthenticationClaimsSet(
+                        CLIENT_ID, new Audience(buildURI(OIDC_BASE_URL, "token")));
+        claimsSet.getExpirationTime().setTime(expiryTime);
+        var privateKeyJWT =
+                new PrivateKeyJWT(claimsSet, algorithm, RSA_KEY_PAIR.getPrivate(), null, null);
+        var privateKeyParams = privateKeyJWT.toParameters();
+        return URLUtils.serializeParameters(privateKeyParams);
+    }
+
+    private KeyPair generateRsaKeyPair() {
+        KeyPairGenerator kpg;
+        try {
+            kpg = KeyPairGenerator.getInstance("RSA");
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+        kpg.initialize(2048);
+        return kpg.generateKeyPair();
+    }
+}

--- a/shared/src/test/java/uk/gov/di/authentication/shared/validation/TokenClientAuthValidatorFactoryTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/validation/TokenClientAuthValidatorFactoryTest.java
@@ -1,0 +1,115 @@
+package uk.gov.di.authentication.shared.validation;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.oauth2.sdk.auth.ClientSecretBasic;
+import com.nimbusds.oauth2.sdk.auth.ClientSecretPost;
+import com.nimbusds.oauth2.sdk.auth.JWTAuthenticationClaimsSet;
+import com.nimbusds.oauth2.sdk.auth.PrivateKeyJWT;
+import com.nimbusds.oauth2.sdk.auth.Secret;
+import com.nimbusds.oauth2.sdk.id.Audience;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.util.URLUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.DynamoClientService;
+import uk.gov.di.authentication.sharedtest.helper.KeyPairHelper;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Collections.emptyMap;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class TokenClientAuthValidatorFactoryTest {
+
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private final DynamoClientService dynamoClientService = mock(DynamoClientService.class);
+    private static final ClientID CLIENT_ID = new ClientID();
+    private static final Secret CLIENT_SECRET = new Secret();
+    private final TokenClientAuthValidatorFactory tokenClientAuthValidatorFactory =
+            new TokenClientAuthValidatorFactory(configurationService, dynamoClientService);
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldReturnPrivateKeyJwtClientAuthValidator(boolean clientSecretSupported)
+            throws JOSEException {
+        when(configurationService.isClientSecretSupported()).thenReturn(clientSecretSupported);
+        var claimsSet =
+                new JWTAuthenticationClaimsSet(new ClientID(), new Audience("https://oidc/token"));
+        var privateKeyJWT =
+                new PrivateKeyJWT(
+                        claimsSet,
+                        JWSAlgorithm.RS256,
+                        KeyPairHelper.GENERATE_RSA_KEY_PAIR().getPrivate(),
+                        null,
+                        null);
+
+        var tokenAuthenticationValidator =
+                tokenClientAuthValidatorFactory.getTokenAuthenticationValidator(
+                        URLUtils.serializeParameters(privateKeyJWT.toParameters()), emptyMap());
+
+        assertInstanceOf(
+                PrivateKeyJwtClientAuthValidator.class, tokenAuthenticationValidator.get());
+    }
+
+    @Test
+    void shouldReturnClientSecretBasicClientAuthValidator() {
+        when(configurationService.isClientSecretSupported()).thenReturn(true);
+        var clientSecretBasic = new ClientSecretBasic(CLIENT_ID, CLIENT_SECRET);
+
+        var tokenAuthenticationValidator =
+                tokenClientAuthValidatorFactory.getTokenAuthenticationValidator(
+                        null,
+                        Map.of("Authorization", clientSecretBasic.toHTTPAuthorizationHeader()));
+
+        assertInstanceOf(
+                ClientSecretBasicClientAuthValidator.class, tokenAuthenticationValidator.get());
+    }
+
+    @Test
+    void shouldReturnClientSecretPostClientAuthValidator() {
+        when(configurationService.isClientSecretSupported()).thenReturn(true);
+        var clientSecretPost = new ClientSecretPost(CLIENT_ID, CLIENT_SECRET);
+        var requestString = URLUtils.serializeParameters(clientSecretPost.toParameters());
+
+        var tokenAuthenticationValidator =
+                tokenClientAuthValidatorFactory.getTokenAuthenticationValidator(
+                        requestString, emptyMap());
+
+        assertInstanceOf(
+                ClientSecretPostClientAuthValidator.class, tokenAuthenticationValidator.get());
+    }
+
+    @Test
+    void shouldReturnEmptyWhenClientSecretBasicButIsNotYetSupported() {
+        when(configurationService.isClientSecretSupported()).thenReturn(false);
+        var clientSecretBasic = new ClientSecretBasic(CLIENT_ID, CLIENT_SECRET);
+
+        var tokenAuthenticationValidator =
+                tokenClientAuthValidatorFactory.getTokenAuthenticationValidator(
+                        null,
+                        Map.of("Authorization", clientSecretBasic.toHTTPAuthorizationHeader()));
+
+        assertThat(tokenAuthenticationValidator, equalTo(Optional.empty()));
+    }
+
+    @Test
+    void shouldReturnEmptyWhenClientSecretPostButIsNotYetSupported() {
+        when(configurationService.isClientSecretSupported()).thenReturn(false);
+        var clientSecretPost = new ClientSecretPost(CLIENT_ID, CLIENT_SECRET);
+        var requestString = URLUtils.serializeParameters(clientSecretPost.toParameters());
+
+        var tokenAuthenticationValidator =
+                tokenClientAuthValidatorFactory.getTokenAuthenticationValidator(
+                        requestString, emptyMap());
+
+        assertThat(tokenAuthenticationValidator, equalTo(Optional.empty()));
+    }
+}


### PR DESCRIPTION
## What?

- Add additional fields to the client registry to allow us to determine the clients authentication method and the client secret. Is the client authentication method is null, we can assume it is private_key_jwt 
- Add additional classes to validate client_secret_post and client_secret_basic and ensure that for now we only support client_secret_post and client_secret_basic in local, build and staging environments
- These classes are not yet used by the **token endpoint** but this is to break down the size of the PR and to split out the validation

## Why?

- We want to start supporting client_secret_post and client_secret_basic for RPs that are using 3rd parties which don't support the use of the private_key_jwt
- Create a factory class to calculate what client authentication method is used for the token endpoint based on what is in the request.
- Create a validation class for each authentication type which will either successfully validate the token authentication method and return the client registry or throw an exception which will return an error to the RP.
