### PR TITLE
AUT-1592: Rename requestedScopeClaims field to claims, refactor AuthC…

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/AuthCodeRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/AuthCodeRequest.java
@@ -4,6 +4,8 @@ import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import uk.gov.di.authentication.shared.validation.Required;
 
+import java.util.List;
+
 public class AuthCodeRequest {
 
     @SerializedName("redirect-uri")
@@ -16,21 +18,20 @@ public class AuthCodeRequest {
     @Required
     private String state;
 
-    @SerializedName("requestedScopeClaims")
+    @SerializedName("claims")
     @Expose
     @Required
-    private String requestedScopeClaims;
+    private List<String> claims;
 
     @SerializedName("email")
     @Expose
     @Required
     private String email;
 
-    public AuthCodeRequest(
-            String redirectUri, String state, String requestedScopeClaims, String email) {
+    public AuthCodeRequest(String redirectUri, String state, List<String> claims, String email) {
         this.redirectUri = redirectUri;
         this.state = state;
-        this.requestedScopeClaims = requestedScopeClaims;
+        this.claims = claims;
         this.email = email;
     }
 
@@ -50,12 +51,12 @@ public class AuthCodeRequest {
         this.state = state;
     }
 
-    public String getRequestedScopeClaims() {
-        return requestedScopeClaims;
+    public List<String> getClaims() {
+        return claims;
     }
 
-    public void setRequestedScopeClaims(String requestedScopeClaims) {
-        this.requestedScopeClaims = requestedScopeClaims;
+    public void setClaims(List<String> claims) {
+        this.claims = claims;
     }
 
     public String getEmail() {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandler.java
@@ -75,7 +75,7 @@ public class AuthenticationAuthCodeHandler extends BaseFrontendHandler<AuthCodeR
                 dynamoAuthCodeService.saveAuthCode(
                         userProfile.get().getSubjectID(),
                         authorisationCode.getValue(),
-                        authCodeRequest.getRequestedScopeClaims(),
+                        authCodeRequest.getClaims(),
                         false);
 
                 var state = State.parse(authCodeRequest.getState());

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandlerTest.java
@@ -20,11 +20,13 @@ import uk.gov.di.authentication.shared.services.SerializationService;
 import uk.gov.di.authentication.shared.services.SessionService;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -39,7 +41,6 @@ class AuthenticationAuthCodeHandlerTest {
     private static final String TEST_EMAIL_ADDRESS = "test@test.com";
     private static final String TEST_REDIRECT_URI = "https://redirect_uri.com";
     private static final String TEST_STATE = "xyz";
-    private static final String TEST_REQUESTED_SCOPE_CLAIMS = "requested-scope-claims";
     private static final String TEST_AUTHORIZATION_CODE = "SplxlOBeZQQYbYS6WxSbIA";
     private static final String TEST_SUBJECT_ID = "subject-id";
 
@@ -150,11 +151,7 @@ class AuthenticationAuthCodeHandlerTest {
         var result = handler.handleRequest(event, context);
 
         verify(dynamoAuthCodeService, times(1))
-                .saveAuthCode(
-                        eq(userProfile.getSubjectID()),
-                        anyString(),
-                        eq(TEST_REQUESTED_SCOPE_CLAIMS),
-                        eq(false));
+                .saveAuthCode(eq(userProfile.getSubjectID()), anyString(), anyList(), eq(false));
         assertThat(result, hasStatus(200));
         var authorizationResponse = new AuthCodeResponse(TEST_AUTHORIZATION_CODE, TEST_STATE);
         assertThat(result, hasBody(objectMapper.writeValueAsString(authorizationResponse)));
@@ -165,11 +162,11 @@ class AuthenticationAuthCodeHandlerTest {
         event.setHeaders(getHeaders());
         event.setBody(
                 format(
-                        "{ \"email\": \"%s\", \"redirect-uri\": \"%s\", \"state\": \"%s\", \"requestedScopeClaims\": \"%s\" }",
+                        "{ \"email\": \"%s\", \"redirect-uri\": \"%s\", \"state\": \"%s\", \"claims\": [\"%s\"] }",
                         TEST_EMAIL_ADDRESS,
                         TEST_REDIRECT_URI,
                         TEST_STATE,
-                        TEST_REQUESTED_SCOPE_CLAIMS));
+                        List.of("email-verified", "email")));
         return event;
     }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationAuthCodeHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationAuthCodeHandlerIntegrationTest.java
@@ -11,10 +11,13 @@ import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegration
 import uk.gov.di.authentication.sharedtest.extensions.AuthCodeExtension;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static uk.gov.di.authentication.external.entity.AuthUserInfoClaims.EMAIL;
+import static uk.gov.di.authentication.external.entity.AuthUserInfoClaims.EMAIL_VERIFIED;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
@@ -39,7 +42,10 @@ class AuthenticationAuthCodeHandlerIntegrationTest extends ApiGatewayHandlerInte
 
     private void setUpDynamo() {
         authCodeExtension.saveAuthCode(
-                TEST_SUBJECT_ID, TEST_AUTHORIZATION_CODE, TEST_REQUESTED_SCOPE_CLAIMS, false);
+                TEST_SUBJECT_ID,
+                TEST_AUTHORIZATION_CODE,
+                List.of(EMAIL_VERIFIED.getValue(), EMAIL.getValue()),
+                false);
         userStore.signUp(TEST_EMAIL_ADDRESS, TEST_PASSWORD);
     }
 
@@ -51,7 +57,7 @@ class AuthenticationAuthCodeHandlerIntegrationTest extends ApiGatewayHandlerInte
                 new AuthCodeRequest(
                         TEST_REDIRECT_URI,
                         TEST_STATE,
-                        TEST_REQUESTED_SCOPE_CLAIMS,
+                        List.of(EMAIL_VERIFIED.getValue(), EMAIL.getValue()),
                         TEST_EMAIL_ADDRESS);
         var response = makeRequest(Optional.of(authRequest), getHeaders(), Map.of());
         assertThat(response, hasStatus(200));
@@ -62,7 +68,10 @@ class AuthenticationAuthCodeHandlerIntegrationTest extends ApiGatewayHandlerInte
         setUpDynamo();
         var authRequest =
                 new AuthCodeRequest(
-                        null, TEST_STATE, TEST_REQUESTED_SCOPE_CLAIMS, TEST_EMAIL_ADDRESS);
+                        null,
+                        TEST_STATE,
+                        List.of(EMAIL_VERIFIED.getValue(), EMAIL.getValue()),
+                        TEST_EMAIL_ADDRESS);
         var response = makeRequest(Optional.of(authRequest), getHeaders(), Map.of());
         assertThat(response, hasStatus(400));
         assertThat(response, hasBody(objectMapper.writeValueAsString(ErrorResponse.ERROR_1001)));
@@ -73,7 +82,10 @@ class AuthenticationAuthCodeHandlerIntegrationTest extends ApiGatewayHandlerInte
         setUpDynamo();
         var authRequest =
                 new AuthCodeRequest(
-                        TEST_REDIRECT_URI, null, TEST_REQUESTED_SCOPE_CLAIMS, TEST_EMAIL_ADDRESS);
+                        TEST_REDIRECT_URI,
+                        null,
+                        List.of(EMAIL_VERIFIED.getValue(), EMAIL.getValue()),
+                        TEST_EMAIL_ADDRESS);
         var response = makeRequest(Optional.of(authRequest), getHeaders(), Map.of());
         assertThat(response, hasStatus(400));
         assertThat(response, hasBody(objectMapper.writeValueAsString(ErrorResponse.ERROR_1001)));

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoAuthCodeServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoAuthCodeServiceIntegrationTest.java
@@ -7,15 +7,18 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoAuthCodeService;
 import uk.gov.di.authentication.sharedtest.extensions.AuthCodeExtension;
 
+import java.util.List;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static uk.gov.di.authentication.external.entity.AuthUserInfoClaims.EMAIL;
+import static uk.gov.di.authentication.external.entity.AuthUserInfoClaims.EMAIL_VERIFIED;
 
 class DynamoAuthCodeServiceIntegrationTest {
 
     private static final String SUBJECT_ID = "test-subject-id";
     private static final String AUTH_CODE = "test-auth-code";
-    private static final String REQUESTED_SCOPE_CLAIMS = "test-requested-scope-claims";
     private static final boolean HAS_BEEN_USED = false;
 
     @RegisterExtension
@@ -26,7 +29,10 @@ class DynamoAuthCodeServiceIntegrationTest {
 
     private void setUpDynamo() {
         authCodeExtension.saveAuthCode(
-                SUBJECT_ID, AUTH_CODE, REQUESTED_SCOPE_CLAIMS, HAS_BEEN_USED);
+                SUBJECT_ID,
+                AUTH_CODE,
+                List.of(EMAIL_VERIFIED.getValue(), EMAIL.getValue()),
+                HAS_BEEN_USED);
     }
 
     @Test

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthCodeExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthCodeExtension.java
@@ -13,6 +13,7 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoAuthCodeService;
 import uk.gov.di.authentication.sharedtest.basetest.DynamoTestConfiguration;
 
+import java.util.List;
 import java.util.Optional;
 
 public class AuthCodeExtension extends DynamoExtension implements AfterEachCallback {
@@ -59,9 +60,9 @@ public class AuthCodeExtension extends DynamoExtension implements AfterEachCallb
     }
 
     public void saveAuthCode(
-            String subjectID, String authCode, String requestedScopeClaims, boolean hasBeenUsed) {
+            String subjectID, String authCode, List<String> claims, boolean hasBeenUsed) {
 
-        dynamoAuthCodeService.saveAuthCode(subjectID, authCode, requestedScopeClaims, hasBeenUsed);
+        dynamoAuthCodeService.saveAuthCode(subjectID, authCode, claims, hasBeenUsed);
     }
 
     private void createAuthCodeStoreTable() {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthCodeStore.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthCodeStore.java
@@ -4,18 +4,20 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbAttri
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
 
+import java.util.List;
+
 @DynamoDbBean
 public class AuthCodeStore {
 
     public static final String ATTRIBUTE_SUBJECT_ID = "SubjectID";
     public static final String ATTRIBUTE_AUTH_CODE = "AuthCode";
-    public static final String ATTRIBUTE_REQUESTED_SCOPES_CLAIMS = "RequestedScopes/Claims";
+    public static final String ATTRIBUTE_CLAIMS = "Claims";
     public static final String ATTRIBUTE_TIME_TO_EXIST = "TimeToExist";
     public static final String ATTRIBUTE_HAS_BEEN_USED = "HasBeenUsed";
 
     private String subjectID;
     private String authCode;
-    private String requestedScopeClaims;
+    private List<String> claims;
     private long timeToExist;
     private boolean hasBeenUsed;
 
@@ -50,17 +52,17 @@ public class AuthCodeStore {
         return this;
     }
 
-    @DynamoDbAttribute(ATTRIBUTE_REQUESTED_SCOPES_CLAIMS)
-    public String getRequestedScopeClaims() {
-        return requestedScopeClaims;
+    @DynamoDbAttribute(ATTRIBUTE_CLAIMS)
+    public List<String> getClaims() {
+        return claims;
     }
 
-    public void setRequestedScopeClaims(String requestedScopeClaims) {
-        this.requestedScopeClaims = requestedScopeClaims;
+    public void setClaims(List<String> claims) {
+        this.claims = claims;
     }
 
-    public AuthCodeStore withRequestedScopeClaims(String requestedScopeClaims) {
-        this.requestedScopeClaims = requestedScopeClaims;
+    public AuthCodeStore withClaims(List<String> claims) {
+        this.claims = claims;
         return this;
     }
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoAuthCodeService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoAuthCodeService.java
@@ -4,6 +4,7 @@ import uk.gov.di.authentication.shared.entity.AuthCodeStore;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 
 import java.time.temporal.ChronoUnit;
+import java.util.List;
 import java.util.Optional;
 
 public class DynamoAuthCodeService extends BaseDynamoService<AuthCodeStore> {
@@ -39,13 +40,13 @@ public class DynamoAuthCodeService extends BaseDynamoService<AuthCodeStore> {
     }
 
     public void saveAuthCode(
-            String subjectID, String authCode, String requestedScopeClaims, boolean hasBeenUsed) {
+            String subjectID, String authCode, List<String> claims, boolean hasBeenUsed) {
         if (isAuthOrchSplitEnabled) {
             var authCodeStore =
                     new AuthCodeStore()
                             .withSubjectID(subjectID)
                             .withAuthCode(authCode)
-                            .withRequestedScopeClaims(requestedScopeClaims)
+                            .withClaims(claims)
                             .withHasBeenUsed(hasBeenUsed)
                             .withTimeToExist(
                                     NowHelper.nowPlus(timeToExist, ChronoUnit.SECONDS)


### PR DESCRIPTION
## What?

Rename `requestedScopeClaims` to `claims` field, Update AuthCodeStore and Request to Accept This Value

## Why?

Represent Claims Using Lists Instead of Strings

## Related PRs

[AuthCode Handler](https://github.com/alphagov/di-authentication-api/pull/3207)
