### PR TITLE
AUT-1346 - Enable error rate alarm in Prod

### DIFF
--- a/ci/terraform/modules/endpoint-module/alerts.tf
+++ b/ci/terraform/modules/endpoint-module/alerts.tf
@@ -26,7 +26,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda_error_cloudwatch_alarm" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "lambda_error_rate_cloudwatch_alarm" {
-  count               = var.use_localstack || var.environment == "production" || var.lambda_error_rate_alarm_disabled ? 0 : 1
+  count               = var.use_localstack || var.lambda_error_rate_alarm_disabled ? 0 : 1
   alarm_name          = replace("${var.environment}-${var.endpoint_name}-error-rate-alarm", ".", "")
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"


### PR DESCRIPTION
## What?

 - Enable error rate alarm in Prod

## Why?

- It's been running in Integration over the weekend so it can be monitored. It seems to be running at the right level now so can be enabled in Production.