### PR TITLE
AUT-1421-part-2: Replace existing code attempts blocked prefix

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeStorageService.java
@@ -14,7 +14,6 @@ public class CodeStorageService {
 
     public static final String CODE_REQUEST_BLOCKED_KEY_PREFIX = "code-request-blocked:";
     public static final String CODE_BLOCKED_KEY_PREFIX = "code-blocked:";
-    public static final String PASSWORD_RESET_BLOCKED_KEY_PREFIX = "password-reset-blocked:";
 
     private static final Logger LOG = LogManager.getLogger(CodeStorageService.class);
 


### PR DESCRIPTION
## What?

This is a second PR to remove the old code block prefix for Password Reset journey as the Redis cache should now be up to date with the new code attempts block prefix.

- Implement code request block prefix for when a user has requested too many Password Reset OTPs
- Implement code attempts block prefix for when a user has requested too many Password Reset OTPs

## Related PRs

The first change, which introduces the new code attempt block prefix for new journey type PASSWORD_RESET, where an OTP is validated via the Verify code handler and a block is being set when the user has entered an invalid OTP 6 times.

First PR (https://github.com/alphagov/di-authentication-api/pull/3170)
