### PR TITLE
BAU: Well-known handler needs to know `FRONTEND_BASE_URL`

### DIFF
--- a/ci/terraform/oidc/wellknown.tf
+++ b/ci/terraform/oidc/wellknown.tf
@@ -18,6 +18,7 @@ module "openid_configuration_discovery" {
     ENVIRONMENT         = var.environment
     OIDC_API_BASE_URL   = local.api_base_url
     LOCALSTACK_ENDPOINT = var.use_localstack ? var.localstack_endpoint : null
+    FRONTEND_BASE_URL   = "https://${local.frontend_fqdn}/"
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.WellknownHandler::handleRequest"
 


### PR DESCRIPTION
The handler was crashing because it needs this environment variable set.