### PR TITLE
AUT-1209: Record new incorrect MFA input counter

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -217,7 +217,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
         if (errorResponse
                 .map(t -> List.of(ErrorResponse.ERROR_1034, ErrorResponse.ERROR_1042).contains(t))
                 .orElse(false)) {
-            blockCodeForSessionAndResetCountIfBlockDoesNotExist(session);
+            blockCodeForSessionAndResetCountIfBlockDoesNotExist(session, mfaMethodType);
         }
 
         auditService.submitAuditEvent(
@@ -236,7 +236,8 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                 pair("mfa-type", mfaMethodType.getValue()));
     }
 
-    private void blockCodeForSessionAndResetCountIfBlockDoesNotExist(Session session) {
+    private void blockCodeForSessionAndResetCountIfBlockDoesNotExist(
+            Session session, MFAMethodType mfaMethodType) {
         if (!codeStorageService.isBlockedForEmail(
                 session.getEmailAddress(), CODE_BLOCKED_KEY_PREFIX)) {
             codeStorageService.saveBlockedForEmail(
@@ -244,6 +245,8 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                     CODE_BLOCKED_KEY_PREFIX,
                     configurationService.getBlockedEmailDuration());
             codeStorageService.deleteIncorrectMfaCodeAttemptsCount(session.getEmailAddress());
+            codeStorageService.deleteIncorrectMfaCodeAttemptsCount(
+                    session.getEmailAddress(), mfaMethodType);
         }
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/validation/AuthAppCodeValidator.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/validation/AuthAppCodeValidator.java
@@ -45,7 +45,7 @@ public class AuthAppCodeValidator extends MfaCodeValidator {
             return Optional.of(ErrorResponse.ERROR_1042);
         }
 
-        incrementRetryCount();
+        incrementRetryCount(MFAMethodType.AUTH_APP);
 
         if (hasExceededRetryLimit()) {
             LOG.info("Exceeded code retry limit");
@@ -64,7 +64,7 @@ public class AuthAppCodeValidator extends MfaCodeValidator {
             return Optional.of(ErrorResponse.ERROR_1043);
         }
         LOG.info("Auth code valid. Resetting code request count");
-        resetCodeRequestCount();
+        resetCodeIncorrectEntryCount(MFAMethodType.AUTH_APP);
 
         return Optional.empty();
     }
@@ -86,10 +86,7 @@ public class AuthAppCodeValidator extends MfaCodeValidator {
                         .filter(MFAMethod::isEnabled)
                         .findAny();
 
-        if (mfaMethod.isPresent()) {
-            return Optional.ofNullable(mfaMethod.get().getCredentialValue());
-        }
-        return Optional.empty();
+        return mfaMethod.map(MFAMethod::getCredentialValue);
     }
 
     public boolean isCodeValid(String code, String secret) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/validation/MfaCodeValidator.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/validation/MfaCodeValidator.java
@@ -3,6 +3,7 @@ package uk.gov.di.authentication.shared.validation;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 
 import java.util.Optional;
@@ -30,12 +31,18 @@ public abstract class MfaCodeValidator {
         return codeStorageService.getIncorrectMfaCodeAttemptsCount(emailAddress) > maxRetries;
     }
 
-    void incrementRetryCount() {
-        codeStorageService.increaseIncorrectMfaCodeAttemptsCount(emailAddress);
+    void incrementRetryCount(MFAMethodType mfaMethodType) {
+        codeStorageService.increaseIncorrectMfaCodeAttemptsCount(
+                emailAddress); // TODO: remove this transitional method call when cache reflects
+        // only following line
+        codeStorageService.increaseIncorrectMfaCodeAttemptsCount(emailAddress, mfaMethodType);
     }
 
-    void resetCodeRequestCount() {
-        codeStorageService.deleteIncorrectMfaCodeAttemptsCount(emailAddress);
+    void resetCodeIncorrectEntryCount(MFAMethodType mfaMethodType) {
+        codeStorageService.deleteIncorrectMfaCodeAttemptsCount(
+                emailAddress); // TODO: remove this transitional method call when cache reflects
+        // only following line
+        codeStorageService.deleteIncorrectMfaCodeAttemptsCount(emailAddress, mfaMethodType);
     }
 
     public abstract Optional<ErrorResponse> validateCode(String code);


### PR DESCRIPTION
NOTE: This PR alone is not intended to change any business logic. It is just to 'fill' the cache with new prefix values so that a subsequent PR can change the business logic without any loss of continuity in production

## What?
- Add an MFA type-specific counter for incorrect MFA code inputs

## Why?
- Currently we 'count' incorrect MFA code inputs in the cache, stored against email address
- However, there is only one counter for all MFA types
- We want to separate counters by MFA type so that e.g. incorrect auth app inputs will not reduce the number of attempts allowed for SMS OTP
- To do this we will introduce a new prefix approach which adds in the MFA Type in the prefix
- To ensure continuirty in prod, we will deploy this change first which duplicates the incorrect MFA counter, without changing any business behaviour
- A subsequent commit can then switch the business behaviour to check incorrect MFA counter against the new prefix - it is that commit that will change business behaviour

