### PR TITLE
AUT-1195: Add country code logging to Notify SMS errors

### DIFF
--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandlerTest.java
@@ -226,7 +226,7 @@ public class NotificationHandlerTest {
                         "Expected to throw exception");
 
         assertEquals(
-                "Error sending with Notify using NotificationType: VERIFY_EMAIL",
+                "Error sending Notify email with NotificationType: VERIFY_EMAIL",
                 exception.getMessage());
     }
 
@@ -256,7 +256,7 @@ public class NotificationHandlerTest {
                         "Expected to throw exception");
 
         assertEquals(
-                "Error sending with Notify using NotificationType: VERIFY_PHONE_NUMBER",
+                "Error sending Notify SMS with NotificationType: VERIFY_PHONE_NUMBER and country code: 44",
                 exception.getMessage());
     }
 


### PR DESCRIPTION
## What?
- Add country code logging to Notify SMS errors

## Why?
- Some Notify texts are being rejected for reasons we do not yet understand
- This is to help identify if there is a pattern for specific countries being rejected
