### PR TITLE
BAU - Remove unused password validator method from ValidationHelper

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ValidationHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ValidationHelper.java
@@ -20,7 +20,6 @@ import static com.google.i18n.phonenumbers.PhoneNumberUtil.PhoneNumberType.MOBIL
 
 public class ValidationHelper {
     private static final Logger LOG = LogManager.getLogger(ValidationHelper.class);
-    private static final Pattern PASSWORD_REGEX = Pattern.compile(".*\\d.*");
     private static final Pattern EMAIL_NOTIFY_REGEX =
             Pattern.compile("^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~\\-]+@([^.@][^@\\s]+)$");
     private static final Pattern HOSTNAME_REGEX =
@@ -88,36 +87,6 @@ public class ValidationHelper {
 
     static boolean isAcceptedPhoneNumberType(PhoneNumberType phoneNumberType) {
         return MOBILE.equals(phoneNumberType) || FIXED_LINE_OR_MOBILE.equals(phoneNumberType);
-    }
-
-    public static Optional<ErrorResponse> validatePassword(String password) {
-        if (password == null || password.isBlank()) {
-            return Optional.of(ErrorResponse.ERROR_1005);
-        }
-        if (password.length() < 8) {
-            return Optional.of(ErrorResponse.ERROR_1006);
-        }
-        if (!PASSWORD_REGEX.matcher(password).matches()) {
-            return Optional.of(ErrorResponse.ERROR_1007);
-        }
-        return Optional.empty();
-    }
-
-    public static boolean hasAtLeastOneDigitAndOneNonDigit(String string) {
-        char[] charArray = string.toCharArray();
-        boolean hasDigit = false;
-        boolean hasNonDigit = false;
-        for (char c : charArray) {
-            if (hasDigit && hasNonDigit) {
-                break;
-            }
-            if (Character.isDigit(c)) {
-                hasDigit = true;
-                continue;
-            }
-            hasNonDigit = true;
-        }
-        return hasDigit && hasNonDigit;
     }
 
     public static Optional<ErrorResponse> validateEmailAddressUpdate(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/validation/PasswordValidator.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/validation/PasswordValidator.java
@@ -1,14 +1,13 @@
 package uk.gov.di.authentication.shared.validation;
 
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
-import uk.gov.di.authentication.shared.helpers.ValidationHelper;
 import uk.gov.di.authentication.shared.services.CommonPasswordsService;
 
 import java.util.Optional;
 
 public class PasswordValidator {
 
-    private CommonPasswordsService commonPasswordsService;
+    private final CommonPasswordsService commonPasswordsService;
 
     public PasswordValidator(CommonPasswordsService commonPasswordsService) {
         this.commonPasswordsService = commonPasswordsService;
@@ -22,7 +21,7 @@ public class PasswordValidator {
         if (password.length() < 8 || password.length() > 256) {
             return Optional.of(ErrorResponse.ERROR_1006);
         }
-        if (!ValidationHelper.hasAtLeastOneDigitAndOneNonDigit(password)) {
+        if (!hasAtLeastOneDigitAndOneNonDigit(password)) {
             return Optional.of(ErrorResponse.ERROR_1007);
         }
 
@@ -31,5 +30,22 @@ public class PasswordValidator {
         }
 
         return Optional.empty();
+    }
+
+    private boolean hasAtLeastOneDigitAndOneNonDigit(String string) {
+        char[] charArray = string.toCharArray();
+        boolean hasDigit = false;
+        boolean hasNonDigit = false;
+        for (char c : charArray) {
+            if (hasDigit && hasNonDigit) {
+                break;
+            }
+            if (Character.isDigit(c)) {
+                hasDigit = true;
+                continue;
+            }
+            hasNonDigit = true;
+        }
+        return hasDigit && hasNonDigit;
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ValidationHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ValidationHelperTest.java
@@ -98,29 +98,6 @@ class ValidationHelperTest {
                 equalTo(Optional.of(ErrorResponse.ERROR_1012)));
     }
 
-    private static Stream<Arguments> invalidPasswords() {
-        return Stream.of(
-                Arguments.of("", ErrorResponse.ERROR_1005),
-                Arguments.of(null, ErrorResponse.ERROR_1005),
-                Arguments.of("passw0r", ErrorResponse.ERROR_1006));
-    }
-
-    @ParameterizedTest
-    @MethodSource("invalidPasswords")
-    void shouldRejectInvalidPasswords(String password, ErrorResponse expectedResponse) {
-        assertEquals(Optional.of(expectedResponse), ValidationHelper.validatePassword(password));
-    }
-
-    private static Stream<String> validPasswords() {
-        return Stream.of("+pa?55worD", "computer-1", "passsssssssssssswwwwoooordddd-2");
-    }
-
-    @ParameterizedTest
-    @MethodSource("validPasswords")
-    void shouldAcceptValidPassword(String password) {
-        assertEquals(Optional.empty(), ValidationHelper.validatePassword(password));
-    }
-
     private static Stream<String> blankEmailAddresses() {
         return Stream.of("", "  ", "\t\t", System.lineSeparator() + System.lineSeparator(), null);
     }
@@ -397,21 +374,5 @@ class ValidationHelperTest {
                 expectedResult,
                 ValidationHelper.validateVerificationCode(
                         notificationType, storedCode, input, codeStorageService, EMAIL_ADDRESS, 5));
-    }
-
-    private static Stream<Arguments> testPasswords() {
-        return Stream.of(
-                arguments("12345896", false),
-                arguments("12a458Z6", true),
-                arguments("a12458Z6", true),
-                arguments("aZZZZkdfndsf!!@", false));
-    }
-
-    @ParameterizedTest
-    @MethodSource("testPasswords")
-    void shouldReturnFalseIfNoDigitOrOnlyDigits(String testPhoneNumber, boolean expectedResponse) {
-        assertEquals(
-                expectedResponse,
-                ValidationHelper.hasAtLeastOneDigitAndOneNonDigit(testPhoneNumber));
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/validation/PasswordValidatorTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/validation/PasswordValidatorTest.java
@@ -31,6 +31,7 @@ class PasswordValidatorTest {
                 Arguments.of("passw0r", ErrorResponse.ERROR_1006),
                 Arguments.of("passwordpasswordpassword", ErrorResponse.ERROR_1007),
                 Arguments.of("1234598765", ErrorResponse.ERROR_1007),
+                Arguments.of("aZZZZkdfndsf!!@", ErrorResponse.ERROR_1007),
                 Arguments.of(
                         new String(new char[300]).replace("\0", "a1"), ErrorResponse.ERROR_1006),
                 Arguments.of("TestCommonPassword1", ErrorResponse.ERROR_1040));


### PR DESCRIPTION
## What?
 - Remove unused password validator method from ValidationHelper

## Why?
- The method was only used by the unit test, so remove the validatePassword method from the ValidationHelper and remove the unit tests.
- Move the hasAtLeastOneDigitAndOneNonDigit method to the PasswordValidator and make it a private method as it is only used by the validate method in the PasswordValidator class