### PR TITLE
AUT-829: Add auditing to the test services api

### DIFF
--- a/ci/tasks/deploy-test-services.yml
+++ b/ci/tasks/deploy-test-services.yml
@@ -11,6 +11,7 @@ params:
   DEPLOY_ENVIRONMENT: build
   STATE_BUCKET: digital-identity-dev-tfstate
   SYNTHETICS_USERS: ""
+  TXMA_ACCOUNT_ID: ((build-txma-account-id))
 
 inputs:
   - name: shared-terraform-outputs
@@ -39,6 +40,7 @@ run:
         -var 'logging_endpoint_arn=arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod' \
         -var 'logging_endpoint_arns=["arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"]' \
         -var "synthetics_users=${SYNTHETICS_USERS}" \
+        -var "txma_account_id=${TXMA_ACCOUNT_ID}" \
         -var-file "${DEPLOY_ENVIRONMENT}-overrides.tfvars" \
 
       terraform output --json > ../../../../terraform-outputs/${DEPLOY_ENVIRONMENT}-terraform-outputs.json

--- a/ci/terraform/test-services/audit.tf
+++ b/ci/terraform/test-services/audit.tf
@@ -1,0 +1,6 @@
+module "test_services_txma_audit" {
+  source          = "../modules/txma-audit-queue"
+  environment     = var.environment
+  txma_account_id = var.txma_account_id
+  service_name    = "test-services"
+}

--- a/ci/terraform/test-services/variables.tf
+++ b/ci/terraform/test-services/variables.tf
@@ -90,3 +90,8 @@ variable "endpoint_memory_size" {
 variable "synthetics_users" {
   type = string
 }
+
+variable "txma_account_id" {
+  default = ""
+  type    = string
+}

--- a/test-services-api/src/main/java/uk/gov/di/authentication/testservices/domain/TestServicesAuditableEvent.java
+++ b/test-services-api/src/main/java/uk/gov/di/authentication/testservices/domain/TestServicesAuditableEvent.java
@@ -1,0 +1,12 @@
+package uk.gov.di.authentication.testservices.domain;
+
+import uk.gov.di.authentication.shared.domain.AuditableEvent;
+
+public enum TestServicesAuditableEvent implements AuditableEvent {
+    SYNTHETICS_USER_DELETED,
+    SYNTHETICS_USER_NOT_FOUND_FOR_DELETION;
+
+    public AuditableEvent parseFromName(String name) {
+        return valueOf(name);
+    }
+}

--- a/test-services-api/src/main/java/uk/gov/di/authentication/testservices/lambda/DeleteSyntheticsUserHandler.java
+++ b/test-services-api/src/main/java/uk/gov/di/authentication/testservices/lambda/DeleteSyntheticsUserHandler.java
@@ -7,9 +7,12 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
+import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
+import uk.gov.di.authentication.testservices.domain.TestServicesAuditableEvent;
 
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
@@ -21,6 +24,7 @@ public class DeleteSyntheticsUserHandler
 
     private final AuthenticationService authenticationService;
     private final ConfigurationService configurationService;
+    private final AuditService auditService;
 
     public DeleteSyntheticsUserHandler() {
         this(ConfigurationService.getInstance());
@@ -28,14 +32,17 @@ public class DeleteSyntheticsUserHandler
 
     public DeleteSyntheticsUserHandler(
             AuthenticationService authenticationService,
-            ConfigurationService configurationService) {
+            ConfigurationService configurationService,
+            AuditService auditService) {
         this.authenticationService = authenticationService;
         this.configurationService = configurationService;
+        this.auditService = auditService;
     }
 
     public DeleteSyntheticsUserHandler(ConfigurationService configurationService) {
         this.authenticationService = new DynamoService(configurationService);
         this.configurationService = configurationService;
+        this.auditService = new AuditService(configurationService);
     }
 
     @Override
@@ -57,11 +64,35 @@ public class DeleteSyntheticsUserHandler
                             authenticationService.removeAccount(userProfile.getEmail());
                             LOG.info("Synthetics user account removed.");
 
+                            auditService.submitAuditEvent(
+                                    TestServicesAuditableEvent.SYNTHETICS_USER_DELETED,
+                                    AuditService.UNKNOWN,
+                                    AuditService.UNKNOWN,
+                                    AuditService.UNKNOWN,
+                                    AuditService.UNKNOWN,
+                                    userProfile.getEmail(),
+                                    IpAddressHelper.extractIpAddress(input),
+                                    AuditService.UNKNOWN,
+                                    AuditService.UNKNOWN);
+
                             return generateApiGatewayProxyResponse(204, "");
                         })
                 .orElseGet(
                         () -> {
                             LOG.info("Synthetics user account not found.");
+
+                            auditService.submitAuditEvent(
+                                    TestServicesAuditableEvent
+                                            .SYNTHETICS_USER_NOT_FOUND_FOR_DELETION,
+                                    AuditService.UNKNOWN,
+                                    AuditService.UNKNOWN,
+                                    AuditService.UNKNOWN,
+                                    AuditService.UNKNOWN,
+                                    email,
+                                    IpAddressHelper.extractIpAddress(input),
+                                    AuditService.UNKNOWN,
+                                    AuditService.UNKNOWN);
+
                             return generateApiGatewayProxyErrorResponse(
                                     404, ErrorResponse.ERROR_1010);
                         });


### PR DESCRIPTION
## What?

Add auditing to the test services api.

- Audit when a test user is deleted.
- Audit when an attempt is made to delete a test user, but the user does not exist.

The test services api is currently running in build and integration, and is consumed by the create account smoke test (which runs only in integration).  When auditing is in place the smoke test should be able to move to production.

## Why?

Provide an audit record for whenever a test user is deleted.

## Related PRs

Infrastructure PR