### PR TITLE
AUT-1348: Add new prefix for code request block

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/SendNotificationRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/SendNotificationRequest.java
@@ -27,6 +27,13 @@ public class SendNotificationRequest extends BaseFrontendRequest {
     @Required
     private JourneyType journeyType;
 
+    public SendNotificationRequest(
+            String email, NotificationType notificationType, JourneyType journeyType) {
+        this.email = email;
+        this.notificationType = notificationType;
+        this.journeyType = journeyType;
+    }
+
     public NotificationType getNotificationType() {
         return notificationType;
     }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
@@ -10,6 +10,7 @@ import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.frontendapi.entity.MfaRequest;
 import uk.gov.di.authentication.shared.domain.AuditableEvent;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
+import uk.gov.di.authentication.shared.entity.CodeRequestType;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
@@ -249,6 +250,15 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
             codeStorageService.saveBlockedForEmail(
                     email,
                     CODE_REQUEST_BLOCKED_KEY_PREFIX,
+                    configurationService.getBlockedEmailDuration());
+            var codeRequestType = CodeRequestType.getCodeRequestType(MFA_SMS, JourneyType.SIGN_IN);
+            var newCodeRequestBlockPrefix = CODE_REQUEST_BLOCKED_KEY_PREFIX + codeRequestType;
+            LOG.info(
+                    "User has requested too many OTP codes. Setting block with new prefix: {}",
+                    newCodeRequestBlockPrefix);
+            codeStorageService.saveBlockedForEmail(
+                    email,
+                    newCodeRequestBlockPrefix,
                     configurationService.getBlockedEmailDuration());
             LOG.info("Resetting code request count");
             sessionService.save(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
+import uk.gov.di.authentication.shared.entity.CodeRequestType;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
@@ -368,6 +369,12 @@ public class MfaHandlerTest {
                 .saveBlockedForEmail(
                         TEST_EMAIL_ADDRESS,
                         CODE_REQUEST_BLOCKED_KEY_PREFIX,
+                        BLOCKED_EMAIL_DURATION);
+
+        verify(codeStorageService)
+                .saveBlockedForEmail(
+                        TEST_EMAIL_ADDRESS,
+                        CODE_REQUEST_BLOCKED_KEY_PREFIX + CodeRequestType.SMS_SIGN_IN,
                         BLOCKED_EMAIL_DURATION);
 
         verify(auditService)

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
@@ -23,6 +23,7 @@ import org.mockito.Mockito;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
+import uk.gov.di.authentication.shared.entity.CodeRequestType;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
@@ -208,6 +209,7 @@ class SendNotificationHandlerTest {
                         TEST_SIX_DIGIT_CODE,
                         CODE_EXPIRY_TIME,
                         notificationType);
+        verify(codeStorageService).getOtpCode(TEST_EMAIL_ADDRESS, notificationType);
         verify(sessionService)
                 .save(
                         argThat(
@@ -580,6 +582,11 @@ class SendNotificationHandlerTest {
                         TEST_EMAIL_ADDRESS,
                         CODE_REQUEST_BLOCKED_KEY_PREFIX,
                         BLOCKED_EMAIL_DURATION);
+        verify(codeStorageService)
+                .saveBlockedForEmail(
+                        TEST_EMAIL_ADDRESS,
+                        CODE_REQUEST_BLOCKED_KEY_PREFIX + CodeRequestType.EMAIL_REGISTRATION,
+                        BLOCKED_EMAIL_DURATION);
         verify(codeStorageService, never())
                 .saveOtpCode(
                         TEST_EMAIL_ADDRESS, TEST_SIX_DIGIT_CODE, CODE_EXPIRY_TIME, VERIFY_EMAIL);
@@ -617,6 +624,11 @@ class SendNotificationHandlerTest {
                 .saveBlockedForEmail(
                         TEST_EMAIL_ADDRESS,
                         ACCOUNT_RECOVERY_CODE_REQUEST_BLOCKED_KEY_PREFIX,
+                        BLOCKED_EMAIL_DURATION);
+        verify(codeStorageService)
+                .saveBlockedForEmail(
+                        TEST_EMAIL_ADDRESS,
+                        CODE_REQUEST_BLOCKED_KEY_PREFIX + CodeRequestType.EMAIL_ACCOUNT_RECOVERY,
                         BLOCKED_EMAIL_DURATION);
         verify(codeStorageService, never())
                 .saveOtpCode(
@@ -659,6 +671,11 @@ class SendNotificationHandlerTest {
                 .saveBlockedForEmail(
                         TEST_EMAIL_ADDRESS,
                         CODE_REQUEST_BLOCKED_KEY_PREFIX,
+                        BLOCKED_EMAIL_DURATION);
+        verify(codeStorageService)
+                .saveBlockedForEmail(
+                        TEST_EMAIL_ADDRESS,
+                        CODE_REQUEST_BLOCKED_KEY_PREFIX + CodeRequestType.SMS_REGISTRATION,
                         BLOCKED_EMAIL_DURATION);
         verify(codeStorageService, never())
                 .saveOtpCode(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/SendNotificationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/SendNotificationIntegrationTest.java
@@ -1,0 +1,48 @@
+package uk.gov.di.authentication.api;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
+import uk.gov.di.authentication.frontendapi.entity.SendNotificationRequest;
+import uk.gov.di.authentication.frontendapi.lambda.SendNotificationHandler;
+import uk.gov.di.authentication.shared.entity.JourneyType;
+import uk.gov.di.authentication.shared.entity.NotificationType;
+import uk.gov.di.authentication.shared.serialization.Json;
+import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
+
+class SendNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
+    private static final String USER_EMAIL = "test@email.com";
+    private String SESSION_ID;
+
+    @BeforeEach
+    void setup() throws Json.JsonException {
+        txmaAuditQueue.clear();
+        handler = new SendNotificationHandler(TXMA_ENABLED_CONFIGURATION_SERVICE);
+        SESSION_ID = redis.createUnauthenticatedSessionWithEmail(USER_EMAIL);
+    }
+
+    @Test
+    void shouldCallSendNotificationEndpointAndPlaceSuccessMessageOnAuditQueueWhenSuccessful() {
+        var response =
+                makeRequest(
+                        Optional.of(
+                                new SendNotificationRequest(
+                                        USER_EMAIL,
+                                        NotificationType.VERIFY_CHANGE_HOW_GET_SECURITY_CODES,
+                                        JourneyType.ACCOUNT_RECOVERY)),
+                        constructFrontendHeaders(SESSION_ID),
+                        Map.of());
+
+        assertThat(response, hasStatus(204));
+        assertTxmaAuditEventsReceived(
+                txmaAuditQueue, List.of(FrontendAuditableEvent.ACCOUNT_RECOVERY_EMAIL_CODE_SENT));
+    }
+}


### PR DESCRIPTION
## What?

- Add new prefix for code request block
- This will run alongside existing code request block until cache is filled with 'new style' prefixes

## Why?
- We will then be able to replace the 'is user blocked for code requests' logic to rely on the new prefix only
- By doing this, we will decouple different types of request block e.g. if a user is blocked from requesting OTPs for email verification, this should not necessarily block them from requesting other OTP types
