### PR TITLE
Revert "AUT-1632: Update terms and conditions version"

### DIFF
--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -132,7 +132,7 @@ variable "use_localstack" {
 
 variable "terms_and_conditions" {
   type    = string
-  default = "1.8"
+  default = "1.7"
 }
 
 variable "localstack_endpoint" {

--- a/ci/terraform/shared/variables.tf
+++ b/ci/terraform/shared/variables.tf
@@ -36,7 +36,7 @@ variable "external_redis_host" {
 
 variable "terms_and_conditions" {
   type    = string
-  default = "1.8"
+  default = "1.7"
 }
 
 variable "external_redis_port" {

--- a/ci/terraform/utils/variables.tf
+++ b/ci/terraform/utils/variables.tf
@@ -63,7 +63,7 @@ variable "cloudwatch_log_retention" {
 
 variable "terms_and_conditions" {
   type        = string
-  default     = "1.8"
+  default     = "1.7"
   description = "The latest Terms and Conditions version number"
 }
 


### PR DESCRIPTION
Reverting since we need to make the [change to the updated at date](https://github.com/alphagov/di-authentication-frontend/pull/1131) live first on the frontend - this commit will be reinstated after that. 

This is because we need to ensure that all frontend changes go live _before_ the backend update, since we want to ensure that no user can have a later terms and conditions version recorded against them than they actually accepted.

 This reverts commit 9049bf5e808fee051833a88ed864d9be093896fc.
