### PR TITLE
AUT-1567: Bulk user email audience loader lambda

### DIFF
--- a/ci/terraform/utils/bulk_user_email_audience_loader_dynamo_access.tf
+++ b/ci/terraform/utils/bulk_user_email_audience_loader_dynamo_access.tf
@@ -1,4 +1,4 @@
-data "aws_iam_policy_document" "bulk_user_email_send_dynamo_write_access" {
+data "aws_iam_policy_document" "bulk_user_email_audience_loader_dynamo_write_access" {
   count = local.deploy_bulk_email_users_count
   statement {
     sid    = "AllowAccessToDynamoTables"
@@ -17,16 +17,16 @@ data "aws_iam_policy_document" "bulk_user_email_send_dynamo_write_access" {
   }
 }
 
-resource "aws_iam_policy" "bulk_user_email_send_dynamo_write_access" {
+resource "aws_iam_policy" "bulk_user_email_audience_loader_dynamo_write_access" {
   count       = local.deploy_bulk_email_users_count
   name_prefix = "dynamo-access-policy"
   description = "IAM policy managing write access for the Bulk User Email Send lambda to the Dynamo Bulk Email Users table"
 
-  policy = data.aws_iam_policy_document.bulk_user_email_send_dynamo_write_access[0].json
+  policy = data.aws_iam_policy_document.bulk_user_email_audience_loader_dynamo_write_access[0].json
 }
 
 
-data "aws_iam_policy_document" "bulk_user_email_send_dynamo_read_access" {
+data "aws_iam_policy_document" "bulk_user_email_audience_loader_dynamo_read_access" {
   count = local.deploy_bulk_email_users_count
   statement {
     sid    = "AllowAccessToDynamoTables"
@@ -50,10 +50,10 @@ data "aws_iam_policy_document" "bulk_user_email_send_dynamo_read_access" {
   }
 }
 
-resource "aws_iam_policy" "bulk_user_email_send_dynamo_read_access" {
+resource "aws_iam_policy" "bulk_user_email_audience_loader_dynamo_read_access" {
   count       = local.deploy_bulk_email_users_count
   name_prefix = "dynamo-access-policy"
   description = "IAM policy managing read access for the Bulk User Email Send lambda to the Dynamo User Profile table"
 
-  policy = data.aws_iam_policy_document.bulk_user_email_send_dynamo_read_access[0].json
+  policy = data.aws_iam_policy_document.bulk_user_email_audience_loader_dynamo_read_access[0].json
 }

--- a/ci/terraform/utils/bulk_user_email_audience_loader_lambda.tf
+++ b/ci/terraform/utils/bulk_user_email_audience_loader_lambda.tf
@@ -41,9 +41,9 @@ resource "aws_lambda_function" "bulk_user_email_audience_loader_lambda" {
 
   environment {
     variables = merge(var.notify_template_map, {
-      ENVIRONMENT                       = var.environment
-      BULK_USER_EMAIL_BATCH_QUERY_LIMIT = var.bulk_user_email_batch_query_limit
-      BULK_USER_EMAIL_MAX_BATCH_COUNT   = var.bulk_user_email_max_batch_count
+      ENVIRONMENT                                  = var.environment
+      BULK_USER_EMAIL_BATCH_QUERY_LIMIT            = var.bulk_user_email_batch_query_limit
+      BULK_USER_EMAIL_MAX_AUDIENCE_LOAD_USER_COUNT = var.bulk_user_email_max_audience_load_user_count
     })
   }
 

--- a/ci/terraform/utils/bulk_user_email_audience_loader_lambda.tf
+++ b/ci/terraform/utils/bulk_user_email_audience_loader_lambda.tf
@@ -1,0 +1,99 @@
+
+module "bulk_user_email_audience_loader_lambda_role" {
+  count       = local.deploy_bulk_email_users_count
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "bulk-user-email-audience-loader-lambda-role"
+  vpc_arn     = local.authentication_vpc_arn
+
+  policies_to_attach = [
+    aws_iam_policy.bulk_user_email_audience_loader_dynamo_read_access[0].arn,
+    aws_iam_policy.bulk_user_email_audience_loader_dynamo_write_access[0].arn,
+    aws_iam_policy.bulk_user_email_dynamo_encryption_key_kms_policy[0].arn,
+  ]
+}
+
+resource "aws_lambda_function" "bulk_user_email_audience_loader_lambda" {
+  count                          = local.deploy_bulk_email_users_count
+  function_name                  = "${var.environment}-bulk-user-email-audience-loader-lambda"
+  role                           = module.bulk_user_email_audience_loader_lambda_role[0].arn
+  handler                        = "uk.gov.di.authentication.utils.lambda.BulkUserEmailAudienceLoaderScheduledEventHandler::handleRequest"
+  timeout                        = lookup(var.performance_tuning, "bulk-user-email-audience-loader", local.default_performance_parameters).timeout
+  memory_size                    = lookup(var.performance_tuning, "bulk-user-email-audience-loader", local.default_performance_parameters).memory
+  reserved_concurrent_executions = 1
+  runtime                        = "java11"
+  tracing_config {
+    mode = "Active"
+  }
+  publish = true
+
+  s3_bucket         = aws_s3_object.utils_release_zip.bucket
+  s3_key            = aws_s3_object.utils_release_zip.key
+  s3_object_version = aws_s3_object.utils_release_zip.version_id
+
+  kms_key_arn             = local.lambda_env_vars_encryption_kms_key_arn
+  code_signing_config_arn = local.lambda_code_signing_configuration_arn
+
+  vpc_config {
+    security_group_ids = [local.authentication_security_group_id]
+    subnet_ids         = local.authentication_subnet_ids
+  }
+
+  environment {
+    variables = merge(var.notify_template_map, {
+      ENVIRONMENT                       = var.environment
+      BULK_USER_EMAIL_BATCH_QUERY_LIMIT = var.bulk_user_email_batch_query_limit
+      BULK_USER_EMAIL_MAX_BATCH_COUNT   = var.bulk_user_email_max_batch_count
+    })
+  }
+
+  tags = local.default_tags
+  # checkov:skip=CKV_AWS_116:Adding a DLQ would not be useful as the events cannot be replayed.
+}
+
+
+resource "aws_cloudwatch_log_group" "bulk_user_email_audience_loader_lambda_log_group" {
+  count = local.deploy_bulk_email_users_count
+
+  name              = "/aws/lambda/${aws_lambda_function.bulk_user_email_audience_loader_lambda[0].function_name}"
+  kms_key_id        = local.cloudwatch_encryption_key_arn
+  retention_in_days = var.cloudwatch_log_retention
+
+  tags = local.default_tags
+  # checkov:skip=CKV_AWS_338:Log retention policy is currently 5d not 1 year. To be reviewed.
+}
+
+resource "aws_cloudwatch_log_subscription_filter" "bulk_user_email_audience_loader_log_subscription" {
+  count           = local.deploy_bulk_email_users_count > 0 ? length(var.logging_endpoint_arns) : 0
+  name            = "${aws_lambda_function.bulk_user_email_audience_loader_lambda[0].function_name}-log-subscription-${count.index}"
+  log_group_name  = aws_cloudwatch_log_group.bulk_user_email_audience_loader_lambda_log_group[0].name
+  filter_pattern  = ""
+  destination_arn = var.logging_endpoint_arns[count.index]
+
+  lifecycle {
+    create_before_destroy = false
+  }
+}
+
+resource "aws_cloudwatch_event_rule" "bulk_user_email_audience_loader_schedule" {
+  count               = local.deploy_bulk_email_users_count
+  name                = "${var.environment}-bulk-user-email-audience-loader-schedule"
+  is_enabled          = var.bulk_user_email_audience_loader_schedule_enabled
+  schedule_expression = var.bulk_user_email_audience_loader_schedule_expression
+}
+
+resource "aws_cloudwatch_event_target" "bulk_user_email_audience_loader_schedule_target" {
+  count     = local.deploy_bulk_email_users_count
+  arn       = aws_lambda_function.bulk_user_email_audience_loader_lambda[0].arn
+  rule      = aws_cloudwatch_event_rule.bulk_user_email_audience_loader_schedule[0].name
+  target_id = aws_lambda_function.bulk_user_email_audience_loader_lambda[0].version
+}
+
+resource "aws_lambda_permission" "allow_cloudwatch_to_call_bulk_user_email_audience_loader_lambda" {
+  count         = local.deploy_bulk_email_users_count
+  statement_id  = "AllowExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.bulk_user_email_audience_loader_lambda[0].function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.bulk_user_email_audience_loader_schedule[0].arn
+}

--- a/ci/terraform/utils/bulk_user_email_dynamodb.tf
+++ b/ci/terraform/utils/bulk_user_email_dynamodb.tf
@@ -1,0 +1,36 @@
+
+data "aws_dynamodb_table" "bulk_email_users_table" {
+  count = local.deploy_bulk_email_users_count
+  name  = "${var.environment}-bulk-email-users"
+}
+
+data "aws_dynamodb_table" "user_profile_table" {
+  count = local.deploy_bulk_email_users_count
+  name  = "${var.environment}-user-profile"
+}
+
+data "aws_iam_policy_document" "bulk_user_email_dynamo_encryption_key_policy_document" {
+  count = local.deploy_bulk_email_users_count
+  statement {
+    sid    = "AllowAccessToBulkUserEmailTableKmsEncryptionKey"
+    effect = "Allow"
+
+    actions = [
+      "kms:Encrypt*",
+      "kms:Decrypt*",
+      "kms:GetPublicKey"
+    ]
+    resources = [
+      local.bulk_user_email_table_encryption_key_arn,
+    ]
+  }
+}
+
+resource "aws_iam_policy" "bulk_user_email_dynamo_encryption_key_kms_policy" {
+  count       = local.deploy_bulk_email_users_count
+  name        = "${var.environment}-bulk-user-email-table-encryption-key-kms-policy"
+  path        = "/"
+  description = "IAM policy for managing KMS encryption of the bulk user email table"
+
+  policy = data.aws_iam_policy_document.bulk_user_email_dynamo_encryption_key_policy_document[0].json
+}

--- a/ci/terraform/utils/bulk_user_email_send_lambda.tf
+++ b/ci/terraform/utils/bulk_user_email_send_lambda.tf
@@ -9,7 +9,7 @@ module "bulk_user_email_send_lambda_role" {
   policies_to_attach = [
     aws_iam_policy.bulk_user_email_send_dynamo_read_access[0].arn,
     aws_iam_policy.bulk_user_email_send_dynamo_write_access[0].arn,
-    aws_iam_policy.bulk_user_email_send_dynamo_encryption_key_kms_policy[0].arn,
+    aws_iam_policy.bulk_user_email_dynamo_encryption_key_kms_policy[0].arn,
   ]
 }
 

--- a/ci/terraform/utils/variables.tf
+++ b/ci/terraform/utils/variables.tf
@@ -111,7 +111,17 @@ variable "bulk_user_email_send_schedule_enabled" {
 
 variable "bulk_user_email_send_schedule_expression" {
   type    = string
-  default = "cron(0 15 ? * MON-FRI *)"
+  default = "cron(0 15 ? * MON-FRI 2049)"
+}
+
+variable "bulk_user_email_audience_loader_schedule_enabled" {
+  type    = bool
+  default = false
+}
+
+variable "bulk_user_email_audience_loader_schedule_expression" {
+  type    = string
+  default = "cron(0 13 ? * MON-FRI 2049)"
 }
 
 variable "txma_account_id" {

--- a/ci/terraform/utils/variables.tf
+++ b/ci/terraform/utils/variables.tf
@@ -99,6 +99,11 @@ variable "bulk_user_email_batch_pause_duration" {
   default = null
 }
 
+variable "bulk_user_email_max_audience_load_user_count" {
+  type    = number
+  default = null
+}
+
 variable "bulk_user_email_email_sending_enabled" {
   type    = string
   default = "false"

--- a/ci/terraform/utils/variables.tf
+++ b/ci/terraform/utils/variables.tf
@@ -115,8 +115,9 @@ variable "bulk_user_email_send_schedule_enabled" {
 }
 
 variable "bulk_user_email_send_schedule_expression" {
-  type    = string
-  default = "cron(0 15 ? * MON-FRI 2049)"
+  type        = string
+  description = "Run at 15:00 every Friday in 2049.  Designed not to trigger, replace with desired expression."
+  default     = "cron(0 15 ? * FRI 2049)"
 }
 
 variable "bulk_user_email_audience_loader_schedule_enabled" {
@@ -125,8 +126,9 @@ variable "bulk_user_email_audience_loader_schedule_enabled" {
 }
 
 variable "bulk_user_email_audience_loader_schedule_expression" {
-  type    = string
-  default = "cron(0 13 ? * MON-FRI 2049)"
+  type        = string
+  description = "Run at 15:00 every Friday in 2049.  Designed not to trigger, replace with desired expression."
+  default     = "cron(0 13 ? * FRI 2049)"
 }
 
 variable "txma_account_id" {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/utils/BulkUserEmailAudienceLoaderScheduledEventHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/utils/BulkUserEmailAudienceLoaderScheduledEventHandlerIntegrationTest.java
@@ -21,7 +21,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class BulkUserEmailAudienceLoaderScheduledEventHandlerIntegrationTest
+class BulkUserEmailAudienceLoaderScheduledEventHandlerIntegrationTest
         extends HandlerIntegrationTest<ScheduledEvent, Void> {
 
     @RegisterExtension

--- a/integration-tests/src/test/java/uk/gov/di/authentication/utils/BulkUserEmailAudienceLoaderScheduledEventHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/utils/BulkUserEmailAudienceLoaderScheduledEventHandlerIntegrationTest.java
@@ -1,0 +1,122 @@
+package uk.gov.di.authentication.utils;
+
+import com.amazonaws.services.lambda.runtime.events.ScheduledEvent;
+import com.nimbusds.oauth2.sdk.id.Subject;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.di.authentication.shared.entity.BulkEmailStatus;
+import uk.gov.di.authentication.shared.serialization.Json;
+import uk.gov.di.authentication.shared.services.BulkEmailUsersService;
+import uk.gov.di.authentication.sharedtest.basetest.HandlerIntegrationTest;
+import uk.gov.di.authentication.sharedtest.extensions.BulkEmailUsersExtension;
+import uk.gov.di.authentication.utils.lambda.BulkUserEmailAudienceLoaderScheduledEventHandler;
+
+import java.util.List;
+import java.util.Map;
+
+import static java.lang.String.format;
+import static java.lang.String.valueOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class BulkUserEmailAudienceLoaderScheduledEventHandlerIntegrationTest
+        extends HandlerIntegrationTest<ScheduledEvent, Void> {
+
+    @RegisterExtension
+    protected static final BulkEmailUsersExtension bulkEmailUsersExtension =
+            new BulkEmailUsersExtension();
+
+    private BulkEmailUsersService bulkEmailUsersService;
+
+    @BeforeEach
+    void setup() {
+        var configuration =
+                new IntegrationTestConfigurationService(
+                        auditTopic,
+                        notificationsQueue,
+                        auditSigningKey,
+                        tokenSigner,
+                        ipvPrivateKeyJwtSigner,
+                        spotQueue,
+                        docAppPrivateKeyJwtSigner,
+                        configurationParameters) {
+
+                    @Override
+                    public String getTxmaAuditQueueUrl() {
+                        return txmaAuditQueue.getQueueUrl();
+                    }
+
+                    @Override
+                    public int getBulkUserEmailBatchQueryLimit() {
+                        return 3;
+                    }
+
+                    @Override
+                    public int getBulkUserEmailMaxBatchCount() {
+                        return 4;
+                    }
+
+                    @Override
+                    public boolean isBulkUserEmailEmailSendingEnabled() {
+                        return true;
+                    }
+                };
+        handler = new BulkUserEmailAudienceLoaderScheduledEventHandler(configuration);
+        bulkEmailUsersService = new BulkEmailUsersService(configuration);
+    }
+
+    @Test
+    void shouldLoadSingleUserFromUserProfile() throws Json.JsonException {
+
+        userStore.signUp("user.1@account.gov.uk", "password123", new Subject("1"));
+
+        makeRequest();
+
+        var usersLoaded = bulkEmailUsersService.getNSubjectIdsByStatus(10, BulkEmailStatus.PENDING);
+
+        assertThat(usersLoaded.get(0), equalTo("1"));
+        assertThat(usersLoaded.size(), equalTo(1));
+    }
+
+    @Test
+    void shouldLoadMultipleUsersFromUserProfile() {
+        final int numberOfUsers = 15;
+        setupDynamo(numberOfUsers);
+        makeRequest();
+
+        var usersLoaded =
+                bulkEmailUsersService.getNSubjectIdsByStatus(
+                        numberOfUsers, BulkEmailStatus.PENDING);
+
+        assertThat(usersLoaded.size(), equalTo(numberOfUsers));
+        for (int i = 1; i <= usersLoaded.size(); i++) {
+            assertTrue(usersLoaded.contains(valueOf(i)));
+        }
+    }
+
+    private void setupDynamo(int numberOfUsers) {
+        for (int i = 1; i <= numberOfUsers; i++) {
+            userStore.signUp(
+                    format("user.%o@account.gov.uk", i), "password123", new Subject(valueOf(i)));
+        }
+    }
+
+    private void makeRequest() {
+        ScheduledEvent scheduledEvent =
+                new ScheduledEvent()
+                        .withAccount("12345678")
+                        .withRegion("eu-west-2")
+                        .withDetailType("Scheduled Event")
+                        .withSource("aws.events")
+                        .withId("abcd-1234-defg-5678")
+                        .withTime(DateTime.now())
+                        .withResources(
+                                List.of(
+                                        "arn:aws:events:eu-west-2:12345678:rule/email-campaign-audience-load-rule"));
+
+        handler.handleRequest(scheduledEvent, context);
+    }
+}

--- a/integration-tests/src/test/java/uk/gov/di/authentication/utils/BulkUserEmailAudienceLoaderScheduledEventHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/utils/BulkUserEmailAudienceLoaderScheduledEventHandlerIntegrationTest.java
@@ -59,6 +59,11 @@ public class BulkUserEmailAudienceLoaderScheduledEventHandlerIntegrationTest
                     }
 
                     @Override
+                    public long getBulkUserEmailMaxAudienceLoadUserCount() {
+                        return 1000L;
+                    }
+
+                    @Override
                     public boolean isBulkUserEmailEmailSendingEnabled() {
                         return true;
                     }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/utils/BulkUserEmailAudienceLoaderScheduledEventHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/utils/BulkUserEmailAudienceLoaderScheduledEventHandlerIntegrationTest.java
@@ -14,7 +14,6 @@ import uk.gov.di.authentication.sharedtest.extensions.BulkEmailUsersExtension;
 import uk.gov.di.authentication.utils.lambda.BulkUserEmailAudienceLoaderScheduledEventHandler;
 
 import java.util.List;
-import java.util.Map;
 
 import static java.lang.String.format;
 import static java.lang.String.valueOf;

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/BulkEmailUsersService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/BulkEmailUsersService.java
@@ -41,6 +41,10 @@ public class BulkEmailUsersService extends BaseDynamoService<BulkEmailUser> {
                         });
     }
 
+    public void addUser(String subjectID, BulkEmailStatus bulkEmailStatus) {
+        put(new BulkEmailUser().withSubjectID(subjectID).withBulkEmailStatus(bulkEmailStatus));
+    }
+
     public List<String> getNSubjectIdsByStatus(Integer limit, BulkEmailStatus bulkEmailStatus) {
         Condition equalsBulkEmailStatus =
                 Condition.builder()

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -91,6 +91,11 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
                 System.getenv().getOrDefault("BULK_USER_EMAIL_MAX_BATCH_COUNT", "20"));
     }
 
+    public long getBulkUserEmailMaxAudienceLoadUserCount() {
+        return Long.parseLong(
+                System.getenv().getOrDefault("BULK_USER_EMAIL_MAX_AUDIENCE_LOAD_USER_COUNT", "0"));
+    }
+
     public long getBulkUserEmailBatchPauseDuration() {
         return Long.parseLong(
                 System.getenv().getOrDefault("BULK_USER_EMAIL_BATCH_PAUSE_DURATION", "0"));

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
@@ -39,6 +39,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static java.util.Objects.nonNull;
 
@@ -729,6 +730,12 @@ public class DynamoService implements AuthenticationService {
 
             dynamoDbEnhancedClient.transactWriteItems(deleteItemsBatchRequest);
         }
+    }
+
+    public Stream<UserProfile> getBulkUserEmailAudienceStream() {
+        ScanEnhancedRequest scanRequest =
+                ScanEnhancedRequest.builder().addAttributeToProject("SubjectID").build();
+        return dynamoUserProfileTable.scan(scanRequest).items().stream();
     }
 
     private static String hashPassword(String password) {

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailAudienceLoaderScheduledEventHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailAudienceLoaderScheduledEventHandler.java
@@ -1,0 +1,65 @@
+package uk.gov.di.authentication.utils.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.ScheduledEvent;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.shared.entity.BulkEmailStatus;
+import uk.gov.di.authentication.shared.services.BulkEmailUsersService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.DynamoService;
+
+public class BulkUserEmailAudienceLoaderScheduledEventHandler
+        implements RequestHandler<ScheduledEvent, Void> {
+
+    private static final Logger LOG =
+            LogManager.getLogger(BulkUserEmailAudienceLoaderScheduledEventHandler.class);
+
+    private final BulkEmailUsersService bulkEmailUsersService;
+
+    private final DynamoService dynamoService;
+
+    private final ConfigurationService configurationService;
+
+    private long itemCounter = 0;
+
+    public BulkUserEmailAudienceLoaderScheduledEventHandler() {
+        this(ConfigurationService.getInstance());
+    }
+
+    public BulkUserEmailAudienceLoaderScheduledEventHandler(
+            BulkEmailUsersService bulkEmailUsersService,
+            DynamoService dynamoService,
+            ConfigurationService configurationService) {
+        this.bulkEmailUsersService = bulkEmailUsersService;
+        this.dynamoService = dynamoService;
+        this.configurationService = configurationService;
+    }
+
+    public BulkUserEmailAudienceLoaderScheduledEventHandler(
+            ConfigurationService configurationService) {
+        this.configurationService = configurationService;
+        this.bulkEmailUsersService = new BulkEmailUsersService(configurationService);
+        this.dynamoService = new DynamoService(configurationService);
+    }
+
+    @Override
+    public Void handleRequest(ScheduledEvent event, Context context) {
+        LOG.info("Bulk User Email audience load triggered.");
+
+        itemCounter = 0;
+        dynamoService
+                .getBulkUserEmailAudienceStream()
+                .forEach(
+                        userProfile -> {
+                            itemCounter++;
+                            bulkEmailUsersService.addUser(
+                                    userProfile.getSubjectID(), BulkEmailStatus.PENDING);
+                            LOG.info("Bulk User Email added item number: {}", itemCounter);
+                        });
+
+        LOG.info("Bulk User Email audience load complete.  Total users added: {}", itemCounter);
+        return null;
+    }
+}

--- a/utils/src/test/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailAudienceLoaderScheduledEventHandlerTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailAudienceLoaderScheduledEventHandlerTest.java
@@ -1,0 +1,80 @@
+package uk.gov.di.authentication.utils.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.ScheduledEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.entity.BulkEmailStatus;
+import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.services.BulkEmailUsersService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.DynamoService;
+
+import java.util.List;
+
+import static org.mockito.Mockito.*;
+
+class BulkUserEmailAudienceLoaderScheduledEventHandlerTest {
+
+    private BulkUserEmailAudienceLoaderScheduledEventHandler
+            bulkUserEmailAudienceLoaderScheduledEventHandler;
+
+    private final Context mockContext = mock(Context.class);
+
+    private final BulkEmailUsersService bulkEmailUsersService = mock(BulkEmailUsersService.class);
+
+    private final DynamoService dynamoService = mock(DynamoService.class);
+
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+
+    private final ScheduledEvent scheduledEvent = mock(ScheduledEvent.class);
+
+    private final String SUBJECT_ID = "subject-id";
+
+    private final String[] TEST_SUBJECT_IDS = {
+        "subject-id-1", "subject-id-2", "subject-id-3", "subject-id-4", "subject-id-5",
+    };
+
+    @BeforeEach
+    void setUp() {
+        bulkUserEmailAudienceLoaderScheduledEventHandler =
+                new BulkUserEmailAudienceLoaderScheduledEventHandler(
+                        bulkEmailUsersService, dynamoService, configurationService);
+    }
+
+    @Test
+    void shouldAddOneBulkEmailUser() {
+        when(dynamoService.getBulkUserEmailAudienceStream())
+                .thenReturn(List.of(new UserProfile().withSubjectID(SUBJECT_ID)).stream());
+
+        bulkUserEmailAudienceLoaderScheduledEventHandler.handleRequest(scheduledEvent, mockContext);
+
+        verify(bulkEmailUsersService).addUser(SUBJECT_ID, BulkEmailStatus.PENDING);
+    }
+
+    @Test
+    void shouldAddManyBulkEmailUsers() {
+        when(dynamoService.getBulkUserEmailAudienceStream())
+                .thenReturn(
+                        List.of(
+                                new UserProfile().withSubjectID(TEST_SUBJECT_IDS[0]),
+                                new UserProfile().withSubjectID(TEST_SUBJECT_IDS[1]),
+                                new UserProfile().withSubjectID(TEST_SUBJECT_IDS[2]),
+                                new UserProfile().withSubjectID(TEST_SUBJECT_IDS[3]),
+                                new UserProfile().withSubjectID(TEST_SUBJECT_IDS[4]))
+                                .stream());
+
+        bulkUserEmailAudienceLoaderScheduledEventHandler.handleRequest(scheduledEvent, mockContext);
+
+        verify(bulkEmailUsersService, times(1))
+                .addUser(TEST_SUBJECT_IDS[0], BulkEmailStatus.PENDING);
+        verify(bulkEmailUsersService, times(1))
+                .addUser(TEST_SUBJECT_IDS[1], BulkEmailStatus.PENDING);
+        verify(bulkEmailUsersService, times(1))
+                .addUser(TEST_SUBJECT_IDS[2], BulkEmailStatus.PENDING);
+        verify(bulkEmailUsersService, times(1))
+                .addUser(TEST_SUBJECT_IDS[3], BulkEmailStatus.PENDING);
+        verify(bulkEmailUsersService, times(1))
+                .addUser(TEST_SUBJECT_IDS[4], BulkEmailStatus.PENDING);
+    }
+}

--- a/utils/src/test/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailAudienceLoaderScheduledEventHandlerTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailAudienceLoaderScheduledEventHandlerTest.java
@@ -12,7 +12,10 @@ import uk.gov.di.authentication.shared.services.DynamoService;
 
 import java.util.List;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class BulkUserEmailAudienceLoaderScheduledEventHandlerTest {
 


### PR DESCRIPTION
## What?

Bulk user email audience loader lambda.

A new lambda function that when triggered queries the user-profile table to retrieve the required audience for an email campaign, then loads those users in to the bulk-user-email table.

Includes both code and infrastructure, will deploy only to sandpit and build.

This is the first iteration of the loader, subsequent versions will refine the query to return a more specific audience based on a user's terms and conditions version, and potentially the ability to segment loads based on the account creation date so that loads can be split up into several runs rather than one.

This initial version will be used to do some performance testing to see how quickly the loads can take place, then subsequent versions will add improvements and batching if required.

## Why?

We need to create the audience for an email campaign before sending the emails.

## Related PRs

#3227 
#3225
