### PR TITLE
AUT-1147 - Create account recovery lambda

### DIFF
--- a/ci/terraform/oidc/account-recovery.tf
+++ b/ci/terraform/oidc/account-recovery.tf
@@ -1,0 +1,66 @@
+module "frontend_api_account_recovery_role" {
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "frontend-api-account-recovery-role"
+  vpc_arn     = local.authentication_vpc_arn
+
+  policies_to_attach = [
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    aws_iam_policy.lambda_sns_policy.arn,
+    aws_iam_policy.dynamo_user_read_access_policy.arn,
+    aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
+    aws_iam_policy.redis_parameter_policy.arn,
+    module.oidc_txma_audit.access_policy_arn
+  ]
+}
+
+
+module "account_recovery" {
+  source = "../modules/endpoint-module"
+
+  endpoint_name   = "account-recovery"
+  path_part       = "account-recovery"
+  endpoint_method = "POST"
+  environment     = var.environment
+
+  handler_environment_variables = {
+    ENVIRONMENT              = var.environment
+    TXMA_AUDIT_QUEUE_URL     = module.oidc_txma_audit.queue_url
+    LOCALSTACK_ENDPOINT      = var.use_localstack ? var.localstack_endpoint : null
+    REDIS_KEY                = local.redis_key
+    DYNAMO_ENDPOINT          = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    HEADERS_CASE_INSENSITIVE = var.use_localstack ? "true" : "false"
+    INTERNAl_SECTOR_URI      = var.internal_sector_uri
+  }
+  handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.AccountRecoveryHandler::handleRequest"
+
+  rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
+  root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
+  execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
+
+  memory_size                 = lookup(var.performance_tuning, "account-recovery", local.default_performance_parameters).memory
+  provisioned_concurrency     = lookup(var.performance_tuning, "account-recovery", local.default_performance_parameters).concurrency
+  max_provisioned_concurrency = lookup(var.performance_tuning, "account-recovery", local.default_performance_parameters).max_concurrency
+  scaling_trigger             = lookup(var.performance_tuning, "account-recovery", local.default_performance_parameters).scaling_trigger
+
+  source_bucket           = aws_s3_bucket.source_bucket.bucket
+  lambda_zip_file         = aws_s3_bucket_object.frontend_api_release_zip.key
+  lambda_zip_file_version = aws_s3_bucket_object.frontend_api_release_zip.version_id
+  code_signing_config_arn = local.lambda_code_signing_configuration_arn
+
+  authentication_vpc_arn = local.authentication_vpc_arn
+  security_group_ids = [
+    local.authentication_security_group_id,
+    local.authentication_oidc_redis_security_group_id,
+  ]
+  subnet_id                              = local.authentication_subnet_ids
+  lambda_role_arn                        = module.frontend_api_account_recovery_role.arn
+  logging_endpoint_arns                  = var.logging_endpoint_arns
+  cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  cloudwatch_log_retention               = var.cloudwatch_log_retention
+  lambda_env_vars_encryption_kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn
+  default_tags                           = local.default_tags
+  api_key_required                       = true
+
+  use_localstack = var.use_localstack
+}

--- a/ci/terraform/oidc/api-gateway-frontend.tf
+++ b/ci/terraform/oidc/api-gateway-frontend.tf
@@ -36,6 +36,8 @@ resource "aws_api_gateway_deployment" "frontend_deployment" {
 
   triggers = {
     redeployment = sha1(jsonencode([
+      module.account_recovery.integration_trigger_value,
+      module.account_recovery.method_trigger_value,
       module.start.integration_trigger_value,
       module.start.method_trigger_value,
       module.login.integration_trigger_value,
@@ -71,6 +73,7 @@ resource "aws_api_gateway_deployment" "frontend_deployment" {
     create_before_destroy = true
   }
   depends_on = [
+    module.account_recovery,
     module.start,
     module.login,
     module.mfa,
@@ -167,6 +170,7 @@ resource "aws_api_gateway_stage" "endpoint_frontend_stage" {
   tags = local.default_tags
 
   depends_on = [
+    module.account_recovery,
     module.start,
     module.login,
     module.mfa,

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/AccountRecoveryRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/AccountRecoveryRequest.java
@@ -1,0 +1,5 @@
+package uk.gov.di.authentication.frontendapi.entity;
+
+import uk.gov.di.authentication.shared.entity.BaseFrontendRequest;
+
+public class AccountRecoveryRequest extends BaseFrontendRequest {}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/AccountRecoveryResponse.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/AccountRecoveryResponse.java
@@ -1,0 +1,19 @@
+package uk.gov.di.authentication.frontendapi.entity;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+
+public class AccountRecoveryResponse {
+
+    @SerializedName("accountRecoveryPermitted")
+    @Expose
+    private boolean accountRecoveryPermitted;
+
+    public AccountRecoveryResponse(boolean accountRecoveryPermitted) {
+        this.accountRecoveryPermitted = accountRecoveryPermitted;
+    }
+
+    public boolean getAccountRecoveryPermitted() {
+        return accountRecoveryPermitted;
+    }
+}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountRecoveryHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountRecoveryHandler.java
@@ -1,0 +1,65 @@
+package uk.gov.di.authentication.frontendapi.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.frontendapi.entity.AccountRecoveryRequest;
+import uk.gov.di.authentication.frontendapi.entity.AccountRecoveryResponse;
+import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
+import uk.gov.di.authentication.shared.serialization.Json.JsonException;
+import uk.gov.di.authentication.shared.services.AuthenticationService;
+import uk.gov.di.authentication.shared.services.ClientService;
+import uk.gov.di.authentication.shared.services.ClientSessionService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.SessionService;
+import uk.gov.di.authentication.shared.state.UserContext;
+
+import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
+
+public class AccountRecoveryHandler extends BaseFrontendHandler<AccountRecoveryRequest> {
+
+    private static final Logger LOG = LogManager.getLogger(AccountRecoveryHandler.class);
+
+    protected AccountRecoveryHandler(
+            ConfigurationService configurationService,
+            SessionService sessionService,
+            ClientSessionService clientSessionService,
+            ClientService clientService,
+            AuthenticationService authenticationService) {
+        super(
+                AccountRecoveryRequest.class,
+                configurationService,
+                sessionService,
+                clientSessionService,
+                clientService,
+                authenticationService);
+    }
+
+    public AccountRecoveryHandler(ConfigurationService configurationService) {
+        super(AccountRecoveryRequest.class, configurationService);
+    }
+
+    public AccountRecoveryHandler() {
+        this(ConfigurationService.getInstance());
+    }
+
+    @Override
+    public APIGatewayProxyResponseEvent handleRequestWithUserContext(
+            APIGatewayProxyRequestEvent input,
+            Context context,
+            AccountRecoveryRequest request,
+            UserContext userContext) {
+        try {
+            LOG.info("Request received to AccountRecoveryHandler");
+
+            var accountRecoveryResponse = new AccountRecoveryResponse(false);
+            LOG.info("Returning response back to frontend");
+            return generateApiGatewayProxyResponse(200, accountRecoveryResponse);
+        } catch (JsonException e) {
+            LOG.error("Unable to serialize account recovery response", e);
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountRecoveryHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountRecoveryHandlerTest.java
@@ -1,0 +1,83 @@
+package uk.gov.di.authentication.frontendapi.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.frontendapi.entity.AccountRecoveryResponse;
+import uk.gov.di.authentication.shared.entity.ClientSession;
+import uk.gov.di.authentication.shared.entity.Session;
+import uk.gov.di.authentication.shared.helpers.IdGenerator;
+import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
+import uk.gov.di.authentication.shared.services.AuthenticationService;
+import uk.gov.di.authentication.shared.services.ClientService;
+import uk.gov.di.authentication.shared.services.ClientSessionService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.SessionService;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.lang.String.format;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.frontendapi.lambda.StartHandlerTest.CLIENT_SESSION_ID;
+import static uk.gov.di.authentication.frontendapi.lambda.StartHandlerTest.CLIENT_SESSION_ID_HEADER;
+import static uk.gov.di.authentication.sharedtest.helper.RequestEventHelper.contextWithSourceIp;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
+
+class AccountRecoveryHandlerTest {
+
+    private static final String EMAIL = "joe.bloggs@test.com";
+    private static final String PERSISTENT_ID = "some-persistent-id-value";
+    private final Context context = mock(Context.class);
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private final AuthenticationService authenticationService = mock(AuthenticationService.class);
+    private final SessionService sessionService = mock(SessionService.class);
+    private final ClientSessionService clientSessionService = mock(ClientSessionService.class);
+    private final ClientSession clientSession = mock(ClientSession.class);
+    private final ClientService clientService = mock(ClientService.class);
+    private AccountRecoveryHandler handler;
+
+    private final Session session = new Session(IdGenerator.generate()).setEmailAddress(EMAIL);
+
+    @BeforeEach
+    void setup() {
+        handler =
+                new AccountRecoveryHandler(
+                        configurationService,
+                        sessionService,
+                        clientSessionService,
+                        clientService,
+                        authenticationService);
+    }
+
+    @Test
+    void shouldNotBePermittedForAccountRecoveryAndReturn200() {
+        usingValidSession();
+        Map<String, String> headers = new HashMap<>();
+        headers.put(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, PERSISTENT_ID);
+        headers.put("Session-Id", session.getSessionId());
+        headers.put(CLIENT_SESSION_ID_HEADER, CLIENT_SESSION_ID);
+
+        var event = new APIGatewayProxyRequestEvent();
+        event.setRequestContext(contextWithSourceIp("123.123.123.123"));
+        event.setHeaders(headers);
+        event.setBody(format("{ \"email\": \"%s\" }", EMAIL.toUpperCase()));
+
+        var expectedResponse = new AccountRecoveryResponse(false);
+        var result = handler.handleRequest(event, context);
+
+        assertThat(result, hasStatus(200));
+        assertThat(result, hasJsonBody(expectedResponse));
+    }
+
+    private void usingValidSession() {
+        when(sessionService.getSessionFromRequestHeaders(anyMap()))
+                .thenReturn(Optional.of(session));
+    }
+}

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AccountRecoveryIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AccountRecoveryIntegrationTest.java
@@ -1,0 +1,70 @@
+package uk.gov.di.authentication.api;
+
+import com.nimbusds.oauth2.sdk.ResponseType;
+import com.nimbusds.oauth2.sdk.Scope;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.id.State;
+import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+import com.nimbusds.openid.connect.sdk.Nonce;
+import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.frontendapi.lambda.AccountRecoveryHandler;
+import uk.gov.di.authentication.shared.entity.ClientSession;
+import uk.gov.di.authentication.shared.entity.VectorOfTrust;
+import uk.gov.di.authentication.shared.serialization.Json;
+import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+
+import java.net.URI;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.lang.String.format;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
+
+public class AccountRecoveryIntegrationTest extends ApiGatewayHandlerIntegrationTest {
+
+    private static final String EMAIL = "joe.bloggs@digital.cabinet-office.gov.uk";
+    public static final String CLIENT_SESSION_ID = "some-client-session-id";
+
+    @BeforeEach
+    void setup() {
+        handler = new AccountRecoveryHandler(TXMA_ENABLED_CONFIGURATION_SERVICE);
+        txmaAuditQueue.clear();
+    }
+
+    @Test
+    void shouldNotBePermittedForAccountRecoveryAndReturn200() throws Json.JsonException {
+        var sessionId = redis.createSession();
+        redis.addEmailToSession(sessionId, EMAIL);
+        redis.createClientSession(CLIENT_SESSION_ID, createClientSession());
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Session-Id", sessionId);
+        headers.put("X-API-Key", FRONTEND_API_KEY);
+        headers.put("Client-Session-Id", CLIENT_SESSION_ID);
+        var response =
+                makeRequest(Optional.of(format("{ \"email\": \"%s\"}", EMAIL)), headers, Map.of());
+
+        assertThat(response, hasStatus(200));
+    }
+
+    private ClientSession createClientSession() {
+        var authRequestBuilder =
+                new AuthenticationRequest.Builder(
+                                ResponseType.CODE,
+                                new Scope(OIDCScopeValue.OPENID),
+                                new ClientID("test-client-id"),
+                                URI.create("http://localhost/redirect"))
+                        .state(new State())
+                        .nonce(new Nonce());
+        return new ClientSession(
+                authRequestBuilder.build().toParameters(),
+                LocalDateTime.now(),
+                VectorOfTrust.getDefaults(),
+                "test-client-name");
+    }
+}


### PR DESCRIPTION
## What?

- Create an account recovery lambda
- Logic will be added to this lambda which will help it make that decision
- Add the terraform to create the account-recovery lambda which will sit behind the frontend-api and therefore require api key authenticaiton

## Why?

- This lambda will be responsible for informing the frontend whether a user is permitted for account recovery or not

