### PR TITLE
AUT-1297: Upgrade remaining lambda runtime versions to Java 17

### DIFF
--- a/ci/terraform/account-management/sqs.tf
+++ b/ci/terraform/account-management/sqs.tf
@@ -165,7 +165,7 @@ resource "aws_lambda_function" "email_sqs_lambda" {
   handler       = "uk.gov.di.accountmanagement.lambda.NotificationHandler::handleRequest"
   timeout       = 30
   memory_size   = 512
-  runtime       = "java11"
+  runtime       = "java17"
   publish       = true
 
   s3_bucket         = aws_s3_bucket.source_bucket.bucket

--- a/ci/terraform/audit-processors/counter_fraud.tf
+++ b/ci/terraform/audit-processors/counter_fraud.tf
@@ -160,7 +160,7 @@ resource "aws_lambda_function" "fraud_realtime_logging_lambda" {
   }
   kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn
 
-  runtime = "java11"
+  runtime = "java17"
 
   tags = local.default_tags
 }

--- a/ci/terraform/audit-processors/performance_analysis.tf
+++ b/ci/terraform/audit-processors/performance_analysis.tf
@@ -73,7 +73,7 @@ resource "aws_lambda_function" "performance_analysis_logging_lambda" {
   }
   kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn
 
-  runtime = "java11"
+  runtime = "java17"
 
   tags = local.default_tags
 }

--- a/ci/terraform/audit-processors/storage.tf
+++ b/ci/terraform/audit-processors/storage.tf
@@ -72,7 +72,7 @@ resource "aws_lambda_function" "audit_processor_lambda" {
   }
   kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn
 
-  runtime = "java11"
+  runtime = "java17"
 
   tags = local.default_tags
 }

--- a/ci/terraform/modules/endpoint-module/variables.tf
+++ b/ci/terraform/modules/endpoint-module/variables.tf
@@ -52,7 +52,7 @@ variable "handler_environment_variables" {
 
 variable "handler_runtime" {
   type    = string
-  default = "java11"
+  default = "java17"
 }
 
 variable "rest_api_id" {

--- a/ci/terraform/oidc/backchannel-logout-request.tf
+++ b/ci/terraform/oidc/backchannel-logout-request.tf
@@ -14,7 +14,7 @@ resource "aws_lambda_function" "backchannel_logout_request_lambda" {
   handler       = "uk.gov.di.authentication.oidc.lambda.BackChannelLogoutRequestHandler::handleRequest"
   timeout       = 30
   memory_size   = 512
-  runtime       = "java11"
+  runtime       = "java17"
   publish       = true
 
   s3_bucket         = aws_s3_bucket.source_bucket.bucket

--- a/ci/terraform/oidc/spot-response.tf
+++ b/ci/terraform/oidc/spot-response.tf
@@ -76,7 +76,7 @@ resource "aws_lambda_function" "spot_response_lambda" {
   handler       = "uk.gov.di.authentication.ipv.lambda.SPOTResponseHandler::handleRequest"
   timeout       = 30
   memory_size   = 512
-  runtime       = "java11"
+  runtime       = "java17"
   publish       = true
 
   s3_bucket         = aws_s3_bucket.source_bucket.bucket

--- a/ci/terraform/oidc/sqs.tf
+++ b/ci/terraform/oidc/sqs.tf
@@ -154,7 +154,7 @@ resource "aws_lambda_function" "email_sqs_lambda" {
   handler       = "uk.gov.di.authentication.frontendapi.lambda.NotificationHandler::handleRequest"
   timeout       = 30
   memory_size   = 512
-  runtime       = "java11"
+  runtime       = "java17"
   publish       = true
 
   s3_bucket         = aws_s3_bucket.source_bucket.bucket

--- a/ci/terraform/utils/bulk_test_user_create_lambda.tf
+++ b/ci/terraform/utils/bulk_test_user_create_lambda.tf
@@ -18,7 +18,7 @@ resource "aws_lambda_function" "bulk_test_user_create_lambda" {
   handler       = "uk.gov.di.authentication.utils.lambda.BulkTestUserCreateHandler::handleRequest"
   timeout       = 900
   memory_size   = 4096
-  runtime       = "java11"
+  runtime       = "java17"
   publish       = true
 
   s3_bucket         = aws_s3_object.utils_release_zip.bucket

--- a/ci/terraform/utils/bulk_test_user_delete_lambda.tf
+++ b/ci/terraform/utils/bulk_test_user_delete_lambda.tf
@@ -17,7 +17,7 @@ resource "aws_lambda_function" "bulk_test_user_delete_lambda" {
   handler       = "uk.gov.di.authentication.utils.lambda.BulkTestUserDeleteHandler::handleRequest"
   timeout       = 900
   memory_size   = 4096
-  runtime       = "java11"
+  runtime       = "java17"
   publish       = true
 
   s3_bucket         = aws_s3_object.utils_release_zip.bucket

--- a/ci/terraform/utils/bulk_user_email_audience_loader_lambda.tf
+++ b/ci/terraform/utils/bulk_user_email_audience_loader_lambda.tf
@@ -46,7 +46,7 @@ resource "aws_lambda_function" "bulk_user_email_audience_loader_lambda" {
   timeout                        = lookup(var.performance_tuning, "bulk-user-email-audience-loader", local.default_performance_parameters).timeout
   memory_size                    = lookup(var.performance_tuning, "bulk-user-email-audience-loader", local.default_performance_parameters).memory
   reserved_concurrent_executions = 3
-  runtime                        = "java11"
+  runtime                        = "java17"
   tracing_config {
     mode = "Active"
   }

--- a/ci/terraform/utils/bulk_user_email_send_lambda.tf
+++ b/ci/terraform/utils/bulk_user_email_send_lambda.tf
@@ -22,7 +22,7 @@ resource "aws_lambda_function" "bulk_user_email_send_lambda" {
   timeout                        = lookup(var.performance_tuning, "bulk-user-email-send", local.default_performance_parameters).timeout
   memory_size                    = lookup(var.performance_tuning, "bulk-user-email-send", local.default_performance_parameters).memory
   reserved_concurrent_executions = 1
-  runtime                        = "java11"
+  runtime                        = "java17"
   tracing_config {
     mode = "Active"
   }

--- a/ci/terraform/utils/common_passwords_update_lambda.tf
+++ b/ci/terraform/utils/common_passwords_update_lambda.tf
@@ -16,7 +16,7 @@ resource "aws_lambda_function" "common_passwords_dynamo_update_lambda" {
   handler       = "uk.gov.di.authentication.utils.lambda.S3ToDynamoDbHandler::handleRequest"
   timeout       = 900
   memory_size   = 4096
-  runtime       = "java11"
+  runtime       = "java17"
   publish       = true
 
   s3_bucket         = aws_s3_object.utils_release_zip.bucket


### PR DESCRIPTION
## What?

Upgrades remaining lambda runtime versions to Java 17 (but they are still compiled on Java 11).

## Why?

One step in process to fully upgrade all lambdas to Java 17.

## Related PRs

[PR to upgrade the first lambda runtime version](https://github.com/alphagov/di-authentication-api/pull/3284)
