### PR TITLE
AUT-969 - Tidy up phone validation logic

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ValidationHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ValidationHelper.java
@@ -46,8 +46,7 @@ public class ValidationHelper {
             String phoneNumberInput, String environment) {
         if (ALLOWED_TEST_NUMBERS.contains(phoneNumberInput)
                 && !Objects.equals(environment, "production")) return Optional.empty();
-        if ((!phoneNumberInput.startsWith("+"))
-                && ((!phoneNumberInput.matches("[0-9]+")) || (phoneNumberInput.length() < 10))) {
+        if ((phoneNumberInput.length() < 5) || (phoneNumberInput.length() > 25)) {
             return Optional.of(ErrorResponse.ERROR_1012);
         }
         var phoneUtil = PhoneNumberUtil.getInstance();


### PR DESCRIPTION
## What?

 - Tidy up phone validation logic

## Why?

- We allow + to be used on both UK mobile numbers and International phone numbers so only checking the second part of the if statement if it doesn't contain an + doesn't make the validation easy to follow.
- The backend doesn't know what type of number it is validating but we should still protect it by enforcing a size limit.
