### PR TITLE
AUT-1218 - Clear account recovery block if present for successful auth app sign in

### DIFF
--- a/ci/terraform/oidc/verify_mfa_code.tf
+++ b/ci/terraform/oidc/verify_mfa_code.tf
@@ -12,6 +12,7 @@ module "frontend_api_verify_mfa_code_role" {
     aws_iam_policy.dynamo_account_recovery_block_delete_access_policy.arn,
     aws_iam_policy.dynamo_account_recovery_block_read_access_policy.arn,
     aws_iam_policy.dynamo_account_modifiers_read_access_policy.arn,
+    aws_iam_policy.dynamo_account_modifiers_write_access_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
     module.oidc_txma_audit.access_policy_arn

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/domain/FrontendAuditableEvent.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/domain/FrontendAuditableEvent.java
@@ -42,7 +42,8 @@ public enum FrontendAuditableEvent implements AuditableEvent {
     ACCOUNT_RECOVERY_EMAIL_CODE_SENT_FOR_TEST_CLIENT,
     ACCOUNT_RECOVERY_PERMITTED,
     ACCOUNT_RECOVERY_NOT_PERMITTED,
-    ACCOUNT_RECOVERY_BLOCK_ADDED;
+    ACCOUNT_RECOVERY_BLOCK_ADDED,
+    ACCOUNT_RECOVERY_BLOCK_REMOVED;
 
     public AuditableEvent parseFromName(String name) {
         return valueOf(name);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessor.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessor.java
@@ -5,7 +5,6 @@ import org.apache.commons.codec.binary.Base32;
 import uk.gov.di.authentication.entity.CodeRequest;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.services.DynamoAccountModifiersService;
-import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.MFAMethod;
@@ -27,15 +26,12 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static uk.gov.di.authentication.shared.entity.MFAMethodType.AUTH_APP;
-import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
 
 public class AuthAppCodeProcessor extends MfaCodeProcessor {
 
-    private final UserContext userContext;
     private final int windowTime;
     private final int allowedWindows;
     private final CodeRequest codeRequest;
-    private final DynamoAccountModifiersService accountModifiersService;
     private static final Base32 base32 = new Base32(0, null, false, (byte) '=', CodecPolicy.STRICT);
 
     public AuthAppCodeProcessor(
@@ -48,16 +44,15 @@ public class AuthAppCodeProcessor extends MfaCodeProcessor {
             AuditService auditService,
             DynamoAccountModifiersService accountModifiersService) {
         super(
-                userContext.getSession().getEmailAddress(),
+                userContext,
                 codeStorageService,
                 maxRetries,
                 dynamoService,
-                auditService);
-        this.userContext = userContext;
+                auditService,
+                accountModifiersService);
         this.windowTime = configurationService.getAuthAppCodeWindowLength();
         this.allowedWindows = configurationService.getAuthAppCodeAllowedWindows();
         this.codeRequest = codeRequest;
-        this.accountModifiersService = accountModifiersService;
     }
 
     @Override
@@ -107,7 +102,6 @@ public class AuthAppCodeProcessor extends MfaCodeProcessor {
                         emailAddress, codeRequest.getProfileInformation());
                 submitAuditEvent(
                         FrontendAuditableEvent.UPDATE_PROFILE_AUTH_APP,
-                        userContext,
                         AUTH_APP,
                         AuditService.UNKNOWN,
                         ipAddress,
@@ -119,7 +113,6 @@ public class AuthAppCodeProcessor extends MfaCodeProcessor {
                         emailAddress, codeRequest.getProfileInformation());
                 submitAuditEvent(
                         FrontendAuditableEvent.UPDATE_PROFILE_AUTH_APP,
-                        userContext,
                         AUTH_APP,
                         AuditService.UNKNOWN,
                         ipAddress,
@@ -127,27 +120,7 @@ public class AuthAppCodeProcessor extends MfaCodeProcessor {
                         true);
                 break;
             case SIGN_IN:
-                var accountRecoveryBlockPresent =
-                        accountModifiersService.isAccountRecoveryBlockPresent(
-                                userContext.getSession().getInternalCommonSubjectIdentifier());
-                if (accountRecoveryBlockPresent) {
-                    accountModifiersService.removeAccountRecoveryBlockIfPresent(
-                            userContext.getSession().getInternalCommonSubjectIdentifier());
-                    auditService.submitAuditEvent(
-                            FrontendAuditableEvent.ACCOUNT_RECOVERY_BLOCK_REMOVED,
-                            userContext.getClientSessionId(),
-                            userContext.getSession().getSessionId(),
-                            userContext
-                                    .getClient()
-                                    .map(ClientRegistry::getClientID)
-                                    .orElse(AuditService.UNKNOWN),
-                            userContext.getSession().getInternalCommonSubjectIdentifier(),
-                            emailAddress,
-                            ipAddress,
-                            AuditService.UNKNOWN,
-                            persistentSessionId,
-                            pair("mfa-type", AUTH_APP.getValue()));
-                }
+                clearAccountRecoveryBlockIfPresent(AUTH_APP, ipAddress, persistentSessionId);
         }
     }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/MfaCodeProcessorFactory.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/MfaCodeProcessorFactory.java
@@ -60,7 +60,8 @@ public class MfaCodeProcessorFactory {
                                 configurationService,
                                 codeRequest,
                                 authenticationService,
-                                auditService));
+                                auditService,
+                                accountModifiersService));
             default:
                 return Optional.empty();
         }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/MfaCodeProcessorFactory.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/MfaCodeProcessorFactory.java
@@ -1,6 +1,7 @@
 package uk.gov.di.authentication.frontendapi.validation;
 
 import uk.gov.di.authentication.entity.CodeRequest;
+import uk.gov.di.authentication.frontendapi.services.DynamoAccountModifiersService;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.services.AuditService;
@@ -17,16 +18,19 @@ public class MfaCodeProcessorFactory {
     private final CodeStorageService codeStorageService;
     private final AuthenticationService authenticationService;
     private final AuditService auditService;
+    private final DynamoAccountModifiersService accountModifiersService;
 
     public MfaCodeProcessorFactory(
             ConfigurationService configurationService,
             CodeStorageService codeStorageService,
             AuthenticationService authenticationService,
-            AuditService auditService) {
+            AuditService auditService,
+            DynamoAccountModifiersService accountModifiersService) {
         this.configurationService = configurationService;
         this.codeStorageService = codeStorageService;
         this.authenticationService = authenticationService;
         this.auditService = auditService;
+        this.accountModifiersService = accountModifiersService;
     }
 
     public Optional<MfaCodeProcessor> getMfaCodeProcessor(
@@ -46,7 +50,8 @@ public class MfaCodeProcessorFactory {
                                 authenticationService,
                                 codeMaxRetries,
                                 codeRequest,
-                                auditService));
+                                auditService,
+                                accountModifiersService));
             case SMS:
                 return Optional.of(
                         new PhoneNumberCodeProcessor(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessor.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessor.java
@@ -2,6 +2,7 @@ package uk.gov.di.authentication.frontendapi.validation;
 
 import uk.gov.di.authentication.entity.CodeRequest;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
+import uk.gov.di.authentication.frontendapi.services.DynamoAccountModifiersService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
@@ -30,13 +31,15 @@ public class PhoneNumberCodeProcessor extends MfaCodeProcessor {
             ConfigurationService configurationService,
             CodeRequest codeRequest,
             AuthenticationService dynamoService,
-            AuditService auditService) {
+            AuditService auditService,
+            DynamoAccountModifiersService dynamoAccountModifiersService) {
         super(
-                userContext.getSession().getEmailAddress(),
+                userContext,
                 codeStorageService,
                 configurationService.getCodeMaxRetries(),
                 dynamoService,
-                auditService);
+                auditService,
+                dynamoAccountModifiersService);
         this.userContext = userContext;
         this.configurationService = configurationService;
         this.codeRequest = codeRequest;
@@ -85,7 +88,6 @@ public class PhoneNumberCodeProcessor extends MfaCodeProcessor {
                         emailAddress, codeRequest.getProfileInformation(), true, true);
                 submitAuditEvent(
                         FrontendAuditableEvent.UPDATE_PROFILE_PHONE_NUMBER,
-                        userContext,
                         MFAMethodType.SMS,
                         codeRequest.getProfileInformation(),
                         ipAddress,
@@ -97,7 +99,6 @@ public class PhoneNumberCodeProcessor extends MfaCodeProcessor {
                         emailAddress, codeRequest.getProfileInformation());
                 submitAuditEvent(
                         FrontendAuditableEvent.UPDATE_PROFILE_PHONE_NUMBER,
-                        userContext,
                         MFAMethodType.SMS,
                         codeRequest.getProfileInformation(),
                         ipAddress,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.authentication.entity.CodeRequest;
 import uk.gov.di.authentication.entity.VerifyMfaCodeRequest;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
-import uk.gov.di.authentication.frontendapi.services.DynamoAccountRecoveryBlockService;
 import uk.gov.di.authentication.frontendapi.validation.AuthAppCodeProcessor;
 import uk.gov.di.authentication.frontendapi.validation.MfaCodeProcessorFactory;
 import uk.gov.di.authentication.frontendapi.validation.PhoneNumberCodeProcessor;
@@ -97,8 +96,6 @@ class VerifyMfaCodeHandlerTest {
     private final SessionService sessionService = mock(SessionService.class);
     private final CodeStorageService codeStorageService = mock(CodeStorageService.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
-    private final DynamoAccountRecoveryBlockService accountRecoveryBlockService =
-            mock(DynamoAccountRecoveryBlockService.class);
     private final MfaCodeProcessorFactory mfaCodeProcessorFactory =
             mock(MfaCodeProcessorFactory.class);
     private final AuthAppCodeProcessor authAppCodeProcessor = mock(AuthAppCodeProcessor.class);
@@ -145,8 +142,7 @@ class VerifyMfaCodeHandlerTest {
                         codeStorageService,
                         auditService,
                         mfaCodeProcessorFactory,
-                        cloudwatchMetricsService,
-                        accountRecoveryBlockService);
+                        cloudwatchMetricsService);
     }
 
     @AfterEach
@@ -191,7 +187,6 @@ class VerifyMfaCodeHandlerTest {
         verify(codeStorageService, never())
                 .saveBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX, 900L);
         verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(TEST_EMAIL_ADDRESS);
-        verify(accountRecoveryBlockService).deleteBlockIfPresent(TEST_EMAIL_ADDRESS);
 
         verify(auditService)
                 .submitAuditEvent(
@@ -232,7 +227,6 @@ class VerifyMfaCodeHandlerTest {
         verify(codeStorageService, never())
                 .saveBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX, 900L);
         verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(TEST_EMAIL_ADDRESS);
-        verify(accountRecoveryBlockService).deleteBlockIfPresent(TEST_EMAIL_ADDRESS);
 
         verify(auditService)
                 .submitAuditEvent(
@@ -298,7 +292,6 @@ class VerifyMfaCodeHandlerTest {
         verifyNoInteractions(auditService);
         verifyNoInteractions(authAppCodeProcessor);
         verifyNoInteractions(codeStorageService);
-        verifyNoInteractions(accountRecoveryBlockService);
     }
 
     private static Stream<Boolean> registration() {
@@ -322,7 +315,6 @@ class VerifyMfaCodeHandlerTest {
                 .saveBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX, 900L);
         verify(codeStorageService)
                 .deleteIncorrectMfaCodeAttemptsCount(TEST_EMAIL_ADDRESS, MFAMethodType.AUTH_APP);
-        verifyNoInteractions(accountRecoveryBlockService);
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CODE_MAX_RETRIES_REACHED,
@@ -355,7 +347,6 @@ class VerifyMfaCodeHandlerTest {
         verify(codeStorageService, never())
                 .saveBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX, 900L);
         verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(TEST_EMAIL_ADDRESS);
-        verifyNoInteractions(accountRecoveryBlockService);
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CODE_MAX_RETRIES_REACHED,
@@ -389,7 +380,6 @@ class VerifyMfaCodeHandlerTest {
         verify(codeStorageService, never())
                 .saveBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX, 900L);
         verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(TEST_EMAIL_ADDRESS);
-        verifyNoInteractions(accountRecoveryBlockService);
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.INVALID_CODE_SENT,
@@ -423,7 +413,6 @@ class VerifyMfaCodeHandlerTest {
         verify(codeStorageService)
                 .saveBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX, 900L);
         verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(TEST_EMAIL_ADDRESS);
-        verifyNoInteractions(accountRecoveryBlockService);
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CODE_MAX_RETRIES_REACHED,
@@ -459,7 +448,6 @@ class VerifyMfaCodeHandlerTest {
         verify(codeStorageService, never())
                 .saveBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX, 900L);
         verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(TEST_EMAIL_ADDRESS);
-        verifyNoInteractions(accountRecoveryBlockService);
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.CODE_MAX_RETRIES_REACHED,
@@ -492,7 +480,6 @@ class VerifyMfaCodeHandlerTest {
         verify(codeStorageService, never())
                 .saveBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX, 900L);
         verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(TEST_EMAIL_ADDRESS);
-        verifyNoInteractions(accountRecoveryBlockService);
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.INVALID_CODE_SENT,
@@ -527,7 +514,6 @@ class VerifyMfaCodeHandlerTest {
         verify(codeStorageService, never())
                 .saveBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX, 900L);
         verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(TEST_EMAIL_ADDRESS);
-        verify(accountRecoveryBlockService, never()).deleteBlockIfPresent(TEST_EMAIL_ADDRESS);
         verifyNoInteractions(auditService);
         verifyNoInteractions(cloudwatchMetricsService);
     }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/MfaCodeProcessorFactoryTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/MfaCodeProcessorFactoryTest.java
@@ -3,6 +3,7 @@ package uk.gov.di.authentication.frontendapi.validation;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.entity.VerifyMfaCodeRequest;
+import uk.gov.di.authentication.frontendapi.services.DynamoAccountModifiersService;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.Session;
@@ -23,9 +24,15 @@ class MfaCodeProcessorFactoryTest {
     private final AuditService auditService = mock(AuditService.class);
     private final UserContext userContext = mock(UserContext.class);
     private final Session session = mock(Session.class);
+    private final DynamoAccountModifiersService accountModifiersService =
+            mock(DynamoAccountModifiersService.class);
     private final MfaCodeProcessorFactory mfaCodeProcessorFactory =
             new MfaCodeProcessorFactory(
-                    configurationService, codeStorageService, authenticationService, auditService);
+                    configurationService,
+                    codeStorageService,
+                    authenticationService,
+                    auditService,
+                    accountModifiersService);
 
     @BeforeEach
     void setUp() {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessorTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessorTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.entity.CodeRequest;
 import uk.gov.di.authentication.entity.VerifyMfaCodeRequest;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
+import uk.gov.di.authentication.frontendapi.services.DynamoAccountModifiersService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
@@ -41,6 +42,8 @@ class PhoneNumberCodeProcessorTest {
     private final AuditService auditService = mock(AuditService.class);
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private final DynamoAccountModifiersService accountModifiersService =
+            mock(DynamoAccountModifiersService.class);
     private static final String TEST_EMAIL_ADDRESS = "joe.bloggs@example.com";
     private static final String VALID_CODE = "123456";
     private static final String INVALID_CODE = "826272";
@@ -200,7 +203,8 @@ class PhoneNumberCodeProcessorTest {
                         configurationService,
                         codeRequest,
                         authenticationService,
-                        auditService);
+                        auditService,
+                        accountModifiersService);
     }
 
     public void setUpPhoneNumberCodeRetryLimitExceeded(CodeRequest codeRequest) {
@@ -220,7 +224,8 @@ class PhoneNumberCodeProcessorTest {
                         configurationService,
                         codeRequest,
                         authenticationService,
-                        auditService);
+                        auditService,
+                        accountModifiersService);
     }
 
     public void setUpBlockedPhoneNumberCode(CodeRequest codeRequest) {
@@ -239,6 +244,7 @@ class PhoneNumberCodeProcessorTest {
                         configurationService,
                         codeRequest,
                         authenticationService,
-                        auditService);
+                        auditService,
+                        accountModifiersService);
     }
 }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuthAppStubTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/AuthAppStubTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.entity.CodeRequest;
+import uk.gov.di.authentication.frontendapi.services.DynamoAccountModifiersService;
 import uk.gov.di.authentication.frontendapi.validation.AuthAppCodeProcessor;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
@@ -38,7 +39,8 @@ class AuthAppStubTest {
                         mock(DynamoService.class),
                         99999,
                         mock(CodeRequest.class),
-                        mock(AuditService.class));
+                        mock(AuditService.class),
+                        mock(DynamoAccountModifiersService.class));
     }
 
     @Test


### PR DESCRIPTION
## What?

- Add permissions to the verify-mfa-code lambda to write to the account modifiers table so that the lambda can set the block to false when a block is present and the code for the sign in request is valid.
- Add an audit event ACCOUNT_RECOVERY_BLOCK_REMOVED for when the block is present and has been removed.

## Why?

- The account modifiers table has replaced the account recovery table 
- When a user has successfully verified their auth app during sign in, we can remove any block that is present. Note that this is only for Auth App sign in as SMS sign in verify code logic lives in the VerifyCodeHandler
