### PR TITLE
AUT-961: Add retries to IPV User Identity endpoint

### DIFF
--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVTokenService.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVTokenService.java
@@ -77,7 +77,16 @@ public class IPVTokenService {
 
     public TokenResponse sendTokenRequest(TokenRequest tokenRequest) {
         try {
-            return TokenResponse.parse(tokenRequest.toHTTPRequest().send());
+            int count = 0;
+            int maxTries = 2;
+            TokenResponse tokenResponse;
+            do {
+                if (count > 0) LOG.warn("Retrying IPV access token request");
+                count++;
+                tokenResponse = TokenResponse.parse(tokenRequest.toHTTPRequest().send());
+            } while (!tokenResponse.indicatesSuccess() && count < maxTries);
+
+            return tokenResponse;
         } catch (IOException e) {
             LOG.error("Error whilst sending TokenRequest", e);
             throw new RuntimeException(e);
@@ -89,8 +98,16 @@ public class IPVTokenService {
 
     public UserInfo sendIpvUserIdentityRequest(UserInfoRequest userInfoRequest) {
         try {
-            var userIdentityResponse =
-                    UserInfoResponse.parse(userInfoRequest.toHTTPRequest().send());
+            int count = 0;
+            int maxTries = 2;
+            UserInfoResponse userIdentityResponse;
+            do {
+                if (count > 0) LOG.warn("Retrying IPV user identity request");
+                count++;
+                userIdentityResponse =
+                        UserInfoResponse.parse(userInfoRequest.toHTTPRequest().send());
+            } while (!userIdentityResponse.indicatesSuccess() && count < maxTries);
+
             if (!userIdentityResponse.indicatesSuccess()) {
                 LOG.error("Response from user-identity does not indicate success");
                 throw new RuntimeException(userIdentityResponse.toErrorResponse().toString());


### PR DESCRIPTION
## What?

- Add retries to IPV User Identity endpoint as well as to the (IPV Access) Token endpoint 
- Note: this follows the same pattern as already existed for DocApp callback: https://github.com/alphagov/di-authentication-api/blob/4df91fcdccc1458a1969fdca313f5187c525ed47/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/services/DocAppCriService.java#L89-L100


## Why?

- The User Identity endpoint retry addresses a known issue where due to lack of read consistency at IPV side, sometimes the access token is not found and therefore rejected despite being valid
- The token endpoint was not an identified area of concern, but a more general lack of robustness to network glitches was raised during discussion about the other endpoint, so this retry was considered prudent for system resilience.
