### PR TITLE
AUT-1286 - Delete from Account Modifiers table when deleting users account

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/helpers/PrincipalValidationHelper.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/helpers/PrincipalValidationHelper.java
@@ -7,7 +7,6 @@ import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 
 import java.util.Map;
-import java.util.Objects;
 
 public class PrincipalValidationHelper {
 
@@ -24,15 +23,8 @@ public class PrincipalValidationHelper {
         if (!authorizerParams.containsKey(PRINCIPAL_ID_KEY)) {
             LOG.warn("principalId is missing");
             return true;
-        } else if (Objects.nonNull(userProfile.getPublicSubjectID())
-                && userProfile
-                        .getPublicSubjectID()
-                        .equals(authorizerParams.get(PRINCIPAL_ID_KEY))) {
-            LOG.info("principalId contains publicSubjectID");
-            return false;
         } else {
-            LOG.info(
-                    "principalId does not contain publicSubjectID. Validating principalId against internal pairwise subject id");
+            LOG.info("Validating principalId against internal pairwise subject id");
             var internalSubjectId =
                     ClientSubjectHelper.getSubjectWithSectorIdentifier(
                             userProfile, internalSectorUri, authenticationService);

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/helpers/PrincipalValidationHelperTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/helpers/PrincipalValidationHelperTest.java
@@ -32,18 +32,7 @@ class PrincipalValidationHelperTest {
     }
 
     @Test
-    void shouldReturnFalseWhenPublicSubjectIdEqualsPrinciple() {
-        var publicSubject = new Subject();
-        var userProfile = new UserProfile().withPublicSubjectID(publicSubject.getValue());
-        authorizerParams.put("principalId", publicSubject.getValue());
-
-        assertFalse(
-                PrincipalValidationHelper.principleIsInvalid(
-                        userProfile, INTERNAL_SECTOR_URI, authenticationService, authorizerParams));
-    }
-
-    @Test
-    void shouldReturnFalseWhenPrincipalDoesNotMatchPublicSubjectIdButMatchesPairwiseSubjectId() {
+    void shouldReturnFalseWhenPrincipalMatchesPairwiseSubjectId() {
         var internalSubject = new Subject();
         var salt = SaltHelper.generateNewSalt();
         var userProfile = new UserProfile().withSubjectID(internalSubject.getValue());
@@ -59,7 +48,7 @@ class PrincipalValidationHelperTest {
     }
 
     @Test
-    void shouldReturnTrueWhenPrincipalDoesNotMatchPublicSubjectIdOrPairwiseSubjectId() {
+    void shouldReturnTrueWhenPrincipalDoesNotMatchPairwiseSubjectId() {
         var salt = SaltHelper.generateNewSalt();
         var userProfile =
                 new UserProfile()

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandlerTest.java
@@ -9,6 +9,7 @@ import uk.gov.di.accountmanagement.domain.AccountManagementAuditableEvent;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
 import uk.gov.di.accountmanagement.exceptions.InvalidPrincipalException;
 import uk.gov.di.accountmanagement.services.AwsSqsClient;
+import uk.gov.di.accountmanagement.services.DynamoDeleteService;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
@@ -30,9 +31,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -60,12 +59,17 @@ class RemoveAccountHandlerTest {
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
     private final AuditService auditService = mock(AuditService.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private final DynamoDeleteService dynamoDeleteService = mock(DynamoDeleteService.class);
 
     @BeforeEach
     public void setUp() {
         handler =
                 new RemoveAccountHandler(
-                        authenticationService, sqsClient, auditService, configurationService);
+                        authenticationService,
+                        sqsClient,
+                        auditService,
+                        configurationService,
+                        dynamoDeleteService);
         when(configurationService.getInternalSectorUri()).thenReturn("https://test.account.gov.uk");
         when(authenticationService.getOrGenerateSalt(any(UserProfile.class))).thenReturn(SALT);
     }
@@ -84,7 +88,7 @@ class RemoveAccountHandlerTest {
         var result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(204));
-        verify(authenticationService).removeAccount(eq(EMAIL));
+        verify(dynamoDeleteService).deleteAccount(EMAIL, expectedCommonSubject);
         verify(sqsClient)
                 .send(
                         objectMapper.writeValueAsString(
@@ -116,7 +120,7 @@ class RemoveAccountHandlerTest {
         var result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(204));
-        verify(authenticationService).removeAccount(EMAIL);
+        verify(dynamoDeleteService).deleteAccount(EMAIL, expectedCommonSubject);
         verify(sqsClient)
                 .send(
                         objectMapper.writeValueAsString(
@@ -165,7 +169,7 @@ class RemoveAccountHandlerTest {
         var event = generateApiGatewayEvent(PUBLIC_SUBJECT.getValue());
         var result = handler.handleRequest(event, context);
 
-        verify(authenticationService, never()).removeAccount(EMAIL);
+        verifyNoInteractions(dynamoDeleteService);
         verifyNoInteractions(auditService);
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1010));

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/RemoveAccountHandlerTest.java
@@ -75,38 +75,6 @@ class RemoveAccountHandlerTest {
     }
 
     @Test
-    void shouldReturn204IfAccountRemovalIsSuccessfulAndPrincipalContainsPublicSubjectId()
-            throws Json.JsonException {
-        var userProfile =
-                new UserProfile()
-                        .withSubjectID(INTERNAL_SUBJECT.getValue())
-                        .withPublicSubjectID(PUBLIC_SUBJECT.getValue());
-        when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
-                .thenReturn(Optional.of(userProfile));
-
-        var event = generateApiGatewayEvent(PUBLIC_SUBJECT.getValue());
-        var result = handler.handleRequest(event, context);
-
-        assertThat(result, hasStatus(204));
-        verify(dynamoDeleteService).deleteAccount(EMAIL, expectedCommonSubject);
-        verify(sqsClient)
-                .send(
-                        objectMapper.writeValueAsString(
-                                new NotifyRequest(EMAIL, DELETE_ACCOUNT, SupportedLanguage.EN)));
-        verify(auditService)
-                .submitAuditEvent(
-                        AccountManagementAuditableEvent.DELETE_ACCOUNT,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        expectedCommonSubject,
-                        userProfile.getEmail(),
-                        "123.123.123.123",
-                        userProfile.getPhoneNumber(),
-                        PERSISTENT_ID);
-    }
-
-    @Test
     void shouldReturn204IfAccountRemovalIsSuccessfulAndPrincipalContainsInternalPairwiseSubjectId()
             throws Json.JsonException {
         var userProfile =

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/UpdatePhoneNumberHandlerTest.java
@@ -54,7 +54,6 @@ class UpdatePhoneNumberHandlerTest {
     private static final String NEW_PHONE_NUMBER = "07755551084";
     private static final String OLD_PHONE_NUMBER = "09876543219";
     private static final String OTP = "123456";
-    private static final Subject PUBLIC_SUBJECT = new Subject();
     private static final String PERSISTENT_ID = "some-persistent-session-id";
     private static final byte[] SALT = SaltHelper.generateNewSalt();
     private static final Subject INTERNAL_SUBJECT = new Subject();
@@ -77,43 +76,6 @@ class UpdatePhoneNumberHandlerTest {
                         configurationService);
         when(configurationService.getInternalSectorUri()).thenReturn("https://test.account.gov.uk");
         when(dynamoService.getOrGenerateSalt(any(UserProfile.class))).thenReturn(SALT);
-    }
-
-    @Test
-    void shouldReturn204WhenPrincipalContainsPublicSubjectId() throws Json.JsonException {
-        when(codeStorageService.isValidOtpCode(EMAIL_ADDRESS, OTP, VERIFY_PHONE_NUMBER))
-                .thenReturn(true);
-        var userProfile =
-                new UserProfile()
-                        .withPublicSubjectID(PUBLIC_SUBJECT.getValue())
-                        .withSubjectID(INTERNAL_SUBJECT.getValue())
-                        .withPhoneNumber(OLD_PHONE_NUMBER);
-        when(dynamoService.getUserProfileByEmailMaybe(EMAIL_ADDRESS))
-                .thenReturn(Optional.of(userProfile));
-
-        var event = generateApiGatewayEvent(PUBLIC_SUBJECT.getValue());
-        var result = handler.handleRequest(event, context);
-
-        assertThat(result, hasStatus(204));
-        verify(dynamoService).updatePhoneNumber(EMAIL_ADDRESS, NEW_PHONE_NUMBER);
-        verify(sqsClient)
-                .send(
-                        objectMapper.writeValueAsString(
-                                new NotifyRequest(
-                                        EMAIL_ADDRESS,
-                                        PHONE_NUMBER_UPDATED,
-                                        SupportedLanguage.EN)));
-        verify(auditService)
-                .submitAuditEvent(
-                        AccountManagementAuditableEvent.UPDATE_PHONE_NUMBER,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        AuditService.UNKNOWN,
-                        expectedCommonSubject,
-                        userProfile.getEmail(),
-                        "123.123.123.123",
-                        NEW_PHONE_NUMBER,
-                        PERSISTENT_ID);
     }
 
     @Test
@@ -164,7 +126,7 @@ class UpdatePhoneNumberHandlerTest {
         when(dynamoService.getUserProfileByEmailMaybe(EMAIL_ADDRESS))
                 .thenReturn(Optional.of(userProfile));
         when(dynamoService.getOrGenerateSalt(userProfile)).thenReturn(SaltHelper.generateNewSalt());
-        var event = generateApiGatewayEvent(PUBLIC_SUBJECT.getValue());
+        var event = generateApiGatewayEvent(expectedCommonSubject);
 
         var expectedException =
                 assertThrows(
@@ -182,7 +144,7 @@ class UpdatePhoneNumberHandlerTest {
         APIGatewayProxyRequestEvent.ProxyRequestContext proxyRequestContext =
                 new APIGatewayProxyRequestEvent.ProxyRequestContext();
         Map<String, Object> authorizerParams = new HashMap<>();
-        authorizerParams.put("principalId", PUBLIC_SUBJECT.getValue());
+        authorizerParams.put("principalId", expectedCommonSubject);
         proxyRequestContext.setAuthorizer(authorizerParams);
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setRequestContext(proxyRequestContext);
@@ -200,7 +162,7 @@ class UpdatePhoneNumberHandlerTest {
         when(codeStorageService.isValidOtpCode(EMAIL_ADDRESS, OTP, VERIFY_PHONE_NUMBER))
                 .thenReturn(false);
 
-        var event = generateApiGatewayEvent(PUBLIC_SUBJECT.getValue());
+        var event = generateApiGatewayEvent(expectedCommonSubject);
         var result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(400));
@@ -216,7 +178,7 @@ class UpdatePhoneNumberHandlerTest {
                 .thenReturn(true);
         when(dynamoService.getUserProfileByEmailMaybe(EMAIL_ADDRESS)).thenReturn(Optional.empty());
 
-        var event = generateApiGatewayEvent(PUBLIC_SUBJECT.getValue());
+        var event = generateApiGatewayEvent(expectedCommonSubject);
         var result = handler.handleRequest(event, context);
 
         assertThat(result, hasStatus(400));

--- a/account-management-integration-tests/build.gradle
+++ b/account-management-integration-tests/build.gradle
@@ -60,6 +60,7 @@ test {
                 project(":shared").sourceSets.main.output)
     }
     dependsOn ":composeUp"
+    finalizedBy ":composeDown"
 }
 
 jacocoTestReport {

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/RemoveAccountIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/RemoveAccountIntegrationTest.java
@@ -83,14 +83,11 @@ public class RemoveAccountIntegrationTest extends ApiGatewayHandlerIntegrationTe
 
     @Test
     void shouldThrowExceptionWhenUserAttemptsToDeleteDifferentAccount() {
-        String user1Email = "joe.bloggs+3@digital.cabinet-office.gov.uk";
         String user2Email = "i-do-not-exist@example.com";
-        String password1 = "password-1";
         String password2 = "password-2";
-        Subject subject1 = new Subject();
         Subject subject2 = new Subject();
 
-        String subjectId1 = userStore.signUp(user1Email, password1, subject1);
+        var subjectId1 = setupUserAndRetrieveInternalCommonSubId();
         userStore.signUp(user2Email, password2, subject2);
 
         Exception ex =

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AccountModifiersStoreExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AccountModifiersStoreExtension.java
@@ -42,6 +42,12 @@ public class AccountModifiersStoreExtension extends DynamoExtension implements A
         return dynamoAccountModifiersService.isAccountRecoveryBlockPresent(internalCommonSubjectId);
     }
 
+    public boolean isEntryForSubjectIdPresent(String internalCommonSubjectId) {
+        return dynamoAccountModifiersService
+                .getAccountModifiers(internalCommonSubjectId)
+                .isPresent();
+    }
+
     public void setAccountRecoveryBlock(String internalCommonSubjectId) {
         dynamoAccountModifiersService.setAccountRecoveryBlock(internalCommonSubjectId, true);
     }


### PR DESCRIPTION
## What?

- When a users account is deleted ensure that we remove any entry from the account modifiers table by using the dynamo delete service to delete the account
- Remove the check of principal against public subject ID
- Always run `compose-down` after the Account Management Integration tests have run 

## Why?

- It's important to clear up any data associated with that user 
- The public subject ID was swapped with the internal sub id in December last year so this check is redundant