### PR TITLE
AUT-1081: Support 'verify change how to get security codes' email message types

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
@@ -35,6 +35,7 @@ import static uk.gov.di.authentication.shared.entity.ErrorResponse.ERROR_1001;
 import static uk.gov.di.authentication.shared.entity.ErrorResponse.ERROR_1002;
 import static uk.gov.di.authentication.shared.entity.ErrorResponse.ERROR_1011;
 import static uk.gov.di.authentication.shared.entity.NotificationType.ACCOUNT_CREATED_CONFIRMATION;
+import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_CHANGE_HOW_GET_SECURITY_CODES;
 import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_PHONE_NUMBER;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
@@ -131,6 +132,7 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
             }
             switch (request.getNotificationType()) {
                 case VERIFY_EMAIL:
+                case VERIFY_CHANGE_HOW_GET_SECURITY_CODES:
                     return handleNotificationRequest(
                             request.getEmail(),
                             request.getNotificationType(),
@@ -209,6 +211,7 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
                 email,
                 newCode,
                 notificationType.equals(VERIFY_PHONE_NUMBER)
+                                || notificationType.equals(VERIFY_CHANGE_HOW_GET_SECURITY_CODES)
                         ? configurationService.getDefaultOtpCodeExpiry()
                         : configurationService.getEmailAccountCreationOtpCodeExpiry(),
                 notificationType);
@@ -244,6 +247,8 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
                 return ErrorResponse.ERROR_1029;
             case VERIFY_PHONE_NUMBER:
                 return ErrorResponse.ERROR_1030;
+            case VERIFY_CHANGE_HOW_GET_SECURITY_CODES:
+                return ErrorResponse.ERROR_1046;
             default:
                 LOG.error("Invalid NotificationType sent");
                 throw new RuntimeException("Invalid NotificationType sent");
@@ -256,6 +261,8 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
                 return ErrorResponse.ERROR_1031;
             case VERIFY_PHONE_NUMBER:
                 return ErrorResponse.ERROR_1032;
+            case VERIFY_CHANGE_HOW_GET_SECURITY_CODES:
+                return ErrorResponse.ERROR_1047;
             default:
                 LOG.error("Invalid NotificationType sent");
                 throw new RuntimeException("Invalid NotificationType sent");
@@ -268,6 +275,8 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
                 return ErrorResponse.ERROR_1033;
             case VERIFY_PHONE_NUMBER:
                 return ErrorResponse.ERROR_1034;
+            case VERIFY_CHANGE_HOW_GET_SECURITY_CODES:
+                return ErrorResponse.ERROR_1048;
             default:
                 LOG.error("Invalid NotificationType sent");
                 throw new RuntimeException("Invalid NotificationType sent");

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
@@ -50,7 +50,17 @@ public enum ErrorResponse {
     ERROR_1042(1042, "User entered invalid authenticator app verification code too many times"),
     ERROR_1043(1043, "User entered invalid authenticator app code"),
     ERROR_1044(1044, "New phone number is the same as current phone number"),
-    ERROR_1045(1045, "User account is temporarily locked from sign in");
+    ERROR_1045(1045, "User account is temporarily locked from sign in"),
+    ERROR_1046(
+            1046,
+            "System has sent too many email verification codes for changing how to receive security codes"),
+    ERROR_1047(
+            1047,
+            "System is blocked from sending any email verification codes for changing how to receive security codes"),
+    ERROR_1048(
+            1048,
+            "User entered invalid email verification code for changing how to receive security codes too many times"),
+    ;
 
     private int code;
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java
@@ -28,6 +28,9 @@ public class CodeStorageService {
     private static final String RESET_PASSWORD_KEY_PREFIX = "reset-password-code:";
     private static final String MULTIPLE_INCORRECT_PASSWORDS_PREFIX =
             "multiple-incorrect-passwords:";
+
+    private static final String VERIFY_CHANGE_HOW_GET_SECURITY_CODES_KEY_PREFIX =
+            "change-how-get-security-codes";
     private static final long MFA_ATTEMPTS_COUNTER_TIME_TO_LIVE_SECONDS = 900;
 
     public CodeStorageService(ConfigurationService configurationService) {
@@ -139,17 +142,6 @@ public class CodeStorageService {
         }
     }
 
-    public void savePasswordResetCode(
-            String subjectId, String code, long codeExpiryTime, NotificationType notificationType) {
-        String prefix = getPrefixForNotificationType(notificationType);
-        String key = prefix + code;
-        try {
-            redisConnectionService.saveWithExpiry(key, subjectId, codeExpiryTime);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
-
     public Optional<String> getSubjectWithPasswordResetCode(String code) {
         return Optional.ofNullable(
                 redisConnectionService.getValue(RESET_PASSWORD_KEY_PREFIX + code));
@@ -201,6 +193,8 @@ public class CodeStorageService {
                 return MFA_KEY_PREFIX;
             case RESET_PASSWORD_WITH_CODE:
                 return RESET_PASSWORD_KEY_PREFIX;
+            case VERIFY_CHANGE_HOW_GET_SECURITY_CODES:
+                return VERIFY_CHANGE_HOW_GET_SECURITY_CODES_KEY_PREFIX;
         }
         throw new RuntimeException(
                 String.format("No redis prefix key configured for %s", notificationType));


### PR DESCRIPTION
## What?

Support 'verify change how to get security codes' email message types.

- Exposes the ability to send this OTP email to the frontend api
- To be consumed by frontend changes for when the user clicks the 'change how you get security codes' link on the 'Check your phone' page.
- Adds a case to handle VERIFY_CHANGE_HOW_GET_SECURITY_CODES in the SendNotificationHandler
- Add a new key type so that the OTP can be stored in Redis like the other OTPs.
- Follows the model for VERIFY_EMAIL with respect to blocking rules for failed OTP attempts.
- Update unit tests to test the new notification type.

## Why?

Users will be required to enter an OTP sent by email in order to attempt to change how they get security codes.

## Related PRs

#2811 
