### PR TITLE
AUT-1371: IPVCallbackHandler redirects to a separate error page when no session

### DIFF
--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/IPVCallbackNoSessionException.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/entity/IPVCallbackNoSessionException.java
@@ -1,0 +1,9 @@
+package uk.gov.di.authentication.ipv.entity;
+
+import uk.gov.di.authentication.shared.exceptions.NoSessionException;
+
+public class IPVCallbackNoSessionException extends NoSessionException {
+    public IPVCallbackNoSessionException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
## What?

IPVCallbackHandler redirects to a separate error page when there is no session (the session has timed-out).

To be depolyed after the corresponding frontend PR which creates the new error page.

## Why?

The new page has been added as part of the work to reduce session timeout from 2hrs to 1hr.  Due to the decrease they may be people who land back in authentication having completed IPV after an hour when the session has expired.  The new screen is to provide more information in this scenario.

## Related PRs

https://github.com/alphagov/di-authentication-frontend/pull/1081