### PR TITLE
AUT-1242 - Rename code validator classes to code processor

### DIFF
--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuthAppStubTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuthAppStubTest.java
@@ -7,7 +7,7 @@ import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
-import uk.gov.di.authentication.shared.validation.AuthAppCodeValidator;
+import uk.gov.di.authentication.shared.validation.AuthAppCodeProcessor;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -15,7 +15,7 @@ import static org.mockito.Mockito.when;
 
 class AuthAppStubTest {
     private AuthAppStub authAppStub;
-    private AuthAppCodeValidator authAppCodeValidator;
+    private AuthAppCodeProcessor authAppCodeProcessor;
     private static ConfigurationService configurationService;
 
     @BeforeAll
@@ -27,8 +27,8 @@ class AuthAppStubTest {
     @BeforeEach
     void setUp() {
         this.authAppStub = new AuthAppStub();
-        this.authAppCodeValidator =
-                new AuthAppCodeValidator(
+        this.authAppCodeProcessor =
+                new AuthAppCodeProcessor(
                         "test-email@test.com",
                         mock(CodeStorageService.class),
                         configurationService,
@@ -38,13 +38,13 @@ class AuthAppStubTest {
     }
 
     @Test
-    void worksWithAuthAppCodeValidatorAlgorithm() {
+    void worksWithAuthAppCodeProcessorAlgorithm() {
         String generatedCode =
                 authAppStub.getAuthAppOneTimeCode(
                         "ABCDAAWOXKUQCDH5QMSPHAGJXMTXFZRZAKFTR6Y3Q5YRN5EVOYRQ");
 
         assertTrue(
-                authAppCodeValidator.isCodeValid(
+                authAppCodeProcessor.isCodeValid(
                         generatedCode, "ABCDAAWOXKUQCDH5QMSPHAGJXMTXFZRZAKFTR6Y3Q5YRN5EVOYRQ"));
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/JwksService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/JwksService.java
@@ -47,14 +47,17 @@ public class JwksService {
     }
 
     public JWK getPublicTokenJwkWithOpaqueId() {
+        LOG.info("Retrieving EC public key");
         return getPublicJWKWithKeyId(configurationService.getTokenSigningKeyAlias());
     }
 
     public JWK getPublicTokenRsaJwkWithOpaqueId() {
+        LOG.info("Retrieving RSA public key");
         return getPublicJWKWithKeyId(configurationService.getTokenSigningKeyRsaAlias());
     }
 
     public JWK getPublicDocAppSigningJwkWithOpaqueId() {
+        LOG.info("Retrieving Doc App public key");
         return getPublicJWKWithKeyId(configurationService.getDocAppTokenSigningKeyAlias());
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/validation/AuthAppCodeProcessor.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/validation/AuthAppCodeProcessor.java
@@ -21,7 +21,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
-public class AuthAppCodeValidator extends MfaCodeValidator {
+public class AuthAppCodeProcessor extends MfaCodeProcessor {
 
     private final int windowTime;
     private final int allowedWindows;
@@ -30,7 +30,7 @@ public class AuthAppCodeValidator extends MfaCodeValidator {
     private final JourneyType journeyType;
     private static final Base32 base32 = new Base32(0, null, false, (byte) '=', CodecPolicy.STRICT);
 
-    public AuthAppCodeValidator(
+    public AuthAppCodeProcessor(
             String emailAddress,
             CodeStorageService codeStorageService,
             ConfigurationService configurationService,

--- a/shared/src/main/java/uk/gov/di/authentication/shared/validation/MfaCodeProcessor.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/validation/MfaCodeProcessor.java
@@ -11,13 +11,13 @@ import java.util.Optional;
 
 import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_BLOCKED_KEY_PREFIX;
 
-public abstract class MfaCodeValidator {
+public abstract class MfaCodeProcessor {
     protected final Logger LOG = LogManager.getLogger(this.getClass());
     public final CodeStorageService codeStorageService;
     private final int maxRetries;
     public final String emailAddress;
 
-    MfaCodeValidator(String emailAddress, CodeStorageService codeStorageService, int maxRetries) {
+    MfaCodeProcessor(String emailAddress, CodeStorageService codeStorageService, int maxRetries) {
         this.emailAddress = emailAddress;
         this.codeStorageService = codeStorageService;
         this.maxRetries = maxRetries;

--- a/shared/src/main/java/uk/gov/di/authentication/shared/validation/MfaCodeProcessorFactory.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/validation/MfaCodeProcessorFactory.java
@@ -9,13 +9,13 @@ import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.util.Optional;
 
-public class MfaCodeValidatorFactory {
+public class MfaCodeProcessorFactory {
 
     private final ConfigurationService configurationService;
     private final CodeStorageService codeStorageService;
     private final AuthenticationService authenticationService;
 
-    public MfaCodeValidatorFactory(
+    public MfaCodeProcessorFactory(
             ConfigurationService configurationService,
             CodeStorageService codeStorageService,
             AuthenticationService authenticationService) {
@@ -24,7 +24,7 @@ public class MfaCodeValidatorFactory {
         this.authenticationService = authenticationService;
     }
 
-    public Optional<MfaCodeValidator> getMfaCodeValidator(
+    public Optional<MfaCodeProcessor> getMfaCodeProcessor(
             MFAMethodType mfaMethodType, JourneyType journeyType, UserContext userContext) {
 
         switch (mfaMethodType) {
@@ -34,7 +34,7 @@ public class MfaCodeValidatorFactory {
                                 ? configurationService.getCodeMaxRetriesRegistration()
                                 : configurationService.getCodeMaxRetries();
                 return Optional.of(
-                        new AuthAppCodeValidator(
+                        new AuthAppCodeProcessor(
                                 userContext.getSession().getEmailAddress(),
                                 codeStorageService,
                                 configurationService,
@@ -43,7 +43,7 @@ public class MfaCodeValidatorFactory {
                                 journeyType));
             case SMS:
                 return Optional.of(
-                        new PhoneNumberCodeValidator(
+                        new PhoneNumberCodeProcessor(
                                 codeStorageService,
                                 userContext,
                                 configurationService,

--- a/shared/src/main/java/uk/gov/di/authentication/shared/validation/PhoneNumberCodeProcessor.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/validation/PhoneNumberCodeProcessor.java
@@ -14,13 +14,13 @@ import java.util.Optional;
 
 import static uk.gov.di.authentication.shared.helpers.TestClientHelper.isTestClientWithAllowedEmail;
 
-public class PhoneNumberCodeValidator extends MfaCodeValidator {
+public class PhoneNumberCodeProcessor extends MfaCodeProcessor {
 
     private final ConfigurationService configurationService;
     private final UserContext userContext;
     private final JourneyType journeyType;
 
-    PhoneNumberCodeValidator(
+    PhoneNumberCodeProcessor(
             CodeStorageService codeStorageService,
             UserContext userContext,
             ConfigurationService configurationService,

--- a/shared/src/test/java/uk/gov/di/authentication/shared/validation/AuthAppCodeProcessorTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/validation/AuthAppCodeProcessorTest.java
@@ -30,8 +30,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_BLOCKED_KEY_PREFIX;
 
-class AuthAppCodeValidatorTest {
-    AuthAppCodeValidator authAppCodeValidator;
+class AuthAppCodeProcessorTest {
+    AuthAppCodeProcessor authAppCodeProcessor;
     Session mockSession;
     CodeStorageService mockCodeStorageService;
     ConfigurationService mockConfigurationService;
@@ -63,7 +63,7 @@ class AuthAppCodeValidatorTest {
 
         assertEquals(
                 Optional.empty(),
-                authAppCodeValidator.validateCode(
+                authAppCodeProcessor.validateCode(
                         new VerifyMfaCodeRequest(
                                 MFAMethodType.AUTH_APP,
                                 authCode,
@@ -80,7 +80,7 @@ class AuthAppCodeValidatorTest {
 
         assertEquals(
                 Optional.of(ErrorResponse.ERROR_1042),
-                authAppCodeValidator.validateCode(
+                authAppCodeProcessor.validateCode(
                         new VerifyMfaCodeRequest(
                                 MFAMethodType.AUTH_APP,
                                 "000000",
@@ -96,7 +96,7 @@ class AuthAppCodeValidatorTest {
 
         assertEquals(
                 Optional.of(ErrorResponse.ERROR_1042),
-                authAppCodeValidator.validateCode(
+                authAppCodeProcessor.validateCode(
                         new VerifyMfaCodeRequest(
                                 MFAMethodType.AUTH_APP,
                                 "000000",
@@ -112,7 +112,7 @@ class AuthAppCodeValidatorTest {
 
         assertEquals(
                 Optional.of(ErrorResponse.ERROR_1043),
-                authAppCodeValidator.validateCode(
+                authAppCodeProcessor.validateCode(
                         new VerifyMfaCodeRequest(
                                 MFAMethodType.AUTH_APP,
                                 "000000",
@@ -125,7 +125,7 @@ class AuthAppCodeValidatorTest {
         setUpValidAuthCode(true);
 
         assertThat(
-                authAppCodeValidator.validateCode(
+                authAppCodeProcessor.validateCode(
                         new VerifyMfaCodeRequest(
                                 MFAMethodType.AUTH_APP,
                                 "000000",
@@ -142,7 +142,7 @@ class AuthAppCodeValidatorTest {
 
         assertEquals(
                 Optional.of(ErrorResponse.ERROR_1043),
-                authAppCodeValidator.validateCode(
+                authAppCodeProcessor.validateCode(
                         new VerifyMfaCodeRequest(
                                 MFAMethodType.AUTH_APP,
                                 "111111",
@@ -151,7 +151,7 @@ class AuthAppCodeValidatorTest {
                                 authAppSecret)));
         assertEquals(
                 Optional.of(ErrorResponse.ERROR_1043),
-                authAppCodeValidator.validateCode(
+                authAppCodeProcessor.validateCode(
                         new VerifyMfaCodeRequest(
                                 MFAMethodType.AUTH_APP,
                                 "",
@@ -160,7 +160,7 @@ class AuthAppCodeValidatorTest {
                                 authAppSecret)));
         assertEquals(
                 Optional.of(ErrorResponse.ERROR_1043),
-                authAppCodeValidator.validateCode(
+                authAppCodeProcessor.validateCode(
                         new VerifyMfaCodeRequest(
                                 MFAMethodType.AUTH_APP,
                                 "999999999999",
@@ -176,8 +176,8 @@ class AuthAppCodeValidatorTest {
 
         var journeyType = isRegistration ? JourneyType.REGISTRATION : JourneyType.SIGN_IN;
 
-        this.authAppCodeValidator =
-                new AuthAppCodeValidator(
+        this.authAppCodeProcessor =
+                new AuthAppCodeProcessor(
                         "blocked-email-address",
                         mockCodeStorageService,
                         mockConfigurationService,
@@ -195,8 +195,8 @@ class AuthAppCodeValidatorTest {
 
         var journeyType = isRegistration ? JourneyType.REGISTRATION : JourneyType.SIGN_IN;
 
-        this.authAppCodeValidator =
-                new AuthAppCodeValidator(
+        this.authAppCodeProcessor =
+                new AuthAppCodeProcessor(
                         "email-address",
                         mockCodeStorageService,
                         mockConfigurationService,
@@ -213,8 +213,8 @@ class AuthAppCodeValidatorTest {
         when(mockDynamoService.getUserCredentialsFromEmail("email-address"))
                 .thenReturn(mock(UserCredentials.class));
 
-        this.authAppCodeValidator =
-                new AuthAppCodeValidator(
+        this.authAppCodeProcessor =
+                new AuthAppCodeProcessor(
                         "email-address",
                         mockCodeStorageService,
                         mockConfigurationService,
@@ -243,8 +243,8 @@ class AuthAppCodeValidatorTest {
 
         var journeyType = isRegistration ? JourneyType.REGISTRATION : JourneyType.SIGN_IN;
 
-        this.authAppCodeValidator =
-                new AuthAppCodeValidator(
+        this.authAppCodeProcessor =
+                new AuthAppCodeProcessor(
                         "email-address",
                         mockCodeStorageService,
                         mockConfigurationService,

--- a/shared/src/test/java/uk/gov/di/authentication/shared/validation/MfaCodeProcessorFactoryTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/validation/MfaCodeProcessorFactoryTest.java
@@ -14,14 +14,14 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-class MfaCodeValidatorFactoryTest {
+class MfaCodeProcessorFactoryTest {
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final CodeStorageService codeStorageService = mock(CodeStorageService.class);
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
     private final UserContext userContext = mock(UserContext.class);
     private final Session session = mock(Session.class);
-    private final MfaCodeValidatorFactory mfaCodeValidatorFactory =
-            new MfaCodeValidatorFactory(
+    private final MfaCodeProcessorFactory mfaCodeProcessorFactory =
+            new MfaCodeProcessorFactory(
                     configurationService, codeStorageService, authenticationService);
 
     @BeforeEach
@@ -33,24 +33,24 @@ class MfaCodeValidatorFactoryTest {
     }
 
     @Test
-    void whenMfaMethodGeneratesAuthAppCodeValidator() {
+    void whenMfaMethodGeneratesAuthAppCodeProcessor() {
         when(session.getEmailAddress()).thenReturn("test@test.com");
         when(userContext.getSession()).thenReturn(session);
-        var mfaCodeValidator =
-                mfaCodeValidatorFactory.getMfaCodeValidator(
+        var mfaCodeProcessor =
+                mfaCodeProcessorFactory.getMfaCodeProcessor(
                         MFAMethodType.AUTH_APP, JourneyType.REGISTRATION, userContext);
 
-        assertInstanceOf(AuthAppCodeValidator.class, mfaCodeValidator.get());
+        assertInstanceOf(AuthAppCodeProcessor.class, mfaCodeProcessor.get());
     }
 
     @Test
-    void whenMfaMethodGeneratesPhoneNumberCodeValidator() {
+    void whenMfaMethodGeneratesPhoneNumberCodeProcessor() {
         when(session.getEmailAddress()).thenReturn("test@test.com");
         when(userContext.getSession()).thenReturn(session);
-        var mfaCodeValidator =
-                mfaCodeValidatorFactory.getMfaCodeValidator(
+        var mfaCodeProcessor =
+                mfaCodeProcessorFactory.getMfaCodeProcessor(
                         MFAMethodType.SMS, JourneyType.REGISTRATION, userContext);
 
-        assertInstanceOf(PhoneNumberCodeValidator.class, mfaCodeValidator.get());
+        assertInstanceOf(PhoneNumberCodeProcessor.class, mfaCodeProcessor.get());
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/validation/PhoneNumberCodeProcessorTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/validation/PhoneNumberCodeProcessorTest.java
@@ -21,9 +21,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_BLOCKED_KEY_PREFIX;
 
-class PhoneNumberCodeValidatorTest {
+class PhoneNumberCodeProcessorTest {
 
-    private PhoneNumberCodeValidator phoneNumberCodeValidator;
+    private PhoneNumberCodeProcessor phoneNumberCodeProcessor;
     private final Session session = mock(Session.class);
     private final CodeStorageService codeStorageService = mock(CodeStorageService.class);
     private final UserContext userContext = mock(UserContext.class);
@@ -43,7 +43,7 @@ class PhoneNumberCodeValidatorTest {
         setupPhoneNumberCode(JourneyType.REGISTRATION);
 
         assertThat(
-                phoneNumberCodeValidator.validateCode(
+                phoneNumberCodeProcessor.validateCode(
                         new VerifyMfaCodeRequest(
                                 MFAMethodType.SMS,
                                 VALID_CODE,
@@ -58,7 +58,7 @@ class PhoneNumberCodeValidatorTest {
         setupPhoneNumberCode(JourneyType.REGISTRATION);
 
         assertThat(
-                phoneNumberCodeValidator.validateCode(
+                phoneNumberCodeProcessor.validateCode(
                         new VerifyMfaCodeRequest(
                                 MFAMethodType.SMS,
                                 INVALID_CODE,
@@ -73,7 +73,7 @@ class PhoneNumberCodeValidatorTest {
         setUpPhoneNumberCodeRetryLimitExceeded();
 
         assertThat(
-                phoneNumberCodeValidator.validateCode(
+                phoneNumberCodeProcessor.validateCode(
                         new VerifyMfaCodeRequest(
                                 MFAMethodType.SMS,
                                 INVALID_CODE,
@@ -88,7 +88,7 @@ class PhoneNumberCodeValidatorTest {
         setUpBlockedPhoneNumberCode();
 
         assertThat(
-                phoneNumberCodeValidator.validateCode(
+                phoneNumberCodeProcessor.validateCode(
                         new VerifyMfaCodeRequest(
                                 MFAMethodType.SMS,
                                 INVALID_CODE,
@@ -106,7 +106,7 @@ class PhoneNumberCodeValidatorTest {
                 assertThrows(
                         RuntimeException.class,
                         () ->
-                                phoneNumberCodeValidator.validateCode(
+                                phoneNumberCodeProcessor.validateCode(
                                         new VerifyMfaCodeRequest(
                                                 MFAMethodType.SMS,
                                                 INVALID_CODE,
@@ -128,8 +128,8 @@ class PhoneNumberCodeValidatorTest {
                 .thenReturn(Optional.of(VALID_CODE));
         when(codeStorageService.isBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX))
                 .thenReturn(false);
-        phoneNumberCodeValidator =
-                new PhoneNumberCodeValidator(
+        phoneNumberCodeProcessor =
+                new PhoneNumberCodeProcessor(
                         codeStorageService, userContext, configurationService, journeyType);
     }
 
@@ -143,8 +143,8 @@ class PhoneNumberCodeValidatorTest {
                 .thenReturn(Optional.of(VALID_CODE));
         when(codeStorageService.isBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX))
                 .thenReturn(false);
-        phoneNumberCodeValidator =
-                new PhoneNumberCodeValidator(
+        phoneNumberCodeProcessor =
+                new PhoneNumberCodeProcessor(
                         codeStorageService,
                         userContext,
                         configurationService,
@@ -160,8 +160,8 @@ class PhoneNumberCodeValidatorTest {
                 .thenReturn(Optional.of(VALID_CODE));
         when(codeStorageService.isBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX))
                 .thenReturn(true);
-        phoneNumberCodeValidator =
-                new PhoneNumberCodeValidator(
+        phoneNumberCodeProcessor =
+                new PhoneNumberCodeProcessor(
                         codeStorageService,
                         userContext,
                         configurationService,


### PR DESCRIPTION
## What?

 - Rename code validator classes to code processor

## Why?

- We will want these classes to do more than just validate. Make them more generic by renaming the classes to processor instead

