### PR TITLE
BAU: Explicity set OneLoginService in stub clients

### DIFF
--- a/ci/terraform/shared/build-stub-clients.tfvars
+++ b/ci/terraform/shared/build-stub-clients.tfvars
@@ -16,6 +16,7 @@ stub_rp_clients = [
       "email",
       "phone",
     ]
+    one_login_service = false
   },
   {
     client_name = "di-auth-stub-relying-party-build-s2"
@@ -34,6 +35,7 @@ stub_rp_clients = [
       "email",
       "phone",
     ]
+    one_login_service = false
   },
   {
     client_name = "di-auth-stub-relying-party-build-app"
@@ -51,5 +53,6 @@ stub_rp_clients = [
       "openid",
       "doc-checking-app",
     ]
+    one_login_service = false
   },
 ]

--- a/ci/terraform/shared/integration-stub-clients.tfvars
+++ b/ci/terraform/shared/integration-stub-clients.tfvars
@@ -16,6 +16,7 @@ stub_rp_clients = [
       "email",
       "phone",
     ]
+    one_login_service = false
   },
   {
     client_name = "di-auth-stub-relying-party-integration-app"
@@ -33,5 +34,6 @@ stub_rp_clients = [
       "openid",
       "doc-checking-app",
     ]
+    one_login_service = false
   },
 ]

--- a/ci/terraform/shared/production-stub-clients.tfvars
+++ b/ci/terraform/shared/production-stub-clients.tfvars
@@ -16,6 +16,7 @@ stub_rp_clients = [
       "email",
       "phone",
     ]
+    one_login_service = false
   },
   {
     client_name = "di-auth-stub-relying-party-production-app"
@@ -33,5 +34,6 @@ stub_rp_clients = [
       "openid",
       "doc-checking-app",
     ]
+    one_login_service = false
   },
 ]

--- a/ci/terraform/shared/sandpit.tfvars
+++ b/ci/terraform/shared/sandpit.tfvars
@@ -24,6 +24,7 @@ stub_rp_clients = [
       "email",
       "phone",
     ]
+    one_login_service = false
   },
 ]
 

--- a/ci/terraform/shared/staging-stub-clients.tfvars
+++ b/ci/terraform/shared/staging-stub-clients.tfvars
@@ -16,6 +16,7 @@ stub_rp_clients = [
       "email",
       "phone",
     ]
+    one_login_service = false
   },
   {
     client_name = "di-auth-stub-relying-party-staging-app"
@@ -33,6 +34,7 @@ stub_rp_clients = [
       "openid",
       "doc-checking-app",
     ]
+    one_login_service = false
   },
   {
     client_name = "di-auth-stub-relying-party-staging-t1"
@@ -51,5 +53,6 @@ stub_rp_clients = [
       "email",
       "phone",
     ]
+    one_login_service = false
   },
 ]

--- a/ci/terraform/shared/stub-rp-clients.tf
+++ b/ci/terraform/shared/stub-rp-clients.tf
@@ -97,5 +97,8 @@ resource "aws_dynamodb_table_item" "stub_rp_client" {
         S = email
       }]
     }
+    OneLoginService = {
+      BOOL = var.stub_rp_clients[count.index].one_login_service
+    }
   })
 }

--- a/ci/terraform/shared/variables.tf
+++ b/ci/terraform/shared/variables.tf
@@ -89,7 +89,7 @@ variable "logging_endpoint_arns" {
 
 variable "stub_rp_clients" {
   default     = []
-  type        = list(object({ client_name : string, callback_urls : list(string), logout_urls : list(string), test_client : string, scopes : list(string), client_type : string, identity_verification_supported : string, consent_required : string }))
+  type        = list(object({ client_name : string, callback_urls : list(string), logout_urls : list(string), test_client : string, scopes : list(string), client_type : string, identity_verification_supported : string, consent_required : string, one_login_service : bool }))
   description = "The details of RP clients to provision in the Client table"
 }
 


### PR DESCRIPTION
## What?

Explicity set OneLoginService in stub clients.

## Why?

As this was not being done any changes made to test clients in the database were not being overwritten by hardened config.
