### PR TITLE
BAU: Remove `resource-id` custom scope and code to add to tokens

### DIFF
--- a/ci/terraform/oidc/token.tf
+++ b/ci/terraform/oidc/token.tf
@@ -58,7 +58,6 @@ module "token" {
     TOKEN_SIGNING_KEY_RSA_ALIAS = aws_kms_alias.id_token_signing_key_alias.name
     LOCALSTACK_ENDPOINT         = var.use_localstack ? var.localstack_endpoint : null
     HEADERS_CASE_INSENSITIVE    = var.use_localstack ? "true" : "false"
-    RESOURCE_ID_SCOPE_ENABLED   = var.environment == "integration" ? "true" : false
     INTERNAl_SECTOR_URI         = var.internal_sector_uri
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.TokenHandler::handleRequest"

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/CustomScopeValue.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/CustomScopeValue.java
@@ -19,9 +19,6 @@ public class CustomScopeValue extends Scope.Value {
             new CustomScopeValue(
                     "doc-checking-app", Requirement.OPTIONAL, new String[] {"read"}, true);
 
-    public static final CustomScopeValue RESOURCE_ID =
-            new CustomScopeValue("resource-id", Requirement.OPTIONAL, new String[] {"read"}, true);
-
     private final String[] claims;
 
     private boolean privateScope = true;

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -417,11 +417,6 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return System.getenv().getOrDefault("SYNTHETICS_USERS", "");
     }
 
-    public boolean isResourceIdScopeEnabled() {
-        return Boolean.parseBoolean(
-                System.getenv().getOrDefault("RESOURCE_ID_SCOPE_ENABLED", "false"));
-    }
-
     public String getTokenSigningKeyAlias() {
         return System.getenv("TOKEN_SIGNING_KEY_ALIAS");
     }


### PR DESCRIPTION
This was a temporary scope implemented to help in our SOLID discovery and is no longer needed.
