### PR TITLE
AUT-1346 - Create new cloudwatch alarm to trigger on error rate of lambda

### DIFF
--- a/ci/terraform/modules/endpoint-module/alerts.tf
+++ b/ci/terraform/modules/endpoint-module/alerts.tf
@@ -25,6 +25,52 @@ resource "aws_cloudwatch_metric_alarm" "lambda_error_cloudwatch_alarm" {
   alarm_actions       = [data.aws_sns_topic.slack_events.arn]
 }
 
+resource "aws_cloudwatch_metric_alarm" "lambda_error_rate_cloudwatch_alarm" {
+  count               = var.use_localstack || var.environment == "production" ? 0 : 1
+  alarm_name          = replace("${var.environment}-${var.endpoint_name}-error-rate-alarm", ".", "")
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  threshold           = var.lambda_log_alarm_error_rate_threshold
+  alarm_description   = "Lambda error rate of ${var.lambda_log_alarm_error_rate_threshold} has been reached in the ${var.environment} ${var.endpoint_name} lambda.ACCOUNT: ${data.aws_iam_account_alias.current.account_alias}"
+
+  metric_query {
+    id          = "e1"
+    return_data = true
+    expression  = "m2/m1*100"
+    label       = "Error Rate"
+  }
+
+  metric_query {
+    id = "m1"
+    metric {
+      namespace   = "AWS/Lambda"
+      metric_name = "Invocations"
+      period      = 60
+      stat        = "Sum"
+      unit        = "Count"
+
+      dimensions = {
+        FunctionName = aws_lambda_function.endpoint_lambda.function_name
+      }
+    }
+  }
+  metric_query {
+    id = "m2"
+    metric {
+      namespace   = "AWS/Lambda"
+      metric_name = "Errors"
+      period      = 60
+      stat        = "Sum"
+      unit        = "Count"
+
+      dimensions = {
+        FunctionName = aws_lambda_function.endpoint_lambda.function_name
+      }
+    }
+  }
+  alarm_actions = [data.aws_sns_topic.slack_events.arn]
+}
+
 data "aws_sns_topic" "slack_events" {
   name = "${var.environment}-slack-events"
 }

--- a/ci/terraform/modules/endpoint-module/variables.tf
+++ b/ci/terraform/modules/endpoint-module/variables.tf
@@ -138,6 +138,12 @@ variable "lambda_log_alarm_threshold" {
   default     = 5
 }
 
+variable "lambda_log_alarm_error_rate_threshold" {
+  type        = number
+  description = "The rate of errors in a lambda before generating a Cloudwatch alarm. Calculated by dividing the number of errors in a lambda divided by the number of invocations in a 60 second period"
+  default     = 10
+}
+
 variable "lambda_env_vars_encryption_kms_key_arn" {
   type = string
 }


### PR DESCRIPTION
## What?

- Create a new Cloudwatch alarm which triggers on the rate of errors which occur during a 60 second period. The rate is calculated by dividing the number of errors by the number of lambda invocations within a 60 second period. By multiplying this figure by 100, it will give us the rate of errors
- When the rate is greater than 10, then the alarm will trigger
- To ensure the alarm is configured correctly, we will only enable it in Integration to start with and output the alarm to slack
- We will monitor this against our existing alarm, which may be removed in the future if it becomes clear it no longer serves a purpose

## Why?

- We currently have a Cloudwatch alarm which triggers when a log message at level ERROR is raised. This doesn't capture unhandled errors/exceptions within the lambda itself.
- This alarm will help us detect any unexpected issues with our lambdas 
