### PR TITLE
AUT-1156 - Create additional policies to the account recovery block table

### DIFF
--- a/ci/terraform/oidc/dynamo-policies.tf
+++ b/ci/terraform/oidc/dynamo-policies.tf
@@ -215,6 +215,36 @@ data "aws_iam_policy_document" "dynamo_account_recovery_block_read_access_policy
   }
 }
 
+data "aws_iam_policy_document" "dynamo_account_recovery_block_delete_access_policy_document" {
+  statement {
+    sid    = "AllowAccessToDynamoTables"
+    effect = "Allow"
+
+    actions = [
+      "dynamodb:DeleteItem",
+
+    ]
+    resources = [
+      data.aws_dynamodb_table.account_recovery_block_table.arn,
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "dynamo_account_recovery_block_write_access_policy_document" {
+  statement {
+    sid    = "AllowAccessToDynamoTables"
+    effect = "Allow"
+
+    actions = [
+      "dynamodb:UpdateItem",
+      "dynamodb:PutItem",
+    ]
+    resources = [
+      data.aws_dynamodb_table.account_recovery_block_table.arn,
+    ]
+  }
+}
+
 resource "aws_iam_policy" "dynamo_client_registry_write_access_policy" {
   name_prefix = "dynamo-client-registry-write-policy"
   path        = "/${var.environment}/oidc-default/"
@@ -301,4 +331,20 @@ resource "aws_iam_policy" "dynamo_account_recovery_block_read_access_policy" {
   description = "IAM policy for managing read permissions to the Dynamo Account Recovery Block table"
 
   policy = data.aws_iam_policy_document.dynamo_account_recovery_block_read_access_policy_document.json
+}
+
+resource "aws_iam_policy" "dynamo_account_recovery_block_delete_access_policy" {
+  name_prefix = "dynamo-account-recovery-delete"
+  path        = "/${var.environment}/oidc-default/"
+  description = "IAM policy for managing delete permissions to the Dynamo Account Recovery Block table"
+
+  policy = data.aws_iam_policy_document.dynamo_account_recovery_block_delete_access_policy_document.json
+}
+
+resource "aws_iam_policy" "dynamo_account_recovery_block_write_access_policy" {
+  name_prefix = "dynamo-account-recovery-write"
+  path        = "/${var.environment}/oidc-default/"
+  description = "IAM policy for managing write permissions to the Dynamo Account Recovery Block table"
+
+  policy = data.aws_iam_policy_document.dynamo_account_recovery_block_write_access_policy_document.json
 }

--- a/ci/terraform/oidc/reset_password.tf
+++ b/ci/terraform/oidc/reset_password.tf
@@ -8,6 +8,8 @@ module "frontend_api_reset_password_role" {
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
     aws_iam_policy.dynamo_user_read_access_policy.arn,
     aws_iam_policy.dynamo_user_write_access_policy.arn,
+    aws_iam_policy.dynamo_account_recovery_block_read_access_policy.arn,
+    aws_iam_policy.dynamo_account_recovery_block_write_access_policy.arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/DynamoAccountRecoveryBlockService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/DynamoAccountRecoveryBlockService.java
@@ -1,6 +1,7 @@
 package uk.gov.di.authentication.frontendapi.services;
 
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
 import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest;
 import uk.gov.di.authentication.frontendapi.entity.AccountRecoveryBlock;
@@ -38,6 +39,10 @@ public class DynamoAccountRecoveryBlockService {
                                         .toInstant()
                                         .getEpochSecond());
         dynamoAccountRecoveryBlockTable.putItem(accountRecoveryBlock);
+    }
+
+    public void deleteBlock(String email) {
+        dynamoAccountRecoveryBlockTable.deleteItem(Key.builder().partitionValue(email).build());
     }
 
     public void addBlockWithNoTTL(String email) {


### PR DESCRIPTION
## What?

- Create additional policies to the account recovery block table
- Assign the read and write policies to the reset password lambda role

## Why?

- The reset password lambda will require permissions to read and write to the new table