### PR TITLE
BAU: Increase retention Notification DLQ

### DIFF
--- a/ci/terraform/oidc/sqs.tf
+++ b/ci/terraform/oidc/sqs.tf
@@ -32,7 +32,7 @@ resource "aws_sqs_queue" "email_dead_letter_queue" {
   kms_master_key_id                 = var.use_localstack ? null : "alias/aws/sqs"
   kms_data_key_reuse_period_seconds = var.use_localstack ? null : 300
 
-  message_retention_seconds = 3600 * 6
+  message_retention_seconds = 60 * 60 * 24 * 5
 
   tags = local.default_tags
 }


### PR DESCRIPTION
## What?
- Increase retention Notification DLQ

## Why?
- 5 days chosen because maximum run of non-working days is 4 (weekend + 2 bank holidays at Christmas)
- This gives that number of days + 24 hours for analysis and redrive
