### PR TITLE
AUT-1125 - Switch Doc App lambdas to use shared NoSessionOrchestrationService class

### DIFF
--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/services/DocAppAuthorisationService.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/services/DocAppAuthorisationService.java
@@ -118,20 +118,6 @@ public class DocAppAuthorisationService {
         }
     }
 
-    public void storeClientSessionIdAgainstState(String clientSessionId, State state) {
-        LOG.info("Storing clientSessionId against state");
-        redisConnectionService.saveWithExpiry(
-                STATE_STORAGE_PREFIX + state.getValue(),
-                clientSessionId,
-                configurationService.getSessionExpiry());
-    }
-
-    public Optional<String> getClientSessionIdFromState(State state) {
-        LOG.info("Getting clientSessionId using state");
-        return Optional.ofNullable(
-                redisConnectionService.getValue(STATE_STORAGE_PREFIX + state.getValue()));
-    }
-
     private boolean isStateValid(String sessionId, String responseState) {
         var value =
                 Optional.ofNullable(

--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppAuthorizeHandlerTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppAuthorizeHandlerTest.java
@@ -43,6 +43,7 @@ import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
 import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.NoSessionOrchestrationService;
 import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.shared.services.SessionService;
 
@@ -99,6 +100,8 @@ class DocAppAuthorizeHandlerTest {
     private final AuditService auditService = mock(AuditService.class);
     private final ClientRegistry clientRegistry = mock(ClientRegistry.class);
     private final ClientService clientService = mock(ClientService.class);
+    private final NoSessionOrchestrationService noSessionOrchestrationService =
+            mock(NoSessionOrchestrationService.class);
 
     private DocAppAuthorizeHandler handler;
     private final Session session = new Session(SESSION_ID);
@@ -113,7 +116,8 @@ class DocAppAuthorizeHandlerTest {
                         configurationService,
                         auditService,
                         clientService,
-                        cloudwatchMetricsService);
+                        cloudwatchMetricsService,
+                        noSessionOrchestrationService);
         when(configurationService.getDocAppAuthorisationClientId()).thenReturn(DOC_APP_CLIENT_ID);
         when(configurationService.getDocAppAuthorisationCallbackURI())
                 .thenReturn(DOC_APP_CALLBACK_URI);
@@ -148,7 +152,7 @@ class DocAppAuthorizeHandlerTest {
                 splitQuery(body.getRedirectUri()).get("request"),
                 equalTo(encryptedJWT.serialize()));
         verify(authorisationService).storeState(eq(session.getSessionId()), any(State.class));
-        verify(authorisationService)
+        verify(noSessionOrchestrationService)
                 .storeClientSessionIdAgainstState(eq(CLIENT_SESSION_ID), any(State.class));
         verify(auditService)
                 .submitAuditEvent(


### PR DESCRIPTION
## What?

- Switch the DocAppCallback lambda to use the NoSessionOrchestrationService
- Switch the DocAppAuthorizeHandler to use the NoSessionOrchestrationService
- Remove redundant methods in the DocAppAuthorisationService

## Why?

- Instead of having the logic within the DocAppCallback lambda we can switch this to use the shared NoSessionOrchestrationService class
- We can remove redundant unit tests which are no longer required as the logic is being tested in the NoSessionOrchestrationServiceTest.java
- The methods in the DocAppAuthorisationService have been moved to the NoSessionOrchestrationService