### PR TITLE
FIREBREAK: Use shared pre-commit rules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,23 +13,9 @@ repos:
         exclude: ^(ci|.github)/.*|docker-compose.*|.pre-commit-config.yaml$
         files: ^.*\.(json|yml|yaml)$
 
-  - repo: local
+  - repo: https://github.com/alphagov/di-pre-commit-hooks.git
+    rev: 0.0.1
     hooks:
       - id: spotless-check
-        name: Run Gradle Spotless Apply
-        language: script
-        entry: ./gradlew spotlessApply
-        files: ^.*(gradle|java)$
-        pass_filenames: false
       - id: terraform-format
-        name: Run Terraform Format
-        language: docker_image
-        entry: hashicorp/terraform:1.0.4 fmt -recursive
-        files: ^.*(.tf|.tfvars)$
-        pass_filenames: false
       - id: terraform-validate
-        name: Run Terraform Validate
-        language: script
-        entry: ci/terraform/precommit-validate.sh
-        files: ^.*(.tf|.tfvars)$
-        pass_filenames: true


### PR DESCRIPTION
## What?

- Use the commit hooks shared in the `di-pre-commit-hooks` repository

## Why?

These rules are going to be shared amongst multiple repos