### PR TITLE
Add support for terraform state locking table

### DIFF
--- a/ci/tasks/deploy-acct-mgmt-api.yml
+++ b/ci/tasks/deploy-acct-mgmt-api.yml
@@ -14,6 +14,7 @@ params:
   DNS_STATE_KEY: ((dns-state-key))
   NOTIFY_API_KEY: ((build-notify-api-key))
   STATE_BUCKET: digital-identity-dev-tfstate
+  STATE_LOCKING_TABLE: digital-identity-dev-tfstate-locking
   TXMA_ACCOUNT_ID: ((build-txma-account-id))
   TEST_CLIENT_VERIFY_EMAIL_OTP: ((test-client-verify-email-otp))
   TEST_CLIENT_VERIFY_PHONE_NUMBER_OTP: ((test-client-verify-phone-number-otp))
@@ -34,7 +35,8 @@ run:
         -backend-config "bucket=${STATE_BUCKET}" \
         -backend-config "key=${DEPLOY_ENVIRONMENT}-account-managment-api-terraform.tfstate" \
         -backend-config "encrypt=true" \
-        -backend-config "region=eu-west-2"
+        -backend-config "region=eu-west-2" \
+        -backend-config "dynamodb_table=${STATE_LOCKING_TABLE}"
 
       terraform apply -auto-approve \
         -var "deployer_role_arn=${DEPLOYER_ROLE_ARN}" \

--- a/ci/tasks/deploy-audit-processors.yml
+++ b/ci/tasks/deploy-audit-processors.yml
@@ -10,6 +10,7 @@ params:
   DEPLOYER_ROLE_ARN: ((deployer-role-arn-non-prod))
   DEPLOY_ENVIRONMENT: build
   STATE_BUCKET: digital-identity-dev-tfstate
+  STATE_LOCKING_TABLE: digital-identity-dev-tfstate-locking
   AUDIT_STORE_EXPIRY_DAYS: 7
   TXMA_OBFUSCATION_SECRET_ARN: ""
   TXMA_OBFUSCATION_SECRET_KMS_KEY_ARN: ""
@@ -30,7 +31,8 @@ run:
         -backend-config "bucket=${STATE_BUCKET}" \
         -backend-config "key=${DEPLOY_ENVIRONMENT}-audit-terraform.tfstate" \
         -backend-config "encrypt=true" \
-        -backend-config "region=eu-west-2"
+        -backend-config "region=eu-west-2" \
+        -backend-config "dynamodb_table=${STATE_LOCKING_TABLE}"
 
       terraform apply -auto-approve \
         -var "lambda_zip_file=$(ls -1 ../../../../audit-processors-release/*.zip)" \

--- a/ci/tasks/deploy-delivery-receipts-api.yml
+++ b/ci/tasks/deploy-delivery-receipts-api.yml
@@ -10,6 +10,7 @@ params:
   DEPLOYER_ROLE_ARN: ((deployer-role-arn-non-prod))
   DEPLOY_ENVIRONMENT: build
   STATE_BUCKET: digital-identity-dev-tfstate
+  STATE_LOCKING_TABLE: digital-identity-dev-tfstate-locking
 inputs:
   - name: api-terraform-src
   - name: delivery-receipts-api-release
@@ -26,7 +27,8 @@ run:
         -backend-config "bucket=${STATE_BUCKET}" \
         -backend-config "key=${DEPLOY_ENVIRONMENT}-delivery-receipts-api-terraform.tfstate" \
         -backend-config "encrypt=true" \
-        -backend-config "region=eu-west-2"
+        -backend-config "region=eu-west-2" \
+        -backend-config "dynamodb_table=${STATE_LOCKING_TABLE}"
 
       terraform apply -auto-approve \
         -var "deployer_role_arn=${DEPLOYER_ROLE_ARN}" \

--- a/ci/tasks/deploy-oidc-api.yml
+++ b/ci/tasks/deploy-oidc-api.yml
@@ -16,6 +16,7 @@ params:
   DNS_STATE_KEY: ((dns-state-key))
   DOC_APP_RP_CLIENT_ID: ((build-doc-app-rp-client-id))
   STATE_BUCKET: digital-identity-dev-tfstate
+  STATE_LOCKING_TABLE: digital-identity-dev-tfstate-locking
   TEST_CLIENT_VERIFY_EMAIL_OTP: ((test-client-verify-email-otp))
   TEST_CLIENT_VERIFY_PHONE_NUMBER_OTP: ((test-client-verify-phone-number-otp))
   SPOT_ACCOUNT_NUMBER: ((staging-spot-account-number))
@@ -44,7 +45,8 @@ run:
         -backend-config "bucket=${STATE_BUCKET}" \
         -backend-config "key=${DEPLOY_ENVIRONMENT}-terraform.tfstate" \
         -backend-config "encrypt=true" \
-        -backend-config "region=eu-west-2"
+        -backend-config "region=eu-west-2" \
+        -backend-config "dynamodb_table=${STATE_LOCKING_TABLE}"
 
       terraform apply -auto-approve \
         -var "oidc_api_lambda_zip_file=$(ls -1 ../../../../oidc-api-release/*.zip)" \

--- a/ci/tasks/deploy-shared-api.yml
+++ b/ci/tasks/deploy-shared-api.yml
@@ -12,6 +12,7 @@ params:
   NOTIFY_API_KEY: ((build-notify-api-key))
   PASSWORD_PEPPER: ((build-password-pepper))
   STATE_BUCKET: digital-identity-dev-tfstate
+  STATE_LOCKING_TABLE: digital-identity-dev-tfstate-locking
   TEST_CLIENT_EMAIL_ALLOWLIST: ((test-client-email-allowlist))
   DI_TOOLS_SIGNING_PROFILE_VERSION_ARN: ((di-tools-signing-profile-version-arn))
   DI_TOOLS_ACCOUNT_NUMBER: ((di-tools-account-id-non-prod))
@@ -37,7 +38,8 @@ run:
         -backend-config "bucket=${STATE_BUCKET}" \
         -backend-config "key=${DEPLOY_ENVIRONMENT}-shared-terraform.tfstate" \
         -backend-config "encrypt=true" \
-        -backend-config "region=eu-west-2"
+        -backend-config "region=eu-west-2" \
+        -backend-config "dynamodb_table=${STATE_LOCKING_TABLE}"
 
       terraform apply -auto-approve \
         -var "deployer_role_arn=${DEPLOYER_ROLE_ARN}" \

--- a/ci/tasks/deploy-test-services.yml
+++ b/ci/tasks/deploy-test-services.yml
@@ -30,7 +30,8 @@ run:
         -backend-config "bucket=${STATE_BUCKET}" \
         -backend-config "key=${DEPLOY_ENVIRONMENT}-test-services-terraform.tfstate" \
         -backend-config "encrypt=true" \
-        -backend-config "region=eu-west-2"
+        -backend-config "region=eu-west-2" \
+        -backend-config "dynamodb_table=${STATE_LOCKING_TABLE}"
 
       terraform apply -auto-approve \
         -var "test_services-api-lambda_zip_file=$(ls -1 ../../../../test-services-release/*.zip)" \

--- a/ci/tasks/deploy-utils.yml
+++ b/ci/tasks/deploy-utils.yml
@@ -10,6 +10,7 @@ params:
   DEPLOYER_ROLE_ARN: ((deployer-role-arn-non-prod))
   DEPLOY_ENVIRONMENT: build
   STATE_BUCKET: digital-identity-dev-tfstate
+  STATE_LOCKING_TABLE: digital-identity-dev-tfstate-locking
 
 
 inputs:
@@ -29,7 +30,8 @@ run:
         -backend-config "bucket=${STATE_BUCKET}" \
         -backend-config "key=${DEPLOY_ENVIRONMENT}-utils-terraform.tfstate" \
         -backend-config "encrypt=true" \
-        -backend-config "region=eu-west-2"
+        -backend-config "region=eu-west-2" \
+        -backend-config "dynamodb_table=${STATE_LOCKING_TABLE}"
 
       terraform apply -auto-approve \
         -var "utils_release_zip_file=$(ls -1 ../../../../utils-release/*.zip)" \


### PR DESCRIPTION
## What?

Add support for terraform state locking table.
Ensures that prod and staging don't use it, as they are in different accounts.

## Why?

Asked for as part of Concourse Move initiative.

## Related PRs

Merge after https://github.com/alphagov/di-infrastructure/pull/480