### PR TITLE
AUT-1544 - Add RP Client ID and Sector Host to secure Auth request to Orchestration

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/OrchestrationToAuthenticationAuthorizeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/OrchestrationToAuthenticationAuthorizeIntegrationTest.java
@@ -55,6 +55,7 @@ class OrchestrationToAuthenticationAuthorizeIntegrationTest
     private static final String CLIENT_ID = "gfdsfdsf7s323hfsd";
     private static final String CLIENT_NAME = "test-client";
     private static final String AUTH_INTERNAL_CLIENT_ID = "authentication-orch-client-id";
+    private static final String RP_SECTOR_URI = "https://rp-sector-uri.com";
     private static final String RP_REDIRECT_URI = "https://rp-uri/redirect";
     private static final String ORCHESTRATION_REDIRECT_URI = "https://orchestration/redirect";
     private static final KeyPair KEY_PAIR = KeyPairHelper.GENERATE_RSA_KEY_PAIR();
@@ -261,6 +262,8 @@ class OrchestrationToAuthenticationAuthorizeIntegrationTest
         assertTrue(Objects.nonNull(signedJWT.getJWTClaimsSet().getClaim("consent_required")));
         assertTrue(Objects.nonNull(signedJWT.getJWTClaimsSet().getClaim("is_one_login_service")));
         assertTrue(Objects.nonNull(signedJWT.getJWTClaimsSet().getClaim("service_type")));
+        assertTrue(Objects.nonNull(signedJWT.getJWTClaimsSet().getClaim("rp_client_id")));
+        assertTrue(Objects.nonNull(signedJWT.getJWTClaimsSet().getClaim("rp_sector_host")));
         assertTrue(
                 Objects.nonNull(signedJWT.getJWTClaimsSet().getClaim("govuk_signin_journey_id")));
         assertTrue(Objects.nonNull(signedJWT.getJWTClaimsSet().getClaim("confidence")));
@@ -292,6 +295,10 @@ class OrchestrationToAuthenticationAuthorizeIntegrationTest
         assertThat(
                 signedJWT.getJWTClaimsSet().getClaim("redirect_uri"),
                 equalTo(ORCHESTRATION_REDIRECT_URI));
+        assertThat(signedJWT.getJWTClaimsSet().getClaim("rp_client_id"), equalTo(CLIENT_ID));
+        assertThat(
+                signedJWT.getJWTClaimsSet().getClaim("rp_sector_host"),
+                equalTo("rp-sector-uri.com"));
         assertThat(signedJWT.getHeader().getAlgorithm(), equalTo(JWSAlgorithm.ES256));
         var scope = Scope.parse((String) signedJWT.getJWTClaimsSet().getClaim("scope"));
         var expectedSentScopes = new Scope(OPENID, EMAIL, PHONE);
@@ -314,7 +321,7 @@ class OrchestrationToAuthenticationAuthorizeIntegrationTest
                 singletonList("https://localhost/post-redirect-logout"),
                 "https://example.com",
                 String.valueOf(ServiceType.MANDATORY),
-                "https://test.com",
+                RP_SECTOR_URI,
                 "public",
                 false,
                 ClientType.WEB,

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -33,6 +33,7 @@ import uk.gov.di.authentication.shared.entity.CustomScopeValue;
 import uk.gov.di.authentication.shared.entity.ResponseHeaders;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.ValidScopes;
+import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.CookieHelper;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
@@ -342,6 +343,9 @@ public class AuthorisationHandler
         if (configurationService.isAuthOrchSplitEnabled()) {
             var jwtID = IdGenerator.generate();
             var expiryDate = NowHelper.nowPlus(3, ChronoUnit.MINUTES);
+            var rpSectorIdentifierHost =
+                    ClientSubjectHelper.getSectorIdentifierForClient(
+                            client, configurationService.getInternalSectorUri());
             var claimsBuilder =
                     new JWTClaimsSet.Builder()
                             .issuer(configurationService.getOrchestrationClientId())
@@ -350,6 +354,8 @@ public class AuthorisationHandler
                             .issueTime(NowHelper.now())
                             .notBeforeTime(NowHelper.now())
                             .jwtID(jwtID)
+                            .claim("rp_client_id", client.getClientID())
+                            .claim("rp_sector_host", rpSectorIdentifierHost)
                             .claim("client_name", client.getClientName())
                             .claim("cookie_consent_shared", client.isCookieConsentShared())
                             .claim("consent_required", client.isConsentRequired())


### PR DESCRIPTION
## What?

- Add RP Client ID and Sector Host to secure Auth request to Orchestration

## Why?

- The RP client ID is needed by Authentication for auditing purposes
- The RP sector host is required to calculate the RP pairwise ID which will be returned in the Authenticaiton userinfo response

