### PR TITLE
BAU: Fix auth app stub test

### DIFF
--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuthAppStubTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuthAppStubTest.java
@@ -1,5 +1,6 @@
 package uk.gov.di.authentication.sharedtest.helper;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
@@ -9,27 +10,39 @@ import uk.gov.di.authentication.shared.validation.AuthAppCodeValidator;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class AuthAppStubTest {
-    AuthAppStub authAppStub;
-    AuthAppCodeValidator authAppCodeValidator;
+    private AuthAppStub authAppStub;
+    private AuthAppCodeValidator authAppCodeValidator;
+    private static ConfigurationService configurationService;
+
+    @BeforeAll
+    static void init() {
+        configurationService = mock(ConfigurationService.class);
+        when(configurationService.getAuthAppCodeWindowLength()).thenReturn(30);
+    }
 
     @BeforeEach
     void setUp() {
         this.authAppStub = new AuthAppStub();
         this.authAppCodeValidator =
                 new AuthAppCodeValidator(
-                        mock(String.class),
+                        "test-email@test.com",
                         mock(CodeStorageService.class),
-                        mock(ConfigurationService.class),
+                        configurationService,
                         mock(DynamoService.class),
                         99999);
     }
 
     @Test
     void worksWithAuthAppCodeValidatorAlgorithm() {
-        String generatedCode = authAppStub.getAuthAppOneTimeCode("ORSXG5BNORSXQ5A=");
+        String generatedCode =
+                authAppStub.getAuthAppOneTimeCode(
+                        "ABCDAAWOXKUQCDH5QMSPHAGJXMTXFZRZAKFTR6Y3Q5YRN5EVOYRQ");
 
-        assertTrue(authAppCodeValidator.isCodeValid(generatedCode, "ORSXG5BNORSXQ5A="));
+        assertTrue(
+                authAppCodeValidator.isCodeValid(
+                        generatedCode, "ABCDAAWOXKUQCDH5QMSPHAGJXMTXFZRZAKFTR6Y3Q5YRN5EVOYRQ"));
     }
 }


### PR DESCRIPTION
## What?

- Auth app stub unit test was not working due to string being unmockable and config service missing a 'when/then'
- Add fixes for these two problems
- Note: This was not picked up automatically because the file is in shared-test, so is not treated as a 'real' test file

## Why?

- Improve quality of tests

## Related PRs

- Amends earlier work here: https://github.com/alphagov/di-authentication-api/pull/2046
