### PR TITLE
AUT-1660: add terraform config and policies for authentication-callback-userinfo dynamodb table

### DIFF
--- a/ci/terraform/oidc/dynamo-policies.tf
+++ b/ci/terraform/oidc/dynamo-policies.tf
@@ -30,6 +30,11 @@ data "aws_dynamodb_table" "access_token_store" {
   name = "${var.environment}-access-token-store"
 }
 
+data "aws_dynamodb_table" "authentication_callback_userinfo_table" {
+  name = "${var.environment}-authentication-callback-userinfo"
+}
+
+
 data "aws_iam_policy_document" "dynamo_user_write_policy_document" {
   statement {
     sid    = "AllowAccessToDynamoTables"
@@ -203,7 +208,6 @@ data "aws_iam_policy_document" "dynamo_common_passwords_read_access_policy_docum
   }
 }
 
-
 data "aws_iam_policy_document" "dynamo_account_modifiers_read_access_policy_document" {
   statement {
     sid    = "AllowAccessToDynamoTables"
@@ -293,6 +297,43 @@ data "aws_iam_policy_document" "dynamo_access_token_read_access_policy_document"
     ]
     resources = [
       data.aws_dynamodb_table.access_token_store.arn,
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "dynamo_authentication_callback_userinfo_write_policy_document" {
+  statement {
+    sid    = "AllowAccessToDynamoTables"
+    effect = "Allow"
+
+    actions = [
+      "dynamodb:BatchWriteItem",
+      "dynamodb:UpdateItem",
+      "dynamodb:PutItem",
+    ]
+    resources = [
+      data.aws_dynamodb_table.authentication_callback_userinfo_table.arn,
+      "${data.aws_dynamodb_table.authentication_callback_userinfo_table.arn}/index/*"
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "dynamo_authentication_callback_userinfo_read_policy_document" {
+  statement {
+    sid    = "AllowAccessToDynamoTables"
+    effect = "Allow"
+
+    actions = [
+      "dynamodb:BatchGetItem",
+      "dynamodb:DescribeStream",
+      "dynamodb:DescribeTable",
+      "dynamodb:Get*",
+      "dynamodb:Query",
+      "dynamodb:Scan",
+    ]
+    resources = [
+      data.aws_dynamodb_table.authentication_callback_userinfo_table.arn,
+      "${data.aws_dynamodb_table.authentication_callback_userinfo_table.arn}/index/*",
     ]
   }
 }
@@ -424,4 +465,20 @@ resource "aws_iam_policy" "dynamo_access_token_delete_access_policy" {
   description = "IAM policy for managing delete permissions to the Dynamo access token store table"
 
   policy = data.aws_iam_policy_document.dynamo_access_token_delete_access_policy_document.json
+}
+
+resource "aws_iam_policy" "dynamo_authentication_callback_userinfo_read_policy" {
+  name_prefix = "dynamo-authentication-callback-userinfo-read-policy"
+  path        = "/${var.environment}/oidc-shared/"
+  description = "IAM policy for managing read permissions to the Dynamo Callback User Info table"
+
+  policy = data.aws_iam_policy_document.dynamo_authentication_callback_userinfo_read_policy_document.json
+}
+
+resource "aws_iam_policy" "dynamo_authentication_callback_userinfo_write_access_policy" {
+  name_prefix = "dynamo-authentication-callback-userinfo-write-policy"
+  path        = "/${var.environment}/oidc-shared/"
+  description = "IAM policy for managing write permissions to the Dynamo Callback User Info table"
+
+  policy = data.aws_iam_policy_document.dynamo_authentication_callback_userinfo_write_policy_document.json
 }

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -12,6 +12,7 @@ module "oidc_userinfo_role" {
     aws_iam_policy.dynamo_user_read_access_policy.arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
+    aws_iam_policy.dynamo_authentication_callback_userinfo_read_policy.arn,
     module.oidc_txma_audit.access_policy_arn
   ]
 }

--- a/ci/terraform/shared/dynamodb.tf
+++ b/ci/terraform/shared/dynamodb.tf
@@ -411,3 +411,50 @@ resource "aws_dynamodb_table" "bulk_email_users" {
 
   tags = local.default_tags
 }
+
+resource "aws_dynamodb_table" "authentication_callback_userinfo" {
+  name         = "${var.environment}-authentication-callback-userinfo"
+  billing_mode = var.provision_dynamo ? "PROVISIONED" : "PAY_PER_REQUEST"
+  hash_key     = "SubjectID"
+
+  read_capacity  = var.provision_dynamo ? var.dynamo_default_read_capacity : null
+  write_capacity = var.provision_dynamo ? var.dynamo_default_write_capacity : null
+
+  attribute {
+    name = "SubjectID"
+    type = "S"
+  }
+
+  attribute {
+    name = "UserInfo"
+    type = "S"
+  }
+
+  global_secondary_index {
+    name            = "UserInfoIndex"
+    hash_key        = "UserInfo"
+    projection_type = "ALL"
+    read_capacity   = var.provision_dynamo ? var.dynamo_default_read_capacity : null
+    write_capacity  = var.provision_dynamo ? var.dynamo_default_write_capacity : null
+  }
+
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = aws_kms_key.authentication_callback_userinfo_encryption_key.arn
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  ttl {
+    attribute_name = "TimeToExist"
+    enabled        = true
+  }
+
+  tags = local.default_tags
+}

--- a/ci/terraform/shared/kms.tf
+++ b/ci/terraform/shared/kms.tf
@@ -421,3 +421,32 @@ resource "aws_kms_key" "bulk_email_users_encryption_key" {
   })
   tags = local.default_tags
 }
+
+resource "aws_kms_key" "authentication_callback_userinfo_encryption_key" {
+  description              = "KMS encryption key for authentication callback user info table in DynamoDB"
+  deletion_window_in_days  = 30
+  key_usage                = "ENCRYPT_DECRYPT"
+  customer_master_key_spec = "SYMMETRIC_DEFAULT"
+  enable_key_rotation      = true
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Id      = "key-policy-dynamodb",
+    Statement = [
+      {
+        Sid       = "Allow IAM to manage this key",
+        Effect    = "Allow",
+        Principal = { AWS = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root" }
+        Action = [
+          "kms:*"
+        ],
+        Resource = "*"
+      }
+    ]
+  })
+  tags = local.default_tags
+}
+
+resource "aws_kms_alias" "authentication_callback_userinfo_encryption_key_alias" {
+  name          = "alias/${var.environment}-authentication-callback-userinfo-encryption-key-alias"
+  target_key_id = aws_kms_key.authentication_callback_userinfo_encryption_key.key_id
+}


### PR DESCRIPTION
## What?

To create the terraform for the `authentication-callback-userinfo` dynamoDB table and the required read/write policies.

## Why?

So the `UserInfo` Lambda can access temporarily stored user info in the `authentication-callback-userinfo` table

## Related PRs
https://github.com/alphagov/di-authentication-api/pull/3305