### PR TITLE
AUT-781: Only use email allowlist regex check on regex entries

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/TestClientHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/TestClientHelper.java
@@ -43,13 +43,17 @@ public class TestClientHelper {
     }
 
     public static boolean emailMatchesAllowlist(String emailAddress, List<String> regexAllowList) {
-        for (String regex : regexAllowList) {
+        for (String allowedEmailEntry : regexAllowList) {
             try {
-                if (Pattern.matches(regex, emailAddress)) {
+                if (allowedEmailEntry.startsWith("^") && allowedEmailEntry.endsWith("$")) {
+                    if (Pattern.matches(allowedEmailEntry, emailAddress)) {
+                        return true;
+                    }
+                } else if (emailAddress.equals(allowedEmailEntry)) {
                     return true;
                 }
             } catch (PatternSyntaxException e) {
-                LOG.warn("PatternSyntaxException for: {}", regex);
+                LOG.warn("PatternSyntaxException for: {}", allowedEmailEntry);
             }
         }
         return false;

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/TestClientHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/TestClientHelperTest.java
@@ -30,6 +30,7 @@ class TestClientHelperTest {
     private static final List<String> ALLOWLIST =
             List.of(
                     "testclient.user1@digital.cabinet-office.gov.uk",
+                    "testclient.user1+1@hello.cabinet-office.gov.uk",
                     "^(.+)@digital.cabinet-office.gov.uk$",
                     "^(.+)@interwebs.org$",
                     "testclient.user2@internet.com");
@@ -83,6 +84,7 @@ class TestClientHelperTest {
     @ValueSource(
             strings = {
                 "testclient.user1@digital.cabinet-office.gov.uk",
+                "testclient.user1+1@hello.cabinet-office.gov.uk",
                 "abc@digital.cabinet-office.gov.uk",
                 "abc.def@digital.cabinet-office.gov.uk",
                 "user.one1@interwebs.org",


### PR DESCRIPTION

## What?

Only use email allowlist regex check on regex entries.

## Why?

The regex only check was not matching against '+1' etc emails.

## Related PRs

#2624 
