### PR TITLE
Only warn on sendCriDataRequest failure to reduce alerting fatigue

### DIFF
--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
@@ -296,7 +296,7 @@ public class DocAppCallbackHandler
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN);
-                LOG.error("Doc App sendCriDataRequest was not successful: {}", e.getMessage());
+                LOG.warn("Doc App sendCriDataRequest was not successful: {}", e.getMessage());
                 return redirectToFrontendErrorPage();
             }
         } catch (DocAppCallbackException | NoSessionException e) {


### PR DESCRIPTION
## What?

Only warn on sendCriDataRequest failure to reduce alerting fatigue.

## Why?

An upstream issue with DCMAW is causing a very high error rate, leading to too much alerting noise.

