### PR TITLE
BAU: Assign T&C version from variable when creating seed test user

### DIFF
--- a/ci/terraform/shared/test-user.tf
+++ b/ci/terraform/shared/test-user.tf
@@ -122,7 +122,7 @@ resource "aws_dynamodb_table_item" "user_profile" {
     "termsAndConditions" = {
       "M" = {
         "version" = {
-          "S" = "1.0"
+          "S" = each.value.terms_and_conditions_version
         },
         "timestamp" = {
           "S" = formatdate("YYYY-MM-DD'T'hh:mm:ss.000000", time_static.create_date[each.key].rfc3339)


### PR DESCRIPTION
## What?

Assign T&C version from variable when creating seed test user.

## Why?

Config that sets the version in the pipeline was being ignored.

## Related PRs

https://github.com/alphagov/di-authentication-api/pull/2917
