### PR TITLE
BAU: Switch DLQ alarms to Avg rather than Sum

### DIFF
--- a/ci/terraform/oidc/alerts.tf
+++ b/ci/terraform/oidc/alerts.tf
@@ -6,7 +6,7 @@ resource "aws_cloudwatch_metric_alarm" "sqs_deadletter_cloudwatch_alarm" {
   metric_name         = "ApproximateNumberOfMessagesVisible"
   namespace           = "AWS/SQS"
   period              = "300"
-  statistic           = "Sum"
+  statistic           = "Average"
   threshold           = var.dlq_alarm_threshold
 
   dimensions = {
@@ -24,7 +24,7 @@ resource "aws_cloudwatch_metric_alarm" "spot_request_sqs_dlq_cloudwatch_alarm" {
   metric_name         = "ApproximateNumberOfMessagesVisible"
   namespace           = "AWS/SQS"
   period              = "300"
-  statistic           = "Sum"
+  statistic           = "Average"
   threshold           = var.dlq_alarm_threshold
 
   dimensions = {


### PR DESCRIPTION

## What?

Switch DLQ alarms to Avg rather than Sum.

## Why?

Sum is adding up the number in the queue every minute for 5 minutes, instead of just seeing if the number in the queue is above the threshold.  For example, if there are 3 items in the DLQ the alarm value is currently 15 as it adds up the number in the queue every minute for 5 mins.
