### PR TITLE
BAU - Only increment the logout cloudwatch metric if session is present

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/LogoutHandler.java
@@ -310,7 +310,7 @@ public class LogoutHandler
             Optional<String> clientId,
             Optional<String> sessionId) {
         LOG.info("Generating default Logout Response");
-        cloudwatchMetricsService.incrementLogout(clientId);
+        sessionId.ifPresent(t -> cloudwatchMetricsService.incrementLogout(clientId));
         return generateLogoutResponse(
                 configurationService.getDefaultLogoutURI(),
                 state,

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/LogoutHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/LogoutHandlerTest.java
@@ -361,7 +361,7 @@ class LogoutHandlerTest {
                 equalTo(DEFAULT_LOGOUT_URI + "?state=" + STATE));
         verify(sessionService, times(0)).deleteSessionFromRedis(SESSION_ID);
 
-        verify(cloudwatchMetricsService).incrementLogout(Optional.empty());
+        verifyNoInteractions(cloudwatchMetricsService);
         verify(auditService)
                 .submitAuditEvent(
                         OidcAuditableEvent.LOG_OUT_SUCCESS,


### PR DESCRIPTION
## What?

- Don't increment the logout Cloudwatch metric if either no cookie is present or no session can be found.

## Why?

- This will give us more accurate logout metrics