### PR TITLE
FIREBREAK: Switch on extended feature flags in all environments

### DIFF
--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -439,7 +439,7 @@ variable "notify_template_per_language" {
 }
 
 variable "extended_feature_flags_enabled" {
-  default = false
+  default = true
   type    = bool
 }
 


### PR DESCRIPTION

## What?

Switch on extended feature flags in all environments.

## Why?

This will enable A/B testing on the frontend for the two versions of the password hint text. 
See the PRs below for the corresponding frontend and backend changes.
To be tested in build first.

## Related PRs

#2610 
https://github.com/alphagov/di-authentication-frontend/pull/877
