### PR TITLE
AUT-1147 - Ensure policy has been created before deploying lambda

### DIFF
--- a/ci/terraform/oidc/account-recovery.tf
+++ b/ci/terraform/oidc/account-recovery.tf
@@ -13,6 +13,10 @@ module "frontend_api_account_recovery_role" {
     aws_iam_policy.dynamo_account_recovery_block_read_access_policy.arn,
     module.oidc_txma_audit.access_policy_arn
   ]
+
+  depends_on = [
+    aws_iam_policy.dynamo_account_recovery_block_read_access_policy
+  ]
 }
 
 

--- a/ci/terraform/oidc/dynamo-policies.tf
+++ b/ci/terraform/oidc/dynamo-policies.tf
@@ -296,7 +296,7 @@ resource "aws_iam_policy" "dynamo_common_passwords_read_access_policy" {
 }
 
 resource "aws_iam_policy" "dynamo_account_recovery_block_read_access_policy" {
-  name_prefix = "dynamo-access-policy"
+  name_prefix = "dynamo-account-recovery-read"
   path        = "/${var.environment}/oidc-default/"
   description = "IAM policy for managing read permissions to the Dynamo Account Recovery Block table"
 


### PR DESCRIPTION
## What?

 - Ensure policy has been created before deploying lambda

## Why?

- The deployment is erroring because it is saying the lambda does not have permissions to perform describeTable. This will ensure that the policy exists before deploying the lambda
