### PR TITLE
BAU - Return false if email address is null

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/TestClientHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/TestClientHelper.java
@@ -44,6 +44,9 @@ public class TestClientHelper {
     }
 
     public static boolean emailMatchesAllowlist(String emailAddress, List<String> regexAllowList) {
+        if (Objects.isNull(emailAddress)) {
+            return false;
+        }
         for (String allowedEmailEntry : regexAllowList) {
             try {
                 if (allowedEmailEntry.startsWith("^") && allowedEmailEntry.endsWith("$")) {

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/TestClientHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/TestClientHelperTest.java
@@ -124,7 +124,7 @@ class TestClientHelperTest {
 
     @Test
     void emailShouldNotMatchRegexAllowlistWhenEmailIsNull() {
-        assertFalse(TestClientHelper.emailMatchesAllowlist(null, List.of("$^", "[", "*")));
+        assertFalse(TestClientHelper.emailMatchesAllowlist(null, List.of("^$", "[", "*")));
         assertThat(logging.events(), everyItem(withMessageContaining("PatternSyntaxException")));
     }
 


### PR DESCRIPTION
## What?

- Return false if email address is null


## Why?
- There is no email address during the doc app journey so this will throw a nullpointer. If the email address is null, return false