### PR TITLE
AUT-1632: Reinstate update to terms and conditions version

### DIFF
--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -132,7 +132,7 @@ variable "use_localstack" {
 
 variable "terms_and_conditions" {
   type    = string
-  default = "1.7"
+  default = "1.8"
 }
 
 variable "localstack_endpoint" {

--- a/ci/terraform/shared/variables.tf
+++ b/ci/terraform/shared/variables.tf
@@ -36,7 +36,7 @@ variable "external_redis_host" {
 
 variable "terms_and_conditions" {
   type    = string
-  default = "1.7"
+  default = "1.8"
 }
 
 variable "external_redis_port" {

--- a/ci/terraform/utils/variables.tf
+++ b/ci/terraform/utils/variables.tf
@@ -63,7 +63,7 @@ variable "cloudwatch_log_retention" {
 
 variable "terms_and_conditions" {
   type        = string
-  default     = "1.7"
+  default     = "1.8"
   description = "The latest Terms and Conditions version number"
 }
 


### PR DESCRIPTION
We had to revert this temporarily to allow a change to the updated date to go live, but can now reinstate this version bump. This reverts commit a46eb6cb8f114dda229d1e0e1fac744cae94b8c4.

## What?

Please include a summary of the change.

## Why?

Please include reason for the change and any other relevant context.

## Related PRs

Please include links to PRs in other repositories relevant to this PR.
Delete this section if not needed.
