### PR TITLE
AUT-1282 - Add JourneyType to SendNotificationRequest

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/SendNotificationRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/SendNotificationRequest.java
@@ -3,6 +3,7 @@ package uk.gov.di.authentication.frontendapi.entity;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import uk.gov.di.authentication.shared.entity.BaseFrontendRequest;
+import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.validation.Required;
 
@@ -21,6 +22,10 @@ public class SendNotificationRequest extends BaseFrontendRequest {
     @Expose
     private Boolean requestNewCode;
 
+    @SerializedName("journeyType")
+    @Expose
+    private JourneyType journeyType;
+
     public NotificationType getNotificationType() {
         return notificationType;
     }
@@ -33,20 +38,7 @@ public class SendNotificationRequest extends BaseFrontendRequest {
         return requestNewCode;
     }
 
-    @Override
-    public String toString() {
-        return "SendNotificationRequest{"
-                + "notificationType="
-                + notificationType
-                + ", phoneNumber='"
-                + phoneNumber
-                + '\''
-                + ", email='"
-                + email
-                + '\''
-                + ", requestNewCode='"
-                + requestNewCode
-                + '\''
-                + '}';
+    public JourneyType getJourneyType() {
+        return journeyType;
     }
 }


### PR DESCRIPTION
## What?

- Add JourneyType to SendNotificationRequest

## Why?

- There are some scenarios where different journeys use the same notification type and there is no way to tell the difference which journey the user is going through. This can cause issues when applying blocks. An example of this is sending SMS otps for registration and sending SMS otps for account recovery.
