### PR TITLE
BAU: Exclude 'shared-test' from sonarcloud coverage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -348,6 +348,7 @@ sonarqube {
         property "sonar.projectKey", "alphagov_di-authentication-api"
         property "sonar.organization", "alphagov"
         property "sonar.host.url", "https://sonarcloud.io"
+        property "sonar.coverage.exlcusions", "shared-test/src/main/**/*.*"
     }
 }
 


### PR DESCRIPTION
## What?

Exclude 'shared-test' from sonarcloud coverage

## Why?

