### PR TITLE
AUT-1411: Uplift terms and conditions version to 1.5 [⚠️ Do not merge before 14 July] 

### DIFF
--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -128,7 +128,7 @@ variable "use_localstack" {
 
 variable "terms_and_conditions" {
   type    = string
-  default = "1.4"
+  default = "1.5"
 }
 
 variable "localstack_endpoint" {

--- a/ci/terraform/shared/variables.tf
+++ b/ci/terraform/shared/variables.tf
@@ -36,7 +36,7 @@ variable "external_redis_host" {
 
 variable "terms_and_conditions" {
   type    = string
-  default = "1.4"
+  default = "1.5"
 }
 
 variable "external_redis_port" {

--- a/ci/terraform/utils/variables.tf
+++ b/ci/terraform/utils/variables.tf
@@ -63,6 +63,6 @@ variable "cloudwatch_log_retention" {
 
 variable "terms_and_conditions" {
   type        = string
-  default     = "1.4"
+  default     = "1.5"
   description = "The latest Terms and Conditions version number"
 }


### PR DESCRIPTION
## What?

Uplift terms and conditions version to 1.5.

## Why?

To accompany the content release of the new terms and conditions for VCs and trigger the T&C acceptance page.

## Related PRs

https://github.com/alphagov/di-authentication-frontend/pull/1097
