### PR TITLE
AUT-1210: Make MFA code block specific per MFA type

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -244,6 +244,11 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
 
         codeStorageService.saveBlockedForEmail(
                 emailAddress,
+                CODE_BLOCKED_KEY_PREFIX + mfaMethodType.getValue(),
+                configurationService.getBlockedEmailDuration());
+
+        codeStorageService.saveBlockedForEmail(
+                emailAddress,
                 CODE_BLOCKED_KEY_PREFIX,
                 configurationService.getBlockedEmailDuration());
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -238,15 +238,21 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
 
     private void blockCodeForSessionAndResetCountIfBlockDoesNotExist(
             Session session, MFAMethodType mfaMethodType) {
-        if (!codeStorageService.isBlockedForEmail(
-                session.getEmailAddress(), CODE_BLOCKED_KEY_PREFIX)) {
-            codeStorageService.saveBlockedForEmail(
-                    session.getEmailAddress(),
-                    CODE_BLOCKED_KEY_PREFIX,
-                    configurationService.getBlockedEmailDuration());
-            codeStorageService.deleteIncorrectMfaCodeAttemptsCount(session.getEmailAddress());
-            codeStorageService.deleteIncorrectMfaCodeAttemptsCount(
-                    session.getEmailAddress(), mfaMethodType);
+        String emailAddress = session.getEmailAddress();
+
+        if (codeStorageService.isBlockedForEmail(emailAddress, CODE_BLOCKED_KEY_PREFIX)) {
+            return;
+        }
+
+        codeStorageService.saveBlockedForEmail(
+                emailAddress,
+                CODE_BLOCKED_KEY_PREFIX,
+                configurationService.getBlockedEmailDuration());
+
+        if (mfaMethodType == MFAMethodType.SMS) {
+            codeStorageService.deleteIncorrectMfaCodeAttemptsCount(emailAddress);
+        } else {
+            codeStorageService.deleteIncorrectMfaCodeAttemptsCount(emailAddress, mfaMethodType);
         }
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -323,7 +323,8 @@ class VerifyMfaCodeHandlerTest {
         verify(authenticationService, never())
                 .setMFAMethodVerifiedTrue(TEST_EMAIL_ADDRESS, MFAMethodType.AUTH_APP);
         verify(authenticationService, never()).setAccountVerified(TEST_EMAIL_ADDRESS);
-        verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(TEST_EMAIL_ADDRESS);
+        verify(codeStorageService)
+                .deleteIncorrectMfaCodeAttemptsCount(TEST_EMAIL_ADDRESS, MFAMethodType.AUTH_APP);
         verifyNoInteractions(accountRecoveryBlockService);
         verify(auditService)
                 .submitAuditEvent(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
@@ -289,7 +289,7 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @Test
     void
-            whenAuthCodeRetriesLimitReachedButEmailAddressNotBlockedAllowSmsAttemptAndReturn400WithoutBlockingFurtherRetries()
+            whenIncorrectAuthCodesInputtedUpToSmsRetriesLimitAllowSmsAttemptAndReturn400WithoutBlockingFurtherRetries()
                     throws Json.JsonException {
         for (int i = 0; i < 5; i++) {
             redis.increaseMfaCodeAttemptsCount(EMAIL_ADDRESS, MFAMethodType.AUTH_APP);

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
@@ -211,8 +211,20 @@ public class RedisExtension
         codeStorageService.saveBlockedForEmail(email, CODE_BLOCKED_KEY_PREFIX, 10);
     }
 
+    public boolean isBlockedMfaCodesForEmail(String email) {
+        return codeStorageService.isBlockedForEmail(email, CODE_BLOCKED_KEY_PREFIX);
+    }
+
     public int getMfaCodeAttemptsCount(String email) {
         return codeStorageService.getIncorrectMfaCodeAttemptsCount(email);
+    }
+
+    public int getMfaCodeAttemptsCount(String email, MFAMethodType mfaMethodType) {
+        return codeStorageService.getIncorrectMfaCodeAttemptsCount(email, mfaMethodType);
+    }
+
+    public void increaseMfaCodeAttemptsCount(String email, MFAMethodType mfaMethodType) {
+        codeStorageService.increaseIncorrectMfaCodeAttemptsCount(email, mfaMethodType);
     }
 
     public void addToRedis(String key, String value, Long expiry) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java
@@ -50,8 +50,17 @@ public class CodeStorageService {
                                         + HashHelper.hashSha256String(email)));
         return count.map(Integer::parseInt).orElse(0);
     }
-    // TODO: remove this transitional method when cache reflects MFA-type-specific prefixing i.e.
-    // method call with MFAMethodType argument
+
+    public int getIncorrectMfaCodeAttemptsCount(String email, MFAMethodType mfaMethodType) {
+        Optional<String> count =
+                Optional.ofNullable(
+                        redisConnectionService.getValue(
+                                MULTIPLE_INCORRECT_MFA_CODES_KEY_PREFIX
+                                        + mfaMethodType.getValue()
+                                        + HashHelper.hashSha256String(email)));
+        return count.map(Integer::parseInt).orElse(0);
+    }
+
     public void increaseIncorrectMfaCodeAttemptsCount(String email) {
         String encodedHash = HashHelper.hashSha256String(email);
         String key = MULTIPLE_INCORRECT_MFA_CODES_KEY_PREFIX + encodedHash;
@@ -81,8 +90,7 @@ public class CodeStorageService {
             throw new RuntimeException(e);
         }
     }
-    // TODO: remove this transitional method when cache reflects MFA-type-specific prefixing i.e.
-    // method call with MFAMethodType argument
+
     public void deleteIncorrectMfaCodeAttemptsCount(String email) {
         String encodedHash = HashHelper.hashSha256String(email);
         String key = MULTIPLE_INCORRECT_MFA_CODES_KEY_PREFIX + encodedHash;

--- a/shared/src/main/java/uk/gov/di/authentication/shared/validation/AuthAppCodeValidator.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/validation/AuthAppCodeValidator.java
@@ -47,7 +47,7 @@ public class AuthAppCodeValidator extends MfaCodeValidator {
 
         incrementRetryCount(MFAMethodType.AUTH_APP);
 
-        if (hasExceededRetryLimit()) {
+        if (hasExceededRetryLimit(MFAMethodType.AUTH_APP)) {
             LOG.info("Exceeded code retry limit");
             return Optional.of(ErrorResponse.ERROR_1042);
         }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/validation/MfaCodeValidator.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/validation/MfaCodeValidator.java
@@ -26,22 +26,17 @@ public abstract class MfaCodeValidator {
         return codeStorageService.isBlockedForEmail(emailAddress, CODE_BLOCKED_KEY_PREFIX);
     }
 
-    boolean hasExceededRetryLimit() {
+    boolean hasExceededRetryLimit(MFAMethodType mfaMethodType) {
         LOG.info("Max retries: {}", maxRetries);
-        return codeStorageService.getIncorrectMfaCodeAttemptsCount(emailAddress) > maxRetries;
+        return codeStorageService.getIncorrectMfaCodeAttemptsCount(emailAddress, mfaMethodType)
+                > maxRetries;
     }
 
     void incrementRetryCount(MFAMethodType mfaMethodType) {
-        codeStorageService.increaseIncorrectMfaCodeAttemptsCount(
-                emailAddress); // TODO: remove this transitional method call when cache reflects
-        // only following line
         codeStorageService.increaseIncorrectMfaCodeAttemptsCount(emailAddress, mfaMethodType);
     }
 
     void resetCodeIncorrectEntryCount(MFAMethodType mfaMethodType) {
-        codeStorageService.deleteIncorrectMfaCodeAttemptsCount(
-                emailAddress); // TODO: remove this transitional method call when cache reflects
-        // only following line
         codeStorageService.deleteIncorrectMfaCodeAttemptsCount(emailAddress, mfaMethodType);
     }
 

--- a/shared/src/test/java/uk/gov/di/authentication/shared/validation/AuthAppCodeValidatorTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/validation/AuthAppCodeValidatorTest.java
@@ -106,7 +106,8 @@ class AuthAppCodeValidatorTest {
     private void setUpRetryLimitExceededUser() {
         when(mockCodeStorageService.isBlockedForEmail("email-address", CODE_BLOCKED_KEY_PREFIX))
                 .thenReturn(false);
-        when(mockCodeStorageService.getIncorrectMfaCodeAttemptsCount("email-address"))
+        when(mockCodeStorageService.getIncorrectMfaCodeAttemptsCount(
+                        "email-address", MFAMethodType.AUTH_APP))
                 .thenReturn(MAX_RETRIES + 1);
 
         this.authAppCodeValidator =


### PR DESCRIPTION
## What?
- Currently there is one prefix used when cacheing the block against an email address
- This is shared between SMS and auth app
- We will change this to a compound prefix which references the MFA type

## Why?
- This will mean a block will apply only to a single type
- e.g. if SMS is blocked, auth app will not be blocked
