### PR TITLE
AUT-1488: New access_token_store dynamodb table

### DIFF
--- a/ci/terraform/oidc/dynamo-policies.tf
+++ b/ci/terraform/oidc/dynamo-policies.tf
@@ -26,6 +26,10 @@ data "aws_dynamodb_table" "account_modifiers_table" {
   name = "${var.environment}-account-modifiers"
 }
 
+data "aws_dynamodb_table" "access_token_store" {
+  name = "${var.environment}-access-token-store"
+}
+
 data "aws_iam_policy_document" "dynamo_user_write_policy_document" {
   statement {
     sid    = "AllowAccessToDynamoTables"
@@ -246,6 +250,54 @@ data "aws_iam_policy_document" "dynamo_account_modifiers_write_access_policy_doc
   }
 }
 
+data "aws_iam_policy_document" "dynamo_access_token_write_access_policy_document" {
+  statement {
+    sid    = "AllowAccessToDynamoTables"
+    effect = "Allow"
+
+    actions = [
+      "dynamodb:UpdateItem",
+      "dynamodb:PutItem",
+    ]
+    resources = [
+      data.aws_dynamodb_table.access_token_store.arn,
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "dynamo_access_token_delete_access_policy_document" {
+  statement {
+    sid    = "AllowAccessToDynamoTables"
+    effect = "Allow"
+
+    actions = [
+      "dynamodb:DeleteItem",
+    ]
+    resources = [
+      data.aws_dynamodb_table.access_token_store.arn,
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "dynamo_access_token_read_access_policy_document" {
+  statement {
+    sid    = "AllowAccessToDynamoTables"
+    effect = "Allow"
+
+    actions = [
+      "dynamodb:BatchGetItem",
+      "dynamodb:DescribeTable",
+      "dynamodb:Get*",
+      "dynamodb:Query",
+      "dynamodb:Scan",
+    ]
+    resources = [
+      data.aws_dynamodb_table.access_token_store.arn,
+    ]
+  }
+}
+
+
 resource "aws_iam_policy" "dynamo_client_registry_write_access_policy" {
   name_prefix = "dynamo-client-registry-write-policy"
   path        = "/${var.environment}/oidc-default/"
@@ -348,4 +400,28 @@ resource "aws_iam_policy" "dynamo_account_modifiers_write_access_policy" {
   description = "IAM policy for managing write permissions to the Dynamo Account Modifiers table"
 
   policy = data.aws_iam_policy_document.dynamo_account_modifiers_write_access_policy_document.json
+}
+
+resource "aws_iam_policy" "dynamo_access_token_write_access_policy" {
+  name_prefix = "dynamo-access-policy"
+  path        = "/${var.environment}/oidc-default/"
+  description = "IAM policy for managing write permissions to the Dynamo access token store table"
+
+  policy = data.aws_iam_policy_document.dynamo_access_token_write_access_policy_document.json
+}
+
+resource "aws_iam_policy" "dynamo_access_token_read_access_policy" {
+  name_prefix = "dynamo-access-policy"
+  path        = "/${var.environment}/oidc-default/"
+  description = "IAM policy for managing read permissions to the Dynamo access token store table"
+
+  policy = data.aws_iam_policy_document.dynamo_access_token_read_access_policy_document.json
+}
+
+resource "aws_iam_policy" "dynamo_access_token_delete_access_policy" {
+  name_prefix = "dynamo-access-policy"
+  path        = "/${var.environment}/oidc-default/"
+  description = "IAM policy for managing delete permissions to the Dynamo access token store table"
+
+  policy = data.aws_iam_policy_document.dynamo_access_token_delete_access_policy_document.json
 }

--- a/ci/terraform/shared/dynamodb.tf
+++ b/ci/terraform/shared/dynamodb.tf
@@ -300,6 +300,40 @@ resource "aws_dynamodb_table" "account_modifiers_table" {
   tags = local.default_tags
 }
 
+resource "aws_dynamodb_table" "access_token_store" {
+  name         = "${var.environment}-access-token-store"
+  billing_mode = var.provision_dynamo ? "PROVISIONED" : "PAY_PER_REQUEST"
+  hash_key     = "AccessToken"
+
+  read_capacity  = var.provision_dynamo ? var.dynamo_default_read_capacity : null
+  write_capacity = var.provision_dynamo ? var.dynamo_default_write_capacity : null
+
+  attribute {
+    name = "AccessToken"
+    type = "S"
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = aws_kms_key.access_token_store_signing_key.arn
+  }
+
+  lifecycle {
+    prevent_destroy = false
+  }
+
+  ttl {
+    attribute_name = "TimeToExist"
+    enabled        = true
+  }
+
+  tags = local.default_tags
+}
+
 resource "aws_dynamodb_table" "auth_code_store" {
   name         = "${var.environment}-auth-code-store"
   billing_mode = var.provision_dynamo ? "PROVISIONED" : "PAY_PER_REQUEST"

--- a/ci/terraform/shared/kms.tf
+++ b/ci/terraform/shared/kms.tf
@@ -374,3 +374,27 @@ resource "aws_kms_alias" "auth_id_token_signing_key_alias" {
   name          = "alias/${var.environment}-auth-id-token-signing-key-alias"
   target_key_id = aws_kms_key.auth_id_token_signing_key.key_id
 }
+resource "aws_kms_key" "access_token_store_signing_key" {
+  description              = "KMS signing key for Authorization code store in DynamoDB"
+  deletion_window_in_days  = 30
+  key_usage                = "ENCRYPT_DECRYPT"
+  customer_master_key_spec = "SYMMETRIC_DEFAULT"
+  enable_key_rotation      = true
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Id      = "key-policy-dynamodb",
+    Statement = [
+      {
+        Sid       = "Allow IAM to manage this key",
+        Effect    = "Allow",
+        Principal = { AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root" }
+        Action = [
+          "kms:*"
+        ],
+        Resource = "*"
+      }
+    ]
+  })
+  tags = local.default_tags
+}
+

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoAccessTokenServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoAccessTokenServiceIntegrationTest.java
@@ -1,0 +1,74 @@
+package uk.gov.di.authentication.services;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.di.authentication.shared.services.AccessTokenService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.sharedtest.extensions.AccessTokenStoreExtension;
+
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class DynamoAccessTokenServiceIntegrationTest {
+
+    @RegisterExtension
+    protected static final AccessTokenStoreExtension accessTokenStoreExtension =
+            new AccessTokenStoreExtension(180);
+
+    public static final String SUBJECT_ID_1 = "12345678";
+    public static final String SUBJECT_ID_2 = "87654321";
+    public static final String ACCESS_TOKEN_STRING = "access-token-string";
+    public static final String ACCESS_TOKEN_STRING_2 = "access-token-string-2";
+    public static final String ACCESS_TOKEN_STRING_3 = "access-token-string-3";
+
+    AccessTokenService accessTokenService =
+            new AccessTokenService(ConfigurationService.getInstance(), true);
+
+    private void setUpDynamo() {
+        accessTokenStoreExtension.addAccessTokenStore(
+                ACCESS_TOKEN_STRING, SUBJECT_ID_1, List.of("scope1"));
+        accessTokenStoreExtension.addAccessTokenStore(
+                ACCESS_TOKEN_STRING_2, SUBJECT_ID_2, List.of("scope1", "scope2"));
+        accessTokenStoreExtension.addAccessTokenStore(
+                ACCESS_TOKEN_STRING_3, SUBJECT_ID_2, List.of("scope1", "scope2", "scope3"));
+    }
+
+    @Test
+    void shouldRetrieveAccessTokenForKey() {
+        setUpDynamo();
+
+        var accessToken = accessTokenService.getAccessTokenStore(ACCESS_TOKEN_STRING);
+
+        assertThat(accessToken.isPresent(), equalTo(true));
+        accessToken.ifPresent(
+                t -> {
+                    assertThat(t.getAccessToken(), equalTo(ACCESS_TOKEN_STRING));
+                    assertThat(t.getSubjectID(), equalTo(SUBJECT_ID_1));
+                    assertThat(t.isUsed(), equalTo(false));
+                    assertThat(t.getScopes(), equalTo(List.of("scope1")));
+                });
+    }
+
+    @Test
+    void shouldUpdateUsedFlag() {
+        setUpDynamo();
+
+        var accessToken = accessTokenService.getAccessTokenStore(ACCESS_TOKEN_STRING_2);
+        assertThat(accessToken.isPresent(), equalTo(true));
+        accessToken.ifPresent(
+                t -> {
+                    assertThat(t.isUsed(), equalTo(false));
+                });
+        accessToken = accessTokenService.setAccessTokenStoreUsed(ACCESS_TOKEN_STRING_2, true);
+        assertThat(accessToken.isPresent(), equalTo(true));
+
+        var updatedAccessToken = accessTokenService.getAccessTokenStore(ACCESS_TOKEN_STRING_2);
+        assertThat(updatedAccessToken.isPresent(), equalTo(true));
+        updatedAccessToken.ifPresent(
+                t -> {
+                    assertThat(t.isUsed(), equalTo(true));
+                });
+    }
+}

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AccessTokenStoreExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AccessTokenStoreExtension.java
@@ -1,0 +1,85 @@
+package uk.gov.di.authentication.sharedtest.extensions;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
+import software.amazon.awssdk.services.dynamodb.model.BillingMode;
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.KeyType;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
+import uk.gov.di.authentication.shared.entity.token.AccessTokenStore;
+import uk.gov.di.authentication.shared.services.AccessTokenService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.sharedtest.basetest.DynamoTestConfiguration;
+
+import java.util.List;
+import java.util.Optional;
+
+public class AccessTokenStoreExtension extends DynamoExtension implements AfterEachCallback {
+
+    public static final String ACCESS_TOKEN_FIELD = "AccessToken";
+    public static final String ACCESS_TOKEN_STORE_TABLE = "local-access-token-store";
+
+    private AccessTokenService dynamoService;
+    private final ConfigurationService configuration;
+
+    public AccessTokenStoreExtension(long ttl) {
+        createInstance();
+        this.configuration =
+                new DynamoTestConfiguration(REGION, ENVIRONMENT, DYNAMO_ENDPOINT) {
+                    @Override
+                    public long getAccessTokenExpiry() {
+                        return ttl;
+                    }
+                };
+        dynamoService = new AccessTokenService(configuration, true);
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+        super.beforeAll(context);
+
+        dynamoService = new AccessTokenService(configuration, true);
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) throws Exception {
+        clearDynamoTable(dynamoDB, ACCESS_TOKEN_STORE_TABLE, ACCESS_TOKEN_FIELD);
+    }
+
+    @Override
+    protected void createTables() {
+        if (!tableExists(ACCESS_TOKEN_STORE_TABLE)) {
+            createAccessTokenStoreTable();
+        }
+    }
+
+    public void addAccessTokenStore(String accessToken, String subjectID, List<String> scopes) {
+        dynamoService.addAccessTokenStore(accessToken, subjectID, scopes);
+    }
+
+    public Optional<AccessTokenStore> getAccessToken(String subjectID, String clientId) {
+        return dynamoService.getAccessTokenStore(subjectID);
+    }
+
+    private void createAccessTokenStoreTable() {
+        CreateTableRequest request =
+                CreateTableRequest.builder()
+                        .tableName(ACCESS_TOKEN_STORE_TABLE)
+                        .keySchema(
+                                KeySchemaElement.builder()
+                                        .keyType(KeyType.HASH)
+                                        .attributeName(ACCESS_TOKEN_FIELD)
+                                        .build())
+                        .billingMode(BillingMode.PAY_PER_REQUEST)
+                        .attributeDefinitions(
+                                AttributeDefinition.builder()
+                                        .attributeName(ACCESS_TOKEN_FIELD)
+                                        .attributeType(ScalarAttributeType.S)
+                                        .build())
+                        .build();
+
+        dynamoDB.createTable(request);
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/token/AccessTokenStore.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/token/AccessTokenStore.java
@@ -1,0 +1,89 @@
+package uk.gov.di.authentication.shared.entity.token;
+
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbAttribute;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@DynamoDbBean
+public class AccessTokenStore {
+
+    private String accessToken;
+    private String subjectID;
+    private List<String> scopes = new ArrayList<>();
+    private long timeToExist;
+    private boolean used;
+
+    @DynamoDbPartitionKey
+    @DynamoDbAttribute("AccessToken")
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    public AccessTokenStore withAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+        return this;
+    }
+
+    @DynamoDbAttribute("SubjectID")
+    public String getSubjectID() {
+        return subjectID;
+    }
+
+    public void setSubjectID(String subjectID) {
+        this.subjectID = subjectID;
+    }
+
+    public AccessTokenStore withSubjectID(String subjectID) {
+        this.subjectID = subjectID;
+        return this;
+    }
+
+    @DynamoDbAttribute("Scopes")
+    public List<String> getScopes() {
+        return scopes;
+    }
+
+    public void setScopes(List<String> scopes) {
+        this.scopes = scopes;
+    }
+
+    public AccessTokenStore withScopes(List<String> scopes) {
+        this.scopes = scopes;
+        return this;
+    }
+
+    @DynamoDbAttribute("TimeToExist")
+    public long getTimeToExist() {
+        return timeToExist;
+    }
+
+    public void setTimeToExist(long timeToExist) {
+        this.timeToExist = timeToExist;
+    }
+
+    public AccessTokenStore withTimeToExist(long timeToExist) {
+        this.timeToExist = timeToExist;
+        return this;
+    }
+
+    @DynamoDbAttribute("Used")
+    public boolean isUsed() {
+        return used;
+    }
+
+    public void setUsed(boolean used) {
+        this.used = used;
+    }
+
+    public AccessTokenStore withUsed(boolean used) {
+        this.used = used;
+        return this;
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AccessTokenService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AccessTokenService.java
@@ -1,0 +1,66 @@
+package uk.gov.di.authentication.shared.services;
+
+import uk.gov.di.authentication.shared.entity.token.AccessTokenStore;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
+
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Optional;
+
+public class AccessTokenService extends BaseDynamoService<AccessTokenStore> {
+
+    private final long timeToExist;
+    private final boolean isAccessTokenStoreEnabled;
+
+    public AccessTokenService(
+            ConfigurationService configurationService, boolean isAccessTokenStoreEnabled) {
+        super(AccessTokenStore.class, "access-token-store", configurationService);
+        this.timeToExist = configurationService.getAccessTokenExpiry();
+        this.isAccessTokenStoreEnabled = isAccessTokenStoreEnabled;
+    }
+
+    public AccessTokenService(ConfigurationService configurationService) {
+        super(AccessTokenStore.class, "access-token-store", configurationService);
+        this.timeToExist = configurationService.getAccessTokenExpiry();
+        this.isAccessTokenStoreEnabled = configurationService.isAccessTokenStoreEnabled();
+    }
+
+    public void addAccessTokenStore(String accessToken, String subjectID, List<String> scopes) {
+        if (isAccessTokenStoreEnabled) {
+            var tokenStore =
+                    get(accessToken)
+                            .orElse(new AccessTokenStore())
+                            .withAccessToken(accessToken)
+                            .withSubjectID(subjectID)
+                            .withScopes(scopes)
+                            .withUsed(false)
+                            .withTimeToExist(
+                                    NowHelper.nowPlus(timeToExist, ChronoUnit.SECONDS)
+                                            .toInstant()
+                                            .getEpochSecond());
+            update(tokenStore);
+        }
+    }
+
+    public Optional<AccessTokenStore> getAccessTokenStore(String accessToken) {
+        return isAccessTokenStoreEnabled
+                ? get(accessToken)
+                        .filter(
+                                t ->
+                                        t.getTimeToExist()
+                                                > NowHelper.now().toInstant().getEpochSecond())
+                : Optional.empty();
+    }
+
+    public Optional<AccessTokenStore> setAccessTokenStoreUsed(String accessToken, boolean used) {
+        return isAccessTokenStoreEnabled
+                ? get(accessToken)
+                        .map(
+                                ts -> {
+                                    ts.setUsed(used);
+                                    update(ts);
+                                    return ts;
+                                })
+                : Optional.empty();
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -119,6 +119,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return System.getenv().getOrDefault("SUPPORT_AUTH_CODE_STORE", "false").equals("true");
     }
 
+    public boolean isAccessTokenStoreEnabled() {
+        return System.getenv().getOrDefault("SUPPORT_ACCESS_TOKEN_STORE", "false").equals("true");
+    }
+
     public String getContactUsLinkRoute() {
         return System.getenv().getOrDefault("CONTACT_US_LINK_ROUTE", "");
     }

--- a/shared/user-dynamo-tables.yaml
+++ b/shared/user-dynamo-tables.yaml
@@ -188,3 +188,30 @@ Resources:
           Value: !Ref Environment
         - Key: application
           Value: shared
+
+  AccessTokenStore:
+    # checkov:skip=CKV_AWS_119: "Ensure DynamoDB Tables are encrypted using a KMS Customer Managed CMK"
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Type: "AWS::DynamoDB::Table"
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: AccessToken
+          AttributeType: S
+      BillingMode: PAY_PER_REQUEST
+      KeySchema:
+        - AttributeName: AccessToken
+          KeyType: HASH
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
+      SSESpecification:
+        SSEEnabled: true
+      TableName: !Sub "${Environment}-access-token-store"
+      TimeToLiveSpecification:
+        AttributeName: TimeToExist
+        Enabled: true
+      Tags:
+        - Key: environment
+          Value: !Ref Environment
+        - Key: application
+          Value: shared


### PR DESCRIPTION
## What?

New access_token_store dynamodb table.

- Create a new table to store access tokens in authentication.
- New service, test extension and integration test to access the new table.
- The table will be created in all environments, but will only be used if a feature switch is on, so no data will actually be populated for the moment until changes using the table are tested and rolled-out.

## Why?

This table will be used to store access tokens in authentication, replacing the use of redis.  Access tokens are stored so they can be validated against the access token provided by the client (orchestration).
