### PR TITLE
AUT-1402 - Use orElseGet instead or orElse when processing optional

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/exceptions/SerializationException.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/exceptions/SerializationException.java
@@ -1,0 +1,12 @@
+package uk.gov.di.authentication.frontendapi.exceptions;
+
+public class SerializationException extends RuntimeException {
+
+    public SerializationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public SerializationException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
## What?

- `orElse` is always called regardless of whether the optional is present or not. This has meant that when validatePasswordResetCount has been returning an optional error response as the user is blocked, we are still sending a password reset OTP to the blocked user. We can fix this by using `orElseGet` which is only called when the Optional returned from that method is empty.
- Add extra conditions to our unit tests to ensure that messages are not placed on the SQS queue when the user is blocked.
- Create a custom exception for handling the JsonException checked exception which is thrown when serializing the notify request. We never expect an exception to be thrown here so it should be treated as a 500 if it is thrown.

## Why?

- To prevent the application sending email OTPs to blocked users. 