### PR TITLE
AUT-1079 - Put reset password SMS behind feature flag

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
@@ -147,7 +147,7 @@ public class ResetPasswordHandler extends BaseFrontendHandler<ResetPasswordCompl
 
                 authenticationService.getUserProfileByEmail(
                         userContext.getSession().getEmailAddress());
-                if (shouldSendConfirmationToSms(userProfile)) {
+                if (shouldSendConfirmationToSms(userProfile, configurationService)) {
                     var smsNotifyRequest =
                             new NotifyRequest(
                                     userProfile.getPhoneNumber(),
@@ -187,8 +187,11 @@ public class ResetPasswordHandler extends BaseFrontendHandler<ResetPasswordCompl
         }
     }
 
-    private boolean shouldSendConfirmationToSms(UserProfile userProfile) {
-        return Objects.nonNull(userProfile.getPhoneNumber()) && userProfile.isPhoneNumberVerified();
+    private boolean shouldSendConfirmationToSms(
+            UserProfile userProfile, ConfigurationService configurationService) {
+        return Objects.nonNull(userProfile.getPhoneNumber())
+                && userProfile.isPhoneNumberVerified()
+                && configurationService.isResetPasswordConfirmationSmsEnabled();
     }
 
     private static boolean verifyPassword(String hashedPassword, String password) {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandlerTest.java
@@ -102,6 +102,7 @@ class ResetPasswordHandlerTest {
                 .when(passwordValidator)
                 .validate("password");
         when(clientService.getClient(TEST_CLIENT_ID)).thenReturn(Optional.of(testClientRegistry));
+        when(configurationService.isResetPasswordConfirmationSmsEnabled()).thenReturn(true);
 
         handler =
                 new ResetPasswordHandler(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -188,6 +188,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return System.getenv().getOrDefault("IDENTITY_ENABLED", "false").equals("true");
     }
 
+    public boolean isResetPasswordConfirmationSmsEnabled() {
+        return List.of("build", "staging", "integration", "local").contains(getEnvironment());
+    }
+
     public boolean isSpotEnabled() {
         return System.getenv().getOrDefault("SPOT_ENABLED", "false").equals("true");
     }


### PR DESCRIPTION
## What?

 - Put reset password SMS behind feature flag

## Why?

- So it can be tested in lower environments whilst preventing other features from being deployed to production
