### PR TITLE
AUT-963 - Add helper method to populate DocAppSubjectId

### DIFF
--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -28,6 +28,7 @@ module "ipv-callback" {
   environment     = var.environment
 
   handler_environment_variables = {
+    CUSTOM_DOC_APP_CLAIM_ENABLED   = var.custom_doc_app_claim_enabled
     DYNAMO_ENDPOINT                = var.use_localstack ? var.lambda_dynamo_endpoint : null
     TXMA_AUDIT_QUEUE_URL           = module.oidc_txma_audit.queue_url
     ENVIRONMENT                    = var.environment

--- a/ci/terraform/oidc/start.tf
+++ b/ci/terraform/oidc/start.tf
@@ -25,6 +25,7 @@ module "start" {
   handler_environment_variables = {
     TXMA_AUDIT_QUEUE_URL           = module.oidc_txma_audit.queue_url
     LOCALSTACK_ENDPOINT            = var.use_localstack ? var.localstack_endpoint : null
+    CUSTOM_DOC_APP_CLAIM_ENABLED   = var.custom_doc_app_claim_enabled
     DOC_APP_DOMAIN                 = var.doc_app_domain
     REDIS_KEY                      = local.redis_key
     ENVIRONMENT                    = var.environment

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -114,6 +114,10 @@ variable "aws_dynamodb_endpoint" {
   default = null
 }
 
+variable "custom_doc_app_claim_enabled" {
+  default = false
+}
+
 variable "lambda_dynamo_endpoint" {
   type        = string
   default     = "http://dynamodb:8000"

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -5,7 +5,6 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.nimbusds.oauth2.sdk.ParseException;
-import com.nimbusds.oauth2.sdk.id.Subject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
@@ -14,10 +13,9 @@ import uk.gov.di.authentication.frontendapi.entity.StartResponse;
 import uk.gov.di.authentication.frontendapi.services.StartService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.UserProfile;
-import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
+import uk.gov.di.authentication.shared.helpers.DocAppSubjectIdHelper;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
-import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.serialization.Json.JsonException;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
@@ -130,13 +128,12 @@ public class StartHandler
                             configurationService.getHeadersCaseInsensitive());
             if (userStartInfo.isDocCheckingAppUser()) {
                 var docAppSubjectId =
-                        ClientSubjectHelper.calculatePairwiseIdentifier(
-                                new Subject().getValue(),
-                                configurationService.getDocAppDomain(),
-                                SaltHelper.generateNewSalt());
+                        DocAppSubjectIdHelper.calculateDocAppSubjectId(
+                                userContext.getClientSession(),
+                                configurationService.isCustomDocAppClaimEnabled(),
+                                configurationService.getDocAppDomain());
                 clientSessionService.saveClientSession(
-                        clientSessionId,
-                        clientSession.get().setDocAppSubjectId(new Subject(docAppSubjectId)));
+                        clientSessionId, clientSession.get().setDocAppSubjectId(docAppSubjectId));
                 LOG.info("Subject saved to ClientSession for DocCheckingAppUser");
             }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/DocAppSubjectIdHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/DocAppSubjectIdHelper.java
@@ -1,0 +1,44 @@
+package uk.gov.di.authentication.shared.helpers;
+
+import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.oauth2.sdk.id.Subject;
+import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.shared.entity.ClientSession;
+
+import java.net.URI;
+import java.util.Objects;
+
+public class DocAppSubjectIdHelper {
+
+    private static final Logger LOG = LogManager.getLogger(DocAppSubjectIdHelper.class);
+
+    private DocAppSubjectIdHelper() {}
+
+    public static Subject calculateDocAppSubjectId(
+            ClientSession clientSession, boolean isCustomDocAppClaimEnabled, URI docAppDomain) {
+        try {
+            LOG.info(
+                    "Calculating DocAppSubjectId. CustomDocAppClaim is enabled: {}",
+                    isCustomDocAppClaimEnabled);
+            var authRequest = AuthenticationRequest.parse(clientSession.getAuthRequestParams());
+            var secureRequestSubject =
+                    authRequest.getRequestObject().getJWTClaimsSet().getSubject();
+            if (isCustomDocAppClaimEnabled && Objects.nonNull(secureRequestSubject)) {
+                LOG.info("CustomDocAppClaimEnabled and SecureRequestObject contains Subject claim");
+                return new Subject(secureRequestSubject);
+            } else {
+                LOG.info("Generating Pairwise ID for DocAPpSubjectId");
+                return new Subject(
+                        ClientSubjectHelper.calculatePairwiseIdentifier(
+                                new Subject().getValue(),
+                                docAppDomain,
+                                SaltHelper.generateNewSalt()));
+            }
+        } catch (ParseException | java.text.ParseException e) {
+            LOG.error("Unable to parse secure request object when calculating DocAppSubjectId", e);
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -104,6 +104,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return Integer.parseInt(System.getenv().getOrDefault("PASSWORD_MAX_RETRIES", "5"));
     }
 
+    public boolean isCustomDocAppClaimEnabled() {
+        return System.getenv().getOrDefault("CUSTOM_DOC_APP_CLAIM_ENABLED", "false").equals("true");
+    }
+
     public URI getDefaultLogoutURI() {
         return URI.create(System.getenv("DEFAULT_LOGOUT_URI"));
     }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/DocAppSubjectIdHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/DocAppSubjectIdHelperTest.java
@@ -1,0 +1,124 @@
+package uk.gov.di.authentication.shared.helpers;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.ResponseType;
+import com.nimbusds.oauth2.sdk.Scope;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.id.State;
+import com.nimbusds.oauth2.sdk.id.Subject;
+import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+import com.nimbusds.openid.connect.sdk.Nonce;
+import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.entity.ClientSession;
+import uk.gov.di.authentication.shared.entity.CustomScopeValue;
+import uk.gov.di.authentication.shared.entity.VectorOfTrust;
+import uk.gov.di.authentication.sharedtest.helper.KeyPairHelper;
+
+import java.net.URI;
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DocAppSubjectIdHelperTest {
+
+    private static final String REDIRECT_URI = "https://localhost:8080";
+    private static final Scope SCOPE =
+            new Scope(OIDCScopeValue.OPENID, CustomScopeValue.DOC_CHECKING_APP);
+    private static final State STATE = new State();
+    private static final Nonce NONCE = new Nonce();
+    private static final ClientID CLIENT_ID = new ClientID("test-id");
+    private static final URI DOC_APP_DOMAIN = URI.create("https://doc-app-domain.gov.uk");
+    private static final String AUDIENCE = "https://localhost/authorize";
+
+    @Test
+    void shouldUseSubjectFromRequestObjectWhenPresentAndCustomDocAppClaimEnabled()
+            throws JOSEException {
+        var expectedSubject = new Subject();
+        var clientSession = generateClientSession(expectedSubject);
+
+        var docAppSubjectId =
+                DocAppSubjectIdHelper.calculateDocAppSubjectId(clientSession, true, DOC_APP_DOMAIN);
+
+        assertThat(docAppSubjectId, equalTo(expectedSubject));
+    }
+
+    @Test
+    void
+            shouldUsePairwiseSubjectWhenSubjectInRequestObjectIsPresentButCustomDocAppClaimIsNotEnabled()
+                    throws JOSEException {
+        var expectedSubject = new Subject();
+        var clientSession = generateClientSession(expectedSubject);
+
+        var docAppSubjectId =
+                DocAppSubjectIdHelper.calculateDocAppSubjectId(
+                        clientSession, false, DOC_APP_DOMAIN);
+
+        assertThat(docAppSubjectId, not(equalTo(expectedSubject)));
+        assertTrue(docAppSubjectId.getValue().startsWith("urn:fdc:gov.uk:2022:"));
+    }
+
+    @Test
+    void shouldUsePairwiseSubjectWhenSubjectNotPresentInRequestObjectAndCustomAppClaimIsNotEnabled()
+            throws JOSEException {
+        var clientSession = generateClientSession(null);
+
+        var docAppSubjectId =
+                DocAppSubjectIdHelper.calculateDocAppSubjectId(
+                        clientSession, false, DOC_APP_DOMAIN);
+
+        assertTrue(docAppSubjectId.getValue().startsWith("urn:fdc:gov.uk:2022:"));
+    }
+
+    @Test
+    void shouldUsePairwiseSubjectWhenCustomAppClaimIsEnabledButSubjectNotPresentInRequestObject()
+            throws JOSEException {
+        var clientSession = generateClientSession(null);
+
+        var docAppSubjectId =
+                DocAppSubjectIdHelper.calculateDocAppSubjectId(clientSession, true, DOC_APP_DOMAIN);
+
+        assertTrue(docAppSubjectId.getValue().startsWith("urn:fdc:gov.uk:2022:"));
+    }
+
+    private ClientSession generateClientSession(Subject subject) throws JOSEException {
+        var jwtClaimsSetBuilder =
+                new JWTClaimsSet.Builder()
+                        .audience(AUDIENCE)
+                        .claim("redirect_uri", REDIRECT_URI)
+                        .claim("response_type", ResponseType.CODE.toString())
+                        .claim("scope", SCOPE.toString())
+                        .claim("nonce", NONCE)
+                        .claim("state", STATE)
+                        .claim("client_id", CLIENT_ID)
+                        .issuer(new ClientID("test-id").getValue());
+        if (Objects.nonNull(subject)) {
+            jwtClaimsSetBuilder.subject(subject.getValue());
+        }
+        var jwsHeader = new JWSHeader(JWSAlgorithm.RS256);
+        var signedJWT = new SignedJWT(jwsHeader, jwtClaimsSetBuilder.build());
+        var signer = new RSASSASigner(KeyPairHelper.GENERATE_RSA_KEY_PAIR().getPrivate());
+        signedJWT.sign(signer);
+        var authRequest =
+                new AuthenticationRequest.Builder(
+                                ResponseType.CODE, SCOPE, CLIENT_ID, URI.create(REDIRECT_URI))
+                        .state(STATE)
+                        .nonce(new Nonce())
+                        .requestObject(signedJWT)
+                        .build();
+        return new ClientSession(
+                authRequest.toParameters(),
+                LocalDateTime.now(),
+                VectorOfTrust.getDefaults(),
+                "client-name");
+    }
+}


### PR DESCRIPTION
## What?

- Add helper method to calculate and populate DocAppSubjectId

## Why?

- We are going to be moving away from populating the DocAppSubjectId with the pairwise identifier and instead populate it with the sub from the Request Object contained in the original Auth Request.
- The helper class will help determine 2 things. Firstly, if the subject is present in the request object and secondly, whether or not we have enabled the system to start using it. To start with this will be disabled.
