### PR TITLE
Terraform will error instead of destroy zones

### DIFF
--- a/ci/terraform/account-management/dns.tf
+++ b/ci/terraform/account-management/dns.tf
@@ -15,6 +15,10 @@ data "aws_route53_zone" "service_domain" {
 
 resource "aws_route53_zone" "account_management_api_zone" {
   name = local.account_management_api_fqdn
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "aws_acm_certificate" "account_management_api" {

--- a/ci/terraform/oidc/dns.tf
+++ b/ci/terraform/oidc/dns.tf
@@ -15,6 +15,10 @@ data "aws_route53_zone" "service_domain" {
 
 resource "aws_route53_zone" "oidc_api_zone" {
   name = local.oidc_api_fqdn
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "aws_acm_certificate" "oidc_api" {


### PR DESCRIPTION
## What?

Terraform will error instead of destroy zones

## Why?

This will ensure hosted zones don't accidentally get deleted, as the name server values will be hardcoded in the root zone.
