### PR TITLE
Remove dev_deployer_role

### DIFF
--- a/ci/terraform/shared/dev.tfvars
+++ b/ci/terraform/shared/dev.tfvars
@@ -1,4 +1,3 @@
-deployer_role_arn                    = "arn:aws:iam::761723964695:role/deployer-role-pipeline-dev"
 logging_endpoint_enabled             = false
 common_state_bucket                  = "digital-identity-dev-tfstate"
 di_tools_signing_profile_version_arn = "arn:aws:signer:eu-west-2:114407264696:/signing-profiles/di_auth_lambda_signing_20220215170204371800000001/zLiNn2Hi1I"


### PR DESCRIPTION
## What?

- Removed deprecated deployer role from dev.tfvars
- Part of the work necessary to complete PLAT-1954

## Why?

- The deployer role assumed by codebuild has all the necessary permissions

