### PR TITLE
[Do not merge before 15/6] AUT-1217: Bump Ts&Cs minor version

### DIFF
--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -128,7 +128,7 @@ variable "use_localstack" {
 
 variable "terms_and_conditions" {
   type    = string
-  default = "1.3"
+  default = "1.4"
 }
 
 variable "localstack_endpoint" {

--- a/ci/terraform/shared/variables.tf
+++ b/ci/terraform/shared/variables.tf
@@ -36,7 +36,7 @@ variable "external_redis_host" {
 
 variable "terms_and_conditions" {
   type    = string
-  default = "1.3"
+  default = "1.4"
 }
 
 variable "external_redis_port" {

--- a/ci/terraform/utils/variables.tf
+++ b/ci/terraform/utils/variables.tf
@@ -62,6 +62,6 @@ variable "cloudwatch_log_retention" {
 
 variable "terms_and_conditions" {
   type        = string
-  default     = "1.3"
+  default     = "1.4"
   description = "The latest Terms and Conditions version number"
 }


### PR DESCRIPTION
## What?

Update `terms_and_conditions` minor version.

## Why?

To reflect an update to the Privacy Notice that is scheduled for 15 June.

## Related PRs

https://github.com/alphagov/di-authentication-frontend/pull/1065
