### PR TITLE
AUT-1604: Upgrade Terraform AWS provider

### DIFF
--- a/ci/terraform/account-management/authenticate.tf
+++ b/ci/terraform/account-management/authenticate.tf
@@ -39,8 +39,8 @@ module "authenticate" {
   scaling_trigger             = lookup(var.performance_tuning, "authenticate", local.default_performance_parameters).scaling_trigger
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket
-  lambda_zip_file         = aws_s3_bucket_object.account_management_api_release_zip.key
-  lambda_zip_file_version = aws_s3_bucket_object.account_management_api_release_zip.version_id
+  lambda_zip_file         = aws_s3_object.account_management_api_release_zip.key
+  lambda_zip_file_version = aws_s3_object.account_management_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.vpc_arn

--- a/ci/terraform/account-management/authorizer.tf
+++ b/ci/terraform/account-management/authorizer.tf
@@ -26,8 +26,8 @@ resource "aws_lambda_function" "authorizer" {
   runtime       = "java11"
 
   s3_bucket         = aws_s3_bucket.source_bucket.bucket
-  s3_key            = aws_s3_bucket_object.account_management_api_release_zip.key
-  s3_object_version = aws_s3_bucket_object.account_management_api_release_zip.version_id
+  s3_key            = aws_s3_object.account_management_api_release_zip.key
+  s3_object_version = aws_s3_object.account_management_api_release_zip.version_id
 
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 

--- a/ci/terraform/account-management/redis.tf
+++ b/ci/terraform/account-management/redis.tf
@@ -23,18 +23,18 @@ resource "random_password" "redis_password" {
 resource "aws_elasticache_replication_group" "account_management_sessions_store" {
   count = var.use_localstack ? 0 : 1
 
-  automatic_failover_enabled    = true
-  availability_zones            = data.aws_availability_zones.available.names
-  replication_group_id          = "${var.environment}-acct-mgmt-session-store"
-  replication_group_description = "A Redis cluster for storing user session data"
-  node_type                     = var.redis_node_size
-  number_cache_clusters         = length(data.aws_availability_zones.available.names)
-  engine                        = "redis"
-  engine_version                = "6.x"
-  parameter_group_name          = "default.redis6.x"
-  port                          = local.redis_port_number
-  maintenance_window            = "tue:22:00-tue:23:00"
-  notification_topic_arn        = data.aws_sns_topic.slack_events.arn
+  automatic_failover_enabled  = true
+  preferred_cache_cluster_azs = data.aws_availability_zones.available.names
+  replication_group_id        = "${var.environment}-acct-mgmt-session-store"
+  description                 = "A Redis cluster for storing user session data"
+  node_type                   = var.redis_node_size
+  num_cache_clusters          = length(data.aws_availability_zones.available.names)
+  engine                      = "redis"
+  engine_version              = "6.x"
+  parameter_group_name        = "default.redis6.x"
+  port                        = local.redis_port_number
+  maintenance_window          = "tue:22:00-tue:23:00"
+  notification_topic_arn      = data.aws_sns_topic.slack_events.arn
 
   multi_az_enabled = true
 

--- a/ci/terraform/account-management/remove-account.tf
+++ b/ci/terraform/account-management/remove-account.tf
@@ -41,8 +41,8 @@ module "delete_account" {
   scaling_trigger             = lookup(var.performance_tuning, "delete-account", local.default_performance_parameters).scaling_trigger
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket
-  lambda_zip_file         = aws_s3_bucket_object.account_management_api_release_zip.key
-  lambda_zip_file_version = aws_s3_bucket_object.account_management_api_release_zip.version_id
+  lambda_zip_file         = aws_s3_object.account_management_api_release_zip.key
+  lambda_zip_file_version = aws_s3_object.account_management_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.vpc_arn

--- a/ci/terraform/account-management/s3-objects.tf
+++ b/ci/terraform/account-management/s3-objects.tf
@@ -1,8 +1,11 @@
 resource "aws_s3_bucket" "source_bucket" {
   bucket_prefix = "${var.environment}-acct-mgmt-lambda-source-"
+}
 
-  aws_s3_bucket_versioning {
-    enabled = true
+resource "aws_s3_bucket_versioning" "source_bucket_versioning" {
+  bucket = aws_s3_bucket.source_bucket.id
+  versioning_configuration {
+    status = "Enabled"
   }
 }
 

--- a/ci/terraform/account-management/s3-objects.tf
+++ b/ci/terraform/account-management/s3-objects.tf
@@ -1,12 +1,12 @@
 resource "aws_s3_bucket" "source_bucket" {
   bucket_prefix = "${var.environment}-acct-mgmt-lambda-source-"
 
-  versioning {
+  aws_s3_bucket_versioning {
     enabled = true
   }
 }
 
-resource "aws_s3_bucket_object" "account_management_api_release_zip" {
+resource "aws_s3_object" "account_management_api_release_zip" {
   bucket = aws_s3_bucket.source_bucket.bucket
   key    = "account-management-api-release.zip"
 

--- a/ci/terraform/account-management/send_otp_notification.tf
+++ b/ci/terraform/account-management/send_otp_notification.tf
@@ -48,8 +48,8 @@ module "send_otp_notification" {
   scaling_trigger             = lookup(var.performance_tuning, "send-otp-notification", local.default_performance_parameters).scaling_trigger
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket
-  lambda_zip_file         = aws_s3_bucket_object.account_management_api_release_zip.key
-  lambda_zip_file_version = aws_s3_bucket_object.account_management_api_release_zip.version_id
+  lambda_zip_file         = aws_s3_object.account_management_api_release_zip.key
+  lambda_zip_file_version = aws_s3_object.account_management_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.vpc_arn

--- a/ci/terraform/account-management/site.tf
+++ b/ci/terraform/account-management/site.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "= 3.63.0"
+      version = "= 5.13.1"
     }
   }
 

--- a/ci/terraform/account-management/site.tf
+++ b/ci/terraform/account-management/site.tf
@@ -21,7 +21,7 @@ provider "aws" {
 
   insecure = var.use_localstack
 
-  s3_force_path_style         = var.use_localstack
+  s3_use_path_style           = var.use_localstack
   skip_credentials_validation = var.use_localstack
   skip_metadata_api_check     = var.use_localstack
   skip_requesting_account_id  = var.use_localstack

--- a/ci/terraform/account-management/sqs.tf
+++ b/ci/terraform/account-management/sqs.tf
@@ -169,8 +169,8 @@ resource "aws_lambda_function" "email_sqs_lambda" {
   publish       = true
 
   s3_bucket         = aws_s3_bucket.source_bucket.bucket
-  s3_key            = aws_s3_bucket_object.account_management_api_release_zip.key
-  s3_object_version = aws_s3_bucket_object.account_management_api_release_zip.version_id
+  s3_key            = aws_s3_object.account_management_api_release_zip.key
+  s3_object_version = aws_s3_object.account_management_api_release_zip.version_id
 
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 

--- a/ci/terraform/account-management/update-email.tf
+++ b/ci/terraform/account-management/update-email.tf
@@ -42,8 +42,8 @@ module "update_email" {
   scaling_trigger             = lookup(var.performance_tuning, "update-email", local.default_performance_parameters).scaling_trigger
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket
-  lambda_zip_file         = aws_s3_bucket_object.account_management_api_release_zip.key
-  lambda_zip_file_version = aws_s3_bucket_object.account_management_api_release_zip.version_id
+  lambda_zip_file         = aws_s3_object.account_management_api_release_zip.key
+  lambda_zip_file_version = aws_s3_object.account_management_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.vpc_arn

--- a/ci/terraform/account-management/update-password.tf
+++ b/ci/terraform/account-management/update-password.tf
@@ -40,8 +40,8 @@ module "update_password" {
   scaling_trigger             = lookup(var.performance_tuning, "update-password", local.default_performance_parameters).scaling_trigger
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket
-  lambda_zip_file         = aws_s3_bucket_object.account_management_api_release_zip.key
-  lambda_zip_file_version = aws_s3_bucket_object.account_management_api_release_zip.version_id
+  lambda_zip_file         = aws_s3_object.account_management_api_release_zip.key
+  lambda_zip_file_version = aws_s3_object.account_management_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.vpc_arn

--- a/ci/terraform/account-management/update-phone-number.tf
+++ b/ci/terraform/account-management/update-phone-number.tf
@@ -41,8 +41,8 @@ module "update_phone_number" {
   scaling_trigger             = lookup(var.performance_tuning, "update-phone-number", local.default_performance_parameters).scaling_trigger
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket
-  lambda_zip_file         = aws_s3_bucket_object.account_management_api_release_zip.key
-  lambda_zip_file_version = aws_s3_bucket_object.account_management_api_release_zip.version_id
+  lambda_zip_file         = aws_s3_object.account_management_api_release_zip.key
+  lambda_zip_file_version = aws_s3_object.account_management_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.vpc_arn

--- a/ci/terraform/audit-processors/counter_fraud.tf
+++ b/ci/terraform/audit-processors/counter_fraud.tf
@@ -143,8 +143,8 @@ resource "aws_lambda_function" "fraud_realtime_logging_lambda" {
   }
 
   s3_bucket         = aws_s3_bucket.source_bucket.bucket
-  s3_key            = aws_s3_bucket_object.audit_processor_release_zip.key
-  s3_object_version = aws_s3_bucket_object.audit_processor_release_zip.version_id
+  s3_key            = aws_s3_object.audit_processor_release_zip.key
+  s3_object_version = aws_s3_object.audit_processor_release_zip.version_id
 
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 

--- a/ci/terraform/audit-processors/performance_analysis.tf
+++ b/ci/terraform/audit-processors/performance_analysis.tf
@@ -56,8 +56,8 @@ resource "aws_lambda_function" "performance_analysis_logging_lambda" {
   }
 
   s3_bucket         = aws_s3_bucket.source_bucket.bucket
-  s3_key            = aws_s3_bucket_object.audit_processor_release_zip.key
-  s3_object_version = aws_s3_bucket_object.audit_processor_release_zip.version_id
+  s3_key            = aws_s3_object.audit_processor_release_zip.key
+  s3_object_version = aws_s3_object.audit_processor_release_zip.version_id
 
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 

--- a/ci/terraform/audit-processors/s3-objects.tf
+++ b/ci/terraform/audit-processors/s3-objects.tf
@@ -1,8 +1,11 @@
 resource "aws_s3_bucket" "source_bucket" {
   bucket_prefix = "${var.environment}-audit-lambda-source-"
+}
 
-  aws_s3_bucket_versioning {
-    enabled = true
+resource "aws_s3_bucket_versioning" "source_bucket_versioning" {
+  bucket = aws_s3_bucket.source_bucket.id
+  versioning_configuration {
+    status = "Enabled"
   }
 }
 

--- a/ci/terraform/audit-processors/s3-objects.tf
+++ b/ci/terraform/audit-processors/s3-objects.tf
@@ -1,12 +1,12 @@
 resource "aws_s3_bucket" "source_bucket" {
   bucket_prefix = "${var.environment}-audit-lambda-source-"
 
-  versioning {
+  aws_s3_bucket_versioning {
     enabled = true
   }
 }
 
-resource "aws_s3_bucket_object" "audit_processor_release_zip" {
+resource "aws_s3_object" "audit_processor_release_zip" {
   bucket = aws_s3_bucket.source_bucket.bucket
   key    = "audit-processor-release.zip"
 

--- a/ci/terraform/audit-processors/site.tf
+++ b/ci/terraform/audit-processors/site.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "= 3.63.0"
+      version = "= 5.13.1"
     }
   }
 

--- a/ci/terraform/audit-processors/site.tf
+++ b/ci/terraform/audit-processors/site.tf
@@ -21,7 +21,7 @@ provider "aws" {
 
   insecure = var.use_localstack
 
-  s3_force_path_style         = var.use_localstack
+  s3_use_path_style           = var.use_localstack
   skip_credentials_validation = var.use_localstack
   skip_metadata_api_check     = var.use_localstack
   skip_requesting_account_id  = var.use_localstack

--- a/ci/terraform/audit-processors/storage.tf
+++ b/ci/terraform/audit-processors/storage.tf
@@ -54,8 +54,8 @@ resource "aws_lambda_function" "audit_processor_lambda" {
   }
 
   s3_bucket         = aws_s3_bucket.source_bucket.bucket
-  s3_key            = aws_s3_bucket_object.audit_processor_release_zip.key
-  s3_object_version = aws_s3_bucket_object.audit_processor_release_zip.version_id
+  s3_key            = aws_s3_object.audit_processor_release_zip.key
+  s3_object_version = aws_s3_object.audit_processor_release_zip.version_id
 
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 

--- a/ci/terraform/delivery-receipts/notify-callback.tf
+++ b/ci/terraform/delivery-receipts/notify-callback.tf
@@ -29,8 +29,8 @@ module "notify_callback" {
   memory_size      = var.endpoint_memory_size
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket
-  lambda_zip_file         = aws_s3_bucket_object.delivery_receipts_api_release_zip.key
-  lambda_zip_file_version = aws_s3_bucket_object.delivery_receipts_api_release_zip.version_id
+  lambda_zip_file         = aws_s3_object.delivery_receipts_api_release_zip.key
+  lambda_zip_file_version = aws_s3_object.delivery_receipts_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.vpc_arn

--- a/ci/terraform/delivery-receipts/s3-objects.tf
+++ b/ci/terraform/delivery-receipts/s3-objects.tf
@@ -1,8 +1,11 @@
 resource "aws_s3_bucket" "source_bucket" {
   bucket_prefix = "${var.environment}-acct-mgmt-lambda-source-"
+}
 
-  aws_s3_bucket_versioning {
-    enabled = true
+resource "aws_s3_bucket_versioning" "source_bucket_versioning" {
+  bucket = aws_s3_bucket.source_bucket.id
+  versioning_configuration {
+    status = "Enabled"
   }
 }
 

--- a/ci/terraform/delivery-receipts/s3-objects.tf
+++ b/ci/terraform/delivery-receipts/s3-objects.tf
@@ -1,12 +1,12 @@
 resource "aws_s3_bucket" "source_bucket" {
   bucket_prefix = "${var.environment}-acct-mgmt-lambda-source-"
 
-  versioning {
+  aws_s3_bucket_versioning {
     enabled = true
   }
 }
 
-resource "aws_s3_bucket_object" "delivery_receipts_api_release_zip" {
+resource "aws_s3_object" "delivery_receipts_api_release_zip" {
   bucket = aws_s3_bucket.source_bucket.bucket
   key    = "delivery-receipts-api-release.zip"
 

--- a/ci/terraform/delivery-receipts/site.tf
+++ b/ci/terraform/delivery-receipts/site.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "= 3.63.0"
+      version = "= 5.13.1"
     }
   }
 

--- a/ci/terraform/delivery-receipts/site.tf
+++ b/ci/terraform/delivery-receipts/site.tf
@@ -21,7 +21,7 @@ provider "aws" {
 
   insecure = var.use_localstack
 
-  s3_force_path_style         = var.use_localstack
+  s3_use_path_style           = var.use_localstack
   skip_credentials_validation = var.use_localstack
   skip_metadata_api_check     = var.use_localstack
   skip_requesting_account_id  = var.use_localstack

--- a/ci/terraform/oidc/account-recovery.tf
+++ b/ci/terraform/oidc/account-recovery.tf
@@ -46,8 +46,8 @@ module "account_recovery" {
   scaling_trigger             = lookup(var.performance_tuning, "account-recovery", local.default_performance_parameters).scaling_trigger
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket
-  lambda_zip_file         = aws_s3_bucket_object.frontend_api_release_zip.key
-  lambda_zip_file_version = aws_s3_bucket_object.frontend_api_release_zip.version_id
+  lambda_zip_file         = aws_s3_object.frontend_api_release_zip.key
+  lambda_zip_file_version = aws_s3_object.frontend_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.authentication_vpc_arn

--- a/ci/terraform/oidc/api-gateway.tf
+++ b/ci/terraform/oidc/api-gateway.tf
@@ -341,25 +341,40 @@ resource "aws_wafv2_web_acl" "wafregional_web_acl_oidc_api" {
         name        = "AWSManagedRulesCommonRuleSet"
         vendor_name = "AWS"
 
-        excluded_rule {
+        rule_action_override {
           name = "GenericRFI_QUERYARGUMENTS"
+          action_to_use {
+            count {}
+          }
         }
-        excluded_rule {
+        rule_action_override {
           name = "GenericRFI_BODY"
+          action_to_use {
+            count {}
+          }
         }
 
-        excluded_rule {
+        rule_action_override {
           name = "NoUserAgent_HEADER"
+          action_to_use {
+            count {}
+          }
         }
 
-        excluded_rule {
+        rule_action_override {
           name = "EC2MetaDataSSRF_QUERYARGUMENTS"
+          action_to_use {
+            count {}
+          }
         }
 
-        dynamic "excluded_rule" {
+        dynamic "rule_action_override" {
           for_each = var.environment != "production" || var.environment != "sandpit" ? ["1"] : []
           content {
             name = "EC2MetaDataSSRF_BODY"
+            action_to_use {
+              count {}
+            }
           }
         }
       }
@@ -371,7 +386,6 @@ resource "aws_wafv2_web_acl" "wafregional_web_acl_oidc_api" {
       sampled_requests_enabled   = true
     }
   }
-
   rule {
     override_action {
       none {}

--- a/ci/terraform/oidc/auth-code.tf
+++ b/ci/terraform/oidc/auth-code.tf
@@ -42,8 +42,8 @@ module "auth-code" {
   scaling_trigger             = lookup(var.performance_tuning, "auth-code", local.default_performance_parameters).scaling_trigger
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket
-  lambda_zip_file         = aws_s3_bucket_object.oidc_api_release_zip.key
-  lambda_zip_file_version = aws_s3_bucket_object.oidc_api_release_zip.version_id
+  lambda_zip_file         = aws_s3_object.oidc_api_release_zip.key
+  lambda_zip_file_version = aws_s3_object.oidc_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.authentication_vpc_arn

--- a/ci/terraform/oidc/authentication-auth-code.tf
+++ b/ci/terraform/oidc/authentication-auth-code.tf
@@ -41,8 +41,8 @@ module "orch_auth_code" {
   scaling_trigger             = lookup(var.performance_tuning, "orch-auth-code", local.default_performance_parameters).scaling_trigger
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket
-  lambda_zip_file         = aws_s3_bucket_object.frontend_api_release_zip.key
-  lambda_zip_file_version = aws_s3_bucket_object.frontend_api_release_zip.version_id
+  lambda_zip_file         = aws_s3_object.frontend_api_release_zip.key
+  lambda_zip_file_version = aws_s3_object.frontend_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.authentication_vpc_arn

--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -57,8 +57,8 @@ module "authorize" {
   scaling_trigger             = lookup(var.performance_tuning, "authorize", local.default_performance_parameters).scaling_trigger
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket
-  lambda_zip_file         = aws_s3_bucket_object.oidc_api_release_zip.key
-  lambda_zip_file_version = aws_s3_bucket_object.oidc_api_release_zip.version_id
+  lambda_zip_file         = aws_s3_object.oidc_api_release_zip.key
+  lambda_zip_file_version = aws_s3_object.oidc_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.authentication_vpc_arn

--- a/ci/terraform/oidc/backchannel-logout-request.tf
+++ b/ci/terraform/oidc/backchannel-logout-request.tf
@@ -18,8 +18,8 @@ resource "aws_lambda_function" "backchannel_logout_request_lambda" {
   publish       = true
 
   s3_bucket         = aws_s3_bucket.source_bucket.bucket
-  s3_key            = aws_s3_bucket_object.oidc_api_release_zip.key
-  s3_object_version = aws_s3_bucket_object.oidc_api_release_zip.version_id
+  s3_key            = aws_s3_object.oidc_api_release_zip.key
+  s3_object_version = aws_s3_object.oidc_api_release_zip.version_id
 
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 

--- a/ci/terraform/oidc/doc-app-authorize.tf
+++ b/ci/terraform/oidc/doc-app-authorize.tf
@@ -49,8 +49,8 @@ module "doc-app-authorize" {
   scaling_trigger             = lookup(var.performance_tuning, "doc-app-authorize", local.default_performance_parameters).scaling_trigger
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket
-  lambda_zip_file         = aws_s3_bucket_object.doc_checking_app_api_release_zip.key
-  lambda_zip_file_version = aws_s3_bucket_object.doc_checking_app_api_release_zip.version_id
+  lambda_zip_file         = aws_s3_object.doc_checking_app_api_release_zip.key
+  lambda_zip_file_version = aws_s3_object.doc_checking_app_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.authentication_vpc_arn

--- a/ci/terraform/oidc/doc-app-callback.tf
+++ b/ci/terraform/oidc/doc-app-callback.tf
@@ -55,8 +55,8 @@ module "doc-app-callback" {
   scaling_trigger             = lookup(var.performance_tuning, "doc-app-callback", local.default_performance_parameters).scaling_trigger
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket
-  lambda_zip_file         = aws_s3_bucket_object.doc_checking_app_api_release_zip.key
-  lambda_zip_file_version = aws_s3_bucket_object.doc_checking_app_api_release_zip.version_id
+  lambda_zip_file         = aws_s3_object.doc_checking_app_api_release_zip.key
+  lambda_zip_file_version = aws_s3_object.doc_checking_app_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.authentication_vpc_arn

--- a/ci/terraform/oidc/ipv-authorize.tf
+++ b/ci/terraform/oidc/ipv-authorize.tf
@@ -52,8 +52,8 @@ module "ipv-authorize" {
   scaling_trigger             = lookup(var.performance_tuning, "ipv-authorize", local.default_performance_parameters).scaling_trigger
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket
-  lambda_zip_file         = aws_s3_bucket_object.ipv_api_release_zip.key
-  lambda_zip_file_version = aws_s3_bucket_object.ipv_api_release_zip.version_id
+  lambda_zip_file         = aws_s3_object.ipv_api_release_zip.key
+  lambda_zip_file_version = aws_s3_object.ipv_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.authentication_vpc_arn

--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -59,8 +59,8 @@ module "ipv-callback" {
   scaling_trigger             = lookup(var.performance_tuning, "ipv-callback", local.default_performance_parameters).scaling_trigger
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket
-  lambda_zip_file         = aws_s3_bucket_object.ipv_api_release_zip.key
-  lambda_zip_file_version = aws_s3_bucket_object.ipv_api_release_zip.version_id
+  lambda_zip_file         = aws_s3_object.ipv_api_release_zip.key
+  lambda_zip_file_version = aws_s3_object.ipv_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.authentication_vpc_arn

--- a/ci/terraform/oidc/ipv-capacity.tf
+++ b/ci/terraform/oidc/ipv-capacity.tf
@@ -43,8 +43,8 @@ module "ipv-capacity" {
   scaling_trigger             = lookup(var.performance_tuning, "ipv-capacity", local.default_performance_parameters).scaling_trigger
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket
-  lambda_zip_file         = aws_s3_bucket_object.ipv_api_release_zip.key
-  lambda_zip_file_version = aws_s3_bucket_object.ipv_api_release_zip.version_id
+  lambda_zip_file         = aws_s3_object.ipv_api_release_zip.key
+  lambda_zip_file_version = aws_s3_object.ipv_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.authentication_vpc_arn

--- a/ci/terraform/oidc/jwks.tf
+++ b/ci/terraform/oidc/jwks.tf
@@ -39,8 +39,8 @@ module "jwks" {
   scaling_trigger             = lookup(var.performance_tuning, "jwks", local.default_performance_parameters).scaling_trigger
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket
-  lambda_zip_file         = aws_s3_bucket_object.oidc_api_release_zip.key
-  lambda_zip_file_version = aws_s3_bucket_object.oidc_api_release_zip.version_id
+  lambda_zip_file         = aws_s3_object.oidc_api_release_zip.key
+  lambda_zip_file_version = aws_s3_object.oidc_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn                 = local.authentication_vpc_arn

--- a/ci/terraform/oidc/login.tf
+++ b/ci/terraform/oidc/login.tf
@@ -48,8 +48,8 @@ module "login" {
   scaling_trigger             = lookup(var.performance_tuning, "login", local.default_performance_parameters).scaling_trigger
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket
-  lambda_zip_file         = aws_s3_bucket_object.frontend_api_release_zip.key
-  lambda_zip_file_version = aws_s3_bucket_object.frontend_api_release_zip.version_id
+  lambda_zip_file         = aws_s3_object.frontend_api_release_zip.key
+  lambda_zip_file_version = aws_s3_object.frontend_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.authentication_vpc_arn

--- a/ci/terraform/oidc/logout.tf
+++ b/ci/terraform/oidc/logout.tf
@@ -48,8 +48,8 @@ module "logout" {
   scaling_trigger             = lookup(var.performance_tuning, "logout", local.default_performance_parameters).scaling_trigger
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket
-  lambda_zip_file         = aws_s3_bucket_object.oidc_api_release_zip.key
-  lambda_zip_file_version = aws_s3_bucket_object.oidc_api_release_zip.version_id
+  lambda_zip_file         = aws_s3_object.oidc_api_release_zip.key
+  lambda_zip_file_version = aws_s3_object.oidc_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.authentication_vpc_arn

--- a/ci/terraform/oidc/mfa.tf
+++ b/ci/terraform/oidc/mfa.tf
@@ -47,8 +47,8 @@ module "mfa" {
   scaling_trigger             = lookup(var.performance_tuning, "mfa", local.default_performance_parameters).scaling_trigger
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket
-  lambda_zip_file         = aws_s3_bucket_object.frontend_api_release_zip.key
-  lambda_zip_file_version = aws_s3_bucket_object.frontend_api_release_zip.version_id
+  lambda_zip_file         = aws_s3_object.frontend_api_release_zip.key
+  lambda_zip_file_version = aws_s3_object.frontend_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.authentication_vpc_arn

--- a/ci/terraform/oidc/processing-identity.tf
+++ b/ci/terraform/oidc/processing-identity.tf
@@ -45,8 +45,8 @@ module "processing-identity" {
   scaling_trigger             = lookup(var.performance_tuning, "processing-identity", local.default_performance_parameters).scaling_trigger
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket
-  lambda_zip_file         = aws_s3_bucket_object.ipv_api_release_zip.key
-  lambda_zip_file_version = aws_s3_bucket_object.ipv_api_release_zip.version_id
+  lambda_zip_file         = aws_s3_object.ipv_api_release_zip.key
+  lambda_zip_file_version = aws_s3_object.ipv_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.authentication_vpc_arn

--- a/ci/terraform/oidc/register.tf
+++ b/ci/terraform/oidc/register.tf
@@ -41,8 +41,8 @@ module "register" {
   scaling_trigger             = lookup(var.performance_tuning, "register", local.default_performance_parameters).scaling_trigger
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket
-  lambda_zip_file         = aws_s3_bucket_object.client_api_release_zip.key
-  lambda_zip_file_version = aws_s3_bucket_object.client_api_release_zip.version_id
+  lambda_zip_file         = aws_s3_object.client_api_release_zip.key
+  lambda_zip_file_version = aws_s3_object.client_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
   security_group_ids                     = [local.authentication_security_group_id]

--- a/ci/terraform/oidc/reset-password-request.tf
+++ b/ci/terraform/oidc/reset-password-request.tf
@@ -47,8 +47,8 @@ module "reset-password-request" {
   scaling_trigger             = lookup(var.performance_tuning, "reset-password-request", local.default_performance_parameters).scaling_trigger
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket
-  lambda_zip_file         = aws_s3_bucket_object.frontend_api_release_zip.key
-  lambda_zip_file_version = aws_s3_bucket_object.frontend_api_release_zip.version_id
+  lambda_zip_file         = aws_s3_object.frontend_api_release_zip.key
+  lambda_zip_file_version = aws_s3_object.frontend_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.authentication_vpc_arn

--- a/ci/terraform/oidc/reset_password.tf
+++ b/ci/terraform/oidc/reset_password.tf
@@ -52,8 +52,8 @@ module "reset_password" {
   scaling_trigger             = lookup(var.performance_tuning, "reset-password", local.default_performance_parameters).scaling_trigger
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket
-  lambda_zip_file         = aws_s3_bucket_object.frontend_api_release_zip.key
-  lambda_zip_file_version = aws_s3_bucket_object.frontend_api_release_zip.version_id
+  lambda_zip_file         = aws_s3_object.frontend_api_release_zip.key
+  lambda_zip_file_version = aws_s3_object.frontend_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.authentication_vpc_arn

--- a/ci/terraform/oidc/s3-objects.tf
+++ b/ci/terraform/oidc/s3-objects.tf
@@ -1,12 +1,12 @@
 resource "aws_s3_bucket" "source_bucket" {
   bucket_prefix = "${var.environment}-lambda-source-"
 
-  versioning {
+  aws_s3_bucket_versioning {
     enabled = true
   }
 }
 
-resource "aws_s3_bucket_object" "oidc_api_release_zip" {
+resource "aws_s3_object" "oidc_api_release_zip" {
   bucket = aws_s3_bucket.source_bucket.bucket
   key    = "oidc-api-release.zip"
 
@@ -15,7 +15,7 @@ resource "aws_s3_bucket_object" "oidc_api_release_zip" {
   source_hash            = filemd5(var.oidc_api_lambda_zip_file)
 }
 
-resource "aws_s3_bucket_object" "client_api_release_zip" {
+resource "aws_s3_object" "client_api_release_zip" {
   bucket = aws_s3_bucket.source_bucket.bucket
   key    = "client-api-release.zip"
 
@@ -24,7 +24,7 @@ resource "aws_s3_bucket_object" "client_api_release_zip" {
   source_hash            = filemd5(var.client_registry_api_lambda_zip_file)
 }
 
-resource "aws_s3_bucket_object" "frontend_api_release_zip" {
+resource "aws_s3_object" "frontend_api_release_zip" {
   bucket = aws_s3_bucket.source_bucket.bucket
   key    = "frontend-api-release.zip"
 
@@ -33,7 +33,7 @@ resource "aws_s3_bucket_object" "frontend_api_release_zip" {
   source_hash            = filemd5(var.frontend_api_lambda_zip_file)
 }
 
-resource "aws_s3_bucket_object" "ipv_api_release_zip" {
+resource "aws_s3_object" "ipv_api_release_zip" {
   bucket = aws_s3_bucket.source_bucket.bucket
   key    = "ipv-api-release.zip"
 
@@ -42,7 +42,7 @@ resource "aws_s3_bucket_object" "ipv_api_release_zip" {
   source_hash            = filemd5(var.ipv_api_lambda_zip_file)
 }
 
-resource "aws_s3_bucket_object" "doc_checking_app_api_release_zip" {
+resource "aws_s3_object" "doc_checking_app_api_release_zip" {
   bucket = aws_s3_bucket.source_bucket.bucket
   key    = "doc-checking-app-api-release.zip"
 

--- a/ci/terraform/oidc/s3-objects.tf
+++ b/ci/terraform/oidc/s3-objects.tf
@@ -1,8 +1,11 @@
 resource "aws_s3_bucket" "source_bucket" {
   bucket_prefix = "${var.environment}-lambda-source-"
+}
 
-  aws_s3_bucket_versioning {
-    enabled = true
+resource "aws_s3_bucket_versioning" "source_bucket_versioning" {
+  bucket = aws_s3_bucket.source_bucket.id
+  versioning_configuration {
+    status = "Enabled"
   }
 }
 

--- a/ci/terraform/oidc/send_notification.tf
+++ b/ci/terraform/oidc/send_notification.tf
@@ -46,8 +46,8 @@ module "send_notification" {
   scaling_trigger             = lookup(var.performance_tuning, "send-notification", local.default_performance_parameters).scaling_trigger
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket
-  lambda_zip_file         = aws_s3_bucket_object.frontend_api_release_zip.key
-  lambda_zip_file_version = aws_s3_bucket_object.frontend_api_release_zip.version_id
+  lambda_zip_file         = aws_s3_object.frontend_api_release_zip.key
+  lambda_zip_file_version = aws_s3_object.frontend_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.authentication_vpc_arn

--- a/ci/terraform/oidc/signup.tf
+++ b/ci/terraform/oidc/signup.tf
@@ -45,8 +45,8 @@ module "signup" {
   scaling_trigger             = lookup(var.performance_tuning, "signup", local.default_performance_parameters).scaling_trigger
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket
-  lambda_zip_file         = aws_s3_bucket_object.frontend_api_release_zip.key
-  lambda_zip_file_version = aws_s3_bucket_object.frontend_api_release_zip.version_id
+  lambda_zip_file         = aws_s3_object.frontend_api_release_zip.key
+  lambda_zip_file_version = aws_s3_object.frontend_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.authentication_vpc_arn

--- a/ci/terraform/oidc/site.tf
+++ b/ci/terraform/oidc/site.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "= 3.67.0"
+      version = "= 5.13.1"
     }
     time = {
       source  = "hashicorp/time"

--- a/ci/terraform/oidc/site.tf
+++ b/ci/terraform/oidc/site.tf
@@ -29,7 +29,7 @@ provider "aws" {
 
   insecure = var.use_localstack
 
-  s3_force_path_style         = var.use_localstack
+  s3_use_path_style           = var.use_localstack
   skip_credentials_validation = var.use_localstack
   skip_metadata_api_check     = var.use_localstack
   skip_requesting_account_id  = var.use_localstack

--- a/ci/terraform/oidc/spot-response.tf
+++ b/ci/terraform/oidc/spot-response.tf
@@ -80,8 +80,8 @@ resource "aws_lambda_function" "spot_response_lambda" {
   publish       = true
 
   s3_bucket         = aws_s3_bucket.source_bucket.bucket
-  s3_key            = aws_s3_bucket_object.ipv_api_release_zip.key
-  s3_object_version = aws_s3_bucket_object.ipv_api_release_zip.version_id
+  s3_key            = aws_s3_object.ipv_api_release_zip.key
+  s3_object_version = aws_s3_object.ipv_api_release_zip.version_id
 
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 

--- a/ci/terraform/oidc/sqs.tf
+++ b/ci/terraform/oidc/sqs.tf
@@ -158,8 +158,8 @@ resource "aws_lambda_function" "email_sqs_lambda" {
   publish       = true
 
   s3_bucket         = aws_s3_bucket.source_bucket.bucket
-  s3_key            = aws_s3_bucket_object.frontend_api_release_zip.key
-  s3_object_version = aws_s3_bucket_object.frontend_api_release_zip.version_id
+  s3_key            = aws_s3_object.frontend_api_release_zip.key
+  s3_object_version = aws_s3_object.frontend_api_release_zip.version_id
 
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 

--- a/ci/terraform/oidc/start.tf
+++ b/ci/terraform/oidc/start.tf
@@ -47,8 +47,8 @@ module "start" {
   scaling_trigger             = lookup(var.performance_tuning, "start", local.default_performance_parameters).scaling_trigger
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket
-  lambda_zip_file         = aws_s3_bucket_object.frontend_api_release_zip.key
-  lambda_zip_file_version = aws_s3_bucket_object.frontend_api_release_zip.version_id
+  lambda_zip_file         = aws_s3_object.frontend_api_release_zip.key
+  lambda_zip_file_version = aws_s3_object.frontend_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.authentication_vpc_arn

--- a/ci/terraform/oidc/token.tf
+++ b/ci/terraform/oidc/token.tf
@@ -72,8 +72,8 @@ module "token" {
   scaling_trigger             = lookup(var.performance_tuning, "token", local.default_performance_parameters).scaling_trigger
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket
-  lambda_zip_file         = aws_s3_bucket_object.oidc_api_release_zip.key
-  lambda_zip_file_version = aws_s3_bucket_object.oidc_api_release_zip.version_id
+  lambda_zip_file         = aws_s3_object.oidc_api_release_zip.key
+  lambda_zip_file_version = aws_s3_object.oidc_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.authentication_vpc_arn

--- a/ci/terraform/oidc/trustmarks.tf
+++ b/ci/terraform/oidc/trustmarks.tf
@@ -33,8 +33,8 @@ module "trustmarks" {
   scaling_trigger             = lookup(var.performance_tuning, "trustmark", local.default_performance_parameters).scaling_trigger
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket
-  lambda_zip_file         = aws_s3_bucket_object.oidc_api_release_zip.key
-  lambda_zip_file_version = aws_s3_bucket_object.oidc_api_release_zip.version_id
+  lambda_zip_file         = aws_s3_object.oidc_api_release_zip.key
+  lambda_zip_file_version = aws_s3_object.oidc_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn                 = local.authentication_vpc_arn

--- a/ci/terraform/oidc/update.tf
+++ b/ci/terraform/oidc/update.tf
@@ -41,8 +41,8 @@ module "update" {
   scaling_trigger             = lookup(var.performance_tuning, "update-client-info", local.default_performance_parameters).scaling_trigger
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket
-  lambda_zip_file         = aws_s3_bucket_object.client_api_release_zip.key
-  lambda_zip_file_version = aws_s3_bucket_object.client_api_release_zip.version_id
+  lambda_zip_file         = aws_s3_object.client_api_release_zip.key
+  lambda_zip_file_version = aws_s3_object.client_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.authentication_vpc_arn

--- a/ci/terraform/oidc/update_profile.tf
+++ b/ci/terraform/oidc/update_profile.tf
@@ -45,8 +45,8 @@ module "update_profile" {
   scaling_trigger             = lookup(var.performance_tuning, "update-profile", local.default_performance_parameters).scaling_trigger
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket
-  lambda_zip_file         = aws_s3_bucket_object.frontend_api_release_zip.key
-  lambda_zip_file_version = aws_s3_bucket_object.frontend_api_release_zip.version_id
+  lambda_zip_file         = aws_s3_object.frontend_api_release_zip.key
+  lambda_zip_file_version = aws_s3_object.frontend_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.authentication_vpc_arn

--- a/ci/terraform/oidc/userexists.tf
+++ b/ci/terraform/oidc/userexists.tf
@@ -44,8 +44,8 @@ module "userexists" {
   scaling_trigger             = lookup(var.performance_tuning, "user-exists", local.default_performance_parameters).scaling_trigger
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket
-  lambda_zip_file         = aws_s3_bucket_object.frontend_api_release_zip.key
-  lambda_zip_file_version = aws_s3_bucket_object.frontend_api_release_zip.version_id
+  lambda_zip_file         = aws_s3_object.frontend_api_release_zip.key
+  lambda_zip_file_version = aws_s3_object.frontend_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.authentication_vpc_arn

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -47,8 +47,8 @@ module "userinfo" {
   scaling_trigger             = lookup(var.performance_tuning, "userinfo", local.default_performance_parameters).scaling_trigger
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket
-  lambda_zip_file         = aws_s3_bucket_object.oidc_api_release_zip.key
-  lambda_zip_file_version = aws_s3_bucket_object.oidc_api_release_zip.version_id
+  lambda_zip_file         = aws_s3_object.oidc_api_release_zip.key
+  lambda_zip_file_version = aws_s3_object.oidc_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.authentication_vpc_arn

--- a/ci/terraform/oidc/verify_code.tf
+++ b/ci/terraform/oidc/verify_code.tf
@@ -50,8 +50,8 @@ module "verify_code" {
   scaling_trigger             = lookup(var.performance_tuning, "verify-code", local.default_performance_parameters).scaling_trigger
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket
-  lambda_zip_file         = aws_s3_bucket_object.frontend_api_release_zip.key
-  lambda_zip_file_version = aws_s3_bucket_object.frontend_api_release_zip.version_id
+  lambda_zip_file         = aws_s3_object.frontend_api_release_zip.key
+  lambda_zip_file_version = aws_s3_object.frontend_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.authentication_vpc_arn

--- a/ci/terraform/oidc/verify_mfa_code.tf
+++ b/ci/terraform/oidc/verify_mfa_code.tf
@@ -50,8 +50,8 @@ module "verify_mfa_code" {
   scaling_trigger             = lookup(var.performance_tuning, "verify-mfa-code", local.default_performance_parameters).scaling_trigger
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket
-  lambda_zip_file         = aws_s3_bucket_object.frontend_api_release_zip.key
-  lambda_zip_file_version = aws_s3_bucket_object.frontend_api_release_zip.version_id
+  lambda_zip_file         = aws_s3_object.frontend_api_release_zip.key
+  lambda_zip_file_version = aws_s3_object.frontend_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn = local.authentication_vpc_arn

--- a/ci/terraform/oidc/wellknown.tf
+++ b/ci/terraform/oidc/wellknown.tf
@@ -32,8 +32,8 @@ module "openid_configuration_discovery" {
   scaling_trigger             = lookup(var.performance_tuning, "openid-configuration", local.default_performance_parameters).scaling_trigger
 
   source_bucket           = aws_s3_bucket.source_bucket.bucket
-  lambda_zip_file         = aws_s3_bucket_object.oidc_api_release_zip.key
-  lambda_zip_file_version = aws_s3_bucket_object.oidc_api_release_zip.version_id
+  lambda_zip_file         = aws_s3_object.oidc_api_release_zip.key
+  lambda_zip_file_version = aws_s3_object.oidc_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
   authentication_vpc_arn                 = local.authentication_vpc_arn

--- a/ci/terraform/shared/redis.tf
+++ b/ci/terraform/shared/redis.tf
@@ -22,19 +22,19 @@ resource "random_password" "redis_password" {
 resource "aws_elasticache_replication_group" "sessions_store" {
   count = var.use_localstack ? 0 : 1
 
-  automatic_failover_enabled    = true
-  availability_zones            = data.aws_availability_zones.available.names
-  replication_group_id          = "${var.environment}-sessions-store"
-  replication_group_description = "A Redis cluster for storing user session data"
-  node_type                     = var.redis_node_size
-  number_cache_clusters         = length(data.aws_availability_zones.available.names)
-  engine                        = "redis"
-  engine_version                = "6.x"
-  parameter_group_name          = "default.redis6.x"
-  port                          = local.redis_port_number
-  multi_az_enabled              = true
-  maintenance_window            = "wed:22:00-wed:23:00"
-  notification_topic_arn        = aws_sns_topic.slack_events.arn
+  automatic_failover_enabled  = true
+  preferred_cache_cluster_azs = data.aws_availability_zones.available.names
+  replication_group_id        = "${var.environment}-sessions-store"
+  description                 = "A Redis cluster for storing user session data"
+  node_type                   = var.redis_node_size
+  num_cache_clusters          = length(data.aws_availability_zones.available.names)
+  engine                      = "redis"
+  engine_version              = "6.x"
+  parameter_group_name        = "default.redis6.x"
+  port                        = local.redis_port_number
+  multi_az_enabled            = true
+  maintenance_window          = "wed:22:00-wed:23:00"
+  notification_topic_arn      = aws_sns_topic.slack_events.arn
 
   at_rest_encryption_enabled = true
   transit_encryption_enabled = true

--- a/ci/terraform/shared/site.tf
+++ b/ci/terraform/shared/site.tf
@@ -29,7 +29,7 @@ provider "aws" {
 
   insecure = var.use_localstack
 
-  s3_force_path_style         = var.use_localstack
+  s3_use_path_style           = var.use_localstack
   skip_credentials_validation = var.use_localstack
   skip_metadata_api_check     = var.use_localstack
   skip_requesting_account_id  = var.use_localstack

--- a/ci/terraform/shared/site.tf
+++ b/ci/terraform/shared/site.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "= 3.63.0"
+      version = "= 5.13.1"
     }
     time = {
       source  = "hashicorp/time"

--- a/ci/terraform/test-services/site.tf
+++ b/ci/terraform/test-services/site.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "= 4.41.0"
+      version = "= 5.13.1"
     }
   }
 

--- a/ci/terraform/utils/site.tf
+++ b/ci/terraform/utils/site.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "= 4.19.0"
+      version = "= 5.13.1"
     }
     time = {
       source  = "hashicorp/time"


### PR DESCRIPTION
## What?

Upgrade Terraform AWS provider in all modules to latest version (5.13.1)

## Why?

A prerequisite to upgrading Lambda runtimes from Java 11 to Java 17.