### PR TITLE
AUT-1168 - Add support to verify code for notification type VERIFY_CHANGE_HOW_GET_SECURITY_CODES

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -36,6 +36,7 @@ import java.util.Optional;
 import static java.util.Map.entry;
 import static uk.gov.di.authentication.shared.entity.LevelOfConfidence.NONE;
 import static uk.gov.di.authentication.shared.entity.NotificationType.MFA_SMS;
+import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_CHANGE_HOW_GET_SECURITY_CODES;
 import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_EMAIL;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateEmptySuccessApiGatewayResponse;
@@ -152,6 +153,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
 
     private ErrorResponse blockedCodeBehaviour(VerifyCodeRequest codeRequest) {
         return Map.ofEntries(
+                        entry(VERIFY_CHANGE_HOW_GET_SECURITY_CODES, ErrorResponse.ERROR_1033),
                         entry(VERIFY_EMAIL, ErrorResponse.ERROR_1033),
                         entry(MFA_SMS, ErrorResponse.ERROR_1027))
                 .get(codeRequest.getNotificationType());
@@ -247,7 +249,8 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
         }
         AuditableEvent auditableEvent;
         if (List.of(ErrorResponse.ERROR_1027, ErrorResponse.ERROR_1033).contains(errorResponse)) {
-            if (!notificationType.equals(VERIFY_EMAIL)
+            if (!List.of(VERIFY_EMAIL, VERIFY_CHANGE_HOW_GET_SECURITY_CODES)
+                            .contains(notificationType)
                     && !errorResponse.equals(ErrorResponse.ERROR_1033)) {
                 blockCodeForSession(session);
             }
@@ -276,6 +279,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
         LOG.info("Using TestClient with NotificationType {}", notificationType);
         switch (notificationType) {
             case VERIFY_EMAIL:
+            case VERIFY_CHANGE_HOW_GET_SECURITY_CODES:
             case RESET_PASSWORD_WITH_CODE:
                 return configurationService.getTestClientVerifyEmailOTP();
             case MFA_SMS:

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
@@ -14,6 +14,7 @@ import uk.gov.di.authentication.shared.entity.AuthCodeExchangeData;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
+import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.VectorOfTrust;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
@@ -189,6 +190,14 @@ public class RedisExtension
     public String generateAndSaveEmailCode(String email, long codeExpiryTime) {
         var code = new CodeGeneratorService().sixDigitCode();
         codeStorageService.saveOtpCode(email, code, codeExpiryTime, VERIFY_EMAIL);
+
+        return code;
+    }
+
+    public String generateAndSaveEmailCode(
+            String email, long codeExpiryTime, NotificationType notificationType) {
+        var code = new CodeGeneratorService().sixDigitCode();
+        codeStorageService.saveOtpCode(email, code, codeExpiryTime, notificationType);
 
         return code;
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ValidationHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ValidationHelper.java
@@ -173,6 +173,7 @@ public class ValidationHelper {
             switch (type) {
                 case MFA_SMS:
                 case VERIFY_EMAIL:
+                case VERIFY_CHANGE_HOW_GET_SECURITY_CODES:
                 case VERIFY_PHONE_NUMBER:
                 case RESET_PASSWORD_WITH_CODE:
                     return Optional.empty();
@@ -187,6 +188,7 @@ public class ValidationHelper {
                 case MFA_SMS:
                     return Optional.of(ErrorResponse.ERROR_1027);
                 case VERIFY_EMAIL:
+                case VERIFY_CHANGE_HOW_GET_SECURITY_CODES:
                     return Optional.of(ErrorResponse.ERROR_1033);
                 case VERIFY_PHONE_NUMBER:
                     return Optional.of(ErrorResponse.ERROR_1034);
@@ -199,6 +201,7 @@ public class ValidationHelper {
             case MFA_SMS:
                 return Optional.of(ErrorResponse.ERROR_1035);
             case VERIFY_EMAIL:
+            case VERIFY_CHANGE_HOW_GET_SECURITY_CODES:
                 return Optional.of(ErrorResponse.ERROR_1036);
             case VERIFY_PHONE_NUMBER:
                 return Optional.of(ErrorResponse.ERROR_1037);


### PR DESCRIPTION
## What?

- Currently the behaviour is the same as VERIFY_CODE although additional functionality will be added shortly
- There will be further work to ensure it can support the additional error scenarios 

## Why?

- So VerifyCode can support requests with the VERIFY_CHANGE_HOW_GET_SECURITY_CODES

