### PR TITLE
AUT-1526: Use audit kms key alias target_key_arn

### DIFF
--- a/ci/terraform/utils/oidc-audit.tf
+++ b/ci/terraform/utils/oidc-audit.tf
@@ -26,7 +26,7 @@ data "aws_iam_policy_document" "txma_audit_queue_access_policy_document" {
       "kms:Decrypt"
     ]
     resources = [
-      data.aws_kms_alias.oidc_txma_audit_queue_encryption_key_alias.arn
+      data.aws_kms_alias.oidc_txma_audit_queue_encryption_key_alias.target_key_arn
     ]
   }
 }


### PR DESCRIPTION
## What?

Use audit kms key alias target_key_arn

## Why?

It is not possible to use kms key aliases arm in iam policy documents.

https://docs.aws.amazon.com/kms/latest/developerguide/cmks-in-iam-policies.html
