### PR TITLE
AUT-1487: Create new Dynamo table to store authorization code

### DIFF
--- a/ci/terraform/shared/dynamodb.tf
+++ b/ci/terraform/shared/dynamodb.tf
@@ -299,3 +299,37 @@ resource "aws_dynamodb_table" "account_modifiers_table" {
 
   tags = local.default_tags
 }
+
+resource "aws_dynamodb_table" "auth_code_store" {
+  name         = "${var.environment}-auth-code-store"
+  billing_mode = var.provision_dynamo ? "PROVISIONED" : "PAY_PER_REQUEST"
+  hash_key     = "SubjectID"
+
+  read_capacity  = var.provision_dynamo ? var.dynamo_default_read_capacity : null
+  write_capacity = var.provision_dynamo ? var.dynamo_default_write_capacity : null
+
+  attribute {
+    name = "SubjectID"
+    type = "S"
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = aws_kms_key.auth_code_store_signing_key.arn
+  }
+
+  lifecycle {
+    prevent_destroy = false
+  }
+
+  ttl {
+    attribute_name = "TimeToExist"
+    enabled        = true
+  }
+
+  tags = local.default_tags
+}

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoAuthCodeServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoAuthCodeServiceIntegrationTest.java
@@ -1,0 +1,52 @@
+package uk.gov.di.authentication.services;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.di.authentication.shared.entity.AuthCodeStore;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.DynamoAuthCodeService;
+import uk.gov.di.authentication.sharedtest.extensions.AuthCodeExtension;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class DynamoAuthCodeServiceIntegrationTest {
+
+    private static final String SUBJECT_ID = "test-subject-id";
+    private static final String AUTH_CODE = "test-auth-code";
+    private static final String REQUESTED_SCOPE_CLAIMS = "test-requested-scope-claims";
+    private static final boolean HAS_BEEN_USED = false;
+
+    @RegisterExtension
+    protected static final AuthCodeExtension authCodeExtension = new AuthCodeExtension(180);
+
+    DynamoAuthCodeService dynamoAuthCodeService =
+            new DynamoAuthCodeService(ConfigurationService.getInstance(), true);
+
+    private void setUpDynamo() {
+        authCodeExtension.saveAuthCode(
+                SUBJECT_ID, AUTH_CODE, REQUESTED_SCOPE_CLAIMS, HAS_BEEN_USED);
+    }
+
+    @Test
+    void shouldUpdateHasBeenUsed() {
+        setUpDynamo();
+
+        dynamoAuthCodeService.updateHasBeenUsed(SUBJECT_ID, true);
+        var updatedAuthCode =
+                dynamoAuthCodeService.getAuthCodeStore(SUBJECT_ID).orElseGet(AuthCodeStore::new);
+
+        assertThat(updatedAuthCode.isHasBeenUsed(), equalTo(true));
+    }
+
+    @Test
+    void shouldDeleteAuthCode() {
+        setUpDynamo();
+
+        dynamoAuthCodeService.deleteAuthCode(SUBJECT_ID);
+        var updatedAuthCode = dynamoAuthCodeService.getAuthCodeStore(SUBJECT_ID);
+
+        assertFalse(updatedAuthCode.isPresent());
+    }
+}

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthCodeExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthCodeExtension.java
@@ -1,0 +1,79 @@
+package uk.gov.di.authentication.sharedtest.extensions;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
+import software.amazon.awssdk.services.dynamodb.model.BillingMode;
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.KeyType;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.DynamoAuthCodeService;
+import uk.gov.di.authentication.sharedtest.basetest.DynamoTestConfiguration;
+
+public class AuthCodeExtension extends DynamoExtension implements AfterEachCallback {
+
+    public static final String SUBJECT_ID_FIELD = "SubjectID";
+    public static final String AUTH_CODE_STORE_TABLE = "local-auth-code-store";
+
+    private DynamoAuthCodeService dynamoAuthCodeService;
+    private final ConfigurationService configuration;
+
+    public AuthCodeExtension(long ttl) {
+        createInstance();
+        this.configuration =
+                new DynamoTestConfiguration(REGION, ENVIRONMENT, DYNAMO_ENDPOINT) {
+                    @Override
+                    public long getAuthCodeExpiry() {
+                        return ttl;
+                    }
+                };
+        dynamoAuthCodeService = new DynamoAuthCodeService(configuration, true);
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+        super.beforeAll(context);
+
+        dynamoAuthCodeService = new DynamoAuthCodeService(configuration, true);
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) throws Exception {
+        clearDynamoTable(dynamoDB, AUTH_CODE_STORE_TABLE, SUBJECT_ID_FIELD);
+    }
+
+    @Override
+    protected void createTables() {
+        if (!tableExists(AUTH_CODE_STORE_TABLE)) {
+            createAuthCodeStoreTable();
+        }
+    }
+
+    public void saveAuthCode(
+            String subjectID, String authCode, String requestedScopeClaims, boolean hasBeenUsed) {
+
+        dynamoAuthCodeService.saveAuthCode(subjectID, authCode, requestedScopeClaims, hasBeenUsed);
+    }
+
+    private void createAuthCodeStoreTable() {
+        CreateTableRequest request =
+                CreateTableRequest.builder()
+                        .tableName(AUTH_CODE_STORE_TABLE)
+                        .keySchema(
+                                KeySchemaElement.builder()
+                                        .keyType(KeyType.HASH)
+                                        .attributeName(SUBJECT_ID_FIELD)
+                                        .build())
+                        .billingMode(BillingMode.PAY_PER_REQUEST)
+                        .attributeDefinitions(
+                                AttributeDefinition.builder()
+                                        .attributeName(SUBJECT_ID_FIELD)
+                                        .attributeType(ScalarAttributeType.S)
+                                        .build())
+                        .build();
+
+        dynamoDB.createTable(request);
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthCodeStore.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthCodeStore.java
@@ -1,0 +1,94 @@
+package uk.gov.di.authentication.shared.entity;
+
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbAttribute;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+
+@DynamoDbBean
+public class AuthCodeStore {
+
+    public static final String ATTRIBUTE_SUBJECT_ID = "SubjectID";
+    public static final String ATTRIBUTE_AUTH_CODE = "AuthCode";
+    public static final String ATTRIBUTE_REQUESTED_SCOPES_CLAIMS = "RequestedScopes/Claims";
+    public static final String ATTRIBUTE_TIME_TO_EXIST = "TimeToExist";
+    public static final String ATTRIBUTE_HAS_BEEN_USED = "HasBeenUsed";
+
+    private String subjectID;
+    private String authCode;
+    private String requestedScopeClaims;
+    private long timeToExist;
+    private boolean hasBeenUsed;
+
+    public AuthCodeStore() {}
+
+    @DynamoDbPartitionKey
+    @DynamoDbAttribute(ATTRIBUTE_SUBJECT_ID)
+    public String getSubjectID() {
+        return subjectID;
+    }
+
+    public void setSubjectID(String subjectID) {
+        this.subjectID = subjectID;
+    }
+
+    public AuthCodeStore withSubjectID(String subjectID) {
+        this.subjectID = subjectID;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_AUTH_CODE)
+    public String getAuthCode() {
+        return authCode;
+    }
+
+    public void setAuthCode(String authCode) {
+        this.authCode = authCode;
+    }
+
+    public AuthCodeStore withAuthCode(String authCode) {
+        this.authCode = authCode;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_REQUESTED_SCOPES_CLAIMS)
+    public String getRequestedScopeClaims() {
+        return requestedScopeClaims;
+    }
+
+    public void setRequestedScopeClaims(String requestedScopeClaims) {
+        this.requestedScopeClaims = requestedScopeClaims;
+    }
+
+    public AuthCodeStore withRequestedScopeClaims(String requestedScopeClaims) {
+        this.requestedScopeClaims = requestedScopeClaims;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_TIME_TO_EXIST)
+    public long getTimeToExist() {
+        return timeToExist;
+    }
+
+    public void setTimeToExist(long timeToExist) {
+        this.timeToExist = timeToExist;
+    }
+
+    public AuthCodeStore withTimeToExist(long timeToExist) {
+        this.timeToExist = timeToExist;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_HAS_BEEN_USED)
+    public boolean isHasBeenUsed() {
+        return hasBeenUsed;
+    }
+
+    public void setHasBeenUsed(boolean hasBeenUsed) {
+        this.hasBeenUsed = hasBeenUsed;
+    }
+
+    public AuthCodeStore withHasBeenUsed(boolean hasBeenUsed) {
+        this.hasBeenUsed = hasBeenUsed;
+        return this;
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -115,6 +115,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return System.getenv().getOrDefault("SUPPORT_AUTH_ORCH_SPLIT", "false").equals("true");
     }
 
+    public boolean isAuthCodeStoreEnabled() {
+        return System.getenv().getOrDefault("SUPPORT_AUTH_CODE_STORE", "false").equals("true");
+    }
+
     public String getContactUsLinkRoute() {
         return System.getenv().getOrDefault("CONTACT_US_LINK_ROUTE", "");
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoAuthCodeService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoAuthCodeService.java
@@ -1,0 +1,74 @@
+package uk.gov.di.authentication.shared.services;
+
+import uk.gov.di.authentication.shared.entity.AuthCodeStore;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
+
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+
+public class DynamoAuthCodeService extends BaseDynamoService<AuthCodeStore> {
+
+    private final long timeToExist;
+    private final boolean isAuthCodeStoreEnabled;
+
+    public DynamoAuthCodeService(
+            ConfigurationService configurationService, boolean isAuthCodeStoreEnabled) {
+        super(AuthCodeStore.class, "auth-code-store", configurationService);
+        this.timeToExist = configurationService.getAuthCodeExpiry();
+        this.isAuthCodeStoreEnabled = isAuthCodeStoreEnabled;
+    }
+
+    public DynamoAuthCodeService(ConfigurationService configurationService) {
+        super(AuthCodeStore.class, "auth-code-store", configurationService);
+        this.timeToExist = configurationService.getAuthCodeExpiry();
+        this.isAuthCodeStoreEnabled = configurationService.isAuthCodeStoreEnabled();
+    }
+
+    public Optional<AuthCodeStore> getAuthCodeStore(String subjectID) {
+        if (isAuthCodeStoreEnabled) {
+            return get(subjectID)
+                    .filter(t -> t.getTimeToExist() > NowHelper.now().toInstant().getEpochSecond());
+        }
+        return Optional.empty();
+    }
+
+    public void deleteAuthCode(String subjectID) {
+        if (isAuthCodeStoreEnabled) {
+            delete(subjectID);
+        }
+    }
+
+    public void saveAuthCode(
+            String subjectID, String authCode, String requestedScopeClaims, boolean hasBeenUsed) {
+        if (isAuthCodeStoreEnabled) {
+            var authCodeStore =
+                    new AuthCodeStore()
+                            .withSubjectID(subjectID)
+                            .withAuthCode(authCode)
+                            .withRequestedScopeClaims(requestedScopeClaims)
+                            .withHasBeenUsed(hasBeenUsed)
+                            .withTimeToExist(
+                                    NowHelper.nowPlus(timeToExist, ChronoUnit.SECONDS)
+                                            .toInstant()
+                                            .getEpochSecond());
+
+            put(authCodeStore);
+        }
+    }
+
+    public void updateHasBeenUsed(String subjectID, boolean hasBeenUsed) {
+        if (isAuthCodeStoreEnabled) {
+            var authCode =
+                    get(subjectID)
+                            .orElse(new AuthCodeStore())
+                            .withSubjectID(subjectID)
+                            .withHasBeenUsed(hasBeenUsed)
+                            .withTimeToExist(
+                                    NowHelper.nowPlus(timeToExist, ChronoUnit.SECONDS)
+                                            .toInstant()
+                                            .getEpochSecond());
+
+            update(authCode);
+        }
+    }
+}

--- a/shared/user-dynamo-tables.yaml
+++ b/shared/user-dynamo-tables.yaml
@@ -161,3 +161,30 @@ Resources:
           Value: !Ref Environment
         - Key: application
           Value: shared
+
+  AuthCodeStore:
+    # checkov:skip=CKV_AWS_119: "Ensure DynamoDB Tables are encrypted using a KMS Customer Managed CMK"
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Type: "AWS::DynamoDB::Table"
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: SubjectID
+          AttributeType: S
+      BillingMode: PAY_PER_REQUEST
+      KeySchema:
+        - AttributeName: SubjectID
+          KeyType: HASH
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
+      SSESpecification:
+        SSEEnabled: true
+      TableName: !Sub "${Environment}-auth-code-store"
+      TimeToLiveSpecification:
+        AttributeName: TimeToExist
+        Enabled: true
+      Tags:
+        - Key: environment
+          Value: !Ref Environment
+        - Key: application
+          Value: shared


### PR DESCRIPTION
## What?

- Create new Dynamo bean `AuthCodeStore`
- Create service for reading and writing to the store
- Create feature flag to enable storage of authorization code
- Implement integration tests to ensure service is able to execute read and writes

## Why?

This is required in order to store the auth session when the /authroize endpoint is invoked
