### PR TITLE
BAU - Attach ids to logs before attempting to retrieve session from Redis

### DIFF
--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -169,18 +169,18 @@ public class IPVCallbackHandler
                         noSessionEntity.getClientSessionId(),
                         AuditService.UNKNOWN);
             }
+            var clientSessionId = sessionCookiesIds.getClientSessionId();
+            var persistentId =
+                    PersistentIdHelper.extractPersistentIdFromCookieHeader(input.getHeaders());
+            attachLogFieldToLogs(PERSISTENT_SESSION_ID, persistentId);
+            attachSessionIdToLogs(sessionCookiesIds.getSessionId());
+            attachLogFieldToLogs(CLIENT_SESSION_ID, clientSessionId);
+            attachLogFieldToLogs(GOVUK_SIGNIN_JOURNEY_ID, clientSessionId);
             var session =
                     sessionService
                             .readSessionFromRedis(sessionCookiesIds.getSessionId())
                             .orElseThrow(() -> new IpvCallbackException("Session not found"));
 
-            attachSessionIdToLogs(session);
-            var persistentId =
-                    PersistentIdHelper.extractPersistentIdFromCookieHeader(input.getHeaders());
-            attachLogFieldToLogs(PERSISTENT_SESSION_ID, persistentId);
-            var clientSessionId = sessionCookiesIds.getClientSessionId();
-            attachLogFieldToLogs(CLIENT_SESSION_ID, clientSessionId);
-            attachLogFieldToLogs(GOVUK_SIGNIN_JOURNEY_ID, clientSessionId);
             var clientSession =
                     clientSessionService
                             .getClientSession(clientSessionId)


### PR DESCRIPTION
## What?

- Attach ids to logs before attempting to retrieve session from Redis

## Why?

- Currently we don't know the sessionId of the session that's not found. If we attach the relevant IDs to the logs before retrieving the session from Redis, we will be able to understand the last interaction with that session in Auth.
- By attaching the govukSigninJourneyId before retrieving the session, we will also be able to link it up to an IPV journey.

