### PR TITLE
AUT-1156 - Give permissions to verify lambdas to delete and read from account recovery table

### DIFF
--- a/ci/terraform/oidc/account-recovery.tf
+++ b/ci/terraform/oidc/account-recovery.tf
@@ -13,10 +13,6 @@ module "frontend_api_account_recovery_role" {
     aws_iam_policy.dynamo_account_recovery_block_read_access_policy.arn,
     module.oidc_txma_audit.access_policy_arn
   ]
-
-  depends_on = [
-    aws_iam_policy.dynamo_account_recovery_block_read_access_policy
-  ]
 }
 
 

--- a/ci/terraform/oidc/verify_code.tf
+++ b/ci/terraform/oidc/verify_code.tf
@@ -9,6 +9,8 @@ module "frontend_api_verify_code_role" {
     aws_iam_policy.dynamo_user_read_access_policy.arn,
     aws_iam_policy.dynamo_user_write_access_policy.arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
+    aws_iam_policy.dynamo_account_recovery_block_delete_access_policy.arn,
+    aws_iam_policy.dynamo_account_recovery_block_read_access_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
     module.oidc_txma_audit.access_policy_arn

--- a/ci/terraform/oidc/verify_mfa_code.tf
+++ b/ci/terraform/oidc/verify_mfa_code.tf
@@ -9,6 +9,8 @@ module "frontend_api_verify_mfa_code_role" {
     aws_iam_policy.dynamo_user_read_access_policy.arn,
     aws_iam_policy.dynamo_user_write_access_policy.arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
+    aws_iam_policy.dynamo_account_recovery_block_delete_access_policy.arn,
+    aws_iam_policy.dynamo_account_recovery_block_read_access_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
     module.oidc_txma_audit.access_policy_arn


### PR DESCRIPTION
## What?

 - Give permissions to verify lambdas to delete and read from account recovery table
- Clear depends_on from account-recovery.tf as it is no longer needed

## Why?

- Verify code lambdas require permissions to delete and read from the account recovery table
