### PR TITLE
AUT-1546: Handle 404 responses received from DCMAW

### DIFF
--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/services/DocAppCriService.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/services/DocAppCriService.java
@@ -119,11 +119,13 @@ public class DocAppCriService {
                 count++;
                 response = request.send();
             } while (!response.indicatesSuccess() && count < maxTries);
+
             if (!response.indicatesSuccess()) {
                 throw new UnsuccessfulCredentialResponseException(
                         format(
                                 "Error %s when attempting to call CRI data endpoint: %s",
-                                response.getStatusCode(), response.getContent()));
+                                response.getStatusCode(), response.getContent()),
+                        response.getStatusCode());
             }
 
             if (!response.getContentAsJSONObject().get("sub").equals(docAppSubjectId)

--- a/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/UnsuccessfulCredentialResponseException.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/UnsuccessfulCredentialResponseException.java
@@ -1,11 +1,25 @@
 package uk.gov.di.authentication.shared.exceptions;
 
 public class UnsuccessfulCredentialResponseException extends Exception {
+
+    private final int httpCode;
+
     public UnsuccessfulCredentialResponseException(String message) {
         super(message);
+        this.httpCode = 0;
+    }
+
+    public UnsuccessfulCredentialResponseException(String message, int code) {
+        super(message);
+        this.httpCode = code;
     }
 
     public UnsuccessfulCredentialResponseException(String message, Throwable cause) {
         super(message, cause);
+        this.httpCode = 0;
+    }
+
+    public int getHttpCode() {
+        return httpCode;
     }
 }


### PR DESCRIPTION
## What?

In situation that DCMAW `/userinfo` endpoint responds with HTTP 404, DocAppCallbackHandler returns HTTP 302 to HMRC with redirect URI containing `error="access_denied"`, `error_description="Not found"`

## Why?

Current functionality is to redirect to frontend error page on any error response (including 404) from `/userinfo` endpoint.

