### PR TITLE
BAU: Don't log batch errors when error collection empty

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CommonPasswordsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CommonPasswordsService.java
@@ -67,7 +67,8 @@ public class CommonPasswordsService {
 
             List<CommonPassword> unprocessedCommonPasswordPutItems =
                     result.unprocessedPutItemsForTable(dynamoCommonPasswordTable);
-            if (Objects.nonNull(unprocessedCommonPasswordPutItems)) {
+            if (Objects.nonNull(unprocessedCommonPasswordPutItems)
+                    && !unprocessedCommonPasswordPutItems.isEmpty()) {
                 LOG.error(
                         "Dynamo batch write returned failed batch, with {} failed batches",
                         unprocessedCommonPasswordPutItems.size());


### PR DESCRIPTION
## What?

Don't log batch errors when error collection empty.

## Why?

Errors are being logged for every entry added to the table, even though no errors have occured.

```
"loggerName": "uk.gov.di.authentication.shared.services.CommonPasswordsService",
"message": "Dynamo batch write returned failed batch, with 0 failed batches",
```

