### PR TITLE
AUT-1207 - Update the MFA Method for registration requests in the VerifyMfaCodeHandler

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/domain/FrontendAuditableEvent.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/domain/FrontendAuditableEvent.java
@@ -40,7 +40,6 @@ public enum FrontendAuditableEvent implements AuditableEvent {
     ACCOUNT_RECOVERY_EMAIL_CODE_SENT,
     ACCOUNT_RECOVERY_EMAIL_INVALID_CODE_REQUEST,
     ACCOUNT_RECOVERY_EMAIL_CODE_SENT_FOR_TEST_CLIENT;
-    ;
 
     public AuditableEvent parseFromName(String name) {
         return valueOf(name);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/VerifyMfaCodeRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/VerifyMfaCodeRequest.java
@@ -10,9 +10,18 @@ public class VerifyMfaCodeRequest {
     public VerifyMfaCodeRequest() {}
 
     public VerifyMfaCodeRequest(MFAMethodType mfaMethodType, String code, boolean isRegistration) {
+        this(mfaMethodType, code, isRegistration, null);
+    }
+
+    public VerifyMfaCodeRequest(
+            MFAMethodType mfaMethodType,
+            String code,
+            boolean isRegistration,
+            String profileInformation) {
         this.mfaMethodType = mfaMethodType;
         this.code = code;
         this.isRegistration = isRegistration;
+        this.profileInformation = profileInformation;
     }
 
     @SerializedName("mfaMethodType")

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -125,6 +125,10 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                     mfaCodeValidator.validateCode(
                             codeRequest.getCode(), codeRequest.getProfileInformation());
 
+            if (errorResponse.filter(ErrorResponse.ERROR_1041::equals).isPresent()) {
+                return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1041);
+            }
+
             processCodeSession(errorResponse, session, input, userContext, codeRequest);
 
             sessionService.save(session);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -6,8 +6,8 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.entity.VerifyMfaCodeRequest;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
-import uk.gov.di.authentication.frontendapi.entity.VerifyMfaCodeRequest;
 import uk.gov.di.authentication.frontendapi.services.DynamoAccountRecoveryBlockService;
 import uk.gov.di.authentication.shared.domain.AuditableEvent;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
@@ -122,9 +122,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                 return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1002);
             }
 
-            var errorResponse =
-                    mfaCodeValidator.validateCode(
-                            codeRequest.getCode(), codeRequest.getProfileInformation());
+            var errorResponse = mfaCodeValidator.validateCode(codeRequest);
 
             if (errorResponse.filter(ErrorResponse.ERROR_1041::equals).isPresent()) {
                 return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1041);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -17,8 +17,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import uk.gov.di.authentication.entity.CodeRequest;
+import uk.gov.di.authentication.entity.VerifyMfaCodeRequest;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
-import uk.gov.di.authentication.frontendapi.entity.VerifyMfaCodeRequest;
 import uk.gov.di.authentication.frontendapi.services.DynamoAccountRecoveryBlockService;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
@@ -170,7 +171,8 @@ class VerifyMfaCodeHandlerTest {
             CredentialTrustLevel credentialTrustLevel) throws Json.JsonException {
         when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), anyBoolean(), any()))
                 .thenReturn(Optional.of(authAppCodeValidator));
-        when(authAppCodeValidator.validateCode(CODE, AUTH_APP_SECRET)).thenReturn(Optional.empty());
+        when(authAppCodeValidator.validateCode(any(CodeRequest.class)))
+                .thenReturn(Optional.empty());
         session.setNewAccount(Session.AccountState.NEW);
         session.setCurrentCredentialStrength(credentialTrustLevel);
         var result =
@@ -226,7 +228,7 @@ class VerifyMfaCodeHandlerTest {
             CredentialTrustLevel credentialTrustLevel) throws Json.JsonException {
         when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), anyBoolean(), any()))
                 .thenReturn(Optional.of(phoneNumberCodeValidator));
-        when(phoneNumberCodeValidator.validateCode(CODE, PHONE_NUMBER))
+        when(phoneNumberCodeValidator.validateCode(any(CodeRequest.class)))
                 .thenReturn(Optional.empty());
         session.setNewAccount(Session.AccountState.NEW);
         session.setCurrentCredentialStrength(credentialTrustLevel);
@@ -281,7 +283,8 @@ class VerifyMfaCodeHandlerTest {
     void shouldReturn204WhenSuccessfulAuthAppCodeLoginRequest() throws Json.JsonException {
         when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), anyBoolean(), any()))
                 .thenReturn(Optional.of(authAppCodeValidator));
-        when(authAppCodeValidator.validateCode(CODE, null)).thenReturn(Optional.empty());
+        when(authAppCodeValidator.validateCode(any(CodeRequest.class)))
+                .thenReturn(Optional.empty());
         session.setNewAccount(Session.AccountState.EXISTING);
         var codeRequest = new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, CODE, false);
         var result = makeCallWithCode(codeRequest);
@@ -337,7 +340,7 @@ class VerifyMfaCodeHandlerTest {
             throws Json.JsonException {
         when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), anyBoolean(), any()))
                 .thenReturn(Optional.of(authAppCodeValidator));
-        when(authAppCodeValidator.validateCode(CODE, null))
+        when(authAppCodeValidator.validateCode(any(CodeRequest.class)))
                 .thenReturn(Optional.of(ErrorResponse.ERROR_1042));
         var codeRequest = new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, CODE, false);
         var result = makeCallWithCode(codeRequest);
@@ -370,7 +373,7 @@ class VerifyMfaCodeHandlerTest {
             throws Json.JsonException {
         when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), anyBoolean(), any()))
                 .thenReturn(Optional.of(authAppCodeValidator));
-        when(authAppCodeValidator.validateCode(CODE, null))
+        when(authAppCodeValidator.validateCode(any(CodeRequest.class)))
                 .thenReturn(Optional.of(ErrorResponse.ERROR_1042));
         when(codeStorageService.isBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX))
                 .thenReturn(true);
@@ -406,7 +409,7 @@ class VerifyMfaCodeHandlerTest {
         when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), anyBoolean(), any()))
                 .thenReturn(Optional.of(authAppCodeValidator));
         var profileInformation = registration ? AUTH_APP_SECRET : null;
-        when(authAppCodeValidator.validateCode(CODE, profileInformation))
+        when(authAppCodeValidator.validateCode(any(CodeRequest.class)))
                 .thenReturn(Optional.of(ErrorResponse.ERROR_1043));
         var codeRequest =
                 new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, CODE, false, profileInformation);
@@ -440,7 +443,7 @@ class VerifyMfaCodeHandlerTest {
                     throws Json.JsonException {
         when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), anyBoolean(), any()))
                 .thenReturn(Optional.of(phoneNumberCodeValidator));
-        when(phoneNumberCodeValidator.validateCode(CODE, PHONE_NUMBER))
+        when(phoneNumberCodeValidator.validateCode(any(CodeRequest.class)))
                 .thenReturn(Optional.of(ErrorResponse.ERROR_1034));
         var codeRequest = new VerifyMfaCodeRequest(MFAMethodType.SMS, CODE, true, PHONE_NUMBER);
         var result = makeCallWithCode(codeRequest);
@@ -476,7 +479,7 @@ class VerifyMfaCodeHandlerTest {
                     throws Json.JsonException {
         when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), anyBoolean(), any()))
                 .thenReturn(Optional.of(phoneNumberCodeValidator));
-        when(phoneNumberCodeValidator.validateCode(CODE, PHONE_NUMBER))
+        when(phoneNumberCodeValidator.validateCode(any(CodeRequest.class)))
                 .thenReturn(Optional.of(ErrorResponse.ERROR_1034));
         when(codeStorageService.isBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX))
                 .thenReturn(true);
@@ -513,7 +516,7 @@ class VerifyMfaCodeHandlerTest {
             throws Json.JsonException {
         when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), anyBoolean(), any()))
                 .thenReturn(Optional.of(phoneNumberCodeValidator));
-        when(phoneNumberCodeValidator.validateCode(CODE, PHONE_NUMBER))
+        when(phoneNumberCodeValidator.validateCode(any(CodeRequest.class)))
                 .thenReturn(Optional.of(ErrorResponse.ERROR_1037));
         var codeRequest = new VerifyMfaCodeRequest(MFAMethodType.SMS, CODE, true, PHONE_NUMBER);
         var result = makeCallWithCode(codeRequest);
@@ -547,7 +550,7 @@ class VerifyMfaCodeHandlerTest {
     void shouldReturn400WhenAuthAppSecretIsInvalid() throws Json.JsonException {
         when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), anyBoolean(), any()))
                 .thenReturn(Optional.of(authAppCodeValidator));
-        when(authAppCodeValidator.validateCode(CODE, "not-base-32-encoded-secret"))
+        when(authAppCodeValidator.validateCode(any(CodeRequest.class)))
                 .thenReturn(Optional.of(ErrorResponse.ERROR_1041));
         session.setNewAccount(Session.AccountState.NEW);
         session.setCurrentCredentialStrength(CredentialTrustLevel.MEDIUM_LEVEL);
@@ -570,7 +573,7 @@ class VerifyMfaCodeHandlerTest {
         verifyNoInteractions(cloudwatchMetricsService);
     }
 
-    private APIGatewayProxyResponseEvent makeCallWithCode(VerifyMfaCodeRequest mfaCodeRequest)
+    private APIGatewayProxyResponseEvent makeCallWithCode(CodeRequest mfaCodeRequest)
             throws Json.JsonException {
         var event = new APIGatewayProxyRequestEvent();
         event.setRequestContext(contextWithSourceIp("123.123.123.123"));

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -203,6 +203,18 @@ class VerifyMfaCodeHandlerTest {
                         AuditService.UNKNOWN,
                         PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
                         pair("mfa-type", MFAMethodType.AUTH_APP.getValue()));
+        verify(auditService)
+                .submitAuditEvent(
+                        FrontendAuditableEvent.UPDATE_PROFILE_AUTH_APP,
+                        CLIENT_SESSION_ID,
+                        session.getSessionId(),
+                        CLIENT_ID,
+                        expectedCommonSubject,
+                        TEST_EMAIL_ADDRESS,
+                        "123.123.123.123",
+                        AuditService.UNKNOWN,
+                        PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
+                        pair("mfa-type", MFAMethodType.AUTH_APP.getValue()));
         verify(cloudwatchMetricsService)
                 .incrementAuthenticationSuccess(
                         Session.AccountState.NEW, CLIENT_ID, CLIENT_NAME, "P0", false, true);
@@ -246,6 +258,18 @@ class VerifyMfaCodeHandlerTest {
                         TEST_EMAIL_ADDRESS,
                         "123.123.123.123",
                         AuditService.UNKNOWN,
+                        PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
+                        pair("mfa-type", MFAMethodType.SMS.getValue()));
+        verify(auditService)
+                .submitAuditEvent(
+                        FrontendAuditableEvent.UPDATE_PROFILE_PHONE_NUMBER,
+                        CLIENT_SESSION_ID,
+                        session.getSessionId(),
+                        CLIENT_ID,
+                        expectedCommonSubject,
+                        TEST_EMAIL_ADDRESS,
+                        "123.123.123.123",
+                        PHONE_NUMBER,
                         PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
                         pair("mfa-type", MFAMethodType.SMS.getValue()));
         verify(cloudwatchMetricsService)

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -79,6 +79,9 @@ class VerifyMfaCodeHandlerTest {
     private static final String TEST_CLIENT_CODE = "654321";
     private static final String CLIENT_SESSION_ID = "client-session-id";
     private static final String SUBJECT_ID = "test-subject-id";
+    private static final String PHONE_NUMBER = "+447700900000";
+    private static final String AUTH_APP_SECRET =
+            "JZ5PYIOWNZDAOBA65S5T77FEEKYCCIT2VE4RQDAJD7SO73T3LODA";
     private final String expectedCommonSubject =
             ClientSubjectHelper.calculatePairwiseIdentifier(
                     new Subject().getValue(), "test.account.gov.uk", SaltHelper.generateNewSalt());
@@ -164,24 +167,27 @@ class VerifyMfaCodeHandlerTest {
 
     @ParameterizedTest
     @MethodSource("credentialTrustLevels")
-    void shouldReturn204WhenSuccessfulAuthCodeRegistrationRequest(
+    void shouldReturn204WhenSuccessfulAuthAppCodeRegistrationRequestAndSetMfaMethod(
             CredentialTrustLevel credentialTrustLevel) throws Json.JsonException {
         when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), anyBoolean(), any()))
                 .thenReturn(Optional.of(authAppCodeValidator));
-        when(authAppCodeValidator.validateCode(CODE)).thenReturn(Optional.empty());
+        when(authAppCodeValidator.validateCode(CODE, AUTH_APP_SECRET)).thenReturn(Optional.empty());
         when(codeStorageService.getOtpCode(TEST_EMAIL_ADDRESS, VERIFY_EMAIL))
                 .thenReturn(Optional.of(CODE));
         session.setNewAccount(Session.AccountState.NEW);
         session.setCurrentCredentialStrength(credentialTrustLevel);
-        var result = makeCallWithCode(MFAMethodType.AUTH_APP, true);
+        var result =
+                makeCallWithCode(
+                        new VerifyMfaCodeRequest(
+                                MFAMethodType.AUTH_APP, CODE, true, AUTH_APP_SECRET));
 
         assertThat(result, hasStatus(204));
         assertThat(session.getVerifiedMfaMethodType(), equalTo(MFAMethodType.AUTH_APP));
         assertThat(
                 session.getCurrentCredentialStrength(), equalTo(CredentialTrustLevel.MEDIUM_LEVEL));
         verify(authenticationService)
-                .setMFAMethodVerifiedTrue(TEST_EMAIL_ADDRESS, MFAMethodType.AUTH_APP);
-        verify(authenticationService).setAccountVerified(TEST_EMAIL_ADDRESS);
+                .updateMFAMethod(
+                        TEST_EMAIL_ADDRESS, MFAMethodType.AUTH_APP, true, true, AUTH_APP_SECRET);
         verify(codeStorageService, never())
                 .saveBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX, 900L);
         verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(TEST_EMAIL_ADDRESS);
@@ -206,21 +212,25 @@ class VerifyMfaCodeHandlerTest {
 
     @ParameterizedTest
     @MethodSource("credentialTrustLevels")
-    void shouldReturn204WhenSuccessfulPhoneCodeRegistrationRequest(
+    void shouldReturn204WhenSuccessfulPhoneCodeRegistrationRequestAndSetPhoneNumber(
             CredentialTrustLevel credentialTrustLevel) throws Json.JsonException {
         when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), anyBoolean(), any()))
                 .thenReturn(Optional.of(phoneNumberCodeValidator));
-        when(phoneNumberCodeValidator.validateCode(CODE)).thenReturn(Optional.empty());
+        when(phoneNumberCodeValidator.validateCode(CODE, PHONE_NUMBER))
+                .thenReturn(Optional.empty());
         when(codeStorageService.getOtpCode(TEST_EMAIL_ADDRESS, VERIFY_EMAIL))
                 .thenReturn(Optional.of(CODE));
         session.setNewAccount(Session.AccountState.NEW);
         session.setCurrentCredentialStrength(credentialTrustLevel);
-        var result = makeCallWithCode(MFAMethodType.SMS, true);
+        var result =
+                makeCallWithCode(
+                        new VerifyMfaCodeRequest(MFAMethodType.SMS, CODE, true, PHONE_NUMBER));
 
         assertThat(result, hasStatus(204));
         assertThat(session.getVerifiedMfaMethodType(), equalTo(MFAMethodType.SMS));
         assertThat(
                 session.getCurrentCredentialStrength(), equalTo(CredentialTrustLevel.MEDIUM_LEVEL));
+        verify(authenticationService).updatePhoneNumber(TEST_EMAIL_ADDRESS, PHONE_NUMBER);
         verify(authenticationService)
                 .updatePhoneNumberAndAccountVerifiedStatus(TEST_EMAIL_ADDRESS, true);
         verify(codeStorageService, never())
@@ -248,23 +258,23 @@ class VerifyMfaCodeHandlerTest {
     }
 
     @Test
-    void shouldReturn204WhenSuccessfulAuthCodeLoginRequest() throws Json.JsonException {
+    void shouldReturn204WhenSuccessfulAuthAppCodeLoginRequest() throws Json.JsonException {
         when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), anyBoolean(), any()))
                 .thenReturn(Optional.of(authAppCodeValidator));
-        when(authAppCodeValidator.validateCode(CODE)).thenReturn(Optional.empty());
+        when(authAppCodeValidator.validateCode(CODE, null)).thenReturn(Optional.empty());
         when(codeStorageService.getOtpCode(TEST_EMAIL_ADDRESS, VERIFY_EMAIL))
                 .thenReturn(Optional.of(CODE));
         session.setNewAccount(Session.AccountState.EXISTING);
-        var result = makeCallWithCode(MFAMethodType.AUTH_APP, false);
+        var codeRequest = new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, CODE, false);
+        var result = makeCallWithCode(codeRequest);
 
         assertThat(result, hasStatus(204));
         assertThat(session.getVerifiedMfaMethodType(), equalTo(MFAMethodType.AUTH_APP));
-        verify(authenticationService, never())
-                .setMFAMethodVerifiedTrue(TEST_EMAIL_ADDRESS, MFAMethodType.AUTH_APP);
         verify(codeStorageService, never())
                 .saveBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX, 900L);
         verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(TEST_EMAIL_ADDRESS);
-
+        verify(authenticationService, never())
+                .updateMFAMethod(any(), any(), anyBoolean(), anyBoolean(), any());
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CODE_VERIFIED,
@@ -288,13 +298,13 @@ class VerifyMfaCodeHandlerTest {
                 .thenReturn(Optional.empty());
         when(codeStorageService.getOtpCode(TEST_EMAIL_ADDRESS, VERIFY_EMAIL))
                 .thenReturn(Optional.of(CODE));
-        var result = makeCallWithCode(MFAMethodType.AUTH_APP, true);
+        var codeRequest =
+                new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, CODE, true, AUTH_APP_SECRET);
+        var result = makeCallWithCode(codeRequest);
 
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1002));
         assertThat(session.getVerifiedMfaMethodType(), equalTo(null));
-        verify(authenticationService, never())
-                .setMFAMethodVerifiedTrue(TEST_EMAIL_ADDRESS, MFAMethodType.AUTH_APP);
         verify(authenticationService, never()).setAccountVerified(TEST_EMAIL_ADDRESS);
         verifyNoInteractions(auditService);
         verifyNoInteractions(authAppCodeValidator);
@@ -311,19 +321,18 @@ class VerifyMfaCodeHandlerTest {
             throws Json.JsonException {
         when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), anyBoolean(), any()))
                 .thenReturn(Optional.of(authAppCodeValidator));
-        when(authAppCodeValidator.validateCode(CODE))
+        when(authAppCodeValidator.validateCode(CODE, null))
                 .thenReturn(Optional.of(ErrorResponse.ERROR_1042));
         when(codeStorageService.getOtpCode(TEST_EMAIL_ADDRESS, VERIFY_EMAIL))
                 .thenReturn(Optional.of(CODE));
-        var result = makeCallWithCode(MFAMethodType.AUTH_APP, false);
+        var codeRequest = new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, CODE, false);
+        var result = makeCallWithCode(codeRequest);
 
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1042));
         assertThat(session.getVerifiedMfaMethodType(), equalTo(null));
         verify(codeStorageService)
                 .saveBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX, 900L);
-        verify(authenticationService, never())
-                .setMFAMethodVerifiedTrue(TEST_EMAIL_ADDRESS, MFAMethodType.AUTH_APP);
         verify(authenticationService, never()).setAccountVerified(TEST_EMAIL_ADDRESS);
         verify(codeStorageService)
                 .deleteIncorrectMfaCodeAttemptsCount(TEST_EMAIL_ADDRESS, MFAMethodType.AUTH_APP);
@@ -347,21 +356,20 @@ class VerifyMfaCodeHandlerTest {
             throws Json.JsonException {
         when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), anyBoolean(), any()))
                 .thenReturn(Optional.of(authAppCodeValidator));
-        when(authAppCodeValidator.validateCode(CODE))
+        when(authAppCodeValidator.validateCode(CODE, null))
                 .thenReturn(Optional.of(ErrorResponse.ERROR_1042));
         when(codeStorageService.getOtpCode(TEST_EMAIL_ADDRESS, VERIFY_EMAIL))
                 .thenReturn(Optional.of(CODE));
         when(codeStorageService.isBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX))
                 .thenReturn(true);
-        var result = makeCallWithCode(MFAMethodType.AUTH_APP, false);
+        var codeRequest = new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, CODE, false);
+        var result = makeCallWithCode(codeRequest);
 
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1042));
         assertThat(session.getVerifiedMfaMethodType(), equalTo(null));
         verify(codeStorageService, never())
                 .saveBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX, 900L);
-        verify(authenticationService, never())
-                .setMFAMethodVerifiedTrue(TEST_EMAIL_ADDRESS, MFAMethodType.AUTH_APP);
         verify(authenticationService, never()).setAccountVerified(TEST_EMAIL_ADDRESS);
         verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(TEST_EMAIL_ADDRESS);
         verifyNoInteractions(accountRecoveryBlockService);
@@ -385,19 +393,20 @@ class VerifyMfaCodeHandlerTest {
             throws Json.JsonException {
         when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), anyBoolean(), any()))
                 .thenReturn(Optional.of(authAppCodeValidator));
-        when(authAppCodeValidator.validateCode(CODE))
+        var profileInformation = registration ? AUTH_APP_SECRET : null;
+        when(authAppCodeValidator.validateCode(CODE, profileInformation))
                 .thenReturn(Optional.of(ErrorResponse.ERROR_1043));
         when(codeStorageService.getOtpCode(TEST_EMAIL_ADDRESS, VERIFY_EMAIL))
                 .thenReturn(Optional.of(CODE));
-        var result = makeCallWithCode(MFAMethodType.AUTH_APP, registration);
+        var codeRequest =
+                new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, CODE, false, profileInformation);
+        var result = makeCallWithCode(codeRequest);
 
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1043));
         assertThat(session.getVerifiedMfaMethodType(), equalTo(null));
         verify(codeStorageService, never())
                 .saveBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX, 900L);
-        verify(authenticationService, never())
-                .setMFAMethodVerifiedTrue(TEST_EMAIL_ADDRESS, MFAMethodType.AUTH_APP);
         verify(authenticationService, never()).setAccountVerified(TEST_EMAIL_ADDRESS);
         verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(TEST_EMAIL_ADDRESS);
         verifyNoInteractions(accountRecoveryBlockService);
@@ -421,11 +430,12 @@ class VerifyMfaCodeHandlerTest {
                     throws Json.JsonException {
         when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), anyBoolean(), any()))
                 .thenReturn(Optional.of(phoneNumberCodeValidator));
-        when(phoneNumberCodeValidator.validateCode(CODE))
+        when(phoneNumberCodeValidator.validateCode(CODE, PHONE_NUMBER))
                 .thenReturn(Optional.of(ErrorResponse.ERROR_1034));
         when(codeStorageService.getOtpCode(TEST_EMAIL_ADDRESS, VERIFY_EMAIL))
                 .thenReturn(Optional.of(CODE));
-        var result = makeCallWithCode(MFAMethodType.SMS, true);
+        var codeRequest = new VerifyMfaCodeRequest(MFAMethodType.SMS, CODE, true, PHONE_NUMBER);
+        var result = makeCallWithCode(codeRequest);
 
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1034));
@@ -458,13 +468,14 @@ class VerifyMfaCodeHandlerTest {
                     throws Json.JsonException {
         when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), anyBoolean(), any()))
                 .thenReturn(Optional.of(phoneNumberCodeValidator));
-        when(phoneNumberCodeValidator.validateCode(CODE))
+        when(phoneNumberCodeValidator.validateCode(CODE, PHONE_NUMBER))
                 .thenReturn(Optional.of(ErrorResponse.ERROR_1034));
         when(codeStorageService.getOtpCode(TEST_EMAIL_ADDRESS, VERIFY_EMAIL))
                 .thenReturn(Optional.of(CODE));
         when(codeStorageService.isBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX))
                 .thenReturn(true);
-        var result = makeCallWithCode(MFAMethodType.SMS, true);
+        var codeRequest = new VerifyMfaCodeRequest(MFAMethodType.SMS, CODE, true, PHONE_NUMBER);
+        var result = makeCallWithCode(codeRequest);
 
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1034));
@@ -496,11 +507,12 @@ class VerifyMfaCodeHandlerTest {
             throws Json.JsonException {
         when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), anyBoolean(), any()))
                 .thenReturn(Optional.of(phoneNumberCodeValidator));
-        when(phoneNumberCodeValidator.validateCode(CODE))
+        when(phoneNumberCodeValidator.validateCode(CODE, PHONE_NUMBER))
                 .thenReturn(Optional.of(ErrorResponse.ERROR_1037));
         when(codeStorageService.getOtpCode(TEST_EMAIL_ADDRESS, VERIFY_EMAIL))
                 .thenReturn(Optional.of(CODE));
-        var result = makeCallWithCode(MFAMethodType.SMS, true);
+        var codeRequest = new VerifyMfaCodeRequest(MFAMethodType.SMS, CODE, true, PHONE_NUMBER);
+        var result = makeCallWithCode(codeRequest);
 
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1037));
@@ -527,8 +539,8 @@ class VerifyMfaCodeHandlerTest {
                         pair("mfa-type", MFAMethodType.SMS.getValue()));
     }
 
-    private APIGatewayProxyResponseEvent makeCallWithCode(
-            MFAMethodType mfaMethodType, boolean registration) throws Json.JsonException {
+    private APIGatewayProxyResponseEvent makeCallWithCode(VerifyMfaCodeRequest mfaCodeRequest)
+            throws Json.JsonException {
         var event = new APIGatewayProxyRequestEvent();
         event.setRequestContext(contextWithSourceIp("123.123.123.123"));
         event.setHeaders(
@@ -537,7 +549,6 @@ class VerifyMfaCodeHandlerTest {
                         session.getSessionId(),
                         "Client-Session-Id",
                         CLIENT_SESSION_ID));
-        var mfaCodeRequest = new VerifyMfaCodeRequest(mfaMethodType, CODE, registration);
         event.setBody(objectMapper.writeValueAsString(mfaCodeRequest));
         when(sessionService.getSessionFromRequestHeaders(event.getHeaders()))
                 .thenReturn(Optional.of(session));

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import uk.gov.di.authentication.frontendapi.entity.VerifyMfaCodeRequest;
+import uk.gov.di.authentication.entity.VerifyMfaCodeRequest;
 import uk.gov.di.authentication.frontendapi.lambda.VerifyMfaCodeHandler;
 import uk.gov.di.authentication.shared.domain.AuditableEvent;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/UserStoreExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/UserStoreExtension.java
@@ -135,10 +135,23 @@ public class UserStoreExtension extends DynamoExtension implements AfterEachCall
         return dynamoService.getUserProfileByEmail(email).getAccountVerified() == 1;
     }
 
+    public boolean isPhoneNumberVerified(String email) {
+        return dynamoService.getUserProfileByEmail(email).isPhoneNumberVerified();
+    }
+
     public boolean isAuthAppVerified(String email) {
-        return dynamoService.getUserCredentialsFromEmail(email).getMfaMethods().stream()
-                .filter(t -> t.getMfaMethodType().equals(MFAMethodType.AUTH_APP.getValue()))
-                .anyMatch(MFAMethod::isMethodVerified);
+        return Optional.ofNullable(dynamoService.getUserCredentialsFromEmail(email).getMfaMethods())
+                .map(
+                        t ->
+                                t.stream()
+                                        .filter(
+                                                e ->
+                                                        e.getMfaMethodType()
+                                                                .equals(
+                                                                        MFAMethodType.AUTH_APP
+                                                                                .getValue()))
+                                        .anyMatch(MFAMethod::isMethodVerified))
+                .orElse(false);
     }
 
     public boolean isAuthAppEnabled(String email) {

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuthAppStubTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuthAppStubTest.java
@@ -32,7 +32,8 @@ class AuthAppStubTest {
                         mock(CodeStorageService.class),
                         configurationService,
                         mock(DynamoService.class),
-                        99999);
+                        99999,
+                        false);
     }
 
     @Test

--- a/shared/src/main/java/uk/gov/di/authentication/entity/CodeRequest.java
+++ b/shared/src/main/java/uk/gov/di/authentication/entity/CodeRequest.java
@@ -1,0 +1,25 @@
+package uk.gov.di.authentication.entity;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import uk.gov.di.authentication.shared.validation.Required;
+
+public abstract class CodeRequest {
+
+    @SerializedName("code")
+    @Expose
+    @Required
+    protected String code;
+
+    @SerializedName("profileInformation")
+    @Expose
+    protected String profileInformation;
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getProfileInformation() {
+        return profileInformation;
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/entity/VerifyMfaCodeRequest.java
+++ b/shared/src/main/java/uk/gov/di/authentication/entity/VerifyMfaCodeRequest.java
@@ -1,11 +1,11 @@
-package uk.gov.di.authentication.frontendapi.entity;
+package uk.gov.di.authentication.entity;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.validation.Required;
 
-public class VerifyMfaCodeRequest {
+public class VerifyMfaCodeRequest extends CodeRequest {
 
     public VerifyMfaCodeRequest() {}
 
@@ -29,33 +29,16 @@ public class VerifyMfaCodeRequest {
     @Required
     private MFAMethodType mfaMethodType;
 
-    @SerializedName("code")
-    @Expose
-    @Required
-    private String code;
-
     @SerializedName("isRegistration")
     @Expose
     @Required
     private boolean isRegistration;
 
-    @SerializedName("profileInformation")
-    @Expose
-    private String profileInformation;
-
     public MFAMethodType getMfaMethodType() {
         return mfaMethodType;
     }
 
-    public String getCode() {
-        return code;
-    }
-
     public boolean isRegistration() {
         return isRegistration;
-    }
-
-    public String getProfileInformation() {
-        return profileInformation;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthenticationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthenticationService.java
@@ -75,7 +75,5 @@ public interface AuthenticationService {
             boolean enabled,
             String credentialValue);
 
-    void setMFAMethodVerifiedTrue(String email, MFAMethodType mfaMethodType);
-
     void setMFAMethodEnabled(String email, MFAMethodType mfaMethodType, boolean enabled);
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
@@ -383,25 +383,6 @@ public class DynamoService implements AuthenticationService {
     }
 
     @Override
-    public void setMFAMethodVerifiedTrue(String email, MFAMethodType mfaMethodType) {
-        var dateTime = NowHelper.toTimestampString(NowHelper.now());
-        var userCredentials =
-                dynamoUserCredentialsTable.getItem(
-                        Key.builder().partitionValue(email.toLowerCase(Locale.ROOT)).build());
-        var mfaMethod =
-                userCredentials.getMfaMethods().stream()
-                        .filter(
-                                method ->
-                                        method.getMfaMethodType().equals(mfaMethodType.getValue()))
-                        .findFirst()
-                        .orElseThrow();
-
-        mfaMethod.withMethodVerified(true);
-        mfaMethod.withUpdated(dateTime);
-        dynamoUserCredentialsTable.updateItem(userCredentials);
-    }
-
-    @Override
     public void setMFAMethodEnabled(String email, MFAMethodType mfaMethodType, boolean enabled) {
         var userCredentials =
                 dynamoUserCredentialsTable.getItem(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/validation/AuthAppCodeValidator.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/validation/AuthAppCodeValidator.java
@@ -14,6 +14,7 @@ import javax.crypto.spec.SecretKeySpec;
 
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
@@ -23,22 +24,25 @@ public class AuthAppCodeValidator extends MfaCodeValidator {
     private final int allowedWindows;
     private final AuthenticationService dynamoService;
     private final String emailAddress;
+    private final boolean isRegistration;
 
     public AuthAppCodeValidator(
             String emailAddress,
             CodeStorageService codeStorageService,
             ConfigurationService configurationService,
             AuthenticationService dynamoService,
-            int maxRetries) {
+            int maxRetries,
+            boolean isRegistration) {
         super(emailAddress, codeStorageService, maxRetries);
         this.dynamoService = dynamoService;
         this.emailAddress = emailAddress;
         this.windowTime = configurationService.getAuthAppCodeWindowLength();
         this.allowedWindows = configurationService.getAuthAppCodeAllowedWindows();
+        this.isRegistration = isRegistration;
     }
 
     @Override
-    public Optional<ErrorResponse> validateCode(String code) {
+    public Optional<ErrorResponse> validateCode(String code, String profileInformation) {
 
         if (isCodeBlockedForSession()) {
             LOG.info("Code blocked for session");
@@ -52,14 +56,15 @@ public class AuthAppCodeValidator extends MfaCodeValidator {
             return Optional.of(ErrorResponse.ERROR_1042);
         }
 
-        Optional<String> storedSecret = getMfaCredentialValue();
+        var authAppSecret =
+                isRegistration ? profileInformation : getMfaCredentialValue().orElse(null);
 
-        if (storedSecret.isEmpty()) {
+        if (Objects.isNull(authAppSecret)) {
             LOG.info("No auth app secret found");
             return Optional.of(ErrorResponse.ERROR_1043);
         }
 
-        if (!isCodeValid(code, storedSecret.get())) {
+        if (!isCodeValid(code, authAppSecret)) {
             LOG.info("Auth code is not valid");
             return Optional.of(ErrorResponse.ERROR_1043);
         }
@@ -67,26 +72,6 @@ public class AuthAppCodeValidator extends MfaCodeValidator {
         resetCodeIncorrectEntryCount(MFAMethodType.AUTH_APP);
 
         return Optional.empty();
-    }
-
-    public Optional<String> getMfaCredentialValue() {
-        var userCredentials = dynamoService.getUserCredentialsFromEmail(emailAddress);
-
-        if (userCredentials == null) {
-            LOG.info("User credentials not found");
-            return Optional.empty();
-        }
-
-        var mfaMethod =
-                userCredentials.getMfaMethods().stream()
-                        .filter(
-                                method ->
-                                        method.getMfaMethodType()
-                                                .equals(MFAMethodType.AUTH_APP.getValue()))
-                        .filter(MFAMethod::isEnabled)
-                        .findAny();
-
-        return mfaMethod.map(MFAMethod::getCredentialValue);
     }
 
     public boolean isCodeValid(String code, String secret) {
@@ -105,6 +90,26 @@ public class AuthAppCodeValidator extends MfaCodeValidator {
         }
 
         return checkCode(secret, codeToCheck, NowHelper.now().getTime());
+    }
+
+    private Optional<String> getMfaCredentialValue() {
+        var userCredentials = dynamoService.getUserCredentialsFromEmail(emailAddress);
+
+        if (userCredentials == null) {
+            LOG.info("User credentials not found");
+            return Optional.empty();
+        }
+
+        var mfaMethod =
+                userCredentials.getMfaMethods().stream()
+                        .filter(
+                                method ->
+                                        method.getMfaMethodType()
+                                                .equals(MFAMethodType.AUTH_APP.getValue()))
+                        .filter(MFAMethod::isEnabled)
+                        .findAny();
+
+        return mfaMethod.map(MFAMethod::getCredentialValue);
     }
 
     private boolean checkCode(String secret, long code, long timestamp) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/validation/AuthAppCodeValidator.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/validation/AuthAppCodeValidator.java
@@ -1,5 +1,6 @@
 package uk.gov.di.authentication.shared.validation;
 
+import org.apache.commons.codec.CodecPolicy;
 import org.apache.commons.codec.binary.Base32;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.MFAMethod;
@@ -25,6 +26,7 @@ public class AuthAppCodeValidator extends MfaCodeValidator {
     private final AuthenticationService dynamoService;
     private final String emailAddress;
     private final boolean isRegistration;
+    private static final Base32 base32 = new Base32(0, null, false, (byte) '=', CodecPolicy.STRICT);
 
     public AuthAppCodeValidator(
             String emailAddress,
@@ -62,6 +64,10 @@ public class AuthAppCodeValidator extends MfaCodeValidator {
         if (Objects.isNull(authAppSecret)) {
             LOG.info("No auth app secret found");
             return Optional.of(ErrorResponse.ERROR_1043);
+        }
+
+        if (isRegistration && !base32.isInAlphabet(profileInformation)) {
+            return Optional.of(ErrorResponse.ERROR_1041);
         }
 
         if (!isCodeValid(code, authAppSecret)) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/validation/MfaCodeValidator.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/validation/MfaCodeValidator.java
@@ -40,5 +40,5 @@ public abstract class MfaCodeValidator {
         codeStorageService.deleteIncorrectMfaCodeAttemptsCount(emailAddress, mfaMethodType);
     }
 
-    public abstract Optional<ErrorResponse> validateCode(String code);
+    public abstract Optional<ErrorResponse> validateCode(String code, String profileInformation);
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/validation/MfaCodeValidator.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/validation/MfaCodeValidator.java
@@ -2,6 +2,7 @@ package uk.gov.di.authentication.shared.validation;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.entity.CodeRequest;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
@@ -40,5 +41,5 @@ public abstract class MfaCodeValidator {
         codeStorageService.deleteIncorrectMfaCodeAttemptsCount(emailAddress, mfaMethodType);
     }
 
-    public abstract Optional<ErrorResponse> validateCode(String code, String profileInformation);
+    public abstract Optional<ErrorResponse> validateCode(CodeRequest codeRequest);
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/validation/MfaCodeValidatorFactory.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/validation/MfaCodeValidatorFactory.java
@@ -38,7 +38,8 @@ public class MfaCodeValidatorFactory {
                                 codeStorageService,
                                 configurationService,
                                 authenticationService,
-                                codeMaxRetries));
+                                codeMaxRetries,
+                                isRegistration));
             case SMS:
                 return Optional.of(
                         new PhoneNumberCodeValidator(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/validation/PhoneNumberCodeValidator.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/validation/PhoneNumberCodeValidator.java
@@ -1,5 +1,6 @@
 package uk.gov.di.authentication.shared.validation;
 
+import uk.gov.di.authentication.entity.CodeRequest;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.exceptions.ClientNotFoundException;
@@ -33,7 +34,7 @@ public class PhoneNumberCodeValidator extends MfaCodeValidator {
     }
 
     @Override
-    public Optional<ErrorResponse> validateCode(String code, String profileInformation) {
+    public Optional<ErrorResponse> validateCode(CodeRequest codeRequest) {
         if (!isRegistration) {
             LOG.error("Sign In Phone number codes are not supported");
             throw new RuntimeException("Sign In Phone number codes are not supported");
@@ -59,7 +60,7 @@ public class PhoneNumberCodeValidator extends MfaCodeValidator {
         return ValidationHelper.validateVerificationCode(
                 notificationType,
                 storedCode,
-                code,
+                codeRequest.getCode(),
                 codeStorageService,
                 emailAddress,
                 configurationService.getCodeMaxRetries());

--- a/shared/src/main/java/uk/gov/di/authentication/shared/validation/PhoneNumberCodeValidator.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/validation/PhoneNumberCodeValidator.java
@@ -33,7 +33,7 @@ public class PhoneNumberCodeValidator extends MfaCodeValidator {
     }
 
     @Override
-    public Optional<ErrorResponse> validateCode(String code) {
+    public Optional<ErrorResponse> validateCode(String code, String profileInformation) {
         if (!isRegistration) {
             LOG.error("Sign In Phone number codes are not supported");
             throw new RuntimeException("Sign In Phone number codes are not supported");

--- a/shared/src/test/java/uk/gov/di/authentication/shared/validation/AuthAppCodeValidatorTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/validation/AuthAppCodeValidatorTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import uk.gov.di.authentication.entity.VerifyMfaCodeRequest;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.MFAMethod;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
@@ -59,7 +60,11 @@ class AuthAppCodeValidatorTest {
         String authCode =
                 authAppStub.getAuthAppOneTimeCode(AUTH_APP_SECRET, NowHelper.now().getTime());
 
-        assertEquals(Optional.empty(), authAppCodeValidator.validateCode(authCode, authAppSecret));
+        assertEquals(
+                Optional.empty(),
+                authAppCodeValidator.validateCode(
+                        new VerifyMfaCodeRequest(
+                                MFAMethodType.AUTH_APP, authCode, isRegistration, authAppSecret)));
     }
 
     @ParameterizedTest
@@ -70,7 +75,9 @@ class AuthAppCodeValidatorTest {
 
         assertEquals(
                 Optional.of(ErrorResponse.ERROR_1042),
-                authAppCodeValidator.validateCode("any-code", authAppSecret));
+                authAppCodeValidator.validateCode(
+                        new VerifyMfaCodeRequest(
+                                MFAMethodType.AUTH_APP, "000000", isRegistration, authAppSecret)));
     }
 
     @ParameterizedTest
@@ -80,7 +87,9 @@ class AuthAppCodeValidatorTest {
 
         assertEquals(
                 Optional.of(ErrorResponse.ERROR_1042),
-                authAppCodeValidator.validateCode("any-code", authAppSecret));
+                authAppCodeValidator.validateCode(
+                        new VerifyMfaCodeRequest(
+                                MFAMethodType.AUTH_APP, "000000", isRegistration, authAppSecret)));
     }
 
     @ParameterizedTest
@@ -90,7 +99,9 @@ class AuthAppCodeValidatorTest {
 
         assertEquals(
                 Optional.of(ErrorResponse.ERROR_1043),
-                authAppCodeValidator.validateCode("any-code", null));
+                authAppCodeValidator.validateCode(
+                        new VerifyMfaCodeRequest(
+                                MFAMethodType.AUTH_APP, "000000", isRegistration)));
     }
 
     @Test
@@ -98,7 +109,12 @@ class AuthAppCodeValidatorTest {
         setUpValidAuthCode(true);
 
         assertThat(
-                authAppCodeValidator.validateCode("123456", "not-base-32-encoded-secret"),
+                authAppCodeValidator.validateCode(
+                        new VerifyMfaCodeRequest(
+                                MFAMethodType.AUTH_APP,
+                                "000000",
+                                true,
+                                "not-base-32-encoded-secret")),
                 equalTo(Optional.of(ErrorResponse.ERROR_1041)));
     }
 
@@ -109,13 +125,18 @@ class AuthAppCodeValidatorTest {
 
         assertEquals(
                 Optional.of(ErrorResponse.ERROR_1043),
-                authAppCodeValidator.validateCode("111111", authAppSecret));
+                authAppCodeValidator.validateCode(
+                        new VerifyMfaCodeRequest(
+                                MFAMethodType.AUTH_APP, "111111", true, authAppSecret)));
         assertEquals(
                 Optional.of(ErrorResponse.ERROR_1043),
-                authAppCodeValidator.validateCode("", authAppSecret));
+                authAppCodeValidator.validateCode(
+                        new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, "", true, authAppSecret)));
         assertEquals(
                 Optional.of(ErrorResponse.ERROR_1043),
-                authAppCodeValidator.validateCode("999999999999", authAppSecret));
+                authAppCodeValidator.validateCode(
+                        new VerifyMfaCodeRequest(
+                                MFAMethodType.AUTH_APP, "999999999999", true, authAppSecret)));
     }
 
     private void setUpBlockedUser(boolean isRegistration) {

--- a/shared/src/test/java/uk/gov/di/authentication/shared/validation/PhoneNumberCodeValidatorTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/validation/PhoneNumberCodeValidatorTest.java
@@ -2,7 +2,9 @@ package uk.gov.di.authentication.shared.validation;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.entity.VerifyMfaCodeRequest;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
@@ -40,7 +42,9 @@ class PhoneNumberCodeValidatorTest {
         setupPhoneNumberCode(true);
 
         assertThat(
-                phoneNumberCodeValidator.validateCode(VALID_CODE, PHONE_NUMBER),
+                phoneNumberCodeValidator.validateCode(
+                        new VerifyMfaCodeRequest(
+                                MFAMethodType.SMS, VALID_CODE, true, PHONE_NUMBER)),
                 equalTo(Optional.empty()));
     }
 
@@ -49,7 +53,9 @@ class PhoneNumberCodeValidatorTest {
         setupPhoneNumberCode(true);
 
         assertThat(
-                phoneNumberCodeValidator.validateCode(INVALID_CODE, PHONE_NUMBER),
+                phoneNumberCodeValidator.validateCode(
+                        new VerifyMfaCodeRequest(
+                                MFAMethodType.SMS, INVALID_CODE, true, PHONE_NUMBER)),
                 equalTo(Optional.of(ErrorResponse.ERROR_1037)));
     }
 
@@ -58,7 +64,9 @@ class PhoneNumberCodeValidatorTest {
         setUpPhoneNumberCodeRetryLimitExceeded();
 
         assertThat(
-                phoneNumberCodeValidator.validateCode(INVALID_CODE, PHONE_NUMBER),
+                phoneNumberCodeValidator.validateCode(
+                        new VerifyMfaCodeRequest(
+                                MFAMethodType.SMS, INVALID_CODE, true, PHONE_NUMBER)),
                 equalTo(Optional.of(ErrorResponse.ERROR_1034)));
     }
 
@@ -67,7 +75,9 @@ class PhoneNumberCodeValidatorTest {
         setUpBlockedPhoneNumberCode();
 
         assertThat(
-                phoneNumberCodeValidator.validateCode(INVALID_CODE, PHONE_NUMBER),
+                phoneNumberCodeValidator.validateCode(
+                        new VerifyMfaCodeRequest(
+                                MFAMethodType.SMS, INVALID_CODE, true, PHONE_NUMBER)),
                 equalTo(Optional.of(ErrorResponse.ERROR_1034)));
     }
 
@@ -78,7 +88,10 @@ class PhoneNumberCodeValidatorTest {
         var expectedException =
                 assertThrows(
                         RuntimeException.class,
-                        () -> phoneNumberCodeValidator.validateCode(INVALID_CODE, null),
+                        () ->
+                                phoneNumberCodeValidator.validateCode(
+                                        new VerifyMfaCodeRequest(
+                                                MFAMethodType.SMS, INVALID_CODE, true, null)),
                         "Expected to throw exception");
 
         assertThat(

--- a/shared/src/test/java/uk/gov/di/authentication/shared/validation/PhoneNumberCodeValidatorTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/validation/PhoneNumberCodeValidatorTest.java
@@ -28,6 +28,7 @@ class PhoneNumberCodeValidatorTest {
     private static final String TEST_EMAIL_ADDRESS = "joe.bloggs@example.com";
     private static final String VALID_CODE = "123456";
     private static final String INVALID_CODE = "826272";
+    private static final String PHONE_NUMBER = "+447700900000";
 
     @BeforeEach
     void setup() {
@@ -38,7 +39,9 @@ class PhoneNumberCodeValidatorTest {
     void shouldReturnNoErrorForValidRegistrationPhoneNumberCode() {
         setupPhoneNumberCode(true);
 
-        assertThat(phoneNumberCodeValidator.validateCode(VALID_CODE), equalTo(Optional.empty()));
+        assertThat(
+                phoneNumberCodeValidator.validateCode(VALID_CODE, PHONE_NUMBER),
+                equalTo(Optional.empty()));
     }
 
     @Test
@@ -46,7 +49,7 @@ class PhoneNumberCodeValidatorTest {
         setupPhoneNumberCode(true);
 
         assertThat(
-                phoneNumberCodeValidator.validateCode(INVALID_CODE),
+                phoneNumberCodeValidator.validateCode(INVALID_CODE, PHONE_NUMBER),
                 equalTo(Optional.of(ErrorResponse.ERROR_1037)));
     }
 
@@ -55,7 +58,7 @@ class PhoneNumberCodeValidatorTest {
         setUpPhoneNumberCodeRetryLimitExceeded();
 
         assertThat(
-                phoneNumberCodeValidator.validateCode(INVALID_CODE),
+                phoneNumberCodeValidator.validateCode(INVALID_CODE, PHONE_NUMBER),
                 equalTo(Optional.of(ErrorResponse.ERROR_1034)));
     }
 
@@ -64,7 +67,7 @@ class PhoneNumberCodeValidatorTest {
         setUpBlockedPhoneNumberCode();
 
         assertThat(
-                phoneNumberCodeValidator.validateCode(INVALID_CODE),
+                phoneNumberCodeValidator.validateCode(INVALID_CODE, PHONE_NUMBER),
                 equalTo(Optional.of(ErrorResponse.ERROR_1034)));
     }
 
@@ -75,7 +78,7 @@ class PhoneNumberCodeValidatorTest {
         var expectedException =
                 assertThrows(
                         RuntimeException.class,
-                        () -> phoneNumberCodeValidator.validateCode(INVALID_CODE),
+                        () -> phoneNumberCodeValidator.validateCode(INVALID_CODE, null),
                         "Expected to throw exception");
 
         assertThat(


### PR DESCRIPTION
## What?

- Update the users phone number or auth app secret in the VerifyMfaCodeHandler for registration requests
- Use the authAppSecret in the VerifyMfaCodeRequest to validate the code for AUTH_APP registration requests 
- We can leave the updating of the user profile in update-profile there for now as the call to the `/verify-mfa-code` endpoint will just overwrite it if it exists
- Validate Auth App secret in VerifyMfaCodeHandler
- Add audit events for when the profile is updated in VerifyMfaCodeHandler


## Why?

- This is required so that we can retain the users existing MFA method until their new one has been confirmed during the account recovery journey.
