### PR TITLE
Decouple usage of DNS, no longer using remote state

### DIFF
--- a/ci/terraform/account-management/api-gateway.tf
+++ b/ci/terraform/account-management/api-gateway.tf
@@ -119,7 +119,7 @@ data "aws_region" "current" {
 }
 
 locals {
-  oidc_api_base_url = var.use_localstack ? "${var.aws_endpoint}/restapis/${aws_api_gateway_rest_api.di_account_management_api.id}/${var.environment}/_user_request_" : module.dns.oidc_api_url
+  oidc_api_base_url = var.use_localstack ? "${var.aws_endpoint}/restapis/${aws_api_gateway_rest_api.di_account_management_api.id}/${var.environment}/_user_request_" : "https://${local.oidc_api_fqdn}/"
 }
 
 resource "aws_api_gateway_deployment" "deployment" {
@@ -264,7 +264,7 @@ resource "aws_api_gateway_base_path_mapping" "api" {
 
   api_id      = aws_api_gateway_rest_api.di_account_management_api.id
   stage_name  = aws_api_gateway_stage.stage.stage_name
-  domain_name = module.dns.account_management_api_fqdn
+  domain_name = local.account_management_api_fqdn
 }
 
 module "dashboard" {

--- a/ci/terraform/account-management/dns.tf
+++ b/ci/terraform/account-management/dns.tf
@@ -1,11 +1,9 @@
-module "dns" {
-  source = "../modules/dns"
+locals {
+  service_domain = var.service_domain == null ? "${var.environment}.account.gov.uk" : var.service_domain
 
-  dns_state_bucket = var.dns_state_bucket
-  dns_state_key    = var.dns_state_key
-  dns_state_role   = var.dns_state_role
-  environment      = var.environment
-
-  is_localstack = var.use_localstack
-  is_sandpit    = var.environment == "sandpit"
+  account_management_fqdn     = local.service_domain
+  account_management_api_fqdn = "manage.${local.service_domain}"
+  frontend_fqdn               = "signin.${local.service_domain}"
+  frontend_api_fqdn           = "auth.${local.service_domain}"
+  oidc_api_fqdn               = "oidc.${local.service_domain}"
 }

--- a/ci/terraform/account-management/sqs.tf
+++ b/ci/terraform/account-management/sqs.tf
@@ -179,7 +179,7 @@ resource "aws_lambda_function" "email_sqs_lambda" {
   }
   environment {
     variables = merge(var.notify_template_map, {
-      FRONTEND_BASE_URL            = module.dns.frontend_url
+      FRONTEND_BASE_URL            = "https://${local.frontend_fqdn}/"
       CONTACT_US_LINK_ROUTE        = var.contact_us_link_route
       NOTIFY_API_KEY               = var.notify_api_key
       NOTIFY_URL                   = var.notify_url

--- a/ci/terraform/account-management/variables.tf
+++ b/ci/terraform/account-management/variables.tf
@@ -35,6 +35,10 @@ variable "environment" {
   type = string
 }
 
+variable "service_domain" {
+  default = null
+}
+
 variable "aws_region" {
   default = "eu-west-2"
 }
@@ -58,18 +62,6 @@ variable "lambda_dynamo_endpoint" {
   type        = string
   default     = "http://dynamodb:8000"
   description = "The endpoint that the Lambda must use to connect to DynamoDB API. This may or may not be the same as aws_dynamodb_endpoint"
-}
-
-variable "dns_state_bucket" {
-  type = string
-}
-
-variable "dns_state_key" {
-  type = string
-}
-
-variable "dns_state_role" {
-  type = string
 }
 
 variable "enable_api_gateway_execution_logging" {

--- a/ci/terraform/oidc/api-gateway-frontend.tf
+++ b/ci/terraform/oidc/api-gateway-frontend.tf
@@ -28,7 +28,7 @@ resource "aws_api_gateway_usage_plan_key" "di_auth_frontend_usage_plan_key" {
 }
 
 locals {
-  frontend_api_base_url = var.use_localstack ? "${var.aws_endpoint}/restapis/${aws_api_gateway_rest_api.di_authentication_frontend_api.id}/${var.environment}/_user_request_" : module.dns.frontend_api_url
+  frontend_api_base_url = var.use_localstack ? "${var.aws_endpoint}/restapis/${aws_api_gateway_rest_api.di_authentication_frontend_api.id}/${var.environment}/_user_request_" : "https://${local.frontend_api_fqdn}/"
 }
 
 resource "aws_api_gateway_deployment" "frontend_deployment" {
@@ -211,7 +211,7 @@ resource "aws_api_gateway_base_path_mapping" "frontend_api" {
 
   api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
   stage_name  = aws_api_gateway_stage.endpoint_frontend_stage.stage_name
-  domain_name = module.dns.frontend_api_fqdn
+  domain_name = local.frontend_api_fqdn
 }
 
 module "dashboard_frontend_api" {

--- a/ci/terraform/oidc/api-gateway.tf
+++ b/ci/terraform/oidc/api-gateway.tf
@@ -111,7 +111,7 @@ data "aws_region" "current" {
 }
 
 locals {
-  api_base_url = var.use_localstack ? "${var.aws_endpoint}/restapis/${aws_api_gateway_rest_api.di_authentication_api.id}/${var.environment}/_user_request_" : module.dns.oidc_api_url
+  api_base_url = var.use_localstack ? "${var.aws_endpoint}/restapis/${aws_api_gateway_rest_api.di_authentication_api.id}/${var.environment}/_user_request_" : "https://${local.oidc_api_fqdn}/"
 }
 
 resource "aws_api_gateway_deployment" "deployment" {
@@ -292,7 +292,7 @@ resource "aws_api_gateway_base_path_mapping" "api" {
 
   api_id      = aws_api_gateway_rest_api.di_authentication_api.id
   stage_name  = aws_api_gateway_stage.endpoint_stage.stage_name
-  domain_name = module.dns.oidc_api_fqdn
+  domain_name = local.oidc_api_fqdn
 }
 
 module "dashboard" {

--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -24,14 +24,14 @@ module "authorize" {
   environment     = var.environment
 
   handler_environment_variables = {
-    DOMAIN_NAME              = module.dns.service_domain_name
+    DOMAIN_NAME              = local.service_domain
     DOC_APP_API_ENABLED      = var.doc_app_api_enabled
     DYNAMO_ENDPOINT          = var.use_localstack ? var.lambda_dynamo_endpoint : null
     TXMA_AUDIT_QUEUE_URL     = module.oidc_txma_audit.queue_url
     ENVIRONMENT              = var.environment
     HEADERS_CASE_INSENSITIVE = var.use_localstack ? "true" : "false"
     LOCALSTACK_ENDPOINT      = var.use_localstack ? var.localstack_endpoint : null
-    LOGIN_URI                = module.dns.frontend_url
+    LOGIN_URI                = "https://${local.frontend_fqdn}/"
     OIDC_API_BASE_URL        = local.api_base_url
     REDIS_KEY                = local.redis_key
     TERMS_CONDITIONS_VERSION = var.terms_and_conditions

--- a/ci/terraform/oidc/dns.tf
+++ b/ci/terraform/oidc/dns.tf
@@ -1,11 +1,9 @@
-module "dns" {
-  source = "../modules/dns"
+locals {
+  service_domain = var.service_domain == null ? "${var.environment}.account.gov.uk" : var.service_domain
 
-  dns_state_bucket = var.dns_state_bucket
-  dns_state_key    = var.dns_state_key
-  dns_state_role   = var.dns_state_role
-  environment      = var.environment
-
-  is_localstack = var.use_localstack
-  is_sandpit    = var.environment == "sandpit"
+  account_management_fqdn     = local.service_domain
+  account_management_api_fqdn = "manage.${local.service_domain}"
+  frontend_fqdn               = "signin.${local.service_domain}"
+  frontend_api_fqdn           = "auth.${local.service_domain}"
+  oidc_api_fqdn               = "oidc.${local.service_domain}"
 }

--- a/ci/terraform/oidc/doc-app-callback.tf
+++ b/ci/terraform/oidc/doc-app-callback.tf
@@ -36,7 +36,7 @@ module "doc-app-callback" {
     ENVIRONMENT                        = var.environment
     INTERNAl_SECTOR_URI                = var.internal_sector_uri
     LOCALSTACK_ENDPOINT                = var.use_localstack ? var.localstack_endpoint : null
-    LOGIN_URI                          = module.dns.frontend_url
+    LOGIN_URI                          = "https://${local.frontend_fqdn}/"
     REDIS_KEY                          = local.redis_key
     TXMA_AUDIT_QUEUE_URL               = module.oidc_txma_audit.queue_url
   }

--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -39,7 +39,7 @@ module "ipv-callback" {
     IPV_BACKEND_URI                 = var.ipv_backend_uri
     IPV_AUDIENCE                    = var.ipv_audience
     IPV_NO_SESSION_RESPONSE_ENABLED = var.ipv_no_session_response_enabled
-    LOGIN_URI                       = module.dns.frontend_url
+    LOGIN_URI                       = "https://${local.frontend_fqdn}/"
     LOCALSTACK_ENDPOINT             = var.use_localstack ? var.localstack_endpoint : null
     OIDC_API_BASE_URL               = local.api_base_url
     REDIS_KEY                       = local.redis_key

--- a/ci/terraform/oidc/logout.tf
+++ b/ci/terraform/oidc/logout.tf
@@ -24,7 +24,7 @@ module "logout" {
   environment     = var.environment
 
   handler_environment_variables = {
-    DEFAULT_LOGOUT_URI            = "${module.dns.frontend_url}signed-out"
+    DEFAULT_LOGOUT_URI            = "https://${local.frontend_fqdn}/signed-out"
     TXMA_AUDIT_QUEUE_URL          = module.oidc_txma_audit.queue_url
     LOCALSTACK_ENDPOINT           = var.use_localstack ? var.localstack_endpoint : null
     REDIS_KEY                     = local.redis_key

--- a/ci/terraform/oidc/outputs.tf
+++ b/ci/terraform/oidc/outputs.tf
@@ -32,7 +32,7 @@ output "email_queue" {
 }
 
 output "analytics_cookie_domain" {
-  value = module.dns.service_domain_name
+  value = local.service_domain
 }
 
 output "events_sns_topic_arn" {

--- a/ci/terraform/oidc/reset-password-request.tf
+++ b/ci/terraform/oidc/reset-password-request.tf
@@ -24,7 +24,7 @@ module "reset-password-request" {
 
   handler_environment_variables = {
     ENVIRONMENT            = var.environment
-    FRONTEND_BASE_URL      = module.dns.frontend_url
+    FRONTEND_BASE_URL      = "https://${local.frontend_fqdn}/"
     RESET_PASSWORD_ROUTE   = var.reset_password_route
     BLOCKED_EMAIL_DURATION = var.blocked_email_duration
     SQS_ENDPOINT           = var.use_localstack ? "http://localhost:45678/" : null

--- a/ci/terraform/oidc/spot-response.tf
+++ b/ci/terraform/oidc/spot-response.tf
@@ -94,7 +94,7 @@ resource "aws_lambda_function" "spot_response_lambda" {
       DYNAMO_ENDPOINT      = var.use_localstack ? var.lambda_dynamo_endpoint : null
       ENVIRONMENT          = var.environment
       TXMA_AUDIT_QUEUE_URL = module.oidc_txma_audit.queue_url
-      FRONTEND_BASE_URL    = module.dns.frontend_url
+      FRONTEND_BASE_URL    = "https://${local.frontend_fqdn}/"
       INTERNAl_SECTOR_URI  = var.internal_sector_uri
     })
   }

--- a/ci/terraform/oidc/sqs.tf
+++ b/ci/terraform/oidc/sqs.tf
@@ -168,8 +168,8 @@ resource "aws_lambda_function" "email_sqs_lambda" {
   }
   environment {
     variables = merge(var.notify_template_map, {
-      FRONTEND_BASE_URL            = module.dns.frontend_url
-      ACCOUNT_MANAGEMENT_URI       = module.dns.account_management_url
+      FRONTEND_BASE_URL            = "https://${local.frontend_fqdn}/"
+      ACCOUNT_MANAGEMENT_URI       = "https://${local.account_management_fqdn}/"
       RESET_PASSWORD_ROUTE         = var.reset_password_route
       CONTACT_US_LINK_ROUTE        = var.contact_us_link_route
       GOV_UK_ACCOUNTS_URL          = var.gov_uk_accounts_url

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -92,6 +92,10 @@ variable "environment" {
   type = string
 }
 
+variable "service_domain" {
+  default = null
+}
+
 variable "account_recovery_block_enabled" {
   default = false
 }
@@ -198,18 +202,6 @@ variable "email_acct_creation_otp_code_ttl_duration" {
 variable "contact_us_link_route" {
   type    = string
   default = "contact-us"
-}
-
-variable "dns_state_bucket" {
-  type = string
-}
-
-variable "dns_state_key" {
-  type = string
-}
-
-variable "dns_state_role" {
-  type = string
 }
 
 variable "gov_uk_accounts_url" {


### PR DESCRIPTION
## What?

Decouple usage of DNS, no longer using remote state

## Why?

This will make things much simpler going forward with migrating away from Concourse/Terraform.
