### PR TITLE
AUT-1297: Upgrade Account Metrics Lambda runtime version to Java 17.

### DIFF
--- a/ci/terraform/utils/account_metrics_lambda.tf
+++ b/ci/terraform/utils/account_metrics_lambda.tf
@@ -41,7 +41,7 @@ resource "aws_lambda_function" "account_metrics_lambda" {
   handler       = "uk.gov.di.authentication.utils.lambda.AccountMetricPublishHandler::handleRequest"
   timeout       = 900
   memory_size   = 4096
-  runtime       = "java11"
+  runtime       = "java17"
   publish       = true
 
   s3_bucket         = aws_s3_object.utils_release_zip.bucket


### PR DESCRIPTION
## What?

Upgrade Account Metrics lambda runtime version to Java 17. 

After this upgrade deploys successfully, the other lambda runtimes will be upgraded to Java 17 in a separate PR.

## Why?

As a first stage to upgrading to Java 17, run this single low-traffic lambda on Java 17 (but still compile it using Java 11).
