### PR TITLE
AUT-1474: Deploy bulk email components to production

### DIFF
--- a/ci/terraform/utils/build-overrides.tfvars
+++ b/ci/terraform/utils/build-overrides.tfvars
@@ -7,7 +7,7 @@ internal_sector_uri = "https://identity.build.account.gov.uk"
 allow_bulk_test_users = true
 
 bulk_user_email_audience_loader_schedule_enabled  = false
-bulk_user_email_included_terms_and_conditions     = "1.5,1.6,1.7"
+bulk_user_email_included_terms_and_conditions     = "1.0,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8"
 bulk_user_email_max_audience_load_user_batch_size = 1000
 bulk_user_email_max_audience_load_user_count      = 5000
 

--- a/ci/terraform/utils/bulk_user_email_audience_loader_lambda.tf
+++ b/ci/terraform/utils/bulk_user_email_audience_loader_lambda.tf
@@ -46,7 +46,7 @@ resource "aws_lambda_function" "bulk_user_email_audience_loader_lambda" {
   timeout                        = lookup(var.performance_tuning, "bulk-user-email-audience-loader", local.default_performance_parameters).timeout
   memory_size                    = lookup(var.performance_tuning, "bulk-user-email-audience-loader", local.default_performance_parameters).memory
   reserved_concurrent_executions = 3
-  runtime                        = "java11"
+  runtime                        = "java17"
   tracing_config {
     mode = "Active"
   }

--- a/ci/terraform/utils/bulk_user_email_send_lambda.tf
+++ b/ci/terraform/utils/bulk_user_email_send_lambda.tf
@@ -22,7 +22,7 @@ resource "aws_lambda_function" "bulk_user_email_send_lambda" {
   timeout                        = lookup(var.performance_tuning, "bulk-user-email-send", local.default_performance_parameters).timeout
   memory_size                    = lookup(var.performance_tuning, "bulk-user-email-send", local.default_performance_parameters).memory
   reserved_concurrent_executions = 1
-  runtime                        = "java11"
+  runtime                        = "java17"
   tracing_config {
     mode = "Active"
   }

--- a/ci/terraform/utils/production-overrides.tfvars
+++ b/ci/terraform/utils/production-overrides.tfvars
@@ -11,3 +11,14 @@ shared_state_bucket = "digital-identity-prod-tfstate"
 notify_template_map = {
   TERMS_AND_CONDITIONS_BULK_EMAIL_TEMPLATE_ID = "173418a1-c442-4c4b-a6d1-d23f473f3dd0"
 }
+
+bulk_user_email_audience_loader_schedule_enabled  = false
+bulk_user_email_included_terms_and_conditions     = "1.0,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8"
+bulk_user_email_max_audience_load_user_batch_size = 0
+bulk_user_email_max_audience_load_user_count      = 0
+
+bulk_user_email_send_schedule_enabled = false
+bulk_user_email_email_sending_enabled = false
+bulk_user_email_batch_query_limit     = 1000
+bulk_user_email_max_batch_count       = 1
+bulk_user_email_batch_pause_duration  = 0

--- a/ci/terraform/utils/site.tf
+++ b/ci/terraform/utils/site.tf
@@ -52,7 +52,7 @@ locals {
   }
 
   request_tracing_allowed                     = contains(["build", "sandpit"], var.environment)
-  deploy_bulk_email_users_count               = contains(["build", "sandpit", "staging", "integration"], var.environment) ? 1 : 0
+  deploy_bulk_email_users_count               = 1
   bulk_user_email_audience_loader_lambda_name = "${var.environment}-bulk-user-email-audience-loader-lambda"
 }
 


### PR DESCRIPTION
## What?

Add default prod config.
Flick switch to deploy to prod.
Upgrade the lambdas from java11 to java 17.

## Why?

Bulk email load and first batch send is coming soon.
Going to run a subset of the user load in production for proving purposes before the full load.

java17 seems to offer performance improvements vs java11
