### PR TITLE
AUT-1289: Add CloudWatch metric to LogoutHandler

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/domain/CloudwatchMetrics.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/domain/CloudwatchMetrics.java
@@ -6,8 +6,8 @@ public enum CloudwatchMetrics {
     AUTHENTICATION_SUCCESS_EXISTING_ACCOUNT_BY_CLIENT(
             "AuthenticationSuccessExistingAccountByClient"),
     SIGN_IN_NEW_ACCOUNT_BY_CLIENT("SignInNewAccountByClient"),
-    SIGN_IN_EXISTING_ACCOUNT_BY_CLIENT("SignInExistingAccountByClient");
-
+    SIGN_IN_EXISTING_ACCOUNT_BY_CLIENT("SignInExistingAccountByClient"),
+    LOGOUT_SUCCESS("LogoutSuccess");
     private String value;
 
     CloudwatchMetrics(String value) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CloudwatchMetricsService.java
@@ -6,6 +6,7 @@ import software.amazon.cloudwatchlogs.emf.model.Unit;
 import uk.gov.di.authentication.shared.entity.Session;
 
 import java.util.Map;
+import java.util.Optional;
 
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.ACCOUNT;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.CLIENT;
@@ -17,6 +18,7 @@ import static uk.gov.di.authentication.shared.domain.CloudwatchMetricDimensions.
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.AUTHENTICATION_SUCCESS;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.AUTHENTICATION_SUCCESS_EXISTING_ACCOUNT_BY_CLIENT;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.AUTHENTICATION_SUCCESS_NEW_ACCOUNT_BY_CLIENT;
+import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.LOGOUT_SUCCESS;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.SIGN_IN_EXISTING_ACCOUNT_BY_CLIENT;
 import static uk.gov.di.authentication.shared.domain.CloudwatchMetrics.SIGN_IN_NEW_ACCOUNT_BY_CLIENT;
 import static uk.gov.di.authentication.shared.entity.Session.AccountState.EXISTING;
@@ -130,5 +132,15 @@ public class CloudwatchMetricsService {
                             CLIENT_NAME.getValue(),
                             clientName));
         }
+    }
+
+    public void incrementLogout(Optional<String> clientId) {
+        incrementCounter(
+                LOGOUT_SUCCESS.getValue(),
+                Map.of(
+                        ENVIRONMENT.getValue(),
+                        configurationService.getEnvironment(),
+                        CLIENT.getValue(),
+                        clientId.orElse("unknown")));
     }
 }


### PR DESCRIPTION
## What?

Add a CloudWatch metric to track the user sign out journey, and logouts by RPs.

## Why?

Improve tracking of user journeys.
