### PR TITLE
BAU: Enable session ids in ID tokens for all non-production environments

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/TokenService.java
@@ -253,7 +253,7 @@ public class TokenService {
                         NowHelper.now());
         idTokenClaims.setAccessTokenHash(accessTokenHash);
 
-        if (!List.of("integration", "production").contains(configService.getEnvironment())) {
+        if (!Objects.equals("production", configService.getEnvironment())) {
             idTokenClaims.setSessionID(new SessionID(journeyId));
         }
 


### PR DESCRIPTION
## What?

This exposes the `sid` claim in ID tokens with the session ID for RP consumption