### PR TITLE
AUT-1468: Set BULK_USER_EMAIL_INCLUDED_TERMS_AND_CONDITIONS in email sender lambda

### DIFF
--- a/ci/terraform/utils/bulk_user_email_send_lambda.tf
+++ b/ci/terraform/utils/bulk_user_email_send_lambda.tf
@@ -42,15 +42,16 @@ resource "aws_lambda_function" "bulk_user_email_send_lambda" {
 
   environment {
     variables = merge(var.notify_template_map, {
-      ENVIRONMENT                           = var.environment
-      INTERNAl_SECTOR_URI                   = var.internal_sector_uri
-      TXMA_AUDIT_QUEUE_URL                  = data.aws_sqs_queue.oidc_txma_audit_queue.url
-      NOTIFY_API_KEY                        = var.notify_api_key
-      NOTIFY_URL                            = var.notify_url
-      BULK_USER_EMAIL_BATCH_QUERY_LIMIT     = var.bulk_user_email_batch_query_limit
-      BULK_USER_EMAIL_MAX_BATCH_COUNT       = var.bulk_user_email_max_batch_count
-      BULK_USER_EMAIL_BATCH_PAUSE_DURATION  = var.bulk_user_email_batch_pause_duration
-      BULK_USER_EMAIL_EMAIL_SENDING_ENABLED = var.bulk_user_email_email_sending_enabled
+      ENVIRONMENT                                   = var.environment
+      INTERNAl_SECTOR_URI                           = var.internal_sector_uri
+      TXMA_AUDIT_QUEUE_URL                          = data.aws_sqs_queue.oidc_txma_audit_queue.url
+      NOTIFY_API_KEY                                = var.notify_api_key
+      NOTIFY_URL                                    = var.notify_url
+      BULK_USER_EMAIL_BATCH_QUERY_LIMIT             = var.bulk_user_email_batch_query_limit
+      BULK_USER_EMAIL_MAX_BATCH_COUNT               = var.bulk_user_email_max_batch_count
+      BULK_USER_EMAIL_BATCH_PAUSE_DURATION          = var.bulk_user_email_batch_pause_duration
+      BULK_USER_EMAIL_EMAIL_SENDING_ENABLED         = var.bulk_user_email_email_sending_enabled
+      BULK_USER_EMAIL_INCLUDED_TERMS_AND_CONDITIONS = var.bulk_user_email_included_terms_and_conditions
     })
   }
 


### PR DESCRIPTION
## What?

Set BULK_USER_EMAIL_INCLUDED_TERMS_AND_CONDITIONS in email sender lambda.

## Why?

Otherwise the config will always be empty...

This configuration is used to determine whether a user has already accepted a version of the terms and conditions that would exclude them from receiving an email.
