### PR TITLE
AUT-1349: Add MFAMethodType to CodeRequestType

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/CodeRequestType.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/CodeRequestType.java
@@ -4,12 +4,11 @@ import java.util.HashMap;
 import java.util.Map;
 
 public enum CodeRequestType {
-    EMAIL_REGISTRATION(NotificationType.VERIFY_EMAIL, JourneyType.REGISTRATION),
-    EMAIL_ACCOUNT_RECOVERY(
-            NotificationType.VERIFY_CHANGE_HOW_GET_SECURITY_CODES, JourneyType.ACCOUNT_RECOVERY),
-    SMS_ACCOUNT_RECOVERY(NotificationType.VERIFY_PHONE_NUMBER, JourneyType.ACCOUNT_RECOVERY),
-    SMS_REGISTRATION(NotificationType.VERIFY_PHONE_NUMBER, JourneyType.REGISTRATION),
-    SMS_SIGN_IN(NotificationType.MFA_SMS, JourneyType.SIGN_IN);
+    EMAIL_REGISTRATION(MFAMethodType.EMAIL, JourneyType.REGISTRATION),
+    EMAIL_ACCOUNT_RECOVERY(MFAMethodType.EMAIL, JourneyType.ACCOUNT_RECOVERY),
+    SMS_ACCOUNT_RECOVERY(MFAMethodType.SMS, JourneyType.ACCOUNT_RECOVERY),
+    SMS_REGISTRATION(MFAMethodType.SMS, JourneyType.REGISTRATION),
+    SMS_SIGN_IN(MFAMethodType.SMS, JourneyType.SIGN_IN);
 
     private static final Map<CodeRequestTypeKey, CodeRequestType> codeRequestTypeMap =
             new HashMap<>();
@@ -18,28 +17,32 @@ public enum CodeRequestType {
         for (CodeRequestType codeRequestType : CodeRequestType.values()) {
             CodeRequestTypeKey key =
                     new CodeRequestTypeKey(
-                            codeRequestType.getNotificationType(),
-                            codeRequestType.getJourneyType());
+                            codeRequestType.getMfaMethodType(), codeRequestType.getJourneyType());
             codeRequestTypeMap.put(key, codeRequestType);
         }
     }
 
-    private final NotificationType notificationType;
+    private final MFAMethodType mfaMethodType;
     private final JourneyType journeyType;
 
-    CodeRequestType(NotificationType notificationType, JourneyType journeyType) {
-        this.notificationType = notificationType;
+    CodeRequestType(MFAMethodType mfaMethodType, JourneyType journeyType) {
+        this.mfaMethodType = mfaMethodType;
         this.journeyType = journeyType;
     }
 
     public static CodeRequestType getCodeRequestType(
             NotificationType notificationType, JourneyType journeyType) {
-        CodeRequestTypeKey key = new CodeRequestTypeKey(notificationType, journeyType);
+        return getCodeRequestType(notificationType.getMfaMethodType(), journeyType);
+    }
+
+    public static CodeRequestType getCodeRequestType(
+            MFAMethodType mfaMethodType, JourneyType journeyType) {
+        CodeRequestTypeKey key = new CodeRequestTypeKey(mfaMethodType, journeyType);
         return codeRequestTypeMap.get(key);
     }
 
-    private NotificationType getNotificationType() {
-        return notificationType;
+    public MFAMethodType getMfaMethodType() {
+        return mfaMethodType;
     }
 
     private JourneyType getJourneyType() {
@@ -47,11 +50,11 @@ public enum CodeRequestType {
     }
 
     private static class CodeRequestTypeKey {
-        private final NotificationType notificationType;
+        private final MFAMethodType mfaMethodType;
         private final JourneyType journeyType;
 
-        CodeRequestTypeKey(NotificationType notificationType, JourneyType journeyType) {
-            this.notificationType = notificationType;
+        CodeRequestTypeKey(MFAMethodType mfaMethodType, JourneyType journeyType) {
+            this.mfaMethodType = mfaMethodType;
             this.journeyType = journeyType;
         }
 
@@ -64,12 +67,12 @@ public enum CodeRequestType {
                 return false;
             }
             CodeRequestTypeKey other = (CodeRequestTypeKey) obj;
-            return notificationType == other.notificationType && journeyType == other.journeyType;
+            return mfaMethodType == other.mfaMethodType && journeyType == other.journeyType;
         }
 
         @Override
         public int hashCode() {
-            return 31 * notificationType.hashCode() + journeyType.hashCode();
+            return 31 * mfaMethodType.hashCode() + journeyType.hashCode();
         }
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/MFAMethodType.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/MFAMethodType.java
@@ -1,8 +1,10 @@
 package uk.gov.di.authentication.shared.entity;
 
 public enum MFAMethodType {
+    EMAIL("EMAIL"),
     AUTH_APP("AUTH_APP"),
-    SMS("SMS");
+    SMS("SMS"),
+    NONE("NONE");
 
     private String value;
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/NotificationType.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/NotificationType.java
@@ -9,43 +9,58 @@ import java.util.Map;
 public enum NotificationType implements TemplateAware {
     VERIFY_EMAIL(
             "VERIFY_EMAIL_TEMPLATE_ID",
-            Map.of(SupportedLanguage.CY, "VERIFY_EMAIL_TEMPLATE_ID_CY")),
+            Map.of(SupportedLanguage.CY, "VERIFY_EMAIL_TEMPLATE_ID_CY"),
+            MFAMethodType.EMAIL),
     VERIFY_PHONE_NUMBER(
             "VERIFY_PHONE_NUMBER_TEMPLATE_ID",
-            Map.of(SupportedLanguage.CY, "VERIFY_PHONE_NUMBER_TEMPLATE_ID_CY")),
-    MFA_SMS("MFA_SMS_TEMPLATE_ID", Map.of(SupportedLanguage.CY, "MFA_SMS_TEMPLATE_ID_CY")),
+            Map.of(SupportedLanguage.CY, "VERIFY_PHONE_NUMBER_TEMPLATE_ID_CY"),
+            MFAMethodType.SMS),
+    MFA_SMS(
+            "MFA_SMS_TEMPLATE_ID",
+            Map.of(SupportedLanguage.CY, "MFA_SMS_TEMPLATE_ID_CY"),
+            MFAMethodType.SMS),
     PASSWORD_RESET_CONFIRMATION(
             "PASSWORD_RESET_CONFIRMATION_TEMPLATE_ID",
-            Map.of(SupportedLanguage.CY, "PASSWORD_RESET_CONFIRMATION_TEMPLATE_ID_CY")),
+            Map.of(SupportedLanguage.CY, "PASSWORD_RESET_CONFIRMATION_TEMPLATE_ID_CY"),
+            MFAMethodType.NONE),
     PASSWORD_RESET_CONFIRMATION_SMS(
             "PASSWORD_RESET_CONFIRMATION_SMS_TEMPLATE_ID",
-            Map.of(SupportedLanguage.CY, "PASSWORD_RESET_CONFIRMATION_SMS_TEMPLATE_ID_CY")),
+            Map.of(SupportedLanguage.CY, "PASSWORD_RESET_CONFIRMATION_SMS_TEMPLATE_ID_CY"),
+            MFAMethodType.NONE),
     ACCOUNT_CREATED_CONFIRMATION(
             "ACCOUNT_CREATED_CONFIRMATION_TEMPLATE_ID",
-            Map.of(SupportedLanguage.CY, "ACCOUNT_CREATED_CONFIRMATION_TEMPLATE_ID_CY")),
+            Map.of(SupportedLanguage.CY, "ACCOUNT_CREATED_CONFIRMATION_TEMPLATE_ID_CY"),
+            MFAMethodType.NONE),
     RESET_PASSWORD_WITH_CODE(
             "RESET_PASSWORD_WITH_CODE_TEMPLATE_ID",
-            Map.of(SupportedLanguage.CY, "RESET_PASSWORD_WITH_CODE_TEMPLATE_ID_CY")),
+            Map.of(SupportedLanguage.CY, "RESET_PASSWORD_WITH_CODE_TEMPLATE_ID_CY"),
+            MFAMethodType.NONE),
     VERIFY_CHANGE_HOW_GET_SECURITY_CODES(
             "VERIFY_CHANGE_HOW_GET_SECURITY_CODES_TEMPLATE_ID",
-            Map.of(SupportedLanguage.CY, "VERIFY_CHANGE_HOW_GET_SECURITY_CODES_TEMPLATE_ID_CY")),
+            Map.of(SupportedLanguage.CY, "VERIFY_CHANGE_HOW_GET_SECURITY_CODES_TEMPLATE_ID_CY"),
+            MFAMethodType.EMAIL),
     CHANGE_HOW_GET_SECURITY_CODES_CONFIRMATION(
             "CHANGE_HOW_GET_SECURITY_CODES_CONFIRMATION_TEMPLATE_ID",
             Map.of(
                     SupportedLanguage.CY,
-                    "CHANGE_HOW_GET_SECURITY_CODES_CONFIRMATION_TEMPLATE_ID_CY"));
+                    "CHANGE_HOW_GET_SECURITY_CODES_CONFIRMATION_TEMPLATE_ID_CY"),
+            MFAMethodType.NONE);
 
     private final String templateName;
+    private final MFAMethodType mfaMethodType;
 
     private Map<SupportedLanguage, String> languageSpecificTemplates = new HashMap<>();
 
-    NotificationType(String templateName) {
+    NotificationType(String templateName, MFAMethodType mfaMethodType) {
         this.templateName = templateName;
+        this.mfaMethodType = mfaMethodType;
     }
 
     NotificationType(
-            String templateName, Map<SupportedLanguage, String> languageSpecificTemplates) {
-        this(templateName);
+            String templateName,
+            Map<SupportedLanguage, String> languageSpecificTemplates,
+            MFAMethodType mfaMethodType) {
+        this(templateName, mfaMethodType);
         this.languageSpecificTemplates = languageSpecificTemplates;
     }
 
@@ -63,5 +78,9 @@ public enum NotificationType implements TemplateAware {
 
     String getTemplateName(SupportedLanguage language) {
         return languageSpecificTemplates.getOrDefault(language, templateName);
+    }
+
+    public MFAMethodType getMfaMethodType() {
+        return mfaMethodType;
     }
 }


### PR DESCRIPTION
## What?
- CodeRequestType was keyed off NotificationType
- However, this is not universal
- All handlers either have direct access to an MFAMethodType or can infer it from the NotificationType
- The reverse is not true
- Making this change will therefore allow certain handlers e.g. VerifyMfaCodeHandler to use the getCodeRequestType static method

## Why?
- This will in turn allow all handers to obtain CodeRequestTypes for the purpose of computing Redis prefixes on a per-OTP basis
- By using the same CodeRequestType class as the basis, this will be cleaner and more consistent than if we had two different bases - one for NotificationType and one for MFAMethodType
- Making this change will allow us to make changes to Redis prefixes for OTP/MFA attempts (which happens in the VerifyMfaCodeHandler amongst others)

## Related PRs
- Changes some of the underlying mechanics (but should not change the actual prefixes in Redis or business behaviour) from: https://github.com/alphagov/di-authentication-api/pull/3090 and https://github.com/alphagov/di-authentication-api/pull/3082
- Supersedes an abandoned PR here: https://github.com/alphagov/di-authentication-api/pull/3094