### PR TITLE
AUT-1065 - Add retry policy when calling JWKs endpoint

### DIFF
--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/services/DocAppAuthorisationService.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/services/DocAppAuthorisationService.java
@@ -235,11 +235,10 @@ public class DocAppAuthorisationService {
     private RSAPublicKey getPublicEncryptionKey() {
         try {
             LOG.info("Getting Doc App Auth Encryption Public Key via JWKS endpoint");
-            var publicJwkSet =
-                    jwksService.retrieveJwkSetFromURL(
-                            configurationService.getDocAppJwksUri().toURL());
             var encryptionJWK =
-                    publicJwkSet.getKeyByKeyId(configurationService.getDocAppEncryptionKeyID());
+                    jwksService.retrieveJwkFromURLWithKeyId(
+                            configurationService.getDocAppJwksUri().toURL(),
+                            configurationService.getDocAppEncryptionKeyID());
             return new RSAKey.Builder((RSAKey) encryptionJWK).build().toRSAPublicKey();
         } catch (JOSEException e) {
             LOG.error("Error parsing the public key to RSAPublicKey", e);

--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/services/DocAppAuthorisationServiceTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/services/DocAppAuthorisationServiceTest.java
@@ -7,7 +7,6 @@ import com.nimbusds.jose.crypto.ECDSASigner;
 import com.nimbusds.jose.crypto.RSADecrypter;
 import com.nimbusds.jose.crypto.impl.ECDSA;
 import com.nimbusds.jose.jwk.Curve;
-import com.nimbusds.jose.jwk.JWKSet;
 import com.nimbusds.jose.jwk.KeyUse;
 import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
@@ -113,7 +112,8 @@ class DocAppAuthorisationServiceTest {
                         .keyUse(KeyUse.ENCRYPTION)
                         .keyID(ENCRYPTION_KID)
                         .build();
-        when(jwksService.retrieveJwkSetFromURL(JWKS_URL.toURL())).thenReturn(new JWKSet(rsaKey));
+        when(jwksService.retrieveJwkFromURLWithKeyId(JWKS_URL.toURL(), ENCRYPTION_KID))
+                .thenReturn(rsaKey);
         when(configurationService.getDocAppEncryptionKeyID()).thenReturn(ENCRYPTION_KID);
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/JwksService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/JwksService.java
@@ -1,10 +1,15 @@
 package uk.gov.di.authentication.shared.services;
 
+import com.nimbusds.jose.KeySourceException;
 import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jose.jwk.JWK;
-import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.JWKMatcher;
+import com.nimbusds.jose.jwk.JWKSelector;
 import com.nimbusds.jose.jwk.KeyUse;
 import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.jwk.source.JWKSourceBuilder;
+import com.nimbusds.jose.proc.SecurityContext;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
@@ -14,12 +19,10 @@ import software.amazon.awssdk.services.kms.model.GetPublicKeyRequest;
 import software.amazon.awssdk.services.kms.model.GetPublicKeyResponse;
 import uk.gov.di.authentication.shared.helpers.CryptoProviderHelper;
 
-import java.io.IOException;
 import java.net.URL;
 import java.security.PublicKey;
 import java.security.interfaces.ECPublicKey;
 import java.security.interfaces.RSAPublicKey;
-import java.text.ParseException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -55,11 +58,21 @@ public class JwksService {
         return getPublicJWKWithKeyId(configurationService.getDocAppTokenSigningKeyAlias());
     }
 
-    public JWKSet retrieveJwkSetFromURL(URL url) {
+    public JWK retrieveJwkFromURLWithKeyId(URL url, String keyId) {
+        JWKSelector selector = new JWKSelector(new JWKMatcher.Builder().keyID(keyId).build());
+        JWKSource<SecurityContext> jwkSource =
+                JWKSourceBuilder.create(url)
+                        .retrying(true)
+                        .refreshAheadCache(false)
+                        .cache(false)
+                        .rateLimited(false)
+                        .build();
         try {
             LOG.info("Retrieving JWKSet with URL: {}", url);
-            return JWKSet.load(url);
-        } catch (IOException | ParseException e) {
+            return jwkSource.get(selector, null).stream()
+                    .findFirst()
+                    .orElseThrow(() -> new KeySourceException("No key found with given keyID"));
+        } catch (KeySourceException e) {
             LOG.error("Unable to load JWKSet", e);
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
## What?

 - Add retry policy when calling DCMAW JWKs endpoint
- Rather than adding in our own implementation of a retry policy I.E using a while loop. We can take advantage of the nimbus library and use the https://www.javadoc.io/doc/com.nimbusds/oauth2-oidc-sdk/5.10/com/nimbusds/oauth2/sdk/jose/jwk/JWKSource.html. This allows you to set certain properties such as retrying.
- By default set the cache and rate limited to false until we have a better understanding of how this might work via key rotations.

## Why?
- When try to call the DCMAW JWKs endpoint we are seeing intermittent network errors. The JWKs is served out of an S3 bucket sitting behind an api gateway and is known to throw a 503. AWS suggests that the consumer adds in a retry policy - https://docs.aws.amazon.com/whitepapers/latest/s3-optimizing-performance-best-practices/timeouts-and-retries-for-latency-sensitive-applications.html
