### PR TITLE
AUT-1348: Switch OTP request block check to new prefix

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java
@@ -13,8 +13,6 @@ import static java.lang.String.format;
 public class CodeStorageService {
 
     public static final String CODE_REQUEST_BLOCKED_KEY_PREFIX = "code-request-blocked:";
-    public static final String ACCOUNT_RECOVERY_CODE_REQUEST_BLOCKED_KEY_PREFIX =
-            "account-recovery-code-request-blocked:";
     public static final String CODE_BLOCKED_KEY_PREFIX = "code-blocked:";
     public static final String ACCOUNT_RECOVERY_CODE_BLOCKED_KEY_PREFIX =
             "account-recovery-code-blocked:";


### PR DESCRIPTION
## What?
- A previous commit introduced a new prefix style for OTP request blocking
- Historically, there was a single OTP code request block per session
- The new approach subdivides this by request type
- For example, a block for email OTP in registration does not mean the session is blocked for an SMS OTP request
- This commit builds on that change, by switching over business logic where the blocking status is checked
- It will now use the 'new' (compound) prefix and not the old prefix

## Why?
- Avoids 'cross pollution' between different types of code request block

## Related PRs
- New prefix style introduced here: https://github.com/alphagov/di-authentication-api/pull/3086
