### PR TITLE
AUT-1248: Initial terraform to set KMS signing key policy for auth handler

### DIFF
--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -11,6 +11,7 @@ module "oidc_authorize_role" {
     aws_iam_policy.lambda_sns_policy.arn,
     aws_iam_policy.ipv_capacity_parameter_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
+    aws_iam_policy.orch_to_auth_kms_policy.arn,
     module.oidc_txma_audit.access_policy_arn
   ]
 }
@@ -24,19 +25,20 @@ module "authorize" {
   environment     = var.environment
 
   handler_environment_variables = {
-    DOMAIN_NAME              = local.service_domain
-    DOC_APP_API_ENABLED      = var.doc_app_api_enabled
-    DYNAMO_ENDPOINT          = var.use_localstack ? var.lambda_dynamo_endpoint : null
-    TXMA_AUDIT_QUEUE_URL     = module.oidc_txma_audit.queue_url
-    ENVIRONMENT              = var.environment
-    HEADERS_CASE_INSENSITIVE = var.use_localstack ? "true" : "false"
-    LOCALSTACK_ENDPOINT      = var.use_localstack ? var.localstack_endpoint : null
-    LOGIN_URI                = "https://${local.frontend_fqdn}/"
-    OIDC_API_BASE_URL        = local.api_base_url
-    REDIS_KEY                = local.redis_key
-    TERMS_CONDITIONS_VERSION = var.terms_and_conditions
-    SUPPORT_LANGUAGE_CY      = tostring(var.language_cy_enabled)
-    INTERNAl_SECTOR_URI      = var.internal_sector_uri
+    DOMAIN_NAME                          = local.service_domain
+    DOC_APP_API_ENABLED                  = var.doc_app_api_enabled
+    DYNAMO_ENDPOINT                      = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    TXMA_AUDIT_QUEUE_URL                 = module.oidc_txma_audit.queue_url
+    ENVIRONMENT                          = var.environment
+    HEADERS_CASE_INSENSITIVE             = var.use_localstack ? "true" : "false"
+    LOCALSTACK_ENDPOINT                  = var.use_localstack ? var.localstack_endpoint : null
+    LOGIN_URI                            = "https://${local.frontend_fqdn}/"
+    OIDC_API_BASE_URL                    = local.api_base_url
+    REDIS_KEY                            = local.redis_key
+    TERMS_CONDITIONS_VERSION             = var.terms_and_conditions
+    SUPPORT_LANGUAGE_CY                  = tostring(var.language_cy_enabled)
+    INTERNAl_SECTOR_URI                  = var.internal_sector_uri
+    ORCH_TO_AUTH_TOKEN_SIGNING_KEY_ALIAS = local.orch_to_auth_signing_key_alias_name
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.AuthorisationHandler::handleRequest"
   rest_api_id           = aws_api_gateway_rest_api.di_authentication_api.id

--- a/ci/terraform/oidc/kms-policies.tf
+++ b/ci/terraform/oidc/kms-policies.tf
@@ -39,6 +39,31 @@ resource "aws_iam_policy" "audit_signing_key_lambda_kms_signing_policy" {
   policy = data.aws_iam_policy_document.audit_payload_kms_signing_policy_document.json
 }
 
+### Signing key access for OIDC/Orch API to send signed authorize payload to Authentication
+
+data "aws_iam_policy_document" "orch_to_auth_kms_policy_document" {
+  statement {
+    sid    = "AllowAccessToKmsSigningKey"
+    effect = "Allow"
+
+    actions = [
+      "kms:Sign",
+      "kms:GetPublicKey",
+    ]
+    resources = [
+      local.orch_to_auth_signing_key_arn
+    ]
+  }
+}
+
+resource "aws_iam_policy" "orch_to_auth_kms_policy" {
+  name_prefix = "kms-orch-to-auth-policy"
+  path        = "/${var.environment}/orch-to-auth-kms-signing/"
+  description = "IAM policy for managing Orch/OIDC API's authorize endpoint KMS key access"
+
+  policy = data.aws_iam_policy_document.orch_to_auth_kms_policy_document.json
+}
+
 ### IPV Token signing key access
 
 data "aws_iam_policy_document" "ipv_token_auth_kms_policy_document" {
@@ -51,7 +76,7 @@ data "aws_iam_policy_document" "ipv_token_auth_kms_policy_document" {
       "kms:GetPublicKey",
     ]
     resources = [
-      local.ipv_token_auth_signing_key_arn
+      local.orch_to_auth_signing_key_arn
     ]
   }
 }

--- a/ci/terraform/oidc/shared.tf
+++ b/ci/terraform/oidc/shared.tf
@@ -26,6 +26,8 @@ locals {
   id_token_signing_key_arn                    = data.terraform_remote_state.shared.outputs.id_token_signing_key_arn
   ipv_token_auth_key_alias_name               = data.terraform_remote_state.shared.outputs.ipv_token_auth_signing_key_alias_name
   ipv_token_auth_signing_key_arn              = data.terraform_remote_state.shared.outputs.ipv_token_auth_signing_key_arn
+  orch_to_auth_signing_key_alias_name         = data.terraform_remote_state.shared.outputs.orch_to_auth_signing_key_alias_name
+  orch_to_auth_signing_key_arn                = data.terraform_remote_state.shared.outputs.orch_to_auth_signing_key_arn
   doc_app_auth_key_alias_name                 = data.terraform_remote_state.shared.outputs.doc_app_auth_signing_key_alias_name
   doc_app_auth_signing_key_arn                = data.terraform_remote_state.shared.outputs.doc_app_auth_signing_key_arn
   audit_signing_key_alias_name                = data.terraform_remote_state.shared.outputs.audit_signing_key_alias_name

--- a/ci/terraform/shared/kms.tf
+++ b/ci/terraform/shared/kms.tf
@@ -317,3 +317,19 @@ resource "aws_kms_alias" "doc_app_auth_signing_key_alias" {
   name          = "alias/${var.environment}-doc-app-auth-kms-key-alias"
   target_key_id = aws_kms_key.doc_app_auth_signing_key.key_id
 }
+
+# Orchestration to Authentication Signing KMS key
+
+resource "aws_kms_key" "orchestration_to_auth_signing_key" {
+  description              = "KMS signing key for Orchestration signing requests to Authentication"
+  deletion_window_in_days  = 30
+  key_usage                = "SIGN_VERIFY"
+  customer_master_key_spec = "ECC_NIST_P256"
+
+  tags = local.default_tags
+}
+
+resource "aws_kms_alias" "orchestration_to_auth_signing_key_alias" {
+  name          = "alias/${var.environment}-orch-signing-key-alias"
+  target_key_id = aws_kms_key.orchestration_to_auth_signing_key.key_id
+}

--- a/ci/terraform/shared/outputs.tf
+++ b/ci/terraform/shared/outputs.tf
@@ -88,6 +88,14 @@ output "doc_app_auth_signing_key_arn" {
   value = aws_kms_key.doc_app_auth_signing_key.arn
 }
 
+output "orch_to_auth_signing_key_alias_name" {
+  value = aws_kms_alias.orchestration_to_auth_signing_key_alias.name
+}
+
+output "orch_to_auth_signing_key_arn" {
+  value = aws_kms_key.orchestration_to_auth_signing_key.arn
+}
+
 output "audit_signing_key_alias_name" {
   value = aws_kms_alias.audit_payload_signing_key_alias.name
 }


### PR DESCRIPTION
## What?

- Initial terraform to set KMS signing policy for auth handler
- Prerequisite for auth handler to access keys for signing

## Why?

- These will in turn allow OIDC/Orch API to 'communicate' with auth frontend in a secure way