### PR TITLE
Aut 1633/fail if no env var

### DIFF
--- a/utils/src/main/java/uk/gov/di/authentication/utils/exceptions/ExcludedTermsAndConditionsConfigMissingException.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/exceptions/ExcludedTermsAndConditionsConfigMissingException.java
@@ -1,7 +1,0 @@
-package uk.gov.di.authentication.utils.exceptions;
-
-public class ExcludedTermsAndConditionsConfigMissingException extends RuntimeException {
-    public ExcludedTermsAndConditionsConfigMissingException(String message) {
-        super(message);
-    }
-}

--- a/utils/src/main/java/uk/gov/di/authentication/utils/exceptions/IncludedTermsAndConditionsConfigMissingException.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/exceptions/IncludedTermsAndConditionsConfigMissingException.java
@@ -1,7 +1,7 @@
 package uk.gov.di.authentication.utils.exceptions;
 
 public class IncludedTermsAndConditionsConfigMissingException extends RuntimeException {
-    public IncludedTermsAndConditionsConfigMissingException(String message) {
-        super(message);
+    public IncludedTermsAndConditionsConfigMissingException() {
+        super("Included terms and conditions configuration is missing");
     }
 }

--- a/utils/src/main/java/uk/gov/di/authentication/utils/exceptions/IncludedTermsAndConditionsConfigMissingException.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/exceptions/IncludedTermsAndConditionsConfigMissingException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.authentication.utils.exceptions;
+
+public class IncludedTermsAndConditionsConfigMissingException extends RuntimeException {
+    public IncludedTermsAndConditionsConfigMissingException(String message) {
+        super(message);
+    }
+}

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailAudienceLoaderScheduledEventHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailAudienceLoaderScheduledEventHandler.java
@@ -78,8 +78,7 @@ public class BulkUserEmailAudienceLoaderScheduledEventHandler
         List<String> includedTermsAndConditions =
                 configurationService.getBulkUserEmailIncludedTermsAndConditions();
         if (includedTermsAndConditions == null || includedTermsAndConditions.isEmpty()) {
-            throw new IncludedTermsAndConditionsConfigMissingException(
-                    "Included terms and conditions configuration is missing");
+            throw new IncludedTermsAndConditionsConfigMissingException();
         }
 
         if (event.getDetail() != null && event.getDetail().containsKey(LAST_EVALUATED_KEY)) {

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailAudienceLoaderScheduledEventHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailAudienceLoaderScheduledEventHandler.java
@@ -12,7 +12,7 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.LambdaInvokerService;
 import uk.gov.di.authentication.shared.services.SystemService;
-import uk.gov.di.authentication.utils.exceptions.ExcludedTermsAndConditionsConfigMissingException;
+import uk.gov.di.authentication.utils.exceptions.IncludedTermsAndConditionsConfigMissingException;
 
 import java.util.List;
 import java.util.Map;
@@ -78,8 +78,8 @@ public class BulkUserEmailAudienceLoaderScheduledEventHandler
         List<String> includedTermsAndConditions =
                 configurationService.getBulkUserEmailIncludedTermsAndConditions();
         if (includedTermsAndConditions == null || includedTermsAndConditions.isEmpty()) {
-            throw new ExcludedTermsAndConditionsConfigMissingException(
-                    "Excluded terms and conditions configuration is missing");
+            throw new IncludedTermsAndConditionsConfigMissingException(
+                    "Included terms and conditions configuration is missing");
         }
 
         if (event.getDetail() != null && event.getDetail().containsKey(LAST_EVALUATED_KEY)) {

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailSenderScheduledEventHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailSenderScheduledEventHandler.java
@@ -18,6 +18,7 @@ import uk.gov.di.authentication.shared.services.NotificationService;
 import uk.gov.di.authentication.shared.services.SystemService;
 import uk.gov.di.authentication.utils.domain.BulkEmailType;
 import uk.gov.di.authentication.utils.domain.UtilsAuditableEvent;
+import uk.gov.di.authentication.utils.exceptions.IncludedTermsAndConditionsConfigMissingException;
 import uk.gov.service.notify.NotificationClient;
 import uk.gov.service.notify.NotificationClientException;
 
@@ -93,6 +94,10 @@ public class BulkUserEmailSenderScheduledEventHandler
                 configurationService.getBulkUserEmailBatchPauseDuration();
         final List<String> bulkUserEmailIncludedTermsAndConditions =
                 configurationService.getBulkUserEmailIncludedTermsAndConditions();
+
+        if (bulkUserEmailIncludedTermsAndConditions.isEmpty()) {
+            throw new IncludedTermsAndConditionsConfigMissingException();
+        }
 
         LOG.info(
                 "Bulk User Email Send configuration - bulkUserEmailBatchQueryLimit: {}, bulkUserEmailMaxBatchCount: {}, bulkUserEmailBatchPauseDuration: {}, includedTermsAndConditions: {}",

--- a/utils/src/test/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailAudienceLoaderScheduledEventHandlerTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/lambda/BulkUserEmailAudienceLoaderScheduledEventHandlerTest.java
@@ -11,7 +11,7 @@ import uk.gov.di.authentication.shared.services.BulkEmailUsersService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.LambdaInvokerService;
-import uk.gov.di.authentication.utils.exceptions.ExcludedTermsAndConditionsConfigMissingException;
+import uk.gov.di.authentication.utils.exceptions.IncludedTermsAndConditionsConfigMissingException;
 
 import java.util.Arrays;
 import java.util.List;
@@ -246,7 +246,7 @@ class BulkUserEmailAudienceLoaderScheduledEventHandlerTest {
         when(configurationService.getBulkUserEmailAudienceLoadUserBatchSize()).thenReturn(10L);
 
         assertThrows(
-                ExcludedTermsAndConditionsConfigMissingException.class,
+                IncludedTermsAndConditionsConfigMissingException.class,
                 () ->
                         bulkUserEmailAudienceLoaderScheduledEventHandler.handleRequest(
                                 scheduledEvent, mockContext),


### PR DESCRIPTION
## What?

Adds a safety check to ensure that the bulk user email sender lambda cannot be misconfigured, ensuring that the environment variable that specifies the versions of the terms and conditions that we want to include as part of the bulk email have been set.
