### PR TITLE
AUT-1526: Re-invoke audience load lambdas asynchronously

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/LambdaInvokerService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/LambdaInvokerService.java
@@ -8,6 +8,7 @@ import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.lambda.LambdaClient;
+import software.amazon.awssdk.services.lambda.model.InvocationType;
 import software.amazon.awssdk.services.lambda.model.InvokeRequest;
 import uk.gov.di.authentication.shared.exceptions.LambdaInvokerServiceException;
 import uk.gov.di.authentication.shared.serialization.Json;
@@ -55,7 +56,11 @@ public class LambdaInvokerService implements LambdaInvoker {
         SdkBytes payload = SdkBytes.fromUtf8String(jsonPayload);
 
         InvokeRequest invokeRequest =
-                InvokeRequest.builder().functionName(lambdaName).payload(payload).build();
+                InvokeRequest.builder()
+                        .functionName(lambdaName)
+                        .invocationType(InvocationType.EVENT)
+                        .payload(payload)
+                        .build();
         lambdaClient.invoke(invokeRequest);
     }
 }

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/LambdaInvokerServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/LambdaInvokerServiceTest.java
@@ -5,6 +5,7 @@ import net.minidev.json.JSONObject;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.lambda.LambdaClient;
+import software.amazon.awssdk.services.lambda.model.InvocationType;
 import software.amazon.awssdk.services.lambda.model.InvokeRequest;
 import uk.gov.di.authentication.shared.serialization.Json;
 
@@ -45,7 +46,11 @@ class LambdaInvokerServiceTest {
 
         var payload = SdkBytes.fromUtf8String(payloadString);
         InvokeRequest invokeRequest =
-                InvokeRequest.builder().functionName(functionName).payload(payload).build();
+                InvokeRequest.builder()
+                        .functionName(functionName)
+                        .invocationType(InvocationType.EVENT)
+                        .payload(payload)
+                        .build();
         LambdaInvokerService lambdaInvokerService =
                 new LambdaInvokerService(configurationService, lambdaClient);
 


### PR DESCRIPTION
## What?

- Re-invoke audience load lambdas asynchronously
- Additional logging to record running totals of users loaded

## Why?

Invocation was previously configured to be synchronous meaning that the first invocation did not terminate before all subsequent invocations.  If set to asynchronous then calling lambdas will terminate straight after the invocation, meaning that a single invocation can complete within the 15 min timeout window.

## Related PRs

#3264 
