### PR TITLE
BAU: Persistent Id in the wrong field in audit event

### DIFF
--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/ProcessingIdentityHandler.java
@@ -120,8 +120,8 @@ public class ProcessingIdentityHandler extends BaseFrontendHandler<ProcessingIde
                             .map(UserProfile::getEmail)
                             .orElse(AuditService.UNKNOWN),
                     IpAddressHelper.extractIpAddress(input),
-                    PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()),
-                    AuditService.UNKNOWN);
+                    AuditService.UNKNOWN,
+                    PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));
             sessionService.save(userContext.getSession());
             LOG.info(
                     "Generating ProcessingIdentityResponse with ProcessingIdentityStatus: {}",


### PR DESCRIPTION
## What?

Send persistent id in the correct field in the audit api.

## Why?

The persistent Id is currently in the wrong place.
