### PR TITLE
AUT-1491: Create Authentication AuthCode lambda 

### DIFF
--- a/ci/terraform/oidc/api-gateway-frontend.tf
+++ b/ci/terraform/oidc/api-gateway-frontend.tf
@@ -75,6 +75,8 @@ resource "aws_api_gateway_deployment" "frontend_deployment" {
       module.processing-identity.method_trigger_value,
       module.doc-app-authorize.integration_trigger_value,
       module.doc-app-authorize.method_trigger_value,
+      module.authentication_auth_code.integration_trigger_value,
+      module.authentication_auth_code.method_trigger_value,
     ]))
   }
 
@@ -96,7 +98,8 @@ resource "aws_api_gateway_deployment" "frontend_deployment" {
     module.reset-password-request,
     module.processing-identity,
     module.ipv-authorize,
-    module.doc-app-authorize
+    module.doc-app-authorize,
+    module.authentication_auth_code,
   ]
 }
 
@@ -194,6 +197,7 @@ resource "aws_api_gateway_stage" "endpoint_frontend_stage" {
     module.ipv-authorize,
     module.processing-identity,
     module.doc-app-authorize,
+    module.authentication_auth_code,
     aws_api_gateway_deployment.deployment,
   ]
 }

--- a/ci/terraform/oidc/authentication-auth-code.tf
+++ b/ci/terraform/oidc/authentication-auth-code.tf
@@ -1,0 +1,69 @@
+module "frontend_api_authentication_auth_code_role" {
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "frontend-api-authentication-auth-code-role"
+  vpc_arn     = local.authentication_vpc_arn
+
+  policies_to_attach = [
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    aws_iam_policy.dynamo_user_read_access_policy.arn,
+    aws_iam_policy.dynamo_user_write_access_policy.arn,
+    aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
+    module.oidc_txma_audit.access_policy_arn
+  ]
+}
+
+module "authentication_auth_code" {
+  source = "../modules/endpoint-module"
+
+  endpoint_name   = "authentication-auth-code"
+  path_part       = "authentication-auth-code"
+  endpoint_method = "POST"
+  environment     = var.environment
+
+  handler_environment_variables = {
+    SUPPORT_AUTH_ORCH_SPLIT = var.support_auth_orch_split
+    DYNAMO_ENDPOINT         = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
+    ENVIRONMENT             = var.environment
+    TXMA_AUDIT_QUEUE_URL    = module.oidc_txma_audit.queue_url
+    INTERNAl_SECTOR_URI     = var.internal_sector_uri
+  }
+  handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.AuthenticationAuthCodeHandler::handleRequest"
+
+  rest_api_id      = aws_api_gateway_rest_api.di_authentication_frontend_api.id
+  root_resource_id = aws_api_gateway_rest_api.di_authentication_frontend_api.root_resource_id
+  execution_arn    = aws_api_gateway_rest_api.di_authentication_frontend_api.execution_arn
+
+  memory_size                 = lookup(var.performance_tuning, "authentication-auth-code", local.default_performance_parameters).memory
+  provisioned_concurrency     = lookup(var.performance_tuning, "authentication-auth-code", local.default_performance_parameters).concurrency
+  max_provisioned_concurrency = lookup(var.performance_tuning, "authentication-auth-code", local.default_performance_parameters).max_concurrency
+  scaling_trigger             = lookup(var.performance_tuning, "authentication-auth-code", local.default_performance_parameters).scaling_trigger
+
+  source_bucket           = aws_s3_bucket.source_bucket.bucket
+  lambda_zip_file         = aws_s3_bucket_object.frontend_api_release_zip.key
+  lambda_zip_file_version = aws_s3_bucket_object.frontend_api_release_zip.version_id
+  code_signing_config_arn = local.lambda_code_signing_configuration_arn
+
+  authentication_vpc_arn = local.authentication_vpc_arn
+  security_group_ids = [
+    local.authentication_security_group_id,
+    local.authentication_oidc_redis_security_group_id,
+  ]
+  subnet_id                              = local.authentication_subnet_ids
+  lambda_role_arn                        = module.frontend_api_authentication_auth_code_role.arn
+  logging_endpoint_arns                  = var.logging_endpoint_arns
+  cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  cloudwatch_log_retention               = var.cloudwatch_log_retention
+  lambda_env_vars_encryption_kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn
+  default_tags                           = local.default_tags
+  api_key_required                       = true
+
+  use_localstack = var.use_localstack
+
+  depends_on = [
+    aws_api_gateway_rest_api.di_authentication_frontend_api,
+    aws_api_gateway_resource.connect_resource,
+    aws_api_gateway_resource.wellknown_resource,
+  ]
+}

--- a/ci/terraform/oidc/build-overrides.tfvars
+++ b/ci/terraform/oidc/build-overrides.tfvars
@@ -11,6 +11,7 @@ spot_enabled                        = false
 language_cy_enabled                 = true
 internal_sector_uri                 = "https://identity.build.account.gov.uk"
 extended_feature_flags_enabled      = true
+support_auth_orch_split             = false
 custom_doc_app_claim_enabled        = true
 ipv_no_session_response_enabled     = true
 doc_app_cri_data_v2_endpoint        = "credentials/issue"

--- a/ci/terraform/oidc/integration-overrides.tfvars
+++ b/ci/terraform/oidc/integration-overrides.tfvars
@@ -21,6 +21,7 @@ internal_sector_uri             = "https://identity.integration.account.gov.uk"
 spot_enabled                    = true
 language_cy_enabled             = true
 extended_feature_flags_enabled  = true
+support_auth_orch_split         = false
 custom_doc_app_claim_enabled    = true
 ipv_no_session_response_enabled = true
 

--- a/ci/terraform/oidc/production-overrides.tfvars
+++ b/ci/terraform/oidc/production-overrides.tfvars
@@ -23,6 +23,7 @@ doc_app_authorisation_uri          = "https://www.review-b.account.gov.uk/dca/oa
 doc_app_jwks_endpoint              = "https://api-backend-api.review-b.account.gov.uk/.well-known/jwks.json"
 doc_app_encryption_key_id          = "7958938d-eea0-4e6d-9ea1-ec0b9d421f77"
 
+support_auth_orch_split         = false
 cloudwatch_log_retention        = 5
 client_registry_api_enabled     = false
 language_cy_enabled             = true

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -101,6 +101,10 @@ variable "account_recovery_block_enabled" {
   default = true
 }
 
+variable "support_auth_orch_split" {
+  default = false
+}
+
 variable "aws_endpoint" {
   type    = string
   default = null

--- a/ci/terraform/shared/dynamodb.tf
+++ b/ci/terraform/shared/dynamodb.tf
@@ -337,13 +337,13 @@ resource "aws_dynamodb_table" "access_token_store" {
 resource "aws_dynamodb_table" "auth_code_store" {
   name         = "${var.environment}-auth-code-store"
   billing_mode = var.provision_dynamo ? "PROVISIONED" : "PAY_PER_REQUEST"
-  hash_key     = "SubjectID"
+  hash_key     = "AuthCode"
 
   read_capacity  = var.provision_dynamo ? var.dynamo_default_read_capacity : null
   write_capacity = var.provision_dynamo ? var.dynamo_default_write_capacity : null
 
   attribute {
-    name = "SubjectID"
+    name = "AuthCode"
     type = "S"
   }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/AuthCodeRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/AuthCodeRequest.java
@@ -1,0 +1,68 @@
+package uk.gov.di.authentication.frontendapi.entity;
+
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+import uk.gov.di.authentication.shared.validation.Required;
+
+public class AuthCodeRequest {
+
+    @SerializedName("redirect-uri")
+    @Expose
+    @Required
+    private String redirectUri;
+
+    @SerializedName("state")
+    @Expose
+    @Required
+    private String state;
+
+    @SerializedName("requestedScopeClaims")
+    @Expose
+    @Required
+    private String requestedScopeClaims;
+
+    @SerializedName("email")
+    @Expose
+    @Required
+    private String email;
+
+    public AuthCodeRequest(
+            String redirectUri, String state, String requestedScopeClaims, String email) {
+        this.redirectUri = redirectUri;
+        this.state = state;
+        this.requestedScopeClaims = requestedScopeClaims;
+        this.email = email;
+    }
+
+    public String getRedirectUri() {
+        return redirectUri;
+    }
+
+    public void setRedirectUri(String redirectUri) {
+        this.redirectUri = redirectUri;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public void setState(String state) {
+        this.state = state;
+    }
+
+    public String getRequestedScopeClaims() {
+        return requestedScopeClaims;
+    }
+
+    public void setRequestedScopeClaims(String requestedScopeClaims) {
+        this.requestedScopeClaims = requestedScopeClaims;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/AuthCodeResponse.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/AuthCodeResponse.java
@@ -1,0 +1,28 @@
+package uk.gov.di.authentication.frontendapi.entity;
+
+public class AuthCodeResponse {
+
+    private String code;
+    private String state;
+
+    public AuthCodeResponse(String code, String state) {
+        this.code = code;
+        this.state = state;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public void setState(String state) {
+        this.state = state;
+    }
+}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandler.java
@@ -1,0 +1,94 @@
+package uk.gov.di.authentication.frontendapi.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import com.nimbusds.oauth2.sdk.AuthorizationSuccessResponse;
+import com.nimbusds.oauth2.sdk.id.State;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.frontendapi.entity.AuthCodeRequest;
+import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
+import uk.gov.di.authentication.shared.serialization.Json.JsonException;
+import uk.gov.di.authentication.shared.services.AuthenticationService;
+import uk.gov.di.authentication.shared.services.ClientService;
+import uk.gov.di.authentication.shared.services.ClientSessionService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.DynamoAuthCodeService;
+import uk.gov.di.authentication.shared.services.SessionService;
+import uk.gov.di.authentication.shared.state.UserContext;
+
+import java.net.URI;
+
+import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
+import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.AWS_REQUEST_ID;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachLogFieldToLogs;
+
+public class AuthenticationAuthCodeHandler extends BaseFrontendHandler<AuthCodeRequest> {
+
+    private static final Logger LOG = LogManager.getLogger(AuthenticationAuthCodeHandler.class);
+
+    private final DynamoAuthCodeService dynamoAuthCodeService;
+
+    public AuthenticationAuthCodeHandler(
+            DynamoAuthCodeService dynamoAuthCodeService,
+            ConfigurationService configurationService,
+            SessionService sessionService,
+            ClientSessionService clientSessionService,
+            ClientService clientService,
+            AuthenticationService authenticationService) {
+        super(
+                AuthCodeRequest.class,
+                configurationService,
+                sessionService,
+                clientSessionService,
+                clientService,
+                authenticationService);
+        this.dynamoAuthCodeService = dynamoAuthCodeService;
+    }
+
+    public AuthenticationAuthCodeHandler(ConfigurationService configurationService) {
+        super(AuthCodeRequest.class, configurationService);
+        this.dynamoAuthCodeService = new DynamoAuthCodeService(configurationService);
+    }
+
+    @Override
+    public APIGatewayProxyResponseEvent handleRequestWithUserContext(
+            APIGatewayProxyRequestEvent input,
+            Context context,
+            AuthCodeRequest authCodeRequest,
+            UserContext userContext) {
+        attachLogFieldToLogs(AWS_REQUEST_ID, context.getAwsRequestId());
+        if (configurationService.isAuthOrchSplitEnabled()) {
+            try {
+                var userProfile = userContext.getUserProfile();
+                if (userProfile.isEmpty()) {
+                    LOG.info(
+                            "Error message: Email from session does not have a user profile required to extract Subject ID");
+                    return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1049);
+                }
+
+                var authorisationCode = new AuthorizationCode();
+                dynamoAuthCodeService.saveAuthCode(
+                        userProfile.get().getSubjectID(),
+                        authorisationCode.getValue(),
+                        authCodeRequest.getRequestedScopeClaims(),
+                        false);
+
+                var state = State.parse(authCodeRequest.getState());
+                var redirectUri = URI.create(authCodeRequest.getRedirectUri());
+                var authorizationResponse =
+                        new AuthorizationSuccessResponse(
+                                redirectUri, authorisationCode, null, state, null);
+
+                return generateApiGatewayProxyResponse(200, authorizationResponse);
+            } catch (JsonException ex) {
+                return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
+            }
+        }
+        return generateApiGatewayProxyErrorResponse(500, ErrorResponse.ERROR_1050);
+    }
+}

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandlerTest.java
@@ -1,0 +1,190 @@
+package uk.gov.di.authentication.frontendapi.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.nimbusds.oauth2.sdk.id.Subject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.frontendapi.entity.AuthCodeResponse;
+import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.entity.Session;
+import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.helpers.IdGenerator;
+import uk.gov.di.authentication.shared.serialization.Json;
+import uk.gov.di.authentication.shared.services.AuthenticationService;
+import uk.gov.di.authentication.shared.services.ClientService;
+import uk.gov.di.authentication.shared.services.ClientSessionService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.DynamoAuthCodeService;
+import uk.gov.di.authentication.shared.services.SerializationService;
+import uk.gov.di.authentication.shared.services.SessionService;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.lang.String.format;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
+
+class AuthenticationAuthCodeHandlerTest {
+    private static final String TEST_EMAIL_ADDRESS = "test@test.com";
+    private static final String TEST_REDIRECT_URI = "https://redirect_uri.com";
+    private static final String TEST_STATE = "xyz";
+    private static final String TEST_REQUESTED_SCOPE_CLAIMS = "requested-scope-claims";
+    private static final String TEST_AUTHORIZATION_CODE = "SplxlOBeZQQYbYS6WxSbIA";
+    private static final String TEST_SUBJECT_ID = "subject-id";
+
+    private AuthenticationAuthCodeHandler handler;
+    private static final Json objectMapper = SerializationService.getInstance();
+    private final Context context = mock(Context.class);
+    private final DynamoAuthCodeService dynamoAuthCodeService = mock(DynamoAuthCodeService.class);
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private final SessionService sessionService = mock(SessionService.class);
+    private final ClientSessionService clientSessionService = mock(ClientSessionService.class);
+    private final AuthenticationService authenticationService = mock(AuthenticationService.class);
+    private final ClientService clientService = mock(ClientService.class);
+    private final Session session =
+            new Session(IdGenerator.generate()).setEmailAddress(TEST_EMAIL_ADDRESS);
+
+    @BeforeEach
+    void setUp() throws Json.JsonException {
+        when(context.getAwsRequestId()).thenReturn("aws-session-id");
+        when(sessionService.getSessionFromRequestHeaders(anyMap()))
+                .thenReturn(Optional.of(session));
+        UserProfile userProfile = generateUserProfile();
+        when(authenticationService.getUserProfileByEmailMaybe(TEST_EMAIL_ADDRESS))
+                .thenReturn(Optional.of(userProfile));
+        handler =
+                new AuthenticationAuthCodeHandler(
+                        dynamoAuthCodeService,
+                        configurationService,
+                        sessionService,
+                        clientSessionService,
+                        clientService,
+                        authenticationService);
+    }
+
+    @Test
+    void shouldReturn500ErrorWhenAuthenticationAuthCodeHandlerIsDisabled()
+            throws Json.JsonException {
+        when(configurationService.isAuthOrchSplitEnabled()).thenReturn(false);
+        var event = validAuthCodeRequest();
+        event.setHeaders(getHeaders());
+
+        var result = handler.handleRequest(event, context);
+        assertThat(result, hasStatus(500));
+        assertThat(result, hasBody(objectMapper.writeValueAsString(ErrorResponse.ERROR_1050)));
+    }
+
+    @Test
+    void shouldReturn400ErrorWhenEmailIsInvalid() throws Json.JsonException {
+        when(configurationService.isAuthOrchSplitEnabled()).thenReturn(true);
+        var event = new APIGatewayProxyRequestEvent();
+        event.setHeaders(getHeaders());
+        event.setBody(format("{ \"email\": \"%s\"}", ""));
+
+        var result = handler.handleRequest(event, context);
+        assertThat(result, hasStatus(400));
+        assertThat(result, hasBody(objectMapper.writeValueAsString(ErrorResponse.ERROR_1001)));
+    }
+
+    @Test
+    void shouldReturn400ErrorWhenRedirectUriIsInvalid() throws Json.JsonException {
+        when(configurationService.isAuthOrchSplitEnabled()).thenReturn(true);
+        var event = new APIGatewayProxyRequestEvent();
+        event.setHeaders(getHeaders());
+        event.setBody(
+                format("{ \"email\": \"%s\", \"redirect-uri\": \"%s\" }", TEST_EMAIL_ADDRESS, ""));
+
+        var result = handler.handleRequest(event, context);
+        assertThat(result, hasStatus(400));
+        assertThat(result, hasBody(objectMapper.writeValueAsString(ErrorResponse.ERROR_1001)));
+    }
+
+    @Test
+    void shouldReturn400ErrorWhenStateIsInvalid() throws Json.JsonException {
+        when(configurationService.isAuthOrchSplitEnabled()).thenReturn(true);
+        var event = new APIGatewayProxyRequestEvent();
+        event.setHeaders(getHeaders());
+        event.setBody(
+                format(
+                        "{ \"email\": \"%s\", \"redirect-uri\": \"%s\", \"state\": \"%s\" }",
+                        TEST_EMAIL_ADDRESS, TEST_REDIRECT_URI, ""));
+
+        var result = handler.handleRequest(event, context);
+        assertThat(result, hasStatus(400));
+        assertThat(result, hasBody(objectMapper.writeValueAsString(ErrorResponse.ERROR_1001)));
+    }
+
+    @Test
+    void shouldReturn400ErrorWhenUnableToFetchEmailFromUserProfile() throws Json.JsonException {
+        when(configurationService.isAuthOrchSplitEnabled()).thenReturn(true);
+        when(authenticationService.getUserProfileByEmailMaybe(TEST_EMAIL_ADDRESS))
+                .thenReturn(Optional.empty());
+        var event = validAuthCodeRequest();
+
+        var result = handler.handleRequest(event, context);
+        assertThat(result, hasStatus(400));
+        assertThat(result, hasBody(objectMapper.writeValueAsString(ErrorResponse.ERROR_1049)));
+    }
+
+    @Test
+    void shouldReturn200AndSaveNewAuthCodeRequest() throws Json.JsonException {
+        when(configurationService.isAuthOrchSplitEnabled()).thenReturn(true);
+        when(configurationService.getAuthCodeExpiry()).thenReturn(Long.valueOf(12));
+        var userProfile = new UserProfile();
+        userProfile.setSubjectID(TEST_SUBJECT_ID);
+        when(authenticationService.getUserProfileFromEmail(TEST_EMAIL_ADDRESS))
+                .thenReturn(Optional.of(userProfile));
+        var event = validAuthCodeRequest();
+
+        var result = handler.handleRequest(event, context);
+
+        verify(dynamoAuthCodeService, times(1))
+                .saveAuthCode(
+                        eq(userProfile.getSubjectID()),
+                        anyString(),
+                        eq(TEST_REQUESTED_SCOPE_CLAIMS),
+                        eq(false));
+        assertThat(result, hasStatus(200));
+        var authorizationResponse = new AuthCodeResponse(TEST_AUTHORIZATION_CODE, TEST_STATE);
+        assertThat(result, hasBody(objectMapper.writeValueAsString(authorizationResponse)));
+    }
+
+    private APIGatewayProxyRequestEvent validAuthCodeRequest() {
+        APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
+        event.setHeaders(getHeaders());
+        event.setBody(
+                format(
+                        "{ \"email\": \"%s\", \"redirect-uri\": \"%s\", \"state\": \"%s\", \"requestedScopeClaims\": \"%s\" }",
+                        TEST_EMAIL_ADDRESS,
+                        TEST_REDIRECT_URI,
+                        TEST_STATE,
+                        TEST_REQUESTED_SCOPE_CLAIMS));
+        return event;
+    }
+
+    private Map<String, String> getHeaders() {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Session-Id", session.getSessionId());
+        return headers;
+    }
+
+    private UserProfile generateUserProfile() {
+        return new UserProfile()
+                .withEmail(TEST_EMAIL_ADDRESS)
+                .withEmailVerified(true)
+                .withPhoneNumberVerified(true)
+                .withPublicSubjectID(new Subject().getValue())
+                .withSubjectID(TEST_SUBJECT_ID);
+    }
+}

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationAuthCodeHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationAuthCodeHandlerIntegrationTest.java
@@ -1,0 +1,99 @@
+package uk.gov.di.authentication.api;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.di.authentication.frontendapi.entity.AuthCodeRequest;
+import uk.gov.di.authentication.frontendapi.lambda.AuthenticationAuthCodeHandler;
+import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.serialization.Json;
+import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.gov.di.authentication.sharedtest.extensions.AuthCodeExtension;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
+
+class AuthenticationAuthCodeHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
+    private static final String TEST_EMAIL_ADDRESS = "test@test.com";
+    private static final String TEST_PASSWORD = "password-1";
+    private static final String TEST_REDIRECT_URI = "https://redirect_uri.com";
+    private static final String TEST_STATE = "xyz";
+    private static final String TEST_REQUESTED_SCOPE_CLAIMS = "requested-scope-claims";
+    private static final String TEST_AUTHORIZATION_CODE = "SplxlOBeZQQYbYS6WxSbIA";
+    private static final String TEST_SUBJECT_ID = "subject-id";
+
+    @RegisterExtension
+    protected static final AuthCodeExtension authCodeExtension = new AuthCodeExtension(180);
+
+    @BeforeEach
+    void setup() throws Json.JsonException {
+        handler =
+                new AuthenticationAuthCodeHandler(AUTH_CODE_HANDLER_ENABLED_CONFIGURATION_SERVICE);
+        txmaAuditQueue.clear();
+    }
+
+    private void setUpDynamo() {
+        authCodeExtension.saveAuthCode(
+                TEST_SUBJECT_ID, TEST_AUTHORIZATION_CODE, TEST_REQUESTED_SCOPE_CLAIMS, false);
+        userStore.signUp(TEST_EMAIL_ADDRESS, TEST_PASSWORD);
+    }
+
+    @Test
+    void shouldReturn200StatusAndReturnMatchingAuthCodeForAuthCodeRequest()
+            throws Json.JsonException {
+        setUpDynamo();
+        var authRequest =
+                new AuthCodeRequest(
+                        TEST_REDIRECT_URI,
+                        TEST_STATE,
+                        TEST_REQUESTED_SCOPE_CLAIMS,
+                        TEST_EMAIL_ADDRESS);
+        var response = makeRequest(Optional.of(authRequest), getHeaders(), Map.of());
+        assertThat(response, hasStatus(200));
+    }
+
+    @Test
+    void shouldReturn400StatusForInvalidRedirectUri() throws Json.JsonException {
+        setUpDynamo();
+        var authRequest =
+                new AuthCodeRequest(
+                        null, TEST_STATE, TEST_REQUESTED_SCOPE_CLAIMS, TEST_EMAIL_ADDRESS);
+        var response = makeRequest(Optional.of(authRequest), getHeaders(), Map.of());
+        assertThat(response, hasStatus(400));
+        assertThat(response, hasBody(objectMapper.writeValueAsString(ErrorResponse.ERROR_1001)));
+    }
+
+    @Test
+    void shouldReturn400StatusForInvalidState() throws Json.JsonException {
+        setUpDynamo();
+        var authRequest =
+                new AuthCodeRequest(
+                        TEST_REDIRECT_URI, null, TEST_REQUESTED_SCOPE_CLAIMS, TEST_EMAIL_ADDRESS);
+        var response = makeRequest(Optional.of(authRequest), getHeaders(), Map.of());
+        assertThat(response, hasStatus(400));
+        assertThat(response, hasBody(objectMapper.writeValueAsString(ErrorResponse.ERROR_1001)));
+    }
+
+    @Test
+    void shouldReturn400StatusForInvalidRequestedScopeClaims() throws Json.JsonException {
+        setUpDynamo();
+        var authRequest =
+                new AuthCodeRequest(TEST_REDIRECT_URI, TEST_STATE, null, TEST_EMAIL_ADDRESS);
+        var response = makeRequest(Optional.of(authRequest), getHeaders(), Map.of());
+        assertThat(response, hasStatus(400));
+        assertThat(response, hasBody(objectMapper.writeValueAsString(ErrorResponse.ERROR_1001)));
+    }
+
+    private Map<String, String> getHeaders() throws Json.JsonException {
+        Map<String, String> headers = new HashMap<>();
+        var sessionId = redis.createSession();
+        redis.addEmailToSession(sessionId, TEST_EMAIL_ADDRESS);
+        headers.put("Session-Id", sessionId);
+        return headers;
+    }
+}

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoAuthCodeServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoAuthCodeServiceIntegrationTest.java
@@ -33,9 +33,9 @@ class DynamoAuthCodeServiceIntegrationTest {
     void shouldUpdateHasBeenUsed() {
         setUpDynamo();
 
-        dynamoAuthCodeService.updateHasBeenUsed(SUBJECT_ID, true);
+        dynamoAuthCodeService.updateHasBeenUsed(AUTH_CODE, true);
         var updatedAuthCode =
-                dynamoAuthCodeService.getAuthCodeStore(SUBJECT_ID).orElseGet(AuthCodeStore::new);
+                dynamoAuthCodeService.getAuthCodeStore(AUTH_CODE).orElseGet(AuthCodeStore::new);
 
         assertThat(updatedAuthCode.isHasBeenUsed(), equalTo(true));
     }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/basetest/HandlerIntegrationTest.java
@@ -139,6 +139,23 @@ public abstract class HandlerIntegrationTest<Q, S> {
                 }
             };
 
+    protected static final ConfigurationService AUTH_CODE_HANDLER_ENABLED_CONFIGURATION_SERVICE =
+            new IntegrationTestConfigurationService(
+                    auditTopic,
+                    notificationsQueue,
+                    auditSigningKey,
+                    tokenSigner,
+                    ipvPrivateKeyJwtSigner,
+                    spotQueue,
+                    docAppPrivateKeyJwtSigner,
+                    configurationParameters) {
+
+                @Override
+                public boolean isAuthOrchSplitEnabled() {
+                    return true;
+                }
+            };
+
     protected RequestHandler<Q, S> handler;
     protected final Json objectMapper = SerializationService.getInstance();
     protected final Context context = mock(Context.class);

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthCodeExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthCodeExtension.java
@@ -8,13 +8,16 @@ import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
 import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
 import software.amazon.awssdk.services.dynamodb.model.KeyType;
 import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
+import uk.gov.di.authentication.shared.entity.AuthCodeStore;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoAuthCodeService;
 import uk.gov.di.authentication.sharedtest.basetest.DynamoTestConfiguration;
 
+import java.util.Optional;
+
 public class AuthCodeExtension extends DynamoExtension implements AfterEachCallback {
 
-    public static final String SUBJECT_ID_FIELD = "SubjectID";
+    public static final String AUTH_CODE_FIELD = "AuthCode";
     public static final String AUTH_CODE_STORE_TABLE = "local-auth-code-store";
 
     private DynamoAuthCodeService dynamoAuthCodeService;
@@ -41,7 +44,7 @@ public class AuthCodeExtension extends DynamoExtension implements AfterEachCallb
 
     @Override
     public void afterEach(ExtensionContext context) throws Exception {
-        clearDynamoTable(dynamoDB, AUTH_CODE_STORE_TABLE, SUBJECT_ID_FIELD);
+        clearDynamoTable(dynamoDB, AUTH_CODE_STORE_TABLE, AUTH_CODE_FIELD);
     }
 
     @Override
@@ -49,6 +52,10 @@ public class AuthCodeExtension extends DynamoExtension implements AfterEachCallb
         if (!tableExists(AUTH_CODE_STORE_TABLE)) {
             createAuthCodeStoreTable();
         }
+    }
+
+    public Optional<AuthCodeStore> getAuthCode(String authCode) {
+        return dynamoAuthCodeService.getAuthCodeStore(authCode);
     }
 
     public void saveAuthCode(
@@ -64,12 +71,12 @@ public class AuthCodeExtension extends DynamoExtension implements AfterEachCallb
                         .keySchema(
                                 KeySchemaElement.builder()
                                         .keyType(KeyType.HASH)
-                                        .attributeName(SUBJECT_ID_FIELD)
+                                        .attributeName(AUTH_CODE_FIELD)
                                         .build())
                         .billingMode(BillingMode.PAY_PER_REQUEST)
                         .attributeDefinitions(
                                 AttributeDefinition.builder()
-                                        .attributeName(SUBJECT_ID_FIELD)
+                                        .attributeName(AUTH_CODE_FIELD)
                                         .attributeType(ScalarAttributeType.S)
                                         .build())
                         .build();

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthCodeStore.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthCodeStore.java
@@ -21,7 +21,6 @@ public class AuthCodeStore {
 
     public AuthCodeStore() {}
 
-    @DynamoDbPartitionKey
     @DynamoDbAttribute(ATTRIBUTE_SUBJECT_ID)
     public String getSubjectID() {
         return subjectID;
@@ -36,6 +35,7 @@ public class AuthCodeStore {
         return this;
     }
 
+    @DynamoDbPartitionKey
     @DynamoDbAttribute(ATTRIBUTE_AUTH_CODE)
     public String getAuthCode() {
         return authCode;

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ErrorResponse.java
@@ -59,7 +59,9 @@ public enum ErrorResponse {
             "System is blocked from sending any email verification codes for changing how to receive security codes"),
     ERROR_1048(
             1048,
-            "User entered invalid email verification code for changing how to receive security codes too many times");
+            "User entered invalid email verification code for changing how to receive security codes too many times"),
+    ERROR_1049(1049, "Email from session does not have a user profile"),
+    ERROR_1050(1050, "Authorization Auth Code not enabled");
 
     private int code;
 


### PR DESCRIPTION
## What?

- Create a new handler 'AuthorizationAuthCodeHandler'
- This is the lambda that will generate an OAuth authorization response to be passed back to Orchestration which will consist of:
- `code` the authorization code generated in the in the newly created lambda
- `state` present in the initial request `AuthCodeRequest`
- This lambda will use the newly created `DynamoAuthCodeService` which will save a new auth code amongst other fields in Dynamo
- The changes also includes the necessary terraform infrastructure to ensure the handler is connected to a corresponding lambda function

## Why?
- Part of auth/orch split. Authentication will need to generate an OAuth authorization response to Orchestration

## Related PRs
[Auth Code Store](https://github.com/alphagov/di-authentication-api/pull/3194)
