### PR TITLE
AUT-1217: Bump Terms and Conditions minor version to reflect changes

### DIFF
--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -128,7 +128,7 @@ variable "use_localstack" {
 
 variable "terms_and_conditions" {
   type    = string
-  default = "1.2"
+  default = "1.3"
 }
 
 variable "localstack_endpoint" {

--- a/ci/terraform/shared/variables.tf
+++ b/ci/terraform/shared/variables.tf
@@ -36,7 +36,7 @@ variable "external_redis_host" {
 
 variable "terms_and_conditions" {
   type    = string
-  default = "1.2"
+  default = "1.3"
 }
 
 variable "external_redis_port" {

--- a/ci/terraform/utils/variables.tf
+++ b/ci/terraform/utils/variables.tf
@@ -62,6 +62,6 @@ variable "cloudwatch_log_retention" {
 
 variable "terms_and_conditions" {
   type        = string
-  default     = "1.2"
+  default     = "1.3"
   description = "The latest Terms and Conditions version number"
 }


### PR DESCRIPTION
## What?

Bumps the `terms_and_conditions` version to `1.3`

## Why?

To reflect changes to the Terms and Conditions that will be released on 22 May. The three PRs necessary to make this change will be merged on 22 May. 

## Related PRs

* https://github.com/alphagov/di-authentication-frontend/pull/1010 changes the privacy notice text
