### PR TITLE
AUT-1254: Add KMS signing key for use by auth token endpoint

### DIFF
--- a/ci/terraform/auth-external-api/kms-policies.tf
+++ b/ci/terraform/auth-external-api/kms-policies.tf
@@ -1,0 +1,23 @@
+### Signing key access for Authentication to send signed token response to Orchestration
+data "aws_iam_policy_document" "auth_id_token_signing_kms_policy_document" {
+  statement {
+    sid    = "AllowAccessToKmsSigningKey"
+    effect = "Allow"
+
+    actions = [
+      "kms:Sign",
+      "kms:GetPublicKey",
+    ]
+    resources = [
+      local.auth_id_token_signing_key_arn
+    ]
+  }
+}
+
+resource "aws_iam_policy" "auth_id_token_signing_kms_policy" {
+  name_prefix = "kms-auth-to-orch-policy"
+  path        = "/${var.environment}/auth-to-orch-kms-signing/"
+  description = "IAM policy for managing Auth Token API's KMS key access to sign response to Orchestration"
+
+  policy = data.aws_iam_policy_document.auth_id_token_signing_kms_policy_document.json
+}

--- a/ci/terraform/auth-external-api/sandpit.hcl
+++ b/ci/terraform/auth-external-api/sandpit.hcl
@@ -1,0 +1,4 @@
+bucket  = "digital-identity-dev-tfstate"
+key     = "sandpit-terraform.tfstate"
+encrypt = true
+region  = "eu-west-2"

--- a/ci/terraform/auth-external-api/sandpit.tfvars
+++ b/ci/terraform/auth-external-api/sandpit.tfvars
@@ -1,5 +1,1 @@
-environment         = "sandpit"
-common_state_bucket = "digital-identity-dev-tfstate"
-
-logging_endpoint_enabled = false
-logging_endpoint_arns    = []
+environment = "sandpit"

--- a/ci/terraform/auth-external-api/shared.tf
+++ b/ci/terraform/auth-external-api/shared.tf
@@ -1,0 +1,20 @@
+
+data "terraform_remote_state" "shared" {
+  backend = "s3"
+  config = {
+    bucket                      = var.shared_state_bucket
+    key                         = "${var.environment}-shared-terraform.tfstate"
+    role_arn                    = var.deployer_role_arn
+    region                      = var.aws_region
+    endpoint                    = null
+    iam_endpoint                = null
+    sts_endpoint                = null
+    skip_credentials_validation = false
+    skip_metadata_api_check     = false
+    force_path_style            = false
+  }
+}
+
+locals {
+  auth_id_token_signing_key_arn = data.terraform_remote_state.shared.outputs.auth_id_token_signing_key_arn
+}

--- a/ci/terraform/auth-external-api/variables.tf
+++ b/ci/terraform/auth-external-api/variables.tf
@@ -1,0 +1,18 @@
+variable "shared_state_bucket" {
+  type    = string
+  default = "digital-identity-dev-tfstate"
+}
+
+variable "environment" {
+  type = string
+}
+
+variable "deployer_role_arn" {
+  default     = ""
+  description = "The name of the AWS role to assume, leave blank when running locally"
+  type        = string
+}
+
+variable "aws_region" {
+  default = "eu-west-2"
+}

--- a/ci/terraform/oidc/sandpit.tfvars
+++ b/ci/terraform/oidc/sandpit.tfvars
@@ -23,6 +23,13 @@ EwIDAQAB
 -----END PUBLIC KEY-----
 EOT
 
+auth_to_orch_token_signing_public_key = <<-EOT
+-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEvvr/3/mHEPLpgsLR3ocLiGrVpVLJ
+AZUx4RCDu+VWAZpPi1NaF5XWvkFNFwH+MyLkATh90UEJDe+ayKW6AXFcRQ==
+-----END PUBLIC KEY-----
+EOT
+
 enable_api_gateway_execution_request_tracing = true
 spot_enabled                                 = false
 

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -325,6 +325,12 @@ variable "auth_frontend_public_encryption_key" {
   description = "Public encryption key which should be used to encrypt JWTs sent to Authentication (frontend)"
 }
 
+variable "auth_to_orch_token_signing_public_key" {
+  type        = string
+  default     = "undefined"
+  description = "Public signing key which should be used to sign token responses sent from Authentication (external API) to Orchestration (callback lambda)"
+}
+
 variable "doc_app_authorisation_uri" {
   type    = string
   default = "undefined"

--- a/ci/terraform/shared/kms.tf
+++ b/ci/terraform/shared/kms.tf
@@ -359,3 +359,18 @@ resource "aws_kms_key" "auth_code_store_signing_key" {
   tags = local.default_tags
 }
 
+# Authorization Token endpoint Signing KMS key
+
+resource "aws_kms_key" "auth_id_token_signing_key" {
+  description              = "KMS signing key for ID tokens issued by Authentication to Orchestration"
+  deletion_window_in_days  = 30
+  key_usage                = "SIGN_VERIFY"
+  customer_master_key_spec = "ECC_NIST_P256"
+
+  tags = local.default_tags
+}
+
+resource "aws_kms_alias" "auth_id_token_signing_key_alias" {
+  name          = "alias/${var.environment}-auth-id-token-signing-key-alias"
+  target_key_id = aws_kms_key.auth_id_token_signing_key.key_id
+}

--- a/ci/terraform/shared/outputs.tf
+++ b/ci/terraform/shared/outputs.tf
@@ -96,6 +96,14 @@ output "orch_to_auth_signing_key_arn" {
   value = aws_kms_key.orchestration_to_auth_signing_key.arn
 }
 
+output "auth_id_token_signing_key_alias_name" {
+  value = aws_kms_alias.auth_id_token_signing_key_alias.name
+}
+
+output "auth_id_token_signing_key_arn" {
+  value = aws_kms_key.auth_id_token_signing_key.arn
+}
+
 output "audit_signing_key_alias_name" {
   value = aws_kms_alias.audit_payload_signing_key_alias.name
 }

--- a/deploy-sandpit.sh
+++ b/deploy-sandpit.sh
@@ -18,7 +18,7 @@ function usage() {
   Requires a GDS CLI, AWS CLI and jq installed and configured.
 
   Usage:
-    $0 [-b|--build] [-c|--clean] [-s|--shared] [-o|--oidc] [-a|--account-management] [-t|--test-services] [--audit] [--destroy] [-p|--prompt]
+    $0 [-b|--build] [-c|--clean] [-s|--shared] [-o|--oidc] [-a|--account-management] [-t|--test-services] [--audit] [--destroy] [-p|--prompt] [-x|--auth-external]
 
   Options:
     -b, --build               run gradle build and buildZip tasks (default)
@@ -32,6 +32,7 @@ function usage() {
     -t, --test-services       run the test services terraform
     --destroy                 run all terraform with the -destroy flag (destroys all managed resources)
     -p, --prompt              will prompt for plan review before applying any terraform
+    -x, --auth-external       run the auth external api terraform
 
     If no options specified the default actions above will be carried out without prompting.
 USAGE
@@ -39,6 +40,7 @@ USAGE
 
 AM=0
 AUDIT=0
+AUTH_EXTERNAL_API=0
 BUILD=0
 OIDC=0
 RECEIPTS=0
@@ -49,6 +51,7 @@ CLEAN=""
 TERRAFORM_OPTS="-auto-approve"
 if [[ $# == 0 ]]; then
   AM=1
+  AUTH_EXTERNAL_API=1
   BUILD=1
   OIDC=1
   SHARED=1
@@ -87,6 +90,9 @@ while [[ $# -gt 0 ]]; do
       ;;
     -p|--prompt)
       TERRAFORM_OPTS=""
+      ;;
+    -x|--auth-external)
+      AUTH_EXTERNAL_API=1
       ;;
     *)
       usage
@@ -141,4 +147,8 @@ fi
 
 if [[ $TEST_SERVICES == "1" ]]; then
   runTerraform "test-services" "${TERRAFORM_OPTS}"
+fi
+
+if [[ $AUTH_EXTERNAL_API == "1" ]]; then
+  runTerraform "auth-external-api" "${TERRAFORM_OPTS}"
 fi


### PR DESCRIPTION
## What?
- The corresponding public keys will be hardcoded into `.tfvars` files to be used by the auth callback lambda (this has been done only for sandpit so far as it is the only environment where we can deploy without merging code to main first)

Notes:
- This approach means that the public keys can only be populated after the KMS deployment happens
- As a result zero-downtime rotation would not be possible for this approach
- The auth token lambda, when created, will need a policy to access this KMS in order to sign the tokens

## Why?
- Part of auth/orch split - the components will need to communicate over OAuth2 protocols in a way which hasn't been the case previously (due to sharing data sources directly)
