### PR TITLE
AUT-1401: Increase WAF rate limit of OIDC API for staging evironment

### DIFF
--- a/ci/terraform/oidc/api-gateway.tf
+++ b/ci/terraform/oidc/api-gateway.tf
@@ -318,7 +318,7 @@ resource "aws_wafv2_web_acl" "wafregional_web_acl_oidc_api" {
     name     = "${var.environment}-oidc-waf-rate-based-rule"
     statement {
       rate_based_statement {
-        limit              = 3600
+        limit              = var.environment == "staging" ? 600000 : 3600
         aggregate_key_type = "IP"
       }
     }


### PR DESCRIPTION
## What?

Increase WAF rate limit of OIDC API for staging environment, from 3600 requests per 5 minutes to 600,000 requests per 5 minutes (equivalent to 2000 requests per second).

## Why?

To prevent hitting the WAF rate limit (and requests failing with 403 response) when doing performance testing.
