### PR TITLE
AUT-1251 - Add the Orchestration client_id and Auth audience to config

### DIFF
--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -26,6 +26,7 @@ module "authorize" {
   environment     = var.environment
 
   handler_environment_variables = {
+    AUTH_AUDIENCE                        = var.auth_audience
     DOMAIN_NAME                          = local.service_domain
     DOC_APP_API_ENABLED                  = var.doc_app_api_enabled
     DYNAMO_ENDPOINT                      = var.use_localstack ? var.lambda_dynamo_endpoint : null
@@ -35,6 +36,7 @@ module "authorize" {
     LOCALSTACK_ENDPOINT                  = var.use_localstack ? var.localstack_endpoint : null
     LOGIN_URI                            = "https://${local.frontend_fqdn}/"
     OIDC_API_BASE_URL                    = local.api_base_url
+    ORCH_CLIENT_ID                       = var.orch_client_id
     REDIS_KEY                            = local.redis_key
     TERMS_CONDITIONS_VERSION             = var.terms_and_conditions
     SUPPORT_LANGUAGE_CY                  = tostring(var.language_cy_enabled)

--- a/ci/terraform/oidc/staging-overrides.tfvars
+++ b/ci/terraform/oidc/staging-overrides.tfvars
@@ -24,6 +24,8 @@ account_recovery_block_enabled     = true
 ipv_no_session_response_enabled    = true
 doc_app_cri_data_v2_endpoint       = "userinfo/v2"
 doc_app_use_cri_data_v2_endpoint   = true
+orch_client_id                     = "orchestrationAuth"
+auth_audience                      = "https://auth.staging.account.gov.uk"
 
 ipv_auth_public_encryption_key = <<-EOT
 -----BEGIN PUBLIC KEY-----

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -449,6 +449,16 @@ variable "extended_feature_flags_enabled" {
   type    = bool
 }
 
+variable "orch_client_id" {
+  type    = string
+  default = ""
+}
+
+variable "auth_audience" {
+  type    = string
+  default = ""
+}
+
 locals {
   default_performance_parameters = {
     memory          = var.endpoint_memory_size


### PR DESCRIPTION
## What?

- Add the Orchestration client_id and Auth audience to config
- Set these values for staging only. Currently the Orch/Auth split API is not enabled in any environment

## Why?

- The client_id populates the client_id and issuer in the secure auth request from Orchestration to Authentication. These values will be populated from config
- The audience populated the audience claim in the secure auth request from Orchestration to Authentication. This value will be populated from config 