### PR TITLE
AUT-1242: Add optional journey type parameter to VerifyMfaCode request

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -111,10 +111,12 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
             var session = userContext.getSession();
             var mfaMethodType = codeRequest.getMfaMethodType();
             var isRegistration = codeRequest.isRegistration();
+            var journeyType = codeRequest.getJourneyType();
 
             var mfaCodeValidator =
                     mfaCodeValidatorFactory
-                            .getMfaCodeValidator(mfaMethodType, isRegistration, userContext)
+                            .getMfaCodeValidator(
+                                    mfaMethodType, isRegistration, journeyType, userContext)
                             .orElse(null);
 
             if (Objects.isNull(mfaCodeValidator)) {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -25,6 +25,7 @@ import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.UserProfile;
@@ -169,7 +170,8 @@ class VerifyMfaCodeHandlerTest {
     @MethodSource("credentialTrustLevels")
     void shouldReturn204WhenSuccessfulAuthAppCodeRegistrationRequestAndSetMfaMethod(
             CredentialTrustLevel credentialTrustLevel) throws Json.JsonException {
-        when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), anyBoolean(), any()))
+        when(mfaCodeValidatorFactory.getMfaCodeValidator(
+                        any(), anyBoolean(), any(JourneyType.class), any()))
                 .thenReturn(Optional.of(authAppCodeValidator));
         when(authAppCodeValidator.validateCode(any(CodeRequest.class)))
                 .thenReturn(Optional.empty());
@@ -178,7 +180,11 @@ class VerifyMfaCodeHandlerTest {
         var result =
                 makeCallWithCode(
                         new VerifyMfaCodeRequest(
-                                MFAMethodType.AUTH_APP, CODE, true, AUTH_APP_SECRET));
+                                MFAMethodType.AUTH_APP,
+                                CODE,
+                                true,
+                                JourneyType.REGISTRATION,
+                                AUTH_APP_SECRET));
 
         assertThat(result, hasStatus(204));
         assertThat(session.getVerifiedMfaMethodType(), equalTo(MFAMethodType.AUTH_APP));
@@ -226,7 +232,8 @@ class VerifyMfaCodeHandlerTest {
     @MethodSource("credentialTrustLevels")
     void shouldReturn204WhenSuccessfulPhoneCodeRegistrationRequestAndSetPhoneNumber(
             CredentialTrustLevel credentialTrustLevel) throws Json.JsonException {
-        when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), anyBoolean(), any()))
+        when(mfaCodeValidatorFactory.getMfaCodeValidator(
+                        any(), anyBoolean(), any(JourneyType.class), any()))
                 .thenReturn(Optional.of(phoneNumberCodeValidator));
         when(phoneNumberCodeValidator.validateCode(any(CodeRequest.class)))
                 .thenReturn(Optional.empty());
@@ -234,7 +241,12 @@ class VerifyMfaCodeHandlerTest {
         session.setCurrentCredentialStrength(credentialTrustLevel);
         var result =
                 makeCallWithCode(
-                        new VerifyMfaCodeRequest(MFAMethodType.SMS, CODE, true, PHONE_NUMBER));
+                        new VerifyMfaCodeRequest(
+                                MFAMethodType.SMS,
+                                CODE,
+                                true,
+                                JourneyType.REGISTRATION,
+                                PHONE_NUMBER));
 
         assertThat(result, hasStatus(204));
         assertThat(session.getVerifiedMfaMethodType(), equalTo(MFAMethodType.SMS));
@@ -281,12 +293,14 @@ class VerifyMfaCodeHandlerTest {
 
     @Test
     void shouldReturn204WhenSuccessfulAuthAppCodeLoginRequest() throws Json.JsonException {
-        when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), anyBoolean(), any()))
+        when(mfaCodeValidatorFactory.getMfaCodeValidator(
+                        any(), anyBoolean(), any(JourneyType.class), any()))
                 .thenReturn(Optional.of(authAppCodeValidator));
         when(authAppCodeValidator.validateCode(any(CodeRequest.class)))
                 .thenReturn(Optional.empty());
         session.setNewAccount(Session.AccountState.EXISTING);
-        var codeRequest = new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, CODE, false);
+        var codeRequest =
+                new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, CODE, false, JourneyType.SIGN_IN);
         var result = makeCallWithCode(codeRequest);
 
         assertThat(result, hasStatus(204));
@@ -315,10 +329,16 @@ class VerifyMfaCodeHandlerTest {
 
     @Test
     void shouldReturn400IfMfaCodeValidatorCannotBeFound() throws Json.JsonException {
-        when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), anyBoolean(), any()))
+        when(mfaCodeValidatorFactory.getMfaCodeValidator(
+                        any(), anyBoolean(), any(JourneyType.class), any()))
                 .thenReturn(Optional.empty());
         var codeRequest =
-                new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, CODE, true, AUTH_APP_SECRET);
+                new VerifyMfaCodeRequest(
+                        MFAMethodType.AUTH_APP,
+                        CODE,
+                        true,
+                        JourneyType.REGISTRATION,
+                        AUTH_APP_SECRET);
         var result = makeCallWithCode(codeRequest);
 
         assertThat(result, hasStatus(400));
@@ -338,11 +358,13 @@ class VerifyMfaCodeHandlerTest {
     @Test
     void shouldReturn400AndBlockCodeWhenUserEnteredInvalidAuthAppCodeTooManyTimes()
             throws Json.JsonException {
-        when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), anyBoolean(), any()))
+        when(mfaCodeValidatorFactory.getMfaCodeValidator(
+                        any(), anyBoolean(), any(JourneyType.class), any()))
                 .thenReturn(Optional.of(authAppCodeValidator));
         when(authAppCodeValidator.validateCode(any(CodeRequest.class)))
                 .thenReturn(Optional.of(ErrorResponse.ERROR_1042));
-        var codeRequest = new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, CODE, false);
+        var codeRequest =
+                new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, CODE, false, JourneyType.SIGN_IN);
         var result = makeCallWithCode(codeRequest);
 
         assertThat(result, hasStatus(400));
@@ -371,13 +393,15 @@ class VerifyMfaCodeHandlerTest {
     @Test
     void shouldReturn400AndNotBlockCodeWhenUserEnteredInvalidAuthAppCodeAndBlockAlreadyExists()
             throws Json.JsonException {
-        when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), anyBoolean(), any()))
+        when(mfaCodeValidatorFactory.getMfaCodeValidator(
+                        any(), anyBoolean(), any(JourneyType.class), any()))
                 .thenReturn(Optional.of(authAppCodeValidator));
         when(authAppCodeValidator.validateCode(any(CodeRequest.class)))
                 .thenReturn(Optional.of(ErrorResponse.ERROR_1042));
         when(codeStorageService.isBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX))
                 .thenReturn(true);
-        var codeRequest = new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, CODE, false);
+        var codeRequest =
+                new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, CODE, false, JourneyType.SIGN_IN);
         var result = makeCallWithCode(codeRequest);
 
         assertThat(result, hasStatus(400));
@@ -406,13 +430,19 @@ class VerifyMfaCodeHandlerTest {
     @MethodSource("registration")
     void shouldReturn400WhenUserEnteredInvalidAuthAppCode(boolean registration)
             throws Json.JsonException {
-        when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), anyBoolean(), any()))
+        when(mfaCodeValidatorFactory.getMfaCodeValidator(
+                        any(), anyBoolean(), any(JourneyType.class), any()))
                 .thenReturn(Optional.of(authAppCodeValidator));
         var profileInformation = registration ? AUTH_APP_SECRET : null;
         when(authAppCodeValidator.validateCode(any(CodeRequest.class)))
                 .thenReturn(Optional.of(ErrorResponse.ERROR_1043));
         var codeRequest =
-                new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, CODE, false, profileInformation);
+                new VerifyMfaCodeRequest(
+                        MFAMethodType.AUTH_APP,
+                        CODE,
+                        false,
+                        JourneyType.SIGN_IN,
+                        profileInformation);
         var result = makeCallWithCode(codeRequest);
 
         assertThat(result, hasStatus(400));
@@ -441,11 +471,14 @@ class VerifyMfaCodeHandlerTest {
     void
             shouldReturn400AndBlockCodeWhenUserEnteredInvalidPhoneNumberCodeDuringRegistrationTooManyTimes()
                     throws Json.JsonException {
-        when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), anyBoolean(), any()))
+        when(mfaCodeValidatorFactory.getMfaCodeValidator(
+                        any(), anyBoolean(), any(JourneyType.class), any()))
                 .thenReturn(Optional.of(phoneNumberCodeValidator));
         when(phoneNumberCodeValidator.validateCode(any(CodeRequest.class)))
                 .thenReturn(Optional.of(ErrorResponse.ERROR_1034));
-        var codeRequest = new VerifyMfaCodeRequest(MFAMethodType.SMS, CODE, true, PHONE_NUMBER);
+        var codeRequest =
+                new VerifyMfaCodeRequest(
+                        MFAMethodType.SMS, CODE, true, JourneyType.REGISTRATION, PHONE_NUMBER);
         var result = makeCallWithCode(codeRequest);
 
         assertThat(result, hasStatus(400));
@@ -478,13 +511,16 @@ class VerifyMfaCodeHandlerTest {
     void
             shouldReturn400AndNotBlockCodeWhenInvalidPhoneNumberCodeEnteredDuringRegistrationAndBlockAlreadyExists()
                     throws Json.JsonException {
-        when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), anyBoolean(), any()))
+        when(mfaCodeValidatorFactory.getMfaCodeValidator(
+                        any(), anyBoolean(), any(JourneyType.class), any()))
                 .thenReturn(Optional.of(phoneNumberCodeValidator));
         when(phoneNumberCodeValidator.validateCode(any(CodeRequest.class)))
                 .thenReturn(Optional.of(ErrorResponse.ERROR_1034));
         when(codeStorageService.isBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX))
                 .thenReturn(true);
-        var codeRequest = new VerifyMfaCodeRequest(MFAMethodType.SMS, CODE, true, PHONE_NUMBER);
+        var codeRequest =
+                new VerifyMfaCodeRequest(
+                        MFAMethodType.SMS, CODE, true, JourneyType.REGISTRATION, PHONE_NUMBER);
         var result = makeCallWithCode(codeRequest);
 
         assertThat(result, hasStatus(400));
@@ -516,11 +552,14 @@ class VerifyMfaCodeHandlerTest {
     @Test
     void shouldReturn400WhenUserEnteredInvalidPhoneNumberCodeForRegistration()
             throws Json.JsonException {
-        when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), anyBoolean(), any()))
+        when(mfaCodeValidatorFactory.getMfaCodeValidator(
+                        any(), anyBoolean(), any(JourneyType.class), any()))
                 .thenReturn(Optional.of(phoneNumberCodeValidator));
         when(phoneNumberCodeValidator.validateCode(any(CodeRequest.class)))
                 .thenReturn(Optional.of(ErrorResponse.ERROR_1037));
-        var codeRequest = new VerifyMfaCodeRequest(MFAMethodType.SMS, CODE, true, PHONE_NUMBER);
+        var codeRequest =
+                new VerifyMfaCodeRequest(
+                        MFAMethodType.SMS, CODE, true, JourneyType.REGISTRATION, PHONE_NUMBER);
         var result = makeCallWithCode(codeRequest);
 
         assertThat(result, hasStatus(400));
@@ -551,7 +590,8 @@ class VerifyMfaCodeHandlerTest {
 
     @Test
     void shouldReturn400WhenAuthAppSecretIsInvalid() throws Json.JsonException {
-        when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), anyBoolean(), any()))
+        when(mfaCodeValidatorFactory.getMfaCodeValidator(
+                        any(), anyBoolean(), any(JourneyType.class), any()))
                 .thenReturn(Optional.of(authAppCodeValidator));
         when(authAppCodeValidator.validateCode(any(CodeRequest.class)))
                 .thenReturn(Optional.of(ErrorResponse.ERROR_1041));
@@ -560,7 +600,11 @@ class VerifyMfaCodeHandlerTest {
         var result =
                 makeCallWithCode(
                         new VerifyMfaCodeRequest(
-                                MFAMethodType.AUTH_APP, CODE, true, "not-base-32-encoded-secret"));
+                                MFAMethodType.AUTH_APP,
+                                CODE,
+                                true,
+                                JourneyType.REGISTRATION,
+                                "not-base-32-encoded-secret"));
 
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1041));

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
@@ -16,6 +16,7 @@ import uk.gov.di.authentication.entity.VerifyMfaCodeRequest;
 import uk.gov.di.authentication.frontendapi.lambda.VerifyMfaCodeHandler;
 import uk.gov.di.authentication.shared.domain.AuditableEvent;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
@@ -78,7 +79,8 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     void whenValidAuthAppOtpCodeReturn204WhenSigningIn() {
         setUpAuthAppRequest(false);
         var code = AUTH_APP_STUB.getAuthAppOneTimeCode(AUTH_APP_SECRET_BASE_32);
-        var codeRequest = new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, code, false);
+        var codeRequest =
+                new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, code, false, JourneyType.SIGN_IN);
 
         var response =
                 makeRequest(
@@ -97,7 +99,9 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     void shouldReturn204WhenSuccessfulAuthAppOtpCodeRegistrationRequestAndSetMfaMethod() {
         var secret = "JZ5PYIOWNZDAOBA65S5T77FEEKYCCIT2VE4RQDAJD7SO73T3LODA";
         var code = AUTH_APP_STUB.getAuthAppOneTimeCode(secret);
-        var codeRequest = new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, code, true, secret);
+        var codeRequest =
+                new VerifyMfaCodeRequest(
+                        MFAMethodType.AUTH_APP, code, true, JourneyType.REGISTRATION, secret);
         var response =
                 makeRequest(
                         Optional.of(codeRequest),
@@ -124,7 +128,9 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     void shouldReturn400WhenAuthAppSecretIsInvalid() {
         var secret = "not-base-32-encoded-secret";
         var code = AUTH_APP_STUB.getAuthAppOneTimeCode(secret);
-        var codeRequest = new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, code, true, secret);
+        var codeRequest =
+                new VerifyMfaCodeRequest(
+                        MFAMethodType.AUTH_APP, code, true, JourneyType.REGISTRATION, secret);
         var response =
                 makeRequest(
                         Optional.of(codeRequest),
@@ -148,7 +154,12 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 EMAIL_ADDRESS, MFAMethodType.AUTH_APP, true, false, currentAuthAppCredential);
         var code = AUTH_APP_STUB.getAuthAppOneTimeCode(newAuthAppCredential);
         var codeRequest =
-                new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, code, true, newAuthAppCredential);
+                new VerifyMfaCodeRequest(
+                        MFAMethodType.AUTH_APP,
+                        code,
+                        true,
+                        JourneyType.REGISTRATION,
+                        newAuthAppCredential);
         var response =
                 makeRequest(
                         Optional.of(codeRequest),
@@ -184,7 +195,11 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var code = AUTH_APP_STUB.getAuthAppOneTimeCode(AUTH_APP_SECRET_BASE_32);
         var codeRequest =
                 new VerifyMfaCodeRequest(
-                        MFAMethodType.AUTH_APP, code, isRegistrationRequest, profileInformation);
+                        MFAMethodType.AUTH_APP,
+                        code,
+                        isRegistrationRequest,
+                        JourneyType.SIGN_IN,
+                        profileInformation);
 
         var response =
                 makeRequest(
@@ -212,7 +227,11 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var code = AUTH_APP_STUB.getAuthAppOneTimeCode(AUTH_APP_SECRET_BASE_32, oneMinuteAgo);
         var codeRequest =
                 new VerifyMfaCodeRequest(
-                        MFAMethodType.AUTH_APP, code, isRegistrationRequest, profileInformation);
+                        MFAMethodType.AUTH_APP,
+                        code,
+                        isRegistrationRequest,
+                        JourneyType.SIGN_IN,
+                        profileInformation);
 
         var response =
                 makeRequest(
@@ -239,7 +258,11 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         String code = AUTH_APP_STUB.getAuthAppOneTimeCode(AUTH_APP_SECRET_BASE_32, tenMinutesAgo);
         VerifyMfaCodeRequest codeRequest =
                 new VerifyMfaCodeRequest(
-                        MFAMethodType.AUTH_APP, code, isRegistrationRequest, profileInformation);
+                        MFAMethodType.AUTH_APP,
+                        code,
+                        isRegistrationRequest,
+                        JourneyType.SIGN_IN,
+                        profileInformation);
 
         var response =
                 makeRequest(
@@ -259,6 +282,7 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     @MethodSource("verifyMfaCodeRequest")
     void whenWrongSecretUsedByAuthAppReturn400(
             boolean isRegistrationRequest, String profileInformation) {
+        var journeyType = isRegistrationRequest ? JourneyType.REGISTRATION : JourneyType.SIGN_IN;
         setUpAuthAppRequest(isRegistrationRequest);
         String invalidCode = AUTH_APP_STUB.getAuthAppOneTimeCode("O5ZG63THFVZWKY3SMV2A====");
         VerifyMfaCodeRequest codeRequest =
@@ -266,6 +290,7 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         MFAMethodType.AUTH_APP,
                         invalidCode,
                         isRegistrationRequest,
+                        journeyType,
                         profileInformation);
 
         var response =
@@ -309,7 +334,8 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 EMAIL_ADDRESS, MFAMethodType.AUTH_APP, true, false, AUTH_APP_SECRET_BASE_32);
         String code = AUTH_APP_STUB.getAuthAppOneTimeCode(AUTH_APP_SECRET_BASE_32);
         VerifyMfaCodeRequest codeRequest =
-                new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, code, true);
+                new VerifyMfaCodeRequest(
+                        MFAMethodType.AUTH_APP, code, true, JourneyType.REGISTRATION);
 
         var response =
                 makeRequest(
@@ -327,7 +353,8 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         userStore.addMfaMethod(
                 EMAIL_ADDRESS, MFAMethodType.AUTH_APP, true, true, AUTH_APP_SECRET_BASE_32);
         String code = AUTH_APP_STUB.getAuthAppOneTimeCode(AUTH_APP_SECRET_BASE_32);
-        VerifyMfaCodeRequest codeRequest = new VerifyMfaCodeRequest(null, code, true);
+        VerifyMfaCodeRequest codeRequest =
+                new VerifyMfaCodeRequest(null, code, true, JourneyType.REGISTRATION);
 
         var response =
                 makeRequest(
@@ -345,7 +372,8 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         setUpAuthAppRequest(isRegistrationRequest);
         String code = AUTH_APP_STUB.getAuthAppOneTimeCode(AUTH_APP_SECRET_BASE_32);
         VerifyMfaCodeRequest codeRequest =
-                new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, code, isRegistrationRequest);
+                new VerifyMfaCodeRequest(
+                        MFAMethodType.AUTH_APP, code, isRegistrationRequest, JourneyType.SIGN_IN);
 
         redis.blockMfaCodesForEmail(EMAIL_ADDRESS);
 
@@ -367,7 +395,8 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         setUpAuthAppRequest(false);
         String invalidCode = AUTH_APP_STUB.getAuthAppOneTimeCode("O5ZG63THFVZWKY3SMV2A====");
         VerifyMfaCodeRequest codeRequest =
-                new VerifyMfaCodeRequest(MFAMethodType.AUTH_APP, invalidCode, false);
+                new VerifyMfaCodeRequest(
+                        MFAMethodType.AUTH_APP, invalidCode, false, JourneyType.REGISTRATION);
 
         for (int i = 0; i < 5; i++) {
             redis.increaseMfaCodeAttemptsCount(EMAIL_ADDRESS, MFAMethodType.AUTH_APP);
@@ -398,7 +427,8 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         String invalidCode = "999999";
         VerifyMfaCodeRequest codeRequest =
-                new VerifyMfaCodeRequest(MFAMethodType.SMS, invalidCode, true);
+                new VerifyMfaCodeRequest(
+                        MFAMethodType.SMS, invalidCode, true, JourneyType.REGISTRATION);
 
         var response =
                 makeRequest(
@@ -415,7 +445,9 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     @Test
     void whenValidPhoneNumberOtpCodeForRegistrationReturn204AndUpdatePhoneNumber() {
         var code = redis.generateAndSavePhoneNumberCode(EMAIL_ADDRESS, 900);
-        var codeRequest = new VerifyMfaCodeRequest(MFAMethodType.SMS, code, true, PHONE_NUMBER);
+        var codeRequest =
+                new VerifyMfaCodeRequest(
+                        MFAMethodType.SMS, code, true, JourneyType.REGISTRATION, PHONE_NUMBER);
 
         var response =
                 makeRequest(
@@ -439,7 +471,9 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     void shouldReturn204WhenSuccessfulSMSRegistrationRequestAndOverwriteExistingPhoneNumber() {
         userStore.addVerifiedPhoneNumber(EMAIL_ADDRESS, "+447700900111");
         var code = redis.generateAndSavePhoneNumberCode(EMAIL_ADDRESS, 900);
-        var codeRequest = new VerifyMfaCodeRequest(MFAMethodType.SMS, code, true, PHONE_NUMBER);
+        var codeRequest =
+                new VerifyMfaCodeRequest(
+                        MFAMethodType.SMS, code, true, JourneyType.REGISTRATION, PHONE_NUMBER);
 
         var response =
                 makeRequest(
@@ -460,7 +494,9 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         userStore.addMfaMethod(
                 EMAIL_ADDRESS, MFAMethodType.AUTH_APP, false, true, AUTH_APP_SECRET_BASE_32);
         var code = redis.generateAndSavePhoneNumberCode(EMAIL_ADDRESS, 900);
-        var codeRequest = new VerifyMfaCodeRequest(MFAMethodType.SMS, code, true, PHONE_NUMBER);
+        var codeRequest =
+                new VerifyMfaCodeRequest(
+                        MFAMethodType.SMS, code, true, JourneyType.REGISTRATION, PHONE_NUMBER);
 
         var response =
                 makeRequest(
@@ -480,7 +516,8 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     @Test
     void whenInvalidPhoneNumberCodeHasExpiredForRegistrationReturn400() {
         var code = redis.generateAndSavePhoneNumberCode(EMAIL_ADDRESS, 1);
-        var codeRequest = new VerifyMfaCodeRequest(MFAMethodType.SMS, code, true);
+        var codeRequest =
+                new VerifyMfaCodeRequest(MFAMethodType.SMS, code, true, JourneyType.REGISTRATION);
 
         await().pollDelay(Duration.ofSeconds(2)).untilAsserted(() -> assertTrue(true));
 
@@ -497,7 +534,9 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @Test
     void whenInvalidPhoneNumberCodeForRegistrationReturn400() {
-        var codeRequest = new VerifyMfaCodeRequest(MFAMethodType.SMS, "123456", true);
+        var codeRequest =
+                new VerifyMfaCodeRequest(
+                        MFAMethodType.SMS, "123456", true, JourneyType.REGISTRATION);
 
         var response =
                 makeRequest(
@@ -515,7 +554,9 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         redis.addEmailToSession(sessionId, EMAIL_ADDRESS);
         redis.blockMfaCodesForEmail(EMAIL_ADDRESS);
 
-        var codeRequest = new VerifyMfaCodeRequest(MFAMethodType.SMS, "123456", true);
+        var codeRequest =
+                new VerifyMfaCodeRequest(
+                        MFAMethodType.SMS, "123456", true, JourneyType.REGISTRATION);
 
         var response =
                 makeRequest(
@@ -531,7 +572,9 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             throws Json.JsonException {
         redis.addEmailToSession(sessionId, EMAIL_ADDRESS);
 
-        var codeRequest = new VerifyMfaCodeRequest(MFAMethodType.SMS, "123456", true);
+        var codeRequest =
+                new VerifyMfaCodeRequest(
+                        MFAMethodType.SMS, "123456", true, JourneyType.REGISTRATION);
 
         for (int i = 0; i < 5; i++) {
             makeRequest(

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuthAppStubTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuthAppStubTest.java
@@ -3,6 +3,7 @@ package uk.gov.di.authentication.sharedtest.helper;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
@@ -33,7 +34,8 @@ class AuthAppStubTest {
                         configurationService,
                         mock(DynamoService.class),
                         99999,
-                        false);
+                        false,
+                        JourneyType.SIGN_IN);
     }
 
     @Test

--- a/shared/src/main/java/uk/gov/di/authentication/entity/VerifyMfaCodeRequest.java
+++ b/shared/src/main/java/uk/gov/di/authentication/entity/VerifyMfaCodeRequest.java
@@ -2,6 +2,7 @@ package uk.gov.di.authentication.entity;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.validation.Required;
 
@@ -9,18 +10,24 @@ public class VerifyMfaCodeRequest extends CodeRequest {
 
     public VerifyMfaCodeRequest() {}
 
-    public VerifyMfaCodeRequest(MFAMethodType mfaMethodType, String code, boolean isRegistration) {
-        this(mfaMethodType, code, isRegistration, null);
+    public VerifyMfaCodeRequest(
+            MFAMethodType mfaMethodType,
+            String code,
+            boolean isRegistration,
+            JourneyType journeyType) {
+        this(mfaMethodType, code, isRegistration, journeyType, null);
     }
 
     public VerifyMfaCodeRequest(
             MFAMethodType mfaMethodType,
             String code,
             boolean isRegistration,
+            JourneyType journeyType,
             String profileInformation) {
         this.mfaMethodType = mfaMethodType;
         this.code = code;
         this.isRegistration = isRegistration;
+        this.journeyType = journeyType;
         this.profileInformation = profileInformation;
     }
 
@@ -34,11 +41,19 @@ public class VerifyMfaCodeRequest extends CodeRequest {
     @Required
     private boolean isRegistration;
 
+    @SerializedName("journeyType")
+    @Expose
+    private JourneyType journeyType;
+
     public MFAMethodType getMfaMethodType() {
         return mfaMethodType;
     }
 
     public boolean isRegistration() {
         return isRegistration;
+    }
+
+    public JourneyType getJourneyType() {
+        return journeyType;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/JourneyType.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/JourneyType.java
@@ -1,0 +1,17 @@
+package uk.gov.di.authentication.shared.entity;
+
+public enum JourneyType {
+    ACCOUNT_RECOVERY("ACCOUNT_RECOVERY"),
+    REGISTRATION("REGISTRATION"),
+    SIGN_IN("SIGN_IN");
+
+    private String value;
+
+    JourneyType(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/validation/AuthAppCodeValidator.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/validation/AuthAppCodeValidator.java
@@ -4,6 +4,7 @@ import org.apache.commons.codec.CodecPolicy;
 import org.apache.commons.codec.binary.Base32;
 import uk.gov.di.authentication.entity.CodeRequest;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.MFAMethod;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
@@ -27,6 +28,7 @@ public class AuthAppCodeValidator extends MfaCodeValidator {
     private final AuthenticationService dynamoService;
     private final String emailAddress;
     private final boolean isRegistration;
+    private final JourneyType journeyType;
     private static final Base32 base32 = new Base32(0, null, false, (byte) '=', CodecPolicy.STRICT);
 
     public AuthAppCodeValidator(
@@ -35,13 +37,15 @@ public class AuthAppCodeValidator extends MfaCodeValidator {
             ConfigurationService configurationService,
             AuthenticationService dynamoService,
             int maxRetries,
-            boolean isRegistration) {
+            boolean isRegistration,
+            JourneyType journeyType) {
         super(emailAddress, codeStorageService, maxRetries);
         this.dynamoService = dynamoService;
         this.emailAddress = emailAddress;
         this.windowTime = configurationService.getAuthAppCodeWindowLength();
         this.allowedWindows = configurationService.getAuthAppCodeAllowedWindows();
         this.isRegistration = isRegistration;
+        this.journeyType = journeyType;
     }
 
     @Override

--- a/shared/src/main/java/uk/gov/di/authentication/shared/validation/MfaCodeValidatorFactory.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/validation/MfaCodeValidatorFactory.java
@@ -1,5 +1,6 @@
 package uk.gov.di.authentication.shared.validation;
 
+import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
@@ -24,7 +25,10 @@ public class MfaCodeValidatorFactory {
     }
 
     public Optional<MfaCodeValidator> getMfaCodeValidator(
-            MFAMethodType mfaMethodType, boolean isRegistration, UserContext userContext) {
+            MFAMethodType mfaMethodType,
+            boolean isRegistration,
+            JourneyType journeyType,
+            UserContext userContext) {
 
         switch (mfaMethodType) {
             case AUTH_APP:
@@ -39,14 +43,16 @@ public class MfaCodeValidatorFactory {
                                 configurationService,
                                 authenticationService,
                                 codeMaxRetries,
-                                isRegistration));
+                                isRegistration,
+                                journeyType));
             case SMS:
                 return Optional.of(
                         new PhoneNumberCodeValidator(
                                 codeStorageService,
                                 userContext,
                                 configurationService,
-                                isRegistration));
+                                isRegistration,
+                                journeyType));
             default:
                 return Optional.empty();
         }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/validation/PhoneNumberCodeValidator.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/validation/PhoneNumberCodeValidator.java
@@ -2,6 +2,7 @@ package uk.gov.di.authentication.shared.validation;
 
 import uk.gov.di.authentication.entity.CodeRequest;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.exceptions.ClientNotFoundException;
 import uk.gov.di.authentication.shared.helpers.ValidationHelper;
@@ -18,12 +19,14 @@ public class PhoneNumberCodeValidator extends MfaCodeValidator {
     private final ConfigurationService configurationService;
     private final UserContext userContext;
     private final boolean isRegistration;
+    private final JourneyType journeyType;
 
     PhoneNumberCodeValidator(
             CodeStorageService codeStorageService,
             UserContext userContext,
             ConfigurationService configurationService,
-            boolean isRegistration) {
+            boolean isRegistration,
+            JourneyType journeyType) {
         super(
                 userContext.getSession().getEmailAddress(),
                 codeStorageService,
@@ -31,6 +34,7 @@ public class PhoneNumberCodeValidator extends MfaCodeValidator {
         this.userContext = userContext;
         this.configurationService = configurationService;
         this.isRegistration = isRegistration;
+        this.journeyType = journeyType;
     }
 
     @Override

--- a/shared/src/test/java/uk/gov/di/authentication/shared/validation/MfaCodeValidatorFactoryTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/validation/MfaCodeValidatorFactoryTest.java
@@ -2,6 +2,7 @@ package uk.gov.di.authentication.shared.validation;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
@@ -37,7 +38,7 @@ class MfaCodeValidatorFactoryTest {
         when(userContext.getSession()).thenReturn(session);
         var mfaCodeValidator =
                 mfaCodeValidatorFactory.getMfaCodeValidator(
-                        MFAMethodType.AUTH_APP, true, userContext);
+                        MFAMethodType.AUTH_APP, true, JourneyType.REGISTRATION, userContext);
 
         assertInstanceOf(AuthAppCodeValidator.class, mfaCodeValidator.get());
     }
@@ -47,7 +48,8 @@ class MfaCodeValidatorFactoryTest {
         when(session.getEmailAddress()).thenReturn("test@test.com");
         when(userContext.getSession()).thenReturn(session);
         var mfaCodeValidator =
-                mfaCodeValidatorFactory.getMfaCodeValidator(MFAMethodType.SMS, true, userContext);
+                mfaCodeValidatorFactory.getMfaCodeValidator(
+                        MFAMethodType.SMS, true, JourneyType.REGISTRATION, userContext);
 
         assertInstanceOf(PhoneNumberCodeValidator.class, mfaCodeValidator.get());
     }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/validation/PhoneNumberCodeValidatorTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/validation/PhoneNumberCodeValidatorTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.entity.VerifyMfaCodeRequest;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.Session;
@@ -44,7 +45,11 @@ class PhoneNumberCodeValidatorTest {
         assertThat(
                 phoneNumberCodeValidator.validateCode(
                         new VerifyMfaCodeRequest(
-                                MFAMethodType.SMS, VALID_CODE, true, PHONE_NUMBER)),
+                                MFAMethodType.SMS,
+                                VALID_CODE,
+                                true,
+                                JourneyType.REGISTRATION,
+                                PHONE_NUMBER)),
                 equalTo(Optional.empty()));
     }
 
@@ -55,7 +60,11 @@ class PhoneNumberCodeValidatorTest {
         assertThat(
                 phoneNumberCodeValidator.validateCode(
                         new VerifyMfaCodeRequest(
-                                MFAMethodType.SMS, INVALID_CODE, true, PHONE_NUMBER)),
+                                MFAMethodType.SMS,
+                                INVALID_CODE,
+                                true,
+                                JourneyType.REGISTRATION,
+                                PHONE_NUMBER)),
                 equalTo(Optional.of(ErrorResponse.ERROR_1037)));
     }
 
@@ -66,7 +75,11 @@ class PhoneNumberCodeValidatorTest {
         assertThat(
                 phoneNumberCodeValidator.validateCode(
                         new VerifyMfaCodeRequest(
-                                MFAMethodType.SMS, INVALID_CODE, true, PHONE_NUMBER)),
+                                MFAMethodType.SMS,
+                                INVALID_CODE,
+                                true,
+                                JourneyType.REGISTRATION,
+                                PHONE_NUMBER)),
                 equalTo(Optional.of(ErrorResponse.ERROR_1034)));
     }
 
@@ -77,7 +90,11 @@ class PhoneNumberCodeValidatorTest {
         assertThat(
                 phoneNumberCodeValidator.validateCode(
                         new VerifyMfaCodeRequest(
-                                MFAMethodType.SMS, INVALID_CODE, true, PHONE_NUMBER)),
+                                MFAMethodType.SMS,
+                                INVALID_CODE,
+                                true,
+                                JourneyType.REGISTRATION,
+                                PHONE_NUMBER)),
                 equalTo(Optional.of(ErrorResponse.ERROR_1034)));
     }
 
@@ -110,7 +127,11 @@ class PhoneNumberCodeValidatorTest {
                 .thenReturn(false);
         phoneNumberCodeValidator =
                 new PhoneNumberCodeValidator(
-                        codeStorageService, userContext, configurationService, isRegistration);
+                        codeStorageService,
+                        userContext,
+                        configurationService,
+                        isRegistration,
+                        JourneyType.REGISTRATION);
     }
 
     public void setUpPhoneNumberCodeRetryLimitExceeded() {
@@ -125,7 +146,11 @@ class PhoneNumberCodeValidatorTest {
                 .thenReturn(false);
         phoneNumberCodeValidator =
                 new PhoneNumberCodeValidator(
-                        codeStorageService, userContext, configurationService, true);
+                        codeStorageService,
+                        userContext,
+                        configurationService,
+                        true,
+                        JourneyType.REGISTRATION);
     }
 
     public void setUpBlockedPhoneNumberCode() {
@@ -139,6 +164,10 @@ class PhoneNumberCodeValidatorTest {
                 .thenReturn(true);
         phoneNumberCodeValidator =
                 new PhoneNumberCodeValidator(
-                        codeStorageService, userContext, configurationService, true);
+                        codeStorageService,
+                        userContext,
+                        configurationService,
+                        true,
+                        JourneyType.REGISTRATION);
     }
 }


### PR DESCRIPTION
## What?

Part 1 of AUT-1242 introduces `JourneyType` parameter in the `VerifyMfaCodeRequest` object for journey type values of:
-  Registration
- Account Recovery
- Sign In

## Why?

- So that the VerifyMfaCode lambda is aware of what journey is being parsed in the request
- Break the work required for AUT-1242 into multiple PRs
