### PR TITLE
BAU: Do not check header case

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -278,7 +278,7 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
     }
 
     public boolean getHeadersCaseInsensitive() {
-        return System.getenv().getOrDefault("HEADERS_CASE_INSENSITIVE", "false").equals("true");
+        return false;
     }
 
     public boolean isClientSecretSupported() {


### PR DESCRIPTION
This was only used in localstack-based tests so we can remove it.

This PR overrides the return value to false.

There will be following PRs to incrementally remove usage of this configuration method before we can delete it.
