### PR TITLE
AUT-941: Add correct Auth App secret for bulk users

### DIFF
--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/BulkTestUserCreateHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/BulkTestUserCreateHandler.java
@@ -180,7 +180,7 @@ public class BulkTestUserCreateHandler implements RequestHandler<S3Event, Void> 
         userCredentials.setTestUser(1);
 
         if (isAuthAppSecondAuthFactor) {
-            String authAppSecret = testUser[4];
+            String authAppSecret = testUser[5];
             List<MFAMethod> mfaMethods = new ArrayList<>();
             var authAppMfaMethod =
                     new MFAMethod(


### PR DESCRIPTION
## What?
- When uploading an auth app secret to the UserCredentials DyanamoDB table, the variable which sets this value now references column 5 of the source CSV, which contains the actual auth app secret.

## Why?

- Lambda was populating secret field with the wrong column of the CSV 
- Was referencing column 4 (values null or 1) which refers to whether auth app 2FA is enabled (this was not throwing any error as "1" was a valid value as far as DynamoDB was concerned)

## Related PRs

- Amends: https://github.com/alphagov/di-authentication-api/pull/2571
