### PR TITLE
Revert "AUT-834: Smoke test clients in build and integration"

### DIFF
--- a/ci/terraform/shared/build-stub-clients.tfvars
+++ b/ci/terraform/shared/build-stub-clients.tfvars
@@ -52,22 +52,4 @@ stub_rp_clients = [
       "doc-checking-app",
     ]
   },
-  {
-    client_name = "di-auth-smoketest-microclient-build"
-    callback_urls = [
-      "http://localhost:3031/callback",
-    ]
-    logout_urls = [
-      "http://localhost:3031/signed-out",
-    ]
-    test_client                     = "1"
-    consent_required                = "0"
-    identity_verification_supported = "0"
-    client_type                     = "web"
-    scopes = [
-      "openid",
-      "email",
-      "phone",
-    ]
-  },
 ]

--- a/ci/terraform/shared/integration-stub-clients.tfvars
+++ b/ci/terraform/shared/integration-stub-clients.tfvars
@@ -34,22 +34,4 @@ stub_rp_clients = [
       "doc-checking-app",
     ]
   },
-  {
-    client_name = "di-auth-smoketest-microclient-integration"
-    callback_urls = [
-      "http://localhost:3031/callback",
-    ]
-    logout_urls = [
-      "http://localhost:3031/signed-out",
-    ]
-    test_client                     = "1"
-    consent_required                = "0"
-    identity_verification_supported = "0"
-    client_type                     = "web"
-    scopes = [
-      "openid",
-      "email",
-      "phone",
-    ]
-  },
 ]


### PR DESCRIPTION
## What

Reverts alphagov/di-authentication-api#2677

## Why

Smoke test clients will instead be created in the smoke test pipeline.  This avoids creating dependencies between two pipelines in order to pass the client id and private key.

# Related

https://github.com/alphagov/di-authentication-smoke-tests/pull/61
