### PR TITLE
BAU: Set any existing auth app to not enabled when adding a phone number

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -211,6 +211,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                 && errorResponse.isEmpty()
                 && mfaMethodType.equals(MFAMethodType.SMS)) {
             authenticationService.updatePhoneNumberAndAccountVerifiedStatus(emailAddress, true);
+            authenticationService.setMFAMethodEnabled(emailAddress, MFAMethodType.AUTH_APP, false);
         }
 
         if (errorResponse

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -227,6 +227,8 @@ class VerifyMfaCodeHandlerTest {
                 .saveBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX, 900L);
         verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(TEST_EMAIL_ADDRESS);
         verify(accountRecoveryBlockService).deleteBlockIfPresent(TEST_EMAIL_ADDRESS);
+        verify(authenticationService)
+                .setMFAMethodEnabled(TEST_EMAIL_ADDRESS, MFAMethodType.AUTH_APP, false);
 
         verify(auditService)
                 .submitAuditEvent(
@@ -432,6 +434,8 @@ class VerifyMfaCodeHandlerTest {
                 .saveBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX, 900L);
         verify(authenticationService, never())
                 .updatePhoneNumberAndAccountVerifiedStatus(TEST_EMAIL_ADDRESS, true);
+        verify(authenticationService, never())
+                .setMFAMethodEnabled(TEST_EMAIL_ADDRESS, MFAMethodType.AUTH_APP, false);
         verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(TEST_EMAIL_ADDRESS);
         verifyNoInteractions(accountRecoveryBlockService);
         verify(auditService)
@@ -469,6 +473,8 @@ class VerifyMfaCodeHandlerTest {
                 .saveBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX, 900L);
         verify(authenticationService, never())
                 .updatePhoneNumberAndAccountVerifiedStatus(TEST_EMAIL_ADDRESS, true);
+        verify(authenticationService, never())
+                .setMFAMethodEnabled(TEST_EMAIL_ADDRESS, MFAMethodType.AUTH_APP, false);
         verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(TEST_EMAIL_ADDRESS);
         verifyNoInteractions(accountRecoveryBlockService);
         verify(auditService)
@@ -503,6 +509,8 @@ class VerifyMfaCodeHandlerTest {
                 .saveBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX, 900L);
         verify(authenticationService, never())
                 .updatePhoneNumberAndAccountVerifiedStatus(TEST_EMAIL_ADDRESS, true);
+        verify(authenticationService, never())
+                .setMFAMethodEnabled(TEST_EMAIL_ADDRESS, MFAMethodType.AUTH_APP, false);
         verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(TEST_EMAIL_ADDRESS);
         verifyNoInteractions(accountRecoveryBlockService);
         verify(auditService)

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
@@ -324,6 +324,24 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         assertThat(response, hasStatus(204));
         assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(CODE_VERIFIED));
+        assertThat(userStore.isAuthAppEnabled(EMAIL_ADDRESS), equalTo(false));
+    }
+
+    @Test
+    void whenValidPhoneNumberCodeForRegistrationReturn204AndInvalidateAuthApp() {
+        setUpAuthAppRequest(true);
+        var code = redis.generateAndSavePhoneNumberCode(EMAIL_ADDRESS, 900);
+        var codeRequest = new VerifyMfaCodeRequest(MFAMethodType.SMS, code, true);
+
+        var response =
+                makeRequest(
+                        Optional.of(codeRequest),
+                        constructFrontendHeaders(sessionId, CLIENT_SESSION_ID),
+                        Map.of());
+
+        assertThat(response, hasStatus(204));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(CODE_VERIFIED));
+        assertThat(userStore.isAuthAppEnabled(EMAIL_ADDRESS), equalTo(false));
     }
 
     @Test

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoServiceIntegrationTest.java
@@ -164,6 +164,23 @@ class DynamoServiceIntegrationTest {
         assertThat(mfaMethod.getCredentialValue(), equalTo(TEST_MFA_APP_CREDENTIAL));
     }
 
+    @Test
+    void shoulSetAuthAppMFAMethodNotEnabled() {
+        setUpDynamo();
+        dynamoService.updateMFAMethod(
+                TEST_EMAIL, MFAMethodType.AUTH_APP, true, true, TEST_MFA_APP_CREDENTIAL);
+        dynamoService.setMFAMethodEnabled(TEST_EMAIL, MFAMethodType.AUTH_APP, false);
+        UserCredentials updatedUserCredentials =
+                dynamoService.getUserCredentialsFromEmail(TEST_EMAIL);
+
+        assertThat(updatedUserCredentials.getMfaMethods().size(), equalTo(1));
+        MFAMethod mfaMethod = updatedUserCredentials.getMfaMethods().get(0);
+        assertThat(mfaMethod.getMfaMethodType(), equalTo(MFAMethodType.AUTH_APP.getValue()));
+        assertThat(mfaMethod.isMethodVerified(), equalTo(true));
+        assertThat(mfaMethod.isEnabled(), equalTo(false));
+        assertThat(mfaMethod.getCredentialValue(), equalTo(TEST_MFA_APP_CREDENTIAL));
+    }
+
     private void testUpdateEmail(UserProfile userProfile, UserCredentials userCredentials) {
         dynamoService.updateEmail(TEST_EMAIL, UPDATED_TEST_EMAIL, CREATED_DATE_TIME);
 

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/UserStoreExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/UserStoreExtension.java
@@ -137,6 +137,14 @@ public class UserStoreExtension extends DynamoExtension implements AfterEachCall
                 .anyMatch(MFAMethod::isMethodVerified);
     }
 
+    public boolean isAuthAppEnabled(String email) {
+        var mfaMethods = dynamoService.getUserCredentialsFromEmail(email).getMfaMethods();
+        return mfaMethods != null
+                && mfaMethods.stream()
+                        .filter(t -> t.getMfaMethodType().equals(MFAMethodType.AUTH_APP.getValue()))
+                        .anyMatch(MFAMethod::isEnabled);
+    }
+
     public void addMfaMethod(
             String email,
             MFAMethodType mfaMethodType,

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthenticationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthenticationService.java
@@ -76,4 +76,6 @@ public interface AuthenticationService {
             String credentialValue);
 
     void setMFAMethodVerifiedTrue(String email, MFAMethodType mfaMethodType);
+
+    void setMFAMethodEnabled(String email, MFAMethodType mfaMethodType, boolean enabled);
 }


### PR DESCRIPTION
## What?

Set any existing auth app to not enabled when adding a phone number.

## Why?

So that users can switch between 2fa types for account recovery
