### PR TITLE
AUT-1474: Deploy bulk email to production in shared component

### DIFF
--- a/ci/terraform/shared/site.tf
+++ b/ci/terraform/shared/site.tf
@@ -59,7 +59,7 @@ locals {
   }
 
   request_tracing_allowed       = contains(["build", "sandpit"], var.environment)
-  deploy_bulk_email_users_count = contains(["build", "sandpit", "staging", "integration"], var.environment) ? 1 : 0
+  deploy_bulk_email_users_count = 1
 }
 
 data "aws_caller_identity" "current" {}


### PR DESCRIPTION
## What?

Deploy bulk email to production in shared component.

## Why?

Bulk email components in 'utils' depend on components in 'shared' (database table for example).

## Related PRs

Fixes a production deploy failure from merging this PR:

#3294 
