### PR TITLE
BAU - Remove legacy code from ResetPasswordRequest

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/ResetPasswordRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/ResetPasswordRequest.java
@@ -1,24 +1,13 @@
 package uk.gov.di.authentication.frontendapi.entity;
 
-import com.google.gson.annotations.Expose;
-import com.google.gson.annotations.SerializedName;
 import uk.gov.di.authentication.shared.entity.BaseFrontendRequest;
 
 public class ResetPasswordRequest extends BaseFrontendRequest {
 
-    @Expose
-    @SerializedName("useCodeFlow")
-    private boolean useCodeFlow = false;
-
     public ResetPasswordRequest() {}
 
-    public ResetPasswordRequest(String email, boolean useCodeFlow) {
+    public ResetPasswordRequest(String email) {
         this.email = email;
-        this.useCodeFlow = useCodeFlow;
-    }
-
-    public boolean isUseCodeFlow() {
-        return useCodeFlow;
     }
 
     @Override

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
@@ -162,7 +162,7 @@ class ResetPasswordRequestHandlerTest {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setRequestContext(contextWithSourceIp("123.123.123.123"));
         event.setHeaders(headers);
-        event.setBody(format("{ \"email\": \"%s\", \"useCodeFlow\": true }", TEST_EMAIL_ADDRESS));
+        event.setBody(format("{ \"email\": \"%s\"}", TEST_EMAIL_ADDRESS));
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertEquals(204, result.getStatusCode());
@@ -206,7 +206,7 @@ class ResetPasswordRequestHandlerTest {
         var event = new APIGatewayProxyRequestEvent();
         event.setRequestContext(contextWithSourceIp("123.123.123.123"));
         event.setHeaders(headers);
-        event.setBody(format("{ \"email\": \"%s\", \"useCodeFlow\": true }", TEST_EMAIL_ADDRESS));
+        event.setBody(format("{ \"email\": \"%s\"}", TEST_EMAIL_ADDRESS));
         var result = handler.handleRequest(event, context);
 
         assertEquals(204, result.getStatusCode());
@@ -248,7 +248,7 @@ class ResetPasswordRequestHandlerTest {
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setRequestContext(contextWithSourceIp("123.123.123.123"));
         event.setHeaders(headers);
-        event.setBody(format("{ \"email\": \"%s\", \"useCodeFlow\": true }", TEST_EMAIL_ADDRESS));
+        event.setBody(format("{ \"email\": \"%s\"}", TEST_EMAIL_ADDRESS));
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         NotifyRequest notifyRequest =
@@ -315,8 +315,7 @@ class ResetPasswordRequestHandlerTest {
         headers.put(PersistentIdHelper.PERSISTENT_ID_HEADER_NAME, PERSISTENT_ID);
         headers.put("Session-Id", session.getSessionId());
         event.setHeaders(headers);
-        event.setBody(
-                format("{ \"email\": \"%s\", \"useCodeFlow\": \"%s\"}", TEST_EMAIL_ADDRESS, true));
+        event.setBody(format("{ \"email\": \"%s\"}", TEST_EMAIL_ADDRESS));
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
         assertEquals(500, result.getStatusCode());

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordRequestIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordRequestIntegrationTest.java
@@ -43,7 +43,7 @@ public class ResetPasswordRequestIntegrationTest extends ApiGatewayHandlerIntegr
 
         var response =
                 makeRequest(
-                        Optional.of(new ResetPasswordRequest(email, true)),
+                        Optional.of(new ResetPasswordRequest(email)),
                         constructFrontendHeaders(sessionId, null, persistentSessionId),
                         Map.of());
 


### PR DESCRIPTION
## What?

 - Remove legacy code from ResetPasswordRequest

## Why?

- We don't use the useCodeFlow boolean passed into the request and assume it is always the code flow so we can remove this.
