### PR TITLE
Aut 1252/create orch callback handler

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
@@ -2,6 +2,7 @@ package uk.gov.di.authentication.api;
 
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.id.ClientID;
@@ -161,7 +162,7 @@ class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHandlerInte
                 startsWith(REDIRECT_URI.toString()));
         assertThat(
                 response.getHeaders().get(ResponseHeaders.LOCATION),
-                containsString("Invalid+state+param+present"));
+                containsString(OAuth2Error.SERVER_ERROR.getCode()));
         assertThat(
                 response.getHeaders().get(ResponseHeaders.LOCATION),
                 containsString(RP_STATE.getValue()));

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
@@ -1,0 +1,329 @@
+package uk.gov.di.authentication.api;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import com.nimbusds.oauth2.sdk.ResponseType;
+import com.nimbusds.oauth2.sdk.Scope;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.id.State;
+import com.nimbusds.oauth2.sdk.id.Subject;
+import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+import com.nimbusds.openid.connect.sdk.Nonce;
+import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
+import org.apache.http.client.utils.URIBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.di.authentication.oidc.domain.OrchestrationAuditableEvent;
+import uk.gov.di.authentication.oidc.entity.AuthenticationUserInfo;
+import uk.gov.di.authentication.oidc.lambda.AuthenticationCallbackHandler;
+import uk.gov.di.authentication.oidc.services.AuthenticationAuthorizationService;
+import uk.gov.di.authentication.shared.entity.ClientSession;
+import uk.gov.di.authentication.shared.entity.ClientType;
+import uk.gov.di.authentication.shared.entity.ResponseHeaders;
+import uk.gov.di.authentication.shared.entity.ServiceType;
+import uk.gov.di.authentication.shared.entity.VectorOfTrust;
+import uk.gov.di.authentication.shared.serialization.Json;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.gov.di.authentication.sharedtest.extensions.AuthExternalApiStubExtension;
+import uk.gov.di.authentication.sharedtest.extensions.AuthenticationCallbackUserInfoStoreExtension;
+import uk.gov.di.authentication.sharedtest.extensions.KmsKeyExtension;
+import uk.gov.di.authentication.sharedtest.extensions.SnsTopicExtension;
+import uk.gov.di.authentication.sharedtest.extensions.SqsQueueExtension;
+import uk.gov.di.authentication.sharedtest.extensions.TokenSigningExtension;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Collections.singletonList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
+
+class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
+
+    public static final String SESSION_ID = "some-session-id";
+    public static final String CLIENT_SESSION_ID = "some-client-session-id";
+    public static final Scope SCOPE = new Scope(OIDCScopeValue.OPENID);
+    public static final State RP_STATE = new State();
+    public static final State ORCH_TO_AUTH_STATE = new State();
+
+    @RegisterExtension
+    public static final AuthExternalApiStubExtension authExternalApiStub =
+            new AuthExternalApiStubExtension();
+
+    @RegisterExtension
+    protected static final AuthenticationCallbackUserInfoStoreExtension userInfoStoreExtension =
+            new AuthenticationCallbackUserInfoStoreExtension(180);
+
+    protected final ConfigurationService configurationService =
+            new AuthenticationCallbackHandlerIntegrationTest.TestConfigurationService(
+                    authExternalApiStub,
+                    auditTopic,
+                    notificationsQueue,
+                    auditSigningKey,
+                    tokenSigner,
+                    ipvPrivateKeyJwtSigner,
+                    spotQueue,
+                    docAppPrivateKeyJwtSigner);
+
+    private static final String CLIENT_ID = "test-client-id";
+    private static final String CLIENT_NAME = "test-client-name";
+
+    private static final URI REDIRECT_URI = URI.create("http://localhost/redirect");
+    private static final Subject SUBJECT_ID = new Subject();
+
+    @BeforeEach
+    void setup() throws JOSEException {
+        handler = new AuthenticationCallbackHandler(configurationService);
+        authExternalApiStub.init(SUBJECT_ID);
+        clientStore.registerClient(
+                CLIENT_ID,
+                "test-client",
+                singletonList(REDIRECT_URI.toString()),
+                singletonList("contact@example.com"),
+                singletonList("openid"),
+                null,
+                singletonList("http://localhost/post-redirect-logout"),
+                "http://example.com",
+                String.valueOf(ServiceType.MANDATORY),
+                "https://test.com",
+                "pairwise",
+                true,
+                ClientType.APP);
+        txmaAuditQueue.clear();
+    }
+
+    @Test
+    void shouldStoreUserInfoAndRedirectToRpWhenSuccessfullyProcessedCallbackResponse()
+            throws Json.JsonException {
+        setupSession();
+
+        var response =
+                makeRequest(
+                        Optional.empty(),
+                        constructHeaders(
+                                Optional.of(buildSessionCookie(SESSION_ID, CLIENT_SESSION_ID))),
+                        constructQueryStringParameters());
+
+        assertThat(response, hasStatus(302));
+
+        URI redirectLocationHeader =
+                URI.create(response.getHeaders().get(ResponseHeaders.LOCATION));
+        assertEquals(
+                REDIRECT_URI.getAuthority() + REDIRECT_URI.getPath(),
+                redirectLocationHeader.getAuthority() + redirectLocationHeader.getPath());
+
+        assertThat(redirectLocationHeader.getQuery(), containsString(RP_STATE.getValue()));
+
+        assertThat(redirectLocationHeader.getQuery(), containsString("code"));
+
+        assertTxmaAuditEventsReceived(
+                txmaAuditQueue,
+                List.of(
+                        OrchestrationAuditableEvent.AUTH_CALLBACK_RESPONSE_RECEIVED,
+                        OrchestrationAuditableEvent.AUTH_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
+                        OrchestrationAuditableEvent.AUTH_SUCCESSFUL_USERINFO_RESPONSE_RECEIVED));
+
+        Optional<AuthenticationUserInfo> userInfoDbEntry =
+                userInfoStoreExtension.getUserInfoBySubjectId(SUBJECT_ID.getValue());
+        assertTrue(userInfoDbEntry.isPresent());
+        assertEquals(SUBJECT_ID.getValue(), userInfoDbEntry.get().getSubjectID());
+        assertThat(userInfoDbEntry.get().getUserInfo(), containsString("new_account"));
+    }
+
+    @Test
+    void shouldRedirectToRpWithErrorWhenStateIsInvalid() throws Json.JsonException {
+        setupSession();
+
+        var response =
+                makeRequest(
+                        Optional.empty(),
+                        constructHeaders(
+                                Optional.of(buildSessionCookie(SESSION_ID, CLIENT_SESSION_ID))),
+                        Map.of("code", "a-random-code", "state", new State().getValue()));
+
+        assertThat(response, hasStatus(302));
+        assertThat(
+                response.getHeaders().get(ResponseHeaders.LOCATION),
+                startsWith(REDIRECT_URI.toString()));
+        assertThat(
+                response.getHeaders().get(ResponseHeaders.LOCATION),
+                containsString("Invalid+state+param+present"));
+        assertThat(
+                response.getHeaders().get(ResponseHeaders.LOCATION),
+                containsString(RP_STATE.getValue()));
+
+        assertTxmaAuditEventsReceived(
+                txmaAuditQueue,
+                List.of(OrchestrationAuditableEvent.AUTH_UNSUCCESSFUL_CALLBACK_RESPONSE_RECEIVED));
+
+        Optional<AuthenticationUserInfo> userInfoDbEntry =
+                userInfoStoreExtension.getUserInfoBySubjectId(SUBJECT_ID.getValue());
+        assertFalse(userInfoDbEntry.isPresent());
+    }
+
+    @Test
+    void shouldRedirectToFrontendErrorPageIfUnsuccessfulResponseReceivedFromTokenEndpoint()
+            throws Json.JsonException {
+        setupSession();
+
+        authExternalApiStub.register(
+                "/token", 400, "application/json", "{\"error\": \"invalid_request\"}");
+
+        var response =
+                makeRequest(
+                        Optional.empty(),
+                        constructHeaders(
+                                Optional.of(buildSessionCookie(SESSION_ID, CLIENT_SESSION_ID))),
+                        constructQueryStringParameters());
+
+        assertThat(response, hasStatus(302));
+        assertThat(
+                response.getHeaders().get(ResponseHeaders.LOCATION),
+                startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
+        assertThat(response.getHeaders().get(ResponseHeaders.LOCATION), endsWith("error"));
+
+        assertTxmaAuditEventsReceived(
+                txmaAuditQueue,
+                List.of(
+                        OrchestrationAuditableEvent.AUTH_CALLBACK_RESPONSE_RECEIVED,
+                        OrchestrationAuditableEvent.AUTH_UNSUCCESSFUL_TOKEN_RESPONSE_RECEIVED));
+    }
+
+    @Test
+    void shouldRedirectToFrontendErrorPageIfUnsuccessfulResponseReceivedFromUserInfoEndpoint()
+            throws Json.JsonException {
+        setupSession();
+
+        authExternalApiStub.register(
+                "/userinfo", 400, "application/json", "{\"error\": \"invalid_request\"}");
+
+        var response =
+                makeRequest(
+                        Optional.empty(),
+                        constructHeaders(
+                                Optional.of(buildSessionCookie(SESSION_ID, CLIENT_SESSION_ID))),
+                        constructQueryStringParameters());
+
+        assertThat(response, hasStatus(302));
+        assertThat(
+                response.getHeaders().get(ResponseHeaders.LOCATION),
+                startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
+        assertThat(response.getHeaders().get(ResponseHeaders.LOCATION), endsWith("error"));
+
+        assertTxmaAuditEventsReceived(
+                txmaAuditQueue,
+                List.of(
+                        OrchestrationAuditableEvent.AUTH_CALLBACK_RESPONSE_RECEIVED,
+                        OrchestrationAuditableEvent.AUTH_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
+                        OrchestrationAuditableEvent.AUTH_UNSUCCESSFUL_USERINFO_RESPONSE_RECEIVED));
+    }
+
+    private void setupSession() throws Json.JsonException {
+        var authRequestBuilder =
+                new AuthenticationRequest.Builder(
+                                ResponseType.CODE, SCOPE, new ClientID(CLIENT_ID), REDIRECT_URI)
+                        .state(RP_STATE)
+                        .nonce(new Nonce());
+        redis.createSession(SESSION_ID);
+        var clientSession =
+                new ClientSession(
+                        authRequestBuilder.build().toParameters(),
+                        LocalDateTime.now(),
+                        VectorOfTrust.getDefaults(),
+                        CLIENT_NAME);
+        redis.createClientSession(CLIENT_SESSION_ID, clientSession);
+        redis.addStateToRedis(
+                AuthenticationAuthorizationService.AUTHENTICATION_STATE_STORAGE_PREFIX,
+                ORCH_TO_AUTH_STATE,
+                SESSION_ID);
+    }
+
+    private Map<String, String> constructQueryStringParameters() {
+        final Map<String, String> queryStringParameters = new HashMap<>();
+        queryStringParameters.putAll(
+                Map.of(
+                        "state",
+                        ORCH_TO_AUTH_STATE.getValue(),
+                        "code",
+                        new AuthorizationCode().getValue()));
+        return queryStringParameters;
+    }
+
+    protected static class TestConfigurationService extends IntegrationTestConfigurationService {
+
+        private final AuthExternalApiStubExtension authExternalApiStub;
+
+        public TestConfigurationService(
+                AuthExternalApiStubExtension authExternalApiStub,
+                SnsTopicExtension auditEventTopic,
+                SqsQueueExtension notificationQueue,
+                KmsKeyExtension auditSigningKey,
+                TokenSigningExtension tokenSigningKey,
+                TokenSigningExtension ipvPrivateKeyJwtSigner,
+                SqsQueueExtension spotQueue,
+                TokenSigningExtension docAppPrivateKeyJwtSigner) {
+            super(
+                    auditEventTopic,
+                    notificationQueue,
+                    auditSigningKey,
+                    tokenSigningKey,
+                    ipvPrivateKeyJwtSigner,
+                    spotQueue,
+                    docAppPrivateKeyJwtSigner,
+                    configurationParameters);
+            this.authExternalApiStub = authExternalApiStub;
+        }
+
+        @Override
+        public URI getAuthenticationBackendURI() {
+            try {
+                return new URIBuilder()
+                        .setHost("localhost")
+                        .setPort(authExternalApiStub.getHttpPort())
+                        .setScheme("http")
+                        .build();
+            } catch (URISyntaxException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public String getOrchestrationClientId() {
+            return CLIENT_ID;
+        }
+
+        @Override
+        public URI getAuthenticationAuthCallbackURI() {
+            return URI.create("http://localhost/redirect");
+        }
+
+        @Override
+        public String getAuthenticationUserInfoEndpoint() {
+            return "/userinfo";
+        }
+
+        @Override
+        public String getTxmaAuditQueueUrl() {
+            return txmaAuditQueue.getQueueUrl();
+        }
+
+        @Override
+        public String getOrchestrationToAuthenticationTokenSigningKeyAlias() {
+            return orchestrationPrivateKeyJwtSigner.getKeyAlias();
+        }
+    }
+}

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/AuthenticationUserInfoStorageServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/AuthenticationUserInfoStorageServiceIntegrationTest.java
@@ -1,0 +1,35 @@
+package uk.gov.di.authentication.services;
+
+import com.nimbusds.oauth2.sdk.id.Subject;
+import com.nimbusds.openid.connect.sdk.claims.UserInfo;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.di.authentication.oidc.entity.AuthenticationUserInfo;
+import uk.gov.di.authentication.sharedtest.extensions.AuthenticationCallbackUserInfoStoreExtension;
+
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+class AuthenticationUserInfoStorageServiceIntegrationTest {
+
+    private static final String SUBJECT_ID = "test-subject-id";
+
+    @RegisterExtension
+    protected static final AuthenticationCallbackUserInfoStoreExtension userInfoExtension =
+            new AuthenticationCallbackUserInfoStoreExtension(180);
+
+    @Test
+    void shouldAddAndRetrieveUserInfo() {
+        UserInfo userInfo = new UserInfo(new Subject(SUBJECT_ID));
+
+        userInfoExtension.addAuthenticationUserInfoData(SUBJECT_ID, userInfo);
+
+        Optional<AuthenticationUserInfo> retrievedUserInfo =
+                userInfoExtension.getUserInfoBySubjectId(SUBJECT_ID);
+
+        assertThat(retrievedUserInfo.isPresent(), equalTo(true));
+        assertThat(retrievedUserInfo.get().getSubjectID(), equalTo(SUBJECT_ID));
+    }
+}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/domain/OrchestrationAuditableEvent.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/domain/OrchestrationAuditableEvent.java
@@ -1,0 +1,17 @@
+package uk.gov.di.authentication.oidc.domain;
+
+import uk.gov.di.authentication.shared.domain.AuditableEvent;
+
+public enum OrchestrationAuditableEvent implements AuditableEvent {
+    AUTH_CALLBACK_RESPONSE_RECEIVED,
+    AUTH_UNSUCCESSFUL_CALLBACK_RESPONSE_RECEIVED,
+    AUTH_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
+    AUTH_UNSUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
+    AUTH_SUCCESSFUL_USERINFO_RESPONSE_RECEIVED,
+    AUTH_UNSUCCESSFUL_USERINFO_RESPONSE_RECEIVED;
+
+    @Override
+    public AuditableEvent parseFromName(String name) {
+        return valueOf(name);
+    }
+}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/AuthenticationUserInfo.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/AuthenticationUserInfo.java
@@ -1,0 +1,59 @@
+package uk.gov.di.authentication.oidc.entity;
+
+import com.nimbusds.openid.connect.sdk.claims.UserInfo;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbAttribute;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+
+@DynamoDbBean
+public class AuthenticationUserInfo {
+
+    private String subjectID;
+    private UserInfo userInfo;
+    private long timeToExist;
+
+    public AuthenticationUserInfo() {}
+
+    @DynamoDbPartitionKey
+    @DynamoDbAttribute("SubjectID")
+    public String getSubjectID() {
+        return subjectID;
+    }
+
+    public void setSubjectID(String subjectID) {
+        this.subjectID = subjectID;
+    }
+
+    public AuthenticationUserInfo withSubjectID(String subjectID) {
+        this.subjectID = subjectID;
+        return this;
+    }
+
+    @DynamoDbAttribute("UserInfo")
+    public UserInfo getUserInfo() {
+        return userInfo;
+    }
+
+    public void setUserInfo(UserInfo userInfo) {
+        this.userInfo = userInfo;
+    }
+
+    public AuthenticationUserInfo withUserInfo(UserInfo userInfo) {
+        this.userInfo = userInfo;
+        return this;
+    }
+
+    @DynamoDbAttribute("TimeToExist")
+    public long getTimeToExist() {
+        return timeToExist;
+    }
+
+    public void setTimeToExist(long timeToExist) {
+        this.timeToExist = timeToExist;
+    }
+
+    public AuthenticationUserInfo withTimeToExist(long timeToExist) {
+        this.timeToExist = timeToExist;
+        return this;
+    }
+}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/AuthenticationUserInfo.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/AuthenticationUserInfo.java
@@ -1,6 +1,5 @@
 package uk.gov.di.authentication.oidc.entity;
 
-import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbAttribute;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
@@ -9,10 +8,8 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbParti
 public class AuthenticationUserInfo {
 
     private String subjectID;
-    private UserInfo userInfo;
+    private String userInfo;
     private long timeToExist;
-
-    public AuthenticationUserInfo() {}
 
     @DynamoDbPartitionKey
     @DynamoDbAttribute("SubjectID")
@@ -30,15 +27,15 @@ public class AuthenticationUserInfo {
     }
 
     @DynamoDbAttribute("UserInfo")
-    public UserInfo getUserInfo() {
+    public String getUserInfo() {
         return userInfo;
     }
 
-    public void setUserInfo(UserInfo userInfo) {
+    public void setUserInfo(String userInfo) {
         this.userInfo = userInfo;
     }
 
-    public AuthenticationUserInfo withUserInfo(UserInfo userInfo) {
+    public AuthenticationUserInfo withUserInfo(String userInfo) {
         this.userInfo = userInfo;
         return this;
     }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/exceptions/AuthenticationCallbackException.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/exceptions/AuthenticationCallbackException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.authentication.oidc.exceptions;
+
+public class AuthenticationCallbackException extends RuntimeException {
+    public AuthenticationCallbackException(String message) {
+        super(message);
+    }
+}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -199,7 +199,7 @@ public class AuthCodeHandler
                         requestedVectorOfTrust.getCredentialTrustLevel());
             }
             var authCode =
-                    authorisationCodeService.generateAuthorisationCode(
+                    authorisationCodeService.generateAndSaveAuthorisationCode(
                             clientSessionId, session.getEmailAddress(), clientSession);
 
             var authenticationResponse =

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -142,6 +142,9 @@ public class AuthenticationCallbackHandler
 
             attachSessionIdToLogs(userSession);
             var clientSessionId = sessionCookiesIds.getClientSessionId();
+            attachLogFieldToLogs(CLIENT_SESSION_ID, clientSessionId);
+            attachLogFieldToLogs(GOVUK_SIGNIN_JOURNEY_ID, clientSessionId);
+
             var clientSession =
                     clientSessionService
                             .getClientSession(clientSessionId)
@@ -149,9 +152,6 @@ public class AuthenticationCallbackHandler
                                     () ->
                                             new AuthenticationCallbackException(
                                                     "ClientSession not found"));
-
-            attachLogFieldToLogs(CLIENT_SESSION_ID, clientSessionId);
-            attachLogFieldToLogs(GOVUK_SIGNIN_JOURNEY_ID, clientSessionId);
 
             String persistentSessionId =
                     PersistentIdHelper.extractPersistentIdFromCookieHeader(input.getHeaders());
@@ -297,7 +297,7 @@ public class AuthenticationCallbackHandler
                 cloudwatchMetricsService.incrementCounter("AuthenticationCallback", dimensions);
 
                 var authCode =
-                        authorisationCodeService.generateAuthorisationCode(
+                        authorisationCodeService.generateAndSaveAuthorisationCode(
                                 clientSessionId, userSession.getEmailAddress(), clientSession);
 
                 var authenticationResponse =

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -27,7 +27,6 @@ import uk.gov.di.authentication.shared.exceptions.UnsuccessfulCredentialResponse
 import uk.gov.di.authentication.shared.helpers.ConstructUriHelper;
 import uk.gov.di.authentication.shared.helpers.CookieHelper;
 import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
-import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthorisationCodeService;
 import uk.gov.di.authentication.shared.services.ClientService;
@@ -37,7 +36,6 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoClientService;
 import uk.gov.di.authentication.shared.services.KmsConnectionService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
-import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.shared.services.SessionService;
 
 import java.net.URI;
@@ -73,7 +71,6 @@ public class AuthenticationCallbackHandler
     private final AuthorisationCodeService authorisationCodeService;
     private final ClientService clientService;
     private final CookieHelper cookieHelper;
-    protected final Json objectMapper = SerializationService.getInstance();
     private static final String ERROR_PAGE_REDIRECT_PATH = "error";
 
     public AuthenticationCallbackHandler() {
@@ -87,8 +84,7 @@ public class AuthenticationCallbackHandler
                 new AuthenticationAuthorizationService(
                         new RedisConnectionService(configurationService));
         this.tokenService =
-                new AuthenticationTokenService(
-                        configurationService, kmsConnectionService, objectMapper);
+                new AuthenticationTokenService(configurationService, kmsConnectionService);
         this.sessionService = new SessionService(configurationService);
         this.clientSessionService = new ClientSessionService(configurationService);
         this.auditService = new AuditService(configurationService);

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -1,0 +1,387 @@
+package uk.gov.di.authentication.oidc.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.oauth2.sdk.ResponseMode;
+import com.nimbusds.oauth2.sdk.http.HTTPRequest;
+import com.nimbusds.oauth2.sdk.id.State;
+import com.nimbusds.openid.connect.sdk.AuthenticationErrorResponse;
+import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+import com.nimbusds.openid.connect.sdk.AuthenticationSuccessResponse;
+import com.nimbusds.openid.connect.sdk.claims.UserInfo;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.oidc.domain.OrchestrationAuditableEvent;
+import uk.gov.di.authentication.oidc.exceptions.AuthenticationCallbackException;
+import uk.gov.di.authentication.oidc.services.AuthenticationAuthorizationService;
+import uk.gov.di.authentication.oidc.services.AuthenticationTokenService;
+import uk.gov.di.authentication.oidc.services.AuthenticationUserInfoStorageService;
+import uk.gov.di.authentication.shared.entity.ResponseHeaders;
+import uk.gov.di.authentication.shared.entity.Session;
+import uk.gov.di.authentication.shared.entity.VectorOfTrust;
+import uk.gov.di.authentication.shared.exceptions.UnsuccessfulCredentialResponseException;
+import uk.gov.di.authentication.shared.helpers.ConstructUriHelper;
+import uk.gov.di.authentication.shared.helpers.CookieHelper;
+import uk.gov.di.authentication.shared.helpers.PersistentIdHelper;
+import uk.gov.di.authentication.shared.serialization.Json;
+import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.shared.services.AuthorisationCodeService;
+import uk.gov.di.authentication.shared.services.ClientService;
+import uk.gov.di.authentication.shared.services.ClientSessionService;
+import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.DynamoClientService;
+import uk.gov.di.authentication.shared.services.KmsConnectionService;
+import uk.gov.di.authentication.shared.services.RedisConnectionService;
+import uk.gov.di.authentication.shared.services.SerializationService;
+import uk.gov.di.authentication.shared.services.SessionService;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.nimbusds.oauth2.sdk.http.HTTPRequest.Method.POST;
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
+import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
+import static uk.gov.di.authentication.shared.helpers.ConstructUriHelper.buildURI;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.CLIENT_ID;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.CLIENT_SESSION_ID;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.GOVUK_SIGNIN_JOURNEY_ID;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.LogFieldName.PERSISTENT_SESSION_ID;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachLogFieldToLogs;
+import static uk.gov.di.authentication.shared.helpers.LogLineHelper.attachSessionIdToLogs;
+
+public class AuthenticationCallbackHandler
+        implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+
+    private static final Logger LOG = LogManager.getLogger(AuthenticationCallbackHandler.class);
+    private final ConfigurationService configurationService;
+    private final AuthenticationAuthorizationService authorisationService;
+    private final AuthenticationTokenService tokenService;
+    private final SessionService sessionService;
+    private final ClientSessionService clientSessionService;
+    private final AuditService auditService;
+    private final AuthenticationUserInfoStorageService userInfoStorageService;
+    private final CloudwatchMetricsService cloudwatchMetricsService;
+    private final AuthorisationCodeService authorisationCodeService;
+    private final ClientService clientService;
+    private final CookieHelper cookieHelper;
+    protected final Json objectMapper = SerializationService.getInstance();
+    private static final String ERROR_PAGE_REDIRECT_PATH = "error";
+
+    public AuthenticationCallbackHandler() {
+        this(ConfigurationService.getInstance());
+    }
+
+    public AuthenticationCallbackHandler(ConfigurationService configurationService) {
+        var kmsConnectionService = new KmsConnectionService(configurationService);
+        this.configurationService = configurationService;
+        this.authorisationService =
+                new AuthenticationAuthorizationService(
+                        new RedisConnectionService(configurationService));
+        this.tokenService =
+                new AuthenticationTokenService(
+                        configurationService, kmsConnectionService, objectMapper);
+        this.sessionService = new SessionService(configurationService);
+        this.clientSessionService = new ClientSessionService(configurationService);
+        this.auditService = new AuditService(configurationService);
+        this.userInfoStorageService =
+                new AuthenticationUserInfoStorageService(configurationService);
+        this.cookieHelper = new CookieHelper();
+        this.cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);
+        this.authorisationCodeService = new AuthorisationCodeService(configurationService);
+        this.clientService = new DynamoClientService(configurationService);
+    }
+
+    public AuthenticationCallbackHandler(
+            ConfigurationService configurationService,
+            AuthenticationAuthorizationService responseService,
+            AuthenticationTokenService tokenService,
+            SessionService sessionService,
+            ClientSessionService clientSessionService,
+            AuditService auditService,
+            AuthenticationUserInfoStorageService dynamoAuthUserInfoService,
+            CookieHelper cookieHelper,
+            CloudwatchMetricsService cloudwatchMetricsService,
+            AuthorisationCodeService authorisationCodeService,
+            ClientService clientService) {
+        this.configurationService = configurationService;
+        this.authorisationService = responseService;
+        this.tokenService = tokenService;
+        this.sessionService = sessionService;
+        this.clientSessionService = clientSessionService;
+        this.auditService = auditService;
+        this.userInfoStorageService = dynamoAuthUserInfoService;
+        this.cookieHelper = cookieHelper;
+        this.cloudwatchMetricsService = cloudwatchMetricsService;
+        this.authorisationCodeService = authorisationCodeService;
+        this.clientService = clientService;
+    }
+
+    public APIGatewayProxyResponseEvent handleRequest(
+            APIGatewayProxyRequestEvent input, Context context) {
+        LOG.info("Request received to AuthenticationCallbackHandler");
+        try {
+            CookieHelper.SessionCookieIds sessionCookiesIds =
+                    cookieHelper.parseSessionCookie(input.getHeaders()).orElse(null);
+
+            if (sessionCookiesIds == null) {
+                throw new AuthenticationCallbackException("No session cookie found");
+            }
+
+            Session userSession =
+                    sessionService
+                            .readSessionFromRedis(sessionCookiesIds.getSessionId())
+                            .orElseThrow(
+                                    () ->
+                                            new AuthenticationCallbackException(
+                                                    "Orchestration user session not found"));
+
+            attachSessionIdToLogs(userSession);
+            var clientSessionId = sessionCookiesIds.getClientSessionId();
+            var clientSession =
+                    clientSessionService
+                            .getClientSession(clientSessionId)
+                            .orElseThrow(
+                                    () ->
+                                            new AuthenticationCallbackException(
+                                                    "ClientSession not found"));
+
+            attachLogFieldToLogs(CLIENT_SESSION_ID, clientSessionId);
+            attachLogFieldToLogs(GOVUK_SIGNIN_JOURNEY_ID, clientSessionId);
+
+            String persistentSessionId =
+                    PersistentIdHelper.extractPersistentIdFromCookieHeader(input.getHeaders());
+            attachLogFieldToLogs(PERSISTENT_SESSION_ID, persistentSessionId);
+
+            var authenticationRequest =
+                    AuthenticationRequest.parse(clientSession.getAuthRequestParams());
+
+            String clientId = authenticationRequest.getClientID().getValue();
+            attachLogFieldToLogs(CLIENT_ID, clientId);
+
+            Optional<ErrorObject> errorObject =
+                    authorisationService.validateRequest(
+                            input.getQueryStringParameters(), userSession.getSessionId());
+
+            if (errorObject.isPresent()) {
+                return generateAuthenticationErrorResponse(
+                        authenticationRequest,
+                        errorObject.get(),
+                        clientSessionId,
+                        userSession.getSessionId(),
+                        persistentSessionId);
+            }
+
+            auditService.submitAuditEvent(
+                    OrchestrationAuditableEvent.AUTH_CALLBACK_RESPONSE_RECEIVED,
+                    clientSessionId,
+                    userSession.getSessionId(),
+                    clientId,
+                    AuditService.UNKNOWN,
+                    AuditService.UNKNOWN,
+                    AuditService.UNKNOWN,
+                    AuditService.UNKNOWN,
+                    persistentSessionId);
+
+            var tokenRequest =
+                    tokenService.constructTokenRequest(
+                            input.getQueryStringParameters().get("code"));
+            var tokenResponse = tokenService.sendTokenRequest(tokenRequest);
+            if (tokenResponse.indicatesSuccess()) {
+                LOG.info("TokenResponse was successful");
+                auditService.submitAuditEvent(
+                        OrchestrationAuditableEvent.AUTH_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
+                        clientSessionId,
+                        userSession.getSessionId(),
+                        clientId,
+                        AuditService.UNKNOWN,
+                        AuditService.UNKNOWN,
+                        AuditService.UNKNOWN,
+                        AuditService.UNKNOWN,
+                        persistentSessionId);
+            } else {
+                LOG.error(
+                        "Authentication TokenResponse was not successful: {}",
+                        tokenResponse.toErrorResponse().toJSONObject());
+                auditService.submitAuditEvent(
+                        OrchestrationAuditableEvent.AUTH_UNSUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
+                        clientSessionId,
+                        userSession.getSessionId(),
+                        clientId,
+                        AuditService.UNKNOWN,
+                        AuditService.UNKNOWN,
+                        AuditService.UNKNOWN,
+                        AuditService.UNKNOWN,
+                        persistentSessionId);
+                return redirectToFrontendErrorPage();
+            }
+
+            try {
+                String userInfoPath = configurationService.getAuthenticationUserInfoEndpoint();
+                URI userInfoURI =
+                        buildURI(
+                                configurationService.getAuthenticationBackendURI().toString(),
+                                userInfoPath);
+
+                HTTPRequest authorizationRequest = new HTTPRequest(POST, userInfoURI);
+                authorizationRequest.setAuthorization(
+                        tokenResponse
+                                .toSuccessResponse()
+                                .getTokens()
+                                .getAccessToken()
+                                .toAuthorizationHeader());
+
+                UserInfo userInfo = tokenService.sendUserInfoDataRequest(authorizationRequest);
+
+                auditService.submitAuditEvent(
+                        OrchestrationAuditableEvent.AUTH_SUCCESSFUL_USERINFO_RESPONSE_RECEIVED,
+                        clientSessionId,
+                        userSession.getSessionId(),
+                        clientId,
+                        AuditService.UNKNOWN,
+                        AuditService.UNKNOWN,
+                        AuditService.UNKNOWN,
+                        AuditService.UNKNOWN,
+                        persistentSessionId);
+                LOG.info("Adding Authentication userinfo to dynamo");
+                userInfoStorageService.addAuthenticationUserInfoData(
+                        userInfo.getSubject().getValue(), userInfo);
+
+                URI clientRedirectURI = authenticationRequest.getRedirectionURI();
+                State state = authenticationRequest.getState();
+                ResponseMode responseMode = authenticationRequest.getResponseMode();
+
+                LOG.info("Redirecting to: {} with state: {}", clientRedirectURI, state);
+
+                VectorOfTrust requestedVectorOfTrust = clientSession.getEffectiveVectorOfTrust();
+                if (isNull(userSession.getCurrentCredentialStrength())
+                        || requestedVectorOfTrust
+                                        .getCredentialTrustLevel()
+                                        .compareTo(userSession.getCurrentCredentialStrength())
+                                > 0) {
+                    userSession.setCurrentCredentialStrength(
+                            requestedVectorOfTrust.getCredentialTrustLevel());
+                }
+
+                boolean isTestJourney = false;
+                if (nonNull(userInfo.getEmailAddress())) {
+                    isTestJourney =
+                            clientService.isTestJourney(clientId, userInfo.getEmailAddress());
+                }
+
+                Map<String, String> dimensions =
+                        new HashMap<>(
+                                Map.of(
+                                        "IsNewAccount",
+                                        (String) userInfo.getClaim("new_account"),
+                                        "Environment",
+                                        configurationService.getEnvironment(),
+                                        "Client",
+                                        clientId,
+                                        "IsTest",
+                                        Boolean.toString(isTestJourney),
+                                        "ClientName",
+                                        clientSession.getClientName()));
+
+                if (Objects.nonNull(userSession.getVerifiedMfaMethodType())) {
+                    dimensions.put("MfaMethod", userSession.getVerifiedMfaMethodType().getValue());
+                } else {
+                    LOG.info(
+                            "No mfa method to set. User is either authenticated or signing in from a low level service");
+                }
+
+                cloudwatchMetricsService.incrementCounter("AuthenticationCallback", dimensions);
+
+                var authCode =
+                        authorisationCodeService.generateAuthorisationCode(
+                                clientSessionId, userSession.getEmailAddress(), clientSession);
+
+                var authenticationResponse =
+                        new AuthenticationSuccessResponse(
+                                clientRedirectURI, authCode, null, null, state, null, responseMode);
+
+                LOG.info("Successfully processed request");
+
+                return generateApiGatewayProxyResponse(
+                        302,
+                        "",
+                        Map.of(ResponseHeaders.LOCATION, authenticationResponse.toURI().toString()),
+                        null);
+
+            } catch (UnsuccessfulCredentialResponseException e) {
+                auditService.submitAuditEvent(
+                        OrchestrationAuditableEvent.AUTH_UNSUCCESSFUL_USERINFO_RESPONSE_RECEIVED,
+                        clientSessionId,
+                        userSession.getSessionId(),
+                        clientId,
+                        AuditService.UNKNOWN,
+                        AuditService.UNKNOWN,
+                        AuditService.UNKNOWN,
+                        AuditService.UNKNOWN,
+                        persistentSessionId);
+                LOG.error(
+                        "Orchestration to Authentication userinfo request was not successful: {}",
+                        e.getMessage());
+                return redirectToFrontendErrorPage();
+            }
+        } catch (AuthenticationCallbackException e) {
+            LOG.warn(e.getMessage());
+            return redirectToFrontendErrorPage();
+        } catch (ParseException e) {
+            LOG.info("Cannot retrieve auth request params from client session id");
+            return redirectToFrontendErrorPage();
+        }
+    }
+
+    private APIGatewayProxyResponseEvent generateAuthenticationErrorResponse(
+            AuthenticationRequest authenticationRequest,
+            ErrorObject errorObject,
+            String clientSessionId,
+            String sessionId,
+            String persistentSessionId) {
+        LOG.warn(
+                "Error in Authentication Authorisation Response. ErrorCode: {}. ErrorDescription: {}",
+                errorObject.getCode(),
+                errorObject.getDescription());
+        auditService.submitAuditEvent(
+                OrchestrationAuditableEvent.AUTH_UNSUCCESSFUL_CALLBACK_RESPONSE_RECEIVED,
+                clientSessionId,
+                sessionId,
+                authenticationRequest.getClientID().getValue(),
+                AuditService.UNKNOWN,
+                AuditService.UNKNOWN,
+                AuditService.UNKNOWN,
+                AuditService.UNKNOWN,
+                persistentSessionId);
+        var errorResponse =
+                new AuthenticationErrorResponse(
+                        authenticationRequest.getRedirectionURI(),
+                        errorObject,
+                        authenticationRequest.getState(),
+                        authenticationRequest.getResponseMode());
+        return generateApiGatewayProxyResponse(
+                302, "", Map.of(ResponseHeaders.LOCATION, errorResponse.toURI().toString()), null);
+    }
+
+    private APIGatewayProxyResponseEvent redirectToFrontendErrorPage() {
+        LOG.info("Redirecting to frontend error page");
+        return generateApiGatewayProxyResponse(
+                302,
+                "",
+                Map.of(
+                        ResponseHeaders.LOCATION,
+                        ConstructUriHelper.buildURI(
+                                        configurationService.getLoginURI().toString(),
+                                        ERROR_PAGE_REDIRECT_PATH)
+                                .toString()),
+                null);
+    }
+}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -5,6 +5,7 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.ResponseMode;
 import com.nimbusds.oauth2.sdk.http.HTTPRequest;
@@ -42,7 +43,6 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 
 import static com.nimbusds.oauth2.sdk.http.HTTPRequest.Method.POST;
 import static java.util.Objects.isNull;
@@ -163,14 +163,14 @@ public class AuthenticationCallbackHandler
             String clientId = authenticationRequest.getClientID().getValue();
             attachLogFieldToLogs(CLIENT_ID, clientId);
 
-            Optional<ErrorObject> errorObject =
+            boolean requestValid =
                     authorisationService.validateRequest(
                             input.getQueryStringParameters(), userSession.getSessionId());
 
-            if (errorObject.isPresent()) {
+            if (!requestValid) {
                 return generateAuthenticationErrorResponse(
                         authenticationRequest,
-                        errorObject.get(),
+                        OAuth2Error.SERVER_ERROR,
                         clientSessionId,
                         userSession.getSessionId(),
                         persistentSessionId);

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthenticationAuthorizationService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthenticationAuthorizationService.java
@@ -1,0 +1,87 @@
+package uk.gov.di.authentication.oidc.services;
+
+import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.OAuth2Error;
+import com.nimbusds.oauth2.sdk.id.State;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.shared.serialization.Json;
+import uk.gov.di.authentication.shared.serialization.Json.JsonException;
+import uk.gov.di.authentication.shared.services.RedisConnectionService;
+import uk.gov.di.authentication.shared.services.SerializationService;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class AuthenticationAuthorizationService {
+    private static final Logger LOG =
+            LogManager.getLogger(AuthenticationAuthorizationService.class);
+    private final RedisConnectionService redisConnectionService;
+    public static final String AUTHENTICATION_STATE_STORAGE_PREFIX = "auth-state:";
+    private final Json objectMapper = SerializationService.getInstance();
+
+    public AuthenticationAuthorizationService(RedisConnectionService redisConnectionService) {
+        this.redisConnectionService = redisConnectionService;
+    }
+
+    public Optional<ErrorObject> validateRequest(
+            Map<String, String> queryParams, String sessionId) {
+        LOG.info("Validating authentication callback request");
+        if (queryParams == null || queryParams.isEmpty()) {
+            LOG.warn("No Query parameters in authentication callback request");
+            return Optional.of(
+                    new ErrorObject(
+                            OAuth2Error.INVALID_REQUEST_CODE, "No query parameters present"));
+        }
+        if (queryParams.containsKey("error")) {
+            LOG.warn("Error response found in authentication callback request");
+            return Optional.of(new ErrorObject(queryParams.get("error")));
+        }
+        if (!queryParams.containsKey("state") || queryParams.get("state").isEmpty()) {
+            LOG.warn("No state param in authentication callback request");
+            return Optional.of(
+                    new ErrorObject(
+                            OAuth2Error.INVALID_REQUEST_CODE,
+                            "No state param present in authentication callback request"));
+        }
+        if (!isStateValid(sessionId, queryParams.get("state"))) {
+            return Optional.of(
+                    new ErrorObject(
+                            OAuth2Error.INVALID_REQUEST_CODE,
+                            "Invalid state param present in authentication callback request"));
+        }
+        if (!queryParams.containsKey("code") || queryParams.get("code").isEmpty()) {
+            LOG.warn("No code param in authentication callback request");
+            return Optional.of(
+                    new ErrorObject(
+                            OAuth2Error.INVALID_REQUEST_CODE,
+                            "No code param present in authentication callback request"));
+        }
+        LOG.info("Authentication callback request passed validation");
+        return Optional.empty();
+    }
+
+    private boolean isStateValid(String sessionId, String responseState) {
+        var value =
+                Optional.ofNullable(
+                        redisConnectionService.getValue(
+                                AUTHENTICATION_STATE_STORAGE_PREFIX + sessionId));
+        if (value.isEmpty()) {
+            LOG.info("No Authentication state found in Redis");
+            return false;
+        }
+        State storedState;
+        try {
+            storedState = objectMapper.readValue(value.get(), State.class);
+        } catch (JsonException e) {
+            LOG.info("Error when deserializing state from redis");
+            return false;
+        }
+        LOG.info(
+                "Response state: {} and Stored state: {}. Are equal: {}",
+                responseState,
+                storedState.getValue(),
+                responseState.equals(storedState.getValue()));
+        return responseState.equals(storedState.getValue());
+    }
+}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthenticationTokenService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthenticationTokenService.java
@@ -25,6 +25,9 @@ import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.kms.model.GetPublicKeyRequest;
 import software.amazon.awssdk.services.kms.model.SignRequest;
 import software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec;
+import uk.gov.di.authentication.shared.exceptions.JwtParseException;
+import uk.gov.di.authentication.shared.exceptions.TokenRequestException;
+import uk.gov.di.authentication.shared.exceptions.TokenResponseException;
 import uk.gov.di.authentication.shared.exceptions.UnsuccessfulCredentialResponseException;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -94,10 +97,10 @@ public class AuthenticationTokenService {
             return tokenResponse;
         } catch (IOException e) {
             LOG.error("Error whilst sending TokenRequest", e);
-            throw new RuntimeException(e);
+            throw new TokenRequestException("Error whilst sending TokenRequest", e);
         } catch (ParseException e) {
             LOG.error("Error whilst parsing TokenResponse", e);
-            throw new RuntimeException(e);
+            throw new TokenResponseException("Error whilst parsing TokenResponse", e);
         }
     }
 
@@ -180,7 +183,8 @@ public class AuthenticationTokenService {
             return new PrivateKeyJWT(SignedJWT.parse(message + "." + signature));
         } catch (JOSEException | java.text.ParseException e) {
             LOG.error("Exception thrown when trying to parse SignedJWT or JWTClaimSet", e);
-            throw new RuntimeException(e);
+            throw new JwtParseException(
+                    "Exception thrown when trying to parse SignedJWT or JWTClaimSet", e);
         }
     }
 }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthenticationTokenService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthenticationTokenService.java
@@ -42,8 +42,6 @@ import static uk.gov.di.authentication.shared.helpers.ConstructUriHelper.buildUR
 import static uk.gov.di.authentication.shared.helpers.HashHelper.hashSha256String;
 
 public class AuthenticationTokenService {
-
-    public static final String CREDENTIAL_SUBJECT_KEY = "credential_subject";
     private final ConfigurationService configurationService;
     private final KmsConnectionService kmsService;
     private static final JWSAlgorithm TOKEN_ALGORITHM = JWSAlgorithm.ES256;
@@ -131,11 +129,11 @@ public class AuthenticationTokenService {
             return parseUserInfoFromResponse(response);
         } catch (IOException e) {
             throw new UnsuccessfulCredentialResponseException(
-                    "Error when attempting to call CRI data endpoint", e);
+                    "Error when attempting to call Authentication userinfo endpoint", e);
         }
     }
 
-    private UserInfo parseUserInfoFromResponse(HTTPResponse response)
+    UserInfo parseUserInfoFromResponse(HTTPResponse response)
             throws UnsuccessfulCredentialResponseException {
         try {
             String content = response.getContent();
@@ -146,7 +144,7 @@ public class AuthenticationTokenService {
         } catch (Json.JsonException e) {
             LOG.warn("Unable to parse userinfo response as UserInfo object");
             throw new UnsuccessfulCredentialResponseException(
-                    "Error Authentication userinfo response", e);
+                    "Error parsing authentication userinfo response as JSON", e);
         }
     }
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthenticationTokenService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthenticationTokenService.java
@@ -1,0 +1,193 @@
+package uk.gov.di.authentication.oidc.services;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.impl.ECDSA;
+import com.nimbusds.jose.util.Base64URL;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import com.nimbusds.oauth2.sdk.AuthorizationCodeGrant;
+import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.oauth2.sdk.TokenRequest;
+import com.nimbusds.oauth2.sdk.TokenResponse;
+import com.nimbusds.oauth2.sdk.auth.JWTAuthenticationClaimsSet;
+import com.nimbusds.oauth2.sdk.auth.PrivateKeyJWT;
+import com.nimbusds.oauth2.sdk.http.HTTPRequest;
+import com.nimbusds.oauth2.sdk.http.HTTPResponse;
+import com.nimbusds.oauth2.sdk.id.Audience;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.id.JWTID;
+import com.nimbusds.openid.connect.sdk.claims.UserInfo;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.kms.model.GetPublicKeyRequest;
+import software.amazon.awssdk.services.kms.model.SignRequest;
+import software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec;
+import uk.gov.di.authentication.shared.exceptions.UnsuccessfulCredentialResponseException;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
+import uk.gov.di.authentication.shared.serialization.Json;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.KmsConnectionService;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.time.temporal.ChronoUnit;
+import java.util.Map;
+
+import static java.lang.String.format;
+import static java.util.Collections.singletonList;
+import static uk.gov.di.authentication.shared.helpers.ConstructUriHelper.buildURI;
+import static uk.gov.di.authentication.shared.helpers.HashHelper.hashSha256String;
+
+public class AuthenticationTokenService {
+
+    public static final String CREDENTIAL_SUBJECT_KEY = "credential_subject";
+    private final ConfigurationService configurationService;
+    private final KmsConnectionService kmsService;
+    private static final JWSAlgorithm TOKEN_ALGORITHM = JWSAlgorithm.ES256;
+    private static final Long PRIVATE_KEY_JWT_EXPIRY = 5L;
+    private static final Logger LOG = LogManager.getLogger(AuthenticationTokenService.class);
+    private final Json objectMapper;
+
+    public AuthenticationTokenService(
+            ConfigurationService configurationService,
+            KmsConnectionService kmsService,
+            Json objectMapper) {
+        this.configurationService = configurationService;
+        this.kmsService = kmsService;
+        this.objectMapper = objectMapper;
+    }
+
+    public TokenRequest constructTokenRequest(String authCode) {
+        LOG.info("Constructing token request");
+        var codeGrant =
+                new AuthorizationCodeGrant(
+                        new AuthorizationCode(authCode),
+                        configurationService.getAuthenticationAuthCallbackURI());
+        var authenticationBackendURI = configurationService.getAuthenticationBackendURI();
+        var tokenURI = buildURI(authenticationBackendURI.toString(), "token");
+        var claimsSet =
+                new JWTAuthenticationClaimsSet(
+                        new ClientID(configurationService.getOrchestrationClientId()),
+                        singletonList(new Audience(tokenURI)),
+                        NowHelper.nowPlus(PRIVATE_KEY_JWT_EXPIRY, ChronoUnit.MINUTES),
+                        NowHelper.now(),
+                        NowHelper.now(),
+                        new JWTID());
+        return new TokenRequest(
+                tokenURI,
+                generatePrivateKeyJwt(claimsSet),
+                codeGrant,
+                null,
+                singletonList(tokenURI),
+                Map.of(
+                        "client_id",
+                        singletonList(configurationService.getOrchestrationClientId())));
+    }
+
+    public TokenResponse sendTokenRequest(TokenRequest tokenRequest) {
+        try {
+            LOG.info("Sending TokenRequest");
+            int count = 0;
+            int maxTries = 2;
+            TokenResponse tokenResponse;
+            do {
+                if (count > 0) LOG.warn("Retrying Authentication token request");
+                count++;
+                tokenResponse = TokenResponse.parse(tokenRequest.toHTTPRequest().send());
+            } while (!tokenResponse.indicatesSuccess() && count < maxTries);
+            return tokenResponse;
+        } catch (IOException e) {
+            LOG.error("Error whilst sending TokenRequest", e);
+            throw new RuntimeException(e);
+        } catch (ParseException e) {
+            LOG.error("Error whilst parsing TokenResponse", e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    public UserInfo sendUserInfoDataRequest(HTTPRequest request)
+            throws UnsuccessfulCredentialResponseException {
+        try {
+            LOG.info("Sending userinfo request");
+            int count = 0;
+            int maxTries = 2;
+            HTTPResponse response;
+            do {
+                if (count > 0) LOG.warn("Retrying Authentication userinfo request");
+                count++;
+                response = request.send();
+            } while (!response.indicatesSuccess() && count < maxTries);
+            if (!response.indicatesSuccess()) {
+                throw new UnsuccessfulCredentialResponseException(
+                        format(
+                                "Error %s when attempting to call Authentication userinfo endpoint: %s",
+                                response.getStatusCode(), response.getContent()));
+            }
+
+            LOG.info("Received successful userinfo response");
+            return parseUserInfoFromResponse(response);
+        } catch (IOException e) {
+            throw new UnsuccessfulCredentialResponseException(
+                    "Error when attempting to call CRI data endpoint", e);
+        }
+    }
+
+    private UserInfo parseUserInfoFromResponse(HTTPResponse response)
+            throws UnsuccessfulCredentialResponseException {
+        try {
+            String content = response.getContent();
+            if (content == null) {
+                throw new UnsuccessfulCredentialResponseException("No content in HTTP response");
+            }
+            return objectMapper.readValue(content, UserInfo.class);
+        } catch (Json.JsonException e) {
+            LOG.warn("Unable to parse userinfo response as UserInfo object");
+            throw new UnsuccessfulCredentialResponseException(
+                    "Error Authentication userinfo response", e);
+        }
+    }
+
+    private PrivateKeyJWT generatePrivateKeyJwt(JWTAuthenticationClaimsSet claimsSet) {
+        try {
+            LOG.info("Generating PrivateKeyJWT");
+            var tokenSigningKeyAlias =
+                    configurationService.getOrchestrationToAuthenticationTokenSigningKeyAlias();
+            var signingKeyId =
+                    kmsService
+                            .getPublicKey(
+                                    GetPublicKeyRequest.builder()
+                                            .keyId(tokenSigningKeyAlias)
+                                            .build())
+                            .keyId();
+            var jwsHeader =
+                    new JWSHeader.Builder(TOKEN_ALGORITHM)
+                            .keyID(hashSha256String(signingKeyId))
+                            .build();
+            var encodedHeader = jwsHeader.toBase64URL();
+            var encodedClaims = Base64URL.encode(claimsSet.toJWTClaimsSet().toString());
+            var message = encodedHeader + "." + encodedClaims;
+            var messageToSign = ByteBuffer.wrap(message.getBytes());
+            var signRequest =
+                    SignRequest.builder()
+                            .message(SdkBytes.fromByteBuffer(messageToSign))
+                            .keyId(tokenSigningKeyAlias)
+                            .signingAlgorithm(SigningAlgorithmSpec.ECDSA_SHA_256)
+                            .build();
+            var signResponse = kmsService.sign(signRequest);
+            LOG.info("PrivateKeyJWT has been signed successfully");
+            var signature =
+                    Base64URL.encode(
+                                    ECDSA.transcodeSignatureToConcat(
+                                            signResponse.signature().asByteArray(),
+                                            ECDSA.getSignatureByteArrayLength(TOKEN_ALGORITHM)))
+                            .toString();
+            return new PrivateKeyJWT(SignedJWT.parse(message + "." + signature));
+        } catch (JOSEException | java.text.ParseException e) {
+            LOG.error("Exception thrown when trying to parse SignedJWT or JWTClaimSet", e);
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthenticationTokenService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthenticationTokenService.java
@@ -47,7 +47,6 @@ public class AuthenticationTokenService {
     private static final JWSAlgorithm TOKEN_ALGORITHM = JWSAlgorithm.ES256;
     private static final Long PRIVATE_KEY_JWT_EXPIRY = 5L;
     private static final Logger LOG = LogManager.getLogger(AuthenticationTokenService.class);
-    private final Json objectMapper;
 
     public AuthenticationTokenService(
             ConfigurationService configurationService,
@@ -140,8 +139,8 @@ public class AuthenticationTokenService {
             if (content == null) {
                 throw new UnsuccessfulCredentialResponseException("No content in HTTP response");
             }
-            return objectMapper.readValue(content, UserInfo.class);
-        } catch (Json.JsonException e) {
+            return UserInfo.parse(content);
+        } catch (ParseException e) {
             LOG.warn("Unable to parse userinfo response as UserInfo object");
             throw new UnsuccessfulCredentialResponseException(
                     "Error parsing authentication userinfo response as JSON", e);

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthenticationTokenService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthenticationTokenService.java
@@ -27,7 +27,6 @@ import software.amazon.awssdk.services.kms.model.SignRequest;
 import software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec;
 import uk.gov.di.authentication.shared.exceptions.UnsuccessfulCredentialResponseException;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
-import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.KmsConnectionService;
 
@@ -49,12 +48,9 @@ public class AuthenticationTokenService {
     private static final Logger LOG = LogManager.getLogger(AuthenticationTokenService.class);
 
     public AuthenticationTokenService(
-            ConfigurationService configurationService,
-            KmsConnectionService kmsService,
-            Json objectMapper) {
+            ConfigurationService configurationService, KmsConnectionService kmsService) {
         this.configurationService = configurationService;
         this.kmsService = kmsService;
-        this.objectMapper = objectMapper;
     }
 
     public TokenRequest constructTokenRequest(String authCode) {

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthenticationUserInfoStorageService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthenticationUserInfoStorageService.java
@@ -7,6 +7,7 @@ import uk.gov.di.authentication.shared.services.BaseDynamoService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.time.temporal.ChronoUnit;
+import java.util.Optional;
 
 public class AuthenticationUserInfoStorageService
         extends BaseDynamoService<AuthenticationUserInfo> {
@@ -22,15 +23,21 @@ public class AuthenticationUserInfoStorageService
     }
 
     public void addAuthenticationUserInfoData(String subjectID, UserInfo userInfo) {
+        String userInfoJson = userInfo.toJSONString();
         var userInfoDbObject =
                 new AuthenticationUserInfo()
                         .withSubjectID(subjectID)
-                        .withUserInfo(userInfo)
+                        .withUserInfo(userInfoJson)
                         .withTimeToExist(
                                 NowHelper.nowPlus(timeToExist, ChronoUnit.SECONDS)
                                         .toInstant()
                                         .getEpochSecond());
 
         put(userInfoDbObject);
+    }
+
+    public Optional<AuthenticationUserInfo> getAuthenticationUserInfoData(String subjectID) {
+        return get(subjectID)
+                .filter(t -> t.getTimeToExist() > NowHelper.now().toInstant().getEpochSecond());
     }
 }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthenticationUserInfoStorageService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthenticationUserInfoStorageService.java
@@ -1,0 +1,36 @@
+package uk.gov.di.authentication.oidc.services;
+
+import com.nimbusds.openid.connect.sdk.claims.UserInfo;
+import uk.gov.di.authentication.oidc.entity.AuthenticationUserInfo;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
+import uk.gov.di.authentication.shared.services.BaseDynamoService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+import java.time.temporal.ChronoUnit;
+
+public class AuthenticationUserInfoStorageService
+        extends BaseDynamoService<AuthenticationUserInfo> {
+
+    private final long timeToExist;
+
+    public AuthenticationUserInfoStorageService(ConfigurationService configurationService) {
+        super(
+                AuthenticationUserInfo.class,
+                "authentication-callback-userinfo",
+                configurationService);
+        this.timeToExist = configurationService.getSessionExpiry();
+    }
+
+    public void addAuthenticationUserInfoData(String subjectID, UserInfo userInfo) {
+        var userInfoDbObject =
+                new AuthenticationUserInfo()
+                        .withSubjectID(subjectID)
+                        .withUserInfo(userInfo)
+                        .withTimeToExist(
+                                NowHelper.nowPlus(timeToExist, ChronoUnit.SECONDS)
+                                        .toInstant()
+                                        .getEpochSecond());
+
+        put(userInfoDbObject);
+    }
+}

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.di.authentication.oidc.domain.OidcAuditableEvent;
 import uk.gov.di.authentication.oidc.entity.AuthCodeResponse;
-import uk.gov.di.authentication.oidc.services.AuthorizationService;
+import uk.gov.di.authentication.oidc.services.OrchestrationAuthorizationService;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
@@ -107,7 +107,8 @@ class AuthCodeHandlerTest {
     private static final byte[] SALT = SaltHelper.generateNewSalt();
     private static final Json objectMapper = SerializationService.getInstance();
 
-    private final AuthorizationService authorizationService = mock(AuthorizationService.class);
+    private final OrchestrationAuthorizationService orchestrationAuthorizationService =
+            mock(OrchestrationAuthorizationService.class);
     private final AuthorisationCodeService authorisationCodeService =
             mock(AuthorisationCodeService.class);
     private final SessionService sessionService = mock(SessionService.class);
@@ -149,7 +150,7 @@ class AuthCodeHandlerTest {
                 new AuthCodeHandler(
                         sessionService,
                         authorisationCodeService,
-                        authorizationService,
+                        orchestrationAuthorizationService,
                         clientSessionService,
                         auditService,
                         cloudwatchMetricsService,
@@ -202,12 +203,12 @@ class AuthCodeHandlerTest {
                         null,
                         authRequest.getResponseMode());
         when(dynamoService.getUserProfileByEmailMaybe(EMAIL)).thenReturn(Optional.of(userProfile));
-        when(authorizationService.isClientRedirectUriValid(CLIENT_ID, REDIRECT_URI))
+        when(orchestrationAuthorizationService.isClientRedirectUriValid(CLIENT_ID, REDIRECT_URI))
                 .thenReturn(true);
         when(authorisationCodeService.generateAuthorisationCode(
                         CLIENT_SESSION_ID, EMAIL, clientSession))
                 .thenReturn(authorizationCode);
-        when(authorizationService.generateSuccessfulAuthResponse(
+        when(orchestrationAuthorizationService.generateSuccessfulAuthResponse(
                         any(AuthenticationRequest.class),
                         any(AuthorizationCode.class),
                         any(URI.class),
@@ -288,12 +289,12 @@ class AuthCodeHandlerTest {
                         authRequest.getResponseMode());
 
         when(clientSession.getDocAppSubjectId()).thenReturn(new Subject(DOC_APP_SUBJECT_ID));
-        when(authorizationService.isClientRedirectUriValid(CLIENT_ID, REDIRECT_URI))
+        when(orchestrationAuthorizationService.isClientRedirectUriValid(CLIENT_ID, REDIRECT_URI))
                 .thenReturn(true);
         when(authorisationCodeService.generateAuthorisationCode(
                         CLIENT_SESSION_ID, null, clientSession))
                 .thenReturn(authorizationCode);
-        when(authorizationService.generateSuccessfulAuthResponse(
+        when(orchestrationAuthorizationService.generateSuccessfulAuthResponse(
                         any(AuthenticationRequest.class),
                         any(AuthorizationCode.class),
                         any(URI.class),
@@ -356,7 +357,8 @@ class AuthCodeHandlerTest {
             throws ClientNotFoundException, JOSEException {
         session.setEmailAddress(EMAIL);
         generateValidSessionAndAuthRequest(MEDIUM_LEVEL, false);
-        when(authorizationService.isClientRedirectUriValid(eq(CLIENT_ID), eq(REDIRECT_URI)))
+        when(orchestrationAuthorizationService.isClientRedirectUriValid(
+                        eq(CLIENT_ID), eq(REDIRECT_URI)))
                 .thenReturn(false);
         APIGatewayProxyResponseEvent response = generateApiRequest();
 
@@ -373,7 +375,7 @@ class AuthCodeHandlerTest {
         AuthenticationErrorResponse authenticationErrorResponse =
                 new AuthenticationErrorResponse(
                         REDIRECT_URI, OAuth2Error.INVALID_CLIENT, null, null);
-        when(authorizationService.generateAuthenticationErrorResponse(
+        when(orchestrationAuthorizationService.generateAuthenticationErrorResponse(
                         any(AuthenticationRequest.class),
                         eq(OAuth2Error.INVALID_CLIENT),
                         any(URI.class),
@@ -381,7 +383,7 @@ class AuthCodeHandlerTest {
                 .thenReturn(authenticationErrorResponse);
         generateValidSessionAndAuthRequest(MEDIUM_LEVEL, false);
         doThrow(ClientNotFoundException.class)
-                .when(authorizationService)
+                .when(orchestrationAuthorizationService)
                 .isClientRedirectUriValid(eq(CLIENT_ID), eq(REDIRECT_URI));
 
         APIGatewayProxyResponseEvent response = generateApiRequest();
@@ -403,7 +405,7 @@ class AuthCodeHandlerTest {
         AuthenticationErrorResponse authenticationErrorResponse =
                 new AuthenticationErrorResponse(
                         REDIRECT_URI, OAuth2Error.INVALID_REQUEST, null, null);
-        when(authorizationService.generateAuthenticationErrorResponse(
+        when(orchestrationAuthorizationService.generateAuthenticationErrorResponse(
                         eq(REDIRECT_URI),
                         isNull(),
                         any(ResponseMode.class),

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -205,7 +205,7 @@ class AuthCodeHandlerTest {
         when(dynamoService.getUserProfileByEmailMaybe(EMAIL)).thenReturn(Optional.of(userProfile));
         when(orchestrationAuthorizationService.isClientRedirectUriValid(CLIENT_ID, REDIRECT_URI))
                 .thenReturn(true);
-        when(authorisationCodeService.generateAuthorisationCode(
+        when(authorisationCodeService.generateAndSaveAuthorisationCode(
                         CLIENT_SESSION_ID, EMAIL, clientSession))
                 .thenReturn(authorizationCode);
         when(orchestrationAuthorizationService.generateSuccessfulAuthResponse(
@@ -291,7 +291,7 @@ class AuthCodeHandlerTest {
         when(clientSession.getDocAppSubjectId()).thenReturn(new Subject(DOC_APP_SUBJECT_ID));
         when(orchestrationAuthorizationService.isClientRedirectUriValid(CLIENT_ID, REDIRECT_URI))
                 .thenReturn(true);
-        when(authorisationCodeService.generateAuthorisationCode(
+        when(authorisationCodeService.generateAndSaveAuthorisationCode(
                         CLIENT_SESSION_ID, null, clientSession))
                 .thenReturn(authorizationCode);
         when(orchestrationAuthorizationService.generateSuccessfulAuthResponse(
@@ -357,8 +357,7 @@ class AuthCodeHandlerTest {
             throws ClientNotFoundException, JOSEException {
         session.setEmailAddress(EMAIL);
         generateValidSessionAndAuthRequest(MEDIUM_LEVEL, false);
-        when(orchestrationAuthorizationService.isClientRedirectUriValid(
-                        eq(CLIENT_ID), eq(REDIRECT_URI)))
+        when(orchestrationAuthorizationService.isClientRedirectUriValid(CLIENT_ID, REDIRECT_URI))
                 .thenReturn(false);
         APIGatewayProxyResponseEvent response = generateApiRequest();
 

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -115,7 +115,7 @@ class AuthenticationCallbackHandlerTest {
                 .thenReturn(URI.create(TEST_AUTH_BACKEND_BASE_URL));
         when(configurationService.getAuthenticationUserInfoEndpoint())
                 .thenReturn(TEST_AUTH_USERINFO_PATH);
-        when(authorisationCodeService.generateAuthorisationCode(
+        when(authorisationCodeService.generateAndSaveAuthorisationCode(
                         CLIENT_SESSION_ID, TEST_EMAIL_ADDRESS, clientSession))
                 .thenReturn(AUTH_CODE_RP_TO_ORCH);
         when(cookieHelper.parseSessionCookie(anyMap())).thenCallRealMethod();

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -1,0 +1,5 @@
+package uk.gov.di.authentication.oidc.lambda;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AuthenticationCallbackHandlerTest {}

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -1,5 +1,327 @@
 package uk.gov.di.authentication.oidc.lambda;
 
-import static org.junit.jupiter.api.Assertions.*;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.nimbusds.oauth2.sdk.AccessTokenResponse;
+import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.OAuth2Error;
+import com.nimbusds.oauth2.sdk.ResponseType;
+import com.nimbusds.oauth2.sdk.Scope;
+import com.nimbusds.oauth2.sdk.TokenErrorResponse;
+import com.nimbusds.oauth2.sdk.TokenResponse;
+import com.nimbusds.oauth2.sdk.http.HTTPRequest;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.id.State;
+import com.nimbusds.oauth2.sdk.id.Subject;
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
+import com.nimbusds.oauth2.sdk.token.Tokens;
+import com.nimbusds.openid.connect.sdk.AuthenticationRequest;
+import com.nimbusds.openid.connect.sdk.Nonce;
+import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
+import com.nimbusds.openid.connect.sdk.claims.UserInfo;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.oidc.domain.OrchestrationAuditableEvent;
+import uk.gov.di.authentication.oidc.services.AuthenticationAuthorizationService;
+import uk.gov.di.authentication.oidc.services.AuthenticationTokenService;
+import uk.gov.di.authentication.oidc.services.AuthenticationUserInfoStorageService;
+import uk.gov.di.authentication.shared.entity.ClientSession;
+import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
+import uk.gov.di.authentication.shared.entity.Session;
+import uk.gov.di.authentication.shared.entity.VectorOfTrust;
+import uk.gov.di.authentication.shared.exceptions.UnsuccessfulCredentialResponseException;
+import uk.gov.di.authentication.shared.helpers.CookieHelper;
+import uk.gov.di.authentication.shared.services.AuditService;
+import uk.gov.di.authentication.shared.services.AuthorisationCodeService;
+import uk.gov.di.authentication.shared.services.ClientService;
+import uk.gov.di.authentication.shared.services.ClientSessionService;
+import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.SessionService;
 
-class AuthenticationCallbackHandlerTest {}
+import java.net.URI;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.lang.String.format;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
+
+class AuthenticationCallbackHandlerTest {
+    private static final ConfigurationService configurationService =
+            mock(ConfigurationService.class);
+    private final AuthenticationAuthorizationService authorizationService =
+            mock(AuthenticationAuthorizationService.class);
+    private final AuthenticationTokenService tokenService = mock(AuthenticationTokenService.class);
+    private final SessionService sessionService = mock(SessionService.class);
+    private final ClientSessionService clientSessionService = mock(ClientSessionService.class);
+    private final AuditService auditService = mock(AuditService.class);
+    private final AuthenticationUserInfoStorageService userInfoStorageService =
+            mock(AuthenticationUserInfoStorageService.class);
+    private final CloudwatchMetricsService cloudwatchMetricsService =
+            mock(CloudwatchMetricsService.class);
+    private static final AuthorisationCodeService authorisationCodeService =
+            mock(AuthorisationCodeService.class);
+    private static final CookieHelper cookieHelper = mock(CookieHelper.class);
+    private final ClientService clientService = mock(ClientService.class);
+    private static final String TEST_FRONTEND_BASE_URL = "test.orchestration.frontend.url";
+    private static final String TEST_AUTH_BACKEND_BASE_URL = "https://test.auth.backend.url";
+    private static final String TEST_AUTH_USERINFO_PATH = "/test-userinfo";
+    private static final String TEST_EMAIL_ADDRESS = "test@test.com";
+    private static final String PERSISTENT_SESSION_ID = "a-persistent-session-id";
+    private static final String SESSION_ID = "a-session-id";
+    private static final Session session =
+            new Session(SESSION_ID).setEmailAddress(TEST_EMAIL_ADDRESS);
+    private static final String CLIENT_SESSION_ID = "a-client-session-id";
+    private static final ClientID CLIENT_ID = new ClientID();
+    private static final Subject PAIRWISE_SUBJECT_ID = new Subject();
+    private static final URI REDIRECT_URI = URI.create("https://test.rp.redirect.uri");
+    private static final State RP_STATE = new State();
+    private static final ClientSession clientSession =
+            new ClientSession(
+                    generateRPAuthRequestForClientSession().toParameters(),
+                    null,
+                    new VectorOfTrust(CredentialTrustLevel.LOW_LEVEL),
+                    "test-name");
+    private static final String COOKIE_HEADER_NAME = "Cookie";
+    private static final AuthorizationCode AUTH_CODE_ORCH_TO_AUTH = new AuthorizationCode();
+    private static final AuthorizationCode AUTH_CODE_RP_TO_ORCH = new AuthorizationCode();
+    private static final State STATE = new State();
+    private static final TokenResponse SUCCESSFUL_TOKEN_RESPONSE =
+            new AccessTokenResponse(new Tokens(new BearerAccessToken(), null));
+    private static final TokenResponse UNSUCCESSFUL_TOKEN_RESPONSE = mock(TokenResponse.class);
+    private static final String TEST_ERROR_MESSAGE = "test-error-message";
+    private static final UserInfo USER_INFO = mock(UserInfo.class);
+    private AuthenticationCallbackHandler handler;
+
+    @BeforeAll
+    static void init() {
+        when(configurationService.getEnvironment()).thenReturn("test-env");
+        when(configurationService.getLoginURI()).thenReturn(URI.create(TEST_FRONTEND_BASE_URL));
+        when(configurationService.getAuthenticationBackendURI())
+                .thenReturn(URI.create(TEST_AUTH_BACKEND_BASE_URL));
+        when(configurationService.getAuthenticationUserInfoEndpoint())
+                .thenReturn(TEST_AUTH_USERINFO_PATH);
+        when(authorisationCodeService.generateAuthorisationCode(
+                        CLIENT_SESSION_ID, TEST_EMAIL_ADDRESS, clientSession))
+                .thenReturn(AUTH_CODE_RP_TO_ORCH);
+        when(cookieHelper.parseSessionCookie(anyMap())).thenCallRealMethod();
+        when(UNSUCCESSFUL_TOKEN_RESPONSE.indicatesSuccess()).thenReturn(false);
+        when(UNSUCCESSFUL_TOKEN_RESPONSE.toErrorResponse())
+                .thenReturn(new TokenErrorResponse(new ErrorObject("1", TEST_ERROR_MESSAGE)));
+        when(USER_INFO.getEmailAddress()).thenReturn(TEST_EMAIL_ADDRESS);
+        when(USER_INFO.getSubject()).thenReturn(PAIRWISE_SUBJECT_ID);
+        when(USER_INFO.getClaim("new_account")).thenReturn("true");
+    }
+
+    @BeforeEach
+    void setUp() {
+        handler =
+                new AuthenticationCallbackHandler(
+                        configurationService,
+                        authorizationService,
+                        tokenService,
+                        sessionService,
+                        clientSessionService,
+                        auditService,
+                        userInfoStorageService,
+                        cookieHelper,
+                        cloudwatchMetricsService,
+                        authorisationCodeService,
+                        clientService);
+    }
+
+    @Test
+    void shouldRedirectToRpRedirectUriWithCodeAndStateOnSuccessfulTokenResponse()
+            throws UnsuccessfulCredentialResponseException {
+        usingValidSession();
+        usingValidClientSession();
+
+        var event = new APIGatewayProxyRequestEvent();
+        setValidHeadersAndQueryParameters(event);
+
+        when(tokenService.sendTokenRequest(any())).thenReturn(SUCCESSFUL_TOKEN_RESPONSE);
+        when(tokenService.sendUserInfoDataRequest(any(HTTPRequest.class))).thenReturn(USER_INFO);
+
+        var response = handler.handleRequest(event, null);
+
+        assertThat(response, hasStatus(302));
+        String redirectLocation = response.getHeaders().get("Location");
+        assertThat(
+                redirectLocation,
+                equalTo(REDIRECT_URI + "?code=" + AUTH_CODE_RP_TO_ORCH + "&state=" + RP_STATE));
+
+        verifyAuditEvents(
+                List.of(
+                        OrchestrationAuditableEvent.AUTH_CALLBACK_RESPONSE_RECEIVED,
+                        OrchestrationAuditableEvent.AUTH_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
+                        OrchestrationAuditableEvent.AUTH_SUCCESSFUL_USERINFO_RESPONSE_RECEIVED),
+                auditService);
+    }
+
+    @Test
+    void shouldRedirectToFrontendErrorPageWhenSessionCookieNotFound() {
+        var event = new APIGatewayProxyRequestEvent();
+        event.setQueryStringParameters(Collections.emptyMap());
+        event.setHeaders(Collections.emptyMap());
+
+        var response = handler.handleRequest(event, null);
+
+        assertThat(response, hasStatus(302));
+        assertThat(
+                response.getHeaders().get("Location"), equalTo(TEST_FRONTEND_BASE_URL + "/error"));
+
+        verifyNoInteractions(
+                tokenService, auditService, userInfoStorageService, cloudwatchMetricsService);
+    }
+
+    @Test
+    void shouldRedirectToRpWithErrorWhenRequestIsInvalid() {
+        usingValidSession();
+        usingValidClientSession();
+
+        var event = new APIGatewayProxyRequestEvent();
+        event.setHeaders(Map.of(COOKIE_HEADER_NAME, buildCookieString()));
+        when(authorizationService.validateRequest(any(), any()))
+                .thenReturn(
+                        Optional.of(
+                                new ErrorObject(
+                                        OAuth2Error.INVALID_REQUEST_CODE, TEST_ERROR_MESSAGE)));
+
+        var response = handler.handleRequest(event, null);
+
+        assertThat(response, hasStatus(302));
+        String locationHeaderRedirect = response.getHeaders().get("Location");
+        assertThat(locationHeaderRedirect, containsString(REDIRECT_URI.toString()));
+        assertThat(locationHeaderRedirect, containsString(TEST_ERROR_MESSAGE));
+        assertThat(locationHeaderRedirect, containsString("&state=" + RP_STATE));
+
+        verifyAuditEvents(
+                List.of(OrchestrationAuditableEvent.AUTH_UNSUCCESSFUL_CALLBACK_RESPONSE_RECEIVED),
+                auditService);
+
+        verifyNoInteractions(tokenService, userInfoStorageService, cloudwatchMetricsService);
+    }
+
+    @Test
+    void shouldRedirectToFrontendErrorPageIfTokenRequestIsUnsuccessful() {
+        usingValidSession();
+        usingValidClientSession();
+
+        var event = new APIGatewayProxyRequestEvent();
+        setValidHeadersAndQueryParameters(event);
+        when(tokenService.sendTokenRequest(any())).thenReturn(UNSUCCESSFUL_TOKEN_RESPONSE);
+
+        var response = handler.handleRequest(event, null);
+
+        assertThat(response, hasStatus(302));
+        assertThat(
+                response.getHeaders().get("Location"), equalTo(TEST_FRONTEND_BASE_URL + "/error"));
+
+        verifyAuditEvents(
+                List.of(
+                        OrchestrationAuditableEvent.AUTH_CALLBACK_RESPONSE_RECEIVED,
+                        OrchestrationAuditableEvent.AUTH_UNSUCCESSFUL_TOKEN_RESPONSE_RECEIVED),
+                auditService);
+        verifyNoInteractions(userInfoStorageService, cloudwatchMetricsService);
+    }
+
+    @Test
+    void shouldRedirectToFrontendErrorPageIfUserInfoRequestIsUnsuccessful()
+            throws UnsuccessfulCredentialResponseException {
+        usingValidSession();
+        usingValidClientSession();
+
+        var event = new APIGatewayProxyRequestEvent();
+        setValidHeadersAndQueryParameters(event);
+        when(tokenService.sendTokenRequest(any())).thenReturn(SUCCESSFUL_TOKEN_RESPONSE);
+        when(tokenService.sendUserInfoDataRequest(any(HTTPRequest.class)))
+                .thenThrow(new UnsuccessfulCredentialResponseException(TEST_ERROR_MESSAGE));
+
+        var response = handler.handleRequest(event, null);
+
+        assertThat(response, hasStatus(302));
+        assertThat(
+                response.getHeaders().get("Location"), equalTo(TEST_FRONTEND_BASE_URL + "/error"));
+
+        verifyAuditEvents(
+                List.of(
+                        OrchestrationAuditableEvent.AUTH_CALLBACK_RESPONSE_RECEIVED,
+                        OrchestrationAuditableEvent.AUTH_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
+                        OrchestrationAuditableEvent.AUTH_UNSUCCESSFUL_USERINFO_RESPONSE_RECEIVED),
+                auditService);
+        verifyNoInteractions(userInfoStorageService, cloudwatchMetricsService);
+    }
+
+    private static void setValidHeadersAndQueryParameters(APIGatewayProxyRequestEvent event) {
+        event.setHeaders(Map.of(COOKIE_HEADER_NAME, buildCookieString()));
+        Map<String, String> responseHeaders = new HashMap<>();
+        responseHeaders.put("code", AUTH_CODE_ORCH_TO_AUTH.getValue());
+        responseHeaders.put("state", STATE.getValue());
+        event.setQueryStringParameters(responseHeaders);
+    }
+
+    private void usingValidSession() {
+        when(sessionService.readSessionFromRedis(SESSION_ID)).thenReturn(Optional.of(session));
+    }
+
+    private void usingValidClientSession() {
+        when(clientSessionService.getClientSession(CLIENT_SESSION_ID))
+                .thenReturn(Optional.of(clientSession));
+    }
+
+    private static AuthenticationRequest generateRPAuthRequestForClientSession() {
+        ResponseType responseType = new ResponseType(ResponseType.Value.CODE);
+        Scope scope = new Scope();
+        Nonce nonce = new Nonce();
+        scope.add(OIDCScopeValue.OPENID);
+        scope.add("phone");
+        scope.add("email");
+        return new AuthenticationRequest.Builder(responseType, scope, CLIENT_ID, REDIRECT_URI)
+                .state(RP_STATE)
+                .nonce(nonce)
+                .build();
+    }
+
+    private static String buildCookieString() {
+        return format(
+                        "%s=%s.%s; Max-Age=%d; %s",
+                        "gs", SESSION_ID, CLIENT_SESSION_ID, 3600, "Secure; HttpOnly;")
+                + format(
+                        "%s=%s; Max-Age=%d; %s",
+                        "di-persistent-session-id",
+                        PERSISTENT_SESSION_ID,
+                        3600,
+                        "Secure; HttpOnly;");
+    }
+
+    private static void verifyAuditEvents(
+            List<OrchestrationAuditableEvent> auditEvents, AuditService auditService) {
+        for (OrchestrationAuditableEvent event : auditEvents) {
+            verify(auditService)
+                    .submitAuditEvent(
+                            eq(event),
+                            eq(CLIENT_SESSION_ID),
+                            eq(SESSION_ID),
+                            eq(CLIENT_ID.getValue()),
+                            any(),
+                            any(),
+                            any(),
+                            any(),
+                            any());
+        }
+    }
+}

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AuthenticationAuthorizationServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AuthenticationAuthorizationServiceTest.java
@@ -1,7 +1,5 @@
 package uk.gov.di.authentication.oidc.services;
 
-import com.nimbusds.oauth2.sdk.ErrorObject;
-import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.id.State;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -9,10 +7,8 @@ import uk.gov.di.authentication.shared.services.RedisConnectionService;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -41,9 +37,9 @@ class AuthenticationAuthorizationServiceTest {
         queryParams.put("state", REDIS_STORED_STATE.getValue());
         queryParams.put("code", EXAMPLE_AUTH_CODE);
 
-        Optional<ErrorObject> result = authService.validateRequest(queryParams, SESSION_ID);
+        boolean result = authService.validateRequest(queryParams, SESSION_ID);
 
-        assertThat(result.isPresent(), is(false));
+        assertThat(result, is(true));
         verify(redisConnectionService)
                 .getValue(
                         AuthenticationAuthorizationService.AUTHENTICATION_STATE_STORAGE_PREFIX
@@ -51,50 +47,46 @@ class AuthenticationAuthorizationServiceTest {
     }
 
     @Test
-    void shouldReturnErrorObjectWhenNoQueryParametersPresent() {
+    void shouldReturnFalseWhenNoQueryParametersPresent() {
         Map<String, String> queryParams = new HashMap<>();
 
-        Optional<ErrorObject> result = authService.validateRequest(queryParams, SESSION_ID);
+        boolean result = authService.validateRequest(queryParams, SESSION_ID);
 
-        assertThat(result.isPresent(), is(true));
-        assertThat(result.get().getCode(), equalTo(OAuth2Error.INVALID_REQUEST_CODE));
+        assertThat(result, is(false));
         verify(redisConnectionService, never()).getValue(anyString());
     }
 
     @Test
-    void shouldReturnErrorObjectWhenErrorParamPresent() {
+    void shouldReturnFalseWhenErrorParamPresent() {
         Map<String, String> queryParams = new HashMap<>();
         queryParams.put("error", "some-error");
 
-        Optional<ErrorObject> result = authService.validateRequest(queryParams, SESSION_ID);
+        boolean result = authService.validateRequest(queryParams, SESSION_ID);
 
-        assertThat(result.isPresent(), is(true));
-        assertThat(result.get().getCode(), equalTo("some-error"));
+        assertThat(result, is(false));
         verify(redisConnectionService, never()).getValue(anyString());
     }
 
     @Test
-    void shouldReturnErrorObjectWhenNoStateParamPresent() {
+    void shouldReturnFalseWhenNoStateParamPresent() {
         Map<String, String> queryParams = new HashMap<>();
         queryParams.put("code", EXAMPLE_AUTH_CODE);
 
-        Optional<ErrorObject> result = authService.validateRequest(queryParams, SESSION_ID);
+        boolean result = authService.validateRequest(queryParams, SESSION_ID);
 
-        assertThat(result.isPresent(), is(true));
-        assertThat(result.get().getCode(), equalTo(OAuth2Error.INVALID_REQUEST_CODE));
+        assertThat(result, is(false));
         verify(redisConnectionService, never()).getValue(anyString());
     }
 
     @Test
-    void shouldReturnErrorObjectWhenInvalidStateParamPresent() {
+    void shouldReturnFalseWhenInvalidStateParamPresent() {
         Map<String, String> queryParams = new HashMap<>();
         queryParams.put("state", new State().getValue());
         queryParams.put("code", EXAMPLE_AUTH_CODE);
 
-        Optional<ErrorObject> result = authService.validateRequest(queryParams, SESSION_ID);
+        boolean result = authService.validateRequest(queryParams, SESSION_ID);
 
-        assertThat(result.isPresent(), is(true));
-        assertThat(result.get().getCode(), equalTo(OAuth2Error.INVALID_REQUEST_CODE));
+        assertThat(result, is(false));
         verify(redisConnectionService)
                 .getValue(
                         AuthenticationAuthorizationService.AUTHENTICATION_STATE_STORAGE_PREFIX
@@ -102,14 +94,13 @@ class AuthenticationAuthorizationServiceTest {
     }
 
     @Test
-    void shouldReturnErrorObjectWhenNoCodeParamPresent() {
+    void shouldReturnFalseWhenNoCodeParamPresent() {
         Map<String, String> queryParams = new HashMap<>();
         queryParams.put("code", EXAMPLE_AUTH_CODE);
 
-        Optional<ErrorObject> result = authService.validateRequest(queryParams, SESSION_ID);
+        boolean result = authService.validateRequest(queryParams, SESSION_ID);
 
-        assertThat(result.isPresent(), is(true));
-        assertThat(result.get().getCode(), equalTo(OAuth2Error.INVALID_REQUEST_CODE));
+        assertThat(result, is(false));
         verify(redisConnectionService, never()).getValue(anyString());
     }
 }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AuthenticationAuthorizationServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AuthenticationAuthorizationServiceTest.java
@@ -1,0 +1,115 @@
+package uk.gov.di.authentication.oidc.services;
+
+import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.OAuth2Error;
+import com.nimbusds.oauth2.sdk.id.State;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.services.RedisConnectionService;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class AuthenticationAuthorizationServiceTest {
+    private final RedisConnectionService redisConnectionService =
+            mock(RedisConnectionService.class);
+    private AuthenticationAuthorizationService authService;
+    private static final State REDIS_STORED_STATE = new State();
+    private static final String SESSION_ID = "a-session-id";
+    private static final String EXAMPLE_AUTH_CODE = "any-text-will-do";
+
+    @BeforeEach
+    void setUp() {
+        when(redisConnectionService.getValue(anyString()))
+                .thenReturn(REDIS_STORED_STATE.getValue());
+        authService = new AuthenticationAuthorizationService(redisConnectionService);
+    }
+
+    @Test
+    void shouldValidateRequestWithValidParams() {
+        Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("state", REDIS_STORED_STATE.getValue());
+        queryParams.put("code", EXAMPLE_AUTH_CODE);
+
+        Optional<ErrorObject> result = authService.validateRequest(queryParams, SESSION_ID);
+
+        assertThat(result.isPresent(), is(false));
+        verify(redisConnectionService)
+                .getValue(
+                        AuthenticationAuthorizationService.AUTHENTICATION_STATE_STORAGE_PREFIX
+                                + SESSION_ID);
+    }
+
+    @Test
+    void shouldReturnErrorObjectWhenNoQueryParametersPresent() {
+        Map<String, String> queryParams = new HashMap<>();
+
+        Optional<ErrorObject> result = authService.validateRequest(queryParams, SESSION_ID);
+
+        assertThat(result.isPresent(), is(true));
+        assertThat(result.get().getCode(), equalTo(OAuth2Error.INVALID_REQUEST_CODE));
+        verify(redisConnectionService, never()).getValue(anyString());
+    }
+
+    @Test
+    void shouldReturnErrorObjectWhenErrorParamPresent() {
+        Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("error", "some-error");
+
+        Optional<ErrorObject> result = authService.validateRequest(queryParams, SESSION_ID);
+
+        assertThat(result.isPresent(), is(true));
+        assertThat(result.get().getCode(), equalTo("some-error"));
+        verify(redisConnectionService, never()).getValue(anyString());
+    }
+
+    @Test
+    void shouldReturnErrorObjectWhenNoStateParamPresent() {
+        Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("code", EXAMPLE_AUTH_CODE);
+
+        Optional<ErrorObject> result = authService.validateRequest(queryParams, SESSION_ID);
+
+        assertThat(result.isPresent(), is(true));
+        assertThat(result.get().getCode(), equalTo(OAuth2Error.INVALID_REQUEST_CODE));
+        verify(redisConnectionService, never()).getValue(anyString());
+    }
+
+    @Test
+    void shouldReturnErrorObjectWhenInvalidStateParamPresent() {
+        Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("state", new State().getValue());
+        queryParams.put("code", EXAMPLE_AUTH_CODE);
+
+        Optional<ErrorObject> result = authService.validateRequest(queryParams, SESSION_ID);
+
+        assertThat(result.isPresent(), is(true));
+        assertThat(result.get().getCode(), equalTo(OAuth2Error.INVALID_REQUEST_CODE));
+        verify(redisConnectionService)
+                .getValue(
+                        AuthenticationAuthorizationService.AUTHENTICATION_STATE_STORAGE_PREFIX
+                                + SESSION_ID);
+    }
+
+    @Test
+    void shouldReturnErrorObjectWhenNoCodeParamPresent() {
+        Map<String, String> queryParams = new HashMap<>();
+        queryParams.put("code", EXAMPLE_AUTH_CODE);
+
+        Optional<ErrorObject> result = authService.validateRequest(queryParams, SESSION_ID);
+
+        assertThat(result.isPresent(), is(true));
+        assertThat(result.get().getCode(), equalTo(OAuth2Error.INVALID_REQUEST_CODE));
+        verify(redisConnectionService, never()).getValue(anyString());
+    }
+}

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AuthenticationTokenServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AuthenticationTokenServiceTest.java
@@ -33,7 +33,6 @@ import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.KmsConnectionService;
-import uk.gov.di.authentication.shared.services.SerializationService;
 
 import java.io.IOException;
 import java.net.URI;
@@ -62,8 +61,6 @@ class AuthenticationTokenServiceTest {
     private ConfigurationService configurationService = mock(ConfigurationService.class);
 
     private KmsConnectionService kmsService = mock(KmsConnectionService.class);
-
-    private SerializationService objectMapper = mock(SerializationService.class);
     private final HTTPRequest httpRequest = mock(HTTPRequest.class);
     private static final String SIGNING_KID = "14342354354353";
     private static final ClientID CLIENT_ID = new ClientID("some-client-id");
@@ -87,7 +84,7 @@ class AuthenticationTokenServiceTest {
         when(kmsService.getPublicKey(any())).thenReturn(PUBLIC_KEY_RESPONSE);
 
         authenticationTokenService =
-                new AuthenticationTokenService(configurationService, kmsService, objectMapper);
+                new AuthenticationTokenService(configurationService, kmsService);
     }
 
     @Test
@@ -167,8 +164,6 @@ class AuthenticationTokenServiceTest {
         headers.put("Content-Type", Collections.singletonList("application/json"));
         when(httpResponse.getHeaderMap()).thenReturn(headers);
 
-        when(objectMapper.readValue(userInfoJson, UserInfo.class)).thenReturn(USER_INFO);
-
         UserInfo result = authenticationTokenService.sendUserInfoDataRequest(httpRequest);
 
         assertThat(result.getSubject(), equalTo(USER_INFO.getSubject()));
@@ -217,12 +212,9 @@ class AuthenticationTokenServiceTest {
     }
 
     @Test
-    void shouldThrowUnsuccessfulCredentialResponseExceptionWhenObjectMapperThrowsJsonException()
-            throws Json.JsonException {
+    void shouldThrowUnsuccessfulCredentialResponseExceptionWhenObjectMapperThrowsException() {
         HTTPResponse httpResponse = mock(HTTPResponse.class);
         when(httpResponse.getContent()).thenReturn("{}");
-        when(objectMapper.readValue(any(), any()))
-                .thenThrow(new Json.JsonException("test-message"));
 
         UnsuccessfulCredentialResponseException thrown =
                 assertThrows(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AuthenticationTokenServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AuthenticationTokenServiceTest.java
@@ -1,0 +1,293 @@
+package uk.gov.di.authentication.oidc.services;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.crypto.impl.ECDSA;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.oauth2.sdk.AuthorizationCode;
+import com.nimbusds.oauth2.sdk.GrantType;
+import com.nimbusds.oauth2.sdk.TokenRequest;
+import com.nimbusds.oauth2.sdk.auth.JWTAuthenticationClaimsSet;
+import com.nimbusds.oauth2.sdk.http.HTTPRequest;
+import com.nimbusds.oauth2.sdk.http.HTTPResponse;
+import com.nimbusds.oauth2.sdk.id.Audience;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.id.JWTID;
+import com.nimbusds.oauth2.sdk.id.Subject;
+import com.nimbusds.openid.connect.sdk.claims.UserInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.kms.model.GetPublicKeyRequest;
+import software.amazon.awssdk.services.kms.model.GetPublicKeyResponse;
+import software.amazon.awssdk.services.kms.model.SignRequest;
+import software.amazon.awssdk.services.kms.model.SignResponse;
+import software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec;
+import uk.gov.di.authentication.shared.exceptions.UnsuccessfulCredentialResponseException;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
+import uk.gov.di.authentication.shared.serialization.Json;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.KmsConnectionService;
+import uk.gov.di.authentication.shared.services.SerializationService;
+
+import java.io.IOException;
+import java.net.URI;
+import java.security.KeyPair;
+import java.security.interfaces.ECPrivateKey;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.nimbusds.common.contenttype.ContentType.APPLICATION_JSON;
+import static java.util.Collections.singletonList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.shared.helpers.ConstructUriHelper.buildURI;
+import static uk.gov.di.authentication.sharedtest.exceptions.Unchecked.unchecked;
+
+class AuthenticationTokenServiceTest {
+    private ConfigurationService configurationService = mock(ConfigurationService.class);
+
+    private KmsConnectionService kmsService = mock(KmsConnectionService.class);
+
+    private SerializationService objectMapper = mock(SerializationService.class);
+    private final HTTPRequest httpRequest = mock(HTTPRequest.class);
+    private static final String SIGNING_KID = "14342354354353";
+    private static final ClientID CLIENT_ID = new ClientID("some-client-id");
+    private static final URI AUTH_BACKEND_URI = URI.create("https://auth.backend.uri/");
+    private static final URI ORCH_CALLBACK_URI = URI.create("https://orch.callback.uri/");
+    private static final GetPublicKeyResponse PUBLIC_KEY_RESPONSE =
+            GetPublicKeyResponse.builder().keyId("test").build();
+    private static final AuthorizationCode AUTH_CODE = new AuthorizationCode();
+    private static final UserInfo USER_INFO = new UserInfo(new Subject());
+
+    private AuthenticationTokenService authenticationTokenService;
+
+    @BeforeEach
+    void setUp() {
+        when(configurationService.getAuthenticationAuthCallbackURI()).thenReturn(ORCH_CALLBACK_URI);
+        when(configurationService.getAuthenticationBackendURI()).thenReturn(AUTH_BACKEND_URI);
+        when(configurationService.getOrchestrationClientId()).thenReturn(CLIENT_ID.getValue());
+        when(configurationService.getOrchestrationToAuthenticationTokenSigningKeyAlias())
+                .thenReturn("token-key-alias");
+
+        when(kmsService.getPublicKey(any())).thenReturn(PUBLIC_KEY_RESPONSE);
+
+        authenticationTokenService =
+                new AuthenticationTokenService(configurationService, kmsService, objectMapper);
+    }
+
+    @Test
+    void shouldConstructTokenRequest() throws JOSEException {
+        signJWTWithKMS();
+        when(kmsService.getPublicKey(any(GetPublicKeyRequest.class)))
+                .thenReturn(GetPublicKeyResponse.builder().keyId("789789789789789").build());
+        TokenRequest tokenRequest =
+                authenticationTokenService.constructTokenRequest(AUTH_CODE.getValue());
+        assertThat(tokenRequest.getEndpointURI().toString(), equalTo(AUTH_BACKEND_URI + "token"));
+        assertThat(
+                tokenRequest.getClientAuthentication().getMethod().getValue(),
+                equalTo("private_key_jwt"));
+        assertThat(
+                tokenRequest.toHTTPRequest().getQueryParameters().get("redirect_uri").get(0),
+                equalTo(ORCH_CALLBACK_URI.toString()));
+        assertThat(
+                tokenRequest.toHTTPRequest().getQueryParameters().get("grant_type").get(0),
+                equalTo(GrantType.AUTHORIZATION_CODE.getValue()));
+        assertThat(
+                tokenRequest.toHTTPRequest().getQueryParameters().get("client_id").get(0),
+                equalTo(CLIENT_ID.getValue()));
+    }
+
+    @Test
+    void shouldCallTokenEndpointAndReturn200() throws IOException {
+        var tokenRequest = mock(TokenRequest.class);
+        when(tokenRequest.toHTTPRequest()).thenReturn(httpRequest);
+        when(tokenRequest.toHTTPRequest().send()).thenReturn(getSuccessfulTokenHttpResponse());
+
+        var tokenResponse = authenticationTokenService.sendTokenRequest(tokenRequest);
+
+        assertThat(tokenResponse.indicatesSuccess(), equalTo(true));
+    }
+
+    @Test
+    void shouldRetryCallToTokenIfFirstCallFails() throws IOException {
+        var tokenRequest = mock(TokenRequest.class);
+        when(tokenRequest.toHTTPRequest()).thenReturn(httpRequest);
+
+        when(tokenRequest.toHTTPRequest().send())
+                .thenReturn(new HTTPResponse(500))
+                .thenReturn(getSuccessfulTokenHttpResponse());
+
+        var tokenResponse = authenticationTokenService.sendTokenRequest(tokenRequest);
+
+        assertThat(tokenResponse.indicatesSuccess(), equalTo(true));
+        verify(tokenRequest.toHTTPRequest(), times(2)).send();
+    }
+
+    @Test
+    void shouldReturnUnsuccessfulTokenResponseIf2CallsToTokenFail() throws IOException {
+        var tokenRequest = mock(TokenRequest.class);
+        when(tokenRequest.toHTTPRequest()).thenReturn(httpRequest);
+
+        when(tokenRequest.toHTTPRequest().send())
+                .thenReturn(new HTTPResponse(500))
+                .thenReturn(new HTTPResponse(500));
+
+        var tokenResponse = authenticationTokenService.sendTokenRequest(tokenRequest);
+
+        assertThat(tokenResponse.indicatesSuccess(), equalTo(false));
+        verify(tokenRequest.toHTTPRequest(), times(2)).send();
+    }
+
+    @Test
+    void shouldSendUserInfoDataRequestSuccessfully()
+            throws IOException, UnsuccessfulCredentialResponseException, Json.JsonException {
+        String userInfoJson = String.format("{\"sub\":\"%s\"}", USER_INFO.getSubject().getValue());
+        HTTPRequest httpRequest = mock(HTTPRequest.class);
+        HTTPResponse httpResponse = mock(HTTPResponse.class);
+        when(httpRequest.send()).thenReturn(httpResponse);
+        when(httpResponse.indicatesSuccess()).thenReturn(true);
+        when(httpResponse.getContent()).thenReturn(userInfoJson);
+
+        Map<String, List<String>> headers = new HashMap<>();
+        headers.put("Content-Type", Collections.singletonList("application/json"));
+        when(httpResponse.getHeaderMap()).thenReturn(headers);
+
+        when(objectMapper.readValue(userInfoJson, UserInfo.class)).thenReturn(USER_INFO);
+
+        UserInfo result = authenticationTokenService.sendUserInfoDataRequest(httpRequest);
+
+        assertThat(result.getSubject(), equalTo(USER_INFO.getSubject()));
+        verify(httpRequest, times(1)).send();
+    }
+
+    @Test
+    void shouldRetrySendingUserInfoDataRequestTwiceIfNotSuccessful() throws IOException {
+        HTTPRequest httpRequest = mock(HTTPRequest.class);
+        HTTPResponse httpResponse = mock(HTTPResponse.class);
+        when(httpRequest.send()).thenReturn(httpResponse);
+        int failureStatusCode = 503;
+        String failureErrorMessage = "Error content";
+        when(httpResponse.getStatusCode()).thenReturn(failureStatusCode);
+        when(httpResponse.getContent()).thenReturn(failureErrorMessage);
+
+        UnsuccessfulCredentialResponseException exception =
+                assertThrows(
+                        UnsuccessfulCredentialResponseException.class,
+                        () -> {
+                            authenticationTokenService.sendUserInfoDataRequest(httpRequest);
+                        });
+
+        assertThat(
+                exception.getMessage(),
+                equalTo(
+                        String.format(
+                                "Error %s when attempting to call Authentication userinfo endpoint: %s",
+                                failureStatusCode, failureErrorMessage)));
+        verify(httpRequest, times(2)).send();
+    }
+
+    @Test
+    void shouldThrowUnsuccessfulCredentialResponseExceptionWhenHttpContentIsNull() {
+        HTTPResponse httpResponse = mock(HTTPResponse.class);
+        when(httpResponse.getContent()).thenReturn(null);
+
+        UnsuccessfulCredentialResponseException thrown =
+                assertThrows(
+                        UnsuccessfulCredentialResponseException.class,
+                        () -> {
+                            authenticationTokenService.parseUserInfoFromResponse(httpResponse);
+                        });
+
+        assertThat(thrown.getMessage(), equalTo("No content in HTTP response"));
+    }
+
+    @Test
+    void shouldThrowUnsuccessfulCredentialResponseExceptionWhenObjectMapperThrowsJsonException()
+            throws Json.JsonException {
+        HTTPResponse httpResponse = mock(HTTPResponse.class);
+        when(httpResponse.getContent()).thenReturn("{}");
+        when(objectMapper.readValue(any(), any()))
+                .thenThrow(new Json.JsonException("test-message"));
+
+        UnsuccessfulCredentialResponseException thrown =
+                assertThrows(
+                        UnsuccessfulCredentialResponseException.class,
+                        () -> {
+                            authenticationTokenService.parseUserInfoFromResponse(httpResponse);
+                        });
+
+        assertThat(
+                thrown.getMessage(),
+                equalTo("Error parsing authentication userinfo response as JSON"));
+    }
+
+    private void signJWTWithKMS() throws JOSEException {
+        var ecSigningKey =
+                new ECKeyGenerator(Curve.P_256)
+                        .keyID(SIGNING_KID)
+                        .algorithm(JWSAlgorithm.ES256)
+                        .generate();
+        var claimsSet =
+                new JWTAuthenticationClaimsSet(
+                        new ClientID(CLIENT_ID),
+                        singletonList(new Audience(buildURI(AUTH_BACKEND_URI.toString(), "token"))),
+                        NowHelper.nowPlus(5, ChronoUnit.MINUTES),
+                        null,
+                        NowHelper.now(),
+                        new JWTID());
+        var ecdsaSigner = new ECDSASigner(ecSigningKey);
+        var jwsHeader =
+                new JWSHeader.Builder(JWSAlgorithm.ES256).keyID(ecSigningKey.getKeyID()).build();
+        var signedJWT = new SignedJWT(jwsHeader, claimsSet.toJWTClaimsSet());
+        unchecked(signedJWT::sign).accept(ecdsaSigner);
+        byte[] idTokenSignatureDer =
+                ECDSA.transcodeSignatureToDER(signedJWT.getSignature().decode());
+        var signResult =
+                SignResponse.builder()
+                        .signature(SdkBytes.fromByteArray(idTokenSignatureDer))
+                        .keyId(SIGNING_KID)
+                        .signingAlgorithm(SigningAlgorithmSpec.ECDSA_SHA_256)
+                        .build();
+
+        when(kmsService.sign(any(SignRequest.class))).thenReturn(signResult);
+    }
+
+    public static SignedJWT generateSignedJWT(JWTClaimsSet jwtClaimsSet, KeyPair keyPair)
+            throws JOSEException {
+        var jwsHeader = new JWSHeader(JWSAlgorithm.ES256);
+        var signedJWT = new SignedJWT(jwsHeader, jwtClaimsSet);
+        var ecdsaSigner = new ECDSASigner((ECPrivateKey) keyPair.getPrivate());
+        signedJWT.sign(ecdsaSigner);
+        return signedJWT;
+    }
+
+    public HTTPResponse getSuccessfulTokenHttpResponse() {
+        var tokenResponseContent =
+                "{"
+                        + "  \"access_token\": \"740e5834-3a29-46b4-9a6f-16142fde533a\","
+                        + "  \"token_type\": \"bearer\","
+                        + "  \"expires_in\": \"3600\","
+                        + "  \"uri\": \"https://localhost\""
+                        + "}";
+        var tokenHTTPResponse = new HTTPResponse(200);
+        tokenHTTPResponse.setEntityContentType(APPLICATION_JSON);
+        tokenHTTPResponse.setContent(tokenResponseContent);
+
+        return tokenHTTPResponse;
+    }
+}

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AuthorizationServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AuthorizationServiceTest.java
@@ -80,7 +80,7 @@ class AuthorizationServiceTest {
     private static final Nonce NONCE = new Nonce();
     private static final String KEY_ID = "14342354354353";
     private static final String CLIENT_NAME = "test-client-name";
-    private AuthorizationService authorizationService;
+    private OrchestrationAuthorizationService orchestrationAuthorizationService;
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final DynamoClientService dynamoClientService = mock(DynamoClientService.class);
     private final IPVCapacityService ipvCapacityService = mock(IPVCapacityService.class);
@@ -89,12 +89,12 @@ class AuthorizationServiceTest {
 
     @RegisterExtension
     public final CaptureLoggingExtension logging =
-            new CaptureLoggingExtension(AuthorizationService.class);
+            new CaptureLoggingExtension(OrchestrationAuthorizationService.class);
 
     @BeforeEach
     void setUp() {
-        authorizationService =
-                new AuthorizationService(
+        orchestrationAuthorizationService =
+                new OrchestrationAuthorizationService(
                         configurationService,
                         dynamoClientService,
                         ipvCapacityService,
@@ -122,7 +122,7 @@ class AuthorizationServiceTest {
                 Assertions.assertThrows(
                         ClientNotFoundException.class,
                         () ->
-                                authorizationService.isClientRedirectUriValid(
+                                orchestrationAuthorizationService.isClientRedirectUriValid(
                                         CLIENT_ID, REDIRECT_URI),
                         "Expected to throw exception");
 
@@ -138,7 +138,9 @@ class AuthorizationServiceTest {
                         Optional.of(
                                 generateClientRegistry(
                                         "http://localhost//", CLIENT_ID.toString())));
-        assertFalse(authorizationService.isClientRedirectUriValid(CLIENT_ID, REDIRECT_URI));
+        assertFalse(
+                orchestrationAuthorizationService.isClientRedirectUriValid(
+                        CLIENT_ID, REDIRECT_URI));
     }
 
     @Test
@@ -148,7 +150,9 @@ class AuthorizationServiceTest {
                         Optional.of(
                                 generateClientRegistry(
                                         REDIRECT_URI.toString(), CLIENT_ID.toString())));
-        assertTrue(authorizationService.isClientRedirectUriValid(CLIENT_ID, REDIRECT_URI));
+        assertTrue(
+                orchestrationAuthorizationService.isClientRedirectUriValid(
+                        CLIENT_ID, REDIRECT_URI));
     }
 
     @Test
@@ -161,7 +165,7 @@ class AuthorizationServiceTest {
                 generateAuthRequest(REDIRECT_URI.toString(), responseType, scope);
 
         AuthenticationSuccessResponse authSuccessResponse =
-                authorizationService.generateSuccessfulAuthResponse(
+                orchestrationAuthorizationService.generateSuccessfulAuthResponse(
                         authRequest, authCode, REDIRECT_URI, STATE);
         assertThat(authSuccessResponse.getState(), equalTo(STATE));
         assertThat(authSuccessResponse.getAuthorizationCode(), equalTo(authCode));
@@ -186,7 +190,7 @@ class AuthorizationServiceTest {
                         scope,
                         jsonArrayOf("P2.Cl.Cm"),
                         Optional.empty());
-        var errorObject = authorizationService.validateAuthRequest(authRequest, true);
+        var errorObject = orchestrationAuthorizationService.validateAuthRequest(authRequest, true);
 
         assertThat(errorObject, equalTo(Optional.empty()));
     }
@@ -208,7 +212,7 @@ class AuthorizationServiceTest {
                         scope,
                         jsonArrayOf("Cm.Cl.P1", "P1.Cl"),
                         Optional.empty());
-        var errorObject = authorizationService.validateAuthRequest(authRequest, true);
+        var errorObject = orchestrationAuthorizationService.validateAuthRequest(authRequest, true);
 
         assertTrue(errorObject.isPresent());
 
@@ -230,7 +234,7 @@ class AuthorizationServiceTest {
                                 generateClientRegistry(
                                         REDIRECT_URI.toString(), CLIENT_ID.toString())));
         var errorObject =
-                authorizationService.validateAuthRequest(
+                orchestrationAuthorizationService.validateAuthRequest(
                         generateAuthRequest(REDIRECT_URI.toString(), responseType, scope), true);
 
         assertTrue(errorObject.isEmpty());
@@ -252,7 +256,7 @@ class AuthorizationServiceTest {
                                 URI.create(REDIRECT_URI.toString()))
                         .state(STATE)
                         .build();
-        var errorObject = authorizationService.validateAuthRequest(authRequest, false);
+        var errorObject = orchestrationAuthorizationService.validateAuthRequest(authRequest, false);
 
         assertTrue(errorObject.isEmpty());
     }
@@ -283,7 +287,7 @@ class AuthorizationServiceTest {
                         scope,
                         jsonArrayOf("Cl.Cm", "Cl"),
                         Optional.of(oidcClaimsRequest));
-        var errorObject = authorizationService.validateAuthRequest(authRequest, true);
+        var errorObject = orchestrationAuthorizationService.validateAuthRequest(authRequest, true);
 
         assertTrue(errorObject.isEmpty());
     }
@@ -307,7 +311,7 @@ class AuthorizationServiceTest {
                         scope,
                         jsonArrayOf("Cl.Cm", "Cl"),
                         Optional.of(oidcClaimsRequest));
-        var errorObject = authorizationService.validateAuthRequest(authRequest, true);
+        var errorObject = orchestrationAuthorizationService.validateAuthRequest(authRequest, true);
 
         assertTrue(errorObject.isPresent());
         assertThat(
@@ -330,7 +334,7 @@ class AuthorizationServiceTest {
                                         CLIENT_ID.toString(),
                                         List.of("openid", "am"))));
         var errorObject =
-                authorizationService.validateAuthRequest(
+                orchestrationAuthorizationService.validateAuthRequest(
                         generateAuthRequest(REDIRECT_URI.toString(), responseType, scope), true);
 
         assertTrue(errorObject.isEmpty());
@@ -346,7 +350,7 @@ class AuthorizationServiceTest {
                                 generateClientRegistry(
                                         REDIRECT_URI.toString(), CLIENT_ID.toString())));
         var errorObject =
-                authorizationService.validateAuthRequest(
+                orchestrationAuthorizationService.validateAuthRequest(
                         generateAuthRequest(REDIRECT_URI.toString(), responseType, scope), true);
 
         assertTrue(errorObject.isPresent());
@@ -364,7 +368,7 @@ class AuthorizationServiceTest {
                 assertThrows(
                         RuntimeException.class,
                         () ->
-                                authorizationService.validateAuthRequest(
+                                orchestrationAuthorizationService.validateAuthRequest(
                                         generateAuthRequest(
                                                 REDIRECT_URI.toString(), responseType, scope),
                                         true),
@@ -385,7 +389,7 @@ class AuthorizationServiceTest {
                                 generateClientRegistry(
                                         REDIRECT_URI.toString(), CLIENT_ID.toString())));
         var errorObject =
-                authorizationService.validateAuthRequest(
+                orchestrationAuthorizationService.validateAuthRequest(
                         generateAuthRequest(REDIRECT_URI.toString(), responseType, scope), true);
 
         assertTrue(errorObject.isPresent());
@@ -405,7 +409,7 @@ class AuthorizationServiceTest {
                                 generateClientRegistry(
                                         REDIRECT_URI.toString(), CLIENT_ID.toString())));
         var errorObject =
-                authorizationService.validateAuthRequest(
+                orchestrationAuthorizationService.validateAuthRequest(
                         generateAuthRequest(REDIRECT_URI.toString(), responseType, scope), true);
 
         assertTrue(errorObject.isPresent());
@@ -427,7 +431,7 @@ class AuthorizationServiceTest {
                                 responseType, scope, new ClientID(CLIENT_ID), REDIRECT_URI)
                         .nonce(new Nonce())
                         .build();
-        var errorObject = authorizationService.validateAuthRequest(authRequest, true);
+        var errorObject = orchestrationAuthorizationService.validateAuthRequest(authRequest, true);
 
         assertTrue(errorObject.isPresent());
         assertThat(
@@ -453,7 +457,7 @@ class AuthorizationServiceTest {
                                 responseType, scope, new ClientID(CLIENT_ID), REDIRECT_URI)
                         .state(new State())
                         .build();
-        var errorObject = authorizationService.validateAuthRequest(authRequest, true);
+        var errorObject = orchestrationAuthorizationService.validateAuthRequest(authRequest, true);
 
         assertTrue(errorObject.isPresent());
         assertThat(
@@ -480,7 +484,7 @@ class AuthorizationServiceTest {
                         .nonce(new Nonce())
                         .customParameter("vtr", jsonArrayOf("Cm"))
                         .build();
-        var errorObject = authorizationService.validateAuthRequest(authRequest, true);
+        var errorObject = orchestrationAuthorizationService.validateAuthRequest(authRequest, true);
 
         assertTrue(errorObject.isPresent());
         assertThat(
@@ -506,7 +510,7 @@ class AuthorizationServiceTest {
                         .nonce(new Nonce())
                         .customParameter("vtr", jsonArrayOf("P2.Cl.Cm"))
                         .build();
-        var errorObject = authorizationService.validateAuthRequest(authRequest, true);
+        var errorObject = orchestrationAuthorizationService.validateAuthRequest(authRequest, true);
 
         assertTrue(errorObject.isPresent());
         assertThat(
@@ -533,7 +537,7 @@ class AuthorizationServiceTest {
                         .nonce(new Nonce())
                         .customParameter("vtr", jsonArrayOf("P2.Cl.Cm"))
                         .build();
-        var errorObject = authorizationService.validateAuthRequest(authRequest, true);
+        var errorObject = orchestrationAuthorizationService.validateAuthRequest(authRequest, true);
 
         assertTrue(errorObject.isEmpty());
     }
@@ -554,7 +558,7 @@ class AuthorizationServiceTest {
                 assertThrows(
                         RuntimeException.class,
                         () ->
-                                authorizationService.validateAuthRequest(
+                                orchestrationAuthorizationService.validateAuthRequest(
                                         generateAuthRequest(redirectURi, responseType, scope),
                                         true),
                         "Expected to throw exception");
@@ -571,7 +575,8 @@ class AuthorizationServiceTest {
                         "di-persistent-session-id=some-persistent-id;gs=session-id.456");
 
         String persistentSessionId =
-                authorizationService.getExistingOrCreateNewPersistentSessionId(requestCookieHeader);
+                orchestrationAuthorizationService.getExistingOrCreateNewPersistentSessionId(
+                        requestCookieHeader);
 
         assertThat(persistentSessionId, equalTo("some-persistent-id"));
     }
@@ -593,7 +598,7 @@ class AuthorizationServiceTest {
                         .build();
 
         var authRequestError =
-                authorizationService.validateAuthRequest(authenticationRequest, true);
+                orchestrationAuthorizationService.validateAuthRequest(authenticationRequest, true);
 
         assertTrue(authRequestError.isPresent());
         assertThat(
@@ -618,7 +623,7 @@ class AuthorizationServiceTest {
                         .build();
 
         var authRequestError =
-                authorizationService.validateAuthRequest(authenticationRequest, true);
+                orchestrationAuthorizationService.validateAuthRequest(authenticationRequest, true);
 
         assertTrue(authRequestError.isPresent());
         assertThat(
@@ -633,10 +638,10 @@ class AuthorizationServiceTest {
                 .thenReturn(dynamoClientServiceReturns);
 
         assertThat(
-                authorizationService.isTestJourney(CLIENT_ID, "test@test.com"),
+                orchestrationAuthorizationService.isTestJourney(CLIENT_ID, "test@test.com"),
                 equalTo(dynamoClientServiceReturns));
         assertThat(
-                authorizationService.isTestJourney(CLIENT_ID, "test@test.com"),
+                orchestrationAuthorizationService.isTestJourney(CLIENT_ID, "test@test.com"),
                 equalTo(dynamoClientServiceReturns));
     }
 
@@ -662,7 +667,7 @@ class AuthorizationServiceTest {
                         .build();
         when(kmsConnectionService.sign(any(SignRequest.class))).thenReturn(signResult);
 
-        var encryptedJWT = authorizationService.getSignedAndEncryptedJWT(jwtClaimsSet);
+        var encryptedJWT = orchestrationAuthorizationService.getSignedAndEncryptedJWT(jwtClaimsSet);
 
         var signedJWTResponse = decryptJWT(encryptedJWT);
 

--- a/shared-test/build.gradle
+++ b/shared-test/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     implementation project(":shared")
     implementation project(":frontend-api")
     implementation project(":doc-checking-app-api")
+    implementation project(":oidc-api")
 }
 
 test {

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthExternalApiStubExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthExternalApiStubExtension.java
@@ -1,0 +1,39 @@
+package uk.gov.di.authentication.sharedtest.extensions;
+
+import com.nimbusds.oauth2.sdk.id.Subject;
+import uk.gov.di.authentication.sharedtest.httpstub.HttpStubExtension;
+
+import static java.lang.String.format;
+
+public class AuthExternalApiStubExtension extends HttpStubExtension {
+
+    public AuthExternalApiStubExtension(int port) {
+        super(port);
+    }
+
+    public AuthExternalApiStubExtension() {
+        super();
+    }
+
+    public void init(Subject subjectId) {
+        register(
+                "/token",
+                200,
+                "application/json",
+                format(
+                        "{"
+                                + "  \"access_token\": \"740e5834-3a29-46b4-9a6f-16142fde533a\","
+                                + "  \"token_type\": \"bearer\","
+                                + "  \"expires_in\": \"3600\","
+                                + "  \"uri\": \"http://localhost:%1$d\""
+                                + "}",
+                        getHttpPort()));
+
+        String userInfoContent =
+                String.format(
+                        "{" + "\"sub\": \"%s\"," + "\"new_account\": \"true\"" + "}",
+                        subjectId.getValue());
+
+        register("/userinfo", 200, "application/json", userInfoContent);
+    }
+}

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthenticationCallbackUserInfoStoreExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthenticationCallbackUserInfoStoreExtension.java
@@ -1,0 +1,80 @@
+package uk.gov.di.authentication.sharedtest.extensions;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
+import software.amazon.awssdk.services.dynamodb.model.BillingMode;
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.KeyType;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
+import uk.gov.di.authentication.oidc.entity.AuthenticationUserInfo;
+import uk.gov.di.authentication.oidc.services.AuthenticationUserInfoStorageService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.sharedtest.basetest.DynamoTestConfiguration;
+
+import java.util.Optional;
+
+public class AuthenticationCallbackUserInfoStoreExtension extends DynamoExtension
+        implements AfterEachCallback {
+
+    public static final String CALLBACK_USERINFO_TABLE = "local-authentication-callback-userinfo";
+    public static final String SUBJECT_ID_FIELD = "SubjectID";
+
+    private AuthenticationUserInfoStorageService userInfoService;
+    private final ConfigurationService configuration;
+
+    public AuthenticationCallbackUserInfoStoreExtension(long ttl) {
+        createInstance();
+        this.configuration =
+                new DynamoTestConfiguration(REGION, ENVIRONMENT, DYNAMO_ENDPOINT) {
+                    @Override
+                    public long getAccessTokenExpiry() {
+                        return ttl;
+                    }
+                };
+        userInfoService = new AuthenticationUserInfoStorageService(configuration);
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+        super.beforeAll(context);
+
+        userInfoService = new AuthenticationUserInfoStorageService(configuration);
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) throws Exception {
+        clearDynamoTable(dynamoDB, CALLBACK_USERINFO_TABLE, SUBJECT_ID_FIELD);
+    }
+
+    @Override
+    protected void createTables() {
+        if (!tableExists(CALLBACK_USERINFO_TABLE)) {
+            createCallbackUserInfoTable(CALLBACK_USERINFO_TABLE);
+        }
+    }
+
+    private void createCallbackUserInfoTable(String tableName) {
+        CreateTableRequest request =
+                CreateTableRequest.builder()
+                        .tableName(tableName)
+                        .keySchema(
+                                KeySchemaElement.builder()
+                                        .keyType(KeyType.HASH)
+                                        .attributeName(SUBJECT_ID_FIELD)
+                                        .build())
+                        .billingMode(BillingMode.PAY_PER_REQUEST)
+                        .attributeDefinitions(
+                                AttributeDefinition.builder()
+                                        .attributeName(SUBJECT_ID_FIELD)
+                                        .attributeType(ScalarAttributeType.S)
+                                        .build())
+                        .build();
+        dynamoDB.createTable(request);
+    }
+
+    public Optional<AuthenticationUserInfo> getUserInfoBySubjectId(String subjectId) {
+        return userInfoService.getAuthenticationUserInfoData(subjectId);
+    }
+}

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthenticationCallbackUserInfoStoreExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthenticationCallbackUserInfoStoreExtension.java
@@ -1,5 +1,6 @@
 package uk.gov.di.authentication.sharedtest.extensions;
 
+import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
@@ -76,5 +77,9 @@ public class AuthenticationCallbackUserInfoStoreExtension extends DynamoExtensio
 
     public Optional<AuthenticationUserInfo> getUserInfoBySubjectId(String subjectId) {
         return userInfoService.getAuthenticationUserInfoData(subjectId);
+    }
+
+    public void addAuthenticationUserInfoData(String subjectId, UserInfo userInfo) {
+        userInfoService.addAuthenticationUserInfoData(subjectId, userInfo);
     }
 }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/RedisExtension.java
@@ -99,7 +99,12 @@ public class RedisExtension
     }
 
     public void addStateToRedis(State state, String sessionId) throws Json.JsonException {
-        redis.saveWithExpiry("state:" + sessionId, objectMapper.writeValueAsString(state), 3600);
+        addStateToRedis("state:", state, sessionId);
+    }
+
+    public void addStateToRedis(String prefix, State state, String sessionId)
+            throws Json.JsonException {
+        redis.saveWithExpiry(prefix + sessionId, objectMapper.writeValueAsString(state), 3600);
     }
 
     public void addClientSessionAndStateToRedis(State state, String clientSessionId) {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/ClientRegistryValidationException.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/ClientRegistryValidationException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.authentication.shared.exceptions;
+
+public class ClientRegistryValidationException extends RuntimeException {
+    public ClientRegistryValidationException(String message) {
+        super(message);
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/JwtParseException.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/JwtParseException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.authentication.shared.exceptions;
+
+public class JwtParseException extends RuntimeException {
+    public JwtParseException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/TokenRequestException.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/TokenRequestException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.authentication.shared.exceptions;
+
+public class TokenRequestException extends RuntimeException {
+    public TokenRequestException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/TokenResponseException.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/TokenResponseException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.authentication.shared.exceptions;
+
+public class TokenResponseException extends RuntimeException {
+    public TokenResponseException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthorisationCodeService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AuthorisationCodeService.java
@@ -39,7 +39,7 @@ public class AuthorisationCodeService {
         this.objectMapper = SerializationService.getInstance();
     }
 
-    public AuthorizationCode generateAuthorisationCode(
+    public AuthorizationCode generateAndSaveAuthorisationCode(
             String clientSessionId, String email, ClientSession clientSession) {
         LOG.info("Generating and saving AuthorisationCode");
         AuthorizationCode authorizationCode = new AuthorizationCode();

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -144,6 +144,19 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
                 .equals("true");
     }
 
+    public URI getAuthenticationAuthCallbackURI() {
+        return URI.create(
+                System.getenv().getOrDefault("AUTHENTICATION_AUTHORIZATION_CALLBACK_URI", ""));
+    }
+
+    public URI getAuthenticationBackendURI() {
+        return URI.create(System.getenv().getOrDefault("AUTHENTICATION_BACKEND_URI", ""));
+    }
+
+    public String getAuthenticationUserInfoEndpoint() {
+        return System.getenv("AUTHENTICATION_USER_INFO_ENDPOINT");
+    }
+
     public String getContactUsLinkRoute() {
         return System.getenv().getOrDefault("CONTACT_US_LINK_ROUTE", "");
     }


### PR DESCRIPTION
**Note to reviewer:** There are quite a few Sonar-flagged code smells that have been left 'as is'. This is something @billrdunn and I paired on, and we discussed all of them, but might be worth talking through them with whoever reviews this PR to ensure we are meeting code quality standards.

## What?

- Add auth callback handler
- This is the lambda that will be called by the authentication frontend (i.e. sign-in/account creation journey) at the end of its authentication flow
- Authentication will supply a code via this callback
- At this point, the lambda in this PR will need to exchange that code for an access token and use that token to obtain a userinfo response
- This will then be saved in Dynamo, and will be used by Orchestration to serve userinfo requests from Relying Parties
- Note: The userinfo response may vary in terms of which fields/content it has - authentication's userinfo lambda (not yet created) will dynamically 'decide' what to populate based on RPs requests scopes/claims

## What isn't included?

- Terraform/infrastructure
- Ability to handle IPV (identity-enabled) journeys
- Redirect to orchestration frontend error page rather than the existing (authentication) frontend error page
- Some degree of cleanup that will need to occur by the end of the auth/orch split, but for various reasons cannot happen yet:
    - Uplifting level of trust (this will be tracked in auth not orch)
    - Tracking MFA method (this will not be available to orch)
    -  Possibly an additional audit event, which corresponds to `ORCH_AUTHENTICATION_SUCCESS`; this was asked for in the Google docs that describes the API phase of the split, but there may be some further questions to answer around this (it may be that `AUTH_CALLBACK_RESPONSE_RECEIVED` is what this is and could be renamed)

## Why?
- Part of auth/orch split. Orchestration currently needs to access User Profile table to serve UserInfo endpoint reponses, but this data source will not be available after the split. This step puts the required information behind HTTP calls, rather than direct Dynamo access.
