### PR TITLE
Do not deploy dynatrace integration, pending rewrite

### DIFF
--- a/ci/terraform/modules/endpoint-module/lambda.tf
+++ b/ci/terraform/modules/endpoint-module/lambda.tf
@@ -122,6 +122,6 @@ resource "aws_appautoscaling_policy" "provisioned-concurrency-policy" {
 }
 
 locals {
-  deploy_dynatrace = var.environment == "staging"
+  deploy_dynatrace = false
   lambda_layers    = flatten(local.deploy_dynatrace ? [local.dynatrace_layer_arn] : [])
 }


### PR DESCRIPTION
## What?

Disables Dynatrace integration.

## Why?

This will be rewritten, or instrumented automatically, soon.
