### PR TITLE
AUT-1182: Remove optional Terraform variable.

### DIFF
--- a/ci/terraform/shared/test-user.tf
+++ b/ci/terraform/shared/test-user.tf
@@ -65,7 +65,7 @@ resource "aws_dynamodb_table_item" "user_credentials" {
         "S" = formatdate("YYYY-MM-DD'T'hh:mm:ss.000000", time_static.create_date[each.key].rfc3339)
       }
       },
-      each.value.auth_app_secret != null ?
+      each.value.auth_app_secret != "" ?
       {
         "MfaMethods" : {
           "L" : [

--- a/ci/terraform/shared/variables.tf
+++ b/ci/terraform/shared/variables.tf
@@ -95,7 +95,7 @@ variable "stub_rp_clients" {
 
 variable "test_users" {
   default     = []
-  type        = list(object({ username : string, hashed_password : string, phone : string, terms_and_conditions_version : string, auth_app_secret : optional(string) }))
+  type        = list(object({ username : string, hashed_password : string, phone : string, terms_and_conditions_version : string, auth_app_secret : string }))
   description = "Test users to add in the database"
 }
 


### PR DESCRIPTION

## What?

Remove optional Terraform variable when creating test users with auth app credentials.

## Why?

Optional is experimental in Terraform.  Checking for empty string instead.

## Related PRs

#2914 
