### PR TITLE
AUT-1349: Replace ATTEMPTS block with new code block prefix

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
@@ -244,31 +244,30 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
         var codeRequestCount = session.getCodeRequestCount(MFA_SMS, JourneyType.SIGN_IN);
         LOG.info("CodeRequestCount is: {}", codeRequestCount);
         var codeRequestType = CodeRequestType.getCodeRequestType(MFA_SMS, JourneyType.SIGN_IN);
-        var newCodeRequestBlockPrefix = CODE_REQUEST_BLOCKED_KEY_PREFIX + codeRequestType;
+        var codeRequestBlockPrefix = CODE_REQUEST_BLOCKED_KEY_PREFIX + codeRequestType;
+        var codeAttemptsBlockPrefix = CODE_BLOCKED_KEY_PREFIX + codeRequestType;
 
         if (codeRequestCount == configurationService.getCodeMaxRetries()) {
             LOG.info(
                     "User has requested too many OTP codes. Setting block with prefix: {}",
-                    newCodeRequestBlockPrefix);
+                    codeRequestBlockPrefix);
             codeStorageService.saveBlockedForEmail(
-                    email,
-                    newCodeRequestBlockPrefix,
-                    configurationService.getBlockedEmailDuration());
+                    email, codeRequestBlockPrefix, configurationService.getBlockedEmailDuration());
             LOG.info("Resetting code request count");
             sessionService.save(
                     session.resetCodeRequestCount(NotificationType.MFA_SMS, JourneyType.SIGN_IN));
             return Optional.of(ErrorResponse.ERROR_1025);
         }
-        if (codeStorageService.isBlockedForEmail(email, newCodeRequestBlockPrefix)) {
+        if (codeStorageService.isBlockedForEmail(email, codeRequestBlockPrefix)) {
             LOG.info(
                     "User is blocked from requesting any OTP codes. Code request block prefix: {}",
-                    newCodeRequestBlockPrefix);
+                    codeRequestBlockPrefix);
             return Optional.of(ErrorResponse.ERROR_1026);
         }
-        if (codeStorageService.isBlockedForEmail(email, CODE_BLOCKED_KEY_PREFIX)) {
+        if (codeStorageService.isBlockedForEmail(email, codeAttemptsBlockPrefix)) {
             LOG.info(
                     "User is blocked from entering any OTP codes. Code attempt block prefix: {}",
-                    CODE_BLOCKED_KEY_PREFIX);
+                    codeAttemptsBlockPrefix);
             return Optional.of(ErrorResponse.ERROR_1027);
         }
         return Optional.empty();

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
@@ -60,7 +60,6 @@ import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.g
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateEmptySuccessApiGatewayResponse;
 import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachSessionIdToLogs;
 import static uk.gov.di.authentication.shared.helpers.TestClientHelper.isTestClientWithAllowedEmail;
-import static uk.gov.di.authentication.shared.services.CodeStorageService.ACCOUNT_RECOVERY_CODE_BLOCKED_KEY_PREFIX;
 import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_BLOCKED_KEY_PREFIX;
 import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_REQUEST_BLOCKED_KEY_PREFIX;
 
@@ -300,15 +299,13 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
             NotificationType notificationType,
             JourneyType journeyType) {
 
-        var codeAttemptsBlockedPrefix =
-                notificationType.equals(VERIFY_CHANGE_HOW_GET_SECURITY_CODES)
-                        ? ACCOUNT_RECOVERY_CODE_BLOCKED_KEY_PREFIX
-                        : CODE_BLOCKED_KEY_PREFIX;
         var codeRequestCount = session.getCodeRequestCount(notificationType, journeyType);
         LOG.info("CodeRequestCount is: {}", codeRequestCount);
 
         var codeRequestType = CodeRequestType.getCodeRequestType(notificationType, journeyType);
         var newCodeRequestBlockPrefix = CODE_REQUEST_BLOCKED_KEY_PREFIX + codeRequestType;
+        var codeAttemptsBlockedPrefix = CODE_BLOCKED_KEY_PREFIX + codeRequestType;
+
         if (codeRequestCount == configurationService.getCodeMaxRetries()) {
             LOG.info(
                     "User has requested too many OTP codes. Setting block with prefix: {}",

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandler.java
@@ -230,19 +230,14 @@ public class VerifyMfaCodeHandler extends BaseFrontendHandler<VerifyMfaCodeReque
             String emailAddress, MFAMethodType mfaMethodType, JourneyType journeyType) {
 
         var codeRequestType = CodeRequestType.getCodeRequestType(mfaMethodType, journeyType);
-        var newCodeBlockedPrefix = CODE_BLOCKED_KEY_PREFIX + codeRequestType;
+        var codeBlockedPrefix = CODE_BLOCKED_KEY_PREFIX + codeRequestType;
 
-        if (codeStorageService.isBlockedForEmail(emailAddress, CODE_BLOCKED_KEY_PREFIX)) {
+        if (codeStorageService.isBlockedForEmail(emailAddress, codeBlockedPrefix)) {
             return;
         }
 
         codeStorageService.saveBlockedForEmail(
-                emailAddress,
-                CODE_BLOCKED_KEY_PREFIX,
-                configurationService.getBlockedEmailDuration());
-
-        codeStorageService.saveBlockedForEmail(
-                emailAddress, newCodeBlockedPrefix, configurationService.getBlockedEmailDuration());
+                emailAddress, codeBlockedPrefix, configurationService.getBlockedEmailDuration());
 
         if (mfaMethodType == MFAMethodType.SMS) {
             codeStorageService.deleteIncorrectMfaCodeAttemptsCount(emailAddress);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
@@ -484,9 +484,9 @@ public class MfaHandlerTest {
     @Test
     void shouldReturn400IfUserIsBlockedFromAttemptingMfaCodes() {
         usingValidSession();
-        when(codeStorageService.isBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX))
+        when(codeStorageService.isBlockedForEmail(
+                        TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX + CodeRequestType.SMS_SIGN_IN))
                 .thenReturn(true);
-
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setHeaders(
                 Map.of(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
@@ -84,7 +84,6 @@ import static uk.gov.di.authentication.shared.entity.NotificationType.MFA_SMS;
 import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_CHANGE_HOW_GET_SECURITY_CODES;
 import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_EMAIL;
 import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_PHONE_NUMBER;
-import static uk.gov.di.authentication.shared.services.CodeStorageService.ACCOUNT_RECOVERY_CODE_BLOCKED_KEY_PREFIX;
 import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_BLOCKED_KEY_PREFIX;
 import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_REQUEST_BLOCKED_KEY_PREFIX;
 import static uk.gov.di.authentication.sharedtest.helper.RequestEventHelper.contextWithSourceIp;
@@ -863,7 +862,9 @@ class SendNotificationHandlerTest {
     void shouldReturn400IfUserIsBlockedFromEnteringRegistrationEmailOtpCodes() {
         usingValidSession();
         usingValidClientSession(CLIENT_ID);
-        when(codeStorageService.isBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX))
+        when(codeStorageService.isBlockedForEmail(
+                        TEST_EMAIL_ADDRESS,
+                        CODE_BLOCKED_KEY_PREFIX + CodeRequestType.EMAIL_REGISTRATION))
                 .thenReturn(true);
 
         var result =
@@ -893,7 +894,8 @@ class SendNotificationHandlerTest {
         usingValidSession();
         usingValidClientSession(CLIENT_ID);
         when(codeStorageService.isBlockedForEmail(
-                        TEST_EMAIL_ADDRESS, ACCOUNT_RECOVERY_CODE_BLOCKED_KEY_PREFIX))
+                        TEST_EMAIL_ADDRESS,
+                        CODE_BLOCKED_KEY_PREFIX + CodeRequestType.EMAIL_ACCOUNT_RECOVERY))
                 .thenReturn(true);
 
         var result =
@@ -922,7 +924,9 @@ class SendNotificationHandlerTest {
 
     @Test
     void shouldReturn400IfUserIsBlockedFromEnteringPhoneOtpCodes() {
-        when(codeStorageService.isBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX))
+        when(codeStorageService.isBlockedForEmail(
+                        TEST_EMAIL_ADDRESS,
+                        CODE_BLOCKED_KEY_PREFIX + CodeRequestType.SMS_REGISTRATION))
                 .thenReturn(true);
         usingValidSession();
         usingValidClientSession(CLIENT_ID);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
+import uk.gov.di.authentication.shared.entity.CodeRequestType;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
@@ -406,8 +407,8 @@ class VerifyCodeHandlerTest {
         when(configurationService.getCodeMaxRetries()).thenReturn(5);
         when(configurationService.getBlockedEmailDuration()).thenReturn(BLOCKED_EMAIL_DURATION);
 
-        when(codeStorageService.isBlockedForEmail(
-                        TEST_EMAIL_ADDRESS, ACCOUNT_RECOVERY_CODE_BLOCKED_KEY_PREFIX))
+        var codeBlockedKeyPrefix = CODE_BLOCKED_KEY_PREFIX + CodeRequestType.EMAIL_ACCOUNT_RECOVERY;
+        when(codeStorageService.isBlockedForEmail(TEST_EMAIL_ADDRESS, codeBlockedKeyPrefix))
                 .thenReturn(false);
         when(codeStorageService.getIncorrectMfaCodeAttemptsCount(TEST_EMAIL_ADDRESS)).thenReturn(6);
 
@@ -417,9 +418,7 @@ class VerifyCodeHandlerTest {
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1048));
         verify(codeStorageService)
                 .saveBlockedForEmail(
-                        TEST_EMAIL_ADDRESS,
-                        ACCOUNT_RECOVERY_CODE_BLOCKED_KEY_PREFIX,
-                        BLOCKED_EMAIL_DURATION);
+                        TEST_EMAIL_ADDRESS, codeBlockedKeyPrefix, BLOCKED_EMAIL_DURATION);
         verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(TEST_EMAIL_ADDRESS);
         verifyNoInteractions(accountModifiersService);
         verify(auditService)
@@ -561,7 +560,9 @@ class VerifyCodeHandlerTest {
         assertThat(session.getRetryCount(), equalTo(0));
         verify(codeStorageService)
                 .saveBlockedForEmail(
-                        TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX, BLOCKED_EMAIL_DURATION);
+                        TEST_EMAIL_ADDRESS,
+                        CODE_BLOCKED_KEY_PREFIX + CodeRequestType.SMS_REGISTRATION,
+                        BLOCKED_EMAIL_DURATION);
         verifyNoInteractions(accountModifiersService);
         verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(TEST_EMAIL_ADDRESS);
         verify(auditService)

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.authentication.entity.CodeRequest;
@@ -26,6 +27,7 @@ import uk.gov.di.authentication.frontendapi.validation.MfaCodeProcessorFactory;
 import uk.gov.di.authentication.frontendapi.validation.PhoneNumberCodeProcessor;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
+import uk.gov.di.authentication.shared.entity.CodeRequestType;
 import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
@@ -409,10 +411,18 @@ class VerifyMfaCodeHandlerTest {
         verifyNoInteractions(cloudwatchMetricsService);
     }
 
+    private static Stream<Arguments> blockedCodeForAuthAppOTPEnteredTooManyTimes() {
+        return Stream.of(
+                Arguments.of(
+                        JourneyType.ACCOUNT_RECOVERY, CodeRequestType.AUTH_APP_ACCOUNT_RECOVERY),
+                Arguments.of(JourneyType.REGISTRATION, CodeRequestType.AUTH_APP_REGISTRATION),
+                Arguments.of(JourneyType.SIGN_IN, CodeRequestType.AUTH_APP_SIGN_IN));
+    }
+
     @ParameterizedTest
-    @EnumSource(JourneyType.class)
+    @MethodSource("blockedCodeForAuthAppOTPEnteredTooManyTimes")
     void shouldReturn400AndBlockCodeWhenUserEnteredInvalidAuthAppCodeTooManyTimes(
-            JourneyType journeyType) throws Json.JsonException {
+            JourneyType journeyType, CodeRequestType codeRequestType) throws Json.JsonException {
         when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
                 .thenReturn(Optional.of(authAppCodeProcessor));
         when(authAppCodeProcessor.validateCode()).thenReturn(Optional.of(ErrorResponse.ERROR_1042));
@@ -425,7 +435,8 @@ class VerifyMfaCodeHandlerTest {
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1042));
         assertThat(session.getVerifiedMfaMethodType(), equalTo(null));
         verify(codeStorageService)
-                .saveBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX, 900L);
+                .saveBlockedForEmail(
+                        TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX + codeRequestType, 900L);
         verify(codeStorageService)
                 .deleteIncorrectMfaCodeAttemptsCount(TEST_EMAIL_ADDRESS, MFAMethodType.AUTH_APP);
         verifyNoInteractions(cloudwatchMetricsService);
@@ -515,13 +526,16 @@ class VerifyMfaCodeHandlerTest {
                         pair("account-recovery", journeyType.equals(JourneyType.ACCOUNT_RECOVERY)));
     }
 
+    private static Stream<Arguments> blockedCodeForInvalidPhoneNumberTooManyTimes() {
+        return Stream.of(
+                Arguments.of(JourneyType.ACCOUNT_RECOVERY, CodeRequestType.SMS_ACCOUNT_RECOVERY),
+                Arguments.of(JourneyType.REGISTRATION, CodeRequestType.SMS_REGISTRATION));
+    }
+
     @ParameterizedTest
-    @EnumSource(
-            value = JourneyType.class,
-            names = {"SIGN_IN"},
-            mode = EnumSource.Mode.EXCLUDE)
+    @MethodSource("blockedCodeForInvalidPhoneNumberTooManyTimes")
     void shouldReturn400AndBlockCodeWhenUserEnteredInvalidPhoneNumberCodeTooManyTimes(
-            JourneyType journeyType) throws Json.JsonException {
+            JourneyType journeyType, CodeRequestType codeRequestType) throws Json.JsonException {
         when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
                 .thenReturn(Optional.of(phoneNumberCodeProcessor));
         when(phoneNumberCodeProcessor.validateCode())
@@ -534,7 +548,8 @@ class VerifyMfaCodeHandlerTest {
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1034));
         assertThat(session.getVerifiedMfaMethodType(), equalTo(null));
         verify(codeStorageService)
-                .saveBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX, 900L);
+                .saveBlockedForEmail(
+                        TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX + codeRequestType, 900L);
         verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(TEST_EMAIL_ADDRESS);
         verifyNoInteractions(cloudwatchMetricsService);
         verify(auditService)
@@ -553,17 +568,15 @@ class VerifyMfaCodeHandlerTest {
     }
 
     @ParameterizedTest
-    @EnumSource(
-            value = JourneyType.class,
-            names = {"SIGN_IN"},
-            mode = EnumSource.Mode.EXCLUDE)
+    @MethodSource("blockedCodeForInvalidPhoneNumberTooManyTimes")
     void shouldReturn400AndNotBlockCodeWhenInvalidPhoneNumberCodeEnteredAndBlockAlreadyExists(
-            JourneyType journeyType) throws Json.JsonException {
+            JourneyType journeyType, CodeRequestType codeRequestType) throws Json.JsonException {
         when(mfaCodeProcessorFactory.getMfaCodeProcessor(any(), any(CodeRequest.class), any()))
                 .thenReturn(Optional.of(phoneNumberCodeProcessor));
         when(phoneNumberCodeProcessor.validateCode())
                 .thenReturn(Optional.of(ErrorResponse.ERROR_1034));
-        when(codeStorageService.isBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX))
+        var codeBlockedPrefix = CODE_BLOCKED_KEY_PREFIX + codeRequestType;
+        when(codeStorageService.isBlockedForEmail(TEST_EMAIL_ADDRESS, codeBlockedPrefix))
                 .thenReturn(true);
         var codeRequest =
                 new VerifyMfaCodeRequest(MFAMethodType.SMS, CODE, journeyType, PHONE_NUMBER);
@@ -573,7 +586,7 @@ class VerifyMfaCodeHandlerTest {
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1034));
         assertThat(session.getVerifiedMfaMethodType(), equalTo(null));
         verify(codeStorageService, never())
-                .saveBlockedForEmail(TEST_EMAIL_ADDRESS, CODE_BLOCKED_KEY_PREFIX, 900L);
+                .saveBlockedForEmail(TEST_EMAIL_ADDRESS, codeBlockedPrefix, 900L);
         verify(codeStorageService, never()).deleteIncorrectMfaCodeAttemptsCount(TEST_EMAIL_ADDRESS);
         verifyNoInteractions(cloudwatchMetricsService);
         verify(auditService)

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
@@ -182,7 +182,10 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
 
         assertThat(response, hasStatus(400));
         assertThat(response, hasJsonBody(ErrorResponse.ERROR_1033));
-        assertThat(redis.isBlockedMfaCodesForEmail(EMAIL_ADDRESS, VERIFY_EMAIL), equalTo(false));
+        assertThat(
+                redis.isBlockedMfaCodeAttemptsForEmail(
+                        EMAIL_ADDRESS, VERIFY_EMAIL, JourneyType.REGISTRATION),
+                equalTo(false));
         assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(CODE_MAX_RETRIES_REACHED));
     }
 
@@ -222,8 +225,10 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
         assertThat(response, hasStatus(400));
         assertThat(response, hasJsonBody(ErrorResponse.ERROR_1048));
         assertThat(
-                redis.isBlockedMfaCodesForEmail(
-                        EMAIL_ADDRESS, VERIFY_CHANGE_HOW_GET_SECURITY_CODES),
+                redis.isBlockedMfaCodeAttemptsForEmail(
+                        EMAIL_ADDRESS,
+                        VERIFY_CHANGE_HOW_GET_SECURITY_CODES,
+                        JourneyType.ACCOUNT_RECOVERY),
                 equalTo(true));
         assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(CODE_MAX_RETRIES_REACHED));
     }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
@@ -20,6 +20,7 @@ import uk.gov.di.authentication.shared.domain.AuditableEvent;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
+import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
@@ -558,7 +559,9 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(response, hasStatus(400));
         assertThat(response, hasJsonBody(ErrorResponse.ERROR_1042));
         assertEquals(0, redis.getMfaCodeAttemptsCount(EMAIL_ADDRESS, MFAMethodType.AUTH_APP));
-        assertTrue(redis.isBlockedMfaCodesForEmail(EMAIL_ADDRESS));
+        assertTrue(
+                redis.isBlockedMfaCodeAttemptsForEmail(
+                        EMAIL_ADDRESS, MFAMethodType.AUTH_APP, JourneyType.SIGN_IN));
         assertTrue(userStore.isAccountVerified(EMAIL_ADDRESS));
         assertTrue(userStore.isAuthAppVerified(EMAIL_ADDRESS));
     }
@@ -584,7 +587,9 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         assertThat(response, hasStatus(400));
         assertThat(response, hasJsonBody(ErrorResponse.ERROR_1043));
-        assertFalse(redis.isBlockedMfaCodesForEmail(EMAIL_ADDRESS));
+        assertFalse(
+                redis.isBlockedMfaCodeAttemptsForEmail(
+                        EMAIL_ADDRESS, MFAMethodType.AUTH_APP, journeyType));
     }
 
     @Test
@@ -607,7 +612,9 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertThat(response, hasStatus(400));
         assertThat(response, hasJsonBody(ErrorResponse.ERROR_1037));
         assertEquals(1, redis.getMfaCodeAttemptsCount(EMAIL_ADDRESS));
-        assertFalse(redis.isBlockedMfaCodesForEmail(EMAIL_ADDRESS));
+        assertFalse(
+                redis.isBlockedMfaCodeAttemptsForEmail(
+                        EMAIL_ADDRESS, NotificationType.MFA_SMS, JourneyType.REGISTRATION));
     }
 
     @Test

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.extension.Extension;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import uk.gov.di.authentication.shared.entity.AuthCodeExchangeData;
 import uk.gov.di.authentication.shared.entity.ClientSession;
+import uk.gov.di.authentication.shared.entity.CodeRequestType;
 import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
@@ -243,16 +244,18 @@ public class RedisExtension
         codeStorageService.saveBlockedForEmail(email, CODE_BLOCKED_KEY_PREFIX, codeBlockedTime);
     }
 
-    public boolean isBlockedMfaCodesForEmail(String email) {
-        return isBlockedMfaCodesForEmail(email, null);
+    public boolean isBlockedMfaCodeAttemptsForEmail(
+            String email, NotificationType notificationType, JourneyType journeyType) {
+        var codeRequestType = CodeRequestType.getCodeRequestType(notificationType, journeyType);
+        String prefixToCheck = CODE_BLOCKED_KEY_PREFIX + codeRequestType;
+        return codeStorageService.isBlockedForEmail(email, prefixToCheck);
     }
 
-    public boolean isBlockedMfaCodesForEmail(String email, NotificationType notificationType) {
-        if (notificationType == VERIFY_CHANGE_HOW_GET_SECURITY_CODES) {
-            return codeStorageService.isBlockedForEmail(
-                    email, ACCOUNT_RECOVERY_CODE_BLOCKED_KEY_PREFIX);
-        }
-        return codeStorageService.isBlockedForEmail(email, CODE_BLOCKED_KEY_PREFIX);
+    public boolean isBlockedMfaCodeAttemptsForEmail(
+            String email, MFAMethodType mfaMethodType, JourneyType journeyType) {
+        var codeRequestType = CodeRequestType.getCodeRequestType(mfaMethodType, journeyType);
+        String prefixToCheck = CODE_BLOCKED_KEY_PREFIX + codeRequestType;
+        return codeStorageService.isBlockedForEmail(email, prefixToCheck);
     }
 
     public int getMfaCodeAttemptsCount(String email) {


### PR DESCRIPTION
## What?
- A previous commit introduced a new prefix style for OTP attempts blocking whilst maintaining the existing key prefix 
- Remove the existing code blocked key prefixes in assumption that the Redis cache is now aligned with the new key prefix

## Why?
- Avoids 'cross pollution' between different types of code block attempts
- Removes old code blocked key prefixes

## Related PRs
- New prefix style introduced here: https://github.com/alphagov/di-authentication-api/pull/3101
