### PR TITLE
FIREBREAK: Fix rebasing error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,6 @@ repos:
   - repo: https://github.com/alphagov/di-pre-commit-hooks.git
     rev: 0.0.1
     hooks:
-      - id: spotless-check
+      - id: gradle-spotless-apply
       - id: terraform-format
       - id: terraform-validate


### PR DESCRIPTION
## What?

- Change prehook ID from `spotless-check` to `gradle-spotless-apply`

## Why?

Pre-commit hook fails because of incorrect ID.

## Related PRs

#2620 
