### PR TITLE
AUT-829: Add txma queue access policy to test services execution role

### DIFF
--- a/ci/terraform/test-services/delete-synthetics-user.tf
+++ b/ci/terraform/test-services/delete-synthetics-user.tf
@@ -7,6 +7,7 @@ module "test_services_api_delete-synthetics-user_role" {
   policies_to_attach = [
     aws_iam_policy.dynamo_test_services_user_read_access_policy.arn,
     aws_iam_policy.dynamo_test_services_user_delete_access_policy.arn,
+    module.test_services_txma_audit.access_policy_arn,
   ]
 }
 


### PR DESCRIPTION

## What?

Add txma queue access policy to test services execution role.

## Why?

Fix 'Access to resource denied' errors.
Allows the lambda to post audit messages.

## Related PRs

#2761 
#2725
