### PR TITLE
BAU - Refactor wellknown endpoint

### DIFF
--- a/ci/terraform/oidc/doc-app-alerts.tf
+++ b/ci/terraform/oidc/doc-app-alerts.tf
@@ -1,11 +1,19 @@
 data "aws_cloudwatch_log_group" "doc_app_callback_lambda_log_group" {
   count = var.use_localstack ? 0 : 1
   name  = replace("/aws/lambda/${var.environment}-doc-app-callback-lambda", ".", "")
+
+  depends_on = [
+    module.doc-app-callback
+  ]
 }
 
 data "aws_cloudwatch_log_group" "doc_app_authorize_lambda_log_group" {
   count = var.use_localstack ? 0 : 1
   name  = replace("/aws/lambda/${var.environment}-doc-app-authorize-lambda", ".", "")
+
+  depends_on = [
+    module.doc-app-authorize
+  ]
 }
 
 resource "aws_cloudwatch_log_metric_filter" "doc_app_callback_metric_filter" {

--- a/ci/terraform/oidc/ipv-handback-alerts.tf
+++ b/ci/terraform/oidc/ipv-handback-alerts.tf
@@ -1,16 +1,27 @@
 data "aws_cloudwatch_log_group" "ipv_callback_lambda_log_group" {
   count = var.use_localstack ? 0 : 1
   name  = replace("/aws/lambda/${var.environment}-ipv-callback-lambda", ".", "")
+
+  depends_on = [
+    module.ipv-callback
+  ]
 }
 
 data "aws_cloudwatch_log_group" "spot_response_lambda_log_group" {
   count = var.use_localstack ? 0 : 1
   name  = replace("/aws/lambda/${var.environment}-spot-response-lambda", ".", "")
+  depends_on = [
+    module.ipv_spot_response_role
+  ]
 }
 
 data "aws_cloudwatch_log_group" "processing_identity_lambda_log_group" {
   count = var.use_localstack ? 0 : 1
   name  = replace("/aws/lambda/${var.environment}-processing-identity-lambda", ".", "")
+
+  depends_on = [
+    module.processing-identity
+  ]
 }
 
 resource "aws_cloudwatch_log_metric_filter" "ipv_callback_metric_filter" {

--- a/ci/terraform/oidc/ipv-handoff-alerts.tf
+++ b/ci/terraform/oidc/ipv-handoff-alerts.tf
@@ -1,6 +1,10 @@
 data "aws_cloudwatch_log_group" "ipv_authorize_lambda_log_group" {
   count = var.use_localstack ? 0 : 1
   name  = replace("/aws/lambda/${var.environment}-ipv-authorize-lambda", ".", "")
+
+  depends_on = [
+    module.ipv-authorize
+  ]
 }
 
 resource "aws_cloudwatch_log_metric_filter" "ipv_authorize_metric_filter" {

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/WellknownHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/WellknownHandlerTest.java
@@ -12,7 +12,6 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.net.URI;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -36,7 +35,6 @@ class WellknownHandlerTest {
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         URI expectedRegistrationURI = URI.create("http://localhost:8080/connect/register");
-        String expectedIdentityURI = "http://localhost:8080/identity";
         String expectedTrustMarkURI = "http://localhost:8080/trustmark";
 
         assertThat(result, hasStatus(200));
@@ -63,9 +61,14 @@ class WellknownHandlerTest {
     void shouldThrowExceptionWhenBaseUrlIsMissing() {
         when(configService.getOidcApiBaseURL()).thenReturn(Optional.empty());
 
-        assertThrows(
-                NoSuchElementException.class,
-                () -> new WellknownHandler(configService),
-                "Expected to throw exception");
+        var expectedException =
+                assertThrows(
+                        RuntimeException.class,
+                        () -> new WellknownHandler(configService),
+                        "Expected to throw exception");
+
+        assertThat(
+                expectedException.getMessage(),
+                equalTo("java.util.NoSuchElementException: No value present"));
     }
 }


### PR DESCRIPTION
## What?

- Build the entire wellknown string in the constructor.
- Make the alerts dependent on the module they are alerting on

## Why?

- Previously we were creating an instance of the wellknown endpoint in the constructor but then setting everything in the handler. We can simplify this by setting all the attributes in the constructor and then just referencing the generated string in the handler itself.
- The attributes of the wellknown endpoint hardly change and when they do it usually forces a deploy of the handler anyway.
- It should have no real impact on cold starts as are already constructing the wellknown object inside the constructor itself
- The alerts use the cloudwatch log groups of certain lambdas so we need to make sure they are created before the alerts are
