### PR TITLE
AUT-1210: Make MFA Code Blocks MFAMethodType dependent

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -228,14 +228,10 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
     private void blockCodeForSessionAndResetCountIfBlockDoesNotExist(
             String emailAddress, MFAMethodType mfaMethodType) {
 
-        if (codeStorageService.isBlockedForEmail(emailAddress, CODE_BLOCKED_KEY_PREFIX)) {
+        if (codeStorageService.isBlockedForEmail(
+                emailAddress, CODE_BLOCKED_KEY_PREFIX + mfaMethodType.getValue())) {
             return;
         }
-
-        codeStorageService.saveBlockedForEmail(
-                emailAddress,
-                CODE_BLOCKED_KEY_PREFIX,
-                configurationService.getBlockedEmailDuration());
 
         codeStorageService.saveBlockedForEmail(
                 emailAddress,

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessor.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessor.java
@@ -57,7 +57,7 @@ public class AuthAppCodeProcessor extends MfaCodeProcessor {
 
     @Override
     public Optional<ErrorResponse> validateCode() {
-        if (isCodeBlockedForSession()) {
+        if (isCodeBlockedForSession(MFAMethodType.AUTH_APP)) {
             LOG.info("Code blocked for session");
             return Optional.of(ErrorResponse.ERROR_1042);
         }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/MfaCodeProcessor.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/MfaCodeProcessor.java
@@ -44,8 +44,9 @@ public abstract class MfaCodeProcessor {
         this.accountModifiersService = accountModifiersService;
     }
 
-    boolean isCodeBlockedForSession() {
-        return codeStorageService.isBlockedForEmail(emailAddress, CODE_BLOCKED_KEY_PREFIX);
+    boolean isCodeBlockedForSession(MFAMethodType mfaMethodType) {
+        return codeStorageService.isBlockedForEmail(
+                emailAddress, CODE_BLOCKED_KEY_PREFIX + mfaMethodType.getValue());
     }
 
     boolean hasExceededRetryLimit(MFAMethodType mfaMethodType) {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessor.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessor.java
@@ -55,7 +55,7 @@ public class PhoneNumberCodeProcessor extends MfaCodeProcessor {
                 codeRequest.getJourneyType().equals(JourneyType.SIGN_IN)
                         ? NotificationType.MFA_SMS
                         : NotificationType.VERIFY_PHONE_NUMBER;
-        if (isCodeBlockedForSession()) {
+        if (isCodeBlockedForSession(MFAMethodType.SMS)) {
             LOG.info("Code blocked for session");
             return Optional.of(ErrorResponse.ERROR_1034);
         }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -425,7 +425,10 @@ class VerifyMfaCodeHandlerTest {
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1042));
         assertThat(session.getVerifiedMfaMethodType(), equalTo(null));
         verify(codeStorageService)
-                .saveBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX, 900L);
+                .saveBlockedForEmail(
+                        TEST_EMAIL_ADDRESS,
+                        CODE_BLOCKED_KEY_PREFIX + MFAMethodType.AUTH_APP.getValue(),
+                        900L);
         verify(codeStorageService)
                 .deleteIncorrectMfaCodeAttemptsCount(TEST_EMAIL_ADDRESS, MFAMethodType.AUTH_APP);
         verifyNoInteractions(cloudwatchMetricsService);
@@ -451,7 +454,9 @@ class VerifyMfaCodeHandlerTest {
         when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
                 .thenReturn(Optional.of(authAppCodeProcessor));
         when(authAppCodeProcessor.validateCode()).thenReturn(Optional.of(ErrorResponse.ERROR_1042));
-        when(codeStorageService.isBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX))
+        when(codeStorageService.isBlockedForEmail(
+                        TEST_EMAIL_ADDRESS,
+                        CODE_BLOCKED_KEY_PREFIX + MFAMethodType.AUTH_APP.getValue()))
                 .thenReturn(true);
         var authAppSecret = journeyType.equals(JourneyType.SIGN_IN) ? null : AUTH_APP_SECRET;
         var codeRequest =
@@ -463,6 +468,11 @@ class VerifyMfaCodeHandlerTest {
         assertThat(session.getVerifiedMfaMethodType(), equalTo(null));
         verify(codeStorageService, never())
                 .saveBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX, 900L);
+        verify(codeStorageService, never())
+                .saveBlockedForEmail(
+                        TEST_EMAIL_ADDRESS,
+                        CODE_BLOCKED_KEY_PREFIX + MFAMethodType.AUTH_APP.getValue(),
+                        900L);
         verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(TEST_EMAIL_ADDRESS);
         verifyNoInteractions(cloudwatchMetricsService);
         verify(auditService)
@@ -534,7 +544,10 @@ class VerifyMfaCodeHandlerTest {
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1034));
         assertThat(session.getVerifiedMfaMethodType(), equalTo(null));
         verify(codeStorageService)
-                .saveBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX, 900L);
+                .saveBlockedForEmail(
+                        TEST_EMAIL_ADDRESS,
+                        CODE_BLOCKED_KEY_PREFIX + MFAMethodType.SMS.getValue(),
+                        900L);
         verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(TEST_EMAIL_ADDRESS);
         verifyNoInteractions(cloudwatchMetricsService);
         verify(auditService)
@@ -563,7 +576,8 @@ class VerifyMfaCodeHandlerTest {
                 .thenReturn(Optional.of(phoneNumberCodeProcessor));
         when(phoneNumberCodeProcessor.validateCode())
                 .thenReturn(Optional.of(ErrorResponse.ERROR_1034));
-        when(codeStorageService.isBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX))
+        when(codeStorageService.isBlockedForEmail(
+                        TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX + MFAMethodType.SMS.getValue()))
                 .thenReturn(true);
         var codeRequest =
                 new VerifyMfaCodeRequest(MFAMethodType.SMS, CODE, journeyType, PHONE_NUMBER);
@@ -574,6 +588,11 @@ class VerifyMfaCodeHandlerTest {
         assertThat(session.getVerifiedMfaMethodType(), equalTo(null));
         verify(codeStorageService, never())
                 .saveBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX, 900L);
+        verify(codeStorageService, never())
+                .saveBlockedForEmail(
+                        TEST_EMAIL_ADDRESS,
+                        CODE_BLOCKED_KEY_PREFIX + MFAMethodType.SMS.getValue(),
+                        900L);
         verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(TEST_EMAIL_ADDRESS);
         verifyNoInteractions(cloudwatchMetricsService);
         verify(auditService)

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessorTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessorTest.java
@@ -285,7 +285,8 @@ class AuthAppCodeProcessorTest {
     private void setUpBlockedUser(CodeRequest codeRequest) {
         when(mockUserContext.getSession().getEmailAddress()).thenReturn("blocked-email-address");
         when(mockCodeStorageService.isBlockedForEmail(
-                        "blocked-email-address", CODE_BLOCKED_KEY_PREFIX))
+                        "blocked-email-address",
+                        CODE_BLOCKED_KEY_PREFIX + MFAMethodType.AUTH_APP.getValue()))
                 .thenReturn(true);
 
         this.authAppCodeProcessor =

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessorTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessorTest.java
@@ -235,7 +235,8 @@ class PhoneNumberCodeProcessorTest {
         when(codeStorageService.getOtpCode(
                         TEST_EMAIL_ADDRESS, NotificationType.VERIFY_PHONE_NUMBER))
                 .thenReturn(Optional.of(VALID_CODE));
-        when(codeStorageService.isBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX))
+        when(codeStorageService.isBlockedForEmail(
+                        TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX + MFAMethodType.SMS.getValue()))
                 .thenReturn(true);
         phoneNumberCodeProcessor =
                 new PhoneNumberCodeProcessor(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
@@ -513,7 +513,7 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 new VerifyMfaCodeRequest(
                         MFAMethodType.AUTH_APP, code, journeyType, profileInformation);
 
-        redis.blockMfaCodesForEmail(EMAIL_ADDRESS);
+        redis.blockAllMfaCodeTypesForEmail(EMAIL_ADDRESS);
 
         var response =
                 makeRequest(
@@ -558,7 +558,9 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(response, hasStatus(400));
         assertThat(response, hasJsonBody(ErrorResponse.ERROR_1042));
         assertEquals(0, redis.getMfaCodeAttemptsCount(EMAIL_ADDRESS, MFAMethodType.AUTH_APP));
-        assertTrue(redis.isBlockedMfaCodesForEmail(EMAIL_ADDRESS));
+        assertTrue(
+                redis.isBlockedMfaCodesForEmailAndSingleMfaMethodType(
+                        EMAIL_ADDRESS, MFAMethodType.AUTH_APP));
         assertTrue(userStore.isAccountVerified(EMAIL_ADDRESS));
         assertTrue(userStore.isAuthAppVerified(EMAIL_ADDRESS));
     }
@@ -584,7 +586,9 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         assertThat(response, hasStatus(400));
         assertThat(response, hasJsonBody(ErrorResponse.ERROR_1043));
-        assertFalse(redis.isBlockedMfaCodesForEmail(EMAIL_ADDRESS));
+        assertFalse(
+                redis.isBlockedMfaCodesForEmailAndSingleMfaMethodType(
+                        EMAIL_ADDRESS, MFAMethodType.AUTH_APP));
     }
 
     @Test
@@ -607,7 +611,9 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(response, hasStatus(400));
         assertThat(response, hasJsonBody(ErrorResponse.ERROR_1037));
         assertEquals(1, redis.getMfaCodeAttemptsCount(EMAIL_ADDRESS));
-        assertFalse(redis.isBlockedMfaCodesForEmail(EMAIL_ADDRESS));
+        assertFalse(
+                redis.isBlockedMfaCodesForEmailAndSingleMfaMethodType(
+                        EMAIL_ADDRESS, MFAMethodType.AUTH_APP));
     }
 
     @Test
@@ -808,7 +814,8 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         setUpSmsRequest(journeyType, PHONE_NUMBER);
 
         redis.addEmailToSession(sessionId, EMAIL_ADDRESS);
-        redis.blockMfaCodesForEmail(EMAIL_ADDRESS);
+
+        redis.blockAllMfaCodeTypesForEmail(EMAIL_ADDRESS);
 
         var codeRequest =
                 new VerifyMfaCodeRequest(

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
@@ -25,6 +25,7 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
 
 import java.time.LocalDateTime;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -227,8 +228,16 @@ public class RedisExtension
         return code;
     }
 
-    public void blockMfaCodesForEmail(String email) {
-        blockMfaCodesForEmail(email, null);
+    public void blockAllMfaCodeTypesForEmail(String email) {
+        int codeBlockedTime = 10;
+        EnumSet.allOf(MFAMethodType.class)
+                .forEach(
+                        mfaMethodType ->
+                                codeStorageService.saveBlockedForEmail(
+                                        email,
+                                        CODE_BLOCKED_KEY_PREFIX + mfaMethodType.getValue(),
+                                        codeBlockedTime));
+        codeStorageService.saveBlockedForEmail(email, CODE_BLOCKED_KEY_PREFIX, codeBlockedTime);
     }
 
     public void blockMfaCodesForEmail(String email, NotificationType notificationType) {
@@ -240,8 +249,10 @@ public class RedisExtension
         codeStorageService.saveBlockedForEmail(email, CODE_BLOCKED_KEY_PREFIX, codeBlockedTime);
     }
 
-    public boolean isBlockedMfaCodesForEmail(String email) {
-        return isBlockedMfaCodesForEmail(email, null);
+    public boolean isBlockedMfaCodesForEmailAndSingleMfaMethodType(
+            String email, MFAMethodType mfaMethodType) {
+        return codeStorageService.isBlockedForEmail(
+                email, CODE_BLOCKED_KEY_PREFIX + mfaMethodType.getValue());
     }
 
     public boolean isBlockedMfaCodesForEmail(String email, NotificationType notificationType) {


### PR DESCRIPTION
## What?
- In the past there was a single prefix for MFA Code blocks - covering email, SMS and Auth APP (T)OTPs
- This led to their behaviour affecting each other e.g. an 'SMS' block would also block Auth app use, even if the correct code was supplied
- To avoid this, we decided to add a qualifier for MFAMethodType to the existing prefix to avoid cross-type collisions:

|         | old         | new             |
|---------|-------------|-----------------|
| EMAIL   | CODE_BLOCKED_KEY_PREFIX        | CODE_BLOCKED_KEY_PREFIX            |
| SMS     | CODE_BLOCKED_KEY_PREFIX        | CODE_BLOCKED_KEY_PREFIX + SMS      |
| AUTH APP| CODE_BLOCKED_KEY_PREFIX        | CODE_BLOCKED_KEY_PREFIX + AUTH_APP |


- A previous commit made blocking actions 'double up' old and new styles (see 'Related PRs')
- Now that Redis has filled up with both types of prefix in production, it is safe to switch to checking for only the new prefix in 'isBlocked' type methods for those classes that extend MFaCodeProcessor (SMS and Auth App)
- Additionally, since the `VerifyMfaCodeHandler` (not to be confused with the `VerifyCodeHandler`) supports only designated MFAMethodTypes (SMS or AuthApp, but NOT email) we no longer need to save the 'base' prefix of CODE_BLOCKED_KEY_PREFIX on its own in that lambda as it is the de facto email prefix i.e. not applicable in this context


## Why?
- Stops one code block (e.g. SMS) affecting use of other MFA methods (e.g. auth app)

## Related PRs
- Redis was initially populated with 'new style' prefixes in a dual running style following this PR being merged: https://github.com/alphagov/di-authentication-api/pull/2930
