### PR TITLE
BAU: Set notification sqs message queue visibility_timeout_seconds to 180s

### DIFF
--- a/ci/terraform/account-management/sqs.tf
+++ b/ci/terraform/account-management/sqs.tf
@@ -6,10 +6,11 @@ module "account_management_sqs_role" {
 }
 
 resource "aws_sqs_queue" "email_queue" {
-  name                      = "${var.environment}-account-management-notification-queue"
-  max_message_size          = 2048
-  message_retention_seconds = 1209600
-  receive_wait_time_seconds = 10
+  name                       = "${var.environment}-account-management-notification-queue"
+  max_message_size           = 2048
+  message_retention_seconds  = 1209600
+  receive_wait_time_seconds  = 10
+  visibility_timeout_seconds = 180
 
   kms_master_key_id                 = var.use_localstack ? null : "alias/aws/sqs"
   kms_data_key_reuse_period_seconds = var.use_localstack ? null : 300

--- a/ci/terraform/oidc/sqs.tf
+++ b/ci/terraform/oidc/sqs.tf
@@ -10,10 +10,11 @@ module "oidc_email_role" {
 }
 
 resource "aws_sqs_queue" "email_queue" {
-  name                      = "${var.environment}-email-notification-queue"
-  max_message_size          = 2048
-  message_retention_seconds = 1209600
-  receive_wait_time_seconds = 10
+  name                       = "${var.environment}-email-notification-queue"
+  max_message_size           = 2048
+  message_retention_seconds  = 1209600
+  receive_wait_time_seconds  = 10
+  visibility_timeout_seconds = 180
   redrive_policy = jsonencode({
     deadLetterTargetArn = aws_sqs_queue.email_dead_letter_queue.arn
     maxReceiveCount     = 3


### PR DESCRIPTION
## What?

Set notification sqs message queue visibility_timeout_seconds to 180s.

## Why?

Following guidance that this should be six times the lambda handler timeout.

There have recently been unexpected items on the DLQ which should not have been rejected and may be due to throttling.  Changing the config as recommended.

https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html#events-sqs-queueconfig

> To allow your function time to process each batch of records, set the source queue's [visibility timeout](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html) to at least six times the [timeout that you configure](https://docs.aws.amazon.com/lambda/latest/dg/configuration-function-common.html#configuration-common-summary) on your function. The extra time allows for Lambda to retry if your function is throttled while processing a previous batch.

## Related PRs

#3052 
