### PR TITLE
AUT-923: Log sms bucket error for smoke test

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandler.java
@@ -192,7 +192,7 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                         PutObjectRequest.builder().bucket(bucketName).key(destination).build();
                 s3Client.putObject(putObjectRequest, RequestBody.fromString(otp));
             } catch (Exception e) {
-                LOG.error("Exception thrown when writing to S3 bucket");
+                LOG.error("Exception thrown when writing to S3 bucket: {}", e.getMessage());
             }
         }
     }


### PR DESCRIPTION
## What?

Log sms bucket error for smoke test.

## Why?

Receiving an 'Exception thrown when writing to S3 bucket' bucket error so adding additional logging to understand the cause.

## Related PRs

https://github.com/alphagov/di-authentication-smoke-tests/pull/86
https://github.com/alphagov/di-authentication-smoke-tests/pull/94