### PR TITLE
AUT-1183 - Give userexists lambda write permissions

### DIFF
--- a/ci/terraform/oidc/userexists.tf
+++ b/ci/terraform/oidc/userexists.tf
@@ -8,6 +8,7 @@ module "frontend_api_user_exists_role" {
     aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
     aws_iam_policy.dynamo_user_read_access_policy.arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
+    aws_iam_policy.dynamo_user_write_access_policy.arn,
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
     module.oidc_txma_audit.access_policy_arn


### PR DESCRIPTION
## What?

- Give userexists lambda write permissions

## Why?

- In case it needs to update the salt
