### PR TITLE
AUT-1346 - Adjust error rate for authorize lambda

### DIFF
--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -45,6 +45,8 @@ module "authorize" {
   root_resource_id      = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
   execution_arn         = aws_api_gateway_rest_api.di_authentication_api.execution_arn
 
+  lambda_log_alarm_error_rate_threshold = 100
+
   memory_size                 = lookup(var.performance_tuning, "authorize", local.default_performance_parameters).memory
   provisioned_concurrency     = lookup(var.performance_tuning, "authorize", local.default_performance_parameters).concurrency
   max_provisioned_concurrency = lookup(var.performance_tuning, "authorize", local.default_performance_parameters).max_concurrency


### PR DESCRIPTION
## What?

 - Adjust error rate for authorize lambda
## Why?

- Authorize is opened to the public so sometimes it is called without query parameters which causes the lambda to throw an exception and hence increase the amount of errors.

