### PR TITLE
Add bulk email timestamp

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/BulkEmailUser.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/BulkEmailUser.java
@@ -9,6 +9,7 @@ public class BulkEmailUser {
 
     private String subjectID;
     private BulkEmailStatus bulkEmailStatus;
+    private String updatedAt;
 
     public BulkEmailUser() {}
 
@@ -38,6 +39,20 @@ public class BulkEmailUser {
 
     public BulkEmailUser withBulkEmailStatus(BulkEmailStatus bulkEmailStatus) {
         this.bulkEmailStatus = bulkEmailStatus;
+        return this;
+    }
+
+    @DynamoDbAttribute("UpdatedAt")
+    public String getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(String timestamp) {
+        this.updatedAt = timestamp;
+    }
+
+    public BulkEmailUser withUpdatedAt(String timestamp) {
+        this.updatedAt = timestamp;
         return this;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/BulkEmailUsersService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/BulkEmailUsersService.java
@@ -7,6 +7,7 @@ import software.amazon.awssdk.services.dynamodb.model.QueryRequest;
 import uk.gov.di.authentication.shared.entity.BulkEmailStatus;
 import uk.gov.di.authentication.shared.entity.BulkEmailUser;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -35,7 +36,8 @@ public class BulkEmailUsersService extends BaseDynamoService<BulkEmailUser> {
         return getBulkEmailUsers(subjectID)
                 .map(
                         user -> {
-                            user.withBulkEmailStatus(bulkEmailStatus);
+                            LocalDateTime now = LocalDateTime.now(configurationService.getClock());
+                            user.withBulkEmailStatus(bulkEmailStatus).withUpdatedAt(now.toString());
                             update(user);
                             return user;
                         });

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -17,6 +17,7 @@ import uk.gov.di.authentication.shared.exceptions.SSMParameterNotFoundException;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 
 import java.net.URI;
+import java.time.Clock;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -119,6 +120,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
 
     public long getDefaultOtpCodeExpiry() {
         return Long.parseLong(System.getenv().getOrDefault("DEFAULT_OTP_CODE_EXPIRY", "900"));
+    }
+
+    public Clock getClock() {
+        return Clock.systemDefaultZone();
     }
 
     public long getEmailAccountCreationOtpCodeExpiry() {


### PR DESCRIPTION
This adds a timestamp when we update a bulk email user's status, which helps for audit purposes.

Also refactors some tests to make the setup less noisy.
