### PR TITLE
AUT-1156 - Add block when user resets their password with verified MFA 

### DIFF
--- a/ci/terraform/oidc/build-overrides.tfvars
+++ b/ci/terraform/oidc/build-overrides.tfvars
@@ -11,6 +11,7 @@ spot_enabled                       = false
 language_cy_enabled                = true
 internal_sector_uri                = "https://identity.build.account.gov.uk"
 extended_feature_flags_enabled     = true
+account_recovery_block_enabled     = true
 
 blocked_email_duration                    = 30
 otp_code_ttl_duration                     = 120

--- a/ci/terraform/oidc/integration-overrides.tfvars
+++ b/ci/terraform/oidc/integration-overrides.tfvars
@@ -19,6 +19,8 @@ internal_sector_uri            = "https://identity.integration.account.gov.uk"
 spot_enabled                   = true
 language_cy_enabled            = true
 extended_feature_flags_enabled = true
+account_recovery_block_enabled = false
+
 
 ipv_auth_public_encryption_key = <<-EOT
 -----BEGIN PUBLIC KEY-----

--- a/ci/terraform/oidc/production-overrides.tfvars
+++ b/ci/terraform/oidc/production-overrides.tfvars
@@ -19,6 +19,7 @@ doc_app_authorisation_uri          = "https://www.review-b.account.gov.uk/dca/oa
 doc_app_jwks_endpoint              = "https://api-backend-api.review-b.account.gov.uk/.well-known/jwks.json"
 doc_app_encryption_key_id          = "7958938d-eea0-4e6d-9ea1-ec0b9d421f77"
 
+account_recovery_block_enabled = false
 cloudwatch_log_retention       = 5
 client_registry_api_enabled    = false
 language_cy_enabled            = true

--- a/ci/terraform/oidc/reset_password.tf
+++ b/ci/terraform/oidc/reset_password.tf
@@ -27,6 +27,7 @@ module "reset_password" {
   environment     = var.environment
 
   handler_environment_variables = {
+    ACCOUNT_RECOVERY_BLOCK_ENABLED         = var.account_recovery_block_enabled
     DYNAMO_ENDPOINT                        = var.use_localstack ? var.lambda_dynamo_endpoint : null
     LOCALSTACK_ENDPOINT                    = var.use_localstack ? var.localstack_endpoint : null
     EMAIL_QUEUE_URL                        = aws_sqs_queue.email_queue.id

--- a/ci/terraform/oidc/staging-overrides.tfvars
+++ b/ci/terraform/oidc/staging-overrides.tfvars
@@ -19,6 +19,7 @@ spot_enabled                       = true
 language_cy_enabled                = true
 extended_feature_flags_enabled     = true
 test_clients_enabled               = "true"
+account_recovery_block_enabled     = false
 
 ipv_auth_public_encryption_key = <<-EOT
 -----BEGIN PUBLIC KEY-----

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -92,6 +92,10 @@ variable "environment" {
   type = string
 }
 
+variable "account_recovery_block_enabled" {
+  default = false
+}
+
 variable "aws_endpoint" {
   type    = string
   default = null

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -40,6 +40,7 @@ test {
     }
     environment "AUDIT_SIGNING_KEY_ALIAS", "alias/local-audit-payload-signing-key-alias"
     environment "AWS_ACCESS_KEY_ID", "mock-access-key"
+    environment "ACCOUNT_RECOVERY_BLOCK_ENABLED", "true"
     environment "AWS_REGION", "eu-west-2"
     environment "AWS_SECRET_ACCESS_KEY", "mock-secret-key "
     environment "OIDC_API_BASE_URL", "http://localhost"

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AccountRecoveryStoreExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AccountRecoveryStoreExtension.java
@@ -48,6 +48,10 @@ public class AccountRecoveryStoreExtension extends DynamoExtension implements Af
         dynamoAccountRecoveryService.addBlockWithTTL(email);
     }
 
+    public boolean isBlockPresent(String email) {
+        return dynamoAccountRecoveryService.blockIsPresent(email);
+    }
+
     public void addBlockWithoutTTL(String email) {
         dynamoAccountRecoveryService.addBlockWithNoTTL(email);
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -66,6 +66,12 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return Long.parseLong(System.getenv().getOrDefault("ACCOUNT_RECOVERY_BLOCK_TTL", "172800"));
     }
 
+    public boolean isAccountRecoveryBlockEnabled() {
+        return System.getenv()
+                .getOrDefault("ACCOUNT_RECOVERY_BLOCK_ENABLED", "false")
+                .equals("true");
+    }
+
     public long getAuthCodeExpiry() {
         return Long.parseLong(System.getenv().getOrDefault("AUTH_CODE_EXPIRY", "300"));
     }


### PR DESCRIPTION
## What?

- If a user resets their password with a verified SMS then set a block with a TTL.
- If a user resets their password with a verified Auth App then set a block with No TTL.
- Enable account_recovery_block for build only

## Why?

- Required as part of the account recovery journey

