### PR TITLE
AUT-1242-part-1: Introduce JourneyType parameter in VerifyMfaCodeRequest

### DIFF
--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -25,6 +25,7 @@ import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.UserProfile;
@@ -169,7 +170,7 @@ class VerifyMfaCodeHandlerTest {
     @MethodSource("credentialTrustLevels")
     void shouldReturn204WhenSuccessfulAuthAppCodeRegistrationRequestAndSetMfaMethod(
             CredentialTrustLevel credentialTrustLevel) throws Json.JsonException {
-        when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), anyBoolean(), any()))
+        when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), any(JourneyType.class), any()))
                 .thenReturn(Optional.of(authAppCodeValidator));
         when(authAppCodeValidator.validateCode(any(CodeRequest.class)))
                 .thenReturn(Optional.empty());
@@ -178,7 +179,10 @@ class VerifyMfaCodeHandlerTest {
         var result =
                 makeCallWithCode(
                         new VerifyMfaCodeRequest(
-                                MFAMethodType.AUTH_APP, CODE, true, AUTH_APP_SECRET));
+                                MFAMethodType.AUTH_APP,
+                                CODE,
+                                JourneyType.REGISTRATION,
+                                AUTH_APP_SECRET));
 
         assertThat(result, hasStatus(204));
         assertThat(session.getVerifiedMfaMethodType(), equalTo(MFAMethodType.AUTH_APP));
@@ -226,7 +230,7 @@ class VerifyMfaCodeHandlerTest {
     @MethodSource("credentialTrustLevels")
     void shouldReturn204WhenSuccessfulPhoneCodeRegistrationRequestAndSetPhoneNumber(
             CredentialTrustLevel credentialTrustLevel) throws Json.JsonException {
-        when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), anyBoolean(), any()))
+        when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), any(JourneyType.class), any()))
                 .thenReturn(Optional.of(phoneNumberCodeValidator));
         when(phoneNumberCodeValidator.validateCode(any(CodeRequest.class)))
                 .thenReturn(Optional.empty());
@@ -234,7 +238,8 @@ class VerifyMfaCodeHandlerTest {
         session.setCurrentCredentialStrength(credentialTrustLevel);
         var result =
                 makeCallWithCode(
-                        new VerifyMfaCodeRequest(MFAMethodType.SMS, CODE, true, PHONE_NUMBER));
+                        new VerifyMfaCodeRequest(
+                                MFAMethodType.SMS, CODE, JourneyType.REGISTRATION, PHONE_NUMBER));
 
         assertThat(result, hasStatus(204));
         assertThat(session.getVerifiedMfaMethodType(), equalTo(MFAMethodType.SMS));
@@ -281,12 +286,13 @@ class VerifyMfaCodeHandlerTest {
 
     @Test
     void shouldReturn204WhenSuccessfulAuthAppCodeLoginRequest() throws Json.JsonException {
-        when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), anyBoolean(), any()))
+        when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), any(JourneyType.class), any()))
                 .thenReturn(Optional.of(authAppCodeValidator));
         when(authAppCodeValidator.validateCode(any(CodeRequest.class)))
                 .thenReturn(Optional.empty());
         session.setNewAccount(Session.AccountState.EXISTING);
-        var codeRequest = new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, CODE, false);
+        var codeRequest =
+                new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, CODE, JourneyType.SIGN_IN);
         var result = makeCallWithCode(codeRequest);
 
         assertThat(result, hasStatus(204));
@@ -315,10 +321,11 @@ class VerifyMfaCodeHandlerTest {
 
     @Test
     void shouldReturn400IfMfaCodeValidatorCannotBeFound() throws Json.JsonException {
-        when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), anyBoolean(), any()))
+        when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), any(JourneyType.class), any()))
                 .thenReturn(Optional.empty());
         var codeRequest =
-                new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, CODE, true, AUTH_APP_SECRET);
+                new VerifyMfaCodeRequest(
+                        MFAMethodType.AUTH_APP, CODE, JourneyType.REGISTRATION, AUTH_APP_SECRET);
         var result = makeCallWithCode(codeRequest);
 
         assertThat(result, hasStatus(400));
@@ -338,11 +345,12 @@ class VerifyMfaCodeHandlerTest {
     @Test
     void shouldReturn400AndBlockCodeWhenUserEnteredInvalidAuthAppCodeTooManyTimes()
             throws Json.JsonException {
-        when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), anyBoolean(), any()))
+        when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), any(JourneyType.class), any()))
                 .thenReturn(Optional.of(authAppCodeValidator));
         when(authAppCodeValidator.validateCode(any(CodeRequest.class)))
                 .thenReturn(Optional.of(ErrorResponse.ERROR_1042));
-        var codeRequest = new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, CODE, false);
+        var codeRequest =
+                new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, CODE, JourneyType.SIGN_IN);
         var result = makeCallWithCode(codeRequest);
 
         assertThat(result, hasStatus(400));
@@ -371,13 +379,14 @@ class VerifyMfaCodeHandlerTest {
     @Test
     void shouldReturn400AndNotBlockCodeWhenUserEnteredInvalidAuthAppCodeAndBlockAlreadyExists()
             throws Json.JsonException {
-        when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), anyBoolean(), any()))
+        when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), any(JourneyType.class), any()))
                 .thenReturn(Optional.of(authAppCodeValidator));
         when(authAppCodeValidator.validateCode(any(CodeRequest.class)))
                 .thenReturn(Optional.of(ErrorResponse.ERROR_1042));
         when(codeStorageService.isBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX))
                 .thenReturn(true);
-        var codeRequest = new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, CODE, false);
+        var codeRequest =
+                new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, CODE, JourneyType.SIGN_IN);
         var result = makeCallWithCode(codeRequest);
 
         assertThat(result, hasStatus(400));
@@ -406,13 +415,14 @@ class VerifyMfaCodeHandlerTest {
     @MethodSource("registration")
     void shouldReturn400WhenUserEnteredInvalidAuthAppCode(boolean registration)
             throws Json.JsonException {
-        when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), anyBoolean(), any()))
+        when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), any(JourneyType.class), any()))
                 .thenReturn(Optional.of(authAppCodeValidator));
         var profileInformation = registration ? AUTH_APP_SECRET : null;
         when(authAppCodeValidator.validateCode(any(CodeRequest.class)))
                 .thenReturn(Optional.of(ErrorResponse.ERROR_1043));
         var codeRequest =
-                new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, CODE, false, profileInformation);
+                new VerifyMfaCodeRequest(
+                        MFAMethodType.AUTH_APP, CODE, JourneyType.SIGN_IN, profileInformation);
         var result = makeCallWithCode(codeRequest);
 
         assertThat(result, hasStatus(400));
@@ -441,11 +451,13 @@ class VerifyMfaCodeHandlerTest {
     void
             shouldReturn400AndBlockCodeWhenUserEnteredInvalidPhoneNumberCodeDuringRegistrationTooManyTimes()
                     throws Json.JsonException {
-        when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), anyBoolean(), any()))
+        when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), any(JourneyType.class), any()))
                 .thenReturn(Optional.of(phoneNumberCodeValidator));
         when(phoneNumberCodeValidator.validateCode(any(CodeRequest.class)))
                 .thenReturn(Optional.of(ErrorResponse.ERROR_1034));
-        var codeRequest = new VerifyMfaCodeRequest(MFAMethodType.SMS, CODE, true, PHONE_NUMBER);
+        var codeRequest =
+                new VerifyMfaCodeRequest(
+                        MFAMethodType.SMS, CODE, JourneyType.REGISTRATION, PHONE_NUMBER);
         var result = makeCallWithCode(codeRequest);
 
         assertThat(result, hasStatus(400));
@@ -478,13 +490,15 @@ class VerifyMfaCodeHandlerTest {
     void
             shouldReturn400AndNotBlockCodeWhenInvalidPhoneNumberCodeEnteredDuringRegistrationAndBlockAlreadyExists()
                     throws Json.JsonException {
-        when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), anyBoolean(), any()))
+        when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), any(JourneyType.class), any()))
                 .thenReturn(Optional.of(phoneNumberCodeValidator));
         when(phoneNumberCodeValidator.validateCode(any(CodeRequest.class)))
                 .thenReturn(Optional.of(ErrorResponse.ERROR_1034));
         when(codeStorageService.isBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX))
                 .thenReturn(true);
-        var codeRequest = new VerifyMfaCodeRequest(MFAMethodType.SMS, CODE, true, PHONE_NUMBER);
+        var codeRequest =
+                new VerifyMfaCodeRequest(
+                        MFAMethodType.SMS, CODE, JourneyType.REGISTRATION, PHONE_NUMBER);
         var result = makeCallWithCode(codeRequest);
 
         assertThat(result, hasStatus(400));
@@ -516,11 +530,13 @@ class VerifyMfaCodeHandlerTest {
     @Test
     void shouldReturn400WhenUserEnteredInvalidPhoneNumberCodeForRegistration()
             throws Json.JsonException {
-        when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), anyBoolean(), any()))
+        when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), any(JourneyType.class), any()))
                 .thenReturn(Optional.of(phoneNumberCodeValidator));
         when(phoneNumberCodeValidator.validateCode(any(CodeRequest.class)))
                 .thenReturn(Optional.of(ErrorResponse.ERROR_1037));
-        var codeRequest = new VerifyMfaCodeRequest(MFAMethodType.SMS, CODE, true, PHONE_NUMBER);
+        var codeRequest =
+                new VerifyMfaCodeRequest(
+                        MFAMethodType.SMS, CODE, JourneyType.REGISTRATION, PHONE_NUMBER);
         var result = makeCallWithCode(codeRequest);
 
         assertThat(result, hasStatus(400));
@@ -551,7 +567,7 @@ class VerifyMfaCodeHandlerTest {
 
     @Test
     void shouldReturn400WhenAuthAppSecretIsInvalid() throws Json.JsonException {
-        when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), anyBoolean(), any()))
+        when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), any(JourneyType.class), any()))
                 .thenReturn(Optional.of(authAppCodeValidator));
         when(authAppCodeValidator.validateCode(any(CodeRequest.class)))
                 .thenReturn(Optional.of(ErrorResponse.ERROR_1041));
@@ -560,7 +576,10 @@ class VerifyMfaCodeHandlerTest {
         var result =
                 makeCallWithCode(
                         new VerifyMfaCodeRequest(
-                                MFAMethodType.AUTH_APP, CODE, true, "not-base-32-encoded-secret"));
+                                MFAMethodType.AUTH_APP,
+                                CODE,
+                                JourneyType.REGISTRATION,
+                                "not-base-32-encoded-secret"));
 
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1041));

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuthAppStubTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuthAppStubTest.java
@@ -3,6 +3,7 @@ package uk.gov.di.authentication.sharedtest.helper;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
@@ -33,7 +34,7 @@ class AuthAppStubTest {
                         configurationService,
                         mock(DynamoService.class),
                         99999,
-                        false);
+                        JourneyType.SIGN_IN);
     }
 
     @Test

--- a/shared/src/main/java/uk/gov/di/authentication/entity/VerifyMfaCodeRequest.java
+++ b/shared/src/main/java/uk/gov/di/authentication/entity/VerifyMfaCodeRequest.java
@@ -2,6 +2,7 @@ package uk.gov.di.authentication.entity;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.validation.Required;
 
@@ -9,18 +10,18 @@ public class VerifyMfaCodeRequest extends CodeRequest {
 
     public VerifyMfaCodeRequest() {}
 
-    public VerifyMfaCodeRequest(MFAMethodType mfaMethodType, String code, boolean isRegistration) {
-        this(mfaMethodType, code, isRegistration, null);
+    public VerifyMfaCodeRequest(MFAMethodType mfaMethodType, String code, JourneyType journeyType) {
+        this(mfaMethodType, code, journeyType, null);
     }
 
     public VerifyMfaCodeRequest(
             MFAMethodType mfaMethodType,
             String code,
-            boolean isRegistration,
+            JourneyType journeyType,
             String profileInformation) {
         this.mfaMethodType = mfaMethodType;
         this.code = code;
-        this.isRegistration = isRegistration;
+        this.journeyType = journeyType;
         this.profileInformation = profileInformation;
     }
 
@@ -29,16 +30,16 @@ public class VerifyMfaCodeRequest extends CodeRequest {
     @Required
     private MFAMethodType mfaMethodType;
 
-    @SerializedName("isRegistration")
+    @SerializedName("journeyType")
     @Expose
     @Required
-    private boolean isRegistration;
+    private JourneyType journeyType;
 
     public MFAMethodType getMfaMethodType() {
         return mfaMethodType;
     }
 
-    public boolean isRegistration() {
-        return isRegistration;
+    public JourneyType getJourneyType() {
+        return journeyType;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/JourneyType.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/JourneyType.java
@@ -1,0 +1,17 @@
+package uk.gov.di.authentication.shared.entity;
+
+public enum JourneyType {
+    ACCOUNT_RECOVERY("ACCOUNT_RECOVERY"),
+    REGISTRATION("REGISTRATION"),
+    SIGN_IN("SIGN_IN");
+
+    private String value;
+
+    JourneyType(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/validation/AuthAppCodeValidator.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/validation/AuthAppCodeValidator.java
@@ -4,6 +4,7 @@ import org.apache.commons.codec.CodecPolicy;
 import org.apache.commons.codec.binary.Base32;
 import uk.gov.di.authentication.entity.CodeRequest;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.MFAMethod;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
@@ -26,7 +27,7 @@ public class AuthAppCodeValidator extends MfaCodeValidator {
     private final int allowedWindows;
     private final AuthenticationService dynamoService;
     private final String emailAddress;
-    private final boolean isRegistration;
+    private final JourneyType journeyType;
     private static final Base32 base32 = new Base32(0, null, false, (byte) '=', CodecPolicy.STRICT);
 
     public AuthAppCodeValidator(
@@ -35,17 +36,19 @@ public class AuthAppCodeValidator extends MfaCodeValidator {
             ConfigurationService configurationService,
             AuthenticationService dynamoService,
             int maxRetries,
-            boolean isRegistration) {
+            JourneyType journeyType) {
         super(emailAddress, codeStorageService, maxRetries);
         this.dynamoService = dynamoService;
         this.emailAddress = emailAddress;
         this.windowTime = configurationService.getAuthAppCodeWindowLength();
         this.allowedWindows = configurationService.getAuthAppCodeAllowedWindows();
-        this.isRegistration = isRegistration;
+        this.journeyType = journeyType;
     }
 
     @Override
     public Optional<ErrorResponse> validateCode(CodeRequest codeRequest) {
+        var isRegistration = journeyType.getValue().equals(JourneyType.REGISTRATION.getValue());
+
         if (isCodeBlockedForSession()) {
             LOG.info("Code blocked for session");
             return Optional.of(ErrorResponse.ERROR_1042);

--- a/shared/src/main/java/uk/gov/di/authentication/shared/validation/MfaCodeValidatorFactory.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/validation/MfaCodeValidatorFactory.java
@@ -1,5 +1,6 @@
 package uk.gov.di.authentication.shared.validation;
 
+import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
@@ -24,8 +25,8 @@ public class MfaCodeValidatorFactory {
     }
 
     public Optional<MfaCodeValidator> getMfaCodeValidator(
-            MFAMethodType mfaMethodType, boolean isRegistration, UserContext userContext) {
-
+            MFAMethodType mfaMethodType, JourneyType journeyType, UserContext userContext) {
+        var isRegistration = journeyType.getValue().equals(JourneyType.REGISTRATION.getValue());
         switch (mfaMethodType) {
             case AUTH_APP:
                 int codeMaxRetries =
@@ -39,14 +40,14 @@ public class MfaCodeValidatorFactory {
                                 configurationService,
                                 authenticationService,
                                 codeMaxRetries,
-                                isRegistration));
+                                journeyType));
             case SMS:
                 return Optional.of(
                         new PhoneNumberCodeValidator(
                                 codeStorageService,
                                 userContext,
                                 configurationService,
-                                isRegistration));
+                                journeyType));
             default:
                 return Optional.empty();
         }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/validation/PhoneNumberCodeValidator.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/validation/PhoneNumberCodeValidator.java
@@ -2,6 +2,7 @@ package uk.gov.di.authentication.shared.validation;
 
 import uk.gov.di.authentication.entity.CodeRequest;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.exceptions.ClientNotFoundException;
 import uk.gov.di.authentication.shared.helpers.ValidationHelper;
@@ -17,24 +18,25 @@ public class PhoneNumberCodeValidator extends MfaCodeValidator {
 
     private final ConfigurationService configurationService;
     private final UserContext userContext;
-    private final boolean isRegistration;
+    private final JourneyType journeyType;
 
     PhoneNumberCodeValidator(
             CodeStorageService codeStorageService,
             UserContext userContext,
             ConfigurationService configurationService,
-            boolean isRegistration) {
+            JourneyType journeyType) {
         super(
                 userContext.getSession().getEmailAddress(),
                 codeStorageService,
                 configurationService.getCodeMaxRetries());
         this.userContext = userContext;
         this.configurationService = configurationService;
-        this.isRegistration = isRegistration;
+        this.journeyType = journeyType;
     }
 
     @Override
     public Optional<ErrorResponse> validateCode(CodeRequest codeRequest) {
+        var isRegistration = journeyType.getValue().equals(JourneyType.REGISTRATION.getValue());
         if (!isRegistration) {
             LOG.error("Sign In Phone number codes are not supported");
             throw new RuntimeException("Sign In Phone number codes are not supported");

--- a/shared/src/test/java/uk/gov/di/authentication/shared/validation/MfaCodeValidatorFactoryTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/validation/MfaCodeValidatorFactoryTest.java
@@ -2,6 +2,7 @@ package uk.gov.di.authentication.shared.validation;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
@@ -37,7 +38,7 @@ class MfaCodeValidatorFactoryTest {
         when(userContext.getSession()).thenReturn(session);
         var mfaCodeValidator =
                 mfaCodeValidatorFactory.getMfaCodeValidator(
-                        MFAMethodType.AUTH_APP, true, userContext);
+                        MFAMethodType.AUTH_APP, JourneyType.REGISTRATION, userContext);
 
         assertInstanceOf(AuthAppCodeValidator.class, mfaCodeValidator.get());
     }
@@ -47,7 +48,8 @@ class MfaCodeValidatorFactoryTest {
         when(session.getEmailAddress()).thenReturn("test@test.com");
         when(userContext.getSession()).thenReturn(session);
         var mfaCodeValidator =
-                mfaCodeValidatorFactory.getMfaCodeValidator(MFAMethodType.SMS, true, userContext);
+                mfaCodeValidatorFactory.getMfaCodeValidator(
+                        MFAMethodType.SMS, JourneyType.REGISTRATION, userContext);
 
         assertInstanceOf(PhoneNumberCodeValidator.class, mfaCodeValidator.get());
     }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/validation/PhoneNumberCodeValidatorTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/validation/PhoneNumberCodeValidatorTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.entity.VerifyMfaCodeRequest;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.Session;
@@ -39,23 +40,29 @@ class PhoneNumberCodeValidatorTest {
 
     @Test
     void shouldReturnNoErrorForValidRegistrationPhoneNumberCode() {
-        setupPhoneNumberCode(true);
+        setupPhoneNumberCode(JourneyType.REGISTRATION);
 
         assertThat(
                 phoneNumberCodeValidator.validateCode(
                         new VerifyMfaCodeRequest(
-                                MFAMethodType.SMS, VALID_CODE, true, PHONE_NUMBER)),
+                                MFAMethodType.SMS,
+                                VALID_CODE,
+                                JourneyType.REGISTRATION,
+                                PHONE_NUMBER)),
                 equalTo(Optional.empty()));
     }
 
     @Test
     void shouldReturnErrorForInvalidRegistrationPhoneNumberCode() {
-        setupPhoneNumberCode(true);
+        setupPhoneNumberCode(JourneyType.REGISTRATION);
 
         assertThat(
                 phoneNumberCodeValidator.validateCode(
                         new VerifyMfaCodeRequest(
-                                MFAMethodType.SMS, INVALID_CODE, true, PHONE_NUMBER)),
+                                MFAMethodType.SMS,
+                                INVALID_CODE,
+                                JourneyType.REGISTRATION,
+                                PHONE_NUMBER)),
                 equalTo(Optional.of(ErrorResponse.ERROR_1037)));
     }
 
@@ -66,7 +73,10 @@ class PhoneNumberCodeValidatorTest {
         assertThat(
                 phoneNumberCodeValidator.validateCode(
                         new VerifyMfaCodeRequest(
-                                MFAMethodType.SMS, INVALID_CODE, true, PHONE_NUMBER)),
+                                MFAMethodType.SMS,
+                                INVALID_CODE,
+                                JourneyType.REGISTRATION,
+                                PHONE_NUMBER)),
                 equalTo(Optional.of(ErrorResponse.ERROR_1034)));
     }
 
@@ -77,13 +87,16 @@ class PhoneNumberCodeValidatorTest {
         assertThat(
                 phoneNumberCodeValidator.validateCode(
                         new VerifyMfaCodeRequest(
-                                MFAMethodType.SMS, INVALID_CODE, true, PHONE_NUMBER)),
+                                MFAMethodType.SMS,
+                                INVALID_CODE,
+                                JourneyType.REGISTRATION,
+                                PHONE_NUMBER)),
                 equalTo(Optional.of(ErrorResponse.ERROR_1034)));
     }
 
     @Test
     void shouldThrowExceptionForSignInPhoneNumberCode() {
-        setupPhoneNumberCode(false);
+        setupPhoneNumberCode(JourneyType.SIGN_IN);
 
         var expectedException =
                 assertThrows(
@@ -91,7 +104,10 @@ class PhoneNumberCodeValidatorTest {
                         () ->
                                 phoneNumberCodeValidator.validateCode(
                                         new VerifyMfaCodeRequest(
-                                                MFAMethodType.SMS, INVALID_CODE, true, null)),
+                                                MFAMethodType.SMS,
+                                                INVALID_CODE,
+                                                JourneyType.REGISTRATION,
+                                                null)),
                         "Expected to throw exception");
 
         assertThat(
@@ -99,7 +115,7 @@ class PhoneNumberCodeValidatorTest {
                 equalTo("Sign In Phone number codes are not supported"));
     }
 
-    public void setupPhoneNumberCode(boolean isRegistration) {
+    public void setupPhoneNumberCode(JourneyType journeyType) {
         when(session.getEmailAddress()).thenReturn(TEST_EMAIL_ADDRESS);
         when(userContext.getSession()).thenReturn(session);
         when(configurationService.isTestClientsEnabled()).thenReturn(false);
@@ -110,7 +126,7 @@ class PhoneNumberCodeValidatorTest {
                 .thenReturn(false);
         phoneNumberCodeValidator =
                 new PhoneNumberCodeValidator(
-                        codeStorageService, userContext, configurationService, isRegistration);
+                        codeStorageService, userContext, configurationService, journeyType);
     }
 
     public void setUpPhoneNumberCodeRetryLimitExceeded() {
@@ -125,7 +141,10 @@ class PhoneNumberCodeValidatorTest {
                 .thenReturn(false);
         phoneNumberCodeValidator =
                 new PhoneNumberCodeValidator(
-                        codeStorageService, userContext, configurationService, true);
+                        codeStorageService,
+                        userContext,
+                        configurationService,
+                        JourneyType.REGISTRATION);
     }
 
     public void setUpBlockedPhoneNumberCode() {
@@ -139,6 +158,9 @@ class PhoneNumberCodeValidatorTest {
                 .thenReturn(true);
         phoneNumberCodeValidator =
                 new PhoneNumberCodeValidator(
-                        codeStorageService, userContext, configurationService, true);
+                        codeStorageService,
+                        userContext,
+                        configurationService,
+                        JourneyType.REGISTRATION);
     }
 }


### PR DESCRIPTION
## What?

Part 1 of AUT-1242 introduces `JourneyType` parameter in the `VerifyMfaCodeRequest` object for journey type values of:
-  Registration
- Account Recovery
- Sign In

## Why?

- So that the VerifyMfaCode lambda is aware of what journey is being parsed in the request
- Break the work required for AUT-1242 into multiple PRs
