### PR TITLE
BAU: Only use CONCAT format for EC signatures

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
@@ -459,7 +459,13 @@ public class TokenService {
                             .signingAlgorithm(signingAlgorithm)
                             .build();
             SignResponse signResult = kmsConnectionService.sign(signRequest);
-            LOG.info("Token has been signed successfully");
+            LOG.info("Token has been signed successfully using {}", algorithm.getName());
+
+            if (algorithm == JWSAlgorithm.RS256) {
+                return SignedJWT.parse(
+                        message + "." + Base64URL.encode(signResult.signature().asByteArray()));
+            }
+
             String signature =
                     Base64URL.encode(
                                     ECDSA.transcodeSignatureToConcat(


### PR DESCRIPTION
Does what it says on the tin.
