### PR TITLE
AUT-1125 - Create shared class for no session orchestration logic

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/NoSessionEntity.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/NoSessionEntity.java
@@ -1,0 +1,29 @@
+package uk.gov.di.authentication.shared.entity;
+
+import com.nimbusds.oauth2.sdk.ErrorObject;
+
+public class NoSessionEntity {
+
+    private final String clientSessionId;
+    private final ErrorObject errorObject;
+    private final ClientSession clientSession;
+
+    public NoSessionEntity(
+            String clientSessionId, ErrorObject errorObject, ClientSession clientSession) {
+        this.clientSessionId = clientSessionId;
+        this.errorObject = errorObject;
+        this.clientSession = clientSession;
+    }
+
+    public String getClientSessionId() {
+        return clientSessionId;
+    }
+
+    public ErrorObject getErrorObject() {
+        return errorObject;
+    }
+
+    public ClientSession getClientSession() {
+        return clientSession;
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/NoSessionException.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/NoSessionException.java
@@ -1,0 +1,8 @@
+package uk.gov.di.authentication.shared.exceptions;
+
+public class NoSessionException extends Exception {
+
+    public NoSessionException(String message) {
+        super(message);
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/NoSessionOrchestrationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/NoSessionOrchestrationService.java
@@ -1,0 +1,101 @@
+package uk.gov.di.authentication.shared.services;
+
+import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.OAuth2Error;
+import com.nimbusds.oauth2.sdk.id.State;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.shared.entity.NoSessionEntity;
+import uk.gov.di.authentication.shared.exceptions.NoSessionException;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static java.lang.String.format;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.CLIENT_SESSION_ID;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.GOVUK_SIGNIN_JOURNEY_ID;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachLogFieldToLogs;
+
+public class NoSessionOrchestrationService {
+
+    private static final Logger LOG = LogManager.getLogger(NoSessionOrchestrationService.class);
+    private final RedisConnectionService redisConnectionService;
+    private final ClientSessionService clientSessionService;
+    private final ConfigurationService configurationService;
+    public static final String STATE_STORAGE_PREFIX = "state:";
+
+    public NoSessionOrchestrationService(
+            RedisConnectionService redisConnectionService,
+            ClientSessionService clientSessionService,
+            ConfigurationService configurationService) {
+        this.redisConnectionService = redisConnectionService;
+        this.clientSessionService = clientSessionService;
+        this.configurationService = configurationService;
+    }
+
+    public NoSessionEntity generateNoSessionOrchestrationEntity(
+            Map<String, String> queryStringParameters, boolean noSessionResponseEnabled)
+            throws NoSessionException {
+        LOG.info(
+                "Attempting to generate error response using state. NoSessionResponseEnabled: {}",
+                noSessionResponseEnabled);
+        if (isAccessDeniedErrorAndStatePresent(queryStringParameters, noSessionResponseEnabled)) {
+            LOG.info("access_denied error and state param are both present");
+            var clientSessionId =
+                    getClientSessionIdFromState(State.parse(queryStringParameters.get("state")))
+                            .orElseThrow(
+                                    () ->
+                                            new NoSessionException(
+                                                    "ClientSessionId could not be found using state param"));
+            LOG.info("ClientSessionID found using state");
+            attachLogFieldToLogs(CLIENT_SESSION_ID, clientSessionId);
+            attachLogFieldToLogs(GOVUK_SIGNIN_JOURNEY_ID, clientSessionId);
+            var clientSession =
+                    clientSessionService
+                            .getClientSession(clientSessionId)
+                            .orElseThrow(
+                                    () ->
+                                            new NoSessionException(
+                                                    "No client session found with given client sessionId"));
+            LOG.info("ClientSession found using clientSessionId");
+            var errorDescription =
+                    Optional.ofNullable(queryStringParameters.get("error_description"))
+                            .orElse(OAuth2Error.ACCESS_DENIED.getDescription());
+            var errorObject = new ErrorObject(queryStringParameters.get("error"), errorDescription);
+            LOG.info(
+                    "ErrorObject created for session cookie not present. Generating NoSessionEntity in preparation for response to RP");
+            return new NoSessionEntity(clientSessionId, errorObject, clientSession);
+        } else {
+            LOG.warn(
+                    "Session Cookie not present and access_denied or state param missing from error response. NoSessionResponseEnabled: {}",
+                    noSessionResponseEnabled);
+            throw new NoSessionException(
+                    format(
+                            "Session Cookie not present and access_denied or state param missing from error response. NoSessionResponseEnabled: %s",
+                            noSessionResponseEnabled));
+        }
+    }
+
+    public void storeClientSessionIdAgainstState(String clientSessionId, State state) {
+        LOG.info("Storing clientSessionId against state");
+        redisConnectionService.saveWithExpiry(
+                STATE_STORAGE_PREFIX + state.getValue(),
+                clientSessionId,
+                configurationService.getSessionExpiry());
+    }
+
+    private Optional<String> getClientSessionIdFromState(State state) {
+        LOG.info("Getting clientSessionId using state");
+        return Optional.ofNullable(
+                redisConnectionService.getValue(STATE_STORAGE_PREFIX + state.getValue()));
+    }
+
+    private boolean isAccessDeniedErrorAndStatePresent(
+            Map<String, String> queryStringParameters, boolean noSessionResponseEnabled) {
+        return noSessionResponseEnabled
+                && queryStringParameters.containsKey("error")
+                && queryStringParameters.get("error").equals(OAuth2Error.ACCESS_DENIED.getCode())
+                && queryStringParameters.containsKey("state")
+                && Boolean.FALSE.equals(queryStringParameters.get("state").isEmpty());
+    }
+}

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/NoSessionOrchestrationServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/NoSessionOrchestrationServiceTest.java
@@ -1,0 +1,256 @@
+package uk.gov.di.authentication.shared.services;
+
+import com.nimbusds.oauth2.sdk.OAuth2Error;
+import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.oauth2.sdk.ResponseType;
+import com.nimbusds.oauth2.sdk.Scope;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.id.State;
+import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+import com.nimbusds.openid.connect.sdk.Nonce;
+import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.entity.ClientSession;
+import uk.gov.di.authentication.shared.exceptions.NoSessionException;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class NoSessionOrchestrationServiceTest {
+
+    private final RedisConnectionService redisConnectionService =
+            mock(RedisConnectionService.class);
+    private final ClientSessionService clientSessionService = mock(ClientSessionService.class);
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    public static final String STATE_STORAGE_PREFIX = "state:";
+    private static final URI REDIRECT_URI = URI.create("test-uri");
+    private static final ClientID CLIENT_ID = new ClientID();
+    private static final State STATE = new State();
+    private static final String CLIENT_SESSION_ID = "a-client-session-id";
+
+    private NoSessionOrchestrationService noSessionOrchestrationService;
+
+    @BeforeEach
+    void setup() {
+        noSessionOrchestrationService =
+                new NoSessionOrchestrationService(
+                        redisConnectionService, clientSessionService, configurationService);
+    }
+
+    @Test
+    void shouldSuccessfullyReturnNoSessionOrchestrationEntity()
+            throws NoSessionException, ParseException {
+        when(redisConnectionService.getValue(STATE_STORAGE_PREFIX + STATE.getValue()))
+                .thenReturn(CLIENT_SESSION_ID);
+        when(clientSessionService.getClientSession(CLIENT_SESSION_ID))
+                .thenReturn(Optional.of(generateClientSession()));
+
+        Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("state", STATE.getValue());
+        queryParams.put("error", OAuth2Error.ACCESS_DENIED_CODE);
+        queryParams.put("error_description", OAuth2Error.ACCESS_DENIED.getDescription());
+        var noSessionEntity =
+                noSessionOrchestrationService.generateNoSessionOrchestrationEntity(
+                        queryParams, true);
+
+        assertThat(
+                noSessionEntity.getErrorObject().getCode(),
+                equalTo(OAuth2Error.ACCESS_DENIED_CODE));
+        assertThat(
+                noSessionEntity.getErrorObject().getDescription(),
+                equalTo(OAuth2Error.ACCESS_DENIED.getDescription()));
+        assertThat(noSessionEntity.getClientSessionId(), equalTo(CLIENT_SESSION_ID));
+
+        var authenticationRequest =
+                AuthenticationRequest.parse(
+                        noSessionEntity.getClientSession().getAuthRequestParams());
+        assertThat(authenticationRequest.getClientID(), equalTo(CLIENT_ID));
+        assertThat(authenticationRequest.getRedirectionURI(), equalTo(REDIRECT_URI));
+    }
+
+    @Test
+    void shouldThrowIfNoSessionResponseIsDisabled() {
+        when(redisConnectionService.getValue(STATE_STORAGE_PREFIX + STATE.getValue()))
+                .thenReturn(CLIENT_SESSION_ID);
+        when(clientSessionService.getClientSession(CLIENT_SESSION_ID))
+                .thenReturn(Optional.of(generateClientSession()));
+
+        Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("state", STATE.getValue());
+        queryParams.put("error", OAuth2Error.ACCESS_DENIED_CODE);
+        queryParams.put("error_description", OAuth2Error.ACCESS_DENIED.getDescription());
+        var noSessionException =
+                assertThrows(
+                        NoSessionException.class,
+                        () ->
+                                noSessionOrchestrationService.generateNoSessionOrchestrationEntity(
+                                        queryParams, false));
+
+        assertThat(
+                noSessionException.getMessage(),
+                equalTo(
+                        "Session Cookie not present and access_denied or state param missing from error response. NoSessionResponseEnabled: false"));
+    }
+
+    @Test
+    void shouldThrowIfErrorIsPresentButIsNotAccessDenied() {
+        when(redisConnectionService.getValue(STATE_STORAGE_PREFIX + STATE.getValue()))
+                .thenReturn(CLIENT_SESSION_ID);
+        when(clientSessionService.getClientSession(CLIENT_SESSION_ID))
+                .thenReturn(Optional.of(generateClientSession()));
+
+        Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("state", STATE.getValue());
+        queryParams.put("error", OAuth2Error.INVALID_CLIENT.getCode());
+        queryParams.put("error_description", OAuth2Error.INVALID_CLIENT.getDescription());
+        var noSessionException =
+                assertThrows(
+                        NoSessionException.class,
+                        () ->
+                                noSessionOrchestrationService.generateNoSessionOrchestrationEntity(
+                                        queryParams, true));
+
+        assertThat(
+                noSessionException.getMessage(),
+                equalTo(
+                        "Session Cookie not present and access_denied or state param missing from error response. NoSessionResponseEnabled: true"));
+    }
+
+    @Test
+    void shouldThrowIfErrorIsNotPresent() {
+        when(redisConnectionService.getValue(STATE_STORAGE_PREFIX + STATE.getValue()))
+                .thenReturn(CLIENT_SESSION_ID);
+        when(clientSessionService.getClientSession(CLIENT_SESSION_ID))
+                .thenReturn(Optional.of(generateClientSession()));
+
+        var queryParams = Map.of("state", STATE.getValue());
+        var noSessionException =
+                assertThrows(
+                        NoSessionException.class,
+                        () ->
+                                noSessionOrchestrationService.generateNoSessionOrchestrationEntity(
+                                        queryParams, true));
+
+        assertThat(
+                noSessionException.getMessage(),
+                equalTo(
+                        "Session Cookie not present and access_denied or state param missing from error response. NoSessionResponseEnabled: true"));
+    }
+
+    @Test
+    void shouldThrowIfStateIsNotPresent() {
+        Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("error", OAuth2Error.ACCESS_DENIED_CODE);
+        queryParams.put("error_description", OAuth2Error.ACCESS_DENIED.getDescription());
+
+        var noSessionException =
+                assertThrows(
+                        NoSessionException.class,
+                        () ->
+                                noSessionOrchestrationService.generateNoSessionOrchestrationEntity(
+                                        queryParams, true));
+
+        assertThat(
+                noSessionException.getMessage(),
+                equalTo(
+                        "Session Cookie not present and access_denied or state param missing from error response. NoSessionResponseEnabled: true"));
+    }
+
+    @Test
+    void shouldThrowIfStateIsPresentButEmpty() {
+        Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("error", OAuth2Error.ACCESS_DENIED_CODE);
+        queryParams.put("error_description", OAuth2Error.ACCESS_DENIED.getDescription());
+        queryParams.put("state", "");
+
+        var noSessionException =
+                assertThrows(
+                        NoSessionException.class,
+                        () ->
+                                noSessionOrchestrationService.generateNoSessionOrchestrationEntity(
+                                        queryParams, true));
+
+        assertThat(
+                noSessionException.getMessage(),
+                equalTo(
+                        "Session Cookie not present and access_denied or state param missing from error response. NoSessionResponseEnabled: true"));
+    }
+
+    @Test
+    void shouldThrowIfNoClientSessionIdIsFoundWithState() {
+        when(redisConnectionService.getValue(STATE_STORAGE_PREFIX + STATE.getValue()))
+                .thenReturn(null);
+
+        Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("state", STATE.getValue());
+        queryParams.put("error", OAuth2Error.ACCESS_DENIED_CODE);
+        queryParams.put("error_description", OAuth2Error.ACCESS_DENIED.getDescription());
+
+        var noSessionException =
+                assertThrows(
+                        NoSessionException.class,
+                        () ->
+                                noSessionOrchestrationService.generateNoSessionOrchestrationEntity(
+                                        queryParams, true));
+
+        assertThat(
+                noSessionException.getMessage(),
+                equalTo("ClientSessionId could not be found using state param"));
+    }
+
+    @Test
+    void shouldThrowIfNoClientSessionIsFoundWithClientSessionId() {
+        when(redisConnectionService.getValue(STATE_STORAGE_PREFIX + STATE.getValue()))
+                .thenReturn(CLIENT_SESSION_ID);
+        when(clientSessionService.getClientSession(CLIENT_SESSION_ID)).thenReturn(Optional.empty());
+
+        Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("state", STATE.getValue());
+        queryParams.put("error", OAuth2Error.ACCESS_DENIED_CODE);
+        queryParams.put("error_description", OAuth2Error.ACCESS_DENIED.getDescription());
+
+        var noSessionException =
+                assertThrows(
+                        NoSessionException.class,
+                        () ->
+                                noSessionOrchestrationService.generateNoSessionOrchestrationEntity(
+                                        queryParams, true));
+
+        assertThat(
+                noSessionException.getMessage(),
+                equalTo("No client session found with given client sessionId"));
+    }
+
+    @Test
+    void shouldCallRedisAndSaveClientSessionIdAgainstState() {
+        when(configurationService.getSessionExpiry()).thenReturn(7200L);
+        noSessionOrchestrationService.storeClientSessionIdAgainstState(CLIENT_SESSION_ID, STATE);
+
+        verify(redisConnectionService)
+                .saveWithExpiry("state:" + STATE.getValue(), CLIENT_SESSION_ID, 7200);
+    }
+
+    private static ClientSession generateClientSession() {
+        var responseType = new ResponseType(ResponseType.Value.CODE);
+        var scope = new Scope();
+        scope.add(OIDCScopeValue.OPENID);
+        scope.add("phone");
+        scope.add("email");
+        var authRequest =
+                new AuthenticationRequest.Builder(responseType, scope, CLIENT_ID, REDIRECT_URI)
+                        .state(new State())
+                        .nonce(new Nonce())
+                        .build();
+        return new ClientSession(authRequest.toParameters(), null, null, null);
+    }
+}


### PR DESCRIPTION
## What?

- The NoSessionOrchestrationService is called in the scenario where no session cookie is found for the user once the user returns from either DCMAW or IPV.
- The main method in this class is the `generateNoSessionOrchestrationEntity` which checks if the query parameters it receives contains an `access_denied` error response along with a `state` parameter. It will also check that this feature is enabled as to start with it will not be enabled across all environments to allow testing.
- If the access_denied error response and state parameter are both present, it will perform a lookup in Redis using the state to retrieve a client session id. It will use that client session id to perform an additional lookup in Redis to retrieve the client session of the user. The client session is required to be able to retrieve the RPs initial authentication request which will contain the RP redirect URI and RP state param, which are both required for sending the access_denied error response back to the RP.
- The generateNoSessionOrchestrationEntity will finally return a NoSessionEntity object, which will contain everything required for the lambda to return the user back to the RP with the access_denied error response.


## Why?

- The logic currently in the DocAppCallback lambda will be very similar for the IpvCallback lambda. Therefore it makes sense to pull this out into a shared class to reduce code duplication and have a single point for the logic.
