### PR TITLE
BAU: Log smoke test otp and phone number in integration only

### DIFF
--- a/ci/terraform/oidc/sqs.tf
+++ b/ci/terraform/oidc/sqs.tf
@@ -179,6 +179,7 @@ resource "aws_lambda_function" "email_sqs_lambda" {
       NOTIFY_TEMPLATE_PER_LANGUAGE = var.notify_template_per_language
       SMOKETEST_SMS_BUCKET_NAME    = local.sms_bucket_name
       JAVA_TOOL_OPTIONS            = "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
+      ENVIRONMENT                  = var.environment
     })
   }
   kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandler.java
@@ -268,6 +268,9 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
                 var putObjectRequest =
                         PutObjectRequest.builder().bucket(bucketName).key(destination).build();
                 s3Client.putObject(putObjectRequest, RequestBody.fromString(otp));
+                if ("integration".equals(configurationService.getEnvironment())) {
+                    LOG.info("Writing OTP to S3 bucket: {}", otp);
+                }
             } catch (Exception e) {
                 LOG.error(
                         "Exception thrown when writing to S3 bucket: {}",


### PR DESCRIPTION
## What?

Log smoke test otp and phone number in integration only.

## Why?

Create account smoke tests are failing intermittently due to the test otp being incorrect.  Adding additional logging to help diagnose the issue.
