### PR TITLE
Reduce lambda defaults to sane levels

### DIFF
--- a/ci/terraform/account-management/variables.tf
+++ b/ci/terraform/account-management/variables.tf
@@ -146,7 +146,7 @@ variable "waf_alarm_blocked_reqeuest_threshold" {
 }
 
 variable "lambda_min_concurrency" {
-  default     = 10
+  default     = 1
   type        = number
   description = "The number of lambda instance to keep 'warm'"
 }
@@ -162,7 +162,7 @@ variable "localstack_endpoint" {
 }
 
 variable "endpoint_memory_size" {
-  default = 4096
+  default = 1024
   type    = number
 }
 
@@ -183,7 +183,7 @@ variable "performance_tuning" {
 }
 
 variable "lambda_max_concurrency" {
-  default = 5
+  default = 0
 }
 
 variable "scaling_trigger" {

--- a/ci/terraform/delivery-receipts/variables.tf
+++ b/ci/terraform/delivery-receipts/variables.tf
@@ -11,7 +11,7 @@ variable "lambda_zip_file" {
 }
 
 variable "lambda_min_concurrency" {
-  default     = 10
+  default     = 1
   type        = number
   description = "The number of lambda instance to keep 'warm'"
 }
@@ -79,7 +79,7 @@ variable "cloudwatch_log_retention" {
 }
 
 variable "endpoint_memory_size" {
-  default = 4096
+  default = 1024
   type    = number
 }
 

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -222,7 +222,7 @@ variable "cloudwatch_log_retention" {
 }
 
 variable "lambda_min_concurrency" {
-  default     = 20
+  default     = 1
   type        = number
   description = "The number of lambda instance to keep 'warm'"
 }
@@ -300,7 +300,7 @@ variable "internal_sector_uri" {
 }
 
 variable "endpoint_memory_size" {
-  default = 4096
+  default = 1024
   type    = number
 }
 
@@ -411,7 +411,7 @@ variable "performance_tuning" {
 }
 
 variable "lambda_max_concurrency" {
-  default = 5
+  default = 0
 }
 
 variable "scaling_trigger" {

--- a/ci/terraform/test-services/variables.tf
+++ b/ci/terraform/test-services/variables.tf
@@ -11,7 +11,7 @@ variable "test_services-api-lambda_zip_file" {
 }
 
 variable "lambda_min_concurrency" {
-  default     = 10
+  default     = 1
   type        = number
   description = "The number of lambda instance to keep 'warm'"
 }


### PR DESCRIPTION
## What?

Reduce lambda defaults to sane levels.

## Why?

20 is far too high and led to costs ballooning accidentally.
