### PR TITLE
AUT-995: Align staging redis sizing with production for performance testing

### DIFF
--- a/ci/terraform/shared/staging-sizing.tfvars
+++ b/ci/terraform/shared/staging-sizing.tfvars
@@ -1,2 +1,2 @@
-redis_node_size  = "cache.t2.small"
+redis_node_size  = "cache.m4.xlarge"
 provision_dynamo = false


### PR DESCRIPTION
## What?

Align staging redis sizing with production for performance testing.

## Why?

Staging will be used for performance testing so should match production sizing.

## Related PRs

https://github.com/alphagov/di-authentication-frontend/pull/903
#2689 