### PR TITLE
AUT-1470 - Submit audit events for bulk emails

### DIFF
--- a/ci/terraform/utils/bulk_user_email_send_lambda.tf
+++ b/ci/terraform/utils/bulk_user_email_send_lambda.tf
@@ -10,6 +10,7 @@ module "bulk_user_email_send_lambda_role" {
     aws_iam_policy.bulk_user_email_send_dynamo_read_access[0].arn,
     aws_iam_policy.bulk_user_email_send_dynamo_write_access[0].arn,
     aws_iam_policy.bulk_user_email_dynamo_encryption_key_kms_policy[0].arn,
+    aws_iam_policy.txma_audit_queue_access_policy.arn
   ]
 }
 
@@ -42,6 +43,8 @@ resource "aws_lambda_function" "bulk_user_email_send_lambda" {
   environment {
     variables = merge(var.notify_template_map, {
       ENVIRONMENT                           = var.environment
+      INTERNAl_SECTOR_URI                   = var.internal_sector_uri
+      TXMA_AUDIT_QUEUE_URL                  = data.aws_sqs_queue.oidc_txma_audit_queue.url
       NOTIFY_API_KEY                        = var.notify_api_key
       NOTIFY_URL                            = var.notify_url
       BULK_USER_EMAIL_BATCH_QUERY_LIMIT     = var.bulk_user_email_batch_query_limit

--- a/utils/src/main/java/uk/gov/di/authentication/utils/domain/BulkEmailType.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/domain/BulkEmailType.java
@@ -1,0 +1,7 @@
+package uk.gov.di.authentication.utils.domain;
+
+public enum BulkEmailType {
+    VC_EXPIRY_BULK_EMAIL;
+
+    BulkEmailType() {}
+}

--- a/utils/src/main/java/uk/gov/di/authentication/utils/domain/UtilsAuditableEvent.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/domain/UtilsAuditableEvent.java
@@ -1,0 +1,12 @@
+package uk.gov.di.authentication.utils.domain;
+
+import uk.gov.di.authentication.shared.domain.AuditableEvent;
+
+public enum UtilsAuditableEvent implements AuditableEvent {
+    BULK_EMAIL_SENT;
+
+    @Override
+    public AuditableEvent parseFromName(String name) {
+        return valueOf(name);
+    }
+}

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailSenderScheduledEventHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailSenderScheduledEventHandler.java
@@ -6,12 +6,16 @@ import com.amazonaws.services.lambda.runtime.events.ScheduledEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.shared.entity.BulkEmailStatus;
+import uk.gov.di.authentication.shared.entity.UserProfile;
+import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper;
+import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.BulkEmailUsersService;
 import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.NotificationService;
+import uk.gov.di.authentication.utils.domain.UtilsAuditableEvent;
 import uk.gov.service.notify.NotificationClient;
 import uk.gov.service.notify.NotificationClientException;
 
@@ -19,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 
 import static uk.gov.di.authentication.shared.entity.NotificationType.TERMS_AND_CONDITIONS_BULK_EMAIL;
+import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
 
 public class BulkUserEmailSenderScheduledEventHandler
         implements RequestHandler<ScheduledEvent, Void> {
@@ -36,6 +41,8 @@ public class BulkUserEmailSenderScheduledEventHandler
 
     private final CloudwatchMetricsService cloudwatchMetricsService;
 
+    private final AuditService auditService;
+
     public BulkUserEmailSenderScheduledEventHandler() {
         this(ConfigurationService.getInstance());
     }
@@ -45,12 +52,14 @@ public class BulkUserEmailSenderScheduledEventHandler
             DynamoService dynamoService,
             ConfigurationService configurationService,
             NotificationService notificationService,
-            CloudwatchMetricsService cloudwatchMetricsService) {
+            CloudwatchMetricsService cloudwatchMetricsService,
+            AuditService auditService) {
         this.bulkEmailUsersService = bulkEmailUsersService;
         this.dynamoService = dynamoService;
         this.configurationService = configurationService;
         this.notificationService = notificationService;
         this.cloudwatchMetricsService = cloudwatchMetricsService;
+        this.auditService = auditService;
     }
 
     public BulkUserEmailSenderScheduledEventHandler(ConfigurationService configurationService) {
@@ -67,6 +76,7 @@ public class BulkUserEmailSenderScheduledEventHandler
                         .orElse(new NotificationClient(configurationService.getNotifyApiKey()));
         this.notificationService = new NotificationService(client, configurationService);
         this.cloudwatchMetricsService = new CloudwatchMetricsService();
+        this.auditService = new AuditService(configurationService);
     }
 
     @Override
@@ -109,6 +119,7 @@ public class BulkUserEmailSenderScheduledEventHandler
                                         userProfile -> {
                                             try {
                                                 sendNotifyEmail(userProfile.getEmail());
+                                                addAuditEventForEmailSent(userProfile);
                                                 updateBulkUserStatus(
                                                         subjectId, BulkEmailStatus.EMAIL_SENT);
                                             } catch (NotificationClientException e) {
@@ -182,5 +193,22 @@ public class BulkUserEmailSenderScheduledEventHandler
                         bulkEmailStatus.getValue(),
                         "Environment",
                         configurationService.getEnvironment()));
+    }
+
+    private void addAuditEventForEmailSent(UserProfile userProfile) {
+        var internalCommonSubjectIdentifier =
+                ClientSubjectHelper.getSubjectWithSectorIdentifier(
+                        userProfile, configurationService.getInternalSectorUri(), dynamoService);
+        auditService.submitAuditEvent(
+                UtilsAuditableEvent.BULK_EMAIL_SENT,
+                AuditService.UNKNOWN,
+                AuditService.UNKNOWN,
+                AuditService.UNKNOWN,
+                internalCommonSubjectIdentifier.getValue(),
+                userProfile.getEmail(),
+                AuditService.UNKNOWN,
+                AuditService.UNKNOWN,
+                AuditService.UNKNOWN,
+                pair("internalSubjectId", userProfile.getSubjectID()));
     }
 }

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailSenderScheduledEventHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailSenderScheduledEventHandler.java
@@ -15,6 +15,7 @@ import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.NotificationService;
+import uk.gov.di.authentication.utils.domain.BulkEmailType;
 import uk.gov.di.authentication.utils.domain.UtilsAuditableEvent;
 import uk.gov.service.notify.NotificationClient;
 import uk.gov.service.notify.NotificationClientException;
@@ -209,6 +210,7 @@ public class BulkUserEmailSenderScheduledEventHandler
                 AuditService.UNKNOWN,
                 AuditService.UNKNOWN,
                 AuditService.UNKNOWN,
-                pair("internalSubjectId", userProfile.getSubjectID()));
+                pair("internalSubjectId", userProfile.getSubjectID()),
+                pair("bulk-email-type", BulkEmailType.VC_EXPIRY_BULK_EMAIL.name()));
     }
 }

--- a/utils/src/test/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailSenderScheduledEventHandlerTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailSenderScheduledEventHandlerTest.java
@@ -136,7 +136,8 @@ class BulkUserEmailSenderScheduledEventHandlerTest {
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
-                        pair("internalSubjectId", SUBJECT_ID));
+                        pair("internalSubjectId", SUBJECT_ID),
+                        pair("bulk-email-type", "VC_EXPIRY_BULK_EMAIL"));
     }
 
     @Test
@@ -180,7 +181,8 @@ class BulkUserEmailSenderScheduledEventHandlerTest {
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
                         AuditService.UNKNOWN,
-                        pair("internalSubjectId", SUBJECT_ID));
+                        pair("internalSubjectId", SUBJECT_ID),
+                        pair("bulk-email-type", "VC_EXPIRY_BULK_EMAIL"));
     }
 
     @Test
@@ -233,7 +235,8 @@ class BulkUserEmailSenderScheduledEventHandlerTest {
                             AuditService.UNKNOWN,
                             AuditService.UNKNOWN,
                             AuditService.UNKNOWN,
-                            pair("internalSubjectId", TEST_SUBJECT_IDS[j]));
+                            pair("internalSubjectId", TEST_SUBJECT_IDS[j]),
+                            pair("bulk-email-type", "VC_EXPIRY_BULK_EMAIL"));
         }
     }
 


### PR DESCRIPTION
## What?

- Add auditing permissions to bulk sending email Lambda
- Add a new audit event called `BULK_EMAIL_SENT`
- Add metadata pair to audit event to identify which bulk email is being sent
- Submit the audit event for each successful sent email
- Add relevant testing to ensure the audit event is submitted

## Why?

- So we have an audit trail for successful emails sent
