### PR TITLE
AUT-1242 - Start using journeyType in VerifyMfaCodeRequest

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -115,8 +115,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
 
             var mfaCodeValidator =
                     mfaCodeValidatorFactory
-                            .getMfaCodeValidator(
-                                    mfaMethodType, isRegistration, journeyType, userContext)
+                            .getMfaCodeValidator(mfaMethodType, journeyType, userContext)
                             .orElse(null);
 
             if (Objects.isNull(mfaCodeValidator)) {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -170,8 +170,7 @@ class VerifyMfaCodeHandlerTest {
     @MethodSource("credentialTrustLevels")
     void shouldReturn204WhenSuccessfulAuthAppCodeRegistrationRequestAndSetMfaMethod(
             CredentialTrustLevel credentialTrustLevel) throws Json.JsonException {
-        when(mfaCodeValidatorFactory.getMfaCodeValidator(
-                        any(), anyBoolean(), any(JourneyType.class), any()))
+        when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), any(JourneyType.class), any()))
                 .thenReturn(Optional.of(authAppCodeValidator));
         when(authAppCodeValidator.validateCode(any(CodeRequest.class)))
                 .thenReturn(Optional.empty());
@@ -232,8 +231,7 @@ class VerifyMfaCodeHandlerTest {
     @MethodSource("credentialTrustLevels")
     void shouldReturn204WhenSuccessfulPhoneCodeRegistrationRequestAndSetPhoneNumber(
             CredentialTrustLevel credentialTrustLevel) throws Json.JsonException {
-        when(mfaCodeValidatorFactory.getMfaCodeValidator(
-                        any(), anyBoolean(), any(JourneyType.class), any()))
+        when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), any(JourneyType.class), any()))
                 .thenReturn(Optional.of(phoneNumberCodeValidator));
         when(phoneNumberCodeValidator.validateCode(any(CodeRequest.class)))
                 .thenReturn(Optional.empty());
@@ -293,8 +291,7 @@ class VerifyMfaCodeHandlerTest {
 
     @Test
     void shouldReturn204WhenSuccessfulAuthAppCodeLoginRequest() throws Json.JsonException {
-        when(mfaCodeValidatorFactory.getMfaCodeValidator(
-                        any(), anyBoolean(), any(JourneyType.class), any()))
+        when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), any(JourneyType.class), any()))
                 .thenReturn(Optional.of(authAppCodeValidator));
         when(authAppCodeValidator.validateCode(any(CodeRequest.class)))
                 .thenReturn(Optional.empty());
@@ -329,8 +326,7 @@ class VerifyMfaCodeHandlerTest {
 
     @Test
     void shouldReturn400IfMfaCodeValidatorCannotBeFound() throws Json.JsonException {
-        when(mfaCodeValidatorFactory.getMfaCodeValidator(
-                        any(), anyBoolean(), any(JourneyType.class), any()))
+        when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), any(JourneyType.class), any()))
                 .thenReturn(Optional.empty());
         var codeRequest =
                 new VerifyMfaCodeRequest(
@@ -358,8 +354,7 @@ class VerifyMfaCodeHandlerTest {
     @Test
     void shouldReturn400AndBlockCodeWhenUserEnteredInvalidAuthAppCodeTooManyTimes()
             throws Json.JsonException {
-        when(mfaCodeValidatorFactory.getMfaCodeValidator(
-                        any(), anyBoolean(), any(JourneyType.class), any()))
+        when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), any(JourneyType.class), any()))
                 .thenReturn(Optional.of(authAppCodeValidator));
         when(authAppCodeValidator.validateCode(any(CodeRequest.class)))
                 .thenReturn(Optional.of(ErrorResponse.ERROR_1042));
@@ -393,8 +388,7 @@ class VerifyMfaCodeHandlerTest {
     @Test
     void shouldReturn400AndNotBlockCodeWhenUserEnteredInvalidAuthAppCodeAndBlockAlreadyExists()
             throws Json.JsonException {
-        when(mfaCodeValidatorFactory.getMfaCodeValidator(
-                        any(), anyBoolean(), any(JourneyType.class), any()))
+        when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), any(JourneyType.class), any()))
                 .thenReturn(Optional.of(authAppCodeValidator));
         when(authAppCodeValidator.validateCode(any(CodeRequest.class)))
                 .thenReturn(Optional.of(ErrorResponse.ERROR_1042));
@@ -430,8 +424,7 @@ class VerifyMfaCodeHandlerTest {
     @MethodSource("registration")
     void shouldReturn400WhenUserEnteredInvalidAuthAppCode(boolean registration)
             throws Json.JsonException {
-        when(mfaCodeValidatorFactory.getMfaCodeValidator(
-                        any(), anyBoolean(), any(JourneyType.class), any()))
+        when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), any(JourneyType.class), any()))
                 .thenReturn(Optional.of(authAppCodeValidator));
         var profileInformation = registration ? AUTH_APP_SECRET : null;
         when(authAppCodeValidator.validateCode(any(CodeRequest.class)))
@@ -471,8 +464,7 @@ class VerifyMfaCodeHandlerTest {
     void
             shouldReturn400AndBlockCodeWhenUserEnteredInvalidPhoneNumberCodeDuringRegistrationTooManyTimes()
                     throws Json.JsonException {
-        when(mfaCodeValidatorFactory.getMfaCodeValidator(
-                        any(), anyBoolean(), any(JourneyType.class), any()))
+        when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), any(JourneyType.class), any()))
                 .thenReturn(Optional.of(phoneNumberCodeValidator));
         when(phoneNumberCodeValidator.validateCode(any(CodeRequest.class)))
                 .thenReturn(Optional.of(ErrorResponse.ERROR_1034));
@@ -511,8 +503,7 @@ class VerifyMfaCodeHandlerTest {
     void
             shouldReturn400AndNotBlockCodeWhenInvalidPhoneNumberCodeEnteredDuringRegistrationAndBlockAlreadyExists()
                     throws Json.JsonException {
-        when(mfaCodeValidatorFactory.getMfaCodeValidator(
-                        any(), anyBoolean(), any(JourneyType.class), any()))
+        when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), any(JourneyType.class), any()))
                 .thenReturn(Optional.of(phoneNumberCodeValidator));
         when(phoneNumberCodeValidator.validateCode(any(CodeRequest.class)))
                 .thenReturn(Optional.of(ErrorResponse.ERROR_1034));
@@ -552,8 +543,7 @@ class VerifyMfaCodeHandlerTest {
     @Test
     void shouldReturn400WhenUserEnteredInvalidPhoneNumberCodeForRegistration()
             throws Json.JsonException {
-        when(mfaCodeValidatorFactory.getMfaCodeValidator(
-                        any(), anyBoolean(), any(JourneyType.class), any()))
+        when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), any(JourneyType.class), any()))
                 .thenReturn(Optional.of(phoneNumberCodeValidator));
         when(phoneNumberCodeValidator.validateCode(any(CodeRequest.class)))
                 .thenReturn(Optional.of(ErrorResponse.ERROR_1037));
@@ -590,8 +580,7 @@ class VerifyMfaCodeHandlerTest {
 
     @Test
     void shouldReturn400WhenAuthAppSecretIsInvalid() throws Json.JsonException {
-        when(mfaCodeValidatorFactory.getMfaCodeValidator(
-                        any(), anyBoolean(), any(JourneyType.class), any()))
+        when(mfaCodeValidatorFactory.getMfaCodeValidator(any(), any(JourneyType.class), any()))
                 .thenReturn(Optional.of(authAppCodeValidator));
         when(authAppCodeValidator.validateCode(any(CodeRequest.class)))
                 .thenReturn(Optional.of(ErrorResponse.ERROR_1041));

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuthAppStubTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuthAppStubTest.java
@@ -34,7 +34,6 @@ class AuthAppStubTest {
                         configurationService,
                         mock(DynamoService.class),
                         99999,
-                        false,
                         JourneyType.SIGN_IN);
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/entity/VerifyMfaCodeRequest.java
+++ b/shared/src/main/java/uk/gov/di/authentication/entity/VerifyMfaCodeRequest.java
@@ -38,11 +38,11 @@ public class VerifyMfaCodeRequest extends CodeRequest {
 
     @SerializedName("isRegistration")
     @Expose
-    @Required
     private boolean isRegistration;
 
     @SerializedName("journeyType")
     @Expose
+    @Required
     private JourneyType journeyType;
 
     public MFAMethodType getMfaMethodType() {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/validation/MfaCodeValidatorFactory.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/validation/MfaCodeValidatorFactory.java
@@ -25,15 +25,12 @@ public class MfaCodeValidatorFactory {
     }
 
     public Optional<MfaCodeValidator> getMfaCodeValidator(
-            MFAMethodType mfaMethodType,
-            boolean isRegistration,
-            JourneyType journeyType,
-            UserContext userContext) {
+            MFAMethodType mfaMethodType, JourneyType journeyType, UserContext userContext) {
 
         switch (mfaMethodType) {
             case AUTH_APP:
                 int codeMaxRetries =
-                        isRegistration
+                        journeyType.equals(JourneyType.REGISTRATION)
                                 ? configurationService.getCodeMaxRetriesRegistration()
                                 : configurationService.getCodeMaxRetries();
                 return Optional.of(
@@ -43,7 +40,6 @@ public class MfaCodeValidatorFactory {
                                 configurationService,
                                 authenticationService,
                                 codeMaxRetries,
-                                isRegistration,
                                 journeyType));
             case SMS:
                 return Optional.of(
@@ -51,7 +47,6 @@ public class MfaCodeValidatorFactory {
                                 codeStorageService,
                                 userContext,
                                 configurationService,
-                                isRegistration,
                                 journeyType));
             default:
                 return Optional.empty();

--- a/shared/src/main/java/uk/gov/di/authentication/shared/validation/PhoneNumberCodeValidator.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/validation/PhoneNumberCodeValidator.java
@@ -18,14 +18,12 @@ public class PhoneNumberCodeValidator extends MfaCodeValidator {
 
     private final ConfigurationService configurationService;
     private final UserContext userContext;
-    private final boolean isRegistration;
     private final JourneyType journeyType;
 
     PhoneNumberCodeValidator(
             CodeStorageService codeStorageService,
             UserContext userContext,
             ConfigurationService configurationService,
-            boolean isRegistration,
             JourneyType journeyType) {
         super(
                 userContext.getSession().getEmailAddress(),
@@ -33,18 +31,19 @@ public class PhoneNumberCodeValidator extends MfaCodeValidator {
                 configurationService.getCodeMaxRetries());
         this.userContext = userContext;
         this.configurationService = configurationService;
-        this.isRegistration = isRegistration;
         this.journeyType = journeyType;
     }
 
     @Override
     public Optional<ErrorResponse> validateCode(CodeRequest codeRequest) {
-        if (!isRegistration) {
+        if (journeyType.equals(JourneyType.SIGN_IN)) {
             LOG.error("Sign In Phone number codes are not supported");
             throw new RuntimeException("Sign In Phone number codes are not supported");
         }
         var notificationType =
-                isRegistration ? NotificationType.VERIFY_PHONE_NUMBER : NotificationType.MFA_SMS;
+                journeyType.equals(JourneyType.REGISTRATION)
+                        ? NotificationType.VERIFY_PHONE_NUMBER
+                        : NotificationType.MFA_SMS;
         if (isCodeBlockedForSession()) {
             LOG.info("Code blocked for session");
             return Optional.of(ErrorResponse.ERROR_1034);

--- a/shared/src/test/java/uk/gov/di/authentication/shared/validation/AuthAppCodeValidatorTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/validation/AuthAppCodeValidatorTest.java
@@ -183,7 +183,6 @@ class AuthAppCodeValidatorTest {
                         mockConfigurationService,
                         mockDynamoService,
                         MAX_RETRIES,
-                        isRegistration,
                         journeyType);
     }
 
@@ -203,7 +202,6 @@ class AuthAppCodeValidatorTest {
                         mockConfigurationService,
                         mockDynamoService,
                         MAX_RETRIES,
-                        isRegistration,
                         journeyType);
     }
 
@@ -222,7 +220,6 @@ class AuthAppCodeValidatorTest {
                         mockConfigurationService,
                         mockDynamoService,
                         MAX_RETRIES,
-                        isRegistration,
                         journeyType);
     }
 
@@ -253,7 +250,6 @@ class AuthAppCodeValidatorTest {
                         mockConfigurationService,
                         mockDynamoService,
                         MAX_RETRIES,
-                        isRegistration,
                         journeyType);
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/validation/MfaCodeValidatorFactoryTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/validation/MfaCodeValidatorFactoryTest.java
@@ -38,7 +38,7 @@ class MfaCodeValidatorFactoryTest {
         when(userContext.getSession()).thenReturn(session);
         var mfaCodeValidator =
                 mfaCodeValidatorFactory.getMfaCodeValidator(
-                        MFAMethodType.AUTH_APP, true, JourneyType.REGISTRATION, userContext);
+                        MFAMethodType.AUTH_APP, JourneyType.REGISTRATION, userContext);
 
         assertInstanceOf(AuthAppCodeValidator.class, mfaCodeValidator.get());
     }
@@ -49,7 +49,7 @@ class MfaCodeValidatorFactoryTest {
         when(userContext.getSession()).thenReturn(session);
         var mfaCodeValidator =
                 mfaCodeValidatorFactory.getMfaCodeValidator(
-                        MFAMethodType.SMS, true, JourneyType.REGISTRATION, userContext);
+                        MFAMethodType.SMS, JourneyType.REGISTRATION, userContext);
 
         assertInstanceOf(PhoneNumberCodeValidator.class, mfaCodeValidator.get());
     }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/validation/PhoneNumberCodeValidatorTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/validation/PhoneNumberCodeValidatorTest.java
@@ -40,7 +40,7 @@ class PhoneNumberCodeValidatorTest {
 
     @Test
     void shouldReturnNoErrorForValidRegistrationPhoneNumberCode() {
-        setupPhoneNumberCode(true);
+        setupPhoneNumberCode(JourneyType.REGISTRATION);
 
         assertThat(
                 phoneNumberCodeValidator.validateCode(
@@ -55,7 +55,7 @@ class PhoneNumberCodeValidatorTest {
 
     @Test
     void shouldReturnErrorForInvalidRegistrationPhoneNumberCode() {
-        setupPhoneNumberCode(true);
+        setupPhoneNumberCode(JourneyType.REGISTRATION);
 
         assertThat(
                 phoneNumberCodeValidator.validateCode(
@@ -100,7 +100,7 @@ class PhoneNumberCodeValidatorTest {
 
     @Test
     void shouldThrowExceptionForSignInPhoneNumberCode() {
-        setupPhoneNumberCode(false);
+        setupPhoneNumberCode(JourneyType.SIGN_IN);
 
         var expectedException =
                 assertThrows(
@@ -108,7 +108,10 @@ class PhoneNumberCodeValidatorTest {
                         () ->
                                 phoneNumberCodeValidator.validateCode(
                                         new VerifyMfaCodeRequest(
-                                                MFAMethodType.SMS, INVALID_CODE, true, null)),
+                                                MFAMethodType.SMS,
+                                                INVALID_CODE,
+                                                true,
+                                                JourneyType.SIGN_IN)),
                         "Expected to throw exception");
 
         assertThat(
@@ -116,7 +119,7 @@ class PhoneNumberCodeValidatorTest {
                 equalTo("Sign In Phone number codes are not supported"));
     }
 
-    public void setupPhoneNumberCode(boolean isRegistration) {
+    public void setupPhoneNumberCode(JourneyType journeyType) {
         when(session.getEmailAddress()).thenReturn(TEST_EMAIL_ADDRESS);
         when(userContext.getSession()).thenReturn(session);
         when(configurationService.isTestClientsEnabled()).thenReturn(false);
@@ -127,11 +130,7 @@ class PhoneNumberCodeValidatorTest {
                 .thenReturn(false);
         phoneNumberCodeValidator =
                 new PhoneNumberCodeValidator(
-                        codeStorageService,
-                        userContext,
-                        configurationService,
-                        isRegistration,
-                        JourneyType.REGISTRATION);
+                        codeStorageService, userContext, configurationService, journeyType);
     }
 
     public void setUpPhoneNumberCodeRetryLimitExceeded() {
@@ -149,7 +148,6 @@ class PhoneNumberCodeValidatorTest {
                         codeStorageService,
                         userContext,
                         configurationService,
-                        true,
                         JourneyType.REGISTRATION);
     }
 
@@ -167,7 +165,6 @@ class PhoneNumberCodeValidatorTest {
                         codeStorageService,
                         userContext,
                         configurationService,
-                        true,
                         JourneyType.REGISTRATION);
     }
 }


### PR DESCRIPTION
## What?

- Stop using the isRegistration and start using the JourneyType in the VerifyMfaCodeHandler
- Once the isRegistration stops being sent we can remove it completely
- Make JourneyType mandatory and isRegistration optional

## Why?

- The JourneyType will support account recovery, registration and sign in so we no longer need the isRegistration attribute in the request
