### PR TITLE
AUT-1297: Upgrade build environment default lambda runtime to java 17

### DIFF
--- a/ci/terraform/oidc/wellknown.tf
+++ b/ci/terraform/oidc/wellknown.tf
@@ -48,6 +48,8 @@ module "openid_configuration_discovery" {
 
   use_localstack = var.use_localstack
 
+  handler_runtime = var.environment == "build" ? "java17" : "java11"
+
   depends_on = [
     aws_api_gateway_rest_api.di_authentication_api,
     aws_api_gateway_resource.connect_resource,


### PR DESCRIPTION
AWS have recently released Java 17 as a default lambda runtime.

This only updates the runtime, not the build version.