### PR TITLE
AUT-1364: Set session cookie max age to one hour

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -389,7 +389,7 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
     }
 
     public int getSessionCookieMaxAge() {
-        return Integer.parseInt(System.getenv().getOrDefault("SESSION_COOKIE_MAX_AGE", "7200"));
+        return Integer.parseInt(System.getenv().getOrDefault("SESSION_COOKIE_MAX_AGE", "3600"));
     }
 
     public int getPersistentCookieMaxAge() {

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/ConfigurationServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/ConfigurationServiceTest.java
@@ -20,7 +20,7 @@ class ConfigurationServiceTest {
     @Test
     void sessionCookieMaxAgeShouldEqualDefaultWhenEnvVarUnset() {
         ConfigurationService configurationService = new ConfigurationService();
-        assertEquals(7200, configurationService.getSessionCookieMaxAge());
+        assertEquals(3600, configurationService.getSessionCookieMaxAge());
     }
 
     @Test


### PR DESCRIPTION
## What?

Sets session cookie max age to 1 hour (3600 seconds) from 2 hours.

## Why?

Session duration has been reduced to 1 hour

## Related PRs

Several PRs combine to introduce this change in functionality and content
* https://github.com/alphagov/di-authentication-frontend/pull/1078
* https://github.com/alphagov/di-authentication-frontend/pull/1077
* https://github.com/alphagov/di-authentication-frontend/pull/1076
* https://github.com/alphagov/di-authentication-api/pull/3109


