### PR TITLE
Add OneAgent to apis

### DIFF
--- a/ci/terraform/modules/endpoint-module/dynatrace.tf
+++ b/ci/terraform/modules/endpoint-module/dynatrace.tf
@@ -28,7 +28,7 @@ data "aws_secretsmanager_secret_version" "dynatrace_tenant" {
 
 locals {
   dynatrace_account_region = "eu-west-2"
-  dynatrace_account_id     = "98415292996982"
+  dynatrace_account_id     = "985486846182"
   dynatrace_layer_arn      = "arn:aws:lambda:eu-west-2:985486846182:layer:DTOneAgentJavaLayer:1"
   dynatrace_environment_variables = {
     AWS_LAMBDA_EXEC_WRAPPER = "/opt/dynatrace"

--- a/ci/terraform/modules/endpoint-module/dynatrace.tf
+++ b/ci/terraform/modules/endpoint-module/dynatrace.tf
@@ -1,0 +1,43 @@
+data "aws_secretsmanager_secret" "dynatrace_auth_token" {
+  arn = "arn:aws:secretsmanager:${local.dynatrace_account_region}:${local.dynatrace_account_id}:secret:AUTH_TOKEN-PhjBZc:SecretString:DT_CONNECTION_AUTH_TOKEN"
+}
+data "aws_secretsmanager_secret_version" "dynatrace_auth_token" {
+  secret_id = data.aws_secretsmanager_secret.dynatrace_auth_token.id
+}
+
+data "aws_secretsmanager_secret" "dynatrace_base_url" {
+  arn = "arn:aws:secretsmanager:${local.dynatrace_account_region}:${local.dynatrace_account_id}:secret:BASE_URL-otGJKy:SecretString:DT_CONNECTION_BASE_URL"
+}
+data "aws_secretsmanager_secret_version" "dynatrace_base_url" {
+  secret_id = data.aws_secretsmanager_secret.dynatrace_base_url.id
+}
+
+data "aws_secretsmanager_secret" "dynatrace_cluster_id" {
+  arn = "arn:aws:secretsmanager:${local.dynatrace_account_region}:${local.dynatrace_account_id}:secret:CLUSTER_ID-BTiQVl:SecretString:DT_CLUSTER_ID"
+}
+data "aws_secretsmanager_secret_version" "dynatrace_cluster_id" {
+  secret_id = data.aws_secretsmanager_secret.dynatrace_cluster_id.id
+}
+
+data "aws_secretsmanager_secret" "dynatrace_tenant" {
+  arn = "arn:aws:secretsmanager:${local.dynatrace_account_region}:${local.dynatrace_account_id}:secret:TENANT-vB41Oz:SecretString:DT_TENANT"
+}
+data "aws_secretsmanager_secret_version" "dynatrace_tenant" {
+  secret_id = data.aws_secretsmanager_secret.dynatrace_tenant.id
+}
+
+locals {
+  dynatrace_account_region = "eu-west-2"
+  dyntrace_account_id      = "98415292996982"
+  dynatrace_layer_arn      = "arn:aws:lambda:eu-west-2:985486846182:layer:DTOneAgentJavaLayer:1"
+  dynatrace_environment_variables = {
+    AWS_LAMBDA_EXEC_WRAPPER = "/opt/dynatrace"
+
+    DT_CONNECTION_AUTH_TOKEN = data.aws_secretsmanager_secret_version.dynatrace_auth_token.secret_string
+    DT_CONNECTION_BASE_URL   = data.aws_secretsmanager_secret_version.dynatrace_base_url.secret_string
+    DT_CLUSTER_ID            = data.aws_secretsmanager_secret_version.dynatrace_cluster_id.secret_string
+    DT_TENANT                = data.aws_secretsmanager_secret_version.dynatrace_tenant.secret_string
+
+    DT_OPEN_TELEMETRY_ENABLE_INTEGRATION = "true"
+  }
+}

--- a/ci/terraform/modules/endpoint-module/dynatrace.tf
+++ b/ci/terraform/modules/endpoint-module/dynatrace.tf
@@ -28,7 +28,7 @@ data "aws_secretsmanager_secret_version" "dynatrace_tenant" {
 
 locals {
   dynatrace_account_region = "eu-west-2"
-  dyntrace_account_id      = "98415292996982"
+  dynatrace_account_id     = "98415292996982"
   dynatrace_layer_arn      = "arn:aws:lambda:eu-west-2:985486846182:layer:DTOneAgentJavaLayer:1"
   dynatrace_environment_variables = {
     AWS_LAMBDA_EXEC_WRAPPER = "/opt/dynatrace"

--- a/ci/terraform/modules/endpoint-module/lambda.tf
+++ b/ci/terraform/modules/endpoint-module/lambda.tf
@@ -18,7 +18,7 @@ resource "aws_lambda_function" "endpoint_lambda" {
 
   code_signing_config_arn = var.code_signing_config_arn
 
-  layers = [local.dynatrace_layer_arn]
+  layers = local.lambda_layers
 
   vpc_config {
     security_group_ids = var.security_group_ids
@@ -119,4 +119,9 @@ resource "aws_appautoscaling_policy" "provisioned-concurrency-policy" {
       predefined_metric_type = "LambdaProvisionedConcurrencyUtilization"
     }
   }
+}
+
+locals {
+  deploy_dynatrace = var.environment == "staging"
+  lambda_layers    = flatten(local.deploy_dynatrace ? [local.dynatrace_layer_arn] : [])
 }

--- a/ci/terraform/modules/endpoint-module/lambda.tf
+++ b/ci/terraform/modules/endpoint-module/lambda.tf
@@ -3,8 +3,10 @@ resource "aws_lambda_function" "endpoint_lambda" {
   role          = var.lambda_role_arn
   handler       = var.handler_function_name
   timeout       = 30
-  memory_size   = var.memory_size
-  publish       = true
+  # Dynatrace documentation suggests an additional 1.5GiB RAM for Java OneAgent,
+  # if this is a bad idea, will revert.
+  memory_size = var.memory_size + 1536
+  publish     = true
 
   tracing_config {
     mode = "Active"
@@ -16,13 +18,18 @@ resource "aws_lambda_function" "endpoint_lambda" {
 
   code_signing_config_arn = var.code_signing_config_arn
 
+  layers = [local.dynatrace_layer_arn]
+
   vpc_config {
     security_group_ids = var.security_group_ids
     subnet_ids         = var.subnet_id
   }
   environment {
-    variables = merge(var.handler_environment_variables, {
-      JAVA_TOOL_OPTIONS = "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
+    variables = merge(
+      var.handler_environment_variables,
+      local.dynatrace_environment_variables,
+      {
+        JAVA_TOOL_OPTIONS = "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
     })
   }
   kms_key_arn = var.lambda_env_vars_encryption_kms_key_arn

--- a/ci/terraform/shared/code-signing-config.tf
+++ b/ci/terraform/shared/code-signing-config.tf
@@ -1,7 +1,8 @@
 resource "aws_lambda_code_signing_config" "code_signing_config" {
   allowed_publishers {
     signing_profile_version_arns = [
-      var.di_tools_signing_profile_version_arn
+      var.di_tools_signing_profile_version_arn,
+      local.dynatrace_layer_signing_profile_arn
     ]
   }
 
@@ -10,4 +11,8 @@ resource "aws_lambda_code_signing_config" "code_signing_config" {
   policies {
     untrusted_artifact_on_deployment = var.enforce_code_signing ? "Enforce" : "Warn"
   }
+}
+
+locals {
+  dynatrace_layer_signing_profile_arn = "arn:aws:signer:eu-west-2:985486846182:/signing-profiles/SigningProfile_2LIsnoqFX0BU/IE6arNMuby"
 }


### PR DESCRIPTION
## What?

Adds the Dynatrace OneAgent layer to our Lambdas.

## Why?

This will instrument the API lambdas within Dynatrace.