### PR TITLE
AUT-1218 - Create Account Modifiers table

### DIFF
--- a/ci/terraform/shared/dynamodb.tf
+++ b/ci/terraform/shared/dynamodb.tf
@@ -304,3 +304,31 @@ resource "aws_dynamodb_table" "account_recovery_block_table" {
 
   tags = local.default_tags
 }
+
+resource "aws_dynamodb_table" "account_modifiers_table" {
+  name         = "${var.environment}-account-modifiers"
+  billing_mode = var.provision_dynamo ? "PROVISIONED" : "PAY_PER_REQUEST"
+  hash_key     = "InternalCommonSubjectIdentifier"
+
+  read_capacity  = var.provision_dynamo ? var.dynamo_default_read_capacity : null
+  write_capacity = var.provision_dynamo ? var.dynamo_default_write_capacity : null
+
+  attribute {
+    name = "InternalCommonSubjectIdentifier"
+    type = "S"
+  }
+
+  point_in_time_recovery {
+    enabled = !var.use_localstack
+  }
+
+  server_side_encryption {
+    enabled = !var.use_localstack
+  }
+
+  lifecycle {
+    prevent_destroy = false
+  }
+
+  tags = local.default_tags
+}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/AccountModifiers.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/AccountModifiers.java
@@ -1,0 +1,72 @@
+package uk.gov.di.authentication.frontendapi.entity;
+
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbAttribute;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+
+@DynamoDbBean
+public class AccountModifiers {
+
+    private String internalCommonSubjectIdentifier;
+    private String created;
+    private String updated;
+    private AccountRecovery accountRecovery;
+
+    @DynamoDbPartitionKey
+    @DynamoDbAttribute("InternalCommonSubjectIdentifier")
+    public String getInternalCommonSubjectIdentifier() {
+        return internalCommonSubjectIdentifier;
+    }
+
+    public void setInternalCommonSubjectIdentifier(String internalCommonSubjectIdentifier) {
+        this.internalCommonSubjectIdentifier = internalCommonSubjectIdentifier;
+    }
+
+    public AccountModifiers withInternalCommonSubjectIdentifier(
+            String internalCommonSubjectIdentifier) {
+        this.internalCommonSubjectIdentifier = internalCommonSubjectIdentifier;
+        return this;
+    }
+
+    @DynamoDbAttribute("AccountRecovery")
+    public AccountRecovery getAccountRecovery() {
+        return accountRecovery;
+    }
+
+    public void setAccountRecovery(AccountRecovery accountRecovery) {
+        this.accountRecovery = accountRecovery;
+    }
+
+    public AccountModifiers withAccountRecovery(AccountRecovery accountRecovery) {
+        this.accountRecovery = accountRecovery;
+        return this;
+    }
+
+    @DynamoDbAttribute("Created")
+    public String getCreated() {
+        return created;
+    }
+
+    public void setCreated(String created) {
+        this.created = created;
+    }
+
+    public AccountModifiers withCreated(String created) {
+        this.created = created;
+        return this;
+    }
+
+    @DynamoDbAttribute("Updated")
+    public String getUpdated() {
+        return updated;
+    }
+
+    public void setUpdated(String updated) {
+        this.updated = updated;
+    }
+
+    public AccountModifiers withUpdated(String updated) {
+        this.updated = updated;
+        return this;
+    }
+}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/AccountRecovery.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/AccountRecovery.java
@@ -1,0 +1,54 @@
+package uk.gov.di.authentication.frontendapi.entity;
+
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbAttribute;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+
+@DynamoDbBean
+public class AccountRecovery {
+
+    private boolean blocked;
+    private String created;
+    private String updated;
+
+    @DynamoDbAttribute("Blocked")
+    public boolean isBlocked() {
+        return blocked;
+    }
+
+    public void setBlocked(boolean blocked) {
+        this.blocked = blocked;
+    }
+
+    public AccountRecovery withBlocked(boolean blocked) {
+        this.blocked = blocked;
+        return this;
+    }
+
+    @DynamoDbAttribute("Created")
+    public String getCreated() {
+        return created;
+    }
+
+    public void setCreated(String created) {
+        this.created = created;
+    }
+
+    public AccountRecovery withCreated(String created) {
+        this.created = created;
+        return this;
+    }
+
+    @DynamoDbAttribute("Updated")
+    public String getUpdated() {
+        return updated;
+    }
+
+    public void setUpdated(String updated) {
+        this.updated = updated;
+    }
+
+    public AccountRecovery withUpdated(String updated) {
+        this.updated = updated;
+        return this;
+    }
+}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/DynamoAccountModifiersService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/DynamoAccountModifiersService.java
@@ -1,0 +1,63 @@
+package uk.gov.di.authentication.frontendapi.services;
+
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import uk.gov.di.authentication.frontendapi.entity.AccountModifiers;
+import uk.gov.di.authentication.frontendapi.entity.AccountRecovery;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+import java.util.Optional;
+
+import static uk.gov.di.authentication.shared.dynamodb.DynamoClientHelper.createDynamoEnhancedClient;
+
+public class DynamoAccountModifiersService {
+
+    private static final String ACCOUNT_MODIFIERS_TABLE_NAME = "account-modifiers";
+    private final DynamoDbTable<AccountModifiers> dynamoAccountModifiersTable;
+
+    public DynamoAccountModifiersService(ConfigurationService configurationService) {
+        var tableName = configurationService.getEnvironment() + "-" + ACCOUNT_MODIFIERS_TABLE_NAME;
+        var dynamoDbEnhancedClient = createDynamoEnhancedClient(configurationService);
+        dynamoAccountModifiersTable =
+                dynamoDbEnhancedClient.table(
+                        tableName, TableSchema.fromBean(AccountModifiers.class));
+        warmUp();
+    }
+
+    public void createAccountModifiersWithAccountBlock(
+            String internalCommonSubjectId, boolean accountRecoveryBlock) {
+        var dateTime = NowHelper.toTimestampString(NowHelper.now());
+        var accountRecovery =
+                new AccountRecovery()
+                        .withBlocked(accountRecoveryBlock)
+                        .withUpdated(dateTime)
+                        .withCreated(dateTime);
+        var accountModifiers =
+                new AccountModifiers()
+                        .withInternalCommonSubjectIdentifier(internalCommonSubjectId)
+                        .withCreated(dateTime)
+                        .withUpdated(dateTime)
+                        .withAccountRecovery(accountRecovery);
+
+        dynamoAccountModifiersTable.putItem(accountModifiers);
+    }
+
+    public void removeAccountModifiersIfPresent(String internalCommonSubjectId) {
+        if (getAccountModifiers(internalCommonSubjectId).isPresent()) {
+            dynamoAccountModifiersTable.deleteItem(
+                    Key.builder().partitionValue(internalCommonSubjectId).build());
+        }
+    }
+
+    public Optional<AccountModifiers> getAccountModifiers(String internalCommonSubjectId) {
+        return Optional.ofNullable(
+                dynamoAccountModifiersTable.getItem(
+                        Key.builder().partitionValue(internalCommonSubjectId).build()));
+    }
+
+    private void warmUp() {
+        dynamoAccountModifiersTable.describeTable();
+    }
+}


### PR DESCRIPTION
## What?

- Create a new Dynamo table to track when an account is unable to perform account recovery

## Why?

- The existing account recovery block table is not yet in production and is not scalable if we decide to add additional fields to the table etc. The Account Modifiers table isn't limited to account recovery and is able to scale if we decide to add additional features
