### PR TITLE
AUT-1292: Use new Redis key for account recovery when verifying OTP code

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
@@ -167,7 +167,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
             throws Json.JsonException {
         String sessionId = redis.createSession();
         redis.addEmailToSession(sessionId, EMAIL_ADDRESS);
-        redis.blockMfaCodesForEmail(EMAIL_ADDRESS);
+        redis.blockMfaCodesForEmail(EMAIL_ADDRESS, emailNotificationType);
 
         VerifyCodeRequest codeRequest = new VerifyCodeRequest(emailNotificationType, "123456");
 

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
@@ -30,10 +30,12 @@ import java.util.Map;
 import java.util.Optional;
 
 import static uk.gov.di.authentication.shared.entity.NotificationType.MFA_SMS;
+import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_CHANGE_HOW_GET_SECURITY_CODES;
 import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_EMAIL;
 import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_PHONE_NUMBER;
 import static uk.gov.di.authentication.shared.services.AuthorisationCodeService.AUTH_CODE_PREFIX;
 import static uk.gov.di.authentication.shared.services.ClientSessionService.CLIENT_SESSION_PREFIX;
+import static uk.gov.di.authentication.shared.services.CodeStorageService.ACCOUNT_RECOVERY_CODE_BLOCKED_KEY_PREFIX;
 import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_BLOCKED_KEY_PREFIX;
 
 public class RedisExtension
@@ -226,10 +228,27 @@ public class RedisExtension
     }
 
     public void blockMfaCodesForEmail(String email) {
-        codeStorageService.saveBlockedForEmail(email, CODE_BLOCKED_KEY_PREFIX, 10);
+        blockMfaCodesForEmail(email, null);
+    }
+
+    public void blockMfaCodesForEmail(String email, NotificationType notificationType) {
+        var codeBlockedTime = 10;
+        if (notificationType == VERIFY_CHANGE_HOW_GET_SECURITY_CODES) {
+            codeStorageService.saveBlockedForEmail(
+                    email, ACCOUNT_RECOVERY_CODE_BLOCKED_KEY_PREFIX, codeBlockedTime);
+        }
+        codeStorageService.saveBlockedForEmail(email, CODE_BLOCKED_KEY_PREFIX, codeBlockedTime);
     }
 
     public boolean isBlockedMfaCodesForEmail(String email) {
+        return isBlockedMfaCodesForEmail(email, null);
+    }
+
+    public boolean isBlockedMfaCodesForEmail(String email, NotificationType notificationType) {
+        if (notificationType == VERIFY_CHANGE_HOW_GET_SECURITY_CODES) {
+            return codeStorageService.isBlockedForEmail(
+                    email, ACCOUNT_RECOVERY_CODE_BLOCKED_KEY_PREFIX);
+        }
         return codeStorageService.isBlockedForEmail(email, CODE_BLOCKED_KEY_PREFIX);
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java
@@ -14,6 +14,8 @@ public class CodeStorageService {
 
     public static final String CODE_REQUEST_BLOCKED_KEY_PREFIX = "code-request-blocked:";
     public static final String CODE_BLOCKED_KEY_PREFIX = "code-blocked:";
+    public static final String ACCOUNT_RECOVERY_CODE_BLOCKED_KEY_PREFIX =
+            "account-recovery-code-blocked:";
     public static final String PASSWORD_RESET_BLOCKED_KEY_PREFIX = "password-reset-blocked:";
 
     private static final Logger LOG = LogManager.getLogger(CodeStorageService.class);


### PR DESCRIPTION
## What?

Store block with a new Redis key specific for Account Recovery Journey when notification type is `VERIFY_CHANGE_HOW_GET_SECURITY_CODES`
- Uses `account-recovery-code-blocked:` as new key

## Why?

Minimise duplication of blocks so that it doesn't clash with other blocks for different notification types.