### PR TITLE
AUT-1138: Make stub client ServiceType configurable

### DIFF
--- a/ci/terraform/shared/build-stub-clients.tfvars
+++ b/ci/terraform/shared/build-stub-clients.tfvars
@@ -17,6 +17,7 @@ stub_rp_clients = [
       "phone",
     ]
     one_login_service = false
+    service_type      = "MANDATORY"
   },
   {
     client_name = "di-auth-stub-relying-party-build-s2"
@@ -36,6 +37,7 @@ stub_rp_clients = [
       "phone",
     ]
     one_login_service = false
+    service_type      = "MANDATORY"
   },
   {
     client_name = "di-auth-stub-relying-party-build-app"
@@ -54,5 +56,26 @@ stub_rp_clients = [
       "doc-checking-app",
     ]
     one_login_service = false
+    service_type      = "MANDATORY"
+  },
+  {
+    client_name = "di-auth-stub-relying-party-build-optional"
+    callback_urls = [
+      "https://di-auth-stub-relying-party-build-optional.london.cloudapps.digital/oidc/authorization-code/callback",
+    ]
+    logout_urls = [
+      "https://di-auth-stub-relying-party-build-optional.london.cloudapps.digital/signed-out",
+    ]
+    test_client                     = "1"
+    consent_required                = "0"
+    identity_verification_supported = "1"
+    client_type                     = "web"
+    scopes = [
+      "openid",
+      "email",
+      "phone",
+    ]
+    one_login_service = false
+    service_type      = "OPTIONAL"
   },
 ]

--- a/ci/terraform/shared/integration-stub-clients.tfvars
+++ b/ci/terraform/shared/integration-stub-clients.tfvars
@@ -17,6 +17,7 @@ stub_rp_clients = [
       "phone",
     ]
     one_login_service = false
+    service_type      = "MANDATORY"
   },
   {
     client_name = "di-auth-stub-relying-party-integration-app"
@@ -35,5 +36,6 @@ stub_rp_clients = [
       "doc-checking-app",
     ]
     one_login_service = false
+    service_type      = "MANDATORY"
   },
 ]

--- a/ci/terraform/shared/production-stub-clients.tfvars
+++ b/ci/terraform/shared/production-stub-clients.tfvars
@@ -17,6 +17,7 @@ stub_rp_clients = [
       "phone",
     ]
     one_login_service = false
+    service_type      = "MANDATORY"
   },
   {
     client_name = "di-auth-stub-relying-party-production-app"
@@ -35,5 +36,6 @@ stub_rp_clients = [
       "doc-checking-app",
     ]
     one_login_service = false
+    service_type      = "MANDATORY"
   },
 ]

--- a/ci/terraform/shared/sandpit.tfvars
+++ b/ci/terraform/shared/sandpit.tfvars
@@ -25,6 +25,7 @@ stub_rp_clients = [
       "phone",
     ]
     one_login_service = false
+    service_type      = "MANDATORY"
   },
 ]
 

--- a/ci/terraform/shared/staging-stub-clients.tfvars
+++ b/ci/terraform/shared/staging-stub-clients.tfvars
@@ -17,6 +17,7 @@ stub_rp_clients = [
       "phone",
     ]
     one_login_service = false
+    service_type      = "MANDATORY"
   },
   {
     client_name = "di-auth-stub-relying-party-staging-app"
@@ -35,6 +36,7 @@ stub_rp_clients = [
       "doc-checking-app",
     ]
     one_login_service = false
+    service_type      = "MANDATORY"
   },
   {
     client_name = "di-auth-stub-relying-party-staging-t1"
@@ -54,5 +56,6 @@ stub_rp_clients = [
       "phone",
     ]
     one_login_service = false
+    service_type      = "MANDATORY"
   },
 ]

--- a/ci/terraform/shared/stub-rp-clients.tf
+++ b/ci/terraform/shared/stub-rp-clients.tf
@@ -72,7 +72,7 @@ resource "aws_dynamodb_table_item" "stub_rp_client" {
       "-----END PUBLIC KEY-----", ""), "\n", "")
     }
     ServiceType = {
-      S = "MANDATORY"
+      S = var.stub_rp_clients[count.index].service_type
     }
     SubjectType = {
       S = "pairwise"

--- a/ci/terraform/shared/variables.tf
+++ b/ci/terraform/shared/variables.tf
@@ -89,7 +89,7 @@ variable "logging_endpoint_arns" {
 
 variable "stub_rp_clients" {
   default     = []
-  type        = list(object({ client_name : string, callback_urls : list(string), logout_urls : list(string), test_client : string, scopes : list(string), client_type : string, identity_verification_supported : string, consent_required : string, one_login_service : bool }))
+  type        = list(object({ client_name : string, callback_urls : list(string), logout_urls : list(string), test_client : string, scopes : list(string), client_type : string, identity_verification_supported : string, consent_required : string, one_login_service : bool, service_type : string }))
   description = "The details of RP clients to provision in the Client table"
 }
 


### PR DESCRIPTION

## What?

Make stub client ServiceType configurable.

Add an OPTIONAL stub client in build.

## Why?

Enable testing of the save and resume scenario which requires an OPTIONAL type client.

