### PR TITLE
BAU - Check that the Doc app subject ID is present in client session

### DIFF
--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
@@ -157,6 +157,8 @@ public class DocAppCallbackHandler
                                     });
             attachSessionIdToLogs(session);
             var clientSessionId = sessionCookiesIds.getClientSessionId();
+            attachLogFieldToLogs(CLIENT_SESSION_ID, clientSessionId);
+            attachLogFieldToLogs(GOVUK_SIGNIN_JOURNEY_ID, clientSessionId);
             var clientSession =
                     clientSessionService
                             .getClientSession(clientSessionId)
@@ -165,8 +167,9 @@ public class DocAppCallbackHandler
                                         throw new DocAppCallbackException(
                                                 "ClientSession not found");
                                     });
-            attachLogFieldToLogs(CLIENT_SESSION_ID, clientSessionId);
-            attachLogFieldToLogs(GOVUK_SIGNIN_JOURNEY_ID, clientSessionId);
+            if (Objects.isNull(clientSession.getDocAppSubjectId()))
+                throw new DocAppCallbackException("No DocAppSubjectId present in ClientSession");
+
             var persistentId =
                     PersistentIdHelper.extractPersistentIdFromCookieHeader(input.getHeaders());
             attachLogFieldToLogs(PERSISTENT_SESSION_ID, persistentId);

--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandlerTest.java
@@ -192,6 +192,26 @@ class DocAppCallbackHandlerTest {
     }
 
     @Test
+    void shouldRedirectToFrontendErrorPageWhenNoDocAppSubjectIdIsPresentInClientSession()
+            throws URISyntaxException {
+        var event = new APIGatewayProxyRequestEvent();
+        event.setQueryStringParameters(Collections.emptyMap());
+        event.setHeaders(Map.of(COOKIE, buildCookieString()));
+        usingValidSession();
+        when(clientSessionService.getClientSession(CLIENT_SESSION_ID))
+                .thenReturn(Optional.of(clientSession));
+
+        var response = handler.handleRequest(event, context);
+        assertThat(response, hasStatus(302));
+        var expectedRedirectURI = new URIBuilder(LOGIN_URL).setPath("error").build();
+        assertThat(response.getHeaders().get("Location"), equalTo(expectedRedirectURI.toString()));
+
+        verifyNoInteractions(auditService);
+        verifyNoInteractions(dynamoDocAppService);
+        verifyNoInteractions(cloudwatchMetricsService);
+    }
+
+    @Test
     void shouldRedirectToRPWhenAuthnResponseContainsError() {
         usingValidSession();
         usingValidClientSession();


### PR DESCRIPTION
## What?

- Check that the Doc app subject ID is present in client session

## Why?

- To avoid nullpointers, check that the doc app subject id is present in the client session and if it isn't we can assume it isn't a valid client session and should redirect to the frontend error page
- We were seeing alerts being triggered due to a nullpointer being thrown 


