### PR TITLE
BAU: Accept FIXED_LINE_OR_MOBILE numbers

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ValidationHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ValidationHelper.java
@@ -2,6 +2,7 @@ package uk.gov.di.authentication.shared.helpers;
 
 import com.google.i18n.phonenumbers.NumberParseException;
 import com.google.i18n.phonenumbers.PhoneNumberUtil;
+import com.google.i18n.phonenumbers.PhoneNumberUtil.PhoneNumberType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
@@ -14,6 +15,7 @@ import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static com.google.i18n.phonenumbers.PhoneNumberUtil.PhoneNumberType.FIXED_LINE_OR_MOBILE;
 import static com.google.i18n.phonenumbers.PhoneNumberUtil.PhoneNumberType.MOBILE;
 
 public class ValidationHelper {
@@ -66,7 +68,7 @@ public class ValidationHelper {
         try {
             var phoneNumber = phoneUtil.parse(phoneNumberInput, "GB");
             var phoneNumberType = phoneUtil.getNumberType(phoneNumber);
-            if (!MOBILE.equals(phoneNumberType)) {
+            if (!isAcceptedPhoneNumberType(phoneNumberType)) {
                 LOG.warn(
                         "Invalid phone number: not a mobile number.  NumberType {} CountryCode {}",
                         phoneNumberType,
@@ -82,6 +84,10 @@ public class ValidationHelper {
             LOG.warn("Invalid phone number: parsing failure");
             return Optional.of(ErrorResponse.ERROR_1012);
         }
+    }
+
+    static boolean isAcceptedPhoneNumberType(PhoneNumberType phoneNumberType) {
+        return MOBILE.equals(phoneNumberType) || FIXED_LINE_OR_MOBILE.equals(phoneNumberType);
     }
 
     public static Optional<ErrorResponse> validatePassword(String password) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ValidationHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ValidationHelper.java
@@ -70,11 +70,11 @@ public class ValidationHelper {
             var phoneNumberType = phoneUtil.getNumberType(phoneNumber);
             if (!isAcceptedPhoneNumberType(phoneNumberType)) {
                 LOG.warn(
-                        "Invalid phone number: not a mobile number.  NumberType {} CountryCode {}",
-                        phoneNumberType,
-                        phoneNumber.getCountryCode());
+                        "Invalid phone number: not a mobile number.  NumberType {}",
+                        phoneNumberType);
                 return Optional.of(ErrorResponse.ERROR_1012);
             }
+            LOG.info("Accepted phone NumberType {}", phoneNumberType);
             if (phoneUtil.isValidNumber(phoneNumber)) {
                 return Optional.empty();
             }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ValidationHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ValidationHelperTest.java
@@ -11,9 +11,13 @@ import uk.gov.di.authentication.shared.services.CodeStorageService;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import static com.google.i18n.phonenumbers.PhoneNumberUtil.PhoneNumberType.FIXED_LINE;
+import static com.google.i18n.phonenumbers.PhoneNumberUtil.PhoneNumberType.FIXED_LINE_OR_MOBILE;
+import static com.google.i18n.phonenumbers.PhoneNumberUtil.PhoneNumberType.MOBILE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.Mockito.mock;
@@ -363,6 +367,13 @@ class ValidationHelperTest {
         assertThat(
                 ValidationHelper.validatePhoneNumber("+447911123456", "07911123456", PRODUCTION),
                 equalTo(Optional.of(ErrorResponse.ERROR_1044)));
+    }
+
+    @Test
+    void shouldAcceptSupportedPhoneNumberTypes() {
+        assertTrue(ValidationHelper.isAcceptedPhoneNumberType(MOBILE));
+        assertTrue(ValidationHelper.isAcceptedPhoneNumberType(FIXED_LINE_OR_MOBILE));
+        assertFalse(ValidationHelper.isAcceptedPhoneNumberType(FIXED_LINE));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
## What?

Accept FIXED_LINE_OR_MOBILE numbers.

## Why?

Following IPN switch-on we are seeing traffic from countries where number ranges can either be fixed or mobile.  Add support for these numbers so that we accept them through phone number validation.

https://groups.google.com/g/libphonenumber-discuss/c/flHAmI5-1sw