### PR TITLE
AUT-1218 - Give VerifyCode read and write access to account modifiers table

### DIFF
--- a/ci/terraform/oidc/verify_code.tf
+++ b/ci/terraform/oidc/verify_code.tf
@@ -11,6 +11,8 @@ module "frontend_api_verify_code_role" {
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.dynamo_account_recovery_block_delete_access_policy.arn,
     aws_iam_policy.dynamo_account_recovery_block_read_access_policy.arn,
+    aws_iam_policy.dynamo_account_modifiers_read_access_policy.arn,
+    aws_iam_policy.dynamo_account_modifiers_write_access_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
     module.oidc_txma_audit.access_policy_arn


### PR DESCRIPTION
## What?

- Give VerifyCode read and write access to account modifiers table

## Why?

- The account modifiers table will replace the account recovery block table


