### PR TITLE
BAU: Additional logging for the notifications sqs handler

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandler.java
@@ -84,13 +84,16 @@ public class NotificationHandler implements RequestHandler<SQSEvent, Void> {
 
     public Void notifcationRequestHandler(SQSEvent event, Context context) {
 
-        Map<String, Object> notifyPersonalisation = new HashMap<>();
-
+        if (event != null && event.getRecords() != null) {
+            LOG.info("Processing Notification batch size: {}", event.getRecords().size());
+        }
         for (SQSMessage msg : event.getRecords()) {
+            LOG.info("Processing Notification message with id: {}", msg.getMessageId());
             try {
                 NotifyRequest notifyRequest =
                         objectMapper.readValue(msg.getBody(), NotifyRequest.class);
                 try {
+                    Map<String, Object> notifyPersonalisation = new HashMap<>();
                     switch (notifyRequest.getNotificationType()) {
                         case ACCOUNT_CREATED_CONFIRMATION:
                             notifyPersonalisation.put(


### PR DESCRIPTION
## What?

Additional logging for the notifications sqs handler.
Recreate the 'notifyPersonalisation' map for each message so that it is clear for each message request.

## Why?

- See how many messages are in the batch
- Log the message id for each message processed.  Will be able to track how many times it takes to process a message and when they are processed.
