### PR TITLE
BAU: Enable support for ui_locales parameter to choose Welsh language in production

### DIFF
--- a/ci/terraform/oidc/production-overrides.tfvars
+++ b/ci/terraform/oidc/production-overrides.tfvars
@@ -21,6 +21,7 @@ doc_app_encryption_key_id          = "7958938d-eea0-4e6d-9ea1-ec0b9d421f77"
 
 cloudwatch_log_retention       = 5
 client_registry_api_enabled    = false
+language_cy_enabled            = true
 spot_enabled                   = true
 ipv_api_enabled                = true
 ipv_capacity_allowed           = true


### PR DESCRIPTION
## What?

Enable support for ui_locales parameter to choose Welsh language in production.

This parameter allows services to specify the user's preferred language for the journey (English or Welsh).

## Why?

The parameter is currently enabled in all other environments but not in production.