### PR TITLE
BAU: Pin dynamodb local version in github actions script

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -126,7 +126,7 @@ jobs:
         ports:
           - 6379:6379
       dynamodb:
-        image: amazon/dynamodb-local:latest
+        image: amazon/dynamodb-local:1.22.0
         options: >-
           --health-cmd "curl http://localhost:8000"
           --health-interval 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
   dynamodb:
     command: "-jar DynamoDBLocal.jar -sharedDb -optimizeDbBeforeStartup -dbPath ."
     working_dir: /home/dynamodblocal
-    image: amazon/dynamodb-local:latest
+    image: amazon/dynamodb-local:1.22.0
     healthcheck:
       test: curl http://localhost:8000
       interval: 5s


### PR DESCRIPTION

## What?

Pin dynamodb local version in github actions script and docker-compose.yml

## Why?

The latest version 2.0 seems to break the tests in Github Actions so switching back to the previous version.

`java.lang.ExceptionInInitializerError
	at java.base/jdk.internal.misc.Unsafe.ensureClassInitialized0(Native Method)

Caused by: software.amazon.awssdk.services.dynamodb.model.DynamoDbException: The Access Key ID or security token is invalid. (Service: DynamoDb, Status Code: 400, Request ID: a3877d86-a80e-44d8-bcfb-b2d44f65541b)
`

