### PR TITLE
AUT-1468: Add 'CreatedAt' timestamp when adding row to bulk-email-users table

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/utils/BulkEmailUsersIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/utils/BulkEmailUsersIntegrationTest.java
@@ -43,6 +43,19 @@ public class BulkEmailUsersIntegrationTest {
     BulkEmailUsersService bulkEmailUsersService = new BulkEmailUsersService(configurationService);
 
     @Test
+    void shouldAddBulkEmailUserWithPendingStatusAndCreatedTimestamp() {
+        bulkEmailUsersService.addUser(SUBJECT_ID_1, BulkEmailStatus.PENDING);
+
+        var createdUser = bulkEmailUsersService.getBulkEmailUsers(SUBJECT_ID_1).get();
+
+        assertEquals(SUBJECT_ID_1, createdUser.getSubjectID());
+        assertEquals(BulkEmailStatus.PENDING, createdUser.getBulkEmailStatus());
+        assertEquals(
+                LocalDateTime.ofInstant(fixedNow, ZoneId.of("UTC")).toString(),
+                createdUser.getCreatedAt());
+    }
+
+    @Test
     void updateUserStatusUpdatesaUserWithTheProvidedStatus() {
         bulkEmailUsersExtension.addBulkEmailUser(SUBJECT_ID_1, BulkEmailStatus.PENDING);
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/BulkEmailUser.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/BulkEmailUser.java
@@ -10,6 +10,7 @@ public class BulkEmailUser {
     private String subjectID;
     private BulkEmailStatus bulkEmailStatus;
     private String updatedAt;
+    private String createdAt;
 
     public BulkEmailUser() {}
 
@@ -53,6 +54,20 @@ public class BulkEmailUser {
 
     public BulkEmailUser withUpdatedAt(String timestamp) {
         this.updatedAt = timestamp;
+        return this;
+    }
+
+    @DynamoDbAttribute("CreatedAt")
+    public String getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(String timestamp) {
+        this.createdAt = timestamp;
+    }
+
+    public BulkEmailUser withCreatedAt(String timestamp) {
+        this.createdAt = timestamp;
         return this;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/BulkEmailUsersService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/BulkEmailUsersService.java
@@ -44,7 +44,12 @@ public class BulkEmailUsersService extends BaseDynamoService<BulkEmailUser> {
     }
 
     public void addUser(String subjectID, BulkEmailStatus bulkEmailStatus) {
-        put(new BulkEmailUser().withSubjectID(subjectID).withBulkEmailStatus(bulkEmailStatus));
+        LocalDateTime now = LocalDateTime.now(configurationService.getClock());
+        put(
+                new BulkEmailUser()
+                        .withSubjectID(subjectID)
+                        .withBulkEmailStatus(bulkEmailStatus)
+                        .withCreatedAt(now.toString()));
     }
 
     public List<String> getNSubjectIdsByStatus(Integer limit, BulkEmailStatus bulkEmailStatus) {


### PR DESCRIPTION
## What?

Add 'CreatedAt' timestamp when adding row to bulk-email-users table.

## Why?

Adds ability to see when each row was loaded.
Makes it easier to differentiate if user loading takes place over several sessions.

## Related PRs

#3293 
