### PR TITLE
AUT-1182: Facility to add auth app credentials to test users

### DIFF
--- a/ci/terraform/shared/sandpit.tfvars
+++ b/ci/terraform/shared/sandpit.tfvars
@@ -37,3 +37,13 @@ test_account_recovery_blocks = [
     time_to_exist = "1171734022"
   }
 ]
+
+test_users = [
+  {
+    username                     = "user.with.auth.app@digital.cabinet-office.gov.uk"
+    hashed_password              = "hashedpassword"
+    phone                        = "1234"
+    terms_and_conditions_version = "1.0"
+    auth_app_secret              = "authappsecret"
+  }
+]

--- a/ci/terraform/shared/variables.tf
+++ b/ci/terraform/shared/variables.tf
@@ -95,7 +95,7 @@ variable "stub_rp_clients" {
 
 variable "test_users" {
   default     = []
-  type        = list(object({ username : string, hashed_password : string, phone : string, terms_and_conditions_version : string }))
+  type        = list(object({ username : string, hashed_password : string, phone : string, terms_and_conditions_version : string, auth_app_secret : optional(string) }))
   description = "Test users to add in the database"
 }
 


### PR DESCRIPTION
## What?

Facility to add auth app credentials to test users.

If an optional auth app secret is provided for the user then create an auth app entry in MfaMethods with the secret, otherwise leave MfaMethods empty.

## Why?

So that we can create pre-existing test users who can login with an auth app.

## Related PRs

https://github.com/alphagov/di-infrastructure/pull/489
