### PR TITLE
BAU - Add alerting to the bulk sending email Lambda

### DIFF
--- a/ci/terraform/utils/account.tf
+++ b/ci/terraform/utils/account.tf
@@ -1,0 +1,1 @@
+data "aws_iam_account_alias" "current" {}

--- a/ci/terraform/utils/bulk-sending-alerts.tf
+++ b/ci/terraform/utils/bulk-sending-alerts.tf
@@ -1,0 +1,49 @@
+resource "aws_cloudwatch_metric_alarm" "lambda_error_rate_cloudwatch_alarm" {
+  count               = local.deploy_bulk_email_users_count
+  alarm_name          = replace("${var.environment}-bulk-sending-error-rate-alarm", ".", "")
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  threshold           = var.lambda_log_alarm_error_rate_threshold
+  alarm_description   = "Lambda error rate of ${var.lambda_log_alarm_error_rate_threshold} has been reached in the ${aws_lambda_function.bulk_user_email_send_lambda[0].function_name} lambda.ACCOUNT: ${data.aws_iam_account_alias.current.account_alias}"
+
+  metric_query {
+    id          = "e1"
+    return_data = true
+    expression  = "m2/m1*100"
+    label       = "Error Rate"
+  }
+
+  metric_query {
+    id = "m1"
+    metric {
+      namespace   = "AWS/Lambda"
+      metric_name = "Invocations"
+      period      = 900
+      stat        = "Sum"
+      unit        = "Count"
+
+      dimensions = {
+        FunctionName = aws_lambda_function.bulk_user_email_send_lambda[0].function_name
+      }
+    }
+  }
+  metric_query {
+    id = "m2"
+    metric {
+      namespace   = "AWS/Lambda"
+      metric_name = "Errors"
+      period      = 900
+      stat        = "Sum"
+      unit        = "Count"
+
+      dimensions = {
+        FunctionName = aws_lambda_function.bulk_user_email_send_lambda[0].function_name
+      }
+    }
+  }
+  alarm_actions = [data.aws_sns_topic.slack_events.arn]
+}
+
+data "aws_sns_topic" "slack_events" {
+  name = "${var.environment}-slack-events"
+}

--- a/ci/terraform/utils/variables.tf
+++ b/ci/terraform/utils/variables.tf
@@ -127,3 +127,9 @@ variable "performance_tuning" {
   description = "A map of performance tuning parameters per lambda"
   default     = {}
 }
+
+variable "lambda_log_alarm_error_rate_threshold" {
+  type        = number
+  description = "The rate of errors in a lambda before generating a Cloudwatch alarm. Calculated by dividing the number of errors in a lambda divided by the number of invocations in a 15 minute period"
+  default     = 1
+}


### PR DESCRIPTION
## What?

- Add a Cloudwatch alarm to trigger if the error rate of the bulk sending email lambda exceeds 10
- Error rate is calculated by dividing the number of errors in a lambda divided by the number of invocations in a 60 second period
- The output of this alarm will be a slack alert

## Why?

- So we are alerted if there are any issues with the Lambda
