### PR TITLE
AUT-1222 - Enable account recovery in Integration

### DIFF
--- a/ci/terraform/oidc/integration-overrides.tfvars
+++ b/ci/terraform/oidc/integration-overrides.tfvars
@@ -21,7 +21,7 @@ internal_sector_uri             = "https://identity.integration.account.gov.uk"
 spot_enabled                    = true
 language_cy_enabled             = true
 extended_feature_flags_enabled  = true
-account_recovery_block_enabled  = false
+account_recovery_block_enabled  = true
 custom_doc_app_claim_enabled    = true
 ipv_no_session_response_enabled = true
 


### PR DESCRIPTION
## What?

 - Enable account recovery in Integration

## Why?

- So that the account recovery journey can be performed in the integration environment
