### PR TITLE
AUT-938: Point staging at One Login rename templates in prod Notify account

### DIFF
--- a/ci/terraform/account-management/staging-overrides.tfvars
+++ b/ci/terraform/account-management/staging-overrides.tfvars
@@ -6,3 +6,12 @@ scaling_trigger        = 0.6
 logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]
+
+notify_template_map = {
+  VERIFY_EMAIL_TEMPLATE_ID         = "09f29c9a-3f34-4a56-88f5-8197aede7f85"
+  VERIFY_PHONE_NUMBER_TEMPLATE_ID  = "8babad52-0e2e-443a-8a5a-c296dc1696cc"
+  EMAIL_UPDATED_TEMPLATE_ID        = "22aac1ce-38c7-45f5-97b2-26ac1a54a235"
+  DELETE_ACCOUNT_TEMPLATE_ID       = "1540bdda-fdff-4297-b627-92102e061bfa"
+  PHONE_NUMBER_UPDATED_TEMPLATE_ID = "8907d080-e69c-42c6-8cf5-54ca1558a2e4"
+  PASSWORD_UPDATED_TEMPLATE_ID     = "ebf3730c-0769-462b-ab39-7d9a7439bac1"
+}

--- a/ci/terraform/oidc/staging-overrides.tfvars
+++ b/ci/terraform/oidc/staging-overrides.tfvars
@@ -56,3 +56,12 @@ scaling_trigger        = 0.6
 logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]
+
+notify_template_map = {
+  VERIFY_EMAIL_TEMPLATE_ID                 = "09f29c9a-3f34-4a56-88f5-8197aede7f85"
+  VERIFY_PHONE_NUMBER_TEMPLATE_ID          = "8babad52-0e2e-443a-8a5a-c296dc1696cc"
+  MFA_SMS_TEMPLATE_ID                      = "31e48dbf-6db6-4864-9710-081b72746698"
+  PASSWORD_RESET_CONFIRMATION_TEMPLATE_ID  = "c5a6a8d6-0a45-4496-bec8-37167fc6ecaa"
+  ACCOUNT_CREATED_CONFIRMATION_TEMPLATE_ID = "99580afe-9d3f-4ed1-816d-3b583a7b9167"
+  RESET_PASSWORD_WITH_CODE_TEMPLATE_ID     = "4f76b165-8935-49fe-8ba8-8ca62a1fe723"
+}


### PR DESCRIPTION
## What?

Point staging at one login rename templates in prod Notify account.

Draft templates for the name change have been updated in the Notify test account.  These templates have been copied to the Notify production account as release candidates.

This PR points staging at the release candidate templates so they can be tested in staging.

The configuration here (the new template ids) will be rolled out to prod at the required time so that the current templates are replaced with the new updated ones.

A new Notify production api key should be created and configured in the pipeline before merging so that message requests from staging are routed to the Notify production account.

## Why?

Enable testing of the new release candidate templates in staging.
Test configuration of the new template ids before moving to production.

## Related PRs


