### PR TITLE
AUT-1347: Add second counter for OTP requests

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/SendNotificationRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/SendNotificationRequest.java
@@ -24,6 +24,7 @@ public class SendNotificationRequest extends BaseFrontendRequest {
 
     @SerializedName("journeyType")
     @Expose
+    @Required
     private JourneyType journeyType;
 
     public NotificationType getNotificationType() {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
@@ -250,7 +250,8 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
                     CODE_REQUEST_BLOCKED_KEY_PREFIX,
                     configurationService.getBlockedEmailDuration());
             LOG.info("Resetting code request count");
-            sessionService.save(session.resetCodeRequestCount());
+            sessionService.save(
+                    session.resetCodeRequestCount(NotificationType.MFA_SMS, JourneyType.SIGN_IN));
             return Optional.of(ErrorResponse.ERROR_1025);
         }
         if (codeStorageService.isBlockedForEmail(email, CODE_REQUEST_BLOCKED_KEY_PREFIX)) {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
@@ -11,6 +11,8 @@ import uk.gov.di.authentication.frontendapi.entity.MfaRequest;
 import uk.gov.di.authentication.shared.domain.AuditableEvent;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.JourneyType;
+import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.NotifyRequest;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.exceptions.ClientNotFoundException;
@@ -192,7 +194,11 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
                                         return newCode;
                                     });
             LOG.info("Incrementing code request count");
-            sessionService.save(userContext.getSession().incrementCodeRequestCount());
+            sessionService.save(
+                    userContext
+                            .getSession()
+                            .incrementCodeRequestCount(
+                                    NotificationType.MFA_SMS, JourneyType.SIGN_IN));
             AuditableEvent auditableEvent;
             if (TestClientHelper.isTestClientWithAllowedEmail(userContext, configurationService)) {
                 LOG.info(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
@@ -226,7 +226,9 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
                                                         notificationType));
 
         LOG.info("Incrementing code request count");
-        sessionService.save(session.incrementCodeRequestCount());
+        sessionService.save(
+                session.incrementCodeRequestCount(
+                        request.getNotificationType(), request.getJourneyType()));
         var testClientWithAllowedEmail =
                 isTestClientWithAllowedEmail(userContext, configurationService);
         if (!testClientWithAllowedEmail) {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
@@ -11,6 +11,7 @@ import uk.gov.di.authentication.frontendapi.entity.SendNotificationRequest;
 import uk.gov.di.authentication.shared.domain.AuditableEvent;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.NotifyRequest;
 import uk.gov.di.authentication.shared.entity.Session;
@@ -141,7 +142,8 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
                     isCodeRequestAttemptValid(
                             request.getEmail(),
                             userContext.getSession(),
-                            request.getNotificationType());
+                            request.getNotificationType(),
+                            request.getJourneyType());
             if (codeRequestValid.isPresent()) {
                 auditService.submitAuditEvent(
                         getInvalidCodeAuditEventFromNotificationType(request.getNotificationType()),
@@ -281,7 +283,10 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
     }
 
     private Optional<ErrorResponse> isCodeRequestAttemptValid(
-            String email, Session session, NotificationType notificationType) {
+            String email,
+            Session session,
+            NotificationType notificationType,
+            JourneyType journeyType) {
         var codeRequestBlockedPrefix =
                 notificationType.equals(VERIFY_CHANGE_HOW_GET_SECURITY_CODES)
                         ? ACCOUNT_RECOVERY_CODE_REQUEST_BLOCKED_KEY_PREFIX
@@ -300,7 +305,7 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
                     codeRequestBlockedPrefix,
                     configurationService.getBlockedEmailDuration());
             LOG.info("Resetting code request count");
-            sessionService.save(session.resetCodeRequestCount());
+            sessionService.save(session.resetCodeRequestCount(notificationType, journeyType));
             return Optional.of(getErrorResponseForCodeRequestLimitReached(notificationType));
         }
         if (codeStorageService.isBlockedForEmail(email, codeRequestBlockedPrefix)) {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
@@ -19,6 +19,7 @@ import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.NotifyRequest;
 import uk.gov.di.authentication.shared.entity.Session;
@@ -339,14 +340,14 @@ public class MfaHandlerTest {
     }
 
     @Test
-    void shouldReturn400IfUserHasReachedTheMfaCodeRequestLimit() {
+    void shouldReturn400IfUserHasReachedTheSmsSignInCodeRequestLimit() {
         usingValidSession();
         when(configurationService.getBlockedEmailDuration()).thenReturn(BLOCKED_EMAIL_DURATION);
-        session.incrementCodeRequestCount();
-        session.incrementCodeRequestCount();
-        session.incrementCodeRequestCount();
-        session.incrementCodeRequestCount();
-        session.incrementCodeRequestCount();
+        session.incrementCodeRequestCount(NotificationType.MFA_SMS, JourneyType.SIGN_IN);
+        session.incrementCodeRequestCount(NotificationType.MFA_SMS, JourneyType.SIGN_IN);
+        session.incrementCodeRequestCount(NotificationType.MFA_SMS, JourneyType.SIGN_IN);
+        session.incrementCodeRequestCount(NotificationType.MFA_SMS, JourneyType.SIGN_IN);
+        session.incrementCodeRequestCount(NotificationType.MFA_SMS, JourneyType.SIGN_IN);
 
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setHeaders(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
@@ -921,7 +921,7 @@ class SendNotificationHandlerTest {
 
     private void maxOutCodeRequestCount(
             NotificationType notificationType, JourneyType journeyType) {
-        session.resetCodeRequestCount();
+        session.resetCodeRequestCount(notificationType, journeyType);
         session.incrementCodeRequestCount(notificationType, journeyType);
         session.incrementCodeRequestCount(notificationType, journeyType);
         session.incrementCodeRequestCount(notificationType, journeyType);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
@@ -24,6 +24,7 @@ import software.amazon.awssdk.core.exception.SdkClientException;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.NotifyRequest;
 import uk.gov.di.authentication.shared.entity.Session;
@@ -189,8 +190,10 @@ class SendNotificationHandlerTest {
         var result =
                 sendRequest(
                         format(
-                                "{ \"email\": \"%s\", \"notificationType\": \"%s\" }",
-                                TEST_EMAIL_ADDRESS, notificationType));
+                                "{ \"email\": \"%s\", \"notificationType\": \"%s\", \"journeyType\": \"%s\" }",
+                                TEST_EMAIL_ADDRESS,
+                                notificationType,
+                                JourneyType.ACCOUNT_RECOVERY));
 
         assertEquals(204, result.getStatusCode());
         verify(awsSqsClient)
@@ -237,8 +240,11 @@ class SendNotificationHandlerTest {
         var result =
                 sendRequest(
                         format(
-                                "{ \"email\": \"%s\", \"notificationType\": \"%s\", \"requestNewCode\": \"%s\" }",
-                                TEST_EMAIL_ADDRESS, notificationType, true));
+                                "{ \"email\": \"%s\", \"notificationType\": \"%s\", \"requestNewCode\": \"%s\", \"journeyType\": \"%s\" }",
+                                TEST_EMAIL_ADDRESS,
+                                notificationType,
+                                true,
+                                JourneyType.ACCOUNT_RECOVERY));
 
         assertThat(result, hasStatus(204));
         verify(codeGeneratorService).sixDigitCode();
@@ -283,8 +289,11 @@ class SendNotificationHandlerTest {
         var result =
                 sendRequest(
                         format(
-                                "{ \"email\": \"%s\", \"notificationType\": \"%s\", \"phoneNumber\": \"%s\" }",
-                                TEST_EMAIL_ADDRESS, VERIFY_PHONE_NUMBER, TEST_PHONE_NUMBER));
+                                "{ \"email\": \"%s\", \"notificationType\": \"%s\", \"phoneNumber\": \"%s\", \"journeyType\": \"%s\" }",
+                                TEST_EMAIL_ADDRESS,
+                                VERIFY_PHONE_NUMBER,
+                                TEST_PHONE_NUMBER,
+                                JourneyType.REGISTRATION));
 
         assertThat(result, hasStatus(204));
         verify(codeGeneratorService, never()).sixDigitCode();
@@ -328,8 +337,10 @@ class SendNotificationHandlerTest {
         var result =
                 sendRequest(
                         format(
-                                "{ \"email\": \"%s\", \"notificationType\": \"%s\" }",
-                                TEST_EMAIL_ADDRESS, notificationType));
+                                "{ \"email\": \"%s\", \"notificationType\": \"%s\", \"journeyType\": \"%s\" }",
+                                TEST_EMAIL_ADDRESS,
+                                notificationType,
+                                JourneyType.ACCOUNT_RECOVERY));
 
         assertEquals(204, result.getStatusCode());
         verifyNoInteractions(awsSqsClient);
@@ -394,8 +405,11 @@ class SendNotificationHandlerTest {
         var result =
                 sendRequest(
                         format(
-                                "{ \"email\": \"%s\", \"notificationType\": \"%s\", \"phoneNumber\": \"%s\" }",
-                                TEST_EMAIL_ADDRESS, VERIFY_PHONE_NUMBER, phoneNumber));
+                                "{ \"email\": \"%s\", \"notificationType\": \"%s\", \"phoneNumber\": \"%s\", \"journeyType\": \"%s\" }",
+                                TEST_EMAIL_ADDRESS,
+                                VERIFY_PHONE_NUMBER,
+                                phoneNumber,
+                                JourneyType.REGISTRATION));
 
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1012));
@@ -438,8 +452,8 @@ class SendNotificationHandlerTest {
         var result =
                 sendRequest(
                         format(
-                                "{ \"email\": \"%s\", \"notificationType\": \"%s\" }",
-                                TEST_EMAIL_ADDRESS, notificationType));
+                                "{ \"email\": \"%s\", \"notificationType\": \"%s\", \"journeyType\": \"%s\" }",
+                                TEST_EMAIL_ADDRESS, notificationType, JourneyType.REGISTRATION));
 
         assertEquals(500, result.getStatusCode());
         assertTrue(result.getBody().contains("Error sending message to queue"));
@@ -488,8 +502,11 @@ class SendNotificationHandlerTest {
         var result =
                 sendRequest(
                         format(
-                                "{ \"email\": \"%s\", \"notificationType\": \"%s\", \"phoneNumber\": \"%s\" }",
-                                TEST_EMAIL_ADDRESS, VERIFY_PHONE_NUMBER, phoneNumber));
+                                "{ \"email\": \"%s\", \"notificationType\": \"%s\", \"phoneNumber\": \"%s\", \"journeyType\": \"%s\" }",
+                                TEST_EMAIL_ADDRESS,
+                                VERIFY_PHONE_NUMBER,
+                                phoneNumber,
+                                JourneyType.REGISTRATION));
 
         assertEquals(204, result.getStatusCode());
         verify(codeGeneratorService).sixDigitCode();
@@ -529,8 +546,8 @@ class SendNotificationHandlerTest {
         var result =
                 sendRequest(
                         format(
-                                "{ \"email\": \"%s\", \"notificationType\": \"%s\" }",
-                                TEST_EMAIL_ADDRESS, VERIFY_PHONE_NUMBER));
+                                "{ \"email\": \"%s\", \"notificationType\": \"%s\", \"journeyType\": \"%s\" }",
+                                TEST_EMAIL_ADDRESS, VERIFY_PHONE_NUMBER, JourneyType.REGISTRATION));
 
         assertEquals(400, result.getStatusCode());
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1011));
@@ -540,15 +557,15 @@ class SendNotificationHandlerTest {
 
     @Test
     void shouldReturn400IfUserHasReachedTheRegistrationEmailOtpRequestLimit() {
-        maxOutCodeRequestCount();
+        maxOutCodeRequestCount(VERIFY_EMAIL, JourneyType.REGISTRATION);
         usingValidSession();
         usingValidClientSession(CLIENT_ID);
 
         var result =
                 sendRequest(
                         format(
-                                "{ \"email\": \"%s\", \"notificationType\": \"%s\" }",
-                                TEST_EMAIL_ADDRESS, VERIFY_EMAIL));
+                                "{ \"email\": \"%s\", \"notificationType\": \"%s\", \"journeyType\": \"%s\" }",
+                                TEST_EMAIL_ADDRESS, VERIFY_EMAIL, JourneyType.REGISTRATION));
 
         assertEquals(400, result.getStatusCode());
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1029));
@@ -576,15 +593,17 @@ class SendNotificationHandlerTest {
 
     @Test
     void shouldReturn400IfUserHasReachedTheAccountRecoveryEmailOtpRequestLimit() {
-        maxOutCodeRequestCount();
+        maxOutCodeRequestCount(VERIFY_EMAIL, JourneyType.ACCOUNT_RECOVERY);
         usingValidSession();
         usingValidClientSession(CLIENT_ID);
 
         var result =
                 sendRequest(
                         format(
-                                "{ \"email\": \"%s\", \"notificationType\": \"%s\" }",
-                                TEST_EMAIL_ADDRESS, VERIFY_CHANGE_HOW_GET_SECURITY_CODES));
+                                "{ \"email\": \"%s\", \"notificationType\": \"%s\", \"journeyType\": \"%s\" }",
+                                TEST_EMAIL_ADDRESS,
+                                VERIFY_CHANGE_HOW_GET_SECURITY_CODES,
+                                JourneyType.ACCOUNT_RECOVERY));
 
         assertEquals(400, result.getStatusCode());
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1046));
@@ -615,15 +634,18 @@ class SendNotificationHandlerTest {
 
     @Test
     void shouldReturn400IfUserHasReachedThePhoneCodeRequestLimit() {
-        maxOutCodeRequestCount();
+        maxOutCodeRequestCount(VERIFY_PHONE_NUMBER, JourneyType.REGISTRATION);
         usingValidSession();
         usingValidClientSession(CLIENT_ID);
 
         var result =
                 sendRequest(
                         format(
-                                "{ \"email\": \"%s\", \"notificationType\": \"%s\",  \"phoneNumber\": \"%s\"  }",
-                                TEST_EMAIL_ADDRESS, VERIFY_PHONE_NUMBER, TEST_PHONE_NUMBER));
+                                "{ \"email\": \"%s\", \"notificationType\": \"%s\",  \"phoneNumber\": \"%s\", \"journeyType\": \"%s\"  }",
+                                TEST_EMAIL_ADDRESS,
+                                VERIFY_PHONE_NUMBER,
+                                TEST_PHONE_NUMBER,
+                                JourneyType.REGISTRATION));
 
         assertEquals(400, result.getStatusCode());
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1030));
@@ -663,8 +685,8 @@ class SendNotificationHandlerTest {
         var result =
                 sendRequest(
                         format(
-                                "{ \"email\": \"%s\", \"notificationType\": \"%s\" }",
-                                TEST_EMAIL_ADDRESS, VERIFY_EMAIL));
+                                "{ \"email\": \"%s\", \"notificationType\": \"%s\", \"journeyType\": \"%s\" }",
+                                TEST_EMAIL_ADDRESS, VERIFY_EMAIL, JourneyType.REGISTRATION));
 
         assertEquals(400, result.getStatusCode());
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1031));
@@ -693,8 +715,10 @@ class SendNotificationHandlerTest {
         var result =
                 sendRequest(
                         format(
-                                "{ \"email\": \"%s\", \"notificationType\": \"%s\" }",
-                                TEST_EMAIL_ADDRESS, VERIFY_CHANGE_HOW_GET_SECURITY_CODES));
+                                "{ \"email\": \"%s\", \"notificationType\": \"%s\", \"journeyType\": \"%s\" }",
+                                TEST_EMAIL_ADDRESS,
+                                VERIFY_CHANGE_HOW_GET_SECURITY_CODES,
+                                JourneyType.ACCOUNT_RECOVERY));
 
         assertEquals(400, result.getStatusCode());
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1047));
@@ -723,8 +747,11 @@ class SendNotificationHandlerTest {
         var result =
                 sendRequest(
                         format(
-                                "{ \"email\": \"%s\", \"notificationType\": \"%s\",  \"phoneNumber\": \"%s\"  }",
-                                TEST_EMAIL_ADDRESS, VERIFY_PHONE_NUMBER, TEST_PHONE_NUMBER));
+                                "{ \"email\": \"%s\", \"notificationType\": \"%s\",  \"phoneNumber\": \"%s\", \"journeyType\": \"%s\"  }",
+                                TEST_EMAIL_ADDRESS,
+                                VERIFY_PHONE_NUMBER,
+                                TEST_PHONE_NUMBER,
+                                JourneyType.REGISTRATION));
 
         assertEquals(400, result.getStatusCode());
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1032));
@@ -753,8 +780,8 @@ class SendNotificationHandlerTest {
         var result =
                 sendRequest(
                         format(
-                                "{ \"email\": \"%s\", \"notificationType\": \"%s\" }",
-                                TEST_EMAIL_ADDRESS, VERIFY_EMAIL));
+                                "{ \"email\": \"%s\", \"notificationType\": \"%s\", \"journeyType\": \"%s\" }",
+                                TEST_EMAIL_ADDRESS, VERIFY_EMAIL, JourneyType.REGISTRATION));
 
         assertEquals(400, result.getStatusCode());
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1033));
@@ -783,8 +810,10 @@ class SendNotificationHandlerTest {
         var result =
                 sendRequest(
                         format(
-                                "{ \"email\": \"%s\", \"notificationType\": \"%s\" }",
-                                TEST_EMAIL_ADDRESS, VERIFY_CHANGE_HOW_GET_SECURITY_CODES));
+                                "{ \"email\": \"%s\", \"notificationType\": \"%s\", \"journeyType\": \"%s\" }",
+                                TEST_EMAIL_ADDRESS,
+                                VERIFY_CHANGE_HOW_GET_SECURITY_CODES,
+                                JourneyType.ACCOUNT_RECOVERY));
 
         assertEquals(400, result.getStatusCode());
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1048));
@@ -812,8 +841,8 @@ class SendNotificationHandlerTest {
         var result =
                 sendRequest(
                         format(
-                                "{ \"email\": \"%s\", \"notificationType\": \"%s\" }",
-                                TEST_EMAIL_ADDRESS, VERIFY_PHONE_NUMBER));
+                                "{ \"email\": \"%s\", \"notificationType\": \"%s\", \"journeyType\": \"%s\" }",
+                                TEST_EMAIL_ADDRESS, VERIFY_PHONE_NUMBER, JourneyType.REGISTRATION));
 
         assertEquals(400, result.getStatusCode());
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1034));
@@ -843,8 +872,8 @@ class SendNotificationHandlerTest {
         event.setHeaders(Map.of("Session-Id", session.getSessionId()));
         event.setBody(
                 format(
-                        "{ \"email\": \"%s\", \"notificationType\": \"%s\" }",
-                        TEST_EMAIL_ADDRESS, notificationType));
+                        "{ \"email\": \"%s\", \"notificationType\": \"%s\", \"journeyType\": \"%s\" }",
+                        TEST_EMAIL_ADDRESS, notificationType, JourneyType.REGISTRATION));
         var result = handler.handleRequest(event, context);
 
         var notifyRequest =
@@ -869,8 +898,8 @@ class SendNotificationHandlerTest {
         var result =
                 sendRequest(
                         format(
-                                "{ \"email\": \"%s\", \"notificationType\": \"%s\" }",
-                                TEST_EMAIL_ADDRESS, notificationType));
+                                "{ \"email\": \"%s\", \"notificationType\": \"%s\", \"journeyType\": \"%s\" }",
+                                TEST_EMAIL_ADDRESS, notificationType, JourneyType.REGISTRATION));
 
         assertEquals(204, result.getStatusCode());
         verifyNoInteractions(awsSqsClient);
@@ -890,13 +919,14 @@ class SendNotificationHandlerTest {
         return handler.handleRequest(event, context);
     }
 
-    private void maxOutCodeRequestCount() {
+    private void maxOutCodeRequestCount(
+            NotificationType notificationType, JourneyType journeyType) {
         session.resetCodeRequestCount();
-        session.incrementCodeRequestCount();
-        session.incrementCodeRequestCount();
-        session.incrementCodeRequestCount();
-        session.incrementCodeRequestCount();
-        session.incrementCodeRequestCount();
+        session.incrementCodeRequestCount(notificationType, journeyType);
+        session.incrementCodeRequestCount(notificationType, journeyType);
+        session.incrementCodeRequestCount(notificationType, journeyType);
+        session.incrementCodeRequestCount(notificationType, journeyType);
+        session.incrementCodeRequestCount(notificationType, journeyType);
     }
 
     private void usingValidSession() {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
@@ -16,6 +16,7 @@ import uk.gov.di.authentication.frontendapi.entity.VerifyCodeRequest;
 import uk.gov.di.authentication.frontendapi.lambda.VerifyCodeHandler;
 import uk.gov.di.authentication.shared.entity.ClientConsent;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.shared.entity.ValidScopes;
@@ -90,9 +91,12 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
     void shouldResetCodeRequestCountWhenSuccessfulEmailCodeAndReturn204(
             NotificationType emailNotificationType) throws Json.JsonException {
         var sessionId = redis.createSession();
-        redis.incrementSessionCodeRequestCount(sessionId);
-        redis.incrementSessionCodeRequestCount(sessionId);
-        redis.incrementSessionCodeRequestCount(sessionId);
+        redis.incrementSessionCodeRequestCount(
+                sessionId, emailNotificationType, JourneyType.ACCOUNT_RECOVERY);
+        redis.incrementSessionCodeRequestCount(
+                sessionId, emailNotificationType, JourneyType.ACCOUNT_RECOVERY);
+        redis.incrementSessionCodeRequestCount(
+                sessionId, emailNotificationType, JourneyType.ACCOUNT_RECOVERY);
         setUpTestWithoutSignUp(sessionId, withScope());
         String code = redis.generateAndSaveEmailCode(EMAIL_ADDRESS, 900, emailNotificationType);
         VerifyCodeRequest codeRequest = new VerifyCodeRequest(emailNotificationType, code);

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import uk.gov.di.authentication.shared.entity.AuthCodeExchangeData;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
+import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.Session;
@@ -190,11 +191,13 @@ public class RedisExtension
         return objectMapper.readValue(redis.getValue(sessionId), Session.class);
     }
 
-    public void incrementSessionCodeRequestCount(String sessionId) throws Json.JsonException {
+    public void incrementSessionCodeRequestCount(
+            String sessionId, NotificationType notificationType, JourneyType journeyType)
+            throws Json.JsonException {
         var session =
                 objectMapper
                         .readValue(redis.getValue(sessionId), Session.class)
-                        .incrementCodeRequestCount();
+                        .incrementCodeRequestCount(notificationType, journeyType);
         redis.saveWithExpiry(sessionId, objectMapper.writeValueAsString(session), 3600);
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/CodeRequestType.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/CodeRequestType.java
@@ -1,0 +1,75 @@
+package uk.gov.di.authentication.shared.entity;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public enum CodeRequestType {
+    EMAIL_REGISTRATION(NotificationType.VERIFY_EMAIL, JourneyType.REGISTRATION),
+    EMAIL_ACCOUNT_RECOVERY(
+            NotificationType.VERIFY_CHANGE_HOW_GET_SECURITY_CODES, JourneyType.ACCOUNT_RECOVERY),
+    SMS_ACCOUNT_RECOVERY(NotificationType.VERIFY_PHONE_NUMBER, JourneyType.ACCOUNT_RECOVERY),
+    SMS_REGISTRATION(NotificationType.VERIFY_PHONE_NUMBER, JourneyType.REGISTRATION),
+    SMS_SIGN_IN(NotificationType.MFA_SMS, JourneyType.SIGN_IN);
+
+    private static final Map<CodeRequestTypeKey, CodeRequestType> codeRequestTypeMap =
+            new HashMap<>();
+
+    static {
+        for (CodeRequestType codeRequestType : CodeRequestType.values()) {
+            CodeRequestTypeKey key =
+                    new CodeRequestTypeKey(
+                            codeRequestType.getNotificationType(),
+                            codeRequestType.getJourneyType());
+            codeRequestTypeMap.put(key, codeRequestType);
+        }
+    }
+
+    private final NotificationType notificationType;
+    private final JourneyType journeyType;
+
+    CodeRequestType(NotificationType notificationType, JourneyType journeyType) {
+        this.notificationType = notificationType;
+        this.journeyType = journeyType;
+    }
+
+    public static CodeRequestType getCodeRequestType(
+            NotificationType notificationType, JourneyType journeyType) {
+        CodeRequestTypeKey key = new CodeRequestTypeKey(notificationType, journeyType);
+        return codeRequestTypeMap.get(key);
+    }
+
+    private NotificationType getNotificationType() {
+        return notificationType;
+    }
+
+    private JourneyType getJourneyType() {
+        return journeyType;
+    }
+
+    private static class CodeRequestTypeKey {
+        private final NotificationType notificationType;
+        private final JourneyType journeyType;
+
+        CodeRequestTypeKey(NotificationType notificationType, JourneyType journeyType) {
+            this.notificationType = notificationType;
+            this.journeyType = journeyType;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            }
+            CodeRequestTypeKey other = (CodeRequestTypeKey) obj;
+            return notificationType == other.notificationType && journeyType == other.journeyType;
+        }
+
+        @Override
+        public int hashCode() {
+            return 31 * notificationType.hashCode() + journeyType.hashCode();
+        }
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
@@ -124,7 +124,11 @@ public class Session {
         return this;
     }
 
-    public Session resetCodeRequestCount() {
+    public Session resetCodeRequestCount(
+            NotificationType notificationType, JourneyType journeyType) {
+        CodeRequestType requestType =
+                CodeRequestType.getCodeRequestType(notificationType, journeyType);
+        codeRequestCounts.put(requestType, 0);
         this.codeRequestCount = 0;
         return this;
     }


### PR DESCRIPTION
## What?

Add second counter for OTP requests

- Add second counter for OTP requests
- The existing counter is a single integer which counts all OTP requests
- The new counter breaks this count into sub-counters which are grouped by code request type
- In practice code request type is a function of notification type and journey type
- Every combination of notification type and journey type maps to a single code request type
- Increment and reset to zero the counter as required in response to each code request type.

This extended counter solution is first being run in parallel with the existing counters in live in order to allow enough time for the existing sessions using the old counter to drain.  When every user has both types of counters we will be able to remove the old counter method.

## Why?

Each code request type needs to be tracked individually so that different types don't conflict with each other and consume the 5 retries allowed.

## Related PRs

#3075 