### PR TITLE
AUT-1333: delete otp code when it is correctly entered

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessor.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessor.java
@@ -78,13 +78,20 @@ public class PhoneNumberCodeProcessor extends MfaCodeProcessor {
                         ? configurationService.getTestClientVerifyPhoneNumberOTP()
                         : codeStorageService.getOtpCode(emailAddress, notificationType);
 
-        return ValidationHelper.validateVerificationCode(
-                notificationType,
-                storedCode,
-                codeRequest.getCode(),
-                codeStorageService,
-                emailAddress,
-                configurationService.getCodeMaxRetries());
+        var errorResponse =
+                ValidationHelper.validateVerificationCode(
+                        notificationType,
+                        storedCode,
+                        codeRequest.getCode(),
+                        codeStorageService,
+                        emailAddress,
+                        configurationService.getCodeMaxRetries());
+
+        if (errorResponse.isEmpty()) {
+            codeStorageService.deleteOtpCode(emailAddress, notificationType);
+        }
+
+        return errorResponse;
     }
 
     @Override

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessorTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessorTest.java
@@ -71,6 +71,18 @@ class PhoneNumberCodeProcessorTest {
     }
 
     @Test
+    void shouldDeleteMfaCodeFromDataStoreWhenValidRegistrationPhoneNumberCode() {
+        setupPhoneNumberCode(
+                new VerifyMfaCodeRequest(
+                        MFAMethodType.SMS, VALID_CODE, JourneyType.REGISTRATION, PHONE_NUMBER),
+                CodeRequestType.SMS_REGISTRATION);
+
+        phoneNumberCodeProcessor.validateCode();
+        verify(codeStorageService)
+                .deleteOtpCode(TEST_EMAIL_ADDRESS, NotificationType.VERIFY_PHONE_NUMBER);
+    }
+
+    @Test
     void shouldReturnErrorForInvalidRegistrationPhoneNumberCode() {
         setupPhoneNumberCode(
                 new VerifyMfaCodeRequest(
@@ -80,6 +92,18 @@ class PhoneNumberCodeProcessorTest {
         assertThat(
                 phoneNumberCodeProcessor.validateCode(),
                 equalTo(Optional.of(ErrorResponse.ERROR_1037)));
+    }
+
+    @Test
+    void shouldNotDeleteMfaCodeFromDataStoreWhenInvalidRegistrationPhoneNumberCode() {
+        setupPhoneNumberCode(
+                new VerifyMfaCodeRequest(
+                        MFAMethodType.SMS, INVALID_CODE, JourneyType.REGISTRATION, PHONE_NUMBER),
+                CodeRequestType.SMS_REGISTRATION);
+
+        phoneNumberCodeProcessor.validateCode();
+        verify(codeStorageService, never())
+                .deleteOtpCode(TEST_EMAIL_ADDRESS, NotificationType.VERIFY_PHONE_NUMBER);
     }
 
     @Test

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
@@ -21,6 +21,7 @@ import uk.gov.di.authentication.shared.entity.CodeRequestType;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.MFAMethodType;
+import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
@@ -645,6 +646,9 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         assertTxmaAuditEventsReceived(
                 txmaAuditQueue, List.of(CODE_VERIFIED, UPDATE_PROFILE_PHONE_NUMBER));
         assertThat(userStore.isAccountVerified(EMAIL_ADDRESS), equalTo(true));
+        assertThat(
+                redis.getMfaCode(EMAIL_ADDRESS, NotificationType.VERIFY_PHONE_NUMBER),
+                equalTo(Optional.empty()));
         assertTrue(
                 userStore
                         .getPhoneNumberForUser(EMAIL_ADDRESS)

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
@@ -227,6 +227,10 @@ public class RedisExtension
         return code;
     }
 
+    public Optional<String> getMfaCode(String email, NotificationType notificationType) {
+        return codeStorageService.getOtpCode(email, notificationType);
+    }
+
     public void blockMfaCodesForEmail(String email, String codeBlockedKeyPrefix) {
         var codeBlockedTime = 10;
         codeStorageService.saveBlockedForEmail(email, codeBlockedKeyPrefix, codeBlockedTime);


### PR DESCRIPTION
## What?

Deletes MFA code for phone verification once it is entered successfully.

## Why?

When creating an account, the same OTP can be reused again as the code is not cleared from the user session when it has been used successfully.  For sign in we clear the OTP from the session as soon as it has been used.

This seems to explain why there are intermittent failures in the create account smoke test (the OTP has been cleared from the session by the 15 minute validity period when the test tries to use it for the sixth time).