### PR TITLE
AUT-930 - Pass email address to IPV Core

### DIFF
--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandler.java
@@ -20,6 +20,7 @@ import uk.gov.di.authentication.ipv.entity.IPVAuthorisationResponse;
 import uk.gov.di.authentication.ipv.services.IPVAuthorisationService;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
@@ -137,7 +138,8 @@ public class IPVAuthorisationHandler extends BaseFrontendHandler<IPVAuthorisatio
                             authRequest.getScope(),
                             pairwiseSubject,
                             claimsSetRequest,
-                            Optional.ofNullable(clientSessionId).orElse("unknown"));
+                            Optional.ofNullable(clientSessionId).orElse("unknown"),
+                            userContext.getUserProfile().map(UserProfile::getEmail).orElseThrow());
             var authRequestBuilder =
                     new AuthorizationRequest.Builder(
                                     new ResponseType(ResponseType.Value.CODE), clientID)

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationService.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationService.java
@@ -133,7 +133,12 @@ public class IPVAuthorisationService {
     }
 
     public EncryptedJWT constructRequestJWT(
-            State state, Scope scope, Subject subject, String claims, String clientSessionId) {
+            State state,
+            Scope scope,
+            Subject subject,
+            String claims,
+            String clientSessionId,
+            String emailAddress) {
         LOG.info("Generating request JWT");
         var jwsHeader = new JWSHeader(SIGNING_ALGORITHM);
         var jwtID = IdGenerator.generate();
@@ -149,6 +154,7 @@ public class IPVAuthorisationService {
                         .notBeforeTime(NowHelper.now())
                         .claim("state", state.getValue())
                         .claim("govuk_signin_journey_id", clientSessionId)
+                        .claim("email_address", emailAddress)
                         .claim(
                                 "redirect_uri",
                                 configurationService.getIPVAuthorisationCallbackURI().toString())

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandlerTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandlerTest.java
@@ -73,6 +73,7 @@ import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -180,7 +181,8 @@ public class IPVAuthorisationHandlerTest {
                         any(Scope.class),
                         any(Subject.class),
                         any(),
-                        eq(CLIENT_SESSION_ID)))
+                        eq(CLIENT_SESSION_ID),
+                        anyString()))
                 .thenReturn(encryptedJWT);
         usingValidSession();
         usingValidClientSession();

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationServiceTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationServiceTest.java
@@ -214,7 +214,7 @@ class IPVAuthorisationServiceTest {
 
         var encryptedJWT =
                 authorisationService.constructRequestJWT(
-                        state, scope, pairwise, claims, "journey-id");
+                        state, scope, pairwise, claims, "journey-id", "test@test.com");
 
         var signedJWTResponse = decryptJWT(encryptedJWT);
 
@@ -231,6 +231,9 @@ class IPVAuthorisationServiceTest {
                 equalTo(singletonList(IPV_URI.toString())));
         assertThat(signedJWTResponse.getJWTClaimsSet().getClaim("response_type"), equalTo("code"));
         assertThat(signedJWTResponse.getJWTClaimsSet().getClaim("claims"), equalTo(claims));
+        assertThat(
+                signedJWTResponse.getJWTClaimsSet().getClaim("email_address"),
+                equalTo("test@test.com"));
         assertThat(
                 signedJWTResponse.getJWTClaimsSet().getClaim("govuk_signin_journey_id"),
                 equalTo("journey-id"));


### PR DESCRIPTION
## What?

- Put the users email address as an additional claim named 'email_address' in the signed and encrypted JAR

## Why?

- This is required so IPV can pass this onto the F2F CRI
