### PR TITLE
AUT-1282 - Add logging to debug bug with email OTP limits for account recovery

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/Session.java
@@ -1,6 +1,8 @@
 package uk.gov.di.authentication.shared.entity;
 
 import com.google.gson.annotations.Expose;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -8,6 +10,8 @@ import java.util.List;
 import java.util.Map;
 
 public class Session {
+
+    private static final Logger LOG = LogManager.getLogger(Session.class);
 
     public enum AccountState {
         NEW,
@@ -104,6 +108,7 @@ public class Session {
     }
 
     public int getCodeRequestCount(CodeRequestType requestType) {
+        LOG.info("CodeRequest count: {}", codeRequestCountMap);
         return codeRequestCountMap.getOrDefault(requestType, 0);
     }
 
@@ -113,6 +118,7 @@ public class Session {
                 CodeRequestType.getCodeRequestType(notificationType, journeyType);
         int currentCount = getCodeRequestCount(requestType);
         codeRequestCountMap.put(requestType, currentCount + 1);
+        LOG.info("CodeRequest count incremented: {}", codeRequestCountMap);
 
         return this;
     }
@@ -122,6 +128,7 @@ public class Session {
         CodeRequestType requestType =
                 CodeRequestType.getCodeRequestType(notificationType, journeyType);
         codeRequestCountMap.put(requestType, 0);
+        LOG.info("CodeRequest count reset: {}", codeRequestCountMap);
         return this;
     }
 


### PR DESCRIPTION
## What?

- Add logging to debug bug with email OTP limits for account recovery

## Why?

 - When a user has a verified SMS and performs the account recovery journey, the user is being blocked on the 5 request rather than the 6th request. This is only present when a user has a verified SMS and works as intended if a user has a verified auth app.

