### PR TITLE
AUT-973: Make OTP codes fixed in account management journeys

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/AuthPolicy.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/AuthPolicy.java
@@ -18,12 +18,17 @@ public class AuthPolicy {
     public static final String CONDITION = "Condition";
 
     String principalId;
+    Map<String, Object> context;
     transient AuthPolicy.PolicyDocument policyDocumentObject;
     Map<String, Object> policyDocument;
 
-    public AuthPolicy(String principalId, AuthPolicy.PolicyDocument policyDocumentObject) {
+    public AuthPolicy(
+            String principalId,
+            AuthPolicy.PolicyDocument policyDocumentObject,
+            Map<String, Object> context) {
         this.principalId = principalId;
         this.policyDocumentObject = policyDocumentObject;
+        this.context = context;
     }
 
     public AuthPolicy() {}
@@ -34,6 +39,10 @@ public class AuthPolicy {
 
     public void setPrincipalId(String principalId) {
         this.principalId = principalId;
+    }
+
+    public Map<String, Object> getContext() {
+        return context;
     }
 
     /**

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/exceptions/MissingConfigurationParameterException.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/exceptions/MissingConfigurationParameterException.java
@@ -1,0 +1,8 @@
+package uk.gov.di.accountmanagement.exceptions;
+
+public class MissingConfigurationParameterException extends RuntimeException {
+
+    public MissingConfigurationParameterException(String message) {
+        super(message);
+    }
+}

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/AuthoriseAccessTokenIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/AuthoriseAccessTokenIntegrationTest.java
@@ -35,6 +35,7 @@ class AuthoriseAccessTokenIntegrationTest
         extends HandlerIntegrationTest<TokenAuthorizerContext, AuthPolicy> {
 
     private static final ClientID CLIENT_ID = new ClientID();
+    private static final String REQUEST_CONTEXT_OBJECT_CLIENT_ID_KEY = "clientId";
     private static final Subject PUBLIC_SUBJECT = new Subject();
     private Date validDate;
 
@@ -68,6 +69,9 @@ class AuthoriseAccessTokenIntegrationTest
         var authPolicy = makeRequest(accessToken.toAuthorizationHeader());
 
         assertThat(authPolicy.getPrincipalId(), equalTo(PUBLIC_SUBJECT.getValue()));
+        assertThat(
+                authPolicy.getContext().get(REQUEST_CONTEXT_OBJECT_CLIENT_ID_KEY),
+                equalTo(CLIENT_ID.getValue()));
     }
 
     @Test

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/SendOtpNotificationIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/SendOtpNotificationIntegrationTest.java
@@ -16,6 +16,7 @@ import uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static com.google.i18n.phonenumbers.PhoneNumberUtil.PhoneNumberType.MOBILE;
@@ -30,6 +31,7 @@ import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyRespon
 class SendOtpNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     private static final String TEST_EMAIL = "joe.bloggs+3@digital.cabinet-office.gov.uk";
+    private static final String TEST_TESTER_CLIENT_ID = "tester-client-id";
     private static final String TEST_PHONE_NUMBER =
             Long.toString(
                     PhoneNumberUtil.getInstance()
@@ -50,7 +52,9 @@ class SendOtpNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTes
                                 new SendNotificationRequest(
                                         TEST_EMAIL, VERIFY_EMAIL, TEST_PHONE_NUMBER)),
                         Collections.emptyMap(),
-                        Collections.emptyMap());
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        Map.of("clientId", TEST_TESTER_CLIENT_ID));
 
         assertThat(response, hasStatus(HttpStatus.SC_NO_CONTENT));
 
@@ -72,7 +76,9 @@ class SendOtpNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTes
                                 new SendNotificationRequest(
                                         TEST_EMAIL, VERIFY_EMAIL, TEST_PHONE_NUMBER)),
                         Collections.emptyMap(),
-                        Collections.emptyMap());
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        Map.of("clientId", TEST_TESTER_CLIENT_ID));
 
         assertThat(response, hasStatus(HttpStatus.SC_BAD_REQUEST));
         assertThat(response, hasBody(objectMapper.writeValueAsString(ErrorResponse.ERROR_1009)));
@@ -90,7 +96,9 @@ class SendOtpNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTes
                                 new SendNotificationRequest(
                                         TEST_EMAIL, VERIFY_PHONE_NUMBER, TEST_PHONE_NUMBER)),
                         Collections.emptyMap(),
-                        Collections.emptyMap());
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        Map.of("clientId", TEST_TESTER_CLIENT_ID));
 
         assertThat(response, hasStatus(HttpStatus.SC_NO_CONTENT));
 
@@ -115,7 +123,9 @@ class SendOtpNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTes
                                         VERIFY_PHONE_NUMBER,
                                         TEST_PHONE_NUMBER)),
                         Collections.emptyMap(),
-                        Collections.emptyMap());
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        Map.of("clientId", TEST_TESTER_CLIENT_ID));
 
         assertThat(response, hasStatus(HttpStatus.SC_NO_CONTENT));
 
@@ -139,7 +149,8 @@ class SendOtpNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTes
                                         TEST_EMAIL, VERIFY_PHONE_NUMBER, badPhoneNumber)),
                         Collections.emptyMap(),
                         Collections.emptyMap(),
-                        Collections.emptyMap());
+                        Collections.emptyMap(),
+                        Map.of("clientId", TEST_TESTER_CLIENT_ID));
 
         assertThat(response, hasStatus(HttpStatus.SC_BAD_REQUEST));
         assertThat(response, hasBody(objectMapper.writeValueAsString(ErrorResponse.ERROR_1012)));
@@ -161,7 +172,8 @@ class SendOtpNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTes
                                         TEST_EMAIL, VERIFY_PHONE_NUMBER, "07755551084")),
                         Collections.emptyMap(),
                         Collections.emptyMap(),
-                        Collections.emptyMap());
+                        Collections.emptyMap(),
+                        Map.of("clientId", TEST_TESTER_CLIENT_ID));
 
         assertThat(response, hasStatus(HttpStatus.SC_BAD_REQUEST));
         assertThat(response, hasBody(objectMapper.writeValueAsString(ErrorResponse.ERROR_1044)));

--- a/ci/terraform/account-management/send_otp_notification.tf
+++ b/ci/terraform/account-management/send_otp_notification.tf
@@ -6,6 +6,7 @@ module "account_management_api_send_notification_role" {
 
   policies_to_attach = [
     aws_iam_policy.dynamo_am_user_read_access_policy.arn,
+    aws_iam_policy.dynamo_am_client_registry_read_access_policy.arn,
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
     aws_iam_policy.parameter_policy.arn,
     module.account_management_txma_audit.access_policy_arn


### PR DESCRIPTION
## What?
- Make OTP codes fixed in account management journeys
- Similar work has previously been performed for sign in journeys

Note: I considered making the changes to the lambdas that end up verifying a code (e.g. `UpdateEmailHandler`) instead of the one that writes the code (`SendOtpNotificationHandler`). The reason I did not take that approach was twofold:
- Writing a fixed OTP to the cache, although somewhat wasteful in terms of cacheing resource, is closer to the 'real' user flow, and therefore a legitimate part of performance testing
- Doing things this way meant that existing lambdas, apart from the OTP Notification lambda, could be left untouched, keeping them 'pure' in terms of not modifying them solely for testing purposes (and marginally more readable)

## Why?
- To enable performance testing

## Related PRs
- Similar to work done for sign in journeys here: https://github.com/alphagov/di-authentication-api/pull/2666
