### PR TITLE
AUT-1182: Terraform to add test account-recovery-block to the database

### DIFF
--- a/ci/tasks/deploy-shared-api.yml
+++ b/ci/tasks/deploy-shared-api.yml
@@ -32,6 +32,12 @@ run:
         TEST_USERS="[]"
       fi
 
+      if test -f "test-users-seed-data/test_account_recovery_blocks.vars"; then
+        TEST_ACCOUNT_RECOVERY_BLOCKS=$(cat test-users-seed-data/test_account_recovery_blocks.vars)
+      else
+        TEST_ACCOUNT_RECOVERY_BLOCKS="[]"
+      fi
+
       if [[ "${DEPLOY_ENVIRONMENT}" == "build" ]]; then
         ENABLE_STATE_LOCKING=true
       else
@@ -54,6 +60,7 @@ run:
         -var 'logging_endpoint_arns=["arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"]' \
         -var "test_client_email_allowlist=${TEST_CLIENT_EMAIL_ALLOWLIST}" \
         -var "test_users=${TEST_USERS}" \
+        -var "test_account_recovery_blocks=${TEST_ACCOUNT_RECOVERY_BLOCKS}" \
         -var "password_pepper=${PASSWORD_PEPPER}" \
         -var "common_state_bucket=${STATE_BUCKET}" \
         -var "di_tools_signing_profile_version_arn=${DI_TOOLS_SIGNING_PROFILE_VERSION_ARN}" \

--- a/ci/terraform/shared/sandpit.tfvars
+++ b/ci/terraform/shared/sandpit.tfvars
@@ -29,3 +29,10 @@ stub_rp_clients = [
 
 logging_endpoint_enabled = false
 enforce_code_signing     = false
+
+test_account_recovery_blocks = [
+  {
+    username      = "account-recovery.blocked@digital.cabinet-office.gov.uk"
+    time_to_exist = "1171734022"
+  }
+]

--- a/ci/terraform/shared/test-account-recovery-block.tf
+++ b/ci/terraform/shared/test-account-recovery-block.tf
@@ -1,0 +1,19 @@
+
+data "aws_dynamodb_table" "account_recovery_block_table" {
+  name = "${var.environment}-account-recovery-block"
+}
+
+resource "aws_dynamodb_table_item" "account-recovery-block" {
+  for_each = { for block in var.test_account_recovery_blocks : block.username => block }
+
+  table_name = data.aws_dynamodb_table.account_recovery_block_table.name
+  hash_key   = data.aws_dynamodb_table.account_recovery_block_table.hash_key
+  item = jsonencode({
+    "Email" = {
+      "S" = each.value.username
+    },
+    "TimeToExist" = {
+      "N" = each.value.time_to_exist
+    }
+  })
+}

--- a/ci/terraform/shared/variables.tf
+++ b/ci/terraform/shared/variables.tf
@@ -99,6 +99,12 @@ variable "test_users" {
   description = "Test users to add in the database"
 }
 
+variable "test_account_recovery_blocks" {
+  default     = []
+  type        = list(object({ username : string, time_to_exist : string }))
+  description = "Test account recovery blocks to add in the database"
+}
+
 variable "aws_region" {
   default = "eu-west-2"
 }


### PR DESCRIPTION
## What?

Terraform to add test account-recovery-block to the database.

## Why?

Adds a facility to set account-recovery-block for test users in the pipeline.
Will be used to setup test data for account recovery acceptance tests.

## Related PRs

https://github.com/alphagov/di-infrastructure/pull/483