### PR TITLE
AUT-1471: Add read_secrets.sh script to the utils component

### DIFF
--- a/ci/terraform/utils/read_secrets.sh
+++ b/ci/terraform/utils/read_secrets.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+ENVIRONMENT=$1
+
+if [ "$ENVIRONMENT" = "dev" ]; then
+	ENVIRONMENT="build";
+fi
+
+secrets=$(aws secretsmanager list-secrets --filter Key="name",Values="/deploy/$ENVIRONMENT/" --region eu-west-2 | jq -c '.SecretList[]')
+
+for i in $secrets; do
+  arn=$(echo $i | jq -r '.ARN')
+  name=$(echo $i | jq -r '.Name | split("/") | last')
+  value=$(aws secretsmanager get-secret-value --secret-id $arn | jq -r '.SecretString')
+  VAR=(TF_VAR_$name=$value)
+  export $VAR
+done

--- a/deploy-sandpit.sh
+++ b/deploy-sandpit.sh
@@ -91,6 +91,9 @@ while [[ $# -gt 0 ]]; do
     -p|--prompt)
       TERRAFORM_OPTS=""
       ;;
+    -r|--refresh)
+      TERRAFORM_OPTS="-refresh-only"
+      ;;
     -x|--auth-external)
       AUTH_EXTERNAL_API=1
       ;;


### PR DESCRIPTION

## What?

Add read_secrets.sh script to the utils component.

## Why?

Build is failing as terraform variables not being read from secrets.

`Error: No value for required variable`

## Related PRs

#3227 
