### PR TITLE
BAU: Remove email field from AuthCodeRequest 

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/AuthCodeRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/AuthCodeRequest.java
@@ -23,16 +23,10 @@ public class AuthCodeRequest {
     @Required
     private List<String> claims;
 
-    @SerializedName("email")
-    @Expose
-    @Required
-    private String email;
-
-    public AuthCodeRequest(String redirectUri, String state, List<String> claims, String email) {
+    public AuthCodeRequest(String redirectUri, String state, List<String> claims) {
         this.redirectUri = redirectUri;
         this.state = state;
         this.claims = claims;
-        this.email = email;
     }
 
     public String getRedirectUri() {
@@ -57,13 +51,5 @@ public class AuthCodeRequest {
 
     public void setClaims(List<String> claims) {
         this.claims = claims;
-    }
-
-    public String getEmail() {
-        return email;
-    }
-
-    public void setEmail(String email) {
-        this.email = email;
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationAuthCodeHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationAuthCodeHandlerIntegrationTest.java
@@ -26,7 +26,6 @@ class AuthenticationAuthCodeHandlerIntegrationTest extends ApiGatewayHandlerInte
     private static final String TEST_PASSWORD = "password-1";
     private static final String TEST_REDIRECT_URI = "https://redirect_uri.com";
     private static final String TEST_STATE = "xyz";
-    private static final String TEST_REQUESTED_SCOPE_CLAIMS = "requested-scope-claims";
     private static final String TEST_AUTHORIZATION_CODE = "SplxlOBeZQQYbYS6WxSbIA";
     private static final String TEST_SUBJECT_ID = "subject-id";
 
@@ -57,8 +56,7 @@ class AuthenticationAuthCodeHandlerIntegrationTest extends ApiGatewayHandlerInte
                 new AuthCodeRequest(
                         TEST_REDIRECT_URI,
                         TEST_STATE,
-                        List.of(EMAIL_VERIFIED.getValue(), EMAIL.getValue()),
-                        TEST_EMAIL_ADDRESS);
+                        List.of(EMAIL_VERIFIED.getValue(), EMAIL.getValue()));
         var response = makeRequest(Optional.of(authRequest), getHeaders(), Map.of());
         assertThat(response, hasStatus(200));
     }
@@ -68,10 +66,7 @@ class AuthenticationAuthCodeHandlerIntegrationTest extends ApiGatewayHandlerInte
         setUpDynamo();
         var authRequest =
                 new AuthCodeRequest(
-                        null,
-                        TEST_STATE,
-                        List.of(EMAIL_VERIFIED.getValue(), EMAIL.getValue()),
-                        TEST_EMAIL_ADDRESS);
+                        null, TEST_STATE, List.of(EMAIL_VERIFIED.getValue(), EMAIL.getValue()));
         var response = makeRequest(Optional.of(authRequest), getHeaders(), Map.of());
         assertThat(response, hasStatus(400));
         assertThat(response, hasBody(objectMapper.writeValueAsString(ErrorResponse.ERROR_1001)));
@@ -84,8 +79,7 @@ class AuthenticationAuthCodeHandlerIntegrationTest extends ApiGatewayHandlerInte
                 new AuthCodeRequest(
                         TEST_REDIRECT_URI,
                         null,
-                        List.of(EMAIL_VERIFIED.getValue(), EMAIL.getValue()),
-                        TEST_EMAIL_ADDRESS);
+                        List.of(EMAIL_VERIFIED.getValue(), EMAIL.getValue()));
         var response = makeRequest(Optional.of(authRequest), getHeaders(), Map.of());
         assertThat(response, hasStatus(400));
         assertThat(response, hasBody(objectMapper.writeValueAsString(ErrorResponse.ERROR_1001)));
@@ -94,8 +88,7 @@ class AuthenticationAuthCodeHandlerIntegrationTest extends ApiGatewayHandlerInte
     @Test
     void shouldReturn400StatusForInvalidRequestedScopeClaims() throws Json.JsonException {
         setUpDynamo();
-        var authRequest =
-                new AuthCodeRequest(TEST_REDIRECT_URI, TEST_STATE, null, TEST_EMAIL_ADDRESS);
+        var authRequest = new AuthCodeRequest(TEST_REDIRECT_URI, TEST_STATE, null);
         var response = makeRequest(Optional.of(authRequest), getHeaders(), Map.of());
         assertThat(response, hasStatus(400));
         assertThat(response, hasBody(objectMapper.writeValueAsString(ErrorResponse.ERROR_1001)));


### PR DESCRIPTION
## What?

Remove redundant email field from AuthCodeRequest as previously required to get Subject ID from UserProfile which is now provided by the BaseFrontendHandler extended by the AuthenticationAuthCodeHandler class"

## Why?

Email in request is no longer required as the Subject ID can now be accessed from the Userprofile


