### PR TITLE
AUT-1180 - Add audit event for when account recovery block is added

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/domain/FrontendAuditableEvent.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/domain/FrontendAuditableEvent.java
@@ -41,7 +41,8 @@ public enum FrontendAuditableEvent implements AuditableEvent {
     ACCOUNT_RECOVERY_EMAIL_INVALID_CODE_REQUEST,
     ACCOUNT_RECOVERY_EMAIL_CODE_SENT_FOR_TEST_CLIENT,
     ACCOUNT_RECOVERY_PERMITTED,
-    ACCOUNT_RECOVERY_NOT_PERMITTED;
+    ACCOUNT_RECOVERY_NOT_PERMITTED,
+    ACCOUNT_RECOVERY_BLOCK_ADDED;
 
     public AuditableEvent parseFromName(String name) {
         return valueOf(name);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandlerTest.java
@@ -224,6 +224,17 @@ class ResetPasswordHandlerTest {
         verify(accountModifiersService).setAccountRecoveryBlock(expectedCommonSubject, true);
         verify(auditService)
                 .submitAuditEvent(
+                        FrontendAuditableEvent.ACCOUNT_RECOVERY_BLOCK_ADDED,
+                        CLIENT_SESSION_ID,
+                        session.getSessionId(),
+                        TEST_CLIENT_ID,
+                        expectedCommonSubject,
+                        EMAIL,
+                        "123.123.123.123",
+                        AuditService.UNKNOWN,
+                        PERSISTENT_ID);
+        verify(auditService)
+                .submitAuditEvent(
                         FrontendAuditableEvent.PASSWORD_RESET_SUCCESSFUL,
                         CLIENT_SESSION_ID,
                         session.getSessionId(),
@@ -427,6 +438,17 @@ class ResetPasswordHandlerTest {
                 .send(objectMapper.writeValueAsString(EXPECTED_EMAIL_NOTIFY_REQUEST));
         verify(sqsClient, never())
                 .send(objectMapper.writeValueAsString(EXPECTED_SMS_NOTIFY_REQUEST));
+        verify(auditService)
+                .submitAuditEvent(
+                        FrontendAuditableEvent.ACCOUNT_RECOVERY_BLOCK_ADDED,
+                        CLIENT_SESSION_ID,
+                        session.getSessionId(),
+                        TEST_CLIENT_ID,
+                        expectedCommonSubject,
+                        EMAIL,
+                        "123.123.123.123",
+                        AuditService.UNKNOWN,
+                        PERSISTENT_ID);
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.PASSWORD_RESET_SUCCESSFUL,


### PR DESCRIPTION
## What?

 - Add audit event for when account recovery block is added

## Why?

- When a user with a verified MFA method resets their password then a account recovery block will be added to the account modifiers table. Add an audit event for when this block is added

