### PR TITLE
AUT-1421-Part-1: Implement new code blocked prefix for Password Reset journey

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -38,6 +38,7 @@ import java.util.Optional;
 import static java.util.Map.entry;
 import static uk.gov.di.authentication.shared.entity.LevelOfConfidence.NONE;
 import static uk.gov.di.authentication.shared.entity.NotificationType.MFA_SMS;
+import static uk.gov.di.authentication.shared.entity.NotificationType.RESET_PASSWORD_WITH_CODE;
 import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_CHANGE_HOW_GET_SECURITY_CODES;
 import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_EMAIL;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
@@ -115,6 +116,9 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                 case MFA_SMS:
                     journeyType = JourneyType.SIGN_IN;
                     break;
+                case RESET_PASSWORD_WITH_CODE:
+                    journeyType = JourneyType.PASSWORD_RESET;
+                    break;
                 default:
                     journeyType = JourneyType.REGISTRATION;
                     break;
@@ -166,6 +170,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
         return Map.ofEntries(
                         entry(VERIFY_CHANGE_HOW_GET_SECURITY_CODES, ErrorResponse.ERROR_1048),
                         entry(VERIFY_EMAIL, ErrorResponse.ERROR_1033),
+                        entry(RESET_PASSWORD_WITH_CODE, ErrorResponse.ERROR_1039),
                         entry(MFA_SMS, ErrorResponse.ERROR_1027))
                 .get(codeRequest.getNotificationType());
     }
@@ -271,10 +276,15 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
                     };
         }
         AuditableEvent auditableEvent;
-        if (List.of(ErrorResponse.ERROR_1027, ErrorResponse.ERROR_1033, ErrorResponse.ERROR_1048)
+        if (List.of(
+                        ErrorResponse.ERROR_1027,
+                        ErrorResponse.ERROR_1033,
+                        ErrorResponse.ERROR_1039,
+                        ErrorResponse.ERROR_1048)
                 .contains(errorResponse)) {
             if (errorResponse.equals(ErrorResponse.ERROR_1027)
-                    || errorResponse.equals(ErrorResponse.ERROR_1048)) {
+                    || errorResponse.equals(ErrorResponse.ERROR_1048)
+                    || errorResponse.equals(ErrorResponse.ERROR_1039)) {
                 blockCodeForSession(session, codeBlockedKeyPrefix);
             }
             resetIncorrectMfaCodeAttemptsCount(session);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -401,6 +401,20 @@ class VerifyCodeHandlerTest {
     }
 
     @Test
+    void shouldReturnMaxReachedAndNotSetBlockWhenPasswordResetEmailCodeIsBlocked() {
+        var codeBlockedKeyPrefix = CODE_BLOCKED_KEY_PREFIX + CodeRequestType.EMAIL_PASSWORD_RESET;
+        when(codeStorageService.isBlockedForEmail(TEST_EMAIL_ADDRESS, codeBlockedKeyPrefix))
+                .thenReturn(true);
+
+        var result = makeCallWithCode(CODE, RESET_PASSWORD_WITH_CODE.name());
+
+        assertThat(result, hasStatus(400));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1039));
+        verifyNoInteractions(accountModifiersService);
+        verifyNoInteractions(auditService);
+    }
+
+    @Test
     void shouldReturnMaxReachedAndNotSetBlockWhenSignInCodeIsBlocked() {
         var codeBlockedKeyPrefix = CODE_BLOCKED_KEY_PREFIX + CodeRequestType.SMS_SIGN_IN;
         when(codeStorageService.isBlockedForEmail(TEST_EMAIL_ADDRESS, codeBlockedKeyPrefix))
@@ -591,6 +605,41 @@ class VerifyCodeHandlerTest {
                         PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
                         pair("notification-type", MFA_SMS.name()),
                         pair("mfa-type", MFAMethodType.SMS.getValue()),
+                        pair("account-recovery", false));
+    }
+
+    @Test
+    void shouldReturnMaxReachedAndSetBlockedMfaCodeAttemptsWhenPasswordResetExceedMaxRetryCount() {
+        when(configurationService.getCodeMaxRetries()).thenReturn(0);
+        when(configurationService.getBlockedEmailDuration()).thenReturn(BLOCKED_EMAIL_DURATION);
+        when(codeStorageService.getOtpCode(TEST_EMAIL_ADDRESS, RESET_PASSWORD_WITH_CODE))
+                .thenReturn(Optional.of(CODE));
+        when(codeStorageService.getIncorrectMfaCodeAttemptsCount(TEST_EMAIL_ADDRESS)).thenReturn(1);
+
+        var result = makeCallWithCode(INVALID_CODE, RESET_PASSWORD_WITH_CODE.toString());
+
+        assertThat(result, hasStatus(400));
+        assertThat(result, hasJsonBody(ErrorResponse.ERROR_1039));
+        assertThat(session.getRetryCount(), equalTo(0));
+        verify(codeStorageService)
+                .saveBlockedForEmail(
+                        TEST_EMAIL_ADDRESS,
+                        CODE_BLOCKED_KEY_PREFIX + CodeRequestType.EMAIL_PASSWORD_RESET,
+                        BLOCKED_EMAIL_DURATION);
+        verifyNoInteractions(accountModifiersService);
+        verify(codeStorageService).deleteIncorrectMfaCodeAttemptsCount(TEST_EMAIL_ADDRESS);
+        verify(auditService)
+                .submitAuditEvent(
+                        FrontendAuditableEvent.CODE_MAX_RETRIES_REACHED,
+                        CLIENT_SESSION_ID,
+                        session.getSessionId(),
+                        CLIENT_ID,
+                        expectedCommonSubject,
+                        TEST_EMAIL_ADDRESS,
+                        "123.123.123.123",
+                        AuditService.UNKNOWN,
+                        PersistentIdHelper.PERSISTENT_ID_UNKNOWN_VALUE,
+                        pair("notification-type", RESET_PASSWORD_WITH_CODE.name()),
                         pair("account-recovery", false));
     }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
@@ -43,6 +43,7 @@ import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.CODE_VERIFIED;
 import static uk.gov.di.authentication.frontendapi.domain.FrontendAuditableEvent.INVALID_CODE_SENT;
 import static uk.gov.di.authentication.shared.entity.NotificationType.MFA_SMS;
+import static uk.gov.di.authentication.shared.entity.NotificationType.RESET_PASSWORD_WITH_CODE;
 import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_CHANGE_HOW_GET_SECURITY_CODES;
 import static uk.gov.di.authentication.shared.entity.NotificationType.VERIFY_EMAIL;
 import static uk.gov.di.authentication.shared.services.CodeStorageService.CODE_BLOCKED_KEY_PREFIX;
@@ -266,6 +267,32 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
 
         assertThat(response, hasStatus(400));
         assertThat(response, hasJsonBody(ErrorResponse.ERROR_1027));
+        assertThat(
+                redis.isBlockedMfaCodesForEmail(EMAIL_ADDRESS, codeBlockedKeyPrefix),
+                equalTo(true));
+        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(CODE_MAX_RETRIES_REACHED));
+    }
+
+    @Test
+    void shouldReturnMaxReachedAndSetBlockWhenPasswordResetEmailCodeAttemptsExceedMaxRetryCount()
+            throws Json.JsonException {
+        String sessionId = redis.createSession();
+        redis.addEmailToSession(sessionId, EMAIL_ADDRESS);
+        for (int i = 0; i < 5; i++) {
+            redis.increaseMfaCodeAttemptsCount(EMAIL_ADDRESS);
+        }
+        var codeRequest = new VerifyCodeRequest(RESET_PASSWORD_WITH_CODE, "123456");
+
+        var response =
+                makeRequest(
+                        Optional.of(codeRequest), constructFrontendHeaders(sessionId), Map.of());
+        var codeRequestType =
+                CodeRequestType.getCodeRequestType(
+                        codeRequest.getNotificationType(), JourneyType.PASSWORD_RESET);
+        var codeBlockedKeyPrefix = CODE_BLOCKED_KEY_PREFIX + codeRequestType;
+
+        assertThat(response, hasStatus(400));
+        assertThat(response, hasJsonBody(ErrorResponse.ERROR_1039));
         assertThat(
                 redis.isBlockedMfaCodesForEmail(EMAIL_ADDRESS, codeBlockedKeyPrefix),
                 equalTo(true));

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/CodeRequestType.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/CodeRequestType.java
@@ -6,6 +6,7 @@ import java.util.Map;
 public enum CodeRequestType {
     EMAIL_REGISTRATION(MFAMethodType.EMAIL, JourneyType.REGISTRATION),
     EMAIL_ACCOUNT_RECOVERY(MFAMethodType.EMAIL, JourneyType.ACCOUNT_RECOVERY),
+    EMAIL_PASSWORD_RESET(MFAMethodType.EMAIL, JourneyType.PASSWORD_RESET),
     SMS_ACCOUNT_RECOVERY(MFAMethodType.SMS, JourneyType.ACCOUNT_RECOVERY),
     SMS_REGISTRATION(MFAMethodType.SMS, JourneyType.REGISTRATION),
     SMS_SIGN_IN(MFAMethodType.SMS, JourneyType.SIGN_IN),

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/JourneyType.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/JourneyType.java
@@ -3,7 +3,8 @@ package uk.gov.di.authentication.shared.entity;
 public enum JourneyType {
     ACCOUNT_RECOVERY("ACCOUNT_RECOVERY"),
     REGISTRATION("REGISTRATION"),
-    SIGN_IN("SIGN_IN");
+    SIGN_IN("SIGN_IN"),
+    PASSWORD_RESET("PASSWORD_RESET");
 
     private String value;
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/NotificationType.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/NotificationType.java
@@ -34,7 +34,7 @@ public enum NotificationType implements TemplateAware {
     RESET_PASSWORD_WITH_CODE(
             "RESET_PASSWORD_WITH_CODE_TEMPLATE_ID",
             Map.of(SupportedLanguage.CY, "RESET_PASSWORD_WITH_CODE_TEMPLATE_ID_CY"),
-            MFAMethodType.NONE),
+            MFAMethodType.EMAIL),
     VERIFY_CHANGE_HOW_GET_SECURITY_CODES(
             "VERIFY_CHANGE_HOW_GET_SECURITY_CODES_TEMPLATE_ID",
             Map.of(SupportedLanguage.CY, "VERIFY_CHANGE_HOW_GET_SECURITY_CODES_TEMPLATE_ID_CY"),

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java
@@ -14,8 +14,6 @@ public class CodeStorageService {
 
     public static final String CODE_REQUEST_BLOCKED_KEY_PREFIX = "code-request-blocked:";
     public static final String CODE_BLOCKED_KEY_PREFIX = "code-blocked:";
-    public static final String ACCOUNT_RECOVERY_CODE_BLOCKED_KEY_PREFIX =
-            "account-recovery-code-blocked:";
     public static final String PASSWORD_RESET_BLOCKED_KEY_PREFIX = "password-reset-blocked:";
 
     private static final Logger LOG = LogManager.getLogger(CodeStorageService.class);


### PR DESCRIPTION
## What?

- Implement new code attempts block prefix for Password Reset journey in the Verify Code handler
- This is a 2 part PR, the first part is to store the new code attempts blocked prefix for Password Reset journey along with the old code blocked prefix in order to keep up with the Redis cache
- The second PR will be to remove the old prefix once the Redis cache is up to date

## Why?

In the Frontend, when a user starts a new session after being blocked from a previous session and they attempt to reset their password, an EMAIL OTP code is being sent to the user even though they are blocked and the user is given another attempt to enter the code again.