### PR TITLE
AUT-834: Smoke test clients in build and integration

### DIFF
--- a/ci/terraform/shared/build-stub-clients.tfvars
+++ b/ci/terraform/shared/build-stub-clients.tfvars
@@ -52,4 +52,22 @@ stub_rp_clients = [
       "doc-checking-app",
     ]
   },
+  {
+    client_name = "di-auth-smoketest-microclient-build"
+    callback_urls = [
+      "http://localhost:3031/callback",
+    ]
+    logout_urls = [
+      "http://localhost:3031/signed-out",
+    ]
+    test_client                     = "1"
+    consent_required                = "0"
+    identity_verification_supported = "0"
+    client_type                     = "web"
+    scopes = [
+      "openid",
+      "email",
+      "phone",
+    ]
+  },
 ]

--- a/ci/terraform/shared/integration-stub-clients.tfvars
+++ b/ci/terraform/shared/integration-stub-clients.tfvars
@@ -34,4 +34,22 @@ stub_rp_clients = [
       "doc-checking-app",
     ]
   },
+  {
+    client_name = "di-auth-smoketest-microclient-integration"
+    callback_urls = [
+      "http://localhost:3031/callback",
+    ]
+    logout_urls = [
+      "http://localhost:3031/signed-out",
+    ]
+    test_client                     = "1"
+    consent_required                = "0"
+    identity_verification_supported = "0"
+    client_type                     = "web"
+    scopes = [
+      "openid",
+      "email",
+      "phone",
+    ]
+  },
 ]


### PR DESCRIPTION
## What?

Smoke test clients in build and integration.

Private keys will be retrieved and deployed in the smoke test pipeline using shared state.

## Why?

In order to remove the smoke test dependency on AM separate clients are needed for the smoke testers.  Smoke tests are not actually deployed in build but the client will be used for local and sandpit testing.
