### PR TITLE
FIREBREAK: Switch on AB testing in build, integration and staging only

### DIFF
--- a/ci/terraform/oidc/build-overrides.tfvars
+++ b/ci/terraform/oidc/build-overrides.tfvars
@@ -10,6 +10,7 @@ doc_app_encryption_key_id          = "7788bc975abd44e8b4fd7646d08ea9428476e37bff
 spot_enabled                       = false
 language_cy_enabled                = true
 internal_sector_uri                = "https://identity.build.account.gov.uk"
+extended_feature_flags_enabled     = true
 
 blocked_email_duration                    = 30
 otp_code_ttl_duration                     = 120

--- a/ci/terraform/oidc/integration-overrides.tfvars
+++ b/ci/terraform/oidc/integration-overrides.tfvars
@@ -19,6 +19,8 @@ internal_sector_uri            = "https://identity.integration.account.gov.uk"
 spot_enabled                   = true
 identity_trace_logging_enabled = true
 language_cy_enabled            = true
+extended_feature_flags_enabled = true
+
 ipv_auth_public_encryption_key = <<-EOT
 -----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzgTML6YZ+XUEPQprWBlW

--- a/ci/terraform/oidc/staging-overrides.tfvars
+++ b/ci/terraform/oidc/staging-overrides.tfvars
@@ -18,7 +18,9 @@ internal_sector_uri                = "https://identity.staging.account.gov.uk"
 spot_enabled                       = true
 identity_trace_logging_enabled     = true
 language_cy_enabled                = true
-ipv_auth_public_encryption_key     = <<-EOT
+extended_feature_flags_enabled     = true
+
+ipv_auth_public_encryption_key = <<-EOT
 -----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyB5V0Tc9KEV5/zGUHLu0
 ZVX0xbDhCyaNwWjJILV0pJE+HmAUc8Azc42MY9mAm0D3LYF8PcWsBa1cIgJF6z7j

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -439,7 +439,7 @@ variable "notify_template_per_language" {
 }
 
 variable "extended_feature_flags_enabled" {
-  default = true
+  default = false
   type    = bool
 }
 


### PR DESCRIPTION
## What?

Switch on AB testing in build, integration and staging only.

## Why?

Do further testing before releasing to prod.

## Related PRs

#2614 
