### PR TITLE
BAU: Remove MaxPermSize gradle properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-org.gradle.jvmargs=-Xmx2g -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx2g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8


### PR DESCRIPTION
## What?
- Remove MaxPermSize from Gradle properties

## Why?
- I introduced this in error when trying to increase JVM memory
- The -Xmx2g was to increase JVM heap memory
- However MaxPermSize refers to PermGen which was replaced in Java 8 by Metaspace (which cannot be controlled directly by such settings)

## Related PRs
- Adjusts this PR: https://github.com/alphagov/di-authentication-api/pull/3233
