### PR TITLE
BAU: Log when no otp code found in session store

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessor.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessor.java
@@ -71,6 +71,10 @@ public class PhoneNumberCodeProcessor extends MfaCodeProcessor {
                         ? configurationService.getTestClientVerifyPhoneNumberOTP()
                         : codeStorageService.getOtpCode(emailAddress, notificationType);
 
+        if (!storedCode.isPresent()) {
+            LOG.info("No stored code returned from the codeStorageService");
+        }
+
         return ValidationHelper.validateVerificationCode(
                 notificationType,
                 storedCode,


### PR DESCRIPTION
## What?

Log when no otp code found in session store.

## Why?

To help investigate why the create account smoke test fails intermittently.
