### PR TITLE
AUT-829: Add smokeTest flag to client registry entry

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
@@ -156,6 +156,8 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
                         .getClient()
                         .map(ClientRegistry::getClientID)
                         .orElse(AuditService.UNKNOWN);
+        boolean isSmokeTest =
+                userContext.getClient().map(ClientRegistry::isSmokeTest).orElse(false);
         switch (request.getUpdateProfileType()) {
             case ADD_PHONE_NUMBER:
                 {
@@ -164,7 +166,9 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
                                     request.getProfileInformation());
                     Optional<ErrorResponse> errorResponse =
                             ValidationHelper.validatePhoneNumber(
-                                    phoneNumber, configurationService.getEnvironment());
+                                    phoneNumber,
+                                    configurationService.getEnvironment(),
+                                    isSmokeTest);
                     if (errorResponse.isPresent()) {
                         return generateErrorResponse(
                                 errorResponse.get(),
@@ -175,6 +179,7 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
                                 persistentSessionId,
                                 session.getInternalCommonSubjectIdentifier());
                     }
+                    if (isSmokeTest) LOG.info("Accepting test number as valid for smoke test");
                     authenticationService.updatePhoneNumber(
                             request.getEmail(), request.getProfileInformation());
                     auditableEvent = UPDATE_PROFILE_PHONE_NUMBER;

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ClientRegistry.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ClientRegistry.java
@@ -34,6 +34,7 @@ public class ClientRegistry {
 
     private boolean oneLoginService = false;
     private String idTokenSigningAlgorithm = "ES256";
+    private boolean smokeTest = false;
 
     public ClientRegistry() {}
 
@@ -344,6 +345,20 @@ public class ClientRegistry {
 
     public ClientRegistry withClientSecret(String clientSecret) {
         this.clientSecret = clientSecret;
+        return this;
+    }
+
+    @DynamoDbAttribute("SmokeTest")
+    public boolean isSmokeTest() {
+        return smokeTest;
+    }
+
+    public void setSmokeTest(boolean smokeTest) {
+        this.smokeTest = smokeTest;
+    }
+
+    public ClientRegistry withSmokeTest(boolean smokeTest) {
+        this.smokeTest = smokeTest;
         return this;
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ValidationHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ValidationHelperTest.java
@@ -43,7 +43,7 @@ class ValidationHelperTest {
     void shouldReturnErrorIfMobileNumberIsInvalid(String phoneNumber) {
         assertEquals(
                 Optional.of(ErrorResponse.ERROR_1012),
-                ValidationHelper.validatePhoneNumber(phoneNumber, PRODUCTION));
+                ValidationHelper.validatePhoneNumber(phoneNumber, PRODUCTION, false));
     }
 
     private static Stream<String> internationalPhoneNumbers() {
@@ -62,15 +62,31 @@ class ValidationHelperTest {
     @MethodSource("internationalPhoneNumbers")
     void shouldAcceptValidInternationPhoneNumbers(String phoneNumber) {
         assertThat(
-                ValidationHelper.validatePhoneNumber(phoneNumber, PRODUCTION),
+                ValidationHelper.validatePhoneNumber(phoneNumber, PRODUCTION, false),
                 equalTo(Optional.empty()));
     }
 
     @Test
     void shouldAcceptValidBritishPhoneNumbers() {
         assertThat(
-                ValidationHelper.validatePhoneNumber("+4407911123456", PRODUCTION),
+                ValidationHelper.validatePhoneNumber("+4407911123456", PRODUCTION, false),
                 equalTo(Optional.empty()));
+    }
+
+    @ParameterizedTest
+    @MethodSource("testPhoneNumbers")
+    void shouldAcceptTestNumberForSmokeTest(String testPhoneNumber) {
+        assertThat(
+                ValidationHelper.validatePhoneNumber(testPhoneNumber, PRODUCTION, true),
+                equalTo(Optional.empty()));
+    }
+
+    @ParameterizedTest
+    @MethodSource("testPhoneNumbers")
+    void shouldRejectTestNumberWhenNotSmokeTest(String testPhoneNumber) {
+        assertThat(
+                ValidationHelper.validatePhoneNumber(testPhoneNumber, PRODUCTION, false),
+                equalTo(Optional.of(ErrorResponse.ERROR_1012)));
     }
 
     private static Stream<Arguments> invalidPasswords() {


### PR DESCRIPTION
## What?

Add smokeTest flag to client registry entry.
Accept test numbers in production for smoke tests only.
Add additional logging when validating phone numbers.

## Why?

Provides ability to accept test numbers for smoke tests in production

Previously when validating phone numbers for new accounts we did not accept test numbers as valid in the production environment.  This PR adds an extra flag to a client registry entry to indicate whether the client is a smoke test client.  If so then test numbers are accepted so that the create account smoke test can succeed.

Additional logging added for phone number validation so we can see exactly which validation rule is failing for an invalid number.

## Related PRs

https://github.com/alphagov/di-authentication-smoke-tests/pull/86
