### PR TITLE
[Do not merge before go-live date] AUT-1370: Update Terms and Conditions version number

### DIFF
--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -128,7 +128,7 @@ variable "use_localstack" {
 
 variable "terms_and_conditions" {
   type    = string
-  default = "1.5"
+  default = "1.6"
 }
 
 variable "localstack_endpoint" {

--- a/ci/terraform/shared/variables.tf
+++ b/ci/terraform/shared/variables.tf
@@ -36,7 +36,7 @@ variable "external_redis_host" {
 
 variable "terms_and_conditions" {
   type    = string
-  default = "1.5"
+  default = "1.6"
 }
 
 variable "external_redis_port" {

--- a/ci/terraform/utils/variables.tf
+++ b/ci/terraform/utils/variables.tf
@@ -63,6 +63,6 @@ variable "cloudwatch_log_retention" {
 
 variable "terms_and_conditions" {
   type        = string
-  default     = "1.5"
+  default     = "1.6"
   description = "The latest Terms and Conditions version number"
 }


### PR DESCRIPTION
## What?

Update Terms and Conditions version number.

## Why?

To account for changes to the privacy notice arising from the F2F journey.

## Related PRs

https://github.com/alphagov/di-authentication-frontend/pull/1086 makes corresponding changes to the privacy notice. 
