### PR TITLE
Use for_each instead of count for creating aws_iam_role_policy_attachment resources

### DIFF
--- a/ci/terraform/modules/lambda-role/role.tf
+++ b/ci/terraform/modules/lambda-role/role.tf
@@ -25,9 +25,9 @@ data "aws_iam_policy_document" "lambda_can_assume_role" {
 }
 
 resource "aws_iam_role_policy_attachment" "provided_policies" {
-  count      = length(var.policies_to_attach)
+  for_each   = toset(var.policies_to_attach)
   role       = aws_iam_role.lambda_role.name
-  policy_arn = var.policies_to_attach[count.index]
+  policy_arn = each.key
 
   depends_on = [
     aws_iam_role.lambda_role


### PR DESCRIPTION
## What?

Use for_each instead of count for creating aws_iam_role_policy_attachment resources.

## Why?

Following the incident today, it is clear that using for_each over count will be more deterministic and won't break if the order of policies changes.
