### PR TITLE
AUTH: Add additional stub client in dev to support acceptance test migration off concourse

### DIFF
--- a/ci/terraform/shared/build-stub-clients.tfvars
+++ b/ci/terraform/shared/build-stub-clients.tfvars
@@ -78,4 +78,24 @@ stub_rp_clients = [
     one_login_service = false
     service_type      = "OPTIONAL"
   },
+  {
+    client_name = "di-auth-stub-relying-party-dev"
+    callback_urls = [
+      "https://di-auth-stub-relying-party-dev.london.cloudapps.digital/oidc/authorization-code/callback",
+    ]
+    logout_urls = [
+      "https://di-auth-stub-relying-party-dev.london.cloudapps.digital/signed-out",
+    ]
+    test_client                     = "1"
+    consent_required                = "0"
+    identity_verification_supported = "1"
+    client_type                     = "web"
+    scopes = [
+      "openid",
+      "email",
+      "phone",
+    ]
+    one_login_service = false
+    service_type      = "MANDATORY"
+  },
 ]


### PR DESCRIPTION

## What?

Add additional stub client in dev to support acceptance test migration off concourse.

## Why?

To support migration off Concourse and into Secure Pipelines an additional logical environment has been built named 'dev' in the 'di-authentication-dev' account.  This environment is being used to test the pipelines.

An additional stub is required to run the acceptance tests against the dev environment.

Work to remove the dependencies on the PaaS stubs may not complete in time for the migration.
