### PR TITLE
AUT-1349: Attempt Block

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/CodeRequestType.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/CodeRequestType.java
@@ -8,7 +8,10 @@ public enum CodeRequestType {
     EMAIL_ACCOUNT_RECOVERY(MFAMethodType.EMAIL, JourneyType.ACCOUNT_RECOVERY),
     SMS_ACCOUNT_RECOVERY(MFAMethodType.SMS, JourneyType.ACCOUNT_RECOVERY),
     SMS_REGISTRATION(MFAMethodType.SMS, JourneyType.REGISTRATION),
-    SMS_SIGN_IN(MFAMethodType.SMS, JourneyType.SIGN_IN);
+    SMS_SIGN_IN(MFAMethodType.SMS, JourneyType.SIGN_IN),
+    AUTH_APP_ACCOUNT_RECOVERY(MFAMethodType.AUTH_APP, JourneyType.ACCOUNT_RECOVERY),
+    AUTH_APP_SIGN_IN(MFAMethodType.AUTH_APP, JourneyType.SIGN_IN),
+    AUTH_APP_REGISTRATION(MFAMethodType.AUTH_APP, JourneyType.REGISTRATION);
 
     private static final Map<CodeRequestTypeKey, CodeRequestType> codeRequestTypeMap =
             new HashMap<>();


### PR DESCRIPTION
## What?

- Set a new prefix code block alongside the existing block when the user has entered the incorrect OTP too many times. During journeys involving `VerifyMfaCodeHandler` and `VerifyCodeHandler`
- The new code block prefix will include an appended `CodeRequestType` ENUM
- This will run alongside existing code request block until cache is filled with 'new style' prefixes

## Why?

- To prevent code attempt blocks from interfering with one another