### PR TITLE
AUT-1218 - Remove account recovery block table

### DIFF
--- a/ci/terraform/oidc/dynamo-policies.tf
+++ b/ci/terraform/oidc/dynamo-policies.tf
@@ -22,10 +22,6 @@ data "aws_dynamodb_table" "common_passwords_table" {
   name = "${var.environment}-common-passwords"
 }
 
-data "aws_dynamodb_table" "account_recovery_block_table" {
-  name = "${var.environment}-account-recovery-block"
-}
-
 data "aws_dynamodb_table" "account_modifiers_table" {
   name = "${var.environment}-account-modifiers"
 }

--- a/ci/terraform/shared/dynamodb.tf
+++ b/ci/terraform/shared/dynamodb.tf
@@ -272,39 +272,6 @@ resource "aws_dynamodb_table" "common_passwords_table" {
   tags = local.default_tags
 }
 
-resource "aws_dynamodb_table" "account_recovery_block_table" {
-  name         = "${var.environment}-account-recovery-block"
-  billing_mode = var.provision_dynamo ? "PROVISIONED" : "PAY_PER_REQUEST"
-  hash_key     = "Email"
-
-  read_capacity  = var.provision_dynamo ? var.dynamo_default_read_capacity : null
-  write_capacity = var.provision_dynamo ? var.dynamo_default_write_capacity : null
-
-  attribute {
-    name = "Email"
-    type = "S"
-  }
-
-  point_in_time_recovery {
-    enabled = !var.use_localstack
-  }
-
-  server_side_encryption {
-    enabled = !var.use_localstack
-  }
-
-  lifecycle {
-    prevent_destroy = false
-  }
-
-  ttl {
-    attribute_name = "TimeToExist"
-    enabled        = true
-  }
-
-  tags = local.default_tags
-}
-
 resource "aws_dynamodb_table" "account_modifiers_table" {
   name         = "${var.environment}-account-modifiers"
   billing_mode = var.provision_dynamo ? "PROVISIONED" : "PAY_PER_REQUEST"


### PR DESCRIPTION
## What?

 - Remove account recovery block table

## Why?

- This is the last part of the old account recovery block table which can now be removed

