### PR TITLE
BAU - Return accepted terms and conditions for smoke test client

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -14,6 +14,7 @@ import uk.gov.di.authentication.frontendapi.services.UserMigrationService;
 import uk.gov.di.authentication.shared.conditions.ConsentHelper;
 import uk.gov.di.authentication.shared.conditions.MfaHelper;
 import uk.gov.di.authentication.shared.conditions.TermsAndConditionsHelper;
+import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.MFAMethod;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
@@ -199,10 +200,13 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
             }
             boolean termsAndConditionsAccepted = false;
             if (Objects.nonNull(userProfile.getTermsAndConditions())) {
+                var isSmokeTestClient =
+                        userContext.getClient().map(ClientRegistry::isSmokeTest).orElse(false);
                 termsAndConditionsAccepted =
                         TermsAndConditionsHelper.hasTermsAndConditionsBeenAccepted(
                                 userProfile.getTermsAndConditions(),
-                                configurationService.getTermsAndConditionsVersion());
+                                configurationService.getTermsAndConditionsVersion(),
+                                isSmokeTestClient);
             }
             sessionService.save(userContext.getSession().setNewAccount(EXISTING));
             var isMfaRequired =

--- a/shared/src/main/java/uk/gov/di/authentication/shared/conditions/TermsAndConditionsHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/conditions/TermsAndConditionsHelper.java
@@ -7,7 +7,8 @@ public class TermsAndConditionsHelper {
     private TermsAndConditionsHelper() {}
 
     public static boolean hasTermsAndConditionsBeenAccepted(
-            TermsAndConditions termsAndConditions, String latestVersion) {
+            TermsAndConditions termsAndConditions, String latestVersion, boolean smokeTestClient) {
+        if (smokeTestClient) return true;
         if (latestVersion == null) return false;
         return termsAndConditions.getVersion().equals(latestVersion);
     }


### PR DESCRIPTION
## What?

- Even if the Smoke Test user hasn't accepted the latest terms and conditions we will bypass this in the login handler and return true to the frontend.

## Why?

- This remove the dependency on the smoke test from when we update the terms and conditions
- We don't test the terms and conditions in the smoke test, we only check the minimal flow to ensure the service is working. 
