### PR TITLE
AUT-1344 - Configure staging to the same as production

### DIFF
--- a/ci/terraform/oidc/staging-overrides.tfvars
+++ b/ci/terraform/oidc/staging-overrides.tfvars
@@ -51,9 +51,23 @@ performance_tuning = {
     max_concurrency = 0
     scaling_trigger = 0
   }
+
+  reset-password = {
+    memory          = 1024
+    concurrency     = 2
+    max_concurrency = 10
+    scaling_trigger = 0.5
+  }
+
+  reset-password-request = {
+    memory          = 1024
+    concurrency     = 2
+    max_concurrency = 10
+    scaling_trigger = 0.5
+  }
 }
-lambda_max_concurrency = 3
-lambda_min_concurrency = 1
+lambda_max_concurrency = 10
+lambda_min_concurrency = 3
 endpoint_memory_size   = 1024
 scaling_trigger        = 0.6
 


### PR DESCRIPTION

## What?

- Configure staging to the same as production

## Why?

- Required as part of the performance test initiative

