### PR TITLE
BAU - Attach clientSessionId to SPOTResponseHandler

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/SpotResponseIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/queuehandlers/SpotResponseIntegrationTest.java
@@ -38,6 +38,7 @@ import static uk.gov.di.authentication.sharedtest.helper.IdentityTestData.PASSPO
 public class SpotResponseIntegrationTest extends HandlerIntegrationTest<SQSEvent, Object> {
 
     private static final String SESSION_ID = "a-session-id";
+    private static final String CLIENT_SESSION_ID = "a-client-session-id";
     private static final String PERSISTENT_SESSION_ID = "a-persistent-id";
     private static final ClientID CLIENT_ID = new ClientID();
     private static final String REQUEST_ID = "request-id";
@@ -64,10 +65,11 @@ public class SpotResponseIntegrationTest extends HandlerIntegrationTest<SQSEvent
         var spotResponse =
                 format(
                         "{\"sub\":\"%s\",\"status\":\"ACCEPTED\","
-                                + "\"claims\":{\"http://something/v1/verifiableIdentityJWT\":\"%s\"}, \"log_ids\":{\"session_id\":\"%s\",\"persistent_session_id\":\"%s\",\"request_id\":\"%s\",\"client_id\":\"%s\"}}",
+                                + "\"claims\":{\"http://something/v1/verifiableIdentityJWT\":\"%s\"}, \"log_ids\":{\"session_id\":\"%s\",\"client_session_id\":\"%s\",\"persistent_session_id\":\"%s\",\"request_id\":\"%s\",\"client_id\":\"%s\"}}",
                         pairwiseIdentifier,
                         signedCredential,
                         SESSION_ID,
+                        CLIENT_SESSION_ID,
                         PERSISTENT_SESSION_ID,
                         REQUEST_ID,
                         CLIENT_ID);
@@ -95,10 +97,11 @@ public class SpotResponseIntegrationTest extends HandlerIntegrationTest<SQSEvent
         var spotResponse =
                 format(
                         "{\"sub\":\"%s\",\"status\":\"ACCEPTED\","
-                                + "\"claims\":{\"http://something/v1/verifiableIdentityJWT\":\"%s\"}, \"log_ids\":{\"session_id\":\"%s\",\"persistent_session_id\":\"%s\",\"request_id\":\"%s\",\"client_id\":\"%s\"}}",
+                                + "\"claims\":{\"http://something/v1/verifiableIdentityJWT\":\"%s\"}, \"log_ids\":{\"session_id\":\"%s\",\"client_session_id\":\"%s\",\"persistent_session_id\":\"%s\",\"request_id\":\"%s\",\"client_id\":\"%s\"}}",
                         pairwiseIdentifier,
                         signedCredential,
                         SESSION_ID,
+                        CLIENT_SESSION_ID,
                         PERSISTENT_SESSION_ID,
                         REQUEST_ID,
                         CLIENT_ID);
@@ -123,9 +126,10 @@ public class SpotResponseIntegrationTest extends HandlerIntegrationTest<SQSEvent
         var spotResponse =
                 format(
                         "{\"sub\":\"%s\",\"status\":\"REJECTED\","
-                                + "\"log_ids\":{\"session_id\":\"%s\",\"persistent_session_id\":\"%s\",\"request_id\":\"%s\",\"client_id\":\"%s\"}}",
+                                + "\"log_ids\":{\"session_id\":\"%s\",\"client_session_id\":\"%s\",\"persistent_session_id\":\"%s\",\"request_id\":\"%s\",\"client_id\":\"%s\"}}",
                         pairwiseIdentifier,
                         SESSION_ID,
+                        CLIENT_SESSION_ID,
                         PERSISTENT_SESSION_ID,
                         REQUEST_ID,
                         CLIENT_ID);

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/SPOTResponseHandler.java
@@ -22,6 +22,8 @@ import uk.gov.di.authentication.shared.services.SerializationService;
 import java.util.NoSuchElementException;
 
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.CLIENT_ID;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.CLIENT_SESSION_ID;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.GOVUK_SIGNIN_JOURNEY_ID;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.PERSISTENT_SESSION_ID;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachLogFieldToLogs;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachSessionIdToLogs;
@@ -59,6 +61,10 @@ public class SPOTResponseHandler implements RequestHandler<SQSEvent, Object> {
                 attachLogFieldToLogs(
                         PERSISTENT_SESSION_ID, spotResponse.getLogIds().getPersistentSessionId());
                 attachLogFieldToLogs(CLIENT_ID, spotResponse.getLogIds().getClientId());
+                attachLogFieldToLogs(
+                        CLIENT_SESSION_ID, spotResponse.getLogIds().getClientSessionId());
+                attachLogFieldToLogs(
+                        GOVUK_SIGNIN_JOURNEY_ID, spotResponse.getLogIds().getClientSessionId());
 
                 if (spotResponse.getStatus().equals(SPOTStatus.ACCEPTED)) {
                     LOG.info(


### PR DESCRIPTION
## What?

- Attach clientSessionId to SPOTResponseHandler

## Why?

- So we have more visibility when debugging journeys
