### PR TITLE
AUT-1526: Add bulk email send lambda to the security group with egress

### DIFF
--- a/ci/terraform/utils/bulk_user_email_send_lambda.tf
+++ b/ci/terraform/utils/bulk_user_email_send_lambda.tf
@@ -36,7 +36,7 @@ resource "aws_lambda_function" "bulk_user_email_send_lambda" {
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
   vpc_config {
-    security_group_ids = [local.authentication_security_group_id]
+    security_group_ids = [local.authentication_egress_security_group_id]
     subnet_ids         = local.authentication_subnet_ids
   }
 

--- a/ci/terraform/utils/shared.tf
+++ b/ci/terraform/utils/shared.tf
@@ -16,6 +16,7 @@ locals {
   authentication_vpc_arn                   = data.terraform_remote_state.shared.outputs.authentication_vpc_arn
   authentication_subnet_ids                = data.terraform_remote_state.shared.outputs.authentication_subnet_ids
   authentication_security_group_id         = data.terraform_remote_state.shared.outputs.authentication_security_group_id
+  authentication_egress_security_group_id  = data.terraform_remote_state.shared.outputs.authentication_egress_security_group_id
   default_performance_parameters = {
     memory  = 1024,
     timeout = 900,


### PR DESCRIPTION

## What?

Add bulk email send lambda to the security group with egress.

## Why?

Enables the lambda to reach Notify to send messages.  Resolves Notify connection timeout issue in build.


