### PR TITLE
BAU - Exclude terraform changes from running the pre-merge checks

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -1,6 +1,7 @@
 name: Pre-merge checks
 on:
   pull_request:
+    paths-ignore: ['ci/terraform/**']
     types:
       - opened
       - reopened


### PR DESCRIPTION
## What?

- Exclude terraform changes from running the pre-merge checks

## Why?

- None of the pre-merge checks rely on terraform so we can bypass these checks when only terraform changes are made.
- This will make it quicker to merge terraform changes
