### PR TITLE
AUT-1347: Replace code request count with new implementation

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
@@ -240,8 +240,9 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
     private Optional<ErrorResponse> validateCodeRequestAttempts(
             String email, UserContext userContext) {
         Session session = userContext.getSession();
-        LOG.info("CodeRequestCount is: {}", session.getCodeRequestCount());
-        if (session.getCodeRequestCount() == configurationService.getCodeMaxRetries()) {
+        var codeRequestCount = session.getCodeRequestCount(MFA_SMS, JourneyType.SIGN_IN);
+        LOG.info("CodeRequestCount is: {}", codeRequestCount);
+        if (codeRequestCount == configurationService.getCodeMaxRetries()) {
             LOG.info(
                     "User has requested too many OTP codes. Setting block with prefix: {}",
                     CODE_REQUEST_BLOCKED_KEY_PREFIX);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
@@ -295,8 +295,9 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
                 notificationType.equals(VERIFY_CHANGE_HOW_GET_SECURITY_CODES)
                         ? ACCOUNT_RECOVERY_CODE_BLOCKED_KEY_PREFIX
                         : CODE_BLOCKED_KEY_PREFIX;
-        LOG.info("CodeRequestCount is: {}", session.getCodeRequestCount());
-        if (session.getCodeRequestCount() == configurationService.getCodeMaxRetries()) {
+        var codeRequestCount = session.getCodeRequestCount(notificationType, journeyType);
+        LOG.info("CodeRequestCount is: {}", codeRequestCount);
+        if (codeRequestCount == configurationService.getCodeMaxRetries()) {
             LOG.info(
                     "User has requested too many OTP codes. Setting block with prefix: {}",
                     codeRequestBlockedPrefix);

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
@@ -26,9 +26,7 @@ public class Session {
 
     @Expose private int passwordResetCount;
 
-    @Expose private int codeRequestCount;
-
-    @Expose private Map<CodeRequestType, Integer> codeRequestCounts;
+    @Expose private Map<CodeRequestType, Integer> codeRequestCountMap;
 
     @Expose private CredentialTrustLevel currentCredentialStrength;
 
@@ -47,8 +45,8 @@ public class Session {
         this.clientSessions = new ArrayList<>();
         this.isNewAccount = AccountState.UNKNOWN;
         this.processingIdentityAttempts = 0;
-        this.codeRequestCounts = new HashMap<>();
-        initializeCodeRequestCounts();
+        this.codeRequestCountMap = new HashMap<>();
+        initializeCodeRequestMap();
     }
 
     public String getSessionId() {
@@ -99,10 +97,6 @@ public class Session {
         return this;
     }
 
-    public int getCodeRequestCount() {
-        return codeRequestCount;
-    }
-
     public int getCodeRequestCount(NotificationType notificationType, JourneyType journeyType) {
         CodeRequestType requestType =
                 CodeRequestType.getCodeRequestType(notificationType, journeyType);
@@ -110,7 +104,7 @@ public class Session {
     }
 
     public int getCodeRequestCount(CodeRequestType requestType) {
-        return codeRequestCounts.getOrDefault(requestType, 0);
+        return codeRequestCountMap.getOrDefault(requestType, 0);
     }
 
     public Session incrementCodeRequestCount(
@@ -118,9 +112,8 @@ public class Session {
         CodeRequestType requestType =
                 CodeRequestType.getCodeRequestType(notificationType, journeyType);
         int currentCount = getCodeRequestCount(requestType);
-        codeRequestCounts.put(requestType, currentCount + 1);
+        codeRequestCountMap.put(requestType, currentCount + 1);
 
-        this.codeRequestCount = codeRequestCount + 1;
         return this;
     }
 
@@ -128,8 +121,7 @@ public class Session {
             NotificationType notificationType, JourneyType journeyType) {
         CodeRequestType requestType =
                 CodeRequestType.getCodeRequestType(notificationType, journeyType);
-        codeRequestCounts.put(requestType, 0);
-        this.codeRequestCount = 0;
+        codeRequestCountMap.put(requestType, 0);
         return this;
     }
 
@@ -191,9 +183,9 @@ public class Session {
         return this;
     }
 
-    private void initializeCodeRequestCounts() {
+    private void initializeCodeRequestMap() {
         for (CodeRequestType requestType : CodeRequestType.values()) {
-            codeRequestCounts.put(requestType, 0);
+            codeRequestCountMap.put(requestType, 0);
         }
     }
 }


### PR DESCRIPTION
## What?

Remove old code request counter to use the new implementation where it passes in NotificationType and JourneyType 

## Why?
Usage of passing in NotificationType and JourneyType in order to differentiate code request counters

## Related PRs
[](https://github.com/alphagov/di-authentication-api/pull/3076)
