### PR TITLE
AUT-834: WAF rules exception for the smoke test client

### DIFF
--- a/ci/terraform/oidc/api-gateway.tf
+++ b/ci/terraform/oidc/api-gateway.tf
@@ -289,10 +289,6 @@ module "dashboard" {
   use_localstack   = var.use_localstack
 }
 
-data "aws_ssm_parameter" "smoke_test_client_id" {
-  name = "${var.environment}-smoke-test-client-id"
-}
-
 resource "aws_wafv2_web_acl" "wafregional_web_acl_oidc_api" {
   count = var.use_localstack ? 0 : 1
   name  = "${var.environment}-oidc-waf-web-acl"

--- a/ci/terraform/oidc/api-gateway.tf
+++ b/ci/terraform/oidc/api-gateway.tf
@@ -389,7 +389,7 @@ resource "aws_wafv2_web_acl" "wafregional_web_acl_oidc_api" {
     name     = "${var.environment}-smoke-test-client-exception"
 
     dynamic "statement" {
-      for_each = var.environment != "integration" ? ["1"] : []
+      for_each = var.environment == "production" || var.environment == "sandpit" ? ["1"] : []
       content {
         and_statement {
           statement {

--- a/ci/terraform/oidc/api-gateway.tf
+++ b/ci/terraform/oidc/api-gateway.tf
@@ -289,6 +289,10 @@ module "dashboard" {
   use_localstack   = var.use_localstack
 }
 
+data "aws_ssm_parameter" "smoke_test_client_id" {
+  name = "${var.environment}-smoke-test-client-id"
+}
+
 resource "aws_wafv2_web_acl" "wafregional_web_acl_oidc_api" {
   count = var.use_localstack ? 0 : 1
   name  = "${var.environment}-oidc-waf-web-acl"
@@ -340,16 +344,14 @@ resource "aws_wafv2_web_acl" "wafregional_web_acl_oidc_api" {
           name = "NoUserAgent_HEADER"
         }
 
+        excluded_rule {
+          name = "EC2MetaDataSSRF_QUERYARGUMENTS"
+        }
+
         dynamic "excluded_rule" {
           for_each = var.environment != "production" ? ["1"] : []
           content {
             name = "EC2MetaDataSSRF_BODY"
-          }
-        }
-        dynamic "excluded_rule" {
-          for_each = var.environment != "production" ? ["1"] : []
-          content {
-            name = "EC2MetaDataSSRF_QUERYARGUMENTS"
           }
         }
       }
@@ -382,6 +384,54 @@ resource "aws_wafv2_web_acl" "wafregional_web_acl_oidc_api" {
       sampled_requests_enabled   = true
     }
   }
+
+  rule {
+    action {
+      block {}
+    }
+    priority = 4
+    name     = "${var.environment}-smoke-test-client-exception"
+
+    dynamic "statement" {
+      for_each = var.environment != "integration" ? ["1"] : []
+      content {
+        and_statement {
+          statement {
+            label_match_statement {
+              key   = "awswaf:managed:aws:core-rule-set:EC2MetaDataSSRF_QueryArguments"
+              scope = "LABEL"
+            }
+          }
+          statement {
+            not_statement {
+              statement {
+                byte_match_statement {
+                  text_transformation {
+                    priority = 0
+                    type     = "NONE"
+                  }
+                  positional_constraint = "EXACTLY"
+                  search_string         = data.aws_ssm_parameter.smoke_test_client_id.value
+                  field_to_match {
+                    single_query_argument {
+                      name = "client_id"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "${replace(var.environment, "-", "")}SmokeTestClientExceptionRule"
+      sampled_requests_enabled   = true
+    }
+  }
+
 
   visibility_config {
     cloudwatch_metrics_enabled = true

--- a/ci/terraform/oidc/api-gateway.tf
+++ b/ci/terraform/oidc/api-gateway.tf
@@ -407,7 +407,7 @@ resource "aws_wafv2_web_acl" "wafregional_web_acl_oidc_api" {
                     type     = "NONE"
                   }
                   positional_constraint = "EXACTLY"
-                  search_string         = data.aws_ssm_parameter.smoke_test_client_id.value
+                  search_string         = data.aws_ssm_parameter.smoke_test_client_id[0].value
                   field_to_match {
                     single_query_argument {
                       name = "client_id"

--- a/ci/terraform/oidc/site.tf
+++ b/ci/terraform/oidc/site.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "= 3.63.0"
+      version = "= 3.67.0"
     }
     time = {
       source  = "hashicorp/time"

--- a/ci/terraform/oidc/ssm.tf
+++ b/ci/terraform/oidc/ssm.tf
@@ -137,5 +137,6 @@ resource "aws_iam_policy" "doc_app_rp_client_id_parameter_policy" {
 }
 
 data "aws_ssm_parameter" "smoke_test_client_id" {
-  name = "${var.environment}-smoke-test-client-id"
+  count = var.environment == "production" || var.environment == "sandpit" ? 1 : 0
+  name  = "${var.environment}-smoke-test-client-id"
 }

--- a/ci/terraform/oidc/ssm.tf
+++ b/ci/terraform/oidc/ssm.tf
@@ -135,3 +135,7 @@ resource "aws_iam_policy" "doc_app_rp_client_id_parameter_policy" {
   path        = "/${var.environment}/lambda-parameters/"
   name_prefix = "doc-app-rp-client-id-parameter-store-policy"
 }
+
+data "aws_ssm_parameter" "smoke_test_client_id" {
+  name = "${var.environment}-smoke-test-client-id"
+}


### PR DESCRIPTION
## What?

WAF rules exception for the smoke test client.

This PR overrides a specific WAF rule for the smoke test client only. The client id is added to SSM in the smoketest pipeline and retrieved when creating the OIDC api.

Includes an update to make the client id ssm parameter read only available in environments where the parameter exists.

## Why?

The smoke test microclient runs on localhost in the smoke test, however the WAF will block authorize requests containing a redircect_uri to localhost, so the smoke test will not run.

## Related PRs

#2734 
#2709 
https://github.com/alphagov/di-authentication-smoke-tests/pull/69
https://github.com/alphagov/di-authentication-smoke-tests/pull/66
