### PR TITLE
Fix production DNS name

### DIFF
--- a/ci/terraform/account-management/dns.tf
+++ b/ci/terraform/account-management/dns.tf
@@ -1,5 +1,5 @@
 locals {
-  service_domain = var.service_domain == null ? "${var.environment}.account.gov.uk" : var.service_domain
+  service_domain = var.environment == "production" ? "account.gov.uk" : "${var.environment}.account.gov.uk"
 
   account_management_fqdn     = local.service_domain
   account_management_api_fqdn = "manage.${local.service_domain}"

--- a/ci/terraform/oidc/dns.tf
+++ b/ci/terraform/oidc/dns.tf
@@ -1,5 +1,5 @@
 locals {
-  service_domain = var.service_domain == null ? "${var.environment}.account.gov.uk" : var.service_domain
+  service_domain = var.environment == "production" ? "account.gov.uk" : "${var.environment}.account.gov.uk"
 
   account_management_fqdn     = local.service_domain
   account_management_api_fqdn = "manage.${local.service_domain}"


### PR DESCRIPTION
## What?

DNS should be 'account.gov.uk', not 'production.account.gov.uk'

## Why?

The previous change tried to overwrite the domain mapping for api gateway and failed catastrophically.