### PR TITLE
BAU - Set testJourney to false in auth code handler if it is a doc app journey

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/TestClientHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/TestClientHelper.java
@@ -7,6 +7,7 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
@@ -49,7 +50,7 @@ public class TestClientHelper {
                     if (Pattern.matches(allowedEmailEntry, emailAddress)) {
                         return true;
                     }
-                } else if (emailAddress.equals(allowedEmailEntry)) {
+                } else if (Objects.equals(emailAddress, allowedEmailEntry)) {
                     return true;
                 }
             } catch (PatternSyntaxException e) {

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/TestClientHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/TestClientHelperTest.java
@@ -122,6 +122,12 @@ class TestClientHelperTest {
         assertThat(logging.events(), everyItem(withMessageContaining("PatternSyntaxException")));
     }
 
+    @Test
+    void emailShouldNotMatchRegexAllowlistWhenEmailIsNull() {
+        assertFalse(TestClientHelper.emailMatchesAllowlist(null, List.of("$^", "[", "*")));
+        assertThat(logging.events(), everyItem(withMessageContaining("PatternSyntaxException")));
+    }
+
     private UserContext buildUserContext(boolean isTestClient, List<String> allowedEmails) {
         var clientRegistry =
                 new ClientRegistry()


### PR DESCRIPTION
## What?

- Set testJourney to false in auth code handler if it is a doc app journey

## Why?

- Currently all Doc App journeys using the stub are throwing a NullPointerException when checking if the journey is a test journey. The nullpointer is thrown because no user logs into auth for doc app journeys
- This is because the Doc App Stub is configured as a test client so we can send a property in the secure auth request to the doc app cri, informing them that the initial journey started at the stub.
- Make the check in the TestClientHelper nullsafe
