### PR TITLE
AdoptOpenJDK is no longer maintained, it is now Temurin

### DIFF
--- a/.github/workflows/build-api-modules.yml
+++ b/.github/workflows/build-api-modules.yml
@@ -43,7 +43,7 @@ jobs:
       uses: actions/setup-java@v3
       with:
         java-version: '11'
-        distribution: 'adopt'
+        distribution: 'temurin'
         cache: gradle
 
     - name: Set up Gradle 7.0.2

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
           cache: 'gradle'
       - name: Run Spotless
         run: ./gradlew --no-daemon spotlessCheck
@@ -31,7 +31,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
           cache: 'gradle'
       - name: Build Cache
         uses: actions/cache@v3
@@ -56,7 +56,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
           cache: 'gradle'
       - name: Build Cache
         uses: actions/cache@v3
@@ -141,7 +141,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
           cache: 'gradle'
       - name: Build Cache
         uses: actions/cache@v3
@@ -206,7 +206,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
           cache: 'gradle'
       - name: Build Cache
         uses: actions/cache@v3


### PR DESCRIPTION
## What?

AdoptOpenJDK is no longer maintained, it is now Temurin

## Why?

See https://github.com/actions/setup-java#supported-distributions
