### PR TITLE
AUT-1253: Orches: Modify userinfo & Token endpoint

### DIFF
--- a/oidc-api/build.gradle
+++ b/oidc-api/build.gradle
@@ -8,6 +8,7 @@ version "unspecified"
 
 dependencies {
 
+    implementation project(path: ':auth-external-api')
     compileOnly             configurations.kms,
             configurations.lambda,
             configurations.sqs,

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandler.java
@@ -38,7 +38,6 @@ public class UserInfoHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     private static final Logger LOG = LogManager.getLogger(UserInfoHandler.class);
-    private final AuthenticationUserInfoStorageService userInfoStorageService;
     private final ConfigurationService configurationService;
     private final UserInfoService userInfoService;
     private final AccessTokenService accessTokenService;
@@ -48,13 +47,11 @@ public class UserInfoHandler
             ConfigurationService configurationService,
             UserInfoService userInfoService,
             AccessTokenService accessTokenService,
-            AuditService auditService,
-            AuthenticationUserInfoStorageService userInfoStorageService) {
+            AuditService auditService) {
         this.configurationService = configurationService;
         this.userInfoService = userInfoService;
         this.accessTokenService = accessTokenService;
         this.auditService = auditService;
-        this.userInfoStorageService = userInfoStorageService;
     }
 
     public UserInfoHandler() {
@@ -81,8 +78,6 @@ public class UserInfoHandler
                                         new KmsConnectionService(configurationService)),
                                 configurationService));
         this.auditService = new AuditService(configurationService);
-        this.userInfoStorageService =
-                new AuthenticationUserInfoStorageService(configurationService);
     }
 
     @Override

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandler.java
@@ -13,6 +13,7 @@ import uk.gov.di.authentication.app.services.DynamoDocAppService;
 import uk.gov.di.authentication.oidc.domain.OidcAuditableEvent;
 import uk.gov.di.authentication.oidc.entity.AccessTokenInfo;
 import uk.gov.di.authentication.oidc.services.AccessTokenService;
+import uk.gov.di.authentication.oidc.services.AuthenticationUserInfoStorageService;
 import uk.gov.di.authentication.oidc.services.UserInfoService;
 import uk.gov.di.authentication.shared.exceptions.AccessTokenException;
 import uk.gov.di.authentication.shared.services.AuditService;
@@ -37,6 +38,7 @@ public class UserInfoHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     private static final Logger LOG = LogManager.getLogger(UserInfoHandler.class);
+    private final AuthenticationUserInfoStorageService userInfoStorageService;
     private final ConfigurationService configurationService;
     private final UserInfoService userInfoService;
     private final AccessTokenService accessTokenService;
@@ -46,11 +48,13 @@ public class UserInfoHandler
             ConfigurationService configurationService,
             UserInfoService userInfoService,
             AccessTokenService accessTokenService,
-            AuditService auditService) {
+            AuditService auditService,
+            AuthenticationUserInfoStorageService userInfoStorageService) {
         this.configurationService = configurationService;
         this.userInfoService = userInfoService;
         this.accessTokenService = accessTokenService;
         this.auditService = auditService;
+        this.userInfoStorageService = userInfoStorageService;
     }
 
     public UserInfoHandler() {
@@ -65,7 +69,8 @@ public class UserInfoHandler
                         new DynamoIdentityService(configurationService),
                         new DynamoDocAppService(configurationService),
                         new CloudwatchMetricsService(),
-                        configurationService);
+                        configurationService,
+                        new AuthenticationUserInfoStorageService(configurationService));
         this.accessTokenService =
                 new AccessTokenService(
                         new RedisConnectionService(configurationService),
@@ -76,6 +81,8 @@ public class UserInfoHandler
                                         new KmsConnectionService(configurationService)),
                                 configurationService));
         this.auditService = new AuditService(configurationService);
+        this.userInfoStorageService =
+                new AuthenticationUserInfoStorageService(configurationService);
     }
 
     @Override

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandlerTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.oidc.domain.OidcAuditableEvent;
 import uk.gov.di.authentication.oidc.entity.AccessTokenInfo;
 import uk.gov.di.authentication.oidc.services.AccessTokenService;
+import uk.gov.di.authentication.oidc.services.AuthenticationUserInfoStorageService;
 import uk.gov.di.authentication.oidc.services.UserInfoService;
 import uk.gov.di.authentication.shared.exceptions.AccessTokenException;
 import uk.gov.di.authentication.shared.services.AuditService;
@@ -39,6 +40,8 @@ public class UserInfoHandlerTest {
     private static final String PHONE_NUMBER = "01234567890";
     private static final Subject SUBJECT = new Subject();
     private static final Subject AUDIT_SUBJECT_ID = new Subject();
+    private final AuthenticationUserInfoStorageService userInfoStorageService =
+            mock(AuthenticationUserInfoStorageService.class);
     private final Context context = mock(Context.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final UserInfoService userInfoService = mock(UserInfoService.class);
@@ -54,7 +57,11 @@ public class UserInfoHandlerTest {
     void setUp() {
         handler =
                 new UserInfoHandler(
-                        configurationService, userInfoService, accessTokenService, auditService);
+                        configurationService,
+                        userInfoService,
+                        accessTokenService,
+                        auditService,
+                        userInfoStorageService);
         when(context.getAwsRequestId()).thenReturn("aws-request-id");
         when(accessTokenInfo.getClientID()).thenReturn("client-id");
         when(accessTokenInfo.getSubject()).thenReturn(SUBJECT.getValue());

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandlerTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.oidc.domain.OidcAuditableEvent;
 import uk.gov.di.authentication.oidc.entity.AccessTokenInfo;
 import uk.gov.di.authentication.oidc.services.AccessTokenService;
-import uk.gov.di.authentication.oidc.services.AuthenticationUserInfoStorageService;
 import uk.gov.di.authentication.oidc.services.UserInfoService;
 import uk.gov.di.authentication.shared.exceptions.AccessTokenException;
 import uk.gov.di.authentication.shared.services.AuditService;
@@ -40,8 +39,6 @@ public class UserInfoHandlerTest {
     private static final String PHONE_NUMBER = "01234567890";
     private static final Subject SUBJECT = new Subject();
     private static final Subject AUDIT_SUBJECT_ID = new Subject();
-    private final AuthenticationUserInfoStorageService userInfoStorageService =
-            mock(AuthenticationUserInfoStorageService.class);
     private final Context context = mock(Context.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final UserInfoService userInfoService = mock(UserInfoService.class);
@@ -57,11 +54,7 @@ public class UserInfoHandlerTest {
     void setUp() {
         handler =
                 new UserInfoHandler(
-                        configurationService,
-                        userInfoService,
-                        accessTokenService,
-                        auditService,
-                        userInfoStorageService);
+                        configurationService, userInfoService, accessTokenService, auditService);
         when(context.getAwsRequestId()).thenReturn("aws-request-id");
         when(accessTokenInfo.getClientID()).thenReturn("client-id");
         when(accessTokenInfo.getSubject()).thenReturn(SUBJECT.getValue());

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
@@ -12,6 +12,7 @@ import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.openid.connect.sdk.OIDCClaimsRequest;
 import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import com.nimbusds.openid.connect.sdk.claims.ClaimsSetRequest;
+import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import net.minidev.json.JSONArray;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -20,12 +21,13 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.authentication.app.entity.DocAppCredential;
 import uk.gov.di.authentication.app.services.DynamoDocAppService;
 import uk.gov.di.authentication.oidc.entity.AccessTokenInfo;
+import uk.gov.di.authentication.oidc.entity.AuthenticationUserInfo;
 import uk.gov.di.authentication.shared.entity.AccessTokenStore;
-import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.CustomScopeValue;
 import uk.gov.di.authentication.shared.entity.IdentityCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.ValidClaims;
+import uk.gov.di.authentication.shared.exceptions.AccessTokenException;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
@@ -91,7 +93,6 @@ class UserInfoServiceTest {
     private final String docAppCredentialJWT =
             SignedCredentialHelper.generateCredential().serialize();
     private AccessToken accessToken;
-    private ClientRegistry clientRegistry;
 
     @RegisterExtension
     public final CaptureLoggingExtension logging =
@@ -114,13 +115,13 @@ class UserInfoServiceTest {
                         cloudwatchMetricsService,
                         configurationService,
                         userInfoStorageService);
-        clientRegistry = generateClientRegistry();
         when(configurationService.getInternalSectorUri()).thenReturn(INTERNAL_SECTOR_URI);
         when(configurationService.getEnvironment()).thenReturn("test");
     }
 
     @Test
-    void shouldJustPopulateUserInfoWhenIdentityNotEnabled() throws JOSEException {
+    void shouldJustPopulateUserInfoWhenIdentityNotEnabled()
+            throws JOSEException, AccessTokenException {
         when(configurationService.isIdentityEnabled()).thenReturn(false);
         accessToken = createSignedAccessToken(null);
         when(authenticationService.getUserProfileFromSubject(INTERNAL_SUBJECT.getValue()))
@@ -143,8 +144,38 @@ class UserInfoServiceTest {
     }
 
     @Test
+    void shouldJustPopulateUserInfoWhenIdentityNotEnabledOrchSplitEnabled()
+            throws JOSEException, AccessTokenException {
+        when(configurationService.isIdentityEnabled()).thenReturn(false);
+        when(configurationService.isAuthOrchSplitEnabled()).thenReturn(true);
+
+        accessToken = createSignedAccessToken(null);
+        var accessTokenStore =
+                new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
+        var accessTokenInfo =
+                new AccessTokenInfo(accessTokenStore, SUBJECT.getValue(), SCOPES, null, CLIENT_ID);
+
+        AuthenticationUserInfo testUserInfo =
+                new AuthenticationUserInfo().withUserInfo(generateUserInfo().toJSONString());
+
+        when(userInfoStorageService.getAuthenticationUserInfoData(
+                        accessTokenInfo.getAccessTokenStore().getInternalSubjectId()))
+                .thenReturn(Optional.of(testUserInfo));
+
+        var userInfo = userInfoService.populateUserInfo(accessTokenInfo);
+        assertThat(userInfo.getEmailAddress(), equalTo(EMAIL));
+        assertThat(userInfo.getEmailVerified(), equalTo(true));
+        assertThat(userInfo.getPhoneNumber(), equalTo(PHONE_NUMBER));
+        assertThat(userInfo.getPhoneNumberVerified(), equalTo(true));
+        assertNull(userInfo.getClaim(ValidClaims.CORE_IDENTITY_JWT.getValue()));
+        assertNull(userInfo.getClaim(ValidClaims.ADDRESS.getValue()));
+        assertNull(userInfo.getClaim(ValidClaims.PASSPORT.getValue()));
+        assertNull(userInfo.getClaim(ValidClaims.DRIVING_PERMIT.getValue()));
+    }
+
+    @Test
     void shouldJustPopulateEmailClaimWhenOnlyEmailScopeIsPresentAndIdentityNotEnabled()
-            throws JOSEException {
+            throws JOSEException, AccessTokenException {
         when(configurationService.isIdentityEnabled()).thenReturn(false);
         accessToken = createSignedAccessToken(null);
         var scopes = List.of(OIDCScopeValue.OPENID.getValue(), OIDCScopeValue.EMAIL.getValue());
@@ -168,8 +199,40 @@ class UserInfoServiceTest {
     }
 
     @Test
+    void
+            shouldJustPopulateEmailClaimWhenOnlyEmailScopeIsPresentAndIdentityNotEnabledOrchSplitEnabled()
+                    throws JOSEException, AccessTokenException {
+        when(configurationService.isIdentityEnabled()).thenReturn(false);
+        when(configurationService.isAuthOrchSplitEnabled()).thenReturn(true);
+        accessToken = createSignedAccessToken(null);
+        var scopes = List.of(OIDCScopeValue.OPENID.getValue(), OIDCScopeValue.EMAIL.getValue());
+
+        var accessTokenStore =
+                new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
+        var accessTokenInfo =
+                new AccessTokenInfo(accessTokenStore, SUBJECT.getValue(), scopes, null, CLIENT_ID);
+
+        AuthenticationUserInfo testUserInfo =
+                new AuthenticationUserInfo().withUserInfo(generateUserInfo().toJSONString());
+
+        when(userInfoStorageService.getAuthenticationUserInfoData(
+                        accessTokenInfo.getAccessTokenStore().getInternalSubjectId()))
+                .thenReturn(Optional.of(testUserInfo));
+
+        var userInfo = userInfoService.populateUserInfo(accessTokenInfo);
+        assertThat(userInfo.getEmailAddress(), equalTo(EMAIL));
+        assertThat(userInfo.getEmailVerified(), equalTo(true));
+        assertNull(userInfo.getPhoneNumber());
+        assertNull(userInfo.getPhoneNumberVerified());
+        assertNull(userInfo.getClaim(ValidClaims.ADDRESS.getValue()));
+        assertNull(userInfo.getClaim(ValidClaims.PASSPORT.getValue()));
+        assertNull(userInfo.getClaim(ValidClaims.DRIVING_PERMIT.getValue()));
+        assertNull(userInfo.getClaim(ValidClaims.CORE_IDENTITY_JWT.getValue()));
+    }
+
+    @Test
     void shouldJustPopulateUserInfoWhenIdentityEnabledButNoIdentityClaimsPresent()
-            throws JOSEException {
+            throws JOSEException, AccessTokenException {
         when(configurationService.isIdentityEnabled()).thenReturn(true);
         accessToken = createSignedAccessToken(null);
         when(authenticationService.getUserProfileFromSubject(INTERNAL_SUBJECT.getValue()))
@@ -192,8 +255,38 @@ class UserInfoServiceTest {
     }
 
     @Test
+    void shouldJustPopulateUserInfoWhenIdentityEnabledButNoIdentityClaimsPresentOrchSplitEnabled()
+            throws JOSEException, AccessTokenException {
+        when(configurationService.isIdentityEnabled()).thenReturn(false);
+        when(configurationService.isAuthOrchSplitEnabled()).thenReturn(true);
+
+        accessToken = createSignedAccessToken(null);
+        var accessTokenStore =
+                new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
+        var accessTokenInfo =
+                new AccessTokenInfo(accessTokenStore, SUBJECT.getValue(), SCOPES, null, CLIENT_ID);
+
+        AuthenticationUserInfo testUserInfo =
+                new AuthenticationUserInfo().withUserInfo(generateUserInfo().toJSONString());
+
+        when(userInfoStorageService.getAuthenticationUserInfoData(
+                        accessTokenInfo.getAccessTokenStore().getInternalSubjectId()))
+                .thenReturn(Optional.of(testUserInfo));
+
+        var userInfo = userInfoService.populateUserInfo(accessTokenInfo);
+        assertThat(userInfo.getEmailAddress(), equalTo(EMAIL));
+        assertThat(userInfo.getEmailVerified(), equalTo(true));
+        assertThat(userInfo.getPhoneNumber(), equalTo(PHONE_NUMBER));
+        assertThat(userInfo.getPhoneNumberVerified(), equalTo(true));
+        assertNull(userInfo.getClaim(ValidClaims.ADDRESS.getValue()));
+        assertNull(userInfo.getClaim(ValidClaims.PASSPORT.getValue()));
+        assertNull(userInfo.getClaim(ValidClaims.DRIVING_PERMIT.getValue()));
+        assertNull(userInfo.getClaim(ValidClaims.CORE_IDENTITY_JWT.getValue()));
+    }
+
+    @Test
     void shouldPopulateIdentityClaimsWhenClaimsArePresentAndIdentityIsEnabled()
-            throws JOSEException {
+            throws JOSEException, AccessTokenException {
         when(configurationService.isIdentityEnabled()).thenReturn(true);
         var identityCredentials =
                 new IdentityCredentials()
@@ -244,8 +337,67 @@ class UserInfoServiceTest {
     }
 
     @Test
+    void shouldPopulateIdentityClaimsWhenClaimsArePresentAndIdentityIsEnabledOrchSplitEnabled()
+            throws JOSEException, AccessTokenException {
+        when(configurationService.isIdentityEnabled()).thenReturn(true);
+        when(configurationService.isAuthOrchSplitEnabled()).thenReturn(true);
+        var identityCredentials =
+                new IdentityCredentials()
+                        .withSubjectID(SUBJECT.getValue())
+                        .withCoreIdentityJWT(coreIdentityJWT)
+                        .withAdditionalClaims(
+                                Map.of(
+                                        ValidClaims.ADDRESS.getValue(),
+                                        ADDRESS_CLAIM,
+                                        ValidClaims.PASSPORT.getValue(),
+                                        PASSPORT_CLAIM,
+                                        ValidClaims.DRIVING_PERMIT.getValue(),
+                                        PASSPORT_CLAIM));
+        accessToken = createSignedAccessToken(oidcValidClaimsRequest);
+
+        when(identityService.getIdentityCredentials(SUBJECT.getValue()))
+                .thenReturn(Optional.of(identityCredentials));
+
+        var accessTokenStore =
+                new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
+        var accessTokenInfo =
+                new AccessTokenInfo(
+                        accessTokenStore,
+                        SUBJECT.getValue(),
+                        SCOPES,
+                        oidcValidClaimsRequest.getUserInfoClaimsRequest().getEntries().stream()
+                                .map(ClaimsSetRequest.Entry::getClaimName)
+                                .collect(Collectors.toList()),
+                        CLIENT_ID);
+
+        AuthenticationUserInfo testUserInfo =
+                new AuthenticationUserInfo().withUserInfo(generateUserInfo().toJSONString());
+
+        when(userInfoStorageService.getAuthenticationUserInfoData(
+                        accessTokenInfo.getAccessTokenStore().getInternalSubjectId()))
+                .thenReturn(Optional.of(testUserInfo));
+
+        var userInfo = userInfoService.populateUserInfo(accessTokenInfo);
+        assertThat(userInfo.getEmailAddress(), equalTo(EMAIL));
+        assertThat(userInfo.getEmailVerified(), equalTo(true));
+        assertThat(userInfo.getPhoneNumber(), equalTo(PHONE_NUMBER));
+        assertThat(userInfo.getPhoneNumberVerified(), equalTo(true));
+        assertThat(
+                userInfo.getClaim(ValidClaims.CORE_IDENTITY_JWT.getValue()),
+                equalTo(coreIdentityJWT));
+        var addressClaim = (JSONArray) userInfo.getClaim(ValidClaims.ADDRESS.getValue());
+        assertThat(((LinkedTreeMap) addressClaim.get(0)).size(), equalTo(7));
+        var passportClaim = (JSONArray) userInfo.getClaim(ValidClaims.PASSPORT.getValue());
+        assertThat(((LinkedTreeMap) passportClaim.get(0)).size(), equalTo(2));
+
+        assertClaimMetricPublished("https://vocab.account.gov.uk/v1/coreIdentityJWT");
+        assertClaimMetricPublished("https://vocab.account.gov.uk/v1/address");
+        assertClaimMetricPublished("https://vocab.account.gov.uk/v1/passport");
+    }
+
+    @Test
     void shouldPopulateIdentityClaimsWhenClaimsArePresentButNoAdditionalClaimsArePresent()
-            throws JOSEException {
+            throws JOSEException, AccessTokenException {
         when(configurationService.isIdentityEnabled()).thenReturn(true);
         var identityCredentials =
                 new IdentityCredentials()
@@ -282,7 +434,81 @@ class UserInfoServiceTest {
     }
 
     @Test
-    void shouldPopulateUserInfoWithDocAppCredentialWhenDocAppScopeIsPresent() throws JOSEException {
+    void
+            shouldPopulateIdentityClaimsWhenClaimsArePresentButNoAdditionalClaimsArePresentOrchSplitEnabled()
+                    throws JOSEException, AccessTokenException {
+        when(configurationService.isIdentityEnabled()).thenReturn(true);
+        when(configurationService.isAuthOrchSplitEnabled()).thenReturn(true);
+        var identityCredentials =
+                new IdentityCredentials()
+                        .withSubjectID(SUBJECT.getValue())
+                        .withCoreIdentityJWT(coreIdentityJWT);
+        accessToken = createSignedAccessToken(oidcValidClaimsRequest);
+
+        when(identityService.getIdentityCredentials(SUBJECT.getValue()))
+                .thenReturn(Optional.of(identityCredentials));
+
+        var accessTokenStore =
+                new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
+        var accessTokenInfo =
+                new AccessTokenInfo(
+                        accessTokenStore,
+                        SUBJECT.getValue(),
+                        SCOPES,
+                        oidcValidClaimsRequest.getUserInfoClaimsRequest().getEntries().stream()
+                                .map(ClaimsSetRequest.Entry::getClaimName)
+                                .collect(Collectors.toList()),
+                        CLIENT_ID);
+
+        AuthenticationUserInfo testUserInfo =
+                new AuthenticationUserInfo().withUserInfo(generateUserInfo().toJSONString());
+
+        when(userInfoStorageService.getAuthenticationUserInfoData(
+                        accessTokenInfo.getAccessTokenStore().getInternalSubjectId()))
+                .thenReturn(Optional.of(testUserInfo));
+
+        var userInfo = userInfoService.populateUserInfo(accessTokenInfo);
+        assertThat(userInfo.getEmailAddress(), equalTo(EMAIL));
+        assertThat(userInfo.getEmailVerified(), equalTo(true));
+        assertThat(userInfo.getPhoneNumber(), equalTo(PHONE_NUMBER));
+        assertThat(userInfo.getPhoneNumberVerified(), equalTo(true));
+        assertThat(
+                userInfo.getClaim(ValidClaims.CORE_IDENTITY_JWT.getValue()),
+                equalTo(coreIdentityJWT));
+
+        assertClaimMetricPublished("https://vocab.account.gov.uk/v1/coreIdentityJWT");
+    }
+
+    @Test
+    void shouldPopulateUserInfoWithDocAppCredentialWhenDocAppScopeIsPresent()
+            throws JOSEException, AccessTokenException {
+        var docAppScope =
+                List.of(
+                        OIDCScopeValue.OPENID.getValue(),
+                        CustomScopeValue.DOC_CHECKING_APP.getValue());
+        var accessToken = createSignedAccessToken(null, docAppScope);
+        var docAppCredential =
+                new DocAppCredential()
+                        .withSubjectID(SUBJECT.getValue())
+                        .withCredential(List.of(docAppCredentialJWT));
+        when(dynamoDocAppService.getDocAppCredential(SUBJECT.getValue()))
+                .thenReturn(Optional.of(docAppCredential));
+
+        var accessTokenStore =
+                new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
+        var accessTokenInfo =
+                new AccessTokenInfo(
+                        accessTokenStore, SUBJECT.getValue(), docAppScope, null, CLIENT_ID);
+
+        var userInfo = userInfoService.populateUserInfo(accessTokenInfo);
+        assertThat(userInfo.getClaim("doc-app-credential"), equalTo(List.of(docAppCredentialJWT)));
+        assertClaimMetricPublished("doc-app-credential");
+    }
+
+    @Test
+    void shouldPopulateUserInfoWithDocAppCredentialWhenDocAppScopeIsPresentOrchSplitEnabled()
+            throws JOSEException, AccessTokenException {
+        when(configurationService.isAuthOrchSplitEnabled()).thenReturn(true);
         var docAppScope =
                 List.of(
                         OIDCScopeValue.OPENID.getValue(),
@@ -329,7 +555,49 @@ class UserInfoServiceTest {
     }
 
     @Test
+    void shouldReturnInternalCommonSubjectIdentifierWhenDocAppScopeIsNotPresentOrchSplitEnabled()
+            throws JOSEException {
+        when(configurationService.isAuthOrchSplitEnabled()).thenReturn(true);
+        var salt = SaltHelper.generateNewSalt();
+        var expectedCommonSubject =
+                ClientSubjectHelper.calculatePairwiseIdentifier(
+                        INTERNAL_SUBJECT.getValue(), "test.account.gov.uk", salt);
+        accessToken = createSignedAccessToken(null);
+        var userProfile = generateUserprofile();
+        when(authenticationService.getUserProfileFromSubject(INTERNAL_SUBJECT.getValue()))
+                .thenReturn(userProfile);
+        when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(salt);
+        var accessTokenStore =
+                new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
+        var accessTokenInfo =
+                new AccessTokenInfo(accessTokenStore, SUBJECT.getValue(), SCOPES, null, CLIENT_ID);
+
+        var subjectForAudit = userInfoService.calculateSubjectForAudit(accessTokenInfo);
+
+        assertThat(subjectForAudit, equalTo(expectedCommonSubject));
+    }
+
+    @Test
     void shouldReturnDocAppSubjectIdWhenDocAppScopeIsPresent() throws JOSEException {
+        accessToken = createSignedAccessToken(null);
+        var docAppScope =
+                List.of(
+                        OIDCScopeValue.OPENID.getValue(),
+                        CustomScopeValue.DOC_CHECKING_APP.getValue());
+        var accessTokenStore =
+                new AccessTokenStore(accessToken.getValue(), DOC_APP_SUBJECT.getValue());
+        var accessTokenInfo =
+                new AccessTokenInfo(
+                        accessTokenStore, DOC_APP_SUBJECT.getValue(), docAppScope, null, CLIENT_ID);
+        var subjectForAudit = userInfoService.calculateSubjectForAudit(accessTokenInfo);
+
+        assertThat(subjectForAudit, equalTo(DOC_APP_SUBJECT.getValue()));
+    }
+
+    @Test
+    void shouldReturnDocAppSubjectIdWhenDocAppScopeIsPresentOrchSplitEnabled()
+            throws JOSEException {
+        when(configurationService.isAuthOrchSplitEnabled()).thenReturn(true);
         accessToken = createSignedAccessToken(null);
         var docAppScope =
                 List.of(
@@ -372,6 +640,15 @@ class UserInfoServiceTest {
         return new BearerAccessToken(signedJWT.serialize());
     }
 
+    private UserInfo generateUserInfo() {
+        UserInfo userInfo = new UserInfo(INTERNAL_SUBJECT);
+        userInfo.setEmailAddress(EMAIL);
+        userInfo.setEmailVerified(true);
+        userInfo.setPhoneNumber(PHONE_NUMBER);
+        userInfo.setPhoneNumberVerified(true);
+        return userInfo;
+    }
+
     private UserProfile generateUserprofile() {
         return new UserProfile()
                 .withEmail("joe.bloggs@digital.cabinet-office.gov.uk")
@@ -381,15 +658,6 @@ class UserInfoServiceTest {
                 .withSubjectID(INTERNAL_SUBJECT.toString())
                 .withCreated(LocalDateTime.now().toString())
                 .withUpdated(LocalDateTime.now().toString());
-    }
-
-    private ClientRegistry generateClientRegistry() {
-        return new ClientRegistry()
-                .withClientID(CLIENT_ID)
-                .withConsentRequired(false)
-                .withClientName("test-client")
-                .withSectorIdentifierUri("https://test.com")
-                .withSubjectType("public");
     }
 
     private void assertClaimMetricPublished(String v3) {

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
@@ -57,7 +57,8 @@ import static uk.gov.di.authentication.sharedtest.helper.IdentityTestData.PASSPO
 import static uk.gov.di.authentication.sharedtest.logging.LogEventMatcher.withMessageContaining;
 
 class UserInfoServiceTest {
-
+    private final AuthenticationUserInfoStorageService userInfoStorageService =
+            mock(AuthenticationUserInfoStorageService.class);
     private UserInfoService userInfoService;
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
     private final DynamoIdentityService identityService = mock(DynamoIdentityService.class);
@@ -111,7 +112,8 @@ class UserInfoServiceTest {
                         identityService,
                         dynamoDocAppService,
                         cloudwatchMetricsService,
-                        configurationService);
+                        configurationService,
+                        userInfoStorageService);
         clientRegistry = generateClientRegistry();
         when(configurationService.getInternalSectorUri()).thenReturn(INTERNAL_SECTOR_URI);
         when(configurationService.getEnvironment()).thenReturn("test");


### PR DESCRIPTION
## What?
Instead of populating the userinfo response with data from the UserProfile table, Orchestration will use the information returned from the Authentication /userinfo endpoint. 

## Why?
We want to restrict Orchestration having access to the User tables in DynamoDB.

## Related PRs
https://github.com/alphagov/di-authentication-api/pull/3211 Orches: Create AuthCallbackHandler
