### PR TITLE
AUT-1347: Initialize new OTP request counter in caches

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/CodeRequestType.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/CodeRequestType.java
@@ -1,0 +1,75 @@
+package uk.gov.di.authentication.shared.entity;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public enum CodeRequestType {
+    EMAIL_REGISTRATION(NotificationType.VERIFY_EMAIL, JourneyType.REGISTRATION),
+    EMAIL_ACCOUNT_RECOVERY(
+            NotificationType.VERIFY_CHANGE_HOW_GET_SECURITY_CODES, JourneyType.ACCOUNT_RECOVERY),
+    SMS_ACCOUNT_RECOVERY(NotificationType.VERIFY_PHONE_NUMBER, JourneyType.ACCOUNT_RECOVERY),
+    SMS_REGISTRATION(NotificationType.VERIFY_PHONE_NUMBER, JourneyType.REGISTRATION),
+    SMS_SIGN_IN(NotificationType.MFA_SMS, JourneyType.SIGN_IN);
+
+    private static final Map<CodeRequestTypeKey, CodeRequestType> codeRequestTypeMap =
+            new HashMap<>();
+
+    static {
+        for (CodeRequestType codeRequestType : CodeRequestType.values()) {
+            CodeRequestTypeKey key =
+                    new CodeRequestTypeKey(
+                            codeRequestType.getNotificationType(),
+                            codeRequestType.getJourneyType());
+            codeRequestTypeMap.put(key, codeRequestType);
+        }
+    }
+
+    private final NotificationType notificationType;
+    private final JourneyType journeyType;
+
+    CodeRequestType(NotificationType notificationType, JourneyType journeyType) {
+        this.notificationType = notificationType;
+        this.journeyType = journeyType;
+    }
+
+    public static CodeRequestType getCodeRequestType(
+            NotificationType notificationType, JourneyType journeyType) {
+        CodeRequestTypeKey key = new CodeRequestTypeKey(notificationType, journeyType);
+        return codeRequestTypeMap.get(key);
+    }
+
+    private NotificationType getNotificationType() {
+        return notificationType;
+    }
+
+    private JourneyType getJourneyType() {
+        return journeyType;
+    }
+
+    private static class CodeRequestTypeKey {
+        private final NotificationType notificationType;
+        private final JourneyType journeyType;
+
+        CodeRequestTypeKey(NotificationType notificationType, JourneyType journeyType) {
+            this.notificationType = notificationType;
+            this.journeyType = journeyType;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            }
+            CodeRequestTypeKey other = (CodeRequestTypeKey) obj;
+            return notificationType == other.notificationType && journeyType == other.journeyType;
+        }
+
+        @Override
+        public int hashCode() {
+            return 31 * notificationType.hashCode() + journeyType.hashCode();
+        }
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
@@ -3,7 +3,9 @@ package uk.gov.di.authentication.shared.entity;
 import com.google.gson.annotations.Expose;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class Session {
 
@@ -25,6 +27,7 @@ public class Session {
     @Expose private int passwordResetCount;
 
     @Expose private int codeRequestCount;
+    @Expose private Map<CodeRequestType, Integer> codeRequestCounts;
 
     @Expose private CredentialTrustLevel currentCredentialStrength;
 
@@ -43,13 +46,8 @@ public class Session {
         this.clientSessions = new ArrayList<>();
         this.isNewAccount = AccountState.UNKNOWN;
         this.processingIdentityAttempts = 0;
-    }
-
-    public Session(String sessionId, List<String> clientSessions, String emailAddress) {
-        this.sessionId = sessionId;
-        this.clientSessions = clientSessions;
-        this.emailAddress = emailAddress;
-        this.isNewAccount = AccountState.UNKNOWN;
+        this.codeRequestCounts = new HashMap<>();
+        initializeCodeRequestCounts();
     }
 
     public String getSessionId() {
@@ -170,5 +168,11 @@ public class Session {
     public Session setInternalCommonSubjectIdentifier(String internalCommonSubjectIdentifier) {
         this.internalCommonSubjectIdentifier = internalCommonSubjectIdentifier;
         return this;
+    }
+
+    private void initializeCodeRequestCounts() {
+        for (CodeRequestType requestType : CodeRequestType.values()) {
+            codeRequestCounts.put(requestType, 0);
+        }
     }
 }


### PR DESCRIPTION
## What?
- Initialize new OTP request counter in caches
- This is a hash map that will break up the existing single-integer counter for all OTP requests
- With the hash map, they will be divided by code request type
- Code request type is a function of notification and journey types

## Why?
- Prerequisite to populating a new hashmap based counter safely 
- When we implement the counter methods, we want to know that all active sessions in production will contain the initialised hashmap to avoid null pointers

