### PR TITLE
Aut 1441/bulk email table

### DIFF
--- a/ci/terraform/shared/dynamodb.tf
+++ b/ci/terraform/shared/dynamodb.tf
@@ -367,3 +367,47 @@ resource "aws_dynamodb_table" "auth_code_store" {
 
   tags = local.default_tags
 }
+
+resource "aws_dynamodb_table" "bulk_email_users" {
+  name         = "${var.environment}-bulk-email-users"
+  count        = contains(["build", "sandpit"], var.environment) ? 1 : 0
+  billing_mode = var.provision_dynamo ? "PROVISIONED" : "PAY_PER_REQUEST"
+
+  hash_key = "SubjectID"
+
+  read_capacity  = var.provision_dynamo ? var.dynamo_default_read_capacity : null
+  write_capacity = var.provision_dynamo ? var.dynamo_default_write_capacity : null
+
+  attribute {
+    name = "SubjectID"
+    type = "S"
+  }
+
+  attribute {
+    name = "BulkEmailStatus"
+    type = "S"
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = aws_kms_key.auth_code_store_signing_key.arn
+  }
+
+  lifecycle {
+    prevent_destroy = false
+  }
+
+  global_secondary_index {
+    name            = "BulkEmailStatusIndex"
+    hash_key        = "BulkEmailStatus"
+    projection_type = "ALL"
+    read_capacity   = var.provision_dynamo ? var.dynamo_default_read_capacity : null
+    write_capacity  = var.provision_dynamo ? var.dynamo_default_write_capacity : null
+  }
+
+  tags = local.default_tags
+}

--- a/ci/terraform/shared/dynamodb.tf
+++ b/ci/terraform/shared/dynamodb.tf
@@ -370,7 +370,7 @@ resource "aws_dynamodb_table" "auth_code_store" {
 
 resource "aws_dynamodb_table" "bulk_email_users" {
   name         = "${var.environment}-bulk-email-users"
-  count        = contains(["build", "sandpit"], var.environment) ? 1 : 0
+  count        = local.deploy_bulk_email_users_count
   billing_mode = var.provision_dynamo ? "PROVISIONED" : "PAY_PER_REQUEST"
 
   hash_key = "SubjectID"
@@ -394,7 +394,7 @@ resource "aws_dynamodb_table" "bulk_email_users" {
 
   server_side_encryption {
     enabled     = true
-    kms_key_arn = aws_kms_key.auth_code_store_signing_key.arn
+    kms_key_arn = aws_kms_key.bulk_email_users_signing_key.arn
   }
 
   lifecycle {

--- a/ci/terraform/shared/kms.tf
+++ b/ci/terraform/shared/kms.tf
@@ -398,3 +398,26 @@ resource "aws_kms_key" "access_token_store_signing_key" {
   tags = local.default_tags
 }
 
+resource "aws_kms_key" "bulk_email_users_signing_key" {
+  description              = "KMS signing key for bulk email users table in DynamoDB"
+  deletion_window_in_days  = 30
+  key_usage                = "ENCRYPT_DECRYPT"
+  customer_master_key_spec = "SYMMETRIC_DEFAULT"
+  enable_key_rotation      = true
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Id      = "key-policy-dynamodb",
+    Statement = [
+      {
+        Sid       = "Allow IAM to manage this key",
+        Effect    = "Allow",
+        Principal = { AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root" }
+        Action = [
+          "kms:*"
+        ],
+        Resource = "*"
+      }
+    ]
+  })
+  tags = local.default_tags
+}

--- a/ci/terraform/shared/site.tf
+++ b/ci/terraform/shared/site.tf
@@ -58,7 +58,8 @@ locals {
     application = "shared"
   }
 
-  request_tracing_allowed = contains(["build", "sandpit"], var.environment)
+  request_tracing_allowed       = contains(["build", "sandpit"], var.environment)
+  deploy_bulk_email_users_count = contains(["build", "sandpit"], var.environment) ? 1 : 0
 }
 
 data "aws_caller_identity" "current" {}

--- a/ci/terraform/utils/bulk_user_email_dynamo_access.tf
+++ b/ci/terraform/utils/bulk_user_email_dynamo_access.tf
@@ -1,8 +1,10 @@
 data "aws_dynamodb_table" "bulk_email_users" {
-  name = "${var.environment}-bulk-email-users"
+  count = local.deploy_bulk_email_users_count
+  name  = "${var.environment}-bulk-email-users"
 }
 
 data "aws_iam_policy_document" "bulk_email_users_full_access" {
+  count = local.deploy_bulk_email_users_count
   statement {
     sid    = "AllowAccessToDynamoTables"
     effect = "Allow"
@@ -20,14 +22,15 @@ data "aws_iam_policy_document" "bulk_email_users_full_access" {
     ]
 
     resources = [
-      data.aws_dynamodb_table.bulk_email_users.arn,
+      data.aws_dynamodb_table.bulk_email_users[0].arn,
     ]
   }
 }
 
 resource "aws_iam_policy" "bulk_email_users_dynamo_full_access" {
+  count       = local.deploy_bulk_email_users_count
   name_prefix = "dynamo-access-policy"
   description = "IAM policy for managing full permissions to the Dynamo Bulk Email Users table"
 
-  policy = data.aws_iam_policy_document.bulk_email_users_full_access.json
+  policy = data.aws_iam_policy_document.bulk_email_users_full_access[0].json
 }

--- a/ci/terraform/utils/bulk_user_email_dynamo_access.tf
+++ b/ci/terraform/utils/bulk_user_email_dynamo_access.tf
@@ -1,0 +1,33 @@
+data "aws_dynamodb_table" "bulk_email_users" {
+  name = "${var.environment}-bulk-email-users"
+}
+
+data "aws_iam_policy_document" "bulk_email_users_full_access" {
+  statement {
+    sid    = "AllowAccessToDynamoTables"
+    effect = "Allow"
+
+    actions = [
+      "dynamodb:DescribeStream",
+      "dynamodb:DescribeTable",
+      "dynamodb:Get*",
+      "dynamodb:Query",
+      "dynamodb:Scan",
+      "dynamodb:BatchWrite*",
+      "dynamodb:CreateTable",
+      "dynamodb:Update*",
+      "dynamodb:PutItem"
+    ]
+
+    resources = [
+      data.aws_dynamodb_table.bulk_email_users.arn,
+    ]
+  }
+}
+
+resource "aws_iam_policy" "bulk_email_users_dynamo_full_access" {
+  name_prefix = "dynamo-access-policy"
+  description = "IAM policy for managing full permissions to the Dynamo Bulk Email Users table"
+
+  policy = data.aws_iam_policy_document.bulk_email_users_full_access.json
+}

--- a/ci/terraform/utils/site.tf
+++ b/ci/terraform/utils/site.tf
@@ -51,7 +51,8 @@ locals {
     application = "utils"
   }
 
-  request_tracing_allowed = contains(["build", "sandpit"], var.environment)
+  request_tracing_allowed       = contains(["build", "sandpit"], var.environment)
+  deploy_bulk_email_users_count = contains(["build", "sandpit"], var.environment) ? 1 : 0
 }
 
 data "aws_caller_identity" "current" {}

--- a/integration-tests/src/test/java/uk/gov/di/authentication/utils/BulkEmailUsersIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/utils/BulkEmailUsersIntegrationTest.java
@@ -1,0 +1,87 @@
+package uk.gov.di.authentication.utils;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.di.authentication.shared.entity.BulkEmailStatus;
+import uk.gov.di.authentication.shared.entity.BulkEmailUser;
+import uk.gov.di.authentication.shared.services.BulkEmailUsersService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.sharedtest.extensions.BulkEmailUsersExtension;
+
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class BulkEmailUsersIntegrationTest {
+
+    public static final String SUBJECT_ID_1 = "subject-id-1";
+    public static final String SUBJECT_ID_2 = "subject-id-2";
+    public static final String SUBJECT_ID_3 = "subject-id-3";
+    public static final String SUBJECT_ID_4 = "subject-id-4";
+    public static final String SUBJECT_ID_5 = "subject-id-5";
+
+    @RegisterExtension
+    protected static final BulkEmailUsersExtension bulkEmailUsersExtension =
+            new BulkEmailUsersExtension();
+
+    BulkEmailUsersService bulkEmailUsersService =
+            new BulkEmailUsersService(ConfigurationService.getInstance());
+
+    @Test
+    void updateUserStatusUpdatesaUserWithTheProvidedStatus() {
+        bulkEmailUsersExtension.addBulkEmailUser(SUBJECT_ID_1, BulkEmailStatus.PENDING);
+
+        var updatedUser =
+                bulkEmailUsersService
+                        .updateUserStatus(SUBJECT_ID_1, BulkEmailStatus.EMAIL_SENT)
+                        .get();
+
+        assertEquals(updatedUser.getSubjectID(), SUBJECT_ID_1);
+        assertEquals(updatedUser.getBulkEmailStatus(), BulkEmailStatus.EMAIL_SENT);
+
+        var bulkEmailStatusOfUserAfterUpdate =
+                bulkEmailUsersService
+                        .getBulkEmailUsers(SUBJECT_ID_1)
+                        .map(BulkEmailUser::getBulkEmailStatus)
+                        .get();
+
+        assertEquals(bulkEmailStatusOfUserAfterUpdate, bulkEmailStatusOfUserAfterUpdate.EMAIL_SENT);
+    }
+
+    @Test
+    void updateUserStatusReturnsNoneIfTheSuppliedSubjectIdDoesNotExist() {
+        var subjectId = "a-non-existent-subject-id";
+        var result = bulkEmailUsersService.updateUserStatus(subjectId, BulkEmailStatus.EMAIL_SENT);
+
+        assertEquals(result, Optional.empty());
+    }
+
+    @Test
+    void shouldReturnBulkListOfUsersPending() {
+        bulkEmailUsersExtension.addBulkEmailUser(SUBJECT_ID_1, BulkEmailStatus.PENDING);
+        bulkEmailUsersExtension.addBulkEmailUser(SUBJECT_ID_2, BulkEmailStatus.PENDING);
+        bulkEmailUsersExtension.addBulkEmailUser(SUBJECT_ID_3, BulkEmailStatus.EMAIL_SENT);
+
+        var subjectIds = bulkEmailUsersService.getNSubjectIdsByStatus(5, BulkEmailStatus.PENDING);
+
+        assertEquals(2, subjectIds.size());
+        assertThat(subjectIds, containsInAnyOrder(SUBJECT_ID_1, SUBJECT_ID_2));
+    }
+
+    @Test
+    void shouldReturnBulkListOfUsersWithLimit() {
+        bulkEmailUsersExtension.addBulkEmailUser(SUBJECT_ID_1, BulkEmailStatus.PENDING);
+        bulkEmailUsersExtension.addBulkEmailUser(SUBJECT_ID_2, BulkEmailStatus.PENDING);
+        bulkEmailUsersExtension.addBulkEmailUser(SUBJECT_ID_3, BulkEmailStatus.EMAIL_SENT);
+        bulkEmailUsersExtension.addBulkEmailUser(SUBJECT_ID_4, BulkEmailStatus.PENDING);
+        bulkEmailUsersExtension.addBulkEmailUser(SUBJECT_ID_5, BulkEmailStatus.PENDING);
+
+        var limit = 3;
+
+        var users = bulkEmailUsersService.getNSubjectIdsByStatus(limit, BulkEmailStatus.PENDING);
+
+        assertEquals(limit, users.size());
+    }
+}

--- a/integration-tests/src/test/java/uk/gov/di/authentication/utils/BulkEmailUsersIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/utils/BulkEmailUsersIntegrationTest.java
@@ -38,8 +38,8 @@ public class BulkEmailUsersIntegrationTest {
                         .updateUserStatus(SUBJECT_ID_1, BulkEmailStatus.EMAIL_SENT)
                         .get();
 
-        assertEquals(updatedUser.getSubjectID(), SUBJECT_ID_1);
-        assertEquals(updatedUser.getBulkEmailStatus(), BulkEmailStatus.EMAIL_SENT);
+        assertEquals(SUBJECT_ID_1, updatedUser.getSubjectID());
+        assertEquals(BulkEmailStatus.EMAIL_SENT, updatedUser.getBulkEmailStatus());
 
         var bulkEmailStatusOfUserAfterUpdate =
                 bulkEmailUsersService
@@ -47,7 +47,7 @@ public class BulkEmailUsersIntegrationTest {
                         .map(BulkEmailUser::getBulkEmailStatus)
                         .get();
 
-        assertEquals(bulkEmailStatusOfUserAfterUpdate, bulkEmailStatusOfUserAfterUpdate.EMAIL_SENT);
+        assertEquals(BulkEmailStatus.EMAIL_SENT, bulkEmailStatusOfUserAfterUpdate);
     }
 
     @Test

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/BulkEmailUsersExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/BulkEmailUsersExtension.java
@@ -1,0 +1,105 @@
+package uk.gov.di.authentication.sharedtest.extensions;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.BillingMode;
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.GlobalSecondaryIndex;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.KeyType;
+import software.amazon.awssdk.services.dynamodb.model.ProjectionType;
+import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
+import uk.gov.di.authentication.shared.entity.BulkEmailStatus;
+import uk.gov.di.authentication.shared.services.BulkEmailUsersService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.sharedtest.basetest.DynamoTestConfiguration;
+
+import java.util.Map;
+
+public class BulkEmailUsersExtension extends DynamoExtension implements AfterEachCallback {
+
+    public static final String SUBJECT_ID_FIELD = "SubjectID";
+    public static final String BULK_EMAIL_STATUS_FIELD = "BulkEmailStatus";
+    public static final String BULK_EMAIL_STATUS_INDEX = "BulkEmailStatusIndex";
+
+    public static final String BULK_EMAIL_USERS_TABLE = "local-bulk-email-users";
+
+    private BulkEmailUsersService dynamoService;
+    private final ConfigurationService configuration;
+
+    public BulkEmailUsersExtension() {
+        createInstance();
+        this.configuration = new DynamoTestConfiguration(REGION, ENVIRONMENT, DYNAMO_ENDPOINT) {};
+        dynamoService = new BulkEmailUsersService(configuration);
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+        super.beforeAll(context);
+        dynamoService = new BulkEmailUsersService(configuration);
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) throws Exception {
+        clearDynamoTable(dynamoDB, BULK_EMAIL_USERS_TABLE, SUBJECT_ID_FIELD);
+    }
+
+    @Override
+    protected void createTables() {
+        if (!tableExists(BULK_EMAIL_USERS_TABLE)) {
+            createBulkEmailUsersTable();
+        }
+    }
+
+    private void createBulkEmailUsersTable() {
+        CreateTableRequest request =
+                CreateTableRequest.builder()
+                        .tableName(BULK_EMAIL_USERS_TABLE)
+                        .keySchema(
+                                KeySchemaElement.builder()
+                                        .keyType(KeyType.HASH)
+                                        .attributeName(SUBJECT_ID_FIELD)
+                                        .build())
+                        .billingMode(BillingMode.PAY_PER_REQUEST)
+                        .attributeDefinitions(
+                                AttributeDefinition.builder()
+                                        .attributeName(SUBJECT_ID_FIELD)
+                                        .attributeType(ScalarAttributeType.S)
+                                        .build(),
+                                AttributeDefinition.builder()
+                                        .attributeName(BULK_EMAIL_STATUS_FIELD)
+                                        .attributeType(ScalarAttributeType.S)
+                                        .build())
+                        .globalSecondaryIndexes(
+                                GlobalSecondaryIndex.builder()
+                                        .indexName(BULK_EMAIL_STATUS_INDEX)
+                                        .keySchema(
+                                                KeySchemaElement.builder()
+                                                        .attributeName(BULK_EMAIL_STATUS_FIELD)
+                                                        .keyType(KeyType.HASH)
+                                                        .build())
+                                        .projection(t -> t.projectionType(ProjectionType.ALL))
+                                        .build())
+                        .build();
+
+        dynamoDB.createTable(request);
+    }
+
+    public void addBulkEmailUser(String subjectID, BulkEmailStatus bulkEmailStatus) {
+        PutItemRequest request =
+                PutItemRequest.builder()
+                        .tableName(BULK_EMAIL_USERS_TABLE)
+                        .item(
+                                Map.of(
+                                        SUBJECT_ID_FIELD,
+                                        AttributeValue.fromS(subjectID),
+                                        BULK_EMAIL_STATUS_FIELD,
+                                        AttributeValue.fromS(bulkEmailStatus.toString())))
+                        .build();
+
+        dynamoDB.putItem(request);
+    }
+}

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/BulkEmailUsersExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/BulkEmailUsersExtension.java
@@ -13,9 +13,6 @@ import software.amazon.awssdk.services.dynamodb.model.ProjectionType;
 import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
 import uk.gov.di.authentication.shared.entity.BulkEmailStatus;
-import uk.gov.di.authentication.shared.services.BulkEmailUsersService;
-import uk.gov.di.authentication.shared.services.ConfigurationService;
-import uk.gov.di.authentication.sharedtest.basetest.DynamoTestConfiguration;
 
 import java.util.Map;
 
@@ -27,19 +24,8 @@ public class BulkEmailUsersExtension extends DynamoExtension implements AfterEac
 
     public static final String BULK_EMAIL_USERS_TABLE = "local-bulk-email-users";
 
-    private BulkEmailUsersService dynamoService;
-    private final ConfigurationService configuration;
-
     public BulkEmailUsersExtension() {
         createInstance();
-        this.configuration = new DynamoTestConfiguration(REGION, ENVIRONMENT, DYNAMO_ENDPOINT) {};
-        dynamoService = new BulkEmailUsersService(configuration);
-    }
-
-    @Override
-    public void beforeAll(ExtensionContext context) throws Exception {
-        super.beforeAll(context);
-        dynamoService = new BulkEmailUsersService(configuration);
     }
 
     @Override

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/BulkEmailStatus.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/BulkEmailStatus.java
@@ -1,0 +1,19 @@
+package uk.gov.di.authentication.shared.entity;
+
+public enum BulkEmailStatus {
+    PENDING("PENDING"),
+    EMAIL_SENT("EMAIL_SENT"),
+    ACCOUNT_NOT_FOUND("ACCOUNT_NOT_FOUND"),
+    ERROR_SENDING_EMAIL("ERROR_SENDING_EMAIL"),
+    TERMS_ACCEPTED_RECENTLY("TERMS_ACCEPTED_RECENTLY");
+
+    private String value;
+
+    BulkEmailStatus(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/BulkEmailUser.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/BulkEmailUser.java
@@ -1,0 +1,43 @@
+package uk.gov.di.authentication.shared.entity;
+
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbAttribute;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+
+@DynamoDbBean
+public class BulkEmailUser {
+
+    private String subjectID;
+    private BulkEmailStatus bulkEmailStatus;
+
+    public BulkEmailUser() {}
+
+    @DynamoDbPartitionKey
+    @DynamoDbAttribute("SubjectID")
+    public String getSubjectID() {
+        return subjectID;
+    }
+
+    public void setSubjectID(String subjectID) {
+        this.subjectID = subjectID;
+    }
+
+    public BulkEmailUser withSubjectID(String subjectID) {
+        this.subjectID = subjectID;
+        return this;
+    }
+
+    @DynamoDbAttribute("BulkEmailStatus")
+    public BulkEmailStatus getBulkEmailStatus() {
+        return bulkEmailStatus;
+    }
+
+    public void setBulkEmailStatus(BulkEmailStatus bulkEmailStatus) {
+        this.bulkEmailStatus = bulkEmailStatus;
+    }
+
+    public BulkEmailUser withBulkEmailStatus(BulkEmailStatus bulkEmailStatus) {
+        this.bulkEmailStatus = bulkEmailStatus;
+        return this;
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/BulkEmailUsersService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/BulkEmailUsersService.java
@@ -14,7 +14,7 @@ import java.util.stream.Collectors;
 
 public class BulkEmailUsersService extends BaseDynamoService<BulkEmailUser> {
 
-    public static ConfigurationService configurationService;
+    private final ConfigurationService configurationService;
 
     private static final String BULK_EMAIL_USERS_TABLE = "bulk-email-users";
     private static final String BULK_EMAIL_STATUS_INDEX = "BulkEmailStatusIndex";

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/BulkEmailUsersService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/BulkEmailUsersService.java
@@ -1,0 +1,74 @@
+package uk.gov.di.authentication.shared.services;
+
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.ComparisonOperator;
+import software.amazon.awssdk.services.dynamodb.model.Condition;
+import software.amazon.awssdk.services.dynamodb.model.QueryRequest;
+import uk.gov.di.authentication.shared.entity.BulkEmailStatus;
+import uk.gov.di.authentication.shared.entity.BulkEmailUser;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class BulkEmailUsersService extends BaseDynamoService<BulkEmailUser> {
+
+    public static ConfigurationService configurationService;
+
+    private static final String BULK_EMAIL_USERS_TABLE = "bulk-email-users";
+    private static final String BULK_EMAIL_STATUS_INDEX = "BulkEmailStatusIndex";
+    private static final String BULK_EMAIL_STATUS_FIELD = "BulkEmailStatus";
+    private static final String SUBJECT_ID_FIELD = "SubjectID";
+
+    public BulkEmailUsersService(ConfigurationService configurationService) {
+        super(BulkEmailUser.class, BULK_EMAIL_USERS_TABLE, configurationService);
+        this.configurationService = configurationService;
+    }
+
+    public Optional<BulkEmailUser> getBulkEmailUsers(String subjectID) {
+        return get(subjectID);
+    }
+
+    public Optional<BulkEmailUser> updateUserStatus(
+            String subjectID, BulkEmailStatus bulkEmailStatus) {
+        return getBulkEmailUsers(subjectID)
+                .map(
+                        user -> {
+                            user.withBulkEmailStatus(bulkEmailStatus);
+                            update(user);
+                            return user;
+                        });
+    }
+
+    public List<String> getNSubjectIdsByStatus(Integer limit, BulkEmailStatus bulkEmailStatus) {
+        Condition equalsBulkEmailStatus =
+                Condition.builder()
+                        .comparisonOperator(ComparisonOperator.EQ)
+                        .attributeValueList(
+                                AttributeValue.builder().s(bulkEmailStatus.toString()).build())
+                        .build();
+
+        QueryRequest queryRequest =
+                QueryRequest.builder()
+                        .tableName(
+                                configurationService.getEnvironment()
+                                        + "-"
+                                        + BULK_EMAIL_USERS_TABLE)
+                        .keyConditions(Map.of(BULK_EMAIL_STATUS_FIELD, equalsBulkEmailStatus))
+                        .indexName(BULK_EMAIL_STATUS_INDEX)
+                        .limit(limit)
+                        .build();
+
+        var queryItems = query(queryRequest).items().stream();
+
+        return queryItems
+                .flatMap(
+                        item ->
+                                item
+                                        .get(SUBJECT_ID_FIELD)
+                                        .getValueForField("S", String.class)
+                                        .stream())
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
## What?

Adds bulk email users table and interface for retrieving and modifying data within it.

Includes:
* Terraform to create a new table.
* Test extension to create and test the table locally.
* Service with data access methods.
* Integration test to test the service

## Why?

As part of sending a bulk email to update on terms and conditions, we need a new DynamoDB table to store all subject ids and their status (whether we've sent the email already or not).

