### PR TITLE
AUT-1695: Add access policies for delivery receipts lambda

### DIFF
--- a/ci/terraform/delivery-receipts/delivery_receipts_bulk_user_email_dynamo_access.tf
+++ b/ci/terraform/delivery-receipts/delivery_receipts_bulk_user_email_dynamo_access.tf
@@ -1,0 +1,50 @@
+data "aws_iam_policy_document" "delivery_receipts_dynamo_update_access" {
+  statement {
+    sid    = "AllowAccessToDynamoTables"
+    effect = "Allow"
+
+    actions = [
+      "dynamodb:PutItem",
+    ]
+
+    resources = [
+      data.aws_dynamodb_table.bulk_email_users_table[0].arn,
+      "${data.aws_dynamodb_table.bulk_email_users_table[0].arn}/index/*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "delivery_receipts_dynamo_update_access" {
+  name_prefix = "dynamo-access-policy"
+  description = "IAM policy managing update access for the Delivery Receipts lambda to the Dynamo Bulk Email Users table"
+
+  policy = data.aws_iam_policy_document.delivery_receipts_dynamo_update_access[0].json
+}
+
+data "aws_iam_policy_document" "delivery_receipts_dynamo_read_access" {
+  statement {
+    sid    = "AllowAccessToDynamoTables"
+    effect = "Allow"
+
+    actions = [
+      "dynamodb:DescribeTable",
+      "dynamodb:Get*",
+      "dynamodb:Query",
+      "dynamodb:Scan",
+    ]
+
+    resources = [
+      data.aws_dynamodb_table.bulk_email_users_table[0].arn,
+      data.aws_dynamodb_table.user_profile_table[0].arn,
+      "${data.aws_dynamodb_table.bulk_email_users_table[0].arn}/index/*",
+      "${data.aws_dynamodb_table.user_profile_table[0].arn}/index/*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "delivery_receipts_dynamo_read_access" {
+  name_prefix = "dynamo-access-policy"
+  description = "IAM policy managing read access for the Bulk User Email Send lambda to the Dynamo User Profile table"
+
+  policy = data.aws_iam_policy_document.delivery_receipts_dynamo_read_access[0].json
+}

--- a/ci/terraform/delivery-receipts/delivery_receipts_dynamodb.tf
+++ b/ci/terraform/delivery-receipts/delivery_receipts_dynamodb.tf
@@ -1,0 +1,35 @@
+data "aws_dynamodb_table" "bulk_email_users_table" {
+  name  = "${var.environment}-bulk-email-users"
+}
+
+data "aws_dynamodb_table" "user_profile_table" {
+  name  = "${var.environment}-user-profile"
+}
+
+//TODO
+#data "aws_iam_policy_document" "bulk_user_email_dynamo_encryption_key_policy_document" {
+#  count = 1 //TODO
+#  statement {
+#    sid    = "AllowAccessToBulkUserEmailTableKmsEncryptionKey"
+#    effect = "Allow"
+#
+#    actions = [
+#      "kms:Encrypt*",
+#      "kms:Decrypt*",
+#      "kms:GetPublicKey"
+#    ]
+#    resources = [
+#      local.bulk_user_email_table_encryption_key_arn,
+#    ]
+#  }
+#}
+
+# TODO
+#resource "aws_iam_policy" "bulk_user_email_dynamo_encryption_key_kms_policy" {
+#  count       = 1 //TODO
+#  name        = "${var.environment}-bulk-user-email-table-encryption-key-kms-policy"
+#  path        = "/"
+#  description = "IAM policy for managing KMS encryption of the bulk user email table"
+#
+#  policy = data.aws_iam_policy_document.bulk_user_email_dynamo_encryption_key_policy_document[0].json
+#}

--- a/ci/terraform/delivery-receipts/notify-callback.tf
+++ b/ci/terraform/delivery-receipts/notify-callback.tf
@@ -6,6 +6,8 @@ module "delivery_receipts_api_notify_callback_role" {
 
   policies_to_attach = [
     aws_iam_policy.parameter_policy.arn,
+    aws_iam_policy.delivery_receipts_dynamo_update_access.arn,
+    aws_iam_policy.delivery_receipts_dynamo_read_access.arn
   ]
 }
 


### PR DESCRIPTION
We are temporarily granting access to the delivery receipts api to the following tables:
* bulk email user table - read and update access
* user profile table - read only

This will enable us to update the status of a user in the bulk email users table according to the delivery receipt status (to note, for example, cases where the delivery receipt indicates failure). We need access to the user profile table to convert an email address (received in the delivery receipt) to a subject id (used for the bulk email users table).

This access can be revoked once work to send the bulk email for terms and conditions update has been completed.

## What?

Please include a summary of the change.

## Why?

Please include reason for the change and any other relevant context.

## Related PRs

Please include links to PRs in other repositories relevant to this PR.
Delete this section if not needed.
