### PR TITLE
AUT-829: Give delete synthetics user txma queue url

### DIFF
--- a/ci/terraform/test-services/delete-synthetics-user.tf
+++ b/ci/terraform/test-services/delete-synthetics-user.tf
@@ -19,9 +19,10 @@ module "delete-synthetics-user" {
   environment     = var.environment
 
   handler_environment_variables = {
-    ENVIRONMENT         = var.environment
-    LOCALSTACK_ENDPOINT = var.use_localstack ? var.localstack_endpoint : null
-    SYNTHETICS_USERS    = var.synthetics_users
+    ENVIRONMENT          = var.environment
+    LOCALSTACK_ENDPOINT  = var.use_localstack ? var.localstack_endpoint : null
+    SYNTHETICS_USERS     = var.synthetics_users
+    TXMA_AUDIT_QUEUE_URL = module.test_services_txma_audit.queue_url
   }
   handler_function_name = "uk.gov.di.authentication.testservices.lambda.DeleteSyntheticsUserHandler::handleRequest"
 


### PR DESCRIPTION
## What?

Give delete synthetics user txma queue url.

## Why?

Fix QueueDoesNotExistException.  Audit cannot currently post audit messages to the queue.

## Related PRs

#2725
