### PR TITLE
AUT-1406 - Change dimension name so that it is different to the metric name

### DIFF
--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailSenderScheduledEventHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailSenderScheduledEventHandler.java
@@ -193,7 +193,7 @@ public class BulkUserEmailSenderScheduledEventHandler
         cloudwatchMetricsService.incrementCounter(
                 "BulkEmailStatus",
                 Map.of(
-                        "BulkEmailStatus",
+                        "Status",
                         bulkEmailStatus.getValue(),
                         "Environment",
                         configurationService.getEnvironment()));


### PR DESCRIPTION
## What?

 - Change dimension name so that it is different to the metric name
 
## Why?

- When the dimension name was the same as the metric name, cloudwatch didn't bring through any of the dimensions. This is resolved by making the dimension name different
