### PR TITLE
Revert "AUT-1297: Upgrade build environment default lambda runtime to java 17"

### DIFF
--- a/ci/terraform/oidc/wellknown.tf
+++ b/ci/terraform/oidc/wellknown.tf
@@ -48,8 +48,6 @@ module "openid_configuration_discovery" {
 
   use_localstack = var.use_localstack
 
-  handler_runtime = var.environment == "build" ? "java17" : "java11"
-
   depends_on = [
     aws_api_gateway_rest_api.di_authentication_api,
     aws_api_gateway_resource.connect_resource,


### PR DESCRIPTION
This reverts commit 9aafd82ac8a9be09e892ac90fad1f7050ef9422a.

We need to upgrade our version of the AWS dependency first
