### PR TITLE
FIREBREAK: Return set of feature flags from 'start' lambda (if enabled)

### DIFF
--- a/ci/terraform/oidc/sandpit.tfvars
+++ b/ci/terraform/oidc/sandpit.tfvars
@@ -22,3 +22,6 @@ endpoint_memory_size   = 1024
 blocked_email_duration                    = 30
 otp_code_ttl_duration                     = 120
 email_acct_creation_otp_code_ttl_duration = 60
+
+txma_account_id                = "12345678"
+extended_feature_flags_enabled = true

--- a/ci/terraform/oidc/start.tf
+++ b/ci/terraform/oidc/start.tf
@@ -23,15 +23,16 @@ module "start" {
   environment     = var.environment
 
   handler_environment_variables = {
-    TXMA_AUDIT_QUEUE_URL     = module.oidc_txma_audit.queue_url
-    LOCALSTACK_ENDPOINT      = var.use_localstack ? var.localstack_endpoint : null
-    DOC_APP_DOMAIN           = var.doc_app_domain
-    REDIS_KEY                = local.redis_key
-    ENVIRONMENT              = var.environment
-    DYNAMO_ENDPOINT          = var.use_localstack ? var.lambda_dynamo_endpoint : null
-    HEADERS_CASE_INSENSITIVE = var.use_localstack ? "true" : "false"
-    IDENTITY_ENABLED         = var.ipv_api_enabled
-    INTERNAl_SECTOR_URI      = var.internal_sector_uri
+    TXMA_AUDIT_QUEUE_URL           = module.oidc_txma_audit.queue_url
+    LOCALSTACK_ENDPOINT            = var.use_localstack ? var.localstack_endpoint : null
+    DOC_APP_DOMAIN                 = var.doc_app_domain
+    REDIS_KEY                      = local.redis_key
+    ENVIRONMENT                    = var.environment
+    DYNAMO_ENDPOINT                = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    HEADERS_CASE_INSENSITIVE       = var.use_localstack ? "true" : "false"
+    IDENTITY_ENABLED               = var.ipv_api_enabled
+    INTERNAl_SECTOR_URI            = var.internal_sector_uri
+    EXTENDED_FEATURE_FLAGS_ENABLED = var.extended_feature_flags_enabled
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.StartHandler::handleRequest"
 

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -438,6 +438,11 @@ variable "notify_template_per_language" {
   type    = bool
 }
 
+variable "extended_feature_flags_enabled" {
+  default = false
+  type    = bool
+}
+
 locals {
   default_performance_parameters = {
     memory          = var.endpoint_memory_size

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/Features.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/Features.java
@@ -1,0 +1,28 @@
+package uk.gov.di.authentication.frontendapi.entity;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+
+public class Features {
+
+    @SerializedName("updatePasswordHintTextVersion")
+    @Expose
+    private String updatePasswordHintTextVersion;
+
+    public String getUpdatePasswordHintTextVersion() {
+        return updatePasswordHintTextVersion;
+    }
+
+    public void setUpdatePasswordHintTextVersion(String updatePasswordHintTextVersion) {
+        this.updatePasswordHintTextVersion = updatePasswordHintTextVersion;
+    }
+
+    @Override
+    public String toString() {
+        return "Features{"
+                + "updatePasswordHintTextVersion='"
+                + updatePasswordHintTextVersion
+                + '\''
+                + '}';
+    }
+}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/StartResponse.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/StartResponse.java
@@ -16,11 +16,20 @@ public class StartResponse {
     @Expose
     private ClientStartInfo client;
 
+    @SerializedName("featureFlags")
+    @Expose
+    private Features features;
+
     public StartResponse() {}
 
     public StartResponse(UserStartInfo user, ClientStartInfo client) {
         this.user = user;
         this.client = client;
+    }
+
+    public StartResponse(UserStartInfo user, ClientStartInfo client, Features features) {
+        this(user, client);
+        this.features = features;
     }
 
     public UserStartInfo getUser() {
@@ -29,5 +38,9 @@ public class StartResponse {
 
     public ClientStartInfo getClient() {
         return client;
+    }
+
+    public Features getFeatures() {
+        return features;
     }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/features/FeatureStrategies.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/features/FeatureStrategies.java
@@ -1,0 +1,14 @@
+package uk.gov.di.authentication.frontendapi.features;
+
+import java.security.SecureRandom;
+
+public class FeatureStrategies {
+
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    private FeatureStrategies() {}
+
+    public static boolean fiftyFiftyStrategy() {
+        return RANDOM.nextBoolean();
+    }
+}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -9,6 +9,7 @@ import com.nimbusds.oauth2.sdk.id.Subject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
+import uk.gov.di.authentication.frontendapi.entity.Features;
 import uk.gov.di.authentication.frontendapi.entity.StartResponse;
 import uk.gov.di.authentication.frontendapi.services.StartService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
@@ -139,7 +140,14 @@ public class StartHandler
                 LOG.info("Subject saved to ClientSession for DocCheckingAppUser");
             }
 
-            var startResponse = new StartResponse(userStartInfo, clientStartInfo);
+            StartResponse startResponse;
+            if (configurationService.isExtendedFeatureFlagsEnabled()) {
+                Features features = startService.getSessionFeatures();
+                LOG.info("Extended feature flags enabled: {}", features);
+                startResponse = new StartResponse(userStartInfo, clientStartInfo, features);
+            } else {
+                startResponse = new StartResponse(userStartInfo, clientStartInfo);
+            }
 
             String internalSubjectId = AuditService.UNKNOWN;
             String internalCommonSubjectIdentifier = AuditService.UNKNOWN;

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
@@ -7,6 +7,7 @@ import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.frontendapi.entity.ClientStartInfo;
+import uk.gov.di.authentication.frontendapi.entity.Features;
 import uk.gov.di.authentication.frontendapi.entity.UserStartInfo;
 import uk.gov.di.authentication.shared.conditions.ConsentHelper;
 import uk.gov.di.authentication.shared.conditions.DocAppUserHelper;
@@ -36,6 +37,7 @@ import java.util.Optional;
 import static java.util.function.Predicate.not;
 import static uk.gov.di.authentication.frontendapi.entity.RequestParameters.COOKIE_CONSENT;
 import static uk.gov.di.authentication.frontendapi.entity.RequestParameters.GA;
+import static uk.gov.di.authentication.frontendapi.features.FeatureStrategies.fiftyFiftyStrategy;
 
 public class StartService {
 
@@ -240,5 +242,11 @@ public class StartService {
                 && authRequestParameters.get(COOKIE_CONSENT).get(0) != null
                 && List.of(COOKIE_CONSENT_ACCEPT, COOKIE_CONSENT_REJECT, COOKIE_CONSENT_NOT_ENGAGED)
                         .contains(authRequestParameters.get(COOKIE_CONSENT).get(0));
+    }
+
+    public Features getSessionFeatures() {
+        Features features = new Features();
+        features.setUpdatePasswordHintTextVersion(fiftyFiftyStrategy() ? "1" : "2");
+        return features;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -187,6 +187,12 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return System.getenv().getOrDefault("SPOT_ENABLED", "false").equals("true");
     }
 
+    public boolean isExtendedFeatureFlagsEnabled() {
+        return System.getenv()
+                .getOrDefault("EXTENDED_FEATURE_FLAGS_ENABLED", "false")
+                .equals("true");
+    }
+
     public boolean isIdentityTraceLoggingEnabled() {
         return System.getenv()
                 .getOrDefault("IDENTITY_TRACE_LOGGING_ENABLED", "false")


### PR DESCRIPTION
## What?

Return set of feature flags from 'start' lambda (if enabled).

Adds a facility to return variable per-session feature flags to the frontend.  The frontend can then read the feature flags into its session and make dynamic behavioural changes accordingly.

The example in this PR sets the value of a feature flag 'updatePasswordHintTextVersion' to either '1' or '2' split 50% across user sessions.

First deployed inactive and switched-off in all environments for regression, no flags will be returned to the frontend.

## Why?

Provides a facility to do A/B testing based on assigning percentages of user sessions to different groups.  Strategies for user group assignment can be varied based on infomration available to Orchestration (if required).

## Related PRs

Corresponding FE PR.
