### PR TITLE
AUT-1645 - Deploy auth external API to s3 bucket 

### DIFF
--- a/.github/workflows/deploy-oidc.yml
+++ b/.github/workflows/deploy-oidc.yml
@@ -69,6 +69,14 @@ jobs:
             --include "signed-ipv-api-${{ github.sha }}-*"
           mv artifacts/signed-ipv-api-*.zip artifacts/ipv-api.zip
 
+      - name: Download and copy Auth External API signed artifact
+        working-directory: ci/terraform/oidc
+        run: |
+          aws s3 cp s3://${{ env.DESTINATION_BUCKET }} ./artifacts \
+            --recursive --exclude "*" \
+            --include "signed-auth-external-api-${{ github.sha }}-*"
+          mv artifacts/signed-auth-external-api-*.zip artifacts/auth-external-api.zip
+
       - name: Upload OIDC Terraform files
         working-directory: ci/terraform
         run: |

--- a/ci/terraform/oidc/s3-objects.tf
+++ b/ci/terraform/oidc/s3-objects.tf
@@ -10,6 +10,7 @@ resource "aws_s3_bucket_versioning" "source_bucket_versioning" {
 }
 
 resource "aws_s3_object" "auth_ext_api_release_zip" {
+  count  = var.environment == "production" ? 0 : 1
   bucket = aws_s3_bucket.source_bucket.bucket
   key    = "auth-ext-api-release.zip"
 


### PR DESCRIPTION
## What?

- Deploy auth external API to s3 bucket via github action 
- Only deploy s3 bucket object to non-prod

## Why?

- The code pipeline needs to retrieve the resource from the bucket 
