### PR TITLE
AUT-1433-Part-1: Implement new code attempts block for SIGN IN journey

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -251,6 +251,23 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                 accountRecoveryJourney ? JourneyType.ACCOUNT_RECOVERY : JourneyType.REGISTRATION;
         var codeRequestType = CodeRequestType.getCodeRequestType(notificationType, journeyType);
         var codeBlockedKeyPrefix = CODE_BLOCKED_KEY_PREFIX + codeRequestType;
+
+        JourneyType newJourneyType;
+        switch (notificationType) {
+            case VERIFY_CHANGE_HOW_GET_SECURITY_CODES:
+                newJourneyType = JourneyType.ACCOUNT_RECOVERY;
+                break;
+            case MFA_SMS:
+                newJourneyType = JourneyType.SIGN_IN;
+                break;
+            default:
+                newJourneyType = JourneyType.REGISTRATION;
+                break;
+        }
+        var newCodeRequestType =
+                CodeRequestType.getCodeRequestType(notificationType, newJourneyType);
+        var newCodeBlockedKeyPrefix = CODE_BLOCKED_KEY_PREFIX + newCodeRequestType;
+
         var metadataPairs =
                 new AuditService.MetadataPair[] {
                     pair("notification-type", notificationType.name()),
@@ -270,6 +287,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
             if (errorResponse.equals(ErrorResponse.ERROR_1027)
                     || errorResponse.equals(ErrorResponse.ERROR_1048)) {
                 blockCodeForSession(session, codeBlockedKeyPrefix);
+                blockCodeForSession(session, newCodeBlockedKeyPrefix);
             }
             resetIncorrectMfaCodeAttemptsCount(session);
             auditableEvent = FrontendAuditableEvent.CODE_MAX_RETRIES_REACHED;


### PR DESCRIPTION
## What?
- The verify code handler takes in the following notification types:
    - `VERIFY_CHANGE_HOW_GET_SECURITY_CODES`
    - `VERIFY_EMAIL`
    - `MFA_SMS`
    - `RESET_PASSWORD_WITH_CODE`

- Currently for Sign In journey or `MFA_SMS`, the journey type defaults to Registration which is incorrect
- Implement new code attempts block prefix for Sign In journey 
- This is a 2 part PR for bug fix regarding Sign In, first part is to store the new code blocked prefix for Sign In journey along with the old code blocked prefix in order to keep up with the Redis cache
- The second PR will be to remove the old prefix once the Redis cache is up to date

## Why?

In the Frontend, when a user starts a new session after being blocked from a previous session and they attempt to Sign In, an SMS OTP code is being sent to the user even though they are blocked. 
