### PR TITLE
BAU: Increase JVM memory for build in Github actions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=-Xmx2g -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8


### PR DESCRIPTION
## What?
- Increase JVM memory for build in Github actions

## Why?
- We are getting an out of memory error
