### PR TITLE
Revert Gradle version change

### DIFF
--- a/ci/tasks/build-api-module.yml
+++ b/ci/tasks/build-api-module.yml
@@ -3,7 +3,7 @@ image_resource:
   type: registry-image
   source:
     repository: gradle
-    tag: 7.6.1-jdk11
+    tag: 7.0.2-jdk11
     username: ((docker-hub-username))
     password: ((docker-hub-password))
 inputs:


### PR DESCRIPTION
## What?

Revert Gradle version change

## Why?

Docker image doesn't appear to work in Concourse
