### PR TITLE
AUT-1648: Convert orchestration scopes to claims

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -466,20 +466,20 @@ public class AuthorisationHandler
             LOG.info("Identity is required. Adding the local_account_id and salt claims");
             claimsSetRequest = claimsSetRequest.add("local_account_id").add("salt");
         }
-        if (amScopePresent) {
+        if (Boolean.TRUE.equals(amScopePresent)) {
             LOG.info("am scope is present. Adding the public_subject_id claim");
             claimsSetRequest = claimsSetRequest.add("public_subject_id");
         }
-        if (govukAccountScopePresent) {
+        if (Boolean.TRUE.equals(govukAccountScopePresent)) {
             LOG.info("govuk-account scope is present. Adding the legacy_subject_id claim");
             claimsSetRequest = claimsSetRequest.add("legacy_subject_id");
         }
-        if (phoneScopePresent) {
+        if (Boolean.TRUE.equals(phoneScopePresent)) {
             LOG.info(
                     "phone scope is present. Adding the phone_number and phone_number_verified claim");
             claimsSetRequest = claimsSetRequest.add("phone_number").add("phone_number_verified");
         }
-        if (emailScopePresent) {
+        if (Boolean.TRUE.equals(emailScopePresent)) {
             LOG.info("email scope is present. Adding the legacy_subject_id claim");
             claimsSetRequest = claimsSetRequest.add("email").add("email_verified");
         }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ValidScopes.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ValidScopes.java
@@ -43,18 +43,6 @@ public class ValidScopes {
         return Collections.emptySet();
     }
 
-    public static Scope extractAuthScopesFromRequestedScopes(Scope requestedScopes) {
-        var scopeList =
-                ValidScopes.getPublicValidScopes().stream()
-                        .filter(
-                                t ->
-                                        !t.equals(OIDCScopeValue.OFFLINE_ACCESS.getValue())
-                                                && requestedScopes.toStringList().contains(t))
-                        .collect(Collectors.toList());
-
-        return Scope.parse(scopeList);
-    }
-
     public static Set<String> getClaimsForListOfScopes(List<String> scopes) {
         Set<String> claims = new HashSet<>();
         for (String scope : scopes) {

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/ValidScopesTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/ValidScopesTest.java
@@ -1,6 +1,5 @@
 package uk.gov.di.authentication.shared.entity;
 
-import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import org.junit.jupiter.api.Test;
 
@@ -13,7 +12,6 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ValidScopesTest {
 
@@ -163,29 +161,5 @@ class ValidScopesTest {
         assertFalse(
                 ValidScopes.getScopesForListOfClaims(claims)
                         .contains(OIDCScopeValue.EMAIL.getValue()));
-    }
-
-    @Test
-    void shouldReturnOnlyScopesPermittedForAuthentication() {
-        var requestedScope =
-                new Scope(
-                        OIDCScopeValue.OPENID,
-                        OIDCScopeValue.EMAIL,
-                        OIDCScopeValue.PHONE,
-                        OIDCScopeValue.OFFLINE_ACCESS,
-                        CustomScopeValue.ACCOUNT_MANAGEMENT,
-                        CustomScopeValue.ACCOUNT_MANAGEMENT,
-                        CustomScopeValue.GOVUK_ACCOUNT,
-                        CustomScopeValue.DOC_CHECKING_APP);
-
-        var scopesForAuthentication =
-                ValidScopes.extractAuthScopesFromRequestedScopes(requestedScope);
-        var scopeList = scopesForAuthentication.toStringList();
-
-        var expectedScopes =
-                new Scope(OIDCScopeValue.OPENID, OIDCScopeValue.EMAIL, OIDCScopeValue.PHONE)
-                        .toStringList();
-        assertThat(scopeList.size(), equalTo(3));
-        assertTrue(scopeList.containsAll(expectedScopes));
     }
 }


### PR DESCRIPTION
This will make it easier to work with on the authentication side, which needs to request claims.

Scopes have now been removed from the request.

Also contains some refactoring to make the tests easier to read by removing some of the noise

[Ticket](https://govukverify.atlassian.net/jira/software/c/projects/AUT/boards/193?modal=detail&selectedIssue=AUT-1648)
