### PR TITLE
AUT-941: Make subject ID unique for each bulk-created user

### DIFF
--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/BulkTestUserCreateHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/BulkTestUserCreateHandler.java
@@ -104,7 +104,6 @@ public class BulkTestUserCreateHandler implements RequestHandler<S3Event, Void> 
 
     private void addTestUsersBatch(List<String> batchOfIndividualUsersAsRawCsv) {
         String dateTime = LocalDateTime.now().toString();
-        String subjectId = new Subject().getValue();
         Map<UserProfile, UserCredentials> testUsers = new HashMap<>();
 
         segmentedFunctionCall(
@@ -113,6 +112,7 @@ public class BulkTestUserCreateHandler implements RequestHandler<S3Event, Void> 
                         batchOfIndividualUsersAsRawCsv.forEach(
                                 rawCsvUserString -> {
                                     String[] testUserCsvAsArray = rawCsvUserString.split(",", -1);
+                                    String subjectId = new Subject().getValue();
 
                                     var userProfile =
                                             getUserProfileFromTestUserArrayList(


### PR DESCRIPTION
## What?

- Make subject ID unique for each bulk-created user

## Why?

- Was previously using a single ID per batch leading to non-unique subject IDs
- Could cause unexpected when these test users are used

## Related PRs

- Amends original PR here: https://github.com/alphagov/di-authentication-api/pull/2571
- Also amends: https://github.com/alphagov/di-authentication-api/pull/2655
