### PR TITLE
AUT-1281 - Return correct error when account recovery email OTPs are blocked

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -149,7 +149,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
 
     private ErrorResponse blockedCodeBehaviour(VerifyCodeRequest codeRequest) {
         return Map.ofEntries(
-                        entry(VERIFY_CHANGE_HOW_GET_SECURITY_CODES, ErrorResponse.ERROR_1033),
+                        entry(VERIFY_CHANGE_HOW_GET_SECURITY_CODES, ErrorResponse.ERROR_1048),
                         entry(VERIFY_EMAIL, ErrorResponse.ERROR_1033),
                         entry(MFA_SMS, ErrorResponse.ERROR_1027))
                 .get(codeRequest.getNotificationType());
@@ -268,13 +268,12 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                     };
         }
         AuditableEvent auditableEvent;
-        if (List.of(ErrorResponse.ERROR_1027, ErrorResponse.ERROR_1033).contains(errorResponse)) {
-            if (!List.of(VERIFY_EMAIL, VERIFY_CHANGE_HOW_GET_SECURITY_CODES)
-                            .contains(notificationType)
-                    && !errorResponse.equals(ErrorResponse.ERROR_1033)) {
+        if (List.of(ErrorResponse.ERROR_1027, ErrorResponse.ERROR_1033, ErrorResponse.ERROR_1048)
+                .contains(errorResponse)) {
+            if (errorResponse.equals(ErrorResponse.ERROR_1027)) {
                 blockCodeForSession(session);
             }
-            if (accountRecoveryJourney) {
+            if (errorResponse.equals(ErrorResponse.ERROR_1048)) {
                 blockCodeForAccountRecoverySession(session);
             }
             resetIncorrectMfaCodeAttemptsCount(session);

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
@@ -264,6 +264,10 @@ public class RedisExtension
         codeStorageService.increaseIncorrectMfaCodeAttemptsCount(email, mfaMethodType);
     }
 
+    public void increaseMfaCodeAttemptsCount(String email) {
+        codeStorageService.increaseIncorrectMfaCodeAttemptsCount(email);
+    }
+
     public void addToRedis(String key, String value, Long expiry) {
         redis.saveWithExpiry(key, value, expiry);
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
@@ -59,8 +59,7 @@ public enum ErrorResponse {
             "System is blocked from sending any email verification codes for changing how to receive security codes"),
     ERROR_1048(
             1048,
-            "User entered invalid email verification code for changing how to receive security codes too many times"),
-    ;
+            "User entered invalid email verification code for changing how to receive security codes too many times");
 
     private int code;
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ValidationHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ValidationHelper.java
@@ -188,8 +188,9 @@ public class ValidationHelper {
                 case MFA_SMS:
                     return Optional.of(ErrorResponse.ERROR_1027);
                 case VERIFY_EMAIL:
-                case VERIFY_CHANGE_HOW_GET_SECURITY_CODES:
                     return Optional.of(ErrorResponse.ERROR_1033);
+                case VERIFY_CHANGE_HOW_GET_SECURITY_CODES:
+                    return Optional.of(ErrorResponse.ERROR_1048);
                 case VERIFY_PHONE_NUMBER:
                     return Optional.of(ErrorResponse.ERROR_1034);
                 case RESET_PASSWORD_WITH_CODE:


### PR DESCRIPTION
## What?

- The frontend needs a different error code for account recovery to verify email exceeded attempts so it can perform different behaviour and show the relevant screen. Therefore when a user has exceeded the amount of OTP attempts for account recovery or is already blocked we will return the ERROR_1048.
- Modify tests to ensure we have sufficient coverage and there are no duplications

## Why?

- Users can be blocked when they exceed the number of OTP attempts for account recovery email OTPs. This is different to email OTPs for registration where users cannot be blocked when entering incorrect OTPs.
