### PR TITLE
AUT-982: Add new account status to auth code issued audit event

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
@@ -10,6 +10,7 @@ public class Session {
     public enum AccountState {
         NEW,
         EXISTING,
+        EXISTING_DOC_APP_JOURNEY,
         UNKNOWN
     }
 


### PR DESCRIPTION
## What?

- Add new account status to auth code issued audit event. 
- **Note:** I have also added a new account status type relating to the Doc App Journey to make it clearer when a recurring sign-in is using this mechanism.

## Why?

- Allows performance analysts to differentiate between sign in and account creation journeys for this event (broadly analogous to first point of handover back to RPs)
