### PR TITLE
AUT-1218 - Create Dynamo policies got Account Modifiers table

### DIFF
--- a/ci/terraform/oidc/account-recovery.tf
+++ b/ci/terraform/oidc/account-recovery.tf
@@ -11,6 +11,7 @@ module "frontend_api_account_recovery_role" {
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
     aws_iam_policy.dynamo_account_recovery_block_read_access_policy.arn,
+    aws_iam_policy.dynamo_account_modifiers_read_access_policy.arn,
     module.oidc_txma_audit.access_policy_arn
   ]
 }

--- a/ci/terraform/oidc/dynamo-policies.tf
+++ b/ci/terraform/oidc/dynamo-policies.tf
@@ -26,6 +26,10 @@ data "aws_dynamodb_table" "account_recovery_block_table" {
   name = "${var.environment}-account-recovery-block"
 }
 
+data "aws_dynamodb_table" "account_modifiers_table" {
+  name = "${var.environment}-account-modifiers"
+}
+
 data "aws_iam_policy_document" "dynamo_user_write_policy_document" {
   statement {
     sid    = "AllowAccessToDynamoTables"
@@ -199,6 +203,53 @@ data "aws_iam_policy_document" "dynamo_common_passwords_read_access_policy_docum
   }
 }
 
+
+data "aws_iam_policy_document" "dynamo_account_modifiers_read_access_policy_document" {
+  statement {
+    sid    = "AllowAccessToDynamoTables"
+    effect = "Allow"
+
+    actions = [
+      "dynamodb:DescribeTable",
+      "dynamodb:Get*",
+
+    ]
+    resources = [
+      data.aws_dynamodb_table.account_modifiers_table.arn,
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "dynamo_account_modifiers_delete_access_policy_document" {
+  statement {
+    sid    = "AllowAccessToDynamoTables"
+    effect = "Allow"
+
+    actions = [
+      "dynamodb:DeleteItem",
+
+    ]
+    resources = [
+      data.aws_dynamodb_table.account_modifiers_table.arn,
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "dynamo_account_modifiers_write_access_policy_document" {
+  statement {
+    sid    = "AllowAccessToDynamoTables"
+    effect = "Allow"
+
+    actions = [
+      "dynamodb:UpdateItem",
+      "dynamodb:PutItem",
+    ]
+    resources = [
+      data.aws_dynamodb_table.account_modifiers_table.arn,
+    ]
+  }
+}
+
 data "aws_iam_policy_document" "dynamo_account_recovery_block_read_access_policy_document" {
   statement {
     sid    = "AllowAccessToDynamoTables"
@@ -347,4 +398,28 @@ resource "aws_iam_policy" "dynamo_account_recovery_block_write_access_policy" {
   description = "IAM policy for managing write permissions to the Dynamo Account Recovery Block table"
 
   policy = data.aws_iam_policy_document.dynamo_account_recovery_block_write_access_policy_document.json
+}
+
+resource "aws_iam_policy" "dynamo_account_modifiers_read_access_policy" {
+  name_prefix = "dynamo-account-modifiers-read"
+  path        = "/${var.environment}/oidc-default/"
+  description = "IAM policy for managing read permissions to the Dynamo Account Modifiers table"
+
+  policy = data.aws_iam_policy_document.dynamo_account_modifiers_read_access_policy_document.json
+}
+
+resource "aws_iam_policy" "dynamo_account_modifiers_delete_access_policy" {
+  name_prefix = "dynamo-account-modifiers-delete"
+  path        = "/${var.environment}/oidc-default/"
+  description = "IAM policy for managing delete permissions to the Dynamo Account Modifiers table"
+
+  policy = data.aws_iam_policy_document.dynamo_account_modifiers_delete_access_policy_document.json
+}
+
+resource "aws_iam_policy" "dynamo_account_modifiers_write_access_policy" {
+  name_prefix = "dynamo-account-modifiers-write"
+  path        = "/${var.environment}/oidc-default/"
+  description = "IAM policy for managing write permissions to the Dynamo Account Modifiers table"
+
+  policy = data.aws_iam_policy_document.dynamo_account_modifiers_write_access_policy_document.json
 }

--- a/ci/terraform/oidc/reset_password.tf
+++ b/ci/terraform/oidc/reset_password.tf
@@ -10,6 +10,7 @@ module "frontend_api_reset_password_role" {
     aws_iam_policy.dynamo_user_write_access_policy.arn,
     aws_iam_policy.dynamo_account_recovery_block_read_access_policy.arn,
     aws_iam_policy.dynamo_account_recovery_block_write_access_policy.arn,
+    aws_iam_policy.dynamo_account_modifiers_read_access_policy.arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,

--- a/ci/terraform/oidc/verify_mfa_code.tf
+++ b/ci/terraform/oidc/verify_mfa_code.tf
@@ -11,6 +11,7 @@ module "frontend_api_verify_mfa_code_role" {
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.dynamo_account_recovery_block_delete_access_policy.arn,
     aws_iam_policy.dynamo_account_recovery_block_read_access_policy.arn,
+    aws_iam_policy.dynamo_account_modifiers_read_access_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
     module.oidc_txma_audit.access_policy_arn


### PR DESCRIPTION
## What?

- Create Read, Write and Delete policies for the new Account Modifiers table.
- For now, give the 3 lambdas which will interact with this table Read permissions only. Additional permissions will be added as and when required.

## Why?

- So the Lambdas are able to interact with the Account Modifiers table
