### PR TITLE
AUT-1249: Add authentication token endpoint

### DIFF
--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/exceptions/AuthCodeStoreRetreivalException.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/exceptions/AuthCodeStoreRetreivalException.java
@@ -1,0 +1,16 @@
+package uk.gov.di.authentication.external.exceptions;
+
+import com.nimbusds.oauth2.sdk.ErrorObject;
+
+public class AuthCodeStoreRetreivalException extends Exception {
+    final ErrorObject oAuth2Error;
+
+    public AuthCodeStoreRetreivalException(String message, ErrorObject oAuth2Error) {
+        super(message);
+        this.oAuth2Error = oAuth2Error;
+    }
+
+    public ErrorObject getOAuth2Error() {
+        return oAuth2Error;
+    }
+}

--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/lambda/TokenHandler.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/lambda/TokenHandler.java
@@ -1,0 +1,178 @@
+package uk.gov.di.authentication.external.lambda;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.nimbusds.oauth2.sdk.AccessTokenResponse;
+import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.OAuth2Error;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.external.exceptions.AuthCodeStoreRetreivalException;
+import uk.gov.di.authentication.external.services.TokenService;
+import uk.gov.di.authentication.external.validators.TokenRequestValidator;
+import uk.gov.di.authentication.shared.entity.AuthCodeStore;
+import uk.gov.di.authentication.shared.exceptions.TokenAuthInvalidException;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
+import uk.gov.di.authentication.shared.helpers.RequestBodyHelper;
+import uk.gov.di.authentication.shared.services.AccessTokenService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.DynamoAuthCodeService;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
+import static uk.gov.di.authentication.shared.helpers.ConstructUriHelper.buildURI;
+import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
+
+public class TokenHandler
+        implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
+
+    private static final Logger LOG = LogManager.getLogger(TokenHandler.class);
+    private final ConfigurationService configurationService;
+    private final DynamoAuthCodeService authorisationCodeService;
+    private final AccessTokenService accessTokenStoreService;
+    private final TokenService tokenUtilityService;
+    private final TokenRequestValidator tokenRequestValidator;
+
+    public TokenHandler(
+            ConfigurationService configurationService,
+            DynamoAuthCodeService authorisationCodeService,
+            AccessTokenService accessTokenService,
+            TokenService tokenUtilityService,
+            TokenRequestValidator tokenRequestValidator) {
+        this.configurationService = configurationService;
+        this.authorisationCodeService = authorisationCodeService;
+        this.accessTokenStoreService = accessTokenService;
+        this.tokenUtilityService = tokenUtilityService;
+        this.tokenRequestValidator = tokenRequestValidator;
+    }
+
+    public TokenHandler() {
+        this(ConfigurationService.getInstance());
+    }
+
+    public TokenHandler(ConfigurationService configurationService) {
+        this.configurationService = configurationService;
+        this.authorisationCodeService = new DynamoAuthCodeService(configurationService);
+        this.accessTokenStoreService = new AccessTokenService(configurationService);
+        this.tokenUtilityService = new TokenService();
+
+        String orchestratorCallbackRedirectUri =
+                configurationService.getAuthenticationAuthCallbackURI().toString();
+        String orchestratorClientId = configurationService.getOrchestrationClientId();
+        this.tokenRequestValidator =
+                new TokenRequestValidator(orchestratorCallbackRedirectUri, orchestratorClientId);
+    }
+
+    @Override
+    public APIGatewayProxyResponseEvent handleRequest(
+            APIGatewayProxyRequestEvent input, Context context) {
+        try {
+            return segmentedFunctionCall(
+                    "auth-external-api::" + getClass().getSimpleName(),
+                    () -> tokenRequestHandler(input));
+        } catch (Exception e) {
+            LOG.error("Unexpected exception: {}", e.getMessage());
+            return generateApiGatewayProxyResponse(500, "server_error");
+        }
+    }
+
+    public APIGatewayProxyResponseEvent tokenRequestHandler(APIGatewayProxyRequestEvent input) {
+        LOG.info("Request received to the TokenHandler");
+
+        Map<String, String> requestBody = RequestBodyHelper.parseRequestBody(input.getBody());
+        Optional<ErrorObject> invalidRequestParamError =
+                tokenRequestValidator.validatePlaintextParams(requestBody);
+
+        if (invalidRequestParamError.isPresent()) {
+            LOG.warn(
+                    "Invalid Token Request. ErrorCode: {}. ErrorDescription: {}",
+                    invalidRequestParamError.get().getCode(),
+                    invalidRequestParamError.get().getDescription());
+            return generateApiGatewayProxyResponse(
+                    400, invalidRequestParamError.get().toJSONObject().toJSONString());
+        }
+
+        try {
+            var authenticationBackendURI = configurationService.getAuthenticationBackendURI();
+            var authExternalApiTokenEndpoint =
+                    buildURI(authenticationBackendURI.toString(), "token");
+
+            tokenRequestValidator.validatePrivateKeyJwtClientAuth(
+                    input.getBody(),
+                    authExternalApiTokenEndpoint,
+                    configurationService.getOrchestrationToAuthenticationSigningPublicKey());
+
+            String suppliedAuthCode = requestBody.get("code");
+
+            AuthCodeStore authCodeStore =
+                    authorisationCodeService
+                            .getAuthCodeStore(suppliedAuthCode)
+                            .orElseThrow(
+                                    () -> {
+                                        String errorMessage =
+                                                String.format(
+                                                        "No auth code store found for %s",
+                                                        suppliedAuthCode);
+                                        LOG.warn(errorMessage);
+                                        return new AuthCodeStoreRetreivalException(
+                                                errorMessage, OAuth2Error.INVALID_REQUEST);
+                                    });
+
+            if (!isCodeStoreValid(authCodeStore)) {
+                var tokenErrorResponse =
+                        tokenUtilityService.generateTokenErrorResponse(OAuth2Error.INVALID_REQUEST);
+                return generateApiGatewayProxyResponse(
+                        tokenErrorResponse.getStatusCode(), tokenErrorResponse.getContent());
+            }
+
+            LOG.info(
+                    "Auth code has been found and validated. Generating bearer token and sending response");
+            AccessTokenResponse tokenResponse =
+                    tokenUtilityService.generateNewBearerTokenAndTokenResponse();
+
+            accessTokenStoreService.addAccessTokenStore(
+                    tokenResponse.getTokens().getAccessToken().getValue(),
+                    authCodeStore.getSubjectID(),
+                    authCodeStore.getClaims(),
+                    authCodeStore.getIsNewAccount(),
+                    authCodeStore.getSectorIdentifier());
+
+            authorisationCodeService.updateHasBeenUsed(authCodeStore.getAuthCode(), true);
+
+            Map<String, String> headers = new HashMap<>();
+            headers.put("Content-Type", "application/json");
+            return generateApiGatewayProxyResponse(
+                    200, tokenResponse.toJSONObject().toJSONString(), headers, null);
+
+        } catch (TokenAuthInvalidException e) {
+            LOG.warn("Unable to validate token auth method", e);
+            var tokenErrorResponse =
+                    tokenUtilityService.generateTokenErrorResponse(e.getErrorObject());
+            return generateApiGatewayProxyResponse(
+                    tokenErrorResponse.getStatusCode(), tokenErrorResponse.getContent());
+        } catch (AuthCodeStoreRetreivalException e) {
+            var tokenErrorResponse =
+                    tokenUtilityService.generateTokenErrorResponse(e.getOAuth2Error());
+            return generateApiGatewayProxyResponse(
+                    tokenErrorResponse.getStatusCode(), tokenErrorResponse.getContent());
+        }
+    }
+
+    private boolean isCodeStoreValid(AuthCodeStore authCodeStore) {
+        if (authCodeStore.isHasBeenUsed()) {
+            LOG.warn("Auth code already used");
+            return false;
+        }
+        if (authCodeStore.getTimeToExist() < NowHelper.now().toInstant().getEpochSecond()) {
+            LOG.error(
+                    "Auth code expired - this should not have been returned from the database service");
+            return false;
+        }
+        return true;
+    }
+}

--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/services/TokenService.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/services/TokenService.java
@@ -1,0 +1,21 @@
+package uk.gov.di.authentication.external.services;
+
+import com.nimbusds.oauth2.sdk.AccessTokenResponse;
+import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.TokenErrorResponse;
+import com.nimbusds.oauth2.sdk.http.HTTPResponse;
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
+import com.nimbusds.oauth2.sdk.token.Tokens;
+
+public class TokenService {
+    public AccessTokenResponse generateNewBearerTokenAndTokenResponse() {
+        BearerAccessToken token = new BearerAccessToken();
+        var tokens = new Tokens(token, null);
+        return new AccessTokenResponse(tokens);
+    }
+
+    public HTTPResponse generateTokenErrorResponse(ErrorObject errorObject) {
+        TokenErrorResponse errorResponse = new TokenErrorResponse(errorObject);
+        return errorResponse.toHTTPResponse();
+    }
+}

--- a/auth-external-api/src/test/java/uk/gov/di/authentication/external/lambda/TokenHandlerTest.java
+++ b/auth-external-api/src/test/java/uk/gov/di/authentication/external/lambda/TokenHandlerTest.java
@@ -1,0 +1,209 @@
+package uk.gov.di.authentication.external.lambda;
+
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.nimbusds.oauth2.sdk.AccessTokenResponse;
+import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.OAuth2Error;
+import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod;
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
+import com.nimbusds.oauth2.sdk.token.Tokens;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.external.services.TokenService;
+import uk.gov.di.authentication.external.validators.TokenRequestValidator;
+import uk.gov.di.authentication.shared.entity.AuthCodeStore;
+import uk.gov.di.authentication.shared.exceptions.TokenAuthInvalidException;
+import uk.gov.di.authentication.shared.services.AccessTokenService;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+import uk.gov.di.authentication.shared.services.DynamoAuthCodeService;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class TokenHandlerTest {
+    private TokenHandler tokenHandler;
+    private ConfigurationService configurationService;
+    private AccessTokenService accessTokenService;
+    private TokenRequestValidator tokenRequestValidator;
+    private static final TokenService tokenUtilityService = mock(TokenService.class);
+    private static final BearerAccessToken SUCCESS_TOKEN_RESPONSE_ACCESS_TOKEN =
+            new BearerAccessToken();
+    private static final AccessTokenResponse SUCCESS_TOKEN_RESPONSE =
+            new AccessTokenResponse(new Tokens(SUCCESS_TOKEN_RESPONSE_ACCESS_TOKEN, null));
+    private static final DynamoAuthCodeService authCodeService = mock(DynamoAuthCodeService.class);
+    private static final long UNIX_TIME_16_08_2099 = 4090554490L;
+    private static final String VALID_AUTH_CODE = "valid-auth-code";
+    private static final AuthCodeStore VALID_AUTH_CODE_STORE =
+            new AuthCodeStore()
+                    .withAuthCode(VALID_AUTH_CODE)
+                    .withIsNewAccount(true)
+                    .withSectorIdentifier("any")
+                    .withClaims(List.of("any"))
+                    .withSubjectID("any")
+                    .withHasBeenUsed(false)
+                    .withTimeToExist(UNIX_TIME_16_08_2099);
+    private static final String USED_AUTH_CODE = "used-auth-code";
+    private static final AuthCodeStore USED_AUTH_CODE_STORE =
+            new AuthCodeStore()
+                    .withAuthCode(USED_AUTH_CODE)
+                    .withIsNewAccount(true)
+                    .withSectorIdentifier("any")
+                    .withClaims(List.of("any"))
+                    .withSubjectID("any")
+                    .withHasBeenUsed(true)
+                    .withTimeToExist(UNIX_TIME_16_08_2099);
+    private static final String EXPIRED_AUTH_CODE = "expired-auth-code";
+    private static final AuthCodeStore EXPIRED_AUTH_CODE_STORE =
+            new AuthCodeStore()
+                    .withAuthCode(EXPIRED_AUTH_CODE)
+                    .withIsNewAccount(true)
+                    .withSectorIdentifier("any")
+                    .withClaims(List.of("any"))
+                    .withSubjectID("any")
+                    .withHasBeenUsed(false)
+                    .withTimeToExist(0L);
+
+    @BeforeAll
+    public static void init() {
+        when(authCodeService.getAuthCodeStore(VALID_AUTH_CODE))
+                .thenReturn(Optional.of(VALID_AUTH_CODE_STORE));
+        when(authCodeService.getAuthCodeStore(EXPIRED_AUTH_CODE))
+                .thenReturn(Optional.of(EXPIRED_AUTH_CODE_STORE));
+        when(authCodeService.getAuthCodeStore(USED_AUTH_CODE))
+                .thenReturn(Optional.of(USED_AUTH_CODE_STORE));
+
+        when(tokenUtilityService.generateNewBearerTokenAndTokenResponse())
+                .thenReturn(SUCCESS_TOKEN_RESPONSE);
+        when(tokenUtilityService.generateTokenErrorResponse(any())).thenCallRealMethod();
+    }
+
+    @BeforeEach
+    public void setUp() {
+        configurationService = mock(ConfigurationService.class);
+        when(configurationService.getAuthenticationAuthCallbackURI())
+                .thenReturn(URI.create("https://test-callback.com"));
+        when(configurationService.getAuthenticationBackendURI())
+                .thenReturn(URI.create("https://test-backend.com"));
+
+        accessTokenService = mock(AccessTokenService.class);
+        tokenRequestValidator = mock(TokenRequestValidator.class);
+
+        tokenHandler =
+                new TokenHandler(
+                        configurationService,
+                        authCodeService,
+                        accessTokenService,
+                        tokenUtilityService,
+                        tokenRequestValidator);
+    }
+
+    @Test
+    void shouldReturn400WithErrorMessageWhenQueryParamIsMissingOrInvalid() {
+        String testErrorDescription = "test-error-description";
+        when(tokenRequestValidator.validatePlaintextParams(any()))
+                .thenReturn(
+                        Optional.of(
+                                new ErrorObject(
+                                        OAuth2Error.INVALID_REQUEST_CODE, testErrorDescription)));
+        APIGatewayProxyRequestEvent request = new APIGatewayProxyRequestEvent();
+
+        APIGatewayProxyResponseEvent response = tokenHandler.tokenRequestHandler(request);
+
+        assertEquals(400, response.getStatusCode());
+        assertTrue(response.getBody().contains(OAuth2Error.INVALID_REQUEST_CODE));
+        assertTrue(response.getBody().contains(testErrorDescription));
+    }
+
+    @Test
+    void shouldReturn400WithErrorMessageWhenClientAssertionJwtCannotBeValidated()
+            throws TokenAuthInvalidException {
+        String testErrorDescription = "test-error-description";
+
+        doThrow(
+                        new TokenAuthInvalidException(
+                                new ErrorObject(
+                                        OAuth2Error.INVALID_CLIENT_CODE, testErrorDescription),
+                                ClientAuthenticationMethod.PRIVATE_KEY_JWT,
+                                "tbc"))
+                .when(tokenRequestValidator)
+                .validatePrivateKeyJwtClientAuth(any(), any(), any());
+        APIGatewayProxyRequestEvent request = new APIGatewayProxyRequestEvent();
+
+        APIGatewayProxyResponseEvent response = tokenHandler.tokenRequestHandler(request);
+
+        assertEquals(400, response.getStatusCode());
+        assertTrue(response.getBody().contains(OAuth2Error.INVALID_CLIENT_CODE));
+        assertTrue(response.getBody().contains(testErrorDescription));
+    }
+
+    @Test
+    void shouldReturn400WithErrorMessageWhenAuthCodeNotFoundInDataStore() {
+        APIGatewayProxyRequestEvent request = new APIGatewayProxyRequestEvent();
+        String formData = "code=" + "auth-code-not-registered-for-mock-auth-code-store-service";
+        request.setBody(formData);
+
+        APIGatewayProxyResponseEvent response = tokenHandler.tokenRequestHandler(request);
+
+        assertEquals(400, response.getStatusCode());
+        assertTrue(response.getBody().contains(OAuth2Error.INVALID_REQUEST.getCode()));
+        assertTrue(response.getBody().contains(OAuth2Error.INVALID_REQUEST.getDescription()));
+    }
+
+    @Test
+    void shouldReturn400WithErrorMessageWhenAuthCodeHasAlreadyBeenUsed() {
+        APIGatewayProxyRequestEvent request = new APIGatewayProxyRequestEvent();
+        String formData = "code=" + USED_AUTH_CODE;
+        request.setBody(formData);
+
+        APIGatewayProxyResponseEvent response = tokenHandler.tokenRequestHandler(request);
+
+        assertEquals(400, response.getStatusCode());
+        assertTrue(response.getBody().contains(OAuth2Error.INVALID_REQUEST.getCode()));
+        assertTrue(response.getBody().contains(OAuth2Error.INVALID_REQUEST.getDescription()));
+    }
+
+    @Test
+    void shouldReturn400WithErrorMessageWhenAuthCodeHasExpired() {
+        APIGatewayProxyRequestEvent request = new APIGatewayProxyRequestEvent();
+        String formData = "code=" + EXPIRED_AUTH_CODE;
+        request.setBody(formData);
+
+        APIGatewayProxyResponseEvent response = tokenHandler.tokenRequestHandler(request);
+
+        assertEquals(400, response.getStatusCode());
+        assertTrue(response.getBody().contains(OAuth2Error.INVALID_REQUEST.getCode()));
+        assertTrue(response.getBody().contains(OAuth2Error.INVALID_REQUEST.getDescription()));
+    }
+
+    @Test
+    void shouldReturn200WithAccessTokenWhenAuthCodeStoreIsValidAndMarkAuthCodeStoreAsUsed() {
+        APIGatewayProxyRequestEvent request = new APIGatewayProxyRequestEvent();
+        String formData = "code=" + VALID_AUTH_CODE;
+        request.setBody(formData);
+
+        APIGatewayProxyResponseEvent response = tokenHandler.tokenRequestHandler(request);
+
+        assertEquals(200, response.getStatusCode());
+        assertTrue(response.getBody().contains(SUCCESS_TOKEN_RESPONSE_ACCESS_TOKEN.getValue()));
+        assertTrue(response.getBody().contains("\"token_type\":\"Bearer\""));
+        verify(accessTokenService)
+                .addAccessTokenStore(
+                        SUCCESS_TOKEN_RESPONSE_ACCESS_TOKEN.getValue(),
+                        VALID_AUTH_CODE_STORE.getSubjectID(),
+                        VALID_AUTH_CODE_STORE.getClaims(),
+                        VALID_AUTH_CODE_STORE.getIsNewAccount(),
+                        VALID_AUTH_CODE_STORE.getSectorIdentifier());
+        verify(authCodeService).updateHasBeenUsed(VALID_AUTH_CODE, true);
+    }
+}

--- a/auth-external-api/src/test/java/uk/gov/di/authentication/external/services/TokenServiceTest.java
+++ b/auth-external-api/src/test/java/uk/gov/di/authentication/external/services/TokenServiceTest.java
@@ -1,0 +1,47 @@
+package uk.gov.di.authentication.external.services;
+
+import com.nimbusds.oauth2.sdk.AccessTokenResponse;
+import com.nimbusds.oauth2.sdk.ErrorObject;
+import com.nimbusds.oauth2.sdk.http.HTTPResponse;
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TokenServiceTest {
+    private TokenService tokenService;
+
+    @BeforeEach
+    void setUp() {
+        tokenService = new TokenService();
+    }
+
+    @Test
+    void generateNewBearerTokenAndTokenResponseShouldGenerateBearerTokenButNoRefreshToken() {
+        AccessTokenResponse response = tokenService.generateNewBearerTokenAndTokenResponse();
+
+        assertNotNull(response);
+        assertNotNull(response.getTokens());
+        assertNotNull(response.getTokens().getBearerAccessToken());
+        assertNull(response.getTokens().getRefreshToken());
+
+        BearerAccessToken bearerAccessToken = response.getTokens().getBearerAccessToken();
+        assertTrue(bearerAccessToken.getValue().length() > 0);
+    }
+
+    @Test
+    void generateTokenErrorResponseShouldGenerateCorrectErrorResponse() {
+        ErrorObject errorObject = new ErrorObject("invalid_request", "Invalid request parameters");
+
+        HTTPResponse httpResponse = tokenService.generateTokenErrorResponse(errorObject);
+
+        assertNotNull(httpResponse);
+        assertEquals(400, httpResponse.getStatusCode());
+        assertTrue(httpResponse.getContent().contains("invalid_request"));
+        assertTrue(httpResponse.getContent().contains("Invalid request parameters"));
+    }
+}

--- a/auth-external-api/src/test/java/uk/gov/di/authentication/external/validators/TokenRequestValidatorTest.java
+++ b/auth-external-api/src/test/java/uk/gov/di/authentication/external/validators/TokenRequestValidatorTest.java
@@ -1,13 +1,37 @@
 package uk.gov.di.authentication.external.validators;
 
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
 import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import uk.gov.di.authentication.shared.exceptions.TokenAuthInvalidException;
+import uk.gov.di.authentication.sharedtest.helper.JwtHelper;
 
+import java.net.URI;
+import java.security.spec.X509EncodedKeySpec;
+import java.text.ParseException;
+import java.util.Base64;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Stream;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 class TokenRequestValidatorTest {
     private static final String VALID_REDIRECT_URI = "https://redirect-uri.co.uk";
@@ -15,111 +39,281 @@ class TokenRequestValidatorTest {
     private TokenRequestValidator validator =
             new TokenRequestValidator(VALID_REDIRECT_URI, VALID_CLIENT_ID);
 
-    @Test
-    void shouldReturnInvalidRequestCodeIfGivenNoGrantType() {
-        Optional<ErrorObject> result = validator.validate(Map.of("key", "value"));
+    @Nested
+    class ValidatePlaintextParamsTests {
+        @Test
+        void shouldReturnInvalidRequestCodeIfGivenNullInput() {
+            Optional<ErrorObject> result = validator.validatePlaintextParams(null);
 
-        assertEquals(OAuth2Error.INVALID_REQUEST_CODE, result.get().getCode());
-        assertEquals("Request is missing grant_type parameter", result.get().getDescription());
+            assertEquals(OAuth2Error.INVALID_REQUEST_CODE, result.get().getCode());
+            assertEquals("Request requires query parameters", result.get().getDescription());
+        }
+
+        @Test
+        void shouldReturnInvalidRequestCodeIfGivenNoGrantType() {
+            Optional<ErrorObject> result =
+                    validator.validatePlaintextParams(Map.of("key", "value"));
+
+            assertEquals(OAuth2Error.INVALID_REQUEST_CODE, result.get().getCode());
+            assertEquals("Request is missing grant_type parameter", result.get().getDescription());
+        }
+
+        @Test
+        void shouldReturnInvalidRequestCodeIfGivenGrantTypeButOfInvalidValue() {
+            Optional<ErrorObject> result =
+                    validator.validatePlaintextParams(Map.of("grant_type", "value"));
+
+            assertEquals(OAuth2Error.INVALID_REQUEST_CODE, result.get().getCode());
+            assertEquals("Request has invalid grant_type parameter", result.get().getDescription());
+        }
+
+        @Test
+        void shouldReturnInvalidRequestCodeIfGivenValidGrantTypeButNoCode() {
+            Optional<ErrorObject> result =
+                    validator.validatePlaintextParams(Map.of("grant_type", "authorization_code"));
+
+            assertEquals(OAuth2Error.INVALID_REQUEST_CODE, result.get().getCode());
+            assertEquals("Request is missing code parameter", result.get().getDescription());
+        }
+
+        @Test
+        void shouldReturnInvalidRequestCodeIfGivenValidGrantTypeAndCodeButNoRedirectUri() {
+            Optional<ErrorObject> result =
+                    validator.validatePlaintextParams(
+                            Map.of("grant_type", "authorization_code", "code", "value"));
+
+            assertEquals(OAuth2Error.INVALID_REQUEST_CODE, result.get().getCode());
+            assertEquals(
+                    "Request is missing redirect_uri parameter", result.get().getDescription());
+        }
+
+        @Test
+        void
+                shouldReturnInvalidRequestCodeIfGivenValidGrantTypeAndCodeAndRedirectUriOtherThanPermittedRedirectUri() {
+            Optional<ErrorObject> result =
+                    validator.validatePlaintextParams(
+                            Map.of(
+                                    "grant_type",
+                                    "authorization_code",
+                                    "code",
+                                    "value",
+                                    "redirect_uri",
+                                    "value"));
+
+            assertEquals(OAuth2Error.INVALID_REQUEST_CODE, result.get().getCode());
+            assertEquals(
+                    "Request redirect_uri is not the permitted redirect_uri",
+                    result.get().getDescription());
+        }
+
+        @Test
+        void
+                shouldReturnInvalidRequestCodeIfGivenValidGrantTypeAndCodeAndPermittedRedirectButNoClientId() {
+            Optional<ErrorObject> result =
+                    validator.validatePlaintextParams(
+                            Map.of(
+                                    "grant_type",
+                                    "authorization_code",
+                                    "code",
+                                    "value",
+                                    "redirect_uri",
+                                    VALID_REDIRECT_URI));
+
+            assertEquals(OAuth2Error.INVALID_REQUEST_CODE, result.get().getCode());
+            assertEquals("Request is missing client_id parameter", result.get().getDescription());
+        }
+
+        @Test
+        void
+                shouldReturnInvalidRequestCodeIfGivenValidGrantTypeAndCodeAndPermittedRedirectButInvalidClientId() {
+            Optional<ErrorObject> result =
+                    validator.validatePlaintextParams(
+                            Map.of(
+                                    "grant_type",
+                                    "authorization_code",
+                                    "code",
+                                    "value",
+                                    "redirect_uri",
+                                    VALID_REDIRECT_URI,
+                                    "client_id",
+                                    "value"));
+
+            assertEquals(OAuth2Error.INVALID_REQUEST_CODE, result.get().getCode());
+            assertEquals(
+                    "Request client_id is not the permitted client_id",
+                    result.get().getDescription());
+        }
+
+        @Test
+        void
+                shouldReturnNoInvalidRequestCodeIfGivenValidGrantTypeAndCodeAndPermittedRedirectUriAndClientId() {
+            Optional<ErrorObject> result =
+                    validator.validatePlaintextParams(
+                            Map.of(
+                                    "grant_type",
+                                    "authorization_code",
+                                    "code",
+                                    "value",
+                                    "redirect_uri",
+                                    VALID_REDIRECT_URI,
+                                    "client_id",
+                                    VALID_CLIENT_ID));
+
+            assertEquals(Optional.empty(), result);
+        }
     }
 
-    @Test
-    void shouldReturnInvalidRequestCodeIfGivenGrantTypeButOfInvalidValue() {
-        Optional<ErrorObject> result = validator.validate(Map.of("grant_type", "value"));
+    @Nested
+    class ValidatePrivateKeyJwtAuthTests {
+        private static final URI EXPECTED_AUDIENCE = URI.create("https://example.com/resource");
+        private static ECKey VALID_KEY_PAIR;
+        private static String VALID_PUBLIC_KEY_AS_X509_STRING;
+        private static ECKey ALTERNATE_EC_KEY_PAIR;
+        private static RSAKey RSA_KEY_PAIR;
+        private static String RSA_PUBLIC_KEY_AS_X509_STRING;
+        private static String VALID_REQUEST_BODY_VALID_SIGNATURE;
+        private static String VALID_REQUEST_BODY_INVALID_SIGNATURE;
+        private static String VALID_REQUEST_BODY_RSA_SIGNATURE;
+        private static String INCOMPLETE_REQUEST_BODY_VALID_SIGNATURE;
 
-        assertEquals(OAuth2Error.INVALID_REQUEST_CODE, result.get().getCode());
-        assertEquals("Request has invalid grant_type parameter", result.get().getDescription());
+        @BeforeAll
+        static void init() throws JOSEException, ParseException {
+            String validClientAssertionPayload =
+                    getClientAssertionPayload(
+                            EXPECTED_AUDIENCE.toString(),
+                            "matching-random",
+                            "matching-random",
+                            9999999999L,
+                            "jti",
+                            0L);
+
+            VALID_KEY_PAIR = new ECKeyGenerator(Curve.P_256).generate();
+            X509EncodedKeySpec x509EncodedKeySpec =
+                    new X509EncodedKeySpec(VALID_KEY_PAIR.toPublicKey().getEncoded());
+            byte[] x509EncodedPublicKey = x509EncodedKeySpec.getEncoded();
+            VALID_PUBLIC_KEY_AS_X509_STRING =
+                    Base64.getEncoder().encodeToString(x509EncodedPublicKey);
+            String clientAssertionValidKeySignature =
+                    JwtHelper.jsonToSignedJwt(validClientAssertionPayload, VALID_KEY_PAIR);
+            VALID_REQUEST_BODY_VALID_SIGNATURE =
+                    getValidRequestBodyWithClientAssertion(clientAssertionValidKeySignature);
+            INCOMPLETE_REQUEST_BODY_VALID_SIGNATURE =
+                    "code=vC-WxcXDLoOHaJN0YvPB0IwG2LiT1ekSVRSccwubwlI"
+                            + "&grant_type=authorization_code"
+                            + "&redirect_uri=https://redirect.uri.com/redirect"
+                            + "&client_assertion="
+                            + clientAssertionValidKeySignature;
+
+            ALTERNATE_EC_KEY_PAIR = new ECKeyGenerator(Curve.P_256).generate();
+            String clientAssertionInvalidEcKeySignature =
+                    JwtHelper.jsonToSignedJwt(validClientAssertionPayload, ALTERNATE_EC_KEY_PAIR);
+            VALID_REQUEST_BODY_INVALID_SIGNATURE =
+                    getValidRequestBodyWithClientAssertion(clientAssertionInvalidEcKeySignature);
+
+            RSA_KEY_PAIR = new RSAKeyGenerator(2048).generate();
+            X509EncodedKeySpec x509EncodedKeySpecRsa =
+                    new X509EncodedKeySpec(RSA_KEY_PAIR.toPublicKey().getEncoded());
+            byte[] x509EncodedPublicKeyRsa = x509EncodedKeySpecRsa.getEncoded();
+            RSA_PUBLIC_KEY_AS_X509_STRING =
+                    Base64.getEncoder().encodeToString(x509EncodedPublicKeyRsa);
+            JWSSigner rsaSigner = new RSASSASigner(RSA_KEY_PAIR.toRSAPrivateKey());
+            String clientAssertionRsaKeySignature =
+                    JwtHelper.jsonToSignedJwt(
+                            validClientAssertionPayload, rsaSigner, JWSAlgorithm.PS256);
+            VALID_REQUEST_BODY_RSA_SIGNATURE =
+                    getValidRequestBodyWithClientAssertion(clientAssertionRsaKeySignature);
+        }
+
+        static Stream<Arguments> validationTestData() {
+            return Stream.of(
+                    arguments(
+                            "string-not-jwt",
+                            OAuth2Error.INVALID_REQUEST_CODE,
+                            "Invalid private_key_jwt",
+                            VALID_PUBLIC_KEY_AS_X509_STRING),
+                    arguments(
+                            INCOMPLETE_REQUEST_BODY_VALID_SIGNATURE,
+                            OAuth2Error.INVALID_REQUEST_CODE,
+                            "Invalid private_key_jwt",
+                            VALID_PUBLIC_KEY_AS_X509_STRING),
+                    arguments(
+                            VALID_REQUEST_BODY_RSA_SIGNATURE,
+                            OAuth2Error.INVALID_CLIENT_CODE,
+                            "Client authentication failed",
+                            RSA_PUBLIC_KEY_AS_X509_STRING),
+                    arguments(
+                            VALID_REQUEST_BODY_INVALID_SIGNATURE,
+                            OAuth2Error.INVALID_CLIENT_CODE,
+                            "Client authentication failed",
+                            VALID_PUBLIC_KEY_AS_X509_STRING));
+        }
+
+        @ParameterizedTest
+        @MethodSource("validationTestData")
+        void shouldThrowTokenAuthInvalidExceptionInAllValidationErrorScenarios(
+                String requestBody,
+                String expectedErrorCode,
+                String expectedErrorDescription,
+                String clientRegistryPublicKey) {
+            TokenAuthInvalidException exception =
+                    assertThrows(
+                            TokenAuthInvalidException.class,
+                            () -> {
+                                validator.validatePrivateKeyJwtClientAuth(
+                                        requestBody, EXPECTED_AUDIENCE, clientRegistryPublicKey);
+                            });
+
+            assertEquals(expectedErrorCode, exception.getErrorObject().getCode());
+            assertEquals(expectedErrorDescription, exception.getErrorObject().getDescription());
+        }
+
+        @Test
+        void
+                shouldNotThrowAnyExceptionsIfValidPublicKeyIsUsedToSignValidClientAssertionAsPartOfValidRequestBody() {
+            assertDoesNotThrow(
+                    () ->
+                            validator.validatePrivateKeyJwtClientAuth(
+                                    VALID_REQUEST_BODY_VALID_SIGNATURE,
+                                    EXPECTED_AUDIENCE,
+                                    VALID_PUBLIC_KEY_AS_X509_STRING));
+        }
     }
 
-    @Test
-    void shouldReturnInvalidRequestCodeIfGivenValidGrantTypeButNoCode() {
-        Optional<ErrorObject> result =
-                validator.validate(Map.of("grant_type", "authorization_code"));
-
-        assertEquals(OAuth2Error.INVALID_REQUEST_CODE, result.get().getCode());
-        assertEquals("Request is missing code parameter", result.get().getDescription());
+    private static String getValidRequestBodyWithClientAssertion(String clientAssertion) {
+        return "code=vC-WxcXDLoOHaJN0YvPB0IwG2LiT1ekSVRSccwubwlI"
+                + "&grant_type=authorization_code"
+                + "&redirect_uri=https://redirect.uri.com/redirect"
+                + "&client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer"
+                + "&client_assertion="
+                + clientAssertion;
     }
 
-    @Test
-    void shouldReturnInvalidRequestCodeIfGivenValidGrantTypeAndCodeButNoRedirectUri() {
-        Optional<ErrorObject> result =
-                validator.validate(Map.of("grant_type", "authorization_code", "code", "value"));
-
-        assertEquals(OAuth2Error.INVALID_REQUEST_CODE, result.get().getCode());
-        assertEquals("Request is missing redirect_uri parameter", result.get().getDescription());
-    }
-
-    @Test
-    void
-            shouldReturnInvalidRequestCodeIfGivenValidGrantTypeAndCodeAndRedirectUriOtherThanPermittedRedirectUri() {
-        Optional<ErrorObject> result =
-                validator.validate(
-                        Map.of(
-                                "grant_type",
-                                "authorization_code",
-                                "code",
-                                "value",
-                                "redirect_uri",
-                                "value"));
-
-        assertEquals(OAuth2Error.INVALID_REQUEST_CODE, result.get().getCode());
-        assertEquals(
-                "Request redirect_uri is not the permitted redirect_uri",
-                result.get().getDescription());
-    }
-
-    @Test
-    void
-            shouldReturnInvalidRequestCodeIfGivenValidGrantTypeAndCodeAndPermittedRedirectButNoClientId() {
-        Optional<ErrorObject> result =
-                validator.validate(
-                        Map.of(
-                                "grant_type",
-                                "authorization_code",
-                                "code",
-                                "value",
-                                "redirect_uri",
-                                VALID_REDIRECT_URI));
-
-        assertEquals(OAuth2Error.INVALID_REQUEST_CODE, result.get().getCode());
-        assertEquals("Request is missing client_id parameter", result.get().getDescription());
-    }
-
-    @Test
-    void
-            shouldReturnInvalidRequestCodeIfGivenValidGrantTypeAndCodeAndPermittedRedirectButInvalidClientId() {
-        Optional<ErrorObject> result =
-                validator.validate(
-                        Map.of(
-                                "grant_type",
-                                "authorization_code",
-                                "code",
-                                "value",
-                                "redirect_uri",
-                                VALID_REDIRECT_URI,
-                                "client_id",
-                                "value"));
-
-        assertEquals(OAuth2Error.INVALID_REQUEST_CODE, result.get().getCode());
-        assertEquals(
-                "Request client_id is not the permitted client_id", result.get().getDescription());
-    }
-
-    @Test
-    void
-            shouldReturnNoInvalidRequestCodeIfGivenValidGrantTypeAndCodeAndPermittedRedirectUriAndClientId() {
-        Optional<ErrorObject> result =
-                validator.validate(
-                        Map.of(
-                                "grant_type",
-                                "authorization_code",
-                                "code",
-                                "value",
-                                "redirect_uri",
-                                VALID_REDIRECT_URI,
-                                "client_id",
-                                VALID_CLIENT_ID));
-
-        assertEquals(Optional.empty(), result);
+    private static String getClientAssertionPayload(
+            String audience,
+            String issuer,
+            String subject,
+            long expiry,
+            String jti,
+            long issuedAt) {
+        return "{\n"
+                + "  \"aud\":\""
+                + audience
+                + "\",\n"
+                + "  \"iss\":\""
+                + issuer
+                + "\",\n"
+                + "  \"sub\":\""
+                + subject
+                + "\",\n"
+                + "  \"exp\":"
+                + expiry
+                + ",\n"
+                + "  \"jti\":\""
+                + jti
+                + "\",\n"
+                + "  \"iat\":"
+                + issuedAt
+                + "\n"
+                + "}";
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationTokenHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationTokenHandlerIntegrationTest.java
@@ -1,0 +1,238 @@
+package uk.gov.di.authentication.api;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.oauth2.sdk.GrantType;
+import com.nimbusds.oauth2.sdk.ParseException;
+import com.nimbusds.oauth2.sdk.TokenResponse;
+import com.nimbusds.oauth2.sdk.auth.JWTAuthenticationClaimsSet;
+import com.nimbusds.oauth2.sdk.auth.PrivateKeyJWT;
+import com.nimbusds.oauth2.sdk.http.HTTPResponse;
+import com.nimbusds.oauth2.sdk.id.Audience;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+import com.nimbusds.oauth2.sdk.id.Subject;
+import com.nimbusds.oauth2.sdk.util.URLUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.di.authentication.external.lambda.TokenHandler;
+import uk.gov.di.authentication.shared.helpers.NowHelper;
+import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.gov.di.authentication.sharedtest.extensions.AccessTokenStoreExtension;
+import uk.gov.di.authentication.sharedtest.extensions.AuthCodeExtension;
+import uk.gov.di.authentication.sharedtest.extensions.KmsKeyExtension;
+import uk.gov.di.authentication.sharedtest.extensions.SnsTopicExtension;
+import uk.gov.di.authentication.sharedtest.extensions.SqsQueueExtension;
+import uk.gov.di.authentication.sharedtest.extensions.TokenSigningExtension;
+
+import java.net.URI;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static uk.gov.di.authentication.shared.helpers.ConstructUriHelper.buildURI;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
+
+class AuthenticationTokenHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
+    public static final String CLIENT_SESSION_ID = "some-client-session-id";
+    public static final String VALID_AUTH_CODE = "valid-auth-code";
+    public static final String INVALID_AUTH_CODE = "invalid-auth-code";
+    private static final String ORCH_CLIENT_ID = "orch-client-id";
+    private static final URI ORCH_REDIRECT_URI = URI.create("http://localhost/redirect");
+    private static final URI AUTH_BACKEND_URI = URI.create("http://auth-backend");
+    private static final Subject TEST_SUBJECT = new Subject();
+    private static final List<String> TEST_CLAIMS = List.of("test-claim-1");
+
+    @RegisterExtension
+    protected static final AuthCodeExtension authCodeStoreExtension = new AuthCodeExtension(180);
+
+    @RegisterExtension
+    protected static final AccessTokenStoreExtension accessTokenStoreExtension =
+            new AccessTokenStoreExtension(180);
+
+    @BeforeEach
+    void setup() throws JOSEException {
+        var configurationService =
+                new AuthenticationTokenHandlerIntegrationTest.TestConfigurationService(
+                        auditTopic,
+                        notificationsQueue,
+                        auditSigningKey,
+                        tokenSigner,
+                        ipvPrivateKeyJwtSigner,
+                        spotQueue,
+                        docAppPrivateKeyJwtSigner);
+
+        handler = new TokenHandler(configurationService);
+
+        authCodeStoreExtension.saveAuthCode(
+                TEST_SUBJECT.getValue(), VALID_AUTH_CODE, TEST_CLAIMS, false);
+
+        txmaAuditQueue.clear();
+    }
+
+    @Test
+    void
+            shouldGenerateASuccessfulTokenResponseWhenPresentedWithAValidAuthCodeAndSetCodeStoreFlagToUsed()
+                    throws ParseException, JOSEException {
+        Map<String, List<String>> baseParams =
+                baseTokenRequestParamsWithoutClientAssertion(VALID_AUTH_CODE);
+        Map<String, List<String>> privateKeyJWT = privateKeyJWTParams(EC_KEY_PAIR);
+        baseParams.putAll(privateKeyJWT);
+        var requestBody = URLUtils.serializeParameters(baseParams);
+
+        var response =
+                makeRequest(
+                        Optional.of(requestBody),
+                        Map.of("Content-Type", "application/x-www-form-urlencoded"),
+                        new HashMap<>());
+
+        assertThat(response, hasStatus(200));
+
+        String responseBody = response.getBody();
+        HTTPResponse httpResponse = new HTTPResponse(200);
+        httpResponse.setContent(responseBody);
+        httpResponse.setContentType(response.getHeaders().get("Content-Type"));
+        TokenResponse tokenResponse = TokenResponse.parse(httpResponse);
+        assertTrue(
+                tokenResponse
+                                .toSuccessResponse()
+                                .getTokens()
+                                .getBearerAccessToken()
+                                .getValue()
+                                .length()
+                        > 0);
+
+        var authCodeStorePostHanderExecution = authCodeStoreExtension.getAuthCode(VALID_AUTH_CODE);
+        assertTrue(authCodeStorePostHanderExecution.isPresent());
+        assertTrue(authCodeStorePostHanderExecution.get().isHasBeenUsed());
+    }
+
+    @Test
+    void validAuthCodeShouldSucceedTheFirstTimeItIsUsedButShouldNotBePossibleToUseTwice()
+            throws JOSEException {
+        Map<String, List<String>> baseParams =
+                baseTokenRequestParamsWithoutClientAssertion(VALID_AUTH_CODE);
+        Map<String, List<String>> privateKeyJWT = privateKeyJWTParams(EC_KEY_PAIR);
+        baseParams.putAll(privateKeyJWT);
+        var requestBody = URLUtils.serializeParameters(baseParams);
+
+        var responseOne =
+                makeRequest(
+                        Optional.of(requestBody),
+                        Map.of("Content-Type", "application/x-www-form-urlencoded"),
+                        new HashMap<>());
+
+        assertThat(responseOne, hasStatus(200));
+
+        var responseTwo =
+                makeRequest(
+                        Optional.of(requestBody),
+                        Map.of("Content-Type", "application/x-www-form-urlencoded"),
+                        new HashMap<>());
+
+        assertThat(responseTwo, hasStatus(400));
+    }
+
+    @Test
+    void shouldReturn400ForAuthCodeThatHasExpired() throws JOSEException {
+        Map<String, List<String>> baseParams =
+                baseTokenRequestParamsWithoutClientAssertion(INVALID_AUTH_CODE);
+        Map<String, List<String>> privateKeyJWT = privateKeyJWTParams(EC_KEY_PAIR);
+        baseParams.putAll(privateKeyJWT);
+        var requestBody = URLUtils.serializeParameters(baseParams);
+
+        var response =
+                makeRequest(
+                        Optional.of(requestBody),
+                        Map.of("Content-Type", "application/x-www-form-urlencoded"),
+                        new HashMap<>());
+
+        assertThat(response, hasStatus(400));
+        assertTrue(
+                response.getBody()
+                        .contains(
+                                "{\"error\":\"invalid_request\",\"error_description\":\"Invalid request\"}"));
+    }
+
+    private static Map<String, List<String>> privateKeyJWTParams(ECKey ecKeyPair)
+            throws JOSEException {
+        var expiryDate = NowHelper.nowPlus(5, ChronoUnit.MINUTES);
+        var claimsSet =
+                new JWTAuthenticationClaimsSet(
+                        new ClientID(ORCH_CLIENT_ID),
+                        new Audience(buildURI(AUTH_BACKEND_URI.toString(), "token")));
+        claimsSet.getExpirationTime().setTime(expiryDate.getTime());
+        var privateKeyJWT =
+                new PrivateKeyJWT(
+                        claimsSet, JWSAlgorithm.ES256, ecKeyPair.toPrivateKey(), null, null);
+        return privateKeyJWT.toParameters();
+    }
+
+    private static Map<String, List<String>> baseTokenRequestParamsWithoutClientAssertion(
+            String authCode) {
+        Map<String, List<String>> baseParams = new HashMap<>();
+        baseParams.put(
+                "grant_type", Collections.singletonList(GrantType.AUTHORIZATION_CODE.getValue()));
+        baseParams.put("client_id", Collections.singletonList(ORCH_CLIENT_ID));
+        baseParams.put("code", Collections.singletonList(authCode));
+        baseParams.put("redirect_uri", Collections.singletonList(ORCH_REDIRECT_URI.toString()));
+        return baseParams;
+    }
+
+    private static class TestConfigurationService extends IntegrationTestConfigurationService {
+        public TestConfigurationService(
+                SnsTopicExtension auditEventTopic,
+                SqsQueueExtension notificationQueue,
+                KmsKeyExtension auditSigningKey,
+                TokenSigningExtension tokenSigningKey,
+                TokenSigningExtension ipvPrivateKeyJwtSigner,
+                SqsQueueExtension spotQueue,
+                TokenSigningExtension docAppPrivateKeyJwtSigner) {
+            super(
+                    auditEventTopic,
+                    notificationQueue,
+                    auditSigningKey,
+                    tokenSigningKey,
+                    ipvPrivateKeyJwtSigner,
+                    spotQueue,
+                    docAppPrivateKeyJwtSigner,
+                    configurationParameters);
+        }
+
+        @Override
+        public boolean isAuthCodeStoreEnabled() {
+            return true;
+        }
+
+        @Override
+        public String getTxmaAuditQueueUrl() {
+            return txmaAuditQueue.getQueueUrl();
+        }
+
+        @Override
+        public URI getAuthenticationAuthCallbackURI() {
+            return ORCH_REDIRECT_URI;
+        }
+
+        @Override
+        public URI getAuthenticationBackendURI() {
+            return AUTH_BACKEND_URI;
+        }
+
+        @Override
+        public String getOrchestrationClientId() {
+            return ORCH_CLIENT_ID;
+        }
+
+        @Override
+        public String getOrchestrationToAuthenticationSigningPublicKey() {
+            return EC_PUBLIC_KEY;
+        }
+    }
+}

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -8,6 +8,7 @@ import com.nimbusds.oauth2.sdk.ErrorObject;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.ResponseMode;
+import com.nimbusds.oauth2.sdk.TokenResponse;
 import com.nimbusds.oauth2.sdk.http.HTTPRequest;
 import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.openid.connect.sdk.AuthenticationErrorResponse;
@@ -190,7 +191,7 @@ public class AuthenticationCallbackHandler
             var tokenRequest =
                     tokenService.constructTokenRequest(
                             input.getQueryStringParameters().get("code"));
-            var tokenResponse = tokenService.sendTokenRequest(tokenRequest);
+            TokenResponse tokenResponse = tokenService.sendTokenRequest(tokenRequest);
             if (tokenResponse.indicatesSuccess()) {
                 LOG.info("TokenResponse was successful");
                 auditService.submitAuditEvent(

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/JwtHelper.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/JwtHelper.java
@@ -1,0 +1,32 @@
+package uk.gov.di.authentication.sharedtest.helper;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+
+import java.text.ParseException;
+
+public class JwtHelper {
+    private JwtHelper() {}
+
+    public static String jsonToSignedJwt(String jsonString, ECKey ecKey)
+            throws JOSEException, ParseException {
+        JWSSigner signer = new ECDSASigner(ecKey.toECPrivateKey());
+        return jsonToSignedJwt(jsonString, signer, JWSAlgorithm.ES256);
+    }
+
+    public static String jsonToSignedJwt(
+            String jsonString, JWSSigner signer, JWSAlgorithm algorithm)
+            throws ParseException, JOSEException {
+        JWTClaimsSet claimsSet = JWTClaimsSet.parse(jsonString);
+        JWSHeader header = new JWSHeader.Builder(algorithm).build();
+        SignedJWT jwt = new SignedJWT(header, claimsSet);
+        jwt.sign(signer);
+        return jwt.serialize();
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthCodeStore.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/AuthCodeStore.java
@@ -9,17 +9,21 @@ import java.util.List;
 @DynamoDbBean
 public class AuthCodeStore {
 
-    public static final String ATTRIBUTE_SUBJECT_ID = "SubjectID";
-    public static final String ATTRIBUTE_AUTH_CODE = "AuthCode";
-    public static final String ATTRIBUTE_CLAIMS = "Claims";
-    public static final String ATTRIBUTE_TIME_TO_EXIST = "TimeToExist";
-    public static final String ATTRIBUTE_HAS_BEEN_USED = "HasBeenUsed";
+    private static final String ATTRIBUTE_SUBJECT_ID = "SubjectID";
+    private static final String ATTRIBUTE_AUTH_CODE = "AuthCode";
+    private static final String ATTRIBUTE_CLAIMS = "Claims";
+    private static final String ATTRIBUTE_TIME_TO_EXIST = "TimeToExist";
+    private static final String ATTRIBUTE_HAS_BEEN_USED = "HasBeenUsed";
+    private static final String ATTRIBUTE_SECTOR_IDENTIFIER = "SectorIdentifier";
+    private static final String ATTRIBUTE_IS_NEW_ACCOUNT = "IsNewAccount";
 
     private String subjectID;
     private String authCode;
     private List<String> claims;
     private long timeToExist;
     private boolean hasBeenUsed;
+    private String sectorIdentifier;
+    private boolean isNewAccount;
 
     public AuthCodeStore() {}
 
@@ -91,6 +95,34 @@ public class AuthCodeStore {
 
     public AuthCodeStore withHasBeenUsed(boolean hasBeenUsed) {
         this.hasBeenUsed = hasBeenUsed;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_SECTOR_IDENTIFIER)
+    public String getSectorIdentifier() {
+        return sectorIdentifier;
+    }
+
+    public void setTimeToExist(String sectorIdentifier) {
+        this.sectorIdentifier = sectorIdentifier;
+    }
+
+    public AuthCodeStore withSectorIdentifier(String sectorIdentifier) {
+        this.sectorIdentifier = sectorIdentifier;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_IS_NEW_ACCOUNT)
+    public boolean getIsNewAccount() {
+        return isNewAccount;
+    }
+
+    public void setIsNewAccount(boolean isNewAccount) {
+        this.isNewAccount = isNewAccount;
+    }
+
+    public AuthCodeStore withIsNewAccount(boolean isNewAccount) {
+        this.isNewAccount = isNewAccount;
         return this;
     }
 }

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -277,6 +277,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return System.getenv("ORCH_TO_AUTH_TOKEN_SIGNING_KEY_ALIAS");
     }
 
+    public String getOrchestrationToAuthenticationSigningPublicKey() {
+        return System.getenv("ORCH_TO_AUTH_TOKEN_SIGNING_PUBLIC_KEY");
+    }
+
     public String getOrchestrationToAuthenticationEncryptionPublicKey() {
         var paramName = format("{0}-auth-public-encryption-key", getEnvironment());
         try {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/validation/PrivateKeyJwtAuthPublicKeySelector.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/validation/PrivateKeyJwtAuthPublicKeySelector.java
@@ -1,0 +1,55 @@
+package uk.gov.di.authentication.shared.validation;
+
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.jwk.KeyType;
+import com.nimbusds.oauth2.sdk.auth.ClientAuthenticationMethod;
+import com.nimbusds.oauth2.sdk.auth.Secret;
+import com.nimbusds.oauth2.sdk.auth.verifier.ClientCredentialsSelector;
+import com.nimbusds.oauth2.sdk.auth.verifier.Context;
+import com.nimbusds.oauth2.sdk.auth.verifier.InvalidClientException;
+import com.nimbusds.oauth2.sdk.id.ClientID;
+
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+
+public class PrivateKeyJwtAuthPublicKeySelector implements ClientCredentialsSelector<String> {
+    private final String publicKey;
+    private final KeyType keyType;
+
+    public PrivateKeyJwtAuthPublicKeySelector(String publicKey, KeyType keyType) {
+        this.publicKey = publicKey;
+        this.keyType = keyType;
+    }
+
+    @Override
+    public List<Secret> selectClientSecrets(
+            ClientID claimedClientID,
+            ClientAuthenticationMethod authMethod,
+            Context<String> context) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<PublicKey> selectPublicKeys(
+            ClientID claimedClientID,
+            ClientAuthenticationMethod authMethod,
+            JWSHeader jwsHeader,
+            boolean forceRefresh,
+            Context<String> context)
+            throws InvalidClientException {
+        byte[] decodedKey = Base64.getMimeDecoder().decode(publicKey);
+        try {
+            X509EncodedKeySpec ecPublicKeySpec = new X509EncodedKeySpec(decodedKey);
+            KeyFactory kf = KeyFactory.getInstance(keyType.getValue());
+            return Collections.singletonList(kf.generatePublic(ecPublicKeySpec));
+        } catch (InvalidKeySpecException | NoSuchAlgorithmException e) {
+            throw new InvalidClientException(e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## What?
- Add authentication token endpoint

## Why?
- This is the endpoint used by orchestrator callback lambda to obtain a token in exchange for a code it receives from auth frontend
- The orchestrator can then use that token to obtain userinfo, which is temporarily stored in an orch datastore
- From that datastore, it can serve userinfo requests to relying parties
- This token endpoint is therefore an important part of the flow which allows orch to handle userinfo responses without direct recourse to user information tables on the auth side
