### PR TITLE
BAU: Add extension with country code to audit events with phone numbers

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/PhoneNumberHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/PhoneNumberHelper.java
@@ -5,6 +5,8 @@ import com.google.i18n.phonenumbers.PhoneNumberUtil;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Optional;
+
 public class PhoneNumberHelper {
 
     private static final Logger LOG = LogManager.getLogger(PhoneNumberHelper.class);
@@ -27,6 +29,14 @@ public class PhoneNumberHelper {
         } catch (NumberParseException e) {
             LOG.warn("Error when trying to parse phone number");
             throw new RuntimeException(e);
+        }
+    }
+
+    public static Optional<String> maybeGetCountry(String phoneNumber) {
+        try {
+            return Optional.of(getCountry(phoneNumber));
+        } catch (Exception e) {
+            return Optional.empty();
         }
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuditService.java
@@ -2,6 +2,7 @@ package uk.gov.di.authentication.shared.services;
 
 import uk.gov.di.audit.TxmaAuditUser;
 import uk.gov.di.authentication.shared.domain.AuditableEvent;
+import uk.gov.di.authentication.shared.helpers.PhoneNumberHelper;
 
 import java.time.Clock;
 import java.util.Arrays;
@@ -10,6 +11,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
 
+import static java.util.function.Predicate.not;
 import static uk.gov.di.audit.TxmaAuditEvent.auditEventWithTime;
 
 public class AuditService {
@@ -67,6 +69,13 @@ public class AuditService {
 
         Arrays.stream(metadataPairs)
                 .forEach(pair -> txmaAuditEvent.addExtension(pair.getKey(), pair.getValue()));
+
+        Optional.ofNullable(phoneNumber)
+                .filter(not(String::isBlank))
+                .flatMap(PhoneNumberHelper::maybeGetCountry)
+                .ifPresent(
+                        country ->
+                                txmaAuditEvent.addExtension("phone_number_country_code", country));
 
         txmaQueueClient.send(txmaAuditEvent.serialize());
     }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AuditServiceTest.java
@@ -109,4 +109,32 @@ class AuditServiceTest {
         assertThat(extensions, hasFieldWithValue("key", equalTo("value")));
         assertThat(extensions, hasFieldWithValue("key2", equalTo("value2")));
     }
+
+    @Test
+    void shouldAddCountryCodeExtensionToPhoneNumberEvents() {
+        var auditService = new AuditService(FIXED_CLOCK, configurationService, awsSqsClient);
+
+        auditService.submitAuditEvent(
+                TEST_EVENT_ONE,
+                "request-id",
+                "session-id",
+                "client-id",
+                "subject-id",
+                "email",
+                "ip-address",
+                "07700900000",
+                "persistent-session-id",
+                pair("key", "value"),
+                pair("key2", "value2"));
+
+        verify(awsSqsClient).send(txmaMessageCaptor.capture());
+
+        var extensions =
+                asJson(txmaMessageCaptor.getValue())
+                        .getAsJsonObject()
+                        .get("extensions")
+                        .getAsJsonObject();
+
+        assertThat(extensions, hasFieldWithValue("phone_number_country_code", equalTo("44")));
+    }
 }


### PR DESCRIPTION
This data is currently only available for sign-in journeys and we want to make it more available for analysis.
