### PR TITLE
Upgrade gradle to v7.6.1

### DIFF
--- a/.github/workflows/build-api-modules.yml
+++ b/.github/workflows/build-api-modules.yml
@@ -46,10 +46,8 @@ jobs:
         distribution: 'adopt'
         cache: gradle
 
-    - name: Set up Gradle 7.0.2
+    - name: Set up Gradle
       uses: gradle/gradle-build-action@v2
-      with:
-        gradle-version: 7.0.2
     
     - name: Build ${{ matrix.module }}
       run: ./gradlew --no-daemon :${{ matrix.module }}:buildZip

--- a/ci/tasks/build-api-module.yml
+++ b/ci/tasks/build-api-module.yml
@@ -3,7 +3,7 @@ image_resource:
   type: registry-image
   source:
     repository: gradle
-    tag: 7.0.2-jdk11
+    tag: 7.6.1-jdk11
     username: ((docker-hub-username))
     password: ((docker-hub-password))
 inputs:

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## What?

Upgrade gradle to v7.6.1

## Why?

We were using Gradle 7.0.2, which is a few years old now!
