### PR TITLE
AUT-1372: Adjust env values for OTP validity time

### DIFF
--- a/ci/terraform/oidc/build-overrides.tfvars
+++ b/ci/terraform/oidc/build-overrides.tfvars
@@ -17,9 +17,8 @@ ipv_no_session_response_enabled    = true
 doc_app_cri_data_v2_endpoint       = "credentials/issue"
 doc_app_use_cri_data_v2_endpoint   = true
 
-blocked_email_duration                    = 30
-otp_code_ttl_duration                     = 120
-email_acct_creation_otp_code_ttl_duration = 60
+blocked_email_duration = 30
+otp_code_ttl_duration  = 120
 
 logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -197,7 +197,7 @@ variable "otp_code_ttl_duration" {
 
 variable "email_acct_creation_otp_code_ttl_duration" {
   type    = number
-  default = 7200
+  default = 3600
 }
 
 variable "contact_us_link_route" {


### PR DESCRIPTION
## What?
- Adjust environment values (variable default and Build env override) for OTP validity time
- Only relates to email OTP in account creation journey
- Note: Other OTPs are set separately; only this one varies independently

## Why?
- We want to test in build

## Related PRs
- Initial change was made here: https://github.com/alphagov/di-authentication-api/pull/3115
