### PR TITLE
Add checkov for Terraform security scanning

### DIFF
--- a/.github/workflows/checkov.yml
+++ b/.github/workflows/checkov.yml
@@ -3,7 +3,7 @@ name: checkov
 on:
   push:
     branches:
-    - checkov
+    - main
   pull_request:
     branches:
     - main

--- a/.github/workflows/checkov.yml
+++ b/.github/workflows/checkov.yml
@@ -42,3 +42,4 @@ jobs:
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: results.sarif
+          category: ${{ matrix.module }}

--- a/.github/workflows/checkov.yml
+++ b/.github/workflows/checkov.yml
@@ -1,0 +1,44 @@
+name: checkov
+
+on:
+  push:
+    branches:
+    - checkov
+  pull_request:
+    branches:
+    - main
+
+  workflow_dispatch:
+
+jobs:
+  scan:
+    strategy:
+      matrix:
+        module:
+        - account-management
+        - audit-processors
+        - delivery-receipts
+        - oidc
+        - shared
+        - test-services
+        - utils
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Checkov GitHub Action
+        uses: bridgecrewio/checkov-action@v12
+        with:
+          directory: ci/terraform/${{ matrix.module }}
+          soft_fail: true
+          output_format: cli,sarif
+          output_file_path: console,results.sarif
+        
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
## What?

Add Checkov for Terraform security scanning.

The security scan results will be available in the Security tab of the repository.

## Why?

Following INCIDENT-411, there is a desire to have better observability of security issues within our IaC.