### PR TITLE
AUT-1125 - Update error_description of for access_denied no session error

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppCallbackHandlerIntegrationTest.java
@@ -5,6 +5,7 @@ import com.nimbusds.jose.jwk.Curve;
 import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.Scope;
@@ -260,9 +261,12 @@ class DocAppCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
                         constructHeaders(Optional.empty()),
                         queryStringParameters);
 
+        var error =
+                new ErrorObject(
+                        OAuth2Error.ACCESS_DENIED_CODE,
+                        "Access denied for security reasons, a new authentication request may be successful");
         var expectedURI =
-                new AuthenticationErrorResponse(
-                                URI.create(REDIRECT_URI), OAuth2Error.ACCESS_DENIED, RP_STATE, null)
+                new AuthenticationErrorResponse(URI.create(REDIRECT_URI), error, RP_STATE, null)
                         .toURI()
                         .toString();
         assertThat(response, hasStatus(302));

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
@@ -2,6 +2,7 @@ package uk.gov.di.authentication.api;
 
 import com.google.gson.internal.LinkedTreeMap;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.Scope;
@@ -238,9 +239,13 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                                         "error",
                                         "access_denied")));
 
+        var error =
+                new ErrorObject(
+                        OAuth2Error.ACCESS_DENIED_CODE,
+                        "Access denied for security reasons, a new authentication request may be successful");
+
         var expectedURI =
-                new AuthenticationErrorResponse(
-                                URI.create(REDIRECT_URI), OAuth2Error.ACCESS_DENIED, RP_STATE, null)
+                new AuthenticationErrorResponse(URI.create(REDIRECT_URI), error, RP_STATE, null)
                         .toURI()
                         .toString();
         assertThat(response, hasStatus(302));

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/NoSessionOrchestrationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/NoSessionOrchestrationService.java
@@ -65,10 +65,10 @@ public class NoSessionOrchestrationService {
                                             new NoSessionException(
                                                     "No client session found with given client sessionId"));
             LOG.info("ClientSession found using clientSessionId");
-            var errorDescription =
-                    Optional.ofNullable(queryStringParameters.get("error_description"))
-                            .orElse(OAuth2Error.ACCESS_DENIED.getDescription());
-            var errorObject = new ErrorObject(queryStringParameters.get("error"), errorDescription);
+            var errorObject =
+                    new ErrorObject(
+                            OAuth2Error.ACCESS_DENIED_CODE,
+                            "Access denied for security reasons, a new authentication request may be successful");
             LOG.info(
                     "ErrorObject created for session cookie not present. Generating NoSessionEntity in preparation for response to RP");
             return new NoSessionEntity(clientSessionId, errorObject, clientSession);

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/NoSessionOrchestrationServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/NoSessionOrchestrationServiceTest.java
@@ -68,7 +68,8 @@ class NoSessionOrchestrationServiceTest {
                 equalTo(OAuth2Error.ACCESS_DENIED_CODE));
         assertThat(
                 noSessionEntity.getErrorObject().getDescription(),
-                equalTo(OAuth2Error.ACCESS_DENIED.getDescription()));
+                equalTo(
+                        "Access denied for security reasons, a new authentication request may be successful"));
         assertThat(noSessionEntity.getClientSessionId(), equalTo(CLIENT_SESSION_ID));
 
         var authenticationRequest =


### PR DESCRIPTION
## What?

- Update error_description of for access_denied no session error

## Why?

- So it is clear to RPs what the error is and to differentiate between other access_denied responses 