### PR TITLE
BAU - Make Nonce optional for the Staging environment

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -167,7 +167,9 @@ public class AuthorisationHandler
             LOG.info("RequestObject auth request received");
             authRequestError = requestObjectService.validateRequestObject(authRequest);
         } else {
-            authRequestError = authorizationService.validateAuthRequest(authRequest);
+            authRequestError =
+                    authorizationService.validateAuthRequest(
+                            authRequest, configurationService.isNonceRequired());
         }
 
         if (authRequestError.isPresent()) {

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthorizationService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthorizationService.java
@@ -79,7 +79,8 @@ public class AuthorizationService {
                 authRequest.getResponseMode());
     }
 
-    public Optional<AuthRequestError> validateAuthRequest(AuthenticationRequest authRequest) {
+    public Optional<AuthRequestError> validateAuthRequest(
+            AuthenticationRequest authRequest, boolean isNonceRequired) {
         var clientId = authRequest.getClientID().toString();
 
         attachLogFieldToLogs(CLIENT_ID, clientId);
@@ -127,7 +128,7 @@ public class AuthorizationService {
                                     "Request contains invalid claims"),
                             redirectURI));
         }
-        if (authRequest.getNonce() == null) {
+        if (authRequest.getNonce() == null && isNonceRequired) {
             LOG.error("Nonce is missing from authRequest");
             return Optional.of(
                     new AuthRequestError(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -62,6 +62,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -119,7 +120,8 @@ class AuthorisationHandlerTest {
         when(configService.getSessionCookieAttributes()).thenReturn("Secure; HttpOnly;");
         when(configService.getSessionCookieMaxAge()).thenReturn(3600);
         when(configService.getPersistentCookieMaxAge()).thenReturn(34190000);
-        when(authorizationService.validateAuthRequest(any(AuthenticationRequest.class)))
+        when(authorizationService.validateAuthRequest(
+                        any(AuthenticationRequest.class), anyBoolean()))
                 .thenReturn(Optional.empty());
         when(authorizationService.getExistingOrCreateNewPersistentSessionId(any()))
                 .thenReturn(PERSISTENT_SESSION_ID);
@@ -425,7 +427,8 @@ class AuthorisationHandlerTest {
 
     @Test
     void shouldReturn400WhenAuthorisationRequestContainsInvalidScope() {
-        when(authorizationService.validateAuthRequest(any(AuthenticationRequest.class)))
+        when(authorizationService.validateAuthRequest(
+                        any(AuthenticationRequest.class), anyBoolean()))
                 .thenReturn(
                         Optional.of(
                                 new AuthRequestError(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AuthorizationServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AuthorizationServiceTest.java
@@ -145,7 +145,7 @@ class AuthorizationServiceTest {
                         scope,
                         jsonArrayOf("P2.Cl.Cm"),
                         Optional.empty());
-        var errorObject = authorizationService.validateAuthRequest(authRequest);
+        var errorObject = authorizationService.validateAuthRequest(authRequest, true);
 
         assertThat(errorObject, equalTo(Optional.empty()));
     }
@@ -167,7 +167,7 @@ class AuthorizationServiceTest {
                         scope,
                         jsonArrayOf("Cm.Cl.P1", "P1.Cl"),
                         Optional.empty());
-        var errorObject = authorizationService.validateAuthRequest(authRequest);
+        var errorObject = authorizationService.validateAuthRequest(authRequest, true);
 
         assertTrue(errorObject.isPresent());
 
@@ -190,7 +190,28 @@ class AuthorizationServiceTest {
                                         REDIRECT_URI.toString(), CLIENT_ID.toString())));
         var errorObject =
                 authorizationService.validateAuthRequest(
-                        generateAuthRequest(REDIRECT_URI.toString(), responseType, scope));
+                        generateAuthRequest(REDIRECT_URI.toString(), responseType, scope), true);
+
+        assertTrue(errorObject.isEmpty());
+    }
+
+    @Test
+    void
+            shouldSuccessfullyValidateAuthRequestWhenNonceIsNotIncludedButOptionalButGivenEnvironment() {
+        when(dynamoClientService.getClient(CLIENT_ID.toString()))
+                .thenReturn(
+                        Optional.of(
+                                generateClientRegistry(
+                                        REDIRECT_URI.toString(), CLIENT_ID.toString())));
+        var authRequest =
+                new AuthenticationRequest.Builder(
+                                new ResponseType(ResponseType.Value.CODE),
+                                new Scope(OIDCScopeValue.OPENID),
+                                CLIENT_ID,
+                                URI.create(REDIRECT_URI.toString()))
+                        .state(STATE)
+                        .build();
+        var errorObject = authorizationService.validateAuthRequest(authRequest, false);
 
         assertTrue(errorObject.isEmpty());
     }
@@ -221,7 +242,7 @@ class AuthorizationServiceTest {
                         scope,
                         jsonArrayOf("Cl.Cm", "Cl"),
                         Optional.of(oidcClaimsRequest));
-        var errorObject = authorizationService.validateAuthRequest(authRequest);
+        var errorObject = authorizationService.validateAuthRequest(authRequest, true);
 
         assertTrue(errorObject.isEmpty());
     }
@@ -245,7 +266,7 @@ class AuthorizationServiceTest {
                         scope,
                         jsonArrayOf("Cl.Cm", "Cl"),
                         Optional.of(oidcClaimsRequest));
-        var errorObject = authorizationService.validateAuthRequest(authRequest);
+        var errorObject = authorizationService.validateAuthRequest(authRequest, true);
 
         assertTrue(errorObject.isPresent());
         assertThat(
@@ -269,7 +290,7 @@ class AuthorizationServiceTest {
                                         List.of("openid", "am"))));
         var errorObject =
                 authorizationService.validateAuthRequest(
-                        generateAuthRequest(REDIRECT_URI.toString(), responseType, scope));
+                        generateAuthRequest(REDIRECT_URI.toString(), responseType, scope), true);
 
         assertTrue(errorObject.isEmpty());
     }
@@ -285,7 +306,7 @@ class AuthorizationServiceTest {
                                         REDIRECT_URI.toString(), CLIENT_ID.toString())));
         var errorObject =
                 authorizationService.validateAuthRequest(
-                        generateAuthRequest(REDIRECT_URI.toString(), responseType, scope));
+                        generateAuthRequest(REDIRECT_URI.toString(), responseType, scope), true);
 
         assertTrue(errorObject.isPresent());
         assertThat(errorObject.get().getErrorObject(), equalTo(OAuth2Error.INVALID_SCOPE));
@@ -304,7 +325,8 @@ class AuthorizationServiceTest {
                         () ->
                                 authorizationService.validateAuthRequest(
                                         generateAuthRequest(
-                                                REDIRECT_URI.toString(), responseType, scope)),
+                                                REDIRECT_URI.toString(), responseType, scope),
+                                        true),
                         "Expected to throw exception");
 
         assertThat(runtimeException.getMessage(), equalTo("No Client found with given ClientID"));
@@ -323,7 +345,7 @@ class AuthorizationServiceTest {
                                         REDIRECT_URI.toString(), CLIENT_ID.toString())));
         var errorObject =
                 authorizationService.validateAuthRequest(
-                        generateAuthRequest(REDIRECT_URI.toString(), responseType, scope));
+                        generateAuthRequest(REDIRECT_URI.toString(), responseType, scope), true);
 
         assertTrue(errorObject.isPresent());
         assertThat(
@@ -343,7 +365,7 @@ class AuthorizationServiceTest {
                                         REDIRECT_URI.toString(), CLIENT_ID.toString())));
         var errorObject =
                 authorizationService.validateAuthRequest(
-                        generateAuthRequest(REDIRECT_URI.toString(), responseType, scope));
+                        generateAuthRequest(REDIRECT_URI.toString(), responseType, scope), true);
 
         assertTrue(errorObject.isPresent());
         assertThat(errorObject.get().getErrorObject(), equalTo(OAuth2Error.INVALID_SCOPE));
@@ -364,7 +386,7 @@ class AuthorizationServiceTest {
                                 responseType, scope, new ClientID(CLIENT_ID), REDIRECT_URI)
                         .nonce(new Nonce())
                         .build();
-        var errorObject = authorizationService.validateAuthRequest(authRequest);
+        var errorObject = authorizationService.validateAuthRequest(authRequest, true);
 
         assertTrue(errorObject.isPresent());
         assertThat(
@@ -390,7 +412,7 @@ class AuthorizationServiceTest {
                                 responseType, scope, new ClientID(CLIENT_ID), REDIRECT_URI)
                         .state(new State())
                         .build();
-        var errorObject = authorizationService.validateAuthRequest(authRequest);
+        var errorObject = authorizationService.validateAuthRequest(authRequest, true);
 
         assertTrue(errorObject.isPresent());
         assertThat(
@@ -417,7 +439,7 @@ class AuthorizationServiceTest {
                         .nonce(new Nonce())
                         .customParameter("vtr", jsonArrayOf("Cm"))
                         .build();
-        var errorObject = authorizationService.validateAuthRequest(authRequest);
+        var errorObject = authorizationService.validateAuthRequest(authRequest, true);
 
         assertTrue(errorObject.isPresent());
         assertThat(
@@ -443,7 +465,7 @@ class AuthorizationServiceTest {
                         .nonce(new Nonce())
                         .customParameter("vtr", jsonArrayOf("P2.Cl.Cm"))
                         .build();
-        var errorObject = authorizationService.validateAuthRequest(authRequest);
+        var errorObject = authorizationService.validateAuthRequest(authRequest, true);
 
         assertTrue(errorObject.isPresent());
         assertThat(
@@ -470,7 +492,7 @@ class AuthorizationServiceTest {
                         .nonce(new Nonce())
                         .customParameter("vtr", jsonArrayOf("P2.Cl.Cm"))
                         .build();
-        var errorObject = authorizationService.validateAuthRequest(authRequest);
+        var errorObject = authorizationService.validateAuthRequest(authRequest, true);
 
         assertTrue(errorObject.isEmpty());
     }
@@ -492,7 +514,8 @@ class AuthorizationServiceTest {
                         RuntimeException.class,
                         () ->
                                 authorizationService.validateAuthRequest(
-                                        generateAuthRequest(redirectURi, responseType, scope)),
+                                        generateAuthRequest(redirectURi, responseType, scope),
+                                        true),
                         "Expected to throw exception");
         assertThat(
                 exception.getMessage(),
@@ -528,7 +551,8 @@ class AuthorizationServiceTest {
                         .requestURI(URI.create("https://localhost/redirect-uri"))
                         .build();
 
-        var authRequestError = authorizationService.validateAuthRequest(authenticationRequest);
+        var authRequestError =
+                authorizationService.validateAuthRequest(authenticationRequest, true);
 
         assertTrue(authRequestError.isPresent());
         assertThat(
@@ -552,7 +576,8 @@ class AuthorizationServiceTest {
                         .requestObject(new PlainJWT(new JWTClaimsSet.Builder().build()))
                         .build();
 
-        var authRequestError = authorizationService.validateAuthRequest(authenticationRequest);
+        var authRequestError =
+                authorizationService.validateAuthRequest(authenticationRequest, true);
 
         assertTrue(authRequestError.isPresent());
         assertThat(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -19,6 +19,7 @@ import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -201,6 +202,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         } else {
             return false;
         }
+    }
+
+    public boolean isNonceRequired() {
+        return !Objects.equals("staging", getEnvironment());
     }
 
     public boolean isNotifyTemplatePerLanguage() {


### PR DESCRIPTION
## What?

- Make Nonce optional for the Staging environment

## Why?

- Nonce is optional in the OIDC spec but we currently make it mandatory as it offers protection against ID token replay attacks.
- Not all OIDC providers make the Nonce parameter mandatory which makes it difficult for RPs to integrate.
- To allow us to be able to test with 3rd parties, we will make the Nonce optional in the Staging environment only.
- If the nonce is not present in the auth request, then we will not attempt to place it in the ID token 

