### PR TITLE
AUT-1155 - Update AccountRecoveryBlock table and create new Dynamo service

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/AccountRecoveryBlock.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/AccountRecoveryBlock.java
@@ -8,7 +8,7 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbParti
 public class AccountRecoveryBlock {
 
     private String email;
-    private long timeToExist;
+    private Long timeToExist;
 
     public AccountRecoveryBlock() {}
 
@@ -28,11 +28,11 @@ public class AccountRecoveryBlock {
     }
 
     @DynamoDbAttribute("TimeToExist")
-    public long getTimeToExist() {
+    public Long getTimeToExist() {
         return timeToExist;
     }
 
-    public void setTimeToExist(long timeToExist) {
+    public void setTimeToExist(Long timeToExist) {
         this.timeToExist = timeToExist;
     }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/DynamoAccountRecoveryBlockService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/DynamoAccountRecoveryBlockService.java
@@ -1,0 +1,65 @@
+package uk.gov.di.authentication.frontendapi.services;
+
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest;
+import uk.gov.di.authentication.frontendapi.entity.AccountRecoveryBlock;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+import java.time.temporal.ChronoUnit;
+import java.util.Objects;
+import java.util.Optional;
+
+import static uk.gov.di.authentication.shared.dynamodb.DynamoClientHelper.createDynamoEnhancedClient;
+
+public class DynamoAccountRecoveryBlockService {
+
+    private static final String ACCOUNT_RECOVERY_BLOCK_TABLE = "account-recovery-block";
+    private final long timeToExist;
+    private final DynamoDbTable<AccountRecoveryBlock> dynamoAccountRecoveryBlockTable;
+
+    public DynamoAccountRecoveryBlockService(ConfigurationService configurationService) {
+        var tableName = configurationService.getEnvironment() + "-" + ACCOUNT_RECOVERY_BLOCK_TABLE;
+        var dynamoDbEnhancedClient = createDynamoEnhancedClient(configurationService);
+        timeToExist = configurationService.getAccountRecoveryBlockTTL();
+        dynamoAccountRecoveryBlockTable =
+                dynamoDbEnhancedClient.table(
+                        tableName, TableSchema.fromBean(AccountRecoveryBlock.class));
+    }
+
+    public void addBlockWithTTL(String email) {
+        var accountRecoveryBlock =
+                new AccountRecoveryBlock()
+                        .withEmail(email)
+                        .withTimeToExist(
+                                NowHelper.nowPlus(timeToExist, ChronoUnit.SECONDS)
+                                        .toInstant()
+                                        .getEpochSecond());
+        dynamoAccountRecoveryBlockTable.putItem(accountRecoveryBlock);
+    }
+
+    public void addBlockWithNoTTL(String email) {
+        var accountRecoveryBlock = new AccountRecoveryBlock().withEmail(email);
+        dynamoAccountRecoveryBlockTable.putItem(accountRecoveryBlock);
+    }
+
+    public boolean blockIsPresent(String email) {
+        var getItemEnhancedRequest =
+                GetItemEnhancedRequest.builder()
+                        .consistentRead(true)
+                        .key(k -> k.partitionValue(email))
+                        .build();
+        var blockedItem =
+                Optional.ofNullable(
+                        dynamoAccountRecoveryBlockTable.getItem(getItemEnhancedRequest));
+
+        return blockedItem
+                .filter(
+                        t ->
+                                Objects.isNull(t.getTimeToExist())
+                                        || t.getTimeToExist()
+                                                > NowHelper.now().toInstant().getEpochSecond())
+                .isPresent();
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -62,6 +62,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return System.getenv("ACCOUNT_MANAGEMENT_URI");
     }
 
+    public Long getAccountRecoveryBlockTTL() {
+        return Long.parseLong(System.getenv().getOrDefault("ACCOUNT_RECOVERY_BLOCK_TTL", "172800"));
+    }
+
     public long getAuthCodeExpiry() {
         return Long.parseLong(System.getenv().getOrDefault("AUTH_CODE_EXPIRY", "300"));
     }


### PR DESCRIPTION
## What?

- Update AccountRecoveryBlock table and set the timeToExist to the Long object type rather than the primitive. 
- Create a Dynamo service which will be used to write and read the AccountRecoveryBlock dynamo DB table.
- Ensure all reads to the the AccountRecoveryBlock table are consistent 
- Add a default TTL of 48 hours to the configuration service 

## Why?

- Null values will sometimes be required for the timeToExists attribute and primitives do not allow nulls
- We will need to know pretty sharpish whether there is an entry in the table for a given email. The default is eventual consistency which will not promise this
- If required, we can lower the TTL for certain environments to make testing easier

