### PR TITLE
AUT-1248: Add auth request passthrough from OIDC API to Auth frontend

### DIFF
--- a/oidc-api/build.gradle
+++ b/oidc-api/build.gradle
@@ -8,7 +8,8 @@ version "unspecified"
 
 dependencies {
 
-    compileOnly configurations.lambda,
+    compileOnly             configurations.kms,
+            configurations.lambda,
             configurations.sqs,
             configurations.sns,
             configurations.dynamodb
@@ -27,6 +28,7 @@ dependencies {
             project(":shared-test"),
             configurations.lambda,
             configurations.sqs,
+            configurations.kms,
             configurations.dynamodb
     testRuntimeOnly configurations.test_runtime
 }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/exceptions/InvalidJWEException.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/exceptions/InvalidJWEException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.authentication.oidc.exceptions;
+
+public class InvalidJWEException extends RuntimeException {
+    public InvalidJWEException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/exceptions/InvalidPublicKeyException.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/exceptions/InvalidPublicKeyException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.authentication.oidc.exceptions;
+
+public class InvalidPublicKeyException extends RuntimeException {
+    public InvalidPublicKeyException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthorizationService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthorizationService.java
@@ -34,6 +34,8 @@ import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.kms.model.SignRequest;
 import software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec;
 import uk.gov.di.authentication.oidc.entity.AuthRequestError;
+import uk.gov.di.authentication.oidc.exceptions.InvalidJWEException;
+import uk.gov.di.authentication.oidc.exceptions.InvalidPublicKeyException;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ValidClaims;
 import uk.gov.di.authentication.shared.entity.ValidScopes;
@@ -232,7 +234,7 @@ public class AuthorizationService {
             return encryptedJWT;
         } catch (ParseException | JOSEException e) {
             LOG.error("Error when generating SignedJWT", e);
-            throw new RuntimeException(e);
+            throw new InvalidJWEException("Error when generating SignedJWT", e);
         }
     }
 
@@ -252,10 +254,10 @@ public class AuthorizationService {
             return EncryptedJWT.parse(jweObject.serialize());
         } catch (JOSEException e) {
             LOG.error("Error when encrypting SignedJWT", e);
-            throw new RuntimeException(e);
+            throw new InvalidJWEException("Error when encrypting SignedJWT", e);
         } catch (ParseException e) {
             LOG.error("Error when parsing JWE object to EncryptedJWT", e);
-            throw new RuntimeException(e);
+            throw new InvalidJWEException("Error when parsing JWE object to EncryptedJWT", e);
         }
     }
 
@@ -270,7 +272,7 @@ public class AuthorizationService {
                     .toRSAPublicKey();
         } catch (JOSEException e) {
             LOG.error("Error parsing the public key to RSAPublicKey", e);
-            throw new RuntimeException();
+            throw new InvalidPublicKeyException("Error parsing the public key to RSAPublicKey", e);
         }
     }
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthorizationService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthorizationService.java
@@ -1,5 +1,21 @@
 package uk.gov.di.authentication.oidc.services;
 
+import com.nimbusds.jose.EncryptionMethod;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWEAlgorithm;
+import com.nimbusds.jose.JWEHeader;
+import com.nimbusds.jose.JWEObject;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.Payload;
+import com.nimbusds.jose.crypto.RSAEncrypter;
+import com.nimbusds.jose.crypto.impl.ECDSA;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.util.Base64URL;
+import com.nimbusds.jwt.EncryptedJWT;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
@@ -14,6 +30,9 @@ import com.nimbusds.openid.connect.sdk.OIDCClaimsRequest;
 import com.nimbusds.openid.connect.sdk.claims.ClaimsSetRequest;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.kms.model.SignRequest;
+import software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec;
 import uk.gov.di.authentication.oidc.entity.AuthRequestError;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ValidClaims;
@@ -23,8 +42,11 @@ import uk.gov.di.authentication.shared.exceptions.ClientNotFoundException;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoClientService;
+import uk.gov.di.authentication.shared.services.KmsConnectionService;
 
 import java.net.URI;
+import java.security.interfaces.RSAPublicKey;
+import java.text.ParseException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -37,20 +59,30 @@ import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachLogFie
 public class AuthorizationService {
 
     public static final String VTR_PARAM = "vtr";
+    private static final JWSAlgorithm SIGNING_ALGORITHM = JWSAlgorithm.ES256;
+    private final ConfigurationService configurationService;
     private final DynamoClientService dynamoClientService;
     private final IPVCapacityService ipvCapacityService;
+    private final KmsConnectionService kmsConnectionService;
     private static final Logger LOG = LogManager.getLogger(AuthorizationService.class);
 
     public AuthorizationService(
-            DynamoClientService dynamoClientService, IPVCapacityService ipvCapacityService) {
+            ConfigurationService configurationService,
+            DynamoClientService dynamoClientService,
+            IPVCapacityService ipvCapacityService,
+            KmsConnectionService kmsConnectionService) {
+        this.configurationService = configurationService;
         this.dynamoClientService = dynamoClientService;
         this.ipvCapacityService = ipvCapacityService;
+        this.kmsConnectionService = kmsConnectionService;
     }
 
     public AuthorizationService(ConfigurationService configurationService) {
         this(
+                configurationService,
                 new DynamoClientService(configurationService),
-                new IPVCapacityService(configurationService));
+                new IPVCapacityService(configurationService),
+                new KmsConnectionService(configurationService));
     }
 
     public boolean isClientRedirectUriValid(ClientID clientID, URI redirectURI)
@@ -167,6 +199,79 @@ public class AuthorizationService {
                             redirectURI));
         }
         return Optional.empty();
+    }
+
+    public EncryptedJWT getSignedAndEncryptedJWT(String clientName) {
+        LOG.info("Generating signed and encrypted JWT");
+        var jwsHeader = new JWSHeader(SIGNING_ALGORITHM);
+        var claimsBuilder = new JWTClaimsSet.Builder().claim("client-name", clientName);
+        var encodedHeader = jwsHeader.toBase64URL();
+        var encodedClaims = Base64URL.encode(claimsBuilder.build().toString());
+        var message = encodedHeader + "." + encodedClaims;
+        var signRequest =
+                SignRequest.builder()
+                        .message(SdkBytes.fromByteArray(message.getBytes()))
+                        .keyId(
+                                configurationService
+                                        .getOrchestrationToAuthenticationTokenSigningKeyAlias())
+                        .signingAlgorithm(SigningAlgorithmSpec.ECDSA_SHA_256)
+                        .build();
+        try {
+            LOG.info("Signing request JWT");
+            var signResult = kmsConnectionService.sign(signRequest);
+            LOG.info("Request JWT has been signed successfully");
+            var signature =
+                    Base64URL.encode(
+                                    ECDSA.transcodeSignatureToConcat(
+                                            signResult.signature().asByteArray(),
+                                            ECDSA.getSignatureByteArrayLength(SIGNING_ALGORITHM)))
+                            .toString();
+            var signedJWT = SignedJWT.parse(message + "." + signature);
+            var encryptedJWT = encryptJWT(signedJWT);
+            LOG.info("Encrypted request JWT has been generated");
+            return encryptedJWT;
+        } catch (ParseException | JOSEException e) {
+            LOG.error("Error when generating SignedJWT", e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    private EncryptedJWT encryptJWT(SignedJWT signedJWT) {
+        try {
+            LOG.info("Encrypting SignedJWT");
+            var publicEncryptionKey = getPublicKey();
+            var jweObject =
+                    new JWEObject(
+                            new JWEHeader.Builder(
+                                            JWEAlgorithm.RSA_OAEP_256, EncryptionMethod.A256GCM)
+                                    .contentType("JWT")
+                                    .build(),
+                            new Payload(signedJWT));
+            jweObject.encrypt(new RSAEncrypter(publicEncryptionKey));
+            LOG.info("SignedJWT has been successfully encrypted");
+            return EncryptedJWT.parse(jweObject.serialize());
+        } catch (JOSEException e) {
+            LOG.error("Error when encrypting SignedJWT", e);
+            throw new RuntimeException(e);
+        } catch (ParseException e) {
+            LOG.error("Error when parsing JWE object to EncryptedJWT", e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    private RSAPublicKey getPublicKey() {
+        try {
+            LOG.info("Getting Orchestration to Authentication Encryption Public Key");
+            var orchToAuthEncryptionPublicKey =
+                    configurationService.getOrchestrationToAuthenticationEncryptionPublicKey();
+            return new RSAKey.Builder(
+                            (RSAKey) JWK.parseFromPEMEncodedObjects(orchToAuthEncryptionPublicKey))
+                    .build()
+                    .toRSAPublicKey();
+        } catch (JOSEException e) {
+            LOG.error("Error parsing the public key to RSAPublicKey", e);
+            throw new RuntimeException();
+        }
     }
 
     public AuthenticationErrorResponse generateAuthenticationErrorResponse(

--- a/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/SSMParameterNotFoundException.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/SSMParameterNotFoundException.java
@@ -1,0 +1,8 @@
+package uk.gov.di.authentication.shared.exceptions;
+
+public class SSMParameterNotFoundException extends RuntimeException {
+
+    public SSMParameterNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -106,6 +106,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return Integer.parseInt(System.getenv().getOrDefault("CODE_AUTH_APP_ALLOWED_WINDOWS", "9"));
     }
 
+    public boolean isAuthOrchSplitEnabled() {
+        return System.getenv().getOrDefault("SUPPORT_AUTH_ORCH_SPLIT", "false").equals("true");
+    }
+
     public String getContactUsLinkRoute() {
         return System.getenv().getOrDefault("CONTACT_US_LINK_ROUTE", "");
     }
@@ -190,6 +194,26 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
 
     public String getFrontendBaseUrl() {
         return System.getenv().getOrDefault("FRONTEND_BASE_URL", "");
+    }
+
+    public String getOrchestrationToAuthenticationTokenSigningKeyAlias() {
+        return System.getenv("ORCH_TO_AUTH_TOKEN_SIGNING_KEY_ALIAS");
+    }
+
+    public String getOrchestrationToAuthenticationEncryptionPublicKey() {
+        var paramName = format("{0}-auth-public-encryption-key", getEnvironment());
+        try {
+            var request =
+                    GetParameterRequest.builder().withDecryption(true).name(paramName).build();
+            return getSsmClient().getParameter(request).parameter().value();
+        } catch (ParameterNotFoundException e) {
+            LOG.error("No parameter exists with name: {}", paramName);
+            throw new RuntimeException(e);
+        }
+    }
+
+    public String getOrchestrationClientIdForAuthenticationOauthFlow() {
+        return System.getenv().getOrDefault("ORCH_TO_AUTHORISATION_CLIENT_ID", "");
     }
 
     public URI getGovUKAccountsURL() {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -13,6 +13,7 @@ import software.amazon.awssdk.services.ssm.model.ParameterNotFoundException;
 import uk.gov.di.authentication.shared.configuration.AuditPublisherConfiguration;
 import uk.gov.di.authentication.shared.configuration.BaseLambdaConfiguration;
 import uk.gov.di.authentication.shared.entity.DeliveryReceiptsNotificationType;
+import uk.gov.di.authentication.shared.exceptions.SSMParameterNotFoundException;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 
 import java.net.URI;
@@ -207,8 +208,9 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
                     GetParameterRequest.builder().withDecryption(true).name(paramName).build();
             return getSsmClient().getParameter(request).parameter().value();
         } catch (ParameterNotFoundException e) {
-            LOG.error("No parameter exists with name: {}", paramName);
-            throw new RuntimeException(e);
+            String message = String.format("No parameter exists with name: %s", paramName);
+            LOG.error(message);
+            throw new SSMParameterNotFoundException(message, e);
         }
     }
 


### PR DESCRIPTION
## What?
- Add auth request passthrough from OIDC API to Auth frontend
- Package certain parameters of auth request as signed and encrypted JWT to be decrypted by Auth frontend
- Currently only client name is being passed as a test field

## Why?
- Will allow frontend to remove its dependency on client registry
