### PR TITLE
AUT-1249: Add token request validator

### DIFF
--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/validators/TokenRequestValidator.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/validators/TokenRequestValidator.java
@@ -1,0 +1,53 @@
+package uk.gov.di.authentication.external.validators;
+
+import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.OAuth2Error;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class TokenRequestValidator {
+    private final String redirectUri;
+    private final String clientId;
+
+    TokenRequestValidator(String redirectUri, String clientId) {
+        this.redirectUri = redirectUri;
+        this.clientId = clientId;
+    }
+
+    public Optional<ErrorObject> validate(Map<Object, Object> requestParameters) {
+        if (!requestParameters.containsKey("grant_type")) {
+            return invalidRequestCode("Request is missing grant_type parameter");
+        }
+
+        if (!"authorization_code".equals(requestParameters.get("grant_type"))) {
+            return invalidRequestCode("Request has invalid grant_type parameter");
+        }
+
+        if (!requestParameters.containsKey("code") || requestParameters.get("code") == null) {
+            return invalidRequestCode("Request is missing code parameter");
+        }
+
+        if (!requestParameters.containsKey("redirect_uri")) {
+            return invalidRequestCode("Request is missing redirect_uri parameter");
+        }
+
+        if (!redirectUri.equals(requestParameters.get("redirect_uri"))) {
+            return invalidRequestCode("Request redirect_uri is not the permitted redirect_uri");
+        }
+
+        if (!requestParameters.containsKey("client_id")) {
+            return invalidRequestCode("Request is missing client_id parameter");
+        }
+
+        if (!clientId.equals(requestParameters.get("client_id"))) {
+            return invalidRequestCode("Request client_id is not the permitted client_id");
+        }
+
+        return Optional.empty();
+    }
+
+    private static Optional<ErrorObject> invalidRequestCode(String description) {
+        return Optional.of(new ErrorObject(OAuth2Error.INVALID_REQUEST_CODE, description));
+    }
+}

--- a/auth-external-api/src/test/java/uk/gov/di/authentication/external/validators/TokenRequestValidatorTest.java
+++ b/auth-external-api/src/test/java/uk/gov/di/authentication/external/validators/TokenRequestValidatorTest.java
@@ -1,0 +1,125 @@
+package uk.gov.di.authentication.external.validators;
+
+import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.OAuth2Error;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TokenRequestValidatorTest {
+    private static final String VALID_REDIRECT_URI = "https://redirect-uri.co.uk";
+    private static final String VALID_CLIENT_ID = "client-id";
+    private TokenRequestValidator validator =
+            new TokenRequestValidator(VALID_REDIRECT_URI, VALID_CLIENT_ID);
+
+    @Test
+    void shouldReturnInvalidRequestCodeIfGivenNoGrantType() {
+        Optional<ErrorObject> result = validator.validate(Map.of("key", "value"));
+
+        assertEquals(OAuth2Error.INVALID_REQUEST_CODE, result.get().getCode());
+        assertEquals("Request is missing grant_type parameter", result.get().getDescription());
+    }
+
+    @Test
+    void shouldReturnInvalidRequestCodeIfGivenGrantTypeButOfInvalidValue() {
+        Optional<ErrorObject> result = validator.validate(Map.of("grant_type", "value"));
+
+        assertEquals(OAuth2Error.INVALID_REQUEST_CODE, result.get().getCode());
+        assertEquals("Request has invalid grant_type parameter", result.get().getDescription());
+    }
+
+    @Test
+    void shouldReturnInvalidRequestCodeIfGivenValidGrantTypeButNoCode() {
+        Optional<ErrorObject> result =
+                validator.validate(Map.of("grant_type", "authorization_code"));
+
+        assertEquals(OAuth2Error.INVALID_REQUEST_CODE, result.get().getCode());
+        assertEquals("Request is missing code parameter", result.get().getDescription());
+    }
+
+    @Test
+    void shouldReturnInvalidRequestCodeIfGivenValidGrantTypeAndCodeButNoRedirectUri() {
+        Optional<ErrorObject> result =
+                validator.validate(Map.of("grant_type", "authorization_code", "code", "value"));
+
+        assertEquals(OAuth2Error.INVALID_REQUEST_CODE, result.get().getCode());
+        assertEquals("Request is missing redirect_uri parameter", result.get().getDescription());
+    }
+
+    @Test
+    void
+            shouldReturnInvalidRequestCodeIfGivenValidGrantTypeAndCodeAndRedirectUriOtherThanPermittedRedirectUri() {
+        Optional<ErrorObject> result =
+                validator.validate(
+                        Map.of(
+                                "grant_type",
+                                "authorization_code",
+                                "code",
+                                "value",
+                                "redirect_uri",
+                                "value"));
+
+        assertEquals(OAuth2Error.INVALID_REQUEST_CODE, result.get().getCode());
+        assertEquals(
+                "Request redirect_uri is not the permitted redirect_uri",
+                result.get().getDescription());
+    }
+
+    @Test
+    void
+            shouldReturnInvalidRequestCodeIfGivenValidGrantTypeAndCodeAndPermittedRedirectButNoClientId() {
+        Optional<ErrorObject> result =
+                validator.validate(
+                        Map.of(
+                                "grant_type",
+                                "authorization_code",
+                                "code",
+                                "value",
+                                "redirect_uri",
+                                VALID_REDIRECT_URI));
+
+        assertEquals(OAuth2Error.INVALID_REQUEST_CODE, result.get().getCode());
+        assertEquals("Request is missing client_id parameter", result.get().getDescription());
+    }
+
+    @Test
+    void
+            shouldReturnInvalidRequestCodeIfGivenValidGrantTypeAndCodeAndPermittedRedirectButInvalidClientId() {
+        Optional<ErrorObject> result =
+                validator.validate(
+                        Map.of(
+                                "grant_type",
+                                "authorization_code",
+                                "code",
+                                "value",
+                                "redirect_uri",
+                                VALID_REDIRECT_URI,
+                                "client_id",
+                                "value"));
+
+        assertEquals(OAuth2Error.INVALID_REQUEST_CODE, result.get().getCode());
+        assertEquals(
+                "Request client_id is not the permitted client_id", result.get().getDescription());
+    }
+
+    @Test
+    void
+            shouldReturnNoInvalidRequestCodeIfGivenValidGrantTypeAndCodeAndPermittedRedirectUriAndClientId() {
+        Optional<ErrorObject> result =
+                validator.validate(
+                        Map.of(
+                                "grant_type",
+                                "authorization_code",
+                                "code",
+                                "value",
+                                "redirect_uri",
+                                VALID_REDIRECT_URI,
+                                "client_id",
+                                VALID_CLIENT_ID));
+
+        assertEquals(Optional.empty(), result);
+    }
+}


### PR DESCRIPTION
## What?
- Add token request validator

## Why?
- This validator will check for the presence of required fields in requests to the authentication external API token endpoint (does not exist yet)

