### PR TITLE
AUT-973: Add params to Account Management deploy job

### DIFF
--- a/ci/tasks/deploy-acct-mgmt-api.yml
+++ b/ci/tasks/deploy-acct-mgmt-api.yml
@@ -15,6 +15,9 @@ params:
   NOTIFY_API_KEY: ((build-notify-api-key))
   STATE_BUCKET: digital-identity-dev-tfstate
   TXMA_ACCOUNT_ID: ((build-txma-account-id))
+  TEST_CLIENT_VERIFY_EMAIL_OTP: ((test-client-verify-email-otp))
+  TEST_CLIENT_VERIFY_PHONE_NUMBER_OTP: ((test-client-verify-phone-number-otp))
+  TEST_CLIENTS_ENABLED: false
 inputs:
   - name: api-terraform-src
   - name: api-release
@@ -45,6 +48,9 @@ run:
         -var "dns_state_key=${DNS_STATE_KEY}" \
         -var "dns_state_role=${DNS_DEPLOYER_ROLE_ARN}" \
         -var "txma_account_id=${TXMA_ACCOUNT_ID}" \
+        -var "test_client_verify_email_otp=${TEST_CLIENT_VERIFY_EMAIL_OTP}" \
+        -var "test_client_verify_phone_number_otp=${TEST_CLIENT_VERIFY_PHONE_NUMBER_OTP}" \
+        -var "test_clients_enabled=${TEST_CLIENTS_ENABLED}" \
         -var-file "${DEPLOY_ENVIRONMENT}-overrides.tfvars" \
         -var-file ${DEPLOY_ENVIRONMENT}-sizing.tfvars \
 

--- a/ci/terraform/account-management/send_otp_notification.tf
+++ b/ci/terraform/account-management/send_otp_notification.tf
@@ -32,6 +32,9 @@ module "send_otp_notification" {
     DEFAULT_OTP_CODE_EXPIRY                = var.otp_code_ttl_duration
     EMAIL_OTP_ACCOUNT_CREATION_CODE_EXPIRY = var.email_acct_creation_otp_code_ttl_duration
     INTERNAl_SECTOR_URI                    = var.internal_sector_uri
+    TEST_CLIENT_VERIFY_EMAIL_OTP           = var.test_client_verify_email_otp
+    TEST_CLIENT_VERIFY_PHONE_NUMBER_OTP    = var.test_client_verify_phone_number_otp
+    TEST_CLIENTS_ENABLED                   = var.test_clients_enabled
   }
   handler_function_name = "uk.gov.di.accountmanagement.lambda.SendOtpNotificationHandler::handleRequest"
 

--- a/ci/terraform/account-management/variables.tf
+++ b/ci/terraform/account-management/variables.tf
@@ -217,6 +217,19 @@ variable "email_acct_creation_otp_code_ttl_duration" {
   default = 7200
 }
 
+variable "test_client_verify_email_otp" {
+  type = string
+}
+
+variable "test_client_verify_phone_number_otp" {
+  type = string
+}
+
+variable "test_clients_enabled" {
+  type    = string
+  default = "false"
+}
+
 locals {
   default_performance_parameters = {
     memory          = var.endpoint_memory_size


### PR DESCRIPTION
## What?
- Add params to Account Management deploy job

## Why?
- Some environment variables were missing for configuration service in AM lambdas
- This affected fixed OTP functionality for test users

## Related PRs
- Amends: https://github.com/alphagov/di-authentication-api/pull/2814
