### PR TITLE
AUT-1443: Add bulk email sending lambda

### DIFF
--- a/ci/terraform/utils/production-overrides.tfvars
+++ b/ci/terraform/utils/production-overrides.tfvars
@@ -5,3 +5,7 @@ logging_endpoint_arns = [
 ]
 
 shared_state_bucket = "digital-identity-prod-tfstate"
+
+notify_template_map = {
+  TERMS_AND_CONDITIONS_BULK_EMAIL_TEMPLATE_ID = "173418a1-c442-4c4b-a6d1-d23f473f3dd0"
+}

--- a/ci/terraform/utils/variables.tf
+++ b/ci/terraform/utils/variables.tf
@@ -66,3 +66,10 @@ variable "terms_and_conditions" {
   default     = "1.6"
   description = "The latest Terms and Conditions version number"
 }
+
+variable "notify_template_map" {
+  type = map(string)
+  default = {
+    TERMS_AND_CONDITIONS_BULK_EMAIL_TEMPLATE_ID = "067548f2-420d-4da9-923f-ec9a941706cf"
+  }
+}

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoServiceIntegrationTest.java
@@ -12,19 +12,18 @@ import uk.gov.di.authentication.shared.entity.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.ValidScopes;
-import uk.gov.di.authentication.shared.exceptions.UserNotFoundBySubjectIdRuntimeException;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.sharedtest.extensions.UserStoreExtension;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import static java.util.Collections.emptyList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class DynamoServiceIntegrationTest {
 
@@ -308,23 +307,31 @@ class DynamoServiceIntegrationTest {
     void shouldRetrieveUserProfileBySubjectId() {
         setupDynamoWithMultipleUsers();
 
-        assertThat(dynamoService.getUserProfileFromSubject("1111").getEmail(), equalTo("email1"));
-        assertThat(dynamoService.getUserProfileFromSubject("2222").getEmail(), equalTo("email2"));
-        assertThat(dynamoService.getUserProfileFromSubject("3333").getEmail(), equalTo("email3"));
-        assertThat(dynamoService.getUserProfileFromSubject("4444").getEmail(), equalTo("email4"));
-        assertThat(dynamoService.getUserProfileFromSubject("5555").getEmail(), equalTo("email5"));
+        assertThat(
+                dynamoService.getOptionalUserProfileFromSubject("1111").get().getEmail(),
+                equalTo("email1"));
+        assertThat(
+                dynamoService.getOptionalUserProfileFromSubject("2222").get().getEmail(),
+                equalTo("email2"));
+        assertThat(
+                dynamoService.getOptionalUserProfileFromSubject("3333").get().getEmail(),
+                equalTo("email3"));
+        assertThat(
+                dynamoService.getOptionalUserProfileFromSubject("4444").get().getEmail(),
+                equalTo("email4"));
+        assertThat(
+                dynamoService.getOptionalUserProfileFromSubject("5555").get().getEmail(),
+                equalTo("email5"));
     }
 
     @Test
     void shouldThrowWhenUserNotFoundBySubjectId() {
         setupDynamoWithMultipleUsers();
 
-        assertThrows(
-                UserNotFoundBySubjectIdRuntimeException.class,
-                () -> dynamoService.getUserProfileFromSubject("7777"));
-        assertThrows(
-                UserNotFoundBySubjectIdRuntimeException.class,
-                () -> dynamoService.getUserProfileFromSubject("8888"));
+        assertThat(
+                dynamoService.getOptionalUserProfileFromSubject("7777"), equalTo(Optional.empty()));
+        assertThat(
+                dynamoService.getOptionalUserProfileFromSubject("8888"), equalTo(Optional.empty()));
     }
 
     private void setupDynamoWithMultipleUsers() {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/utils/BulkUserEmailSenderScheduledEventHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/utils/BulkUserEmailSenderScheduledEventHandlerIntegrationTest.java
@@ -86,6 +86,11 @@ public class BulkUserEmailSenderScheduledEventHandlerIntegrationTest
                     public int getBulkUserEmailMaxBatchCount() {
                         return 4;
                     }
+
+                    @Override
+                    public boolean isBulkUserEmailEmailSendingEnabled() {
+                        return true;
+                    }
                 };
         handler = new BulkUserEmailSenderScheduledEventHandler(configuration);
         bulkEmailUsersService = new BulkEmailUsersService(configuration);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/utils/BulkUserEmailSenderScheduledEventHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/utils/BulkUserEmailSenderScheduledEventHandlerIntegrationTest.java
@@ -1,0 +1,203 @@
+package uk.gov.di.authentication.utils;
+
+import com.amazonaws.services.lambda.runtime.events.ScheduledEvent;
+import com.google.gson.JsonElement;
+import com.nimbusds.oauth2.sdk.id.Subject;
+import org.apache.commons.codec.binary.Hex;
+import org.apache.http.client.utils.URIBuilder;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.di.authentication.shared.entity.BulkEmailStatus;
+import uk.gov.di.authentication.shared.serialization.Json;
+import uk.gov.di.authentication.shared.services.BulkEmailUsersService;
+import uk.gov.di.authentication.shared.services.SerializationService;
+import uk.gov.di.authentication.sharedtest.basetest.HandlerIntegrationTest;
+import uk.gov.di.authentication.sharedtest.extensions.BulkEmailUsersExtension;
+import uk.gov.di.authentication.sharedtest.extensions.NotifyStubExtension;
+import uk.gov.di.authentication.utils.lambda.BulkUserEmailSenderScheduledEventHandler;
+
+import java.security.SecureRandom;
+import java.util.List;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static uk.gov.di.authentication.sharedtest.matchers.JsonMatcher.hasFieldWithValue;
+
+public class BulkUserEmailSenderScheduledEventHandlerIntegrationTest
+        extends HandlerIntegrationTest<ScheduledEvent, Void> {
+
+    @RegisterExtension
+    protected static final BulkEmailUsersExtension bulkEmailUsersExtension =
+            new BulkEmailUsersExtension();
+
+    @RegisterExtension
+    public static final NotifyStubExtension notifyStub =
+            new NotifyStubExtension(SerializationService.getInstance());
+
+    private BulkEmailUsersService bulkEmailUsersService;
+
+    @BeforeEach
+    void setup() {
+        notifyStub.init();
+        var configuration =
+                new IntegrationTestConfigurationService(
+                        auditTopic,
+                        notificationsQueue,
+                        auditSigningKey,
+                        tokenSigner,
+                        ipvPrivateKeyJwtSigner,
+                        spotQueue,
+                        docAppPrivateKeyJwtSigner,
+                        configurationParameters) {
+
+                    @Override
+                    public String getTxmaAuditQueueUrl() {
+                        return txmaAuditQueue.getQueueUrl();
+                    }
+
+                    @Override
+                    public Optional<String> getNotifyApiUrl() {
+                        return Optional.of(
+                                new URIBuilder()
+                                        .setHost("localhost")
+                                        .setPort(notifyStub.getHttpPort())
+                                        .setScheme("http")
+                                        .toString());
+                    }
+
+                    @Override
+                    public String getNotifyApiKey() {
+                        byte[] bytes = new byte[36];
+                        new SecureRandom().nextBytes(bytes);
+                        return Hex.encodeHexString(bytes);
+                    }
+
+                    @Override
+                    public int getBulkUserEmailBatchQueryLimit() {
+                        return 3;
+                    }
+
+                    @Override
+                    public int getBulkUserEmailMaxBatchCount() {
+                        return 4;
+                    }
+                };
+        handler = new BulkUserEmailSenderScheduledEventHandler(configuration);
+        bulkEmailUsersService = new BulkEmailUsersService(configuration);
+    }
+
+    @AfterEach
+    void resetStub() {
+        notifyStub.reset();
+    }
+
+    @Test
+    void shouldSendSingleEmailWhenSinglePendingUserAndUpdateStatus() throws Json.JsonException {
+        bulkEmailUsersExtension.addBulkEmailUser("1", BulkEmailStatus.PENDING);
+        userStore.signUp("user.1@account.gov.uk", "password123", new Subject("1"));
+
+        makeRequest();
+
+        var request = notifyStub.waitForRequest(60);
+        var noOfStatusEmailSent =
+                bulkEmailUsersService.getNSubjectIdsByStatus(10, BulkEmailStatus.EMAIL_SENT).size();
+
+        assertThat(request, hasFieldWithValue("email_address", equalTo("user.1@account.gov.uk")));
+        assertThat(noOfStatusEmailSent, equalTo(1));
+    }
+
+    @Test
+    void shouldSendCorrectNoOfEmailsForListOfUsersWithVariousStatusAndUpdateStatus()
+            throws Json.JsonException {
+        setupDynamo();
+        makeRequest();
+
+        var emailsSent = notifyStub.waitForNumberOfRequests(60, 8);
+
+        assertThat(
+                bulkEmailUsersService.getNSubjectIdsByStatus(10, BulkEmailStatus.EMAIL_SENT).size(),
+                equalTo(9));
+        assertThat(
+                bulkEmailUsersService
+                        .getNSubjectIdsByStatus(10, BulkEmailStatus.ERROR_SENDING_EMAIL)
+                        .size(),
+                equalTo(1));
+        assertThat(emailsSent.size(), equalTo(8));
+        assertEmailNotSentTo(emailsSent, "user.email.sent.alreadt@account.gov.uk");
+        assertEmailNotSentTo(emailsSent, "user.error.sending@account.gov.uk");
+    }
+
+    @Test
+    void shouldSendCorrectNoOfEmailsAndUpdateStatusWhenTwoUsersHaveNoCorrespondingAccount()
+            throws Json.JsonException {
+        setupDynamo();
+        bulkEmailUsersExtension.addBulkEmailUser("11", BulkEmailStatus.PENDING);
+        bulkEmailUsersExtension.addBulkEmailUser("12", BulkEmailStatus.PENDING);
+
+        makeRequest();
+
+        var emailsSent = notifyStub.waitForNumberOfRequests(60, 8);
+
+        assertThat(
+                bulkEmailUsersService.getNSubjectIdsByStatus(15, BulkEmailStatus.EMAIL_SENT).size(),
+                equalTo(9));
+        assertThat(
+                bulkEmailUsersService
+                        .getNSubjectIdsByStatus(15, BulkEmailStatus.ACCOUNT_NOT_FOUND)
+                        .size(),
+                equalTo(2));
+        assertThat(emailsSent.size(), equalTo(8));
+        assertEmailNotSentTo(emailsSent, "user.email.sent.already@account.gov.uk");
+        assertEmailNotSentTo(emailsSent, "user.error.sending@account.gov.uk");
+    }
+
+    void assertEmailNotSentTo(List<JsonElement> emailsSent, String email) {
+        emailsSent.forEach(
+                e -> assertThat(e, hasFieldWithValue("email_address", not(equalTo(email)))));
+    }
+
+    private void setupDynamo() {
+        bulkEmailUsersExtension.addBulkEmailUser("1", BulkEmailStatus.PENDING);
+        bulkEmailUsersExtension.addBulkEmailUser("2", BulkEmailStatus.PENDING);
+        bulkEmailUsersExtension.addBulkEmailUser("3", BulkEmailStatus.EMAIL_SENT);
+        bulkEmailUsersExtension.addBulkEmailUser("4", BulkEmailStatus.PENDING);
+        bulkEmailUsersExtension.addBulkEmailUser("5", BulkEmailStatus.PENDING);
+        bulkEmailUsersExtension.addBulkEmailUser("6", BulkEmailStatus.ERROR_SENDING_EMAIL);
+        bulkEmailUsersExtension.addBulkEmailUser("7", BulkEmailStatus.PENDING);
+        bulkEmailUsersExtension.addBulkEmailUser("8", BulkEmailStatus.PENDING);
+        bulkEmailUsersExtension.addBulkEmailUser("9", BulkEmailStatus.PENDING);
+        bulkEmailUsersExtension.addBulkEmailUser("10", BulkEmailStatus.PENDING);
+
+        userStore.signUp("user.1@account.gov.uk", "password123", new Subject("1"));
+        userStore.signUp("user.2@account.gov.uk", "password123", new Subject("2"));
+        userStore.signUp("user.email.sent.already@account.gov.uk", "password123", new Subject("3"));
+        userStore.signUp("user.4@account.gov.uk", "password123", new Subject("4"));
+        userStore.signUp("user.5@account.gov.uk", "password123", new Subject("5"));
+        userStore.signUp("user.error.sending@account.gov.uk", "password123", new Subject("6"));
+        userStore.signUp("user.7@account.gov.uk", "password123", new Subject("7"));
+        userStore.signUp("user.8@account.gov.uk", "password123", new Subject("8"));
+        userStore.signUp("user.9@account.gov.uk", "password123", new Subject("9"));
+        userStore.signUp("user.10@account.gov.uk", "password123", new Subject("10"));
+    }
+
+    private void makeRequest() {
+        ScheduledEvent scheduledEvent =
+                new ScheduledEvent()
+                        .withAccount("12345678")
+                        .withRegion("eu-west-2")
+                        .withDetailType("Scheduled Event")
+                        .withSource("aws.events")
+                        .withId("abcd-1234-defg-5678")
+                        .withTime(DateTime.now())
+                        .withResources(
+                                List.of(
+                                        "arn:aws:events:eu-west-2:12345678:rule/email-scheduled-campaign-rule"));
+
+        handler.handleRequest(scheduledEvent, context);
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/NotificationType.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/NotificationType.java
@@ -44,7 +44,9 @@ public enum NotificationType implements TemplateAware {
             Map.of(
                     SupportedLanguage.CY,
                     "CHANGE_HOW_GET_SECURITY_CODES_CONFIRMATION_TEMPLATE_ID_CY"),
-            MFAMethodType.NONE);
+            MFAMethodType.NONE),
+    TERMS_AND_CONDITIONS_BULK_EMAIL(
+            "TERMS_AND_CONDITIONS_BULK_EMAIL_TEMPLATE_ID", MFAMethodType.NONE);
 
     private final String templateName;
     private final MFAMethodType mfaMethodType;

--- a/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/UserNotFoundBySubjectIdRuntimeException.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/UserNotFoundBySubjectIdRuntimeException.java
@@ -1,0 +1,8 @@
+package uk.gov.di.authentication.shared.exceptions;
+
+public class UserNotFoundBySubjectIdRuntimeException extends RuntimeException {
+
+    public UserNotFoundBySubjectIdRuntimeException(String message) {
+        super(message);
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/UserNotFoundBySubjectIdRuntimeException.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/UserNotFoundBySubjectIdRuntimeException.java
@@ -1,8 +1,0 @@
-package uk.gov.di.authentication.shared.exceptions;
-
-public class UserNotFoundBySubjectIdRuntimeException extends RuntimeException {
-
-    public UserNotFoundBySubjectIdRuntimeException(String message) {
-        super(message);
-    }
-}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -138,6 +138,12 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return System.getenv().getOrDefault("SUPPORT_ACCESS_TOKEN_STORE", "false").equals("true");
     }
 
+    public boolean isBulkUserEmailEmailSendingEnabled() {
+        return System.getenv()
+                .getOrDefault("BULK_USER_EMAIL_EMAIL_SENDING_ENABLED", "false")
+                .equals("true");
+    }
+
     public String getContactUsLinkRoute() {
         return System.getenv().getOrDefault("CONTACT_US_LINK_ROUTE", "");
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -81,6 +81,21 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return Long.parseLong(System.getenv().getOrDefault("BLOCKED_EMAIL_DURATION", "900"));
     }
 
+    public int getBulkUserEmailBatchQueryLimit() {
+        return Integer.parseInt(
+                System.getenv().getOrDefault("BULK_USER_EMAIL_BATCH_QUERY_LIMIT", "25"));
+    }
+
+    public int getBulkUserEmailMaxBatchCount() {
+        return Integer.parseInt(
+                System.getenv().getOrDefault("BULK_USER_EMAIL_MAX_BATCH_COUNT", "8000"));
+    }
+
+    public long getBulkUserEmailBatchPauseDuration() {
+        return Long.parseLong(
+                System.getenv().getOrDefault("BULK_USER_EMAIL_BATCH_PAUSE_DURATION", "0"));
+    }
+
     public long getDefaultOtpCodeExpiry() {
         return Long.parseLong(System.getenv().getOrDefault("DEFAULT_OTP_CODE_EXPIRY", "900"));
     }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -88,7 +88,7 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
 
     public int getBulkUserEmailMaxBatchCount() {
         return Integer.parseInt(
-                System.getenv().getOrDefault("BULK_USER_EMAIL_MAX_BATCH_COUNT", "8000"));
+                System.getenv().getOrDefault("BULK_USER_EMAIL_MAX_BATCH_COUNT", "20"));
     }
 
     public long getBulkUserEmailBatchPauseDuration() {

--- a/utils/build.gradle
+++ b/utils/build.gradle
@@ -12,6 +12,7 @@ dependencies {
             configurations.dynamodb
 
     implementation project(":shared"),
+            configurations.govuk_notify,
             configurations.nimbus,
             configurations.xray
 

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailSenderScheduledEventHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailSenderScheduledEventHandler.java
@@ -1,0 +1,142 @@
+package uk.gov.di.authentication.utils.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.ScheduledEvent;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.shared.entity.BulkEmailStatus;
+import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.exceptions.UserNotFoundBySubjectIdRuntimeException;
+import uk.gov.di.authentication.shared.helpers.LocaleHelper;
+import uk.gov.di.authentication.shared.serialization.Json;
+import uk.gov.di.authentication.shared.services.BulkEmailUsersService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.DynamoService;
+import uk.gov.di.authentication.shared.services.NotificationService;
+import uk.gov.di.authentication.shared.services.SerializationService;
+import uk.gov.service.notify.NotificationClient;
+import uk.gov.service.notify.NotificationClientException;
+
+import java.util.List;
+import java.util.Map;
+
+import static uk.gov.di.authentication.shared.entity.NotificationType.TERMS_AND_CONDITIONS_BULK_EMAIL;
+
+public class BulkUserEmailSenderScheduledEventHandler
+        implements RequestHandler<ScheduledEvent, Void> {
+
+    private static final Logger LOG =
+            LogManager.getLogger(BulkUserEmailSenderScheduledEventHandler.class);
+
+    private final BulkEmailUsersService bulkEmailUsersService;
+
+    private final DynamoService dynamoService;
+
+    private final NotificationService notificationService;
+
+    private final ConfigurationService configurationService;
+
+    protected final Json objectMapper = SerializationService.getInstance();
+
+    public BulkUserEmailSenderScheduledEventHandler() {
+        this(ConfigurationService.getInstance());
+    }
+
+    public BulkUserEmailSenderScheduledEventHandler(
+            BulkEmailUsersService bulkEmailUsersService,
+            DynamoService dynamoService,
+            ConfigurationService configurationService,
+            NotificationService notificationService) {
+        this.bulkEmailUsersService = bulkEmailUsersService;
+        this.dynamoService = dynamoService;
+        this.configurationService = configurationService;
+        this.notificationService = notificationService;
+    }
+
+    public BulkUserEmailSenderScheduledEventHandler(ConfigurationService configurationService) {
+        this.configurationService = configurationService;
+        this.bulkEmailUsersService = new BulkEmailUsersService(configurationService);
+        this.dynamoService = new DynamoService(configurationService);
+        NotificationClient client =
+                configurationService
+                        .getNotifyApiUrl()
+                        .map(
+                                url ->
+                                        new NotificationClient(
+                                                configurationService.getNotifyApiKey(), url))
+                        .orElse(new NotificationClient(configurationService.getNotifyApiKey()));
+        this.notificationService = new NotificationService(client, configurationService);
+    }
+
+    @Override
+    public Void handleRequest(ScheduledEvent event, Context context) {
+
+        LOG.info("Bulk User Email Send has been triggered.");
+        final int bulkUserEmailBatchQueryLimit =
+                configurationService.getBulkUserEmailBatchQueryLimit();
+        final int bulkUserEmailMaxBatchCount = configurationService.getBulkUserEmailMaxBatchCount();
+        final long bulkUserEmailBatchPauseDuration =
+                configurationService.getBulkUserEmailBatchPauseDuration();
+        List<String> userSubjectIdBatch;
+
+        int batchCounter = 0;
+        do {
+            batchCounter++;
+            userSubjectIdBatch =
+                    bulkEmailUsersService.getNSubjectIdsByStatus(
+                            bulkUserEmailBatchQueryLimit, BulkEmailStatus.PENDING);
+
+            LOG.info(
+                    "Retrieved user subject ids for batch no: {} no of users: {}",
+                    batchCounter,
+                    userSubjectIdBatch.size());
+
+            userSubjectIdBatch.forEach(
+                    subjectId -> {
+                        try {
+                            UserProfile userProfile =
+                                    dynamoService.getUserProfileFromSubject(subjectId);
+                            sendNotifyEmail(userProfile.getEmail());
+                            updateBulkUserStatus(subjectId, BulkEmailStatus.EMAIL_SENT);
+                        } catch (NotificationClientException e) {
+                            LOG.error("Unable to send bulk email to user: {}", e.getMessage());
+                            updateBulkUserStatus(subjectId, BulkEmailStatus.ERROR_SENDING_EMAIL);
+                        } catch (UserNotFoundBySubjectIdRuntimeException e) {
+                            LOG.warn("User not found by subject id");
+                            updateBulkUserStatus(subjectId, BulkEmailStatus.ACCOUNT_NOT_FOUND);
+                        }
+                    });
+
+            try {
+                if (bulkUserEmailBatchPauseDuration > 0) {
+                    LOG.info(
+                            "Bulk user email batch pausing for: {}ms",
+                            bulkUserEmailBatchPauseDuration);
+                    Thread.sleep(bulkUserEmailBatchPauseDuration);
+                    LOG.info("Bulk user email batch pause complete.");
+                }
+            } catch (InterruptedException e) {
+                LOG.warn("Thread sleep for bulk user email batch pause interrupted.");
+            }
+        } while (!userSubjectIdBatch.isEmpty() && batchCounter < bulkUserEmailMaxBatchCount);
+
+        return null;
+    }
+
+    private void sendNotifyEmail(String email) throws NotificationClientException {
+        notificationService.sendEmail(
+                email,
+                Map.of(),
+                TERMS_AND_CONDITIONS_BULK_EMAIL,
+                LocaleHelper.SupportedLanguage.EN);
+    }
+
+    private void updateBulkUserStatus(String subjectId, BulkEmailStatus bulkEmailStatus) {
+        if (bulkEmailUsersService.updateUserStatus(subjectId, bulkEmailStatus).isPresent()) {
+            LOG.info("Bulk email user status updated to: {}", bulkEmailStatus.getValue());
+        } else {
+            LOG.warn("Bulk user email status not updated, user not found.");
+        }
+    }
+}

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailSenderScheduledEventHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailSenderScheduledEventHandler.java
@@ -133,11 +133,16 @@ public class BulkUserEmailSenderScheduledEventHandler
     }
 
     private void sendNotifyEmail(String email) throws NotificationClientException {
-        notificationService.sendEmail(
-                email,
-                Map.of(),
-                TERMS_AND_CONDITIONS_BULK_EMAIL,
-                LocaleHelper.SupportedLanguage.EN);
+        if (configurationService.isBulkUserEmailEmailSendingEnabled()) {
+            LOG.info("Bulk user email sending email.");
+            notificationService.sendEmail(
+                    email,
+                    Map.of(),
+                    TERMS_AND_CONDITIONS_BULK_EMAIL,
+                    LocaleHelper.SupportedLanguage.EN);
+        } else {
+            LOG.info("Bulk user email email sending not enabled.");
+        }
     }
 
     private void updateBulkUserStatus(String subjectId, BulkEmailStatus bulkEmailStatus) {

--- a/utils/src/test/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailSenderScheduledEventHandlerTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailSenderScheduledEventHandlerTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.shared.entity.BulkEmailStatus;
 import uk.gov.di.authentication.shared.entity.BulkEmailUser;
 import uk.gov.di.authentication.shared.entity.UserProfile;
-import uk.gov.di.authentication.shared.exceptions.UserNotFoundBySubjectIdRuntimeException;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper;
 import uk.gov.di.authentication.shared.services.BulkEmailUsersService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -75,8 +74,8 @@ class BulkUserEmailSenderScheduledEventHandlerTest {
         when(configurationService.getBulkUserEmailBatchPauseDuration()).thenReturn(1L);
         when(bulkEmailUsersService.getNSubjectIdsByStatus(1, BulkEmailStatus.PENDING))
                 .thenReturn(List.of(SUBJECT_ID));
-        when(dynamoService.getUserProfileFromSubject(SUBJECT_ID))
-                .thenReturn(new UserProfile().withEmail(EMAIL));
+        when(dynamoService.getOptionalUserProfileFromSubject(SUBJECT_ID))
+                .thenReturn(Optional.of(new UserProfile().withEmail(EMAIL)));
         when(bulkEmailUsersService.updateUserStatus(SUBJECT_ID, BulkEmailStatus.EMAIL_SENT))
                 .thenReturn(
                         Optional.of(
@@ -104,8 +103,8 @@ class BulkUserEmailSenderScheduledEventHandlerTest {
         when(bulkEmailUsersService.getNSubjectIdsByStatus(5, BulkEmailStatus.PENDING))
                 .thenReturn(Arrays.asList(TEST_SUBJECT_IDS));
         for (int i = 0; i < TEST_SUBJECT_IDS.length; i++) {
-            when(dynamoService.getUserProfileFromSubject(TEST_SUBJECT_IDS[i]))
-                    .thenReturn(new UserProfile().withEmail(TEST_EMAILS[i]));
+            when(dynamoService.getOptionalUserProfileFromSubject(TEST_SUBJECT_IDS[i]))
+                    .thenReturn(Optional.of(new UserProfile().withEmail(TEST_EMAILS[i])));
             when(bulkEmailUsersService.updateUserStatus(
                             TEST_SUBJECT_IDS[i], BulkEmailStatus.EMAIL_SENT))
                     .thenReturn(
@@ -136,8 +135,8 @@ class BulkUserEmailSenderScheduledEventHandlerTest {
         when(configurationService.getBulkUserEmailMaxBatchCount()).thenReturn(1);
         when(bulkEmailUsersService.getNSubjectIdsByStatus(1, BulkEmailStatus.PENDING))
                 .thenReturn(List.of(SUBJECT_ID));
-        when(dynamoService.getUserProfileFromSubject(SUBJECT_ID))
-                .thenThrow(new UserNotFoundBySubjectIdRuntimeException("User not found"));
+        when(dynamoService.getOptionalUserProfileFromSubject(SUBJECT_ID))
+                .thenReturn(Optional.empty());
         when(bulkEmailUsersService.updateUserStatus(SUBJECT_ID, BulkEmailStatus.ACCOUNT_NOT_FOUND))
                 .thenReturn(
                         Optional.of(
@@ -164,8 +163,8 @@ class BulkUserEmailSenderScheduledEventHandlerTest {
         when(configurationService.getBulkUserEmailMaxBatchCount()).thenReturn(1);
         when(bulkEmailUsersService.getNSubjectIdsByStatus(1, BulkEmailStatus.PENDING))
                 .thenReturn(List.of(SUBJECT_ID));
-        when(dynamoService.getUserProfileFromSubject(SUBJECT_ID))
-                .thenReturn(new UserProfile().withEmail(EMAIL));
+        when(dynamoService.getOptionalUserProfileFromSubject(SUBJECT_ID))
+                .thenReturn(Optional.of(new UserProfile().withEmail(EMAIL)));
         doThrow(NotificationClientException.class)
                 .when(notificationService)
                 .sendEmail(

--- a/utils/src/test/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailSenderScheduledEventHandlerTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailSenderScheduledEventHandlerTest.java
@@ -1,0 +1,195 @@
+package uk.gov.di.authentication.utils.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.ScheduledEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.entity.BulkEmailStatus;
+import uk.gov.di.authentication.shared.entity.BulkEmailUser;
+import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.exceptions.UserNotFoundBySubjectIdRuntimeException;
+import uk.gov.di.authentication.shared.helpers.LocaleHelper;
+import uk.gov.di.authentication.shared.services.BulkEmailUsersService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.DynamoService;
+import uk.gov.di.authentication.shared.services.NotificationService;
+import uk.gov.service.notify.NotificationClientException;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.shared.entity.NotificationType.TERMS_AND_CONDITIONS_BULK_EMAIL;
+
+class BulkUserEmailSenderScheduledEventHandlerTest {
+
+    private BulkUserEmailSenderScheduledEventHandler bulkUserEmailSenderScheduledEventHandler;
+
+    private final Context mockContext = mock(Context.class);
+
+    private final BulkEmailUsersService bulkEmailUsersService = mock(BulkEmailUsersService.class);
+
+    private final DynamoService dynamoService = mock(DynamoService.class);
+
+    private final NotificationService notificationService = mock(NotificationService.class);
+
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+
+    private final ScheduledEvent scheduledEvent = mock(ScheduledEvent.class);
+
+    private final String SUBJECT_ID = "subject-id";
+    private final String EMAIL = "user@account.gov.uk";
+
+    private final String[] TEST_EMAILS = {
+        "user.1@account.gov.uk",
+        "user.2@account.gov.uk",
+        "user.3@account.gov.uk",
+        "user.4@account.gov.uk",
+        "user.5@account.gov.uk"
+    };
+    private final String[] TEST_SUBJECT_IDS = {
+        "subject-id-1", "subject-id-2", "subject-id-3", "subject-id-4", "subject-id-5",
+    };
+
+    @BeforeEach
+    void setUp() {
+        bulkUserEmailSenderScheduledEventHandler =
+                new BulkUserEmailSenderScheduledEventHandler(
+                        bulkEmailUsersService,
+                        dynamoService,
+                        configurationService,
+                        notificationService);
+    }
+
+    @Test
+    void shouldSendSingleBatchOfSingleEmailAndUpdateStatusToEmailSent()
+            throws NotificationClientException {
+        when(configurationService.getBulkUserEmailBatchQueryLimit()).thenReturn(1);
+        when(configurationService.getBulkUserEmailMaxBatchCount()).thenReturn(1);
+        when(configurationService.getBulkUserEmailBatchPauseDuration()).thenReturn(1L);
+        when(bulkEmailUsersService.getNSubjectIdsByStatus(1, BulkEmailStatus.PENDING))
+                .thenReturn(List.of(SUBJECT_ID));
+        when(dynamoService.getUserProfileFromSubject(SUBJECT_ID))
+                .thenReturn(new UserProfile().withEmail(EMAIL));
+        when(bulkEmailUsersService.updateUserStatus(SUBJECT_ID, BulkEmailStatus.EMAIL_SENT))
+                .thenReturn(
+                        Optional.of(
+                                new BulkEmailUser()
+                                        .withBulkEmailStatus(BulkEmailStatus.EMAIL_SENT)
+                                        .withSubjectID(SUBJECT_ID)));
+
+        bulkUserEmailSenderScheduledEventHandler.handleRequest(scheduledEvent, mockContext);
+
+        verify(notificationService, times(1))
+                .sendEmail(
+                        EMAIL,
+                        Map.of(),
+                        TERMS_AND_CONDITIONS_BULK_EMAIL,
+                        LocaleHelper.SupportedLanguage.EN);
+        verify(bulkEmailUsersService, times(1))
+                .updateUserStatus(SUBJECT_ID, BulkEmailStatus.EMAIL_SENT);
+    }
+
+    @Test
+    void shouldSendSingleBatchOfEmailsAndUpdateStatusToEmailSent()
+            throws NotificationClientException {
+        when(configurationService.getBulkUserEmailBatchQueryLimit()).thenReturn(5);
+        when(configurationService.getBulkUserEmailMaxBatchCount()).thenReturn(1);
+        when(bulkEmailUsersService.getNSubjectIdsByStatus(5, BulkEmailStatus.PENDING))
+                .thenReturn(Arrays.asList(TEST_SUBJECT_IDS));
+        for (int i = 0; i < TEST_SUBJECT_IDS.length; i++) {
+            when(dynamoService.getUserProfileFromSubject(TEST_SUBJECT_IDS[i]))
+                    .thenReturn(new UserProfile().withEmail(TEST_EMAILS[i]));
+            when(bulkEmailUsersService.updateUserStatus(
+                            TEST_SUBJECT_IDS[i], BulkEmailStatus.EMAIL_SENT))
+                    .thenReturn(
+                            Optional.of(
+                                    new BulkEmailUser()
+                                            .withBulkEmailStatus(BulkEmailStatus.EMAIL_SENT)
+                                            .withSubjectID(TEST_SUBJECT_IDS[i])));
+        }
+
+        bulkUserEmailSenderScheduledEventHandler.handleRequest(scheduledEvent, mockContext);
+
+        for (int j = 0; j < TEST_EMAILS.length; j++) {
+            verify(notificationService, times(1))
+                    .sendEmail(
+                            TEST_EMAILS[j],
+                            Map.of(),
+                            TERMS_AND_CONDITIONS_BULK_EMAIL,
+                            LocaleHelper.SupportedLanguage.EN);
+            verify(bulkEmailUsersService, times(1))
+                    .updateUserStatus(TEST_SUBJECT_IDS[j], BulkEmailStatus.EMAIL_SENT);
+        }
+    }
+
+    @Test
+    void shouldNotSendSingleEmailAndUpdateStatusToAccountNotFoundWhenNoUserProfileForSubjectId()
+            throws NotificationClientException {
+        when(configurationService.getBulkUserEmailBatchQueryLimit()).thenReturn(1);
+        when(configurationService.getBulkUserEmailMaxBatchCount()).thenReturn(1);
+        when(bulkEmailUsersService.getNSubjectIdsByStatus(1, BulkEmailStatus.PENDING))
+                .thenReturn(List.of(SUBJECT_ID));
+        when(dynamoService.getUserProfileFromSubject(SUBJECT_ID))
+                .thenThrow(new UserNotFoundBySubjectIdRuntimeException("User not found"));
+        when(bulkEmailUsersService.updateUserStatus(SUBJECT_ID, BulkEmailStatus.ACCOUNT_NOT_FOUND))
+                .thenReturn(
+                        Optional.of(
+                                new BulkEmailUser()
+                                        .withBulkEmailStatus(BulkEmailStatus.ACCOUNT_NOT_FOUND)
+                                        .withSubjectID(SUBJECT_ID)));
+
+        bulkUserEmailSenderScheduledEventHandler.handleRequest(scheduledEvent, mockContext);
+
+        verify(notificationService, times(0))
+                .sendEmail(
+                        EMAIL,
+                        Map.of(),
+                        TERMS_AND_CONDITIONS_BULK_EMAIL,
+                        LocaleHelper.SupportedLanguage.EN);
+        verify(bulkEmailUsersService, times(1))
+                .updateUserStatus(SUBJECT_ID, BulkEmailStatus.ACCOUNT_NOT_FOUND);
+    }
+
+    @Test
+    void shouldNotSendSingleEmailAndUpdateStatusToErrorWhenNotifySendEmailFails()
+            throws NotificationClientException {
+        when(configurationService.getBulkUserEmailBatchQueryLimit()).thenReturn(1);
+        when(configurationService.getBulkUserEmailMaxBatchCount()).thenReturn(1);
+        when(bulkEmailUsersService.getNSubjectIdsByStatus(1, BulkEmailStatus.PENDING))
+                .thenReturn(List.of(SUBJECT_ID));
+        when(dynamoService.getUserProfileFromSubject(SUBJECT_ID))
+                .thenReturn(new UserProfile().withEmail(EMAIL));
+        doThrow(NotificationClientException.class)
+                .when(notificationService)
+                .sendEmail(
+                        EMAIL,
+                        Map.of(),
+                        TERMS_AND_CONDITIONS_BULK_EMAIL,
+                        LocaleHelper.SupportedLanguage.EN);
+        when(bulkEmailUsersService.updateUserStatus(
+                        SUBJECT_ID, BulkEmailStatus.ERROR_SENDING_EMAIL))
+                .thenReturn(
+                        Optional.of(
+                                new BulkEmailUser()
+                                        .withBulkEmailStatus(BulkEmailStatus.ERROR_SENDING_EMAIL)
+                                        .withSubjectID(SUBJECT_ID)));
+
+        bulkUserEmailSenderScheduledEventHandler.handleRequest(scheduledEvent, mockContext);
+
+        verify(notificationService, times(1))
+                .sendEmail(
+                        EMAIL,
+                        Map.of(),
+                        TERMS_AND_CONDITIONS_BULK_EMAIL,
+                        LocaleHelper.SupportedLanguage.EN);
+        verify(bulkEmailUsersService, times(1))
+                .updateUserStatus(SUBJECT_ID, BulkEmailStatus.ERROR_SENDING_EMAIL);
+    }
+}


### PR DESCRIPTION
## What?

Add bulk email sending lambda

Lambda triggered by a cloudwatch scheduled event which reads the contents of the bulk-user-email table, retrieves the email corresponding to the subject id, sends an email to the user, then updates the status for the user email in the table.

The table is read and the emails are sent in batches with a configurable size.  After a batch has been processed sending can be paused (sleeped) for a configurable period in order to throttle email sending if required.

Includes unit and integration tests for the handler.

'getUserProfileFromSubject' in the DynamoService has been updated to throw an exception when a user is not found by subject id.

This PR only adds the code for the lambda handler and tests it.  Infrastructure to deploy the handler will follow.

## Why?

We want to be able to bulk email a specific template to a controlled audience of users.

## Related PRs

#3219 