### PR TITLE
BAU - Ensure persistent session ID is attached to log lines when available

### DIFF
--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppAuthorizeHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppAuthorizeHandler.java
@@ -41,6 +41,7 @@ import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segm
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.CLIENT_ID;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.CLIENT_SESSION_ID;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.GOVUK_SIGNIN_JOURNEY_ID;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.PERSISTENT_SESSION_ID;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachLogFieldToLogs;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachSessionIdToLogs;
 import static uk.gov.di.authentication.shared.helpers.RequestHeaderHelper.getHeaderValueFromHeaders;
@@ -138,6 +139,9 @@ public class DocAppAuthorizeHandler
                             configurationService.getHeadersCaseInsensitive());
             attachLogFieldToLogs(CLIENT_SESSION_ID, clientSessionId);
             attachLogFieldToLogs(GOVUK_SIGNIN_JOURNEY_ID, clientSessionId);
+            attachLogFieldToLogs(
+                    PERSISTENT_SESSION_ID,
+                    PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));
             var clientID = new ClientID(configurationService.getDocAppAuthorisationClientId());
             attachLogFieldToLogs(CLIENT_ID, clientID.getValue());
             var clientRegistry =

--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
@@ -21,6 +21,7 @@ import uk.gov.di.authentication.shared.exceptions.NoSessionException;
 import uk.gov.di.authentication.shared.exceptions.UnsuccessfulCredentialResponseException;
 import uk.gov.di.authentication.shared.helpers.ConstructUriHelper;
 import uk.gov.di.authentication.shared.helpers.CookieHelper;
+import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.ClientSessionService;
@@ -44,6 +45,7 @@ import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segm
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.CLIENT_ID;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.CLIENT_SESSION_ID;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.GOVUK_SIGNIN_JOURNEY_ID;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.PERSISTENT_SESSION_ID;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachLogFieldToLogs;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachSessionIdToLogs;
 
@@ -163,6 +165,9 @@ public class DocAppCallbackHandler
                                     });
             attachLogFieldToLogs(CLIENT_SESSION_ID, clientSessionId);
             attachLogFieldToLogs(GOVUK_SIGNIN_JOURNEY_ID, clientSessionId);
+            var persistentId =
+                    PersistentIdHelper.extractPersistentIdFromCookieHeader(input.getHeaders());
+            attachLogFieldToLogs(PERSISTENT_SESSION_ID, persistentId);
 
             var authenticationRequest =
                     AuthenticationRequest.parse(clientSession.getAuthRequestParams());

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -31,10 +31,8 @@ import java.util.Optional;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.CLIENT_ID;
-import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.PERSISTENT_SESSION_ID;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachLogFieldToLogs;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachSessionIdToLogs;
-import static uk.gov.di.authentication.shared.helpers.PersistentIdHelper.extractPersistentIdFromHeaders;
 
 public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsRequest>
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
@@ -81,8 +79,6 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
             UserContext userContext) {
 
         attachSessionIdToLogs(userContext.getSession());
-        attachLogFieldToLogs(
-                PERSISTENT_SESSION_ID, extractPersistentIdFromHeaders(input.getHeaders()));
         attachLogFieldToLogs(
                 CLIENT_ID,
                 userContext.getClient().map(ClientRegistry::getClientID).orElse("unknown"));

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
@@ -41,7 +41,6 @@ import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_PHO
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateEmptySuccessApiGatewayResponse;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.CLIENT_ID;
-import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.PERSISTENT_SESSION_ID;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachLogFieldToLogs;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachSessionIdToLogs;
 import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_BLOCKED_KEY_PREFIX;
@@ -115,7 +114,6 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
                     PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders());
 
             attachSessionIdToLogs(userContext.getSession().getSessionId());
-            attachLogFieldToLogs(PERSISTENT_SESSION_ID, persistentSessionId);
             attachLogFieldToLogs(
                     CLIENT_ID,
                     userContext.getClient().map(ClientRegistry::getClientID).orElse("unknown"));

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
@@ -54,10 +54,8 @@ import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.g
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateEmptySuccessApiGatewayResponse;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName;
-import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.PERSISTENT_SESSION_ID;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachLogFieldToLogs;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachSessionIdToLogs;
-import static uk.gov.di.authentication.shared.helpers.PersistentIdHelper.extractPersistentIdFromHeaders;
 import static uk.gov.di.authentication.shared.helpers.TestClientHelper.isTestClientWithAllowedEmail;
 import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_BLOCKED_KEY_PREFIX;
 import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_REQUEST_BLOCKED_KEY_PREFIX;
@@ -116,8 +114,6 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
             UserContext userContext) {
 
         attachSessionIdToLogs(userContext.getSession());
-        attachLogFieldToLogs(
-                PERSISTENT_SESSION_ID, extractPersistentIdFromHeaders(input.getHeaders()));
         attachLogFieldToLogs(
                 LogFieldName.CLIENT_ID,
                 userContext.getClient().map(ClientRegistry::getClientID).orElse("unknown"));

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
@@ -37,10 +37,8 @@ import static uk.gov.di.authentication.shared.entity.Session.AccountState.NEW;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.CLIENT_ID;
-import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.PERSISTENT_SESSION_ID;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachLogFieldToLogs;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachSessionIdToLogs;
-import static uk.gov.di.authentication.shared.helpers.PersistentIdHelper.extractPersistentIdFromHeaders;
 import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
 
 public class SignUpHandler extends BaseFrontendHandler<SignupRequest>
@@ -92,8 +90,6 @@ public class SignUpHandler extends BaseFrontendHandler<SignupRequest>
             UserContext userContext) {
 
         attachSessionIdToLogs(userContext.getSession());
-        attachLogFieldToLogs(
-                PERSISTENT_SESSION_ID, extractPersistentIdFromHeaders(input.getHeaders()));
         attachLogFieldToLogs(
                 CLIENT_ID,
                 userContext.getClient().map(ClientRegistry::getClientID).orElse("unknown"));

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
@@ -49,7 +49,6 @@ import static uk.gov.di.authentication.shared.entity.MFAMethodType.AUTH_APP;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateEmptySuccessApiGatewayResponse;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.CLIENT_ID;
-import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.PERSISTENT_SESSION_ID;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachLogFieldToLogs;
 
 public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileRequest>
@@ -127,7 +126,6 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
                 PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders());
 
         LogLineHelper.attachSessionIdToLogs(session);
-        attachLogFieldToLogs(PERSISTENT_SESSION_ID, persistentSessionId);
 
         LOG.info("Processing request");
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -44,7 +44,6 @@ import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_PHO
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateEmptySuccessApiGatewayResponse;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.CLIENT_ID;
-import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.PERSISTENT_SESSION_ID;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachLogFieldToLogs;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachSessionIdToLogs;
 import static uk.gov.di.authentication.shared.helpers.PersistentIdHelper.extractPersistentIdFromHeaders;
@@ -106,8 +105,6 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
             UserContext userContext) {
 
         attachSessionIdToLogs(userContext.getSession());
-        attachLogFieldToLogs(
-                PERSISTENT_SESSION_ID, extractPersistentIdFromHeaders(input.getHeaders()));
         attachLogFieldToLogs(
                 CLIENT_ID,
                 userContext.getClient().map(ClientRegistry::getClientID).orElse("unknown"));

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -40,7 +40,6 @@ import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent
 import static uk.gov.di.authentication.shared.entity.LevelOfConfidence.NONE;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.CLIENT_ID;
-import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.PERSISTENT_SESSION_ID;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachLogFieldToLogs;
 import static uk.gov.di.authentication.shared.helpers.PersistentIdHelper.extractPersistentIdFromHeaders;
 import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
@@ -106,8 +105,6 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
             VerifyMfaCodeRequest codeRequest,
             UserContext userContext) {
 
-        attachLogFieldToLogs(
-                PERSISTENT_SESSION_ID, extractPersistentIdFromHeaders(input.getHeaders()));
         attachLogFieldToLogs(
                 CLIENT_ID,
                 userContext.getClient().map(ClientRegistry::getClientID).orElse("unknown"));

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVAuthorisationHandler.java
@@ -45,7 +45,6 @@ import static uk.gov.di.authentication.shared.domain.RequestHeaders.CLIENT_SESSI
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.CLIENT_ID;
-import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.PERSISTENT_SESSION_ID;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.UNKNOWN;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachLogFieldToLogs;
 import static uk.gov.di.authentication.shared.helpers.RequestHeaderHelper.getHeaderValueFromHeaders;
@@ -114,7 +113,6 @@ public class IPVAuthorisationHandler extends BaseFrontendHandler<IPVAuthorisatio
             }
             var persistentId =
                     PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders());
-            attachLogFieldToLogs(PERSISTENT_SESSION_ID, persistentId);
             var rpClientID = userContext.getClient().map(ClientRegistry::getClientID);
             attachLogFieldToLogs(CLIENT_ID, rpClientID.orElse(UNKNOWN));
             LOG.info("IPVAuthorisationHandler received request");

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -50,6 +50,7 @@ import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segm
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.CLIENT_ID;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.CLIENT_SESSION_ID;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.GOVUK_SIGNIN_JOURNEY_ID;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.PERSISTENT_SESSION_ID;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachLogFieldToLogs;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachSessionIdToLogs;
 import static uk.gov.di.authentication.shared.helpers.RequestHeaderHelper.getHeaderValueFromHeaders;
@@ -165,6 +166,9 @@ public class AuthCodeHandler
         }
 
         attachLogFieldToLogs(CLIENT_ID, authenticationRequest.getClientID().getValue());
+        attachLogFieldToLogs(
+                PERSISTENT_SESSION_ID,
+                PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));
         addAnnotation(
                 "client_id", String.valueOf(clientSession.getAuthRequestParams().get("client_id")));
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/lambda/BaseFrontendHandler.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/lambda/BaseFrontendHandler.java
@@ -10,6 +10,7 @@ import uk.gov.di.authentication.shared.entity.BaseFrontendRequest;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.Session;
+import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.serialization.Json.JsonException;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
@@ -30,6 +31,8 @@ import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.g
 import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
 import static uk.gov.di.authentication.shared.helpers.LocaleHelper.getUserLanguageFromRequestHeaders;
 import static uk.gov.di.authentication.shared.helpers.LocaleHelper.matchSupportedLanguage;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.PERSISTENT_SESSION_ID;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachLogFieldToLogs;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachSessionIdToLogs;
 import static uk.gov.di.authentication.shared.helpers.RequestHeaderHelper.getHeaderValueFromHeaders;
 
@@ -134,6 +137,10 @@ public abstract class BaseFrontendHandler<T>
         } else {
             attachSessionIdToLogs(session.get());
         }
+        attachLogFieldToLogs(
+                PERSISTENT_SESSION_ID,
+                PersistentIdHelper.extractPersistentIdFromHeaders(input.getHeaders()));
+
         Optional<String> userLanguage =
                 getUserLanguageFromRequestHeaders(input.getHeaders(), configurationService);
         final T request;


### PR DESCRIPTION
## What?

- Attach the persistentSessionId to the log line in the BaseFrontendHandler to ensure every lambda that extends it automatically gets the ID attached. There were several lambdas which extended the BaseFrontendHandler that didn't have the persistentSessionId attached.
- Remove the manual attaching of persistentSessionId from any lambda that extends the BaseFrontendHandler.
- Ensure that any lambda that does not extend the BaseFrontendHandler attaches the persistentSessionId to the log line, when possible.

## Why?

- So that we can track a persistentSessionId across all lambdas which reduce any gaps in our logging
