### PR TITLE
Adding configuration files for all terraform components

### DIFF
--- a/.github/workflows/build-api-modules.yml
+++ b/.github/workflows/build-api-modules.yml
@@ -15,15 +15,15 @@ jobs:
     strategy:
       matrix:
         module:
-        - oidc-api
         - account-management-api
+        - audit-processors
         - client-registry-api
+        - doc-checking-app-api
         - frontend-api
         - ipv-api
-        - doc-checking-app-api
-        - audit-processors
-        - utils
+        - oidc-api
         - test-services-api
+        - utils
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:

--- a/ci/terraform/account-management/dev.tfvars
+++ b/ci/terraform/account-management/dev.tfvars
@@ -1,0 +1,4 @@
+logging_endpoint_arn  = ""
+logging_endpoint_arns = []
+lambda_zip_file       = "./artifacts/account-management-api.zip"
+common_state_bucket   = "digital-identity-dev-tfstate"

--- a/ci/terraform/account-management/read_secrets.sh
+++ b/ci/terraform/account-management/read_secrets.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+ENVIRONMENT=$1
+
+if [ "$ENVIRONMENT" = "dev" ]; then
+	ENVIRONMENT="build";
+fi
+
+secrets=$(aws secretsmanager list-secrets --filter Key="name",Values="/deploy/$ENVIRONMENT/" --region eu-west-2 | jq -c '.SecretList[]')
+
+for i in $secrets; do
+  arn=$(echo $i | jq -r '.ARN')
+  name=$(echo $i | jq -r '.Name | split("/") | last')
+  value=$(aws secretsmanager get-secret-value --secret-id $arn | jq -r '.SecretString')
+  VAR=(TF_VAR_$name=$value)
+  export $VAR
+done

--- a/ci/terraform/audit-processors/dev.tfvars
+++ b/ci/terraform/audit-processors/dev.tfvars
@@ -1,0 +1,8 @@
+lambda_zip_file                     = "./artifacts/audit-processors.zip"
+deployer_role_arn                   = "arn:aws:iam::761723964695:role/deployer-role-pipeline-dev"
+logging_endpoint_arn                = ""
+logging_endpoint_arns               = []
+audit_storage_expiry_days           = 7
+txma_obfuscation_secret_arn         = ""
+txma_obfuscation_secret_kms_key_arn = ""
+shared_state_bucket                 = "digital-identity-dev-tfstate"

--- a/ci/terraform/delivery-receipts/dev.tfvars
+++ b/ci/terraform/delivery-receipts/dev.tfvars
@@ -1,0 +1,4 @@
+logging_endpoint_arn  = ""
+logging_endpoint_arns = []
+lambda_zip_file       = "./artifacts/delivery-receipts-api.jar"
+common_state_bucket   = "digital-identity-dev-tfstate"

--- a/ci/terraform/oidc/dev.tfvars
+++ b/ci/terraform/oidc/dev.tfvars
@@ -1,0 +1,11 @@
+oidc_api_lambda_zip_file             = "./artifacts/oidc-api.zip"
+frontend_api_lambda_zip_file         = "./artifacts/frontend-api.zip"
+client_registry_api_lambda_zip_file  = "./artifacts/client-registry-api.zip"
+ipv_api_lambda_zip_file              = "./artifacts/ipv-api.zip"
+doc_checking_app_api_lambda_zip_file = "./artifacts/doc-checking-app-api.zip"
+deployer_role_arn                    = "arn:aws:iam::761723964695:role/deployer-role-pipeline-dev"
+logging_endpoint_arn                 = ""
+logging_endpoint_arns                = []
+shared_state_bucket                  = "digital-identity-dev-tfstate"
+test_clients_enabled                 = true
+internal_sector_uri                  = "https://identity.dev.account.gov.uk"

--- a/ci/terraform/oidc/read_secrets.sh
+++ b/ci/terraform/oidc/read_secrets.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+ENVIRONMENT=$1
+
+if [ "$ENVIRONMENT" = "dev" ]; then
+	ENVIRONMENT="build";
+fi
+
+secrets=$(aws secretsmanager list-secrets --filter Key="name",Values="/deploy/$ENVIRONMENT/" --region eu-west-2 | jq -c '.SecretList[]')
+
+for i in $secrets; do
+  arn=$(echo $i | jq -r '.ARN')
+  name=$(echo $i | jq -r '.Name | split("/") | last')
+  value=$(aws secretsmanager get-secret-value --secret-id $arn | jq -r '.SecretString')
+  VAR=(TF_VAR_$name=$value)
+  export $VAR
+done

--- a/ci/terraform/shared/dev.tfvars
+++ b/ci/terraform/shared/dev.tfvars
@@ -1,0 +1,5 @@
+deployer_role_arn                    = "arn:aws:iam::761723964695:role/deployer-role-pipeline-dev"
+logging_endpoint_enabled             = false
+common_state_bucket                  = "digital-identity-dev-tfstate"
+di_tools_signing_profile_version_arn = "arn:aws:signer:eu-west-2:114407264696:/signing-profiles/di_auth_lambda_signing_20220215170204371800000001/zLiNn2Hi1I"
+tools_account_id                     = 706615647326

--- a/ci/terraform/shared/read_secrets.sh
+++ b/ci/terraform/shared/read_secrets.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+ENVIRONMENT=$1
+
+if [ "$ENVIRONMENT" = "dev" ]; then
+	ENVIRONMENT="build";
+fi
+
+secrets=$(aws secretsmanager list-secrets --filter Key="name",Values="/deploy/$ENVIRONMENT/" --region eu-west-2 | jq -c '.SecretList[]')
+
+for i in $secrets; do
+  arn=$(echo $i | jq -r '.ARN')
+  name=$(echo $i | jq -r '.Name | split("/") | last')
+  value=$(aws secretsmanager get-secret-value --secret-id $arn --region eu-west-2 | jq -r '.SecretString')
+  VAR=(TF_VAR_$name=$value)
+  export $VAR
+done
+
+TEST_CLIENT_EMAIL_ALLOWLIST=$(aws secretsmanager get-secret-value \
+	--secret-id test-client-email-allowlist \
+	--region eu-west-2 \
+	| jq --raw-output '.SecretString' | jq -r '."test-client-email-allowlist"'
+)
+
+export TF_VAR_test_client_email_allowlist=$TEST_CLIENT_EMAIL_ALLOWLIST

--- a/ci/terraform/test-services/dev.tfvars
+++ b/ci/terraform/test-services/dev.tfvars
@@ -1,0 +1,6 @@
+deployer_role_arn                 = "arn:aws:iam::761723964695:role/deployer-role-pipeline-dev"
+logging_endpoint_arn              = ""
+logging_endpoint_arns             = []
+shared_state_bucket               = "digital-identity-dev-tfstate"
+synthetics_users                  = ""
+test_services-api-lambda_zip_file = "./artifacts/test-services-api.zip"

--- a/ci/terraform/test-services/read_secrets.sh
+++ b/ci/terraform/test-services/read_secrets.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+ENVIRONMENT=$1
+
+if [ "$ENVIRONMENT" = "dev" ]; then
+	ENVIRONMENT="build";
+fi
+
+secrets=$(aws secretsmanager list-secrets --filter Key="name",Values="/deploy/$ENVIRONMENT/" --region eu-west-2 | jq -c '.SecretList[]')
+
+for i in $secrets; do
+  arn=$(echo $i | jq -r '.ARN')
+  name=$(echo $i | jq -r '.Name | split("/") | last')
+  value=$(aws secretsmanager get-secret-value --secret-id $arn | jq -r '.SecretString')
+  VAR=(TF_VAR_$name=$value)
+  export $VAR
+done

--- a/ci/terraform/utils/dev.tfvars
+++ b/ci/terraform/utils/dev.tfvars
@@ -1,0 +1,4 @@
+utils_release_zip_file = "./artifacts/utils.zip"
+shared_state_bucket    = "digital-identity-dev-tfstate"
+logging_endpoint_arn   = ""
+logging_endpoint_arns  = []


### PR DESCRIPTION
## What & Why?

To make the `auth-deploy-pipeline` run terraform the following have been created for each component:
- `dev.tfvars` file containing the input vars
- A `read_secretes.sh` file to get any secrets from SM

[PLAT-1412: Create the configs for each terraform component](https://govukverify.atlassian.net/browse/PLAT-1412)
Passing build for all comps: https://eu-west-2.console.aws.amazon.com/codesuite/codebuild/761723964695/projects/Deploy-auth-deploy-pipeline-dev/history?region=eu-west-2&builds-meta=eyJmIjp7InRleHQiOiIifSwicyI6e30sIm4iOjIwLCJpIjowfQ
