### PR TITLE
AUT-1622: Pass Google Analytics parameter to auth frontend via `/authorize` endpoint

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -74,7 +74,7 @@ public class AuthorisationHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     private static final Logger LOG = LogManager.getLogger(AuthorisationHandler.class);
-    public static final String GOOGLE_ANALYTICS_QUERY_PARAMETER_KEY = "email";
+    public static final String GOOGLE_ANALYTICS_QUERY_PARAMETER_KEY = "result";
 
     private final SessionService sessionService;
     private final ConfigurationService configurationService;

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -74,6 +74,7 @@ public class AuthorisationHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     private static final Logger LOG = LogManager.getLogger(AuthorisationHandler.class);
+    public static final String GOOGLE_ANALYTICS_QUERY_PARAMETER_KEY = "email";
 
     private final SessionService sessionService;
     private final ConfigurationService configurationService;
@@ -310,6 +311,15 @@ public class AuthorisationHandler
                     && authenticationRequest.getPrompt().contains(Prompt.Type.LOGIN)) {
                 redirectUriBuilder.addParameter("prompt", String.valueOf(Prompt.Type.LOGIN));
             }
+
+            List<String> optionalGaTrackingParameter =
+                    authenticationRequest.getCustomParameter(GOOGLE_ANALYTICS_QUERY_PARAMETER_KEY);
+            if (Objects.nonNull(optionalGaTrackingParameter)
+                    && !optionalGaTrackingParameter.isEmpty()) {
+                redirectUriBuilder.addParameter(
+                        GOOGLE_ANALYTICS_QUERY_PARAMETER_KEY, optionalGaTrackingParameter.get(0));
+            }
+
             redirectURI = redirectUriBuilder.build().toString();
         } catch (URISyntaxException e) {
             throw new RuntimeException("Error constructing redirect URI", e);

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -375,17 +375,13 @@ class AuthorisationHandlerTest {
 
         Map<String, String> requestParams =
                 buildRequestParams(
-                        Map.of(
-                                "an-irrelevant-key",
-                                "an-irrelevant-value",
-                                "email",
-                                "confirmation"));
+                        Map.of("an-irrelevant-key", "an-irrelevant-value", "result", "sign-in"));
         APIGatewayProxyResponseEvent response = makeHandlerRequest(withRequestEvent(requestParams));
         URI uri = URI.create(response.getHeaders().get(ResponseHeaders.LOCATION));
 
         assertThat(response, hasStatus(302));
         assertEquals(LOGIN_URL.getAuthority(), uri.getAuthority());
-        assertThat(uri.getQuery(), containsString("email=confirmation"));
+        assertThat(uri.getQuery(), containsString("result=sign-in"));
         assertThat(uri.getQuery(), not(containsString("an-irrelevant-key=an-irrelevant-value")));
     }
 

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -361,6 +361,34 @@ class AuthorisationHandlerTest {
                         pair("client-name", RP_CLIENT_NAME));
     }
 
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldRetainGoogleAnalyticsParamThroughRedirectToLoginWhenClientIsFaceToFaceRp(
+            boolean isAuthOrchSplitEnabled) {
+        when(configService.isAuthOrchSplitEnabled()).thenReturn(isAuthOrchSplitEnabled);
+
+        withExistingSession(session);
+        when(userContext.getClientSession()).thenReturn(clientSession);
+        when(userContext.getSession()).thenReturn(session);
+        when(clientSession.getAuthRequestParams())
+                .thenReturn(generateAuthRequest(Optional.empty()).toParameters());
+
+        Map<String, String> requestParams =
+                buildRequestParams(
+                        Map.of(
+                                "an-irrelevant-key",
+                                "an-irrelevant-value",
+                                "email",
+                                "confirmation"));
+        APIGatewayProxyResponseEvent response = makeHandlerRequest(withRequestEvent(requestParams));
+        URI uri = URI.create(response.getHeaders().get(ResponseHeaders.LOCATION));
+
+        assertThat(response, hasStatus(302));
+        assertEquals(LOGIN_URL.getAuthority(), uri.getAuthority());
+        assertThat(uri.getQuery(), containsString("email=confirmation"));
+        assertThat(uri.getQuery(), not(containsString("an-irrelevant-key=an-irrelevant-value")));
+    }
+
     @Test
     void shouldRedirectToLoginWhenUserNeedsToBeUplifted() {
         session.setCurrentCredentialStrength(CredentialTrustLevel.LOW_LEVEL);


### PR DESCRIPTION
## What?
- Pass a Google Analytics parameter to the authentication frontend via OIDC/orchestration `/authorize` endpoint

## Why?

- This is a Google Analytics value that needs to be picked up in the authentication frontend
- It originates in an email sent by the Face-to-Face service to let users know that their identity has been processed
- From there the IPV Return Relying Party passes this query param alongside its 'normal' authorize request
- In this commit, I have added the ability to pass through the value to the auth frontend
- A separate commit will be needed in the frontend repository to do anything with that value
- It should never change any system behaviour and is purely for analytics

## Related PRs
- Frontend PR to follow
- A change has also previously been made in IPV Return RP to add this parameter to their `/authorize` request