### PR TITLE
AUT-1218 - Clear account modifiers block when user verifies their MFA SMS code

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/DynamoAccountModifiersService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/DynamoAccountModifiersService.java
@@ -39,13 +39,14 @@ public class DynamoAccountModifiersService {
                                         Objects.nonNull(t.getAccountRecovery())
                                                 ? t.withAccountRecovery(
                                                         t.getAccountRecovery()
-                                                                .withBlocked(true)
+                                                                .withBlocked(accountRecoveryBlock)
                                                                 .withUpdated(dateTime))
                                                 : t.withAccountRecovery(
                                                         new AccountRecovery()
                                                                 .withCreated(dateTime)
                                                                 .withUpdated(dateTime)
-                                                                .withBlocked(true)));
+                                                                .withBlocked(
+                                                                        accountRecoveryBlock)));
 
         var accountModifiers =
                 optionalAccountModifiers.orElse(
@@ -73,6 +74,12 @@ public class DynamoAccountModifiersService {
                 .map(AccountModifiers::getAccountRecovery)
                 .filter(AccountRecovery::isBlocked)
                 .isPresent();
+    }
+
+    public void removeAccountRecoveryBlockIfPresent(String internalCommonSubjectId) {
+        if (isAccountRecoveryBlockPresent(internalCommonSubjectId)) {
+            setAccountRecoveryBlock(internalCommonSubjectId, false);
+        }
     }
 
     private void warmUp() {

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
@@ -147,6 +147,15 @@ public class RedisExtension
                 3600);
     }
 
+    public void addInternalCommonSubjectIdToSession(
+            String sessionId, String internalCommonSubjectId) throws Json.JsonException {
+        var session =
+                objectMapper
+                        .readValue(redis.getValue(sessionId), Session.class)
+                        .setInternalCommonSubjectIdentifier(internalCommonSubjectId);
+        redis.saveWithExpiry(sessionId, objectMapper.writeValueAsString(session), 3600);
+    }
+
     public void addIDTokenToSession(String clientSessionId, String idTokenHint)
             throws Json.JsonException {
         ClientSession clientSession =


### PR DESCRIPTION
## What?

- Clear account modifiers block when user verifies their MFA SMS code

## Why?

- The account modifiers table is replacing the account recovery block table. Instead of clearing the account recovery block table when a MFA SMS OTP has been verified, we will set the account blocked to false if it exists for that user in the account modifiers table.

