### PR TITLE
AUT-938: Downgrade missing template messages from error to warn

### DIFF
--- a/delivery-receipts-api/src/main/java/uk/gov/di/authentication/deliveryreceiptsapi/lambda/NotifyCallbackHandler.java
+++ b/delivery-receipts-api/src/main/java/uk/gov/di/authentication/deliveryreceiptsapi/lambda/NotifyCallbackHandler.java
@@ -140,7 +140,7 @@ public class NotifyCallbackHandler
                 .map(DeliveryReceiptsNotificationType::getTemplateAlias)
                 .orElseThrow(
                         () -> {
-                            LOG.error("No template found with template ID: {}", templateID);
+                            LOG.warn("No template found with template ID: {}", templateID);
                             throw new RuntimeException("No template found with template ID");
                         });
     }


### PR DESCRIPTION
## What?

Downgrade missing template messages from error to warn.

## Why?

Avoid triggering an alert for missing template ids.

Staging templates are currently deployed to the prod notify account in order to facilitate an easier rollout from staging to prod for the GOV.UK One Login name change.

We don't want to include staging messages in message totals, but also don't want alerts to trigger.

## Related PRs

#2746 