### PR TITLE
AUT-1180 -  Add account recovery attribute to audit events for code verification 

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -15,6 +15,7 @@ import uk.gov.di.authentication.shared.domain.AuditableEvent;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper;
@@ -203,7 +204,12 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                         .orElse(CODE_VERIFIED);
 
         submitAuditEvent(
-                auditableEvent, session, userContext, input, codeRequest.getMfaMethodType());
+                auditableEvent,
+                session,
+                userContext,
+                input,
+                codeRequest.getMfaMethodType(),
+                codeRequest.getJourneyType().equals(JourneyType.ACCOUNT_RECOVERY));
 
         if (errorResponse.isEmpty()) {
             mfaCodeProcessor.processSuccessfulCodeRequest(
@@ -248,7 +254,8 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
             Session session,
             UserContext userContext,
             APIGatewayProxyRequestEvent input,
-            MFAMethodType mfaMethodType) {
+            MFAMethodType mfaMethodType,
+            boolean isAccountRecovery) {
         auditService.submitAuditEvent(
                 auditableEvent,
                 userContext.getClientSessionId(),
@@ -262,6 +269,7 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
                 IpAddressHelper.extractIpAddress(input),
                 AuditService.UNKNOWN,
                 extractPersistentIdFromHeaders(input.getHeaders()),
-                pair("mfa-type", mfaMethodType.getValue()));
+                pair("mfa-type", mfaMethodType.getValue()),
+                pair("account-recovery", isAccountRecovery));
     }
 }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -199,7 +199,11 @@ class VerifyCodeHandlerTest {
                         "123.123.123.123",
                         AuditService.UNKNOWN,
                         PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
-                        pair("notification-type", emailNotificationType.name()));
+                        pair("notification-type", emailNotificationType.name()),
+                        pair(
+                                "account-recovery",
+                                emailNotificationType.equals(
+                                        VERIFY_CHANGE_HOW_GET_SECURITY_CODES)));
     }
 
     @ParameterizedTest
@@ -285,7 +289,11 @@ class VerifyCodeHandlerTest {
                         "123.123.123.123",
                         AuditService.UNKNOWN,
                         PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
-                        pair("notification-type", emailNotificationType.name()));
+                        pair("notification-type", emailNotificationType.name()),
+                        pair(
+                                "account-recovery",
+                                emailNotificationType.equals(
+                                        VERIFY_CHANGE_HOW_GET_SECURITY_CODES)));
     }
 
     @ParameterizedTest
@@ -330,7 +338,8 @@ class VerifyCodeHandlerTest {
                         AuditService.UNKNOWN,
                         PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
                         pair("notification-type", MFA_SMS.name()),
-                        pair("mfa-type", MFAMethodType.SMS.getValue()));
+                        pair("mfa-type", MFAMethodType.SMS.getValue()),
+                        pair("account-recovery", false));
         verify(auditService)
                 .submitAuditEvent(
                         FrontendAuditableEvent.ACCOUNT_RECOVERY_BLOCK_REMOVED,
@@ -376,7 +385,8 @@ class VerifyCodeHandlerTest {
                         AuditService.UNKNOWN,
                         PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
                         pair("notification-type", MFA_SMS.name()),
-                        pair("mfa-type", MFAMethodType.SMS.getValue()));
+                        pair("mfa-type", MFAMethodType.SMS.getValue()),
+                        pair("account-recovery", false));
         verify(cloudwatchMetricsService)
                 .incrementAuthenticationSuccess(
                         Session.AccountState.EXISTING, CLIENT_ID, CLIENT_NAME, "P0", false, true);
@@ -425,7 +435,8 @@ class VerifyCodeHandlerTest {
                         AuditService.UNKNOWN,
                         PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
                         pair("notification-type", MFA_SMS.name()),
-                        pair("mfa-type", MFAMethodType.SMS.getValue()));
+                        pair("mfa-type", MFAMethodType.SMS.getValue()),
+                        pair("account-recovery", false));
     }
 
     @Test


### PR DESCRIPTION
## What?

- Add an `account-recovery` attribute to audit events which are generated when a user has entered either a valid or invalid OTP code
- Add extra unit tests to improve test coverage

## Why?

- So we can clearly distinguish whether an OTP has been sent as part of the account recovery journey
