### PR TITLE
BAU - Fix Sonarcloud analysis

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -342,7 +342,7 @@ task utilsTerraform (type: Terraform) {
     dependsOn "oidcTerraform"
 }
 
-sonarqube {
+sonar {
     properties {
         property "sonar.projectKey", "alphagov_di-authentication-api"
         property "sonar.organization", "alphagov"


### PR DESCRIPTION
## What?

 - Fix Sonarcloud analysis

## Why?

- Task 'sonarqube' is deprecated. Use 'sonar' instead. - Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.
