### PR TITLE
Firebreak 🔥  - Give /token the ability to support client_secret_basic and client_secret_post

### DIFF
--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandler.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandler.java
@@ -5,6 +5,7 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
+import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod;
 import org.apache.commons.validator.routines.UrlValidator;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -122,7 +123,9 @@ public class ClientRegistrationHandler
                     !clientRegistrationRequest.isIdentityVerificationRequired(),
                     clientRegistrationRequest.getClaims(),
                     clientRegistrationRequest.getClientType(),
-                    clientRegistrationRequest.isIdentityVerificationRequired());
+                    clientRegistrationRequest.isIdentityVerificationRequired(),
+                    null,
+                    ClientAuthenticationMethod.PRIVATE_KEY_JWT.getValue());
 
             var clientRegistrationResponse =
                     new ClientRegistrationResponse(

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandlerTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandlerTest.java
@@ -4,6 +4,7 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
+import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod;
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -118,7 +119,9 @@ class ClientRegistrationHandlerTest {
                         true,
                         emptyList(),
                         ClientType.WEB.getValue(),
-                        false);
+                        false,
+                        null,
+                        ClientAuthenticationMethod.PRIVATE_KEY_JWT.getValue());
     }
 
     @Test
@@ -159,7 +162,9 @@ class ClientRegistrationHandlerTest {
                         false,
                         emptyList(),
                         ClientType.WEB.getValue(),
-                        true);
+                        true,
+                        null,
+                        ClientAuthenticationMethod.PRIVATE_KEY_JWT.getValue());
     }
 
     @Test
@@ -192,7 +197,9 @@ class ClientRegistrationHandlerTest {
                         true,
                         emptyList(),
                         ClientType.WEB.getValue(),
-                        false);
+                        false,
+                        null,
+                        ClientAuthenticationMethod.PRIVATE_KEY_JWT.getValue());
     }
 
     @Test

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/ClientStoreExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/ClientStoreExtension.java
@@ -1,5 +1,6 @@
 package uk.gov.di.authentication.sharedtest.extensions;
 
+import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
@@ -100,6 +101,43 @@ public class ClientStoreExtension extends DynamoExtension implements AfterEachCa
             String subjectType,
             boolean consentRequired,
             ClientType clientType,
+            boolean identityVerificationSupported,
+            String clientSecret,
+            String clientAuthMethod) {
+        dynamoClientService.addClient(
+                clientID,
+                clientName,
+                redirectUris,
+                contacts,
+                scopes,
+                publicKey,
+                postLogoutRedirectUris,
+                backChannelLogoutUri,
+                serviceType,
+                sectorIdentifierUri,
+                subjectType,
+                consentRequired,
+                Collections.emptyList(),
+                clientType.getValue(),
+                identityVerificationSupported,
+                clientSecret,
+                clientAuthMethod);
+    }
+
+    public void registerClient(
+            String clientID,
+            String clientName,
+            List<String> redirectUris,
+            List<String> contacts,
+            List<String> scopes,
+            String publicKey,
+            List<String> postLogoutRedirectUris,
+            String backChannelLogoutUri,
+            String serviceType,
+            String sectorIdentifierUri,
+            String subjectType,
+            boolean consentRequired,
+            ClientType clientType,
             boolean identityVerificationSupported) {
         dynamoClientService.addClient(
                 clientID,
@@ -116,7 +154,9 @@ public class ClientStoreExtension extends DynamoExtension implements AfterEachCa
                 consentRequired,
                 Collections.emptyList(),
                 clientType.getValue(),
-                identityVerificationSupported);
+                identityVerificationSupported,
+                null,
+                ClientAuthenticationMethod.PRIVATE_KEY_JWT.getValue());
     }
 
     public boolean clientExists(String clientID) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ClientService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ClientService.java
@@ -26,7 +26,9 @@ public interface ClientService {
             boolean consentRequired,
             List<String> claims,
             String clientType,
-            boolean identityVerificationSupported);
+            boolean identityVerificationSupported,
+            String clientSecret,
+            String tokenAuthMethod);
 
     Optional<ClientRegistry> getClient(String clientId);
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoClientService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoClientService.java
@@ -7,9 +7,11 @@ import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.UpdateClientConfigRequest;
+import uk.gov.di.authentication.shared.helpers.Argon2EncoderHelper;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
 
@@ -58,7 +60,9 @@ public class DynamoClientService implements ClientService {
             boolean consentRequired,
             List<String> claims,
             String clientType,
-            boolean identityVerificationSupported) {
+            boolean identityVerificationSupported,
+            String clientSecret,
+            String tokenAuthMethod) {
         var clientRegistry =
                 new ClientRegistry()
                         .withClientID(clientID)
@@ -75,7 +79,11 @@ public class DynamoClientService implements ClientService {
                         .withConsentRequired(consentRequired)
                         .withClaims(claims)
                         .withClientType(clientType)
-                        .withIdentityVerificationSupported(identityVerificationSupported);
+                        .withIdentityVerificationSupported(identityVerificationSupported)
+                        .withTokenAuthMethod(tokenAuthMethod);
+        if (Objects.nonNull(clientSecret)) {
+            clientRegistry.withClientSecret(Argon2EncoderHelper.argon2Hash(clientSecret));
+        }
         dynamoClientRegistryTable.putItem(clientRegistry);
     }
 


### PR DESCRIPTION
## What?

- This allows the token endpoint to determine what authentication method is used by the client and retrieve the correct validator. 
- Add additional integration tests to ensure that token works with client_secret_basic and client_secret_post
- Default the client registration endpoint to private_key_jwt
- Remove unused methods from the tokenservice

## Why?

- To give /token the ability to support client_secret_basic and client_secret_post. Currently we only support client secrets in local, build and staging. But it will eventually be rolled out to other environments.
- Some 3rd party providers do not support private_key_jwt so this will make it easier for more client to onboard easier

## Related PRs
https://github.com/alphagov/di-authentication-api/pull/2600