### PR TITLE
AUT-1372: Reduce email OTP validity on registration journey

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -86,7 +86,7 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
 
     public long getEmailAccountCreationOtpCodeExpiry() {
         return Long.parseLong(
-                System.getenv().getOrDefault("EMAIL_OTP_ACCOUNT_CREATION_CODE_EXPIRY", "7200"));
+                System.getenv().getOrDefault("EMAIL_OTP_ACCOUNT_CREATION_CODE_EXPIRY", "3600"));
     }
 
     public int getCodeMaxRetries() {


### PR DESCRIPTION
## What?
- Reduce email OTP validity on registration journey
- Going from 2 hours to 1 hour

## Why?
- This reflects that the session is now capped at 1 hour
