### PR TITLE
BAU - Exclude shared-test directory from Sonar code coverage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -347,6 +347,7 @@ sonarqube {
         property "sonar.projectKey", "alphagov_di-authentication-api"
         property "sonar.organization", "alphagov"
         property "sonar.host.url", "https://sonarcloud.io"
+        property "sonar.exclusions", "shared-test/*"
     }
 }
 


### PR DESCRIPTION
## What?

 - Exclude shared-test directory from Sonar code coverage

## Why?

- As these classes are only used for the purpose of tests, they should not be included as part of the code coverage stats
