### PR TITLE
AUT-1346 - Disable cloudwatch metric alarm for authorize lambda

### DIFF
--- a/ci/terraform/modules/endpoint-module/alerts.tf
+++ b/ci/terraform/modules/endpoint-module/alerts.tf
@@ -26,7 +26,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda_error_cloudwatch_alarm" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "lambda_error_rate_cloudwatch_alarm" {
-  count               = var.use_localstack || var.environment == "production" ? 0 : 1
+  count               = var.use_localstack || var.environment == "production" || var.lambda_error_rate_alarm_disabled ? 0 : 1
   alarm_name          = replace("${var.environment}-${var.endpoint_name}-error-rate-alarm", ".", "")
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"

--- a/ci/terraform/modules/endpoint-module/variables.tf
+++ b/ci/terraform/modules/endpoint-module/variables.tf
@@ -144,6 +144,11 @@ variable "lambda_log_alarm_error_rate_threshold" {
   default     = 10
 }
 
+variable "lambda_error_rate_alarm_disabled" {
+  type    = bool
+  default = false
+}
+
 variable "lambda_env_vars_encryption_kms_key_arn" {
   type = string
 }

--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -45,7 +45,7 @@ module "authorize" {
   root_resource_id      = aws_api_gateway_rest_api.di_authentication_api.root_resource_id
   execution_arn         = aws_api_gateway_rest_api.di_authentication_api.execution_arn
 
-  lambda_log_alarm_error_rate_threshold = 100
+  lambda_error_rate_alarm_disabled = true
 
   memory_size                 = lookup(var.performance_tuning, "authorize", local.default_performance_parameters).memory
   provisioned_concurrency     = lookup(var.performance_tuning, "authorize", local.default_performance_parameters).concurrency


### PR DESCRIPTION
## What?

 - Disable cloudwatch metric alarm for authorize lambda

## Why?

- Threshold is reguarly getting breached in when the threshold is increased. Disable the alarm for now for the authorize lambda until we can prevent this from happening
