### PR TITLE
AUT-1542 - Create Private api gateway for Authentication external API

### DIFF
--- a/ci/terraform/oidc/api-gateway-auth-external.tf
+++ b/ci/terraform/oidc/api-gateway-auth-external.tf
@@ -67,6 +67,7 @@ resource "aws_api_gateway_usage_plan" "di_auth_ext_api_usage_plan" {
     aws_api_gateway_stage.di_auth_ext_stage,
     aws_api_gateway_rest_api.di_auth_ext_api,
   ]
+  # checkov:skip=CKV_AWS_120:We do not want API caching on this Lambda
 }
 
 resource "aws_api_gateway_stage" "di_auth_ext_stage" {
@@ -87,6 +88,8 @@ resource "aws_api_gateway_stage" "di_auth_ext_stage" {
   }
 
   tags = local.default_tags
+  # checkov:skip=CKV_AWS_51:Client cert authentication is something we might want to consider in the future
+  # checkov:skip=CKV_AWS_120:We do not want API caching on this Lambda
 }
 
 resource "aws_api_gateway_method_settings" "di_auth_ext_api_logging_settings" {
@@ -105,6 +108,8 @@ resource "aws_api_gateway_method_settings" "di_auth_ext_api_logging_settings" {
   depends_on = [
     aws_api_gateway_stage.di_auth_ext_stage
   ]
+  # checkov:skip=CKV_AWS_225:We do not want API caching on this Lambda
+  # checkov:skip=CKV_AWS_308:We do not want API caching on this Lambda
 }
 
 resource "aws_api_gateway_deployment" "auth_ext_api_deployment" {

--- a/ci/terraform/oidc/api-gateway-auth-external.tf
+++ b/ci/terraform/oidc/api-gateway-auth-external.tf
@@ -1,0 +1,122 @@
+data "aws_vpc" "auth_shared_vpc" {
+  filter {
+    name   = "tag:Name"
+    values = ["${var.environment}-shared-vpc"]
+  }
+
+}
+
+data "aws_vpc_endpoint" "auth_api_vpc_endpoint" {
+  vpc_id       = data.aws_vpc.auth_shared_vpc.id
+  service_name = "com.amazonaws.eu-west-2.execute-api"
+  tags = {
+    environment = var.environment
+    terraform   = "core"
+  }
+}
+
+resource "aws_api_gateway_rest_api" "di_auth_ext_api" {
+  name = "${var.environment}-di-auth-ext-api"
+
+  tags   = local.default_tags
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": "*",
+            "Action": "execute-api:Invoke",
+            "Resource": [
+                "execute-api:/*"
+            ]
+        },
+        {
+            "Effect": "Deny",
+            "Principal": "*",
+            "Action": "execute-api:Invoke",
+            "Resource": [
+                "execute-api:/*"
+            ],
+            "Condition" : {
+                "StringNotEquals": {
+                    "aws:SourceVpce": "${data.aws_vpc_endpoint.auth_api_vpc_endpoint.id}"
+                }
+            }
+        }
+    ]
+}
+EOF
+  endpoint_configuration {
+    types            = ["PRIVATE"]
+    vpc_endpoint_ids = [data.aws_vpc_endpoint.auth_api_vpc_endpoint.id]
+  }
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_api_gateway_usage_plan" "di_auth_ext_api_usage_plan" {
+  name = "${var.environment}-di-auth-ext-api-usage-plan"
+
+  api_stages {
+    api_id = aws_api_gateway_rest_api.di_auth_ext_api.id
+    stage  = aws_api_gateway_stage.di_auth_ext_stage.stage_name
+  }
+  depends_on = [
+    aws_api_gateway_stage.di_auth_ext_stage,
+    aws_api_gateway_rest_api.di_auth_ext_api,
+  ]
+}
+
+resource "aws_api_gateway_stage" "di_auth_ext_stage" {
+  deployment_id         = aws_api_gateway_deployment.auth_ext_api_deployment.id
+  rest_api_id           = aws_api_gateway_rest_api.di_auth_ext_api.id
+  stage_name            = var.environment
+  cache_cluster_enabled = false
+
+  xray_tracing_enabled = true
+
+  dynamic "access_log_settings" {
+    for_each = var.use_localstack ? [] : aws_cloudwatch_log_group.oidc_stage_access_logs
+    iterator = log_group
+    content {
+      destination_arn = log_group.value.arn
+      format          = local.access_logging_template
+    }
+  }
+
+  tags = local.default_tags
+}
+
+resource "aws_api_gateway_method_settings" "di_auth_ext_api_logging_settings" {
+  count = var.enable_api_gateway_execution_logging ? 1 : 0
+
+  rest_api_id = aws_api_gateway_rest_api.di_auth_ext_api.id
+  stage_name  = aws_api_gateway_stage.di_auth_ext_stage.stage_name
+  method_path = "*/*"
+
+  settings {
+    metrics_enabled    = true
+    data_trace_enabled = var.enable_api_gateway_execution_request_tracing && local.request_tracing_allowed
+    logging_level      = "INFO"
+    caching_enabled    = false
+  }
+  depends_on = [
+    aws_api_gateway_stage.di_auth_ext_stage
+  ]
+}
+
+resource "aws_api_gateway_deployment" "auth_ext_api_deployment" {
+  rest_api_id = aws_api_gateway_rest_api.di_auth_ext_api.id
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+module "dashboard_auth_ext_api" {
+  source           = "../modules/dashboards"
+  api_gateway_name = aws_api_gateway_rest_api.di_auth_ext_api.name
+  use_localstack   = false
+}

--- a/ci/terraform/oidc/s3-objects.tf
+++ b/ci/terraform/oidc/s3-objects.tf
@@ -9,6 +9,15 @@ resource "aws_s3_bucket_versioning" "source_bucket_versioning" {
   }
 }
 
+resource "aws_s3_object" "auth_ext_api_release_zip" {
+  bucket = aws_s3_bucket.source_bucket.bucket
+  key    = "auth-ext-api-release.zip"
+
+  server_side_encryption = "AES256"
+  source                 = var.auth_ext_lambda_zip_file
+  source_hash            = filemd5(var.auth_ext_lambda_zip_file)
+}
+
 resource "aws_s3_object" "oidc_api_release_zip" {
   bucket = aws_s3_bucket.source_bucket.bucket
   key    = "oidc-api-release.zip"

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -4,6 +4,12 @@ variable "oidc_api_lambda_zip_file" {
   type        = string
 }
 
+variable "auth_ext_lambda_zip_file" {
+  default     = "../../../auth-external-api/build/distributions/auth-external-api.zip"
+  description = "Location of the Auth External API Lambda ZIP file"
+  type        = string
+}
+
 variable "frontend_api_lambda_zip_file" {
   default     = "../../../frontend-api/build/distributions/frontend-api.zip"
   description = "Location of the Frontend API Lambda ZIP file"


### PR DESCRIPTION
## What?

 - Create Private api gateway for Authentication external API which will only allow traffic routed through a specific VPC endpoint 
- Create new S3 bucket object to store the source code for the auth external API

## Why?

- This will limit which traffic can hit the API based on whether it has been routed via the expected VPC endpoint
- This VPC endpoint currently lives in the same VPC as Authentication as Orchestration is still within this VPC. When Orchestration moves into a new VPC then there will be a new VPC endpoint that we need to permit traffic from
- The API can be called via the following - `https://{rest-api-id}-{vpce-id}.execute-api.{region}.amazonaws.com/{stage}`