### PR TITLE
AUT-1403: Upshift code block max retries so that user is blocked on the 6th time of requesting too many Email OTP codes 

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
@@ -306,7 +306,7 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
         var newCodeRequestBlockPrefix = CODE_REQUEST_BLOCKED_KEY_PREFIX + codeRequestType;
         var codeAttemptsBlockedPrefix = CODE_BLOCKED_KEY_PREFIX + codeRequestType;
 
-        if (codeRequestCount == configurationService.getCodeMaxRetries()) {
+        if (codeRequestCount > configurationService.getCodeMaxRetries()) {
             LOG.info(
                     "User has requested too many OTP codes. Setting block with prefix: {}",
                     newCodeRequestBlockPrefix);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
@@ -1020,6 +1020,7 @@ class SendNotificationHandlerTest {
         session.incrementCodeRequestCount(notificationType, journeyType);
         session.incrementCodeRequestCount(notificationType, journeyType);
         session.incrementCodeRequestCount(notificationType, journeyType);
+        session.incrementCodeRequestCount(notificationType, journeyType);
     }
 
     private void usingValidSession() {


### PR DESCRIPTION
## What?

- In the account recovery journey, a user is blocked on the 5th attempt of requesting an email OTP, they should be blocked on the 6th attempt instead.
- The default code_max_retries is set to 5
- Initiate code block when user's codeRequestCount is greater than code_max_retries

## Why?

Ensure users are given enough attempts to have a go at requesting Email OTP during account recovery journey
