### PR TITLE
AUT-941: Add filter to bulk test user Dynamo scan

### DIFF
--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/UserStoreExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/UserStoreExtension.java
@@ -89,7 +89,7 @@ public class UserStoreExtension extends DynamoExtension implements AfterEachCall
     }
 
     public List<UserProfile> getAllTestUsers() {
-        return dynamoService.getAllTestUsers();
+        return dynamoService.getAllBulkTestUsers();
     }
 
     public void updateConsent(String email, ClientConsent clientConsent) {

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/BulkTestUserDeleteHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/BulkTestUserDeleteHandler.java
@@ -28,7 +28,7 @@ public class BulkTestUserDeleteHandler implements RequestHandler<String, Void> {
         LOG.info("Commencing deletion of all test users");
 
         long startTime = System.nanoTime();
-        List<UserProfile> allTestUsers = dynamoService.getAllTestUsers();
+        List<UserProfile> allTestUsers = dynamoService.getAllBulkTestUsers();
         long endTime = System.nanoTime();
         long durationInMilliseconds = (endTime - startTime) / 1000000;
         LOG.info("{} records found in {} ms", allTestUsers.size(), durationInMilliseconds);


### PR DESCRIPTION
## What?
- Continue to query only `TestUserIndex` Global Secondary Index as part of scan operation
- However, add a filter that `testUser` attribute must equal `1` (Number data type in the table)

Note: I have also refactored `getTestUsers` function name to make it clear that the field specifically targets bulk-created users i.e. users who were created programmatically via the bulk creation lambda. The old name might have implied it included other test users e.g. those used for acceptance tests.

## Why?
- Due to a change to `UserProfile` Java class, all new users will have a value of either 0 or 1 for testUser, even when not explicitly set
- This means that all new users will be part of the `TestUserIndex` GSI (but existing users, who do not have this attribute are not)
- This was overlooked in the original commit, which expected only bulk test users to fall in the index, and I therefore erroneously thought that scanning the index alone was enough to target the right entries. However, it in fact caught many extra table entries. This filter fixes the resulting bug

## Related PRs
- Amends original PR here: https://github.com/alphagov/di-authentication-api/pull/2571
