### PR TITLE
AUT-1470 - Provide access to OIDC audit queue for Utils directory

### DIFF
--- a/ci/terraform/utils/build-overrides.tfvars
+++ b/ci/terraform/utils/build-overrides.tfvars
@@ -2,4 +2,6 @@ logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]
 
+internal_sector_uri = "https://identity.build.account.gov.uk"
+
 allow_bulk_test_users = true

--- a/ci/terraform/utils/integration-overrides.tfvars
+++ b/ci/terraform/utils/integration-overrides.tfvars
@@ -2,4 +2,6 @@ logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]
 
+internal_sector_uri = "https://identity.integration.account.gov.uk"
+
 allow_bulk_test_users = true

--- a/ci/terraform/utils/oidc-audit.tf
+++ b/ci/terraform/utils/oidc-audit.tf
@@ -1,0 +1,40 @@
+data "aws_sqs_queue" "oidc_txma_audit_queue" {
+
+  name = "${var.environment}-oidc-txma-audit-queue"
+}
+
+data "aws_kms_alias" "oidc_txma_audit_queue_encryption_key_alias" {
+  name = "alias/${var.environment}-oidc-audit-kms-alias"
+}
+
+data "aws_iam_policy_document" "txma_audit_queue_access_policy_document" {
+  version   = "2012-10-17"
+  policy_id = "${var.environment}-txma-audit-queue-access-policy"
+
+  statement {
+    effect    = "Allow"
+    sid       = "AllowWriteAccessToTxmaAuditQueue"
+    actions   = ["sqs:SendMessage", ]
+    resources = [data.aws_sqs_queue.oidc_txma_audit_queue.arn]
+  }
+
+  statement {
+    effect = "Allow"
+    sid    = "AllowAccessToKeyForEncryptingPayloads"
+    actions = [
+      "kms:GenerateDataKey",
+      "kms:Decrypt"
+    ]
+    resources = [
+      data.aws_kms_alias.oidc_txma_audit_queue_encryption_key_alias.arn
+    ]
+  }
+}
+
+resource "aws_iam_policy" "txma_audit_queue_access_policy" {
+  name_prefix = "txma-audit-queue-access-"
+  path        = "/${var.environment}/"
+  description = "IAM Policy for write access to the TxMA audit queue"
+
+  policy = data.aws_iam_policy_document.txma_audit_queue_access_policy_document.json
+}

--- a/ci/terraform/utils/production-overrides.tfvars
+++ b/ci/terraform/utils/production-overrides.tfvars
@@ -4,6 +4,8 @@ logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]
 
+internal_sector_uri = "https://identity.account.gov.uk"
+
 shared_state_bucket = "digital-identity-prod-tfstate"
 
 notify_template_map = {

--- a/ci/terraform/utils/sandpit.tfvars
+++ b/ci/terraform/utils/sandpit.tfvars
@@ -1,4 +1,5 @@
 environment                              = "sandpit"
+internal_sector_uri                      = "https://identity.sandpit.account.gov.uk"
 shared_state_bucket                      = "digital-identity-dev-tfstate"
 allow_bulk_test_users                    = true
 bulk_user_email_send_schedule_enabled    = false

--- a/ci/terraform/utils/staging-overrides.tfvars
+++ b/ci/terraform/utils/staging-overrides.tfvars
@@ -2,6 +2,8 @@ logging_endpoint_arns = [
   "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
 ]
 
+internal_sector_uri = "https://identity.staging.account.gov.uk"
+
 allow_bulk_test_users = true
 
 shared_state_bucket = "di-auth-staging-tfstate"

--- a/ci/terraform/utils/variables.tf
+++ b/ci/terraform/utils/variables.tf
@@ -150,3 +150,8 @@ variable "lambda_log_alarm_error_rate_threshold" {
   description = "The rate of errors in a lambda before generating a Cloudwatch alarm. Calculated by dividing the number of errors in a lambda divided by the number of invocations in a 15 minute period"
   default     = 1
 }
+
+variable "internal_sector_uri" {
+  type    = string
+  default = "undefined"
+}


### PR DESCRIPTION
## What?

- Give the utils directory access to the OIDC txma module so we can use the OIDC TXMA audit queue instead of creating a new one for the purpose of the bulk email sending
- Add the internal sector URI to config as it is required for generating the internal pairwise subject ID

## Why?

- So we can send audit events to TXMA using the OIDC audit queue and avoid creating a new one