### PR TITLE
BAU: Add sessionId and clientSessionId fields to Notify request objects

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/NotifyRequest.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/NotifyRequest.java
@@ -18,6 +18,10 @@ public class NotifyRequest {
 
     @Expose private SupportedLanguage language;
 
+    @Expose private String sessionId;
+
+    @Expose private String clientSessionId;
+
     public NotifyRequest() {}
 
     public NotifyRequest(
@@ -32,8 +36,31 @@ public class NotifyRequest {
     }
 
     public NotifyRequest(
+            String destination,
+            NotificationType notificationType,
+            String code,
+            SupportedLanguage language,
+            String sessionId,
+            String clientSessionId) {
+        this(destination, notificationType, code, language);
+        this.sessionId = sessionId;
+        this.clientSessionId = clientSessionId;
+    }
+
+    public NotifyRequest(
             String destination, NotificationType notificationType, SupportedLanguage language) {
         this(destination, notificationType, null, language);
+    }
+
+    public NotifyRequest(
+            String destination,
+            NotificationType notificationType,
+            SupportedLanguage language,
+            String sessionId,
+            String clientSessionId) {
+        this(destination, notificationType, null, language);
+        this.sessionId = sessionId;
+        this.clientSessionId = clientSessionId;
     }
 
     public NotificationType getNotificationType() {
@@ -50,5 +77,13 @@ public class NotifyRequest {
 
     public SupportedLanguage getLanguage() {
         return language;
+    }
+
+    public String getSessionId() {
+        return sessionId;
+    }
+
+    public String getClientSessionId() {
+        return clientSessionId;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/NotifyRequest.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/NotifyRequest.java
@@ -18,6 +18,10 @@ public class NotifyRequest {
 
     @Expose private SupportedLanguage language;
 
+    @Expose private String sessionId;
+
+    @Expose private String clientSessionId;
+
     public NotifyRequest() {}
 
     public NotifyRequest(
@@ -32,8 +36,31 @@ public class NotifyRequest {
     }
 
     public NotifyRequest(
+            String destination,
+            NotificationType notificationType,
+            String code,
+            SupportedLanguage language,
+            String sessionId,
+            String clientSessionId) {
+        this(destination, notificationType, code, language);
+        this.sessionId = sessionId;
+        this.clientSessionId = clientSessionId;
+    }
+
+    public NotifyRequest(
             String destination, NotificationType notificationType, SupportedLanguage language) {
         this(destination, notificationType, null, language);
+    }
+
+    public NotifyRequest(
+            String destination,
+            NotificationType notificationType,
+            SupportedLanguage language,
+            String sessionId,
+            String clientSessionId) {
+        this(destination, notificationType, null, language);
+        this.sessionId = sessionId;
+        this.clientSessionId = clientSessionId;
     }
 
     public NotificationType getNotificationType() {
@@ -50,5 +77,13 @@ public class NotifyRequest {
 
     public SupportedLanguage getLanguage() {
         return language;
+    }
+
+    public String getSessionId() {
+        return sessionId;
+    }
+
+    public String getClientSessionId() {
+        return clientSessionId;
     }
 }


### PR DESCRIPTION

## What?

Add sessionId and clientSessionId fields to Notify request objects.

And provide additional constructors.

## Why?

Groundwork for logging session ids in the Notify handlers when sending messages.
Changes are backwards compatible and introduce the new fields for a ZDD deployment.  This means that the new fields will already be available when the next PR starts to consume them, so there will be no failures related to the new fields being available in the producer before the consumer during a deployment.

