### PR TITLE
AUT-963 - Store Doc App RP Client ID in parameter store

### DIFF
--- a/ci/tasks/deploy-oidc-api.yml
+++ b/ci/tasks/deploy-oidc-api.yml
@@ -14,6 +14,7 @@ params:
   DNS_DEPLOYER_ROLE_ARN: ((deployer-role-arn-production))
   DNS_STATE_BUCKET: ((dns-state-bucket))
   DNS_STATE_KEY: ((dns-state-key))
+  DOC_APP_RP_CLIENT_ID: ((build-doc-app-rp-client-id))
   STATE_BUCKET: digital-identity-dev-tfstate
   TEST_CLIENT_VERIFY_EMAIL_OTP: ((test-client-verify-email-otp))
   TEST_CLIENT_VERIFY_PHONE_NUMBER_OTP: ((test-client-verify-phone-number-otp))
@@ -52,6 +53,7 @@ run:
         -var "client_registry_api_lambda_zip_file=$(ls -1 ../../../../client-registry-api-release/*.zip)" \
         -var "ipv_api_lambda_zip_file=$(ls -1 ../../../../ipv-api-release/*.zip)" \
         -var "doc_checking_app_api_lambda_zip_file=$(ls -1 ../../../../doc-checking-app-api-release/*.zip)" \
+        -var "doc_app_rp_client_id=${DOC_APP_RP_CLIENT_ID}" \
         -var "lambda_warmer_zip_file=$(ls -1 ../../../../lambda-warmer-release/*.zip)" \
         -var "deployer_role_arn=${DEPLOYER_ROLE_ARN}" \
         -var "notify_api_key=${NOTIFY_API_KEY}" \

--- a/ci/terraform/oidc/doc-app-callback.tf
+++ b/ci/terraform/oidc/doc-app-callback.tf
@@ -11,6 +11,7 @@ module "doc_app_callback_role" {
     aws_iam_policy.doc_app_auth_kms_policy.arn,
     aws_iam_policy.dynamo_doc_app_write_access_policy.arn,
     aws_iam_policy.dynamo_doc_app_read_access_policy.arn,
+    aws_iam_policy.doc_app_rp_client_id_parameter_policy.arn,
     module.oidc_txma_audit.access_policy_arn
   ]
 }

--- a/ci/terraform/oidc/ssm.tf
+++ b/ci/terraform/oidc/ssm.tf
@@ -105,3 +105,33 @@ resource "aws_ssm_parameter" "spot_response_queue_kms_arn" {
   type  = "String"
   value = var.spot_response_queue_kms_arn
 }
+
+## DCMAW
+
+resource "aws_ssm_parameter" "doc_app_rp_client_id" {
+  name  = "${var.environment}-doc-app-rp-client-id"
+  type  = "String"
+  value = var.doc_app_rp_client_id
+}
+
+data "aws_iam_policy_document" "doc_app_rp_client_id_parameter_policy_document" {
+  statement {
+    sid    = "AllowGetParameters"
+    effect = "Allow"
+
+    actions = [
+      "ssm:GetParameter",
+      "ssm:GetParameters",
+    ]
+
+    resources = [
+      aws_ssm_parameter.doc_app_rp_client_id.arn
+    ]
+  }
+}
+
+resource "aws_iam_policy" "doc_app_rp_client_id_parameter_policy" {
+  policy      = data.aws_iam_policy_document.doc_app_rp_client_id_parameter_policy_document.json
+  path        = "/${var.environment}/lambda-parameters/"
+  name_prefix = "doc-app-rp-client-id-parameter-store-policy"
+}

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -385,6 +385,11 @@ variable "doc_app_jwks_endpoint" {
   default = "undefined"
 }
 
+variable "doc_app_rp_client_id" {
+  type    = string
+  default = "undefined"
+}
+
 variable "spot_account_number" {
   type        = string
   default     = "undefined"


### PR DESCRIPTION
## What?

- Read the Doc App Client ID evironment variable which is set in our deployment pipeline and set it to a terraform variable.
- Create a new SSM parameter which store the value of the doc_app_rp_client_id terraform variable.
- Create a new policy to read in the SSM parameter and attach this policy to the doc app callback lambda.

## Why?

- Usually we retrieve the client id from the users session. However, AUT-936 is aimed at handling users who do not have a valid session and therefore we not have the users client id available to us. This means we need to store the client ID in config so it can be accessed by the lambda when needed. 
