### PR TITLE
AUT-1223: Enable account recovery block in all environments

### DIFF
--- a/ci/terraform/oidc/build-overrides.tfvars
+++ b/ci/terraform/oidc/build-overrides.tfvars
@@ -11,7 +11,6 @@ spot_enabled                        = false
 language_cy_enabled                 = true
 internal_sector_uri                 = "https://identity.build.account.gov.uk"
 extended_feature_flags_enabled      = true
-account_recovery_block_enabled      = true
 custom_doc_app_claim_enabled        = true
 ipv_no_session_response_enabled     = true
 doc_app_cri_data_v2_endpoint        = "credentials/issue"

--- a/ci/terraform/oidc/integration-overrides.tfvars
+++ b/ci/terraform/oidc/integration-overrides.tfvars
@@ -21,7 +21,6 @@ internal_sector_uri             = "https://identity.integration.account.gov.uk"
 spot_enabled                    = true
 language_cy_enabled             = true
 extended_feature_flags_enabled  = true
-account_recovery_block_enabled  = true
 custom_doc_app_claim_enabled    = true
 ipv_no_session_response_enabled = true
 

--- a/ci/terraform/oidc/production-overrides.tfvars
+++ b/ci/terraform/oidc/production-overrides.tfvars
@@ -23,7 +23,6 @@ doc_app_authorisation_uri          = "https://www.review-b.account.gov.uk/dca/oa
 doc_app_jwks_endpoint              = "https://api-backend-api.review-b.account.gov.uk/.well-known/jwks.json"
 doc_app_encryption_key_id          = "7958938d-eea0-4e6d-9ea1-ec0b9d421f77"
 
-account_recovery_block_enabled  = false
 cloudwatch_log_retention        = 5
 client_registry_api_enabled     = false
 language_cy_enabled             = true

--- a/ci/terraform/oidc/staging-overrides.tfvars
+++ b/ci/terraform/oidc/staging-overrides.tfvars
@@ -20,7 +20,6 @@ spot_enabled                       = true
 language_cy_enabled                = true
 extended_feature_flags_enabled     = true
 test_clients_enabled               = "true"
-account_recovery_block_enabled     = true
 ipv_no_session_response_enabled    = true
 doc_app_cri_data_v2_endpoint       = "userinfo/v2"
 doc_app_use_cri_data_v2_endpoint   = true

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -98,7 +98,7 @@ variable "service_domain" {
 }
 
 variable "account_recovery_block_enabled" {
-  default = false
+  default = true
 }
 
 variable "aws_endpoint" {


### PR DESCRIPTION
## What?
- Enable account recovery block in all environments
- Change default value and remove per-env overrides

## Why?
- This is part of putting account recovery journeys live in production

## Related PRs
- Corresponding PR for front end MUST NOT be merged until this PR is merged: https://github.com/alphagov/di-authentication-frontend/pull/1122