### PR TITLE
BAU: Include session id (`sid`) on ID tokens

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
@@ -254,7 +254,8 @@ public class TokenHandler
                                             false,
                                             finalClaimsRequest,
                                             true,
-                                            signingAlgorithm));
+                                            signingAlgorithm,
+                                            authCodeExchangeData.getClientSessionId()));
         } else {
             UserProfile userProfile =
                     dynamoService.getUserProfileByEmail(authCodeExchangeData.getEmail());
@@ -279,7 +280,8 @@ public class TokenHandler
                                             isConsentRequired,
                                             finalClaimsRequest,
                                             false,
-                                            signingAlgorithm));
+                                            signingAlgorithm,
+                                            authCodeExchangeData.getClientSessionId()));
         }
 
         clientSessionService.saveClientSession(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
@@ -230,7 +230,8 @@ public class TokenHandlerTest {
                         expectedConsentRequired,
                         null,
                         false,
-                        JWSAlgorithm.ES256))
+                        JWSAlgorithm.ES256,
+                        CLIENT_SESSION_ID))
                 .thenReturn(tokenResponse);
 
         APIGatewayProxyResponseEvent result =
@@ -301,7 +302,8 @@ public class TokenHandlerTest {
                         expectedConsentRequired,
                         null,
                         false,
-                        JWSAlgorithm.RS256))
+                        JWSAlgorithm.RS256,
+                        CLIENT_SESSION_ID))
                 .thenReturn(tokenResponse);
 
         APIGatewayProxyResponseEvent result =
@@ -591,7 +593,8 @@ public class TokenHandlerTest {
                         false,
                         null,
                         true,
-                        JWSAlgorithm.ES256))
+                        JWSAlgorithm.ES256,
+                        CLIENT_SESSION_ID))
                 .thenReturn(tokenResponse);
 
         var result =

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
@@ -116,6 +116,7 @@ public class TokenServiceTest {
         when(configurationService.getAccessTokenExpiry()).thenReturn(300L);
         when(configurationService.getIDTokenExpiry()).thenReturn(120L);
         when(configurationService.getSessionExpiry()).thenReturn(300L);
+        when(configurationService.getEnvironment()).thenReturn("test");
         when(kmsConnectionService.getPublicKey(any(GetPublicKeyRequest.class)))
                 .thenReturn(GetPublicKeyResponse.builder().keyId("789789789789789").build());
 
@@ -154,7 +155,8 @@ public class TokenServiceTest {
                         false,
                         null,
                         false,
-                        JWSAlgorithm.ES256);
+                        JWSAlgorithm.ES256,
+                        "client-session-id");
 
         assertSuccessfulTokenResponse(tokenResponse);
 
@@ -208,7 +210,8 @@ public class TokenServiceTest {
                         false,
                         oidcClaimsRequest,
                         false,
-                        JWSAlgorithm.ES256);
+                        JWSAlgorithm.ES256,
+                        "client-session-id");
 
         assertSuccessfulTokenResponse(tokenResponse);
 
@@ -278,7 +281,8 @@ public class TokenServiceTest {
                         false,
                         null,
                         false,
-                        JWSAlgorithm.ES256);
+                        JWSAlgorithm.ES256,
+                        "client-session-id");
 
         assertSuccessfulTokenResponse(tokenResponse);
 
@@ -493,5 +497,9 @@ public class TokenServiceTest {
                                         JWSAlgorithm.ES256,
                                         null)
                                 .toString()));
+
+        assertThat(
+                tokenResponse.getOIDCTokens().getIDToken().getJWTClaimsSet().getStringClaim("sid"),
+                is("client-session-id"));
     }
 }


### PR DESCRIPTION
This implements ADR 0071 to expose our journey id to RPs on the ID token as session identifier

