### PR TITLE
AUT-1147 - Add logic to account recovery lambda

### DIFF
--- a/ci/terraform/oidc/account-recovery.tf
+++ b/ci/terraform/oidc/account-recovery.tf
@@ -10,6 +10,7 @@ module "frontend_api_account_recovery_role" {
     aws_iam_policy.dynamo_user_read_access_policy.arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
+    aws_iam_policy.dynamo_account_recovery_block_read_access_policy.arn,
     module.oidc_txma_audit.access_policy_arn
   ]
 }

--- a/ci/terraform/oidc/dynamo-policies.tf
+++ b/ci/terraform/oidc/dynamo-policies.tf
@@ -22,6 +22,10 @@ data "aws_dynamodb_table" "common_passwords_table" {
   name = "${var.environment}-common-passwords"
 }
 
+data "aws_dynamodb_table" "account_recovery_block_table" {
+  name = "${var.environment}-account-recovery-block"
+}
+
 data "aws_iam_policy_document" "dynamo_user_write_policy_document" {
   statement {
     sid    = "AllowAccessToDynamoTables"
@@ -195,6 +199,22 @@ data "aws_iam_policy_document" "dynamo_common_passwords_read_access_policy_docum
   }
 }
 
+data "aws_iam_policy_document" "dynamo_account_recovery_block_read_access_policy_document" {
+  statement {
+    sid    = "AllowAccessToDynamoTables"
+    effect = "Allow"
+
+    actions = [
+      "dynamodb:DescribeTable",
+      "dynamodb:Get*",
+
+    ]
+    resources = [
+      data.aws_dynamodb_table.account_recovery_block_table.arn,
+    ]
+  }
+}
+
 resource "aws_iam_policy" "dynamo_client_registry_write_access_policy" {
   name_prefix = "dynamo-client-registry-write-policy"
   path        = "/${var.environment}/oidc-default/"
@@ -273,4 +293,12 @@ resource "aws_iam_policy" "dynamo_common_passwords_read_access_policy" {
   description = "IAM policy for managing read permissions to the Dynamo Common Passwords table"
 
   policy = data.aws_iam_policy_document.dynamo_common_passwords_read_access_policy_document.json
+}
+
+resource "aws_iam_policy" "dynamo_account_recovery_block_read_access_policy" {
+  name_prefix = "dynamo-access-policy"
+  path        = "/${var.environment}/oidc-default/"
+  description = "IAM policy for managing read permissions to the Dynamo Account Recovery Block table"
+
+  policy = data.aws_iam_policy_document.dynamo_account_recovery_block_read_access_policy_document.json
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/DynamoAccountRecoveryBlockService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/DynamoAccountRecoveryBlockService.java
@@ -26,6 +26,7 @@ public class DynamoAccountRecoveryBlockService {
         dynamoAccountRecoveryBlockTable =
                 dynamoDbEnhancedClient.table(
                         tableName, TableSchema.fromBean(AccountRecoveryBlock.class));
+        warmUp();
     }
 
     public void addBlockWithTTL(String email) {
@@ -61,5 +62,9 @@ public class DynamoAccountRecoveryBlockService {
                                         || t.getTimeToExist()
                                                 > NowHelper.now().toInstant().getEpochSecond())
                 .isPresent();
+    }
+
+    private void warmUp() {
+        dynamoAccountRecoveryBlockTable.describeTable();
     }
 }

--- a/shared-test/build.gradle
+++ b/shared-test/build.gradle
@@ -23,6 +23,7 @@ dependencies {
             "com.google.code.gson:gson:2.10.1"
 
     implementation project(":shared")
+    implementation project(":frontend-api")
     implementation project(":doc-checking-app-api")
 }
 

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
@@ -7,6 +7,7 @@ import software.amazon.awssdk.services.kms.model.KeyUsageType;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SerializationService;
+import uk.gov.di.authentication.sharedtest.extensions.AccountRecoveryStoreExtension;
 import uk.gov.di.authentication.sharedtest.extensions.AuditSnsTopicExtension;
 import uk.gov.di.authentication.sharedtest.extensions.ClientStoreExtension;
 import uk.gov.di.authentication.sharedtest.extensions.CommonPasswordsExtension;
@@ -146,6 +147,10 @@ public abstract class HandlerIntegrationTest<Q, S> {
 
     @RegisterExtension
     protected static final IdentityStoreExtension identityStore = new IdentityStoreExtension(180);
+
+    @RegisterExtension
+    protected static final AccountRecoveryStoreExtension accountRecoveryStore =
+            new AccountRecoveryStoreExtension(100);
 
     @RegisterExtension
     protected static final DocumentAppCredentialStoreExtension documentAppCredentialStore =

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AccountRecoveryStoreExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AccountRecoveryStoreExtension.java
@@ -1,0 +1,81 @@
+package uk.gov.di.authentication.sharedtest.extensions;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
+import software.amazon.awssdk.services.dynamodb.model.BillingMode;
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.KeyType;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
+import uk.gov.di.authentication.frontendapi.services.DynamoAccountRecoveryBlockService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.sharedtest.basetest.DynamoTestConfiguration;
+
+public class AccountRecoveryStoreExtension extends DynamoExtension implements AfterEachCallback {
+
+    public static final String EMAIL_FIELD = "Email";
+    public static final String ACCOUNT_RECOVERY_BLOCK_TABLE = "local-account-recovery-block";
+
+    private DynamoAccountRecoveryBlockService dynamoAccountRecoveryService;
+    private final ConfigurationService configuration;
+
+    public AccountRecoveryStoreExtension(long ttl) {
+        createInstance();
+        this.configuration =
+                new DynamoTestConfiguration(REGION, ENVIRONMENT, DYNAMO_ENDPOINT) {
+                    @Override
+                    public Long getAccountRecoveryBlockTTL() {
+                        return ttl;
+                    }
+                };
+        dynamoAccountRecoveryService = new DynamoAccountRecoveryBlockService(configuration);
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+        super.beforeAll(context);
+
+        dynamoAccountRecoveryService = new DynamoAccountRecoveryBlockService(configuration);
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) throws Exception {
+        clearDynamoTable(dynamoDB, ACCOUNT_RECOVERY_BLOCK_TABLE, EMAIL_FIELD);
+    }
+
+    public void addBlockWithTTL(String email) {
+        dynamoAccountRecoveryService.addBlockWithTTL(email);
+    }
+
+    public void addBlockWithoutTTL(String email) {
+        dynamoAccountRecoveryService.addBlockWithNoTTL(email);
+    }
+
+    @Override
+    protected void createTables() {
+        if (!tableExists(ACCOUNT_RECOVERY_BLOCK_TABLE)) {
+            createAccountRecoveryBlockTable();
+        }
+    }
+
+    private void createAccountRecoveryBlockTable() {
+        CreateTableRequest request =
+                CreateTableRequest.builder()
+                        .tableName(ACCOUNT_RECOVERY_BLOCK_TABLE)
+                        .keySchema(
+                                KeySchemaElement.builder()
+                                        .keyType(KeyType.HASH)
+                                        .attributeName(EMAIL_FIELD)
+                                        .build())
+                        .attributeDefinitions(
+                                AttributeDefinition.builder()
+                                        .attributeName(EMAIL_FIELD)
+                                        .attributeType(ScalarAttributeType.S)
+                                        .build())
+                        .billingMode(BillingMode.PAY_PER_REQUEST)
+                        .build();
+
+        dynamoDB.createTable(request);
+    }
+}


### PR DESCRIPTION
## What?

- Add logic to account recovery lambda
- Integrate the DynamoAccountRecoveryBlockService within the AccountRecoveryHandler
- Create a AccountRecoveryStoreExtension to enable us to add data to the table for the Integration tests
- Add new unit and integration tests to test various scenarios
- Give the account recovery lambda read permissions to the account-recovery-block dynamo table

## Why?

- So the AccountRecoveryHandler knows whether account recovery is permitted or not
- The AccountRecoveryHandler only ever needs to read from the table so we can avoid giving it write permissions 