### PR TITLE
AUT-1281: Add log info for visibility purpose to ensure otp is blocked for account recovery

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -157,8 +157,11 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
 
     private boolean isCodeBlockedForSession(Session session, NotificationType notificationType) {
         if (notificationType.equals(VERIFY_CHANGE_HOW_GET_SECURITY_CODES)) {
-            return codeStorageService.isBlockedForEmail(
-                    session.getEmailAddress(), ACCOUNT_RECOVERY_CODE_BLOCKED_KEY_PREFIX);
+            var blockedForAccountRecovery =
+                    codeStorageService.isBlockedForEmail(
+                            session.getEmailAddress(), ACCOUNT_RECOVERY_CODE_BLOCKED_KEY_PREFIX);
+            LOG.info("Code is blocked for AccountRecovery: {}", blockedForAccountRecovery);
+            return blockedForAccountRecovery;
         }
         return codeStorageService.isBlockedForEmail(
                 session.getEmailAddress(), CODE_BLOCKED_KEY_PREFIX);


### PR DESCRIPTION

## What?

Add log info in `isCodeblockedForSession` method.

## Why?

Visibility purpose to ensure OTP is blocked for account recovery
