### PR TITLE
AUT-955: Enable and add test client to staging for performance testing

### DIFF
--- a/ci/terraform/oidc/staging-overrides.tfvars
+++ b/ci/terraform/oidc/staging-overrides.tfvars
@@ -19,6 +19,7 @@ spot_enabled                       = true
 identity_trace_logging_enabled     = true
 language_cy_enabled                = true
 extended_feature_flags_enabled     = true
+test_clients_enabled               = "true"
 
 ipv_auth_public_encryption_key = <<-EOT
 -----BEGIN PUBLIC KEY-----

--- a/ci/terraform/shared/staging-stub-clients.tfvars
+++ b/ci/terraform/shared/staging-stub-clients.tfvars
@@ -34,4 +34,22 @@ stub_rp_clients = [
       "doc-checking-app",
     ]
   },
+  {
+    client_name = "di-auth-stub-relying-party-staging-t1"
+    callback_urls = [
+      "https://di-auth-stub-relying-party-staging-t1.london.cloudapps.digital/oidc/authorization-code/callback",
+    ]
+    logout_urls = [
+      "https://di-auth-stub-relying-party-staging-t1.london.cloudapps.digital/signed-out",
+    ]
+    test_client                     = "1"
+    consent_required                = "0"
+    identity_verification_supported = "1"
+    client_type                     = "web"
+    scopes = [
+      "openid",
+      "email",
+      "phone",
+    ]
+  },
 ]


### PR DESCRIPTION
## What?

Enable and add test client to staging for performance testing.

## Why?

Performance testing in staging requires a test client and for test clients to be enabled to support OTP scenarios.

## Related PRs

https://github.com/alphagov/di-authentication-frontend/pull/903