### PR TITLE
AUT-1248: Copy public encryption key for auth frontend into TF vars

### DIFF
--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -12,7 +12,8 @@ module "oidc_authorize_role" {
     aws_iam_policy.ipv_capacity_parameter_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
     module.oidc_txma_audit.access_policy_arn,
-    aws_iam_policy.orch_to_auth_kms_policy.arn
+    aws_iam_policy.orch_to_auth_kms_policy.arn,
+    aws_iam_policy.auth_public_encryption_key_parameter_policy.arn
   ]
 }
 

--- a/ci/terraform/oidc/build-overrides.tfvars
+++ b/ci/terraform/oidc/build-overrides.tfvars
@@ -1,21 +1,32 @@
-doc_app_api_enabled                = true
-doc_app_cri_data_endpoint          = "credentials/issue"
-doc_app_backend_uri                = "https://build-doc-app-cri-stub.london.cloudapps.digital"
-doc_app_domain                     = "https://build-doc-app-cri-stub.london.cloudapps.digital"
-doc_app_authorisation_client_id    = "authOrchestratorDocApp"
-doc_app_authorisation_callback_uri = "https://oidc.build.account.gov.uk/doc-app-callback"
-doc_app_authorisation_uri          = "https://build-doc-app-cri-stub.london.cloudapps.digital/authorize"
-doc_app_jwks_endpoint              = "https://build-doc-app-cri-stub.london.cloudapps.digital/.well-known/jwks.json"
-doc_app_encryption_key_id          = "7788bc975abd44e8b4fd7646d08ea9428476e37bff3e4365804b41cc29f8ef21"
-spot_enabled                       = false
-language_cy_enabled                = true
-internal_sector_uri                = "https://identity.build.account.gov.uk"
-extended_feature_flags_enabled     = true
-account_recovery_block_enabled     = true
-custom_doc_app_claim_enabled       = true
-ipv_no_session_response_enabled    = true
-doc_app_cri_data_v2_endpoint       = "credentials/issue"
-doc_app_use_cri_data_v2_endpoint   = true
+doc_app_api_enabled                 = true
+doc_app_cri_data_endpoint           = "credentials/issue"
+doc_app_backend_uri                 = "https://build-doc-app-cri-stub.london.cloudapps.digital"
+doc_app_domain                      = "https://build-doc-app-cri-stub.london.cloudapps.digital"
+doc_app_authorisation_client_id     = "authOrchestratorDocApp"
+doc_app_authorisation_callback_uri  = "https://oidc.build.account.gov.uk/doc-app-callback"
+doc_app_authorisation_uri           = "https://build-doc-app-cri-stub.london.cloudapps.digital/authorize"
+doc_app_jwks_endpoint               = "https://build-doc-app-cri-stub.london.cloudapps.digital/.well-known/jwks.json"
+doc_app_encryption_key_id           = "7788bc975abd44e8b4fd7646d08ea9428476e37bff3e4365804b41cc29f8ef21"
+spot_enabled                        = false
+language_cy_enabled                 = true
+internal_sector_uri                 = "https://identity.build.account.gov.uk"
+extended_feature_flags_enabled      = true
+account_recovery_block_enabled      = true
+custom_doc_app_claim_enabled        = true
+ipv_no_session_response_enabled     = true
+doc_app_cri_data_v2_endpoint        = "credentials/issue"
+doc_app_use_cri_data_v2_endpoint    = true
+auth_frontend_public_encryption_key = <<-EOT
+-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApLJWOHz7uHLinSJr8XM0
+fhyq0aLm8HP06lCT7csGUoRav2xybsCsypufvJHbuD5SLkg25/VGFt21KH2g60u8
+6mV7ULLG/m4hvAiXbwSGdcRTToPS+UULX3YDnDXZHvd+3ypane82+XLjVZ9B2V0i
+1MGCJ7kiRurXCuE+9Kx/MQYBCqhz/OwHlCe3FJZXKvgnqqpO5ZtyjrxDJSZJpxbi
+KsVnLksPKV10Z0/XvpJ6oHtOjseetk8TRdekRWBvqCX5MqLjdi1TfiaDu2Tjg2N0
+dqhoDR3/THktb4KThc+U5EOWCWpH4OIAetYtjFChnkR8kU05Ol9zfdR08uO0RxMk
+1wIDAQAB
+-----END PUBLIC KEY-----
+EOT
 
 blocked_email_duration = 30
 otp_code_ttl_duration  = 120

--- a/ci/terraform/oidc/integration-overrides.tfvars
+++ b/ci/terraform/oidc/integration-overrides.tfvars
@@ -25,6 +25,17 @@ account_recovery_block_enabled  = false
 custom_doc_app_claim_enabled    = true
 ipv_no_session_response_enabled = true
 
+auth_frontend_public_encryption_key = <<-EOT
+-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAojSigrHTBqF/2xuSptZo
+rifAahfOOD6BKOfRMZauLYLITU7+AASC+oIUU8vfJ6yMstuLbrpFHQ5lPgnbNQ4h
+Hp91wzXl2w/4TPgx9sH6AIVEe0nzM7w808jzGK1xkqeDN24TSdTCS9uU340K+1lg
+vHJ6RPURwpGKmwi/yQs4aEdBswK1qjdwtyz3KQF6a5sI3d4uCwtsLYfwD+yxIVnX
+L5tIdMLWFTMX7PCN24cwWFMz8JJr5D/3Gujy3oEJgaBLVSkBEQcGcR9zTcF46e0x
+qZM9NOP2fgb26CFV/vGQj21Jo+z4NK9+3doXwVESaw+8iTvlavUg1l91cJ1iHzde
+UQIDAQAB
+-----END PUBLIC KEY-----
+EOT
 
 ipv_auth_public_encryption_key = <<-EOT
 -----BEGIN PUBLIC KEY-----
@@ -37,6 +48,7 @@ cX8yiRmHf7ID9br2MsdrTO9YyVWfI0z7OZB1GnNe5lJhGBXvd3xg4UjWbnHikliE
 NQIDAQAB
 -----END PUBLIC KEY-----
 EOT
+
 logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]

--- a/ci/terraform/oidc/production-overrides.tfvars
+++ b/ci/terraform/oidc/production-overrides.tfvars
@@ -49,6 +49,18 @@ swIDAQAB
 -----END PUBLIC KEY-----
 EOT
 
+auth_frontend_public_encryption_key = <<-EOT
+-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAppKCOhyLiKs5QTB1L+XK
+Tgs9kosxma0PuagvNkP+UEPd0KumWc4sWlYUzR1D1aPX8AGDSQ1awOIb7PhlE5Ss
+5LilounpT9Pi+FvHFlGKgQzRO63j9CRXzYxhgHGpruzAAKUQ+6D0cuOdao3YF0zz
+RmaMSdHB4HsNhxV5DHY+2Rr7GeEfl6lQB8EHTAQzoagsIxihxNieUIGhHcegbCv6
+X5aV67lUEbjjfvGu888GL8qJakOPNoIn/pMBB5LIKVxbyoCB9nfFZ5fPFxBpLdvy
+p0qsf76XAFuA3nhupIqkXl8jOIDN3U79V1kAgyS8uoilhhblqAtCoJElEiDYQh1M
+NQIDAQAB
+-----END PUBLIC KEY-----
+EOT
+
 performance_tuning = {
   register = {
     memory          = 512

--- a/ci/terraform/oidc/sandpit.tfvars
+++ b/ci/terraform/oidc/sandpit.tfvars
@@ -11,6 +11,18 @@ ipv_authorisation_client_id    = ""
 logging_endpoint_enabled       = false
 logging_endpoint_arns          = []
 
+auth_frontend_public_encryption_key = <<-EOT
+-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAs41htFRe62BIfwQZ0OCT
+g5p2NHAekvIAJaNb6ZkLuLXYdLBax+2c9f4ALTrltmLMBpgtS6VQg2zO8UmSE4bX
++Nhaw2nf3/VRBIlAi2NiD4cUIwNtxIx5qpBeDxb+YR7NuTJ0nFq6u6jv34RB1RWE
+J1sEOiv9aSPEt6eK8TGL6uZbPGU8CKJuWwPfW1ko/lyuM1HG0G/KAZ8DaLJzOMWX
++2aZatj9RHtOCtGxwMrZlU4n/O1gbVPBfXx9RugTi0W4upmeNFR5CsC+WgENkr0v
+pXEyIW7edR6lDsSYzJI+yurVFyt82Bn7Vo2x5CIoLiH/1ZcKaApNU02/eK/gMBf+
+EwIDAQAB
+-----END PUBLIC KEY-----
+EOT
+
 enable_api_gateway_execution_request_tracing = true
 spot_enabled                                 = false
 

--- a/ci/terraform/oidc/ssm.tf
+++ b/ci/terraform/oidc/ssm.tf
@@ -86,6 +86,37 @@ resource "aws_iam_policy" "ipv_public_encryption_key_parameter_policy" {
   name_prefix = "ipv-public-encryption-key-parameter-store-policy"
 }
 
+## Authentication public encryption key parameter
+
+resource "aws_ssm_parameter" "auth_public_encryption_key" {
+  name  = "${var.environment}-auth-public-encryption-key"
+  type  = "String"
+  value = var.auth_frontend_public_encryption_key
+}
+
+data "aws_iam_policy_document" "auth_public_encryption_key_parameter_policy_document" {
+  statement {
+    sid    = "AllowGetParameters"
+    effect = "Allow"
+
+    actions = [
+      "ssm:GetParameter",
+      "ssm:GetParameters",
+    ]
+
+    resources = [
+      aws_ssm_parameter.auth_public_encryption_key.arn
+    ]
+  }
+}
+
+resource "aws_iam_policy" "auth_public_encryption_key_parameter_policy" {
+  description = "Policy to allow Orchestration to access Authentication's public encryption key in order to send encrypted JWTs that can be decrypted by Authentication (frontend)"
+  policy      = data.aws_iam_policy_document.auth_public_encryption_key_parameter_policy_document.json
+  path        = "/${var.environment}/lambda-parameters/"
+  name_prefix = "auth-public-encryption-key-parameter-store-policy"
+}
+
 ## SPOT
 
 resource "aws_ssm_parameter" "spot_account_number" {

--- a/ci/terraform/oidc/staging-overrides.tfvars
+++ b/ci/terraform/oidc/staging-overrides.tfvars
@@ -37,6 +37,18 @@ RWDJd2Fit4x9bFIqpZKqc1pGLu39UEaHLzRgi0hVDQhG5A7LpErOMjWquS2lmkwa
 -----END PUBLIC KEY-----
 EOT
 
+auth_frontend_public_encryption_key = <<-EOT
+-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzZGTSE8TLLtQjdmD6SiF
+SKbfv63JPCV+acPLQc4MjAKK7yT/QhERkemky+oPBIqCJgUq1gmOzdCAje/QEFlD
+qwry65oEaUBlWmGlNTPBnUzy/d6mYMfZObsr+yI1HszZE193ABAwtPttCFhFZWov
++rF2Oc9dmiAKXuT0whbOXaj1+751w5qJpsMWgHj91at9gdOZ31huoxnLkuAK/rus
+wEBMjmuOzy5osorLg9RCJQVN91Bp932vQS7hXirDpfBhCuQfYQMjFXv4MhCKnk42
+pi0FWWzbnn9UcbdcS/Sl5UeuTyCQ+MrunV/XGjIrPMWaFUIQomX1+pCMHkthbQ0J
+AQIDAQAB
+-----END PUBLIC KEY-----
+EOT
+
 performance_tuning = {
   register = {
     memory          = 512

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -319,6 +319,12 @@ variable "ipv_auth_public_encryption_key" {
   default = "undefined"
 }
 
+variable "auth_frontend_public_encryption_key" {
+  type        = string
+  default     = "undefined"
+  description = "Public encryption key which should be used to encrypt JWTs sent to Authentication (frontend)"
+}
+
 variable "doc_app_authorisation_uri" {
   type    = string
   default = "undefined"


### PR DESCRIPTION
## What?
- Copy public encryption key for auth frontend into TF vars. This relates to KMS that was created in the frontend ([here](https://github.com/alphagov/di-authentication-frontend/pull/1067)) and which has been established in all environments.
- The KMS keypair has been created via Terraform in the frontend repo
- This simply copies the public values and makes them exist as SSM parameters, which are then available to the config service for the OIDC/orchestration authorize lambda

Note: This approach of hard-coding values into TF vars is somewhat brittle. If the KMS ever rotates, this would need to be updated manually, which would be difficult (impossible?) to achieve with zero downtime. And if the KMS is accidentally deleted or anything like that, this would break the entire decryption mechanism, so it may be worth considering IAM based KMS access instead before this is put into production

## Why?
- The authorize lambda will be able to use this public key to encrypt JWTs sent to authentication frontend
- This is part of a wider project to receive more information as part of the authorize request to the frontend, so that it no longer needs to access information relating to the client registry - this will all be packaged within the authorize request itself (suitably encrypted and signed)

## Related PRs
- Terraform to set up _signing_ key was done here: https://github.com/alphagov/di-authentication-api/pull/3070
- This is the other 'half' of what needs to happen to auth request JWTs - signing and encryption

- Also this line: https://github.com/alphagov/di-authentication-api/pull/3073/files#diff-54beeddd61b7f115674fb289684006ff7344e75ea4be2def0ae8f806aa936e44R92 will need to match the SSM name expected here: https://github.com/alphagov/di-authentication-api/pull/3069/files#diff-d19c42eb829a8b56588fa4bd05b279042e09e71b698b8cc9231e0565e9dab4a9R204
