### PR TITLE
AUT-1347: Remove duplicate variable created by merge

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
@@ -27,7 +27,6 @@ public class Session {
     @Expose private int passwordResetCount;
 
     @Expose private int codeRequestCount;
-    @Expose private Map<CodeRequestType, Integer> codeRequestCounts;
 
     @Expose private Map<CodeRequestType, Integer> codeRequestCounts;
 


### PR DESCRIPTION
## What?

Remove duplicate variable created by merge.

## Why?

When merging github created a duplicate variable rather than seeing it was the same thing.

## Related PRs

#3076 
#3082 