### PR TITLE
AUT-963 - Send back custom error to RP when it is received from DCMAW

### DIFF
--- a/ci/terraform/oidc/doc-app-callback.tf
+++ b/ci/terraform/oidc/doc-app-callback.tf
@@ -11,6 +11,7 @@ module "doc_app_callback_role" {
     aws_iam_policy.doc_app_auth_kms_policy.arn,
     aws_iam_policy.dynamo_doc_app_write_access_policy.arn,
     aws_iam_policy.dynamo_doc_app_read_access_policy.arn,
+    aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.doc_app_rp_client_id_parameter_policy.arn,
     module.oidc_txma_audit.access_policy_arn
   ]
@@ -31,6 +32,7 @@ module "doc-app-callback" {
     LOGIN_URI                          = module.dns.frontend_url
     REDIS_KEY                          = local.redis_key
     DYNAMO_ENDPOINT                    = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    CUSTOM_DOC_APP_CLAIM_ENABLED       = var.custom_doc_app_claim_enabled
     DOC_APP_AUTHORISATION_CALLBACK_URI = var.doc_app_authorisation_callback_uri
     DOC_APP_AUTHORISATION_CLIENT_ID    = var.doc_app_authorisation_client_id
     DOC_APP_TOKEN_SIGNING_KEY_ALIAS    = local.doc_app_auth_key_alias_name

--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -28,7 +28,6 @@ module "ipv-callback" {
   environment     = var.environment
 
   handler_environment_variables = {
-    CUSTOM_DOC_APP_CLAIM_ENABLED   = var.custom_doc_app_claim_enabled
     DYNAMO_ENDPOINT                = var.use_localstack ? var.lambda_dynamo_endpoint : null
     TXMA_AUDIT_QUEUE_URL           = module.oidc_txma_audit.queue_url
     ENVIRONMENT                    = var.environment

--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
@@ -5,7 +5,9 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.oauth2.sdk.auth.verifier.InvalidClientException;
 import com.nimbusds.oauth2.sdk.http.HTTPRequest;
 import com.nimbusds.openid.connect.sdk.AuthenticationErrorResponse;
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
@@ -24,15 +26,18 @@ import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.DynamoClientService;
 import uk.gov.di.authentication.shared.services.JwksService;
 import uk.gov.di.authentication.shared.services.KmsConnectionService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
 import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.shared.services.SessionService;
 
+import java.net.URI;
 import java.util.Map;
 
 import static com.nimbusds.oauth2.sdk.http.HTTPRequest.Method.POST;
+import static java.lang.String.format;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.authentication.shared.helpers.ConstructUriHelper.buildURI;
 import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
@@ -53,11 +58,12 @@ public class DocAppCallbackHandler
     private final ClientSessionService clientSessionService;
     private final AuditService auditService;
     private final DynamoDocAppService dynamoDocAppService;
+    private final DynamoClientService dynamoClientService;
     private final CookieHelper cookieHelper;
     protected final Json objectMapper = SerializationService.getInstance();
     private static final String REDIRECT_PATH = "doc-app-callback";
-
-    private static final String ERROR_PAGE_REDIRECT_PATH = "error";
+    private static final String ERROR = "error";
+    private static final String ERROR_DESCRIPTION = "error_description";
 
     public DocAppCallbackHandler() {
         this(ConfigurationService.getInstance());
@@ -71,7 +77,8 @@ public class DocAppCallbackHandler
             ClientSessionService clientSessionService,
             AuditService auditService,
             DynamoDocAppService dynamoDocAppService,
-            CookieHelper cookieHelper) {
+            CookieHelper cookieHelper,
+            DynamoClientService dynamoClientService) {
         this.configurationService = configurationService;
         this.authorisationService = responseService;
         this.tokenService = tokenService;
@@ -80,6 +87,7 @@ public class DocAppCallbackHandler
         this.auditService = auditService;
         this.dynamoDocAppService = dynamoDocAppService;
         this.cookieHelper = cookieHelper;
+        this.dynamoClientService = dynamoClientService;
     }
 
     public DocAppCallbackHandler(ConfigurationService configurationService) {
@@ -97,6 +105,7 @@ public class DocAppCallbackHandler
         this.auditService = new AuditService(configurationService);
         this.dynamoDocAppService = new DynamoDocAppService(configurationService);
         this.cookieHelper = new CookieHelper();
+        this.dynamoClientService = new DynamoClientService(configurationService);
     }
 
     @Override
@@ -111,6 +120,29 @@ public class DocAppCallbackHandler
             APIGatewayProxyRequestEvent input, Context context) {
         LOG.info("Request received to DocAppCallbackHandler");
         try {
+            if (isCustomDocAppClaimEnabledAndCustomErrorPresent(input.getQueryStringParameters())) {
+                var clientId = configurationService.getDocAppRPClientId();
+                var clientRegistry =
+                        dynamoClientService
+                                .getClient(clientId)
+                                .orElseThrow(
+                                        () ->
+                                                new InvalidClientException(
+                                                        format(
+                                                                "No client found with clientId: %s",
+                                                                clientId)));
+                var redirectUrl = clientRegistry.getRedirectUrls().get(0);
+                var errorObject =
+                        new ErrorObject(OAuth2Error.ACCESS_DENIED_CODE, "Missing Context");
+                var errorResponse =
+                        new AuthenticationErrorResponse(
+                                URI.create(redirectUrl), errorObject, null, null);
+                return generateApiGatewayProxyResponse(
+                        302,
+                        "",
+                        Map.of(ResponseHeaders.LOCATION, errorResponse.toURI().toString()),
+                        null);
+            }
             var sessionCookiesIds =
                     cookieHelper
                             .parseSessionCookie(input.getHeaders())
@@ -255,6 +287,9 @@ public class DocAppCallbackHandler
         } catch (ParseException e) {
             LOG.info("Cannot retrieve auth request params from client session id");
             return redirectToFrontendErrorPage();
+        } catch (InvalidClientException e) {
+            LOG.error("Client not found with given clientID", e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -282,9 +317,16 @@ public class DocAppCallbackHandler
                 Map.of(
                         ResponseHeaders.LOCATION,
                         ConstructUriHelper.buildURI(
-                                        configurationService.getLoginURI().toString(),
-                                        ERROR_PAGE_REDIRECT_PATH)
+                                        configurationService.getLoginURI().toString(), ERROR)
                                 .toString()),
                 null);
+    }
+
+    private boolean isCustomDocAppClaimEnabledAndCustomErrorPresent(
+            Map<String, String> queryStringParameters) {
+        return configurationService.isCustomDocAppClaimEnabled()
+                && queryStringParameters.containsKey(ERROR)
+                && queryStringParameters.get(ERROR).equals(OAuth2Error.ACCESS_DENIED.getCode())
+                && queryStringParameters.get(ERROR_DESCRIPTION).equals("Missing Context");
     }
 }

--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppAuthorizeHandlerTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppAuthorizeHandlerTest.java
@@ -46,11 +46,8 @@ import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.shared.services.SessionService;
 
 import java.net.URI;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -65,6 +62,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.sharedtest.helper.QueryParamHelper.splitQuery;
 import static uk.gov.di.authentication.sharedtest.helper.RequestEventHelper.contextWithSourceIp;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
@@ -226,20 +224,6 @@ class DocAppAuthorizeHandlerTest {
                         new Payload(signedJWT));
         jweObject.encrypt(new RSAEncrypter(rsaEncryptionKey));
         return EncryptedJWT.parse(jweObject.serialize());
-    }
-
-    public static Map<String, String> splitQuery(String stringUrl) {
-        var uri = URI.create(stringUrl);
-        Map<String, String> query_pairs = new LinkedHashMap<>();
-        var query = uri.getQuery();
-        var pairs = query.split("&");
-        for (String pair : pairs) {
-            int idx = pair.indexOf("=");
-            query_pairs.put(
-                    URLDecoder.decode(pair.substring(0, idx), StandardCharsets.UTF_8),
-                    URLDecoder.decode(pair.substring(idx + 1), StandardCharsets.UTF_8));
-        }
-        return query_pairs;
     }
 
     private AuthenticationRequest generateAuthRequest() {

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandlerTest.java
@@ -53,14 +53,12 @@ import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.shared.services.SessionService;
 
 import java.net.URI;
-import java.net.URLDecoder;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -76,10 +74,11 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.sharedtest.helper.QueryParamHelper.splitQuery;
 import static uk.gov.di.authentication.sharedtest.helper.RequestEventHelper.contextWithSourceIp;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
-public class IPVAuthorisationHandlerTest {
+class IPVAuthorisationHandlerTest {
 
     private final Context context = mock(Context.class);
     private final ConfigurationService configService = mock(ConfigurationService.class);
@@ -242,20 +241,6 @@ public class IPVAuthorisationHandlerTest {
                 .nonce(new Nonce())
                 .claims(oidcClaimsRequest)
                 .build();
-    }
-
-    public static Map<String, String> splitQuery(String stringUrl) {
-        URI uri = URI.create(stringUrl);
-        Map<String, String> query_pairs = new LinkedHashMap<>();
-        String query = uri.getQuery();
-        String[] pairs = query.split("&");
-        for (String pair : pairs) {
-            int idx = pair.indexOf("=");
-            query_pairs.put(
-                    URLDecoder.decode(pair.substring(0, idx), StandardCharsets.UTF_8),
-                    URLDecoder.decode(pair.substring(idx + 1), StandardCharsets.UTF_8));
-        }
-        return query_pairs;
     }
 
     private ClientRegistry generateClientRegistry() {

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/QueryParamHelper.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/QueryParamHelper.java
@@ -1,0 +1,26 @@
+package uk.gov.di.authentication.sharedtest.helper;
+
+import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class QueryParamHelper {
+
+    private QueryParamHelper() {}
+
+    public static Map<String, String> splitQuery(String stringUrl) {
+        URI uri = URI.create(stringUrl);
+        Map<String, String> queryPairs = new LinkedHashMap<>();
+        String query = uri.getQuery();
+        String[] pairs = query.split("&");
+        for (String pair : pairs) {
+            int idx = pair.indexOf("=");
+            queryPairs.put(
+                    URLDecoder.decode(pair.substring(0, idx), StandardCharsets.UTF_8),
+                    URLDecoder.decode(pair.substring(idx + 1), StandardCharsets.UTF_8));
+        }
+        return queryPairs;
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -152,6 +152,17 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return URI.create(System.getenv("DOC_APP_DOMAIN"));
     }
 
+    public String getDocAppRPClientId() {
+        var paramName = format("{0}-doc-app-rp-client-id", getEnvironment());
+        try {
+            var request = GetParameterRequest.builder().name(paramName).build();
+            return getSsmClient().getParameter(request).parameter().value();
+        } catch (ParameterNotFoundException e) {
+            LOG.error("No parameter exists with name: {}", paramName);
+            throw new RuntimeException(e);
+        }
+    }
+
     public String getDomainName() {
         return System.getenv("DOMAIN_NAME");
     }


### PR DESCRIPTION
## What?

- When the customDocAppClaim is enabled and we have received the custom error response from DCMAW, then we want to forward on that error directly to the RP.
- This is to mitigate the issue where the user does not have a valid session due to cross browser issues. Therefore we will not have the clientID handy, so retrieve that from parameter store. We can then use the clientID to get the redirectURI.
- Normally we would use the redirectURI in the auth request but as that is not available, we will get it from the clientRegistry. There could be multiple redirectURIs configured so we will just get the first one in this case.

## Why?

- The users were not being redirected back to the RP because of cross browser issues so this is to mitigate that by identifying which users have been impacted and redirecting them back to the RP with an error.


## TODO 
- Confirm with DCMAW which custom error they will be sending back and make the changes to this draft PR 
- Confirm that there is only ever 1 redirect URI on record with this RP 