### PR TITLE
AUT-1156 - Delete block when user successfully enters sign in OTP 

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/DynamoAccountRecoveryBlockService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/DynamoAccountRecoveryBlockService.java
@@ -41,8 +41,10 @@ public class DynamoAccountRecoveryBlockService {
         dynamoAccountRecoveryBlockTable.putItem(accountRecoveryBlock);
     }
 
-    public void deleteBlock(String email) {
-        dynamoAccountRecoveryBlockTable.deleteItem(Key.builder().partitionValue(email).build());
+    public void deleteBlockIfPresent(String email) {
+        if (blockIsPresent(email)) {
+            dynamoAccountRecoveryBlockTable.deleteItem(Key.builder().partitionValue(email).build());
+        }
     }
 
     public void addBlockWithNoTTL(String email) {


### PR DESCRIPTION
## What?


- Delete any block what exists when a user enters valid Auth App or MFA otp

## Why?

- If there is any block present in the account recovery table and a users enters a valid SMS or Auth App OTP then ensure we remove the block
