### PR TITLE
AUT-1322 - Remove limit of Auth App OTP attempts for account recovery

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/MfaCodeProcessorFactory.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/MfaCodeProcessorFactory.java
@@ -39,9 +39,9 @@ public class MfaCodeProcessorFactory {
         switch (mfaMethodType) {
             case AUTH_APP:
                 int codeMaxRetries =
-                        codeRequest.getJourneyType().equals(JourneyType.REGISTRATION)
-                                ? configurationService.getCodeMaxRetriesRegistration()
-                                : configurationService.getCodeMaxRetries();
+                        codeRequest.getJourneyType().equals(JourneyType.SIGN_IN)
+                                ? configurationService.getCodeMaxRetries()
+                                : configurationService.getCodeMaxRetriesRegistration();
                 return Optional.of(
                         new AuthAppCodeProcessor(
                                 userContext,


### PR DESCRIPTION
## What?

- Remove limit of Auth App OTP attempts for account recovery

## Why?

- This makes setting up an auth app for account recovery consistent with setting up an auth app in the registration journey
