### PR TITLE
BAU: Parameterise the frontend waf rate limit and increase in staging only

### DIFF
--- a/ci/terraform/oidc/api-gateway-frontend.tf
+++ b/ci/terraform/oidc/api-gateway-frontend.tf
@@ -233,7 +233,7 @@ resource "aws_wafv2_web_acl" "wafregional_web_acl_frontend_api" {
     name     = "${var.environment}-frontend-waf-rate-based-rule"
     statement {
       rate_based_statement {
-        limit              = 3600
+        limit              = var.frontend_waf_rate_limit
         aggregate_key_type = "IP"
       }
     }

--- a/ci/terraform/oidc/staging-overrides.tfvars
+++ b/ci/terraform/oidc/staging-overrides.tfvars
@@ -20,6 +20,7 @@ identity_trace_logging_enabled     = true
 language_cy_enabled                = true
 extended_feature_flags_enabled     = true
 test_clients_enabled               = "true"
+frontend_waf_rate_limit            = 36000
 
 ipv_auth_public_encryption_key = <<-EOT
 -----BEGIN PUBLIC KEY-----

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -258,6 +258,12 @@ variable "waf_alarm_blocked_reqeuest_threshold" {
   description = "The number of blocked requests caught by the WAF before a Cloudwatch alarm is generated"
 }
 
+variable "frontend_waf_rate_limit" {
+  default     = 3600
+  type        = number
+  description = "Rate limit per 300s for the Frontend API WAF"
+}
+
 variable "test_client_verify_email_otp" {
   type = string
 }


### PR DESCRIPTION
## What?

Parameterise the frontend waf rate limit and increase in staging only by 10x.

## Why?

Performance testing has hit the rate limit in staging.  WAF rules don't support a count in Terraform to switch them off so increasing the limit by 10x instead to effectively switch off.
