### PR TITLE
AUT-1526: Deploy bulk email table in shared to integration and staging

### DIFF
--- a/ci/terraform/shared/site.tf
+++ b/ci/terraform/shared/site.tf
@@ -59,7 +59,7 @@ locals {
   }
 
   request_tracing_allowed       = contains(["build", "sandpit"], var.environment)
-  deploy_bulk_email_users_count = contains(["build", "sandpit"], var.environment) ? 1 : 0
+  deploy_bulk_email_users_count = contains(["build", "sandpit", "staging", "integration"], var.environment) ? 1 : 0
 }
 
 data "aws_caller_identity" "current" {}


### PR DESCRIPTION

## What?

Deploy bulk email table in shared to integration and staging.

## Why?

Components in utils depend on this table being created.
Fixes failed deployments of 'utils' in staging and integration.

## Related PRs

#3276 
