### PR TITLE
AUT-1645 - Add shared state override

### DIFF
--- a/ci/terraform/auth-external-api/build.tfvars
+++ b/ci/terraform/auth-external-api/build.tfvars
@@ -1,2 +1,3 @@
 auth_ext_lambda_zip_file = "./artifacts/auth-external-api.zip"
 common_state_bucket      = "digital-identity-dev-tfstate"
+shared_state_bucket      = "digital-identity-dev-tfstate"

--- a/ci/terraform/auth-external-api/integration.tfvars
+++ b/ci/terraform/auth-external-api/integration.tfvars
@@ -1,2 +1,3 @@
 auth_ext_lambda_zip_file = "./artifacts/auth-external-api.zip"
 common_state_bucket      = "digital-identity-dev-tfstate"
+shared_state_bucket      = "digital-identity-dev-tfstate"

--- a/ci/terraform/auth-external-api/production.tfvars
+++ b/ci/terraform/auth-external-api/production.tfvars
@@ -1,2 +1,3 @@
 auth_ext_lambda_zip_file = "./artifacts/auth-external-api.zip"
 common_state_bucket      = "digital-identity-prod-tfstate"
+shared_state_bucket      = "digital-identity-prod-tfstate"

--- a/ci/terraform/auth-external-api/staging.tfvars
+++ b/ci/terraform/auth-external-api/staging.tfvars
@@ -1,2 +1,3 @@
 auth_ext_lambda_zip_file = "./artifacts/auth-external-api.zip"
 common_state_bucket      = "di-auth-staging-tfstate"
+shared_state_bucket      = "di-auth-staging-tfstate"


### PR DESCRIPTION
## What?

- Add shared state override

## Why?

- Required so it can access the relevant state
