### PR TITLE
AUT-1498: Initiate IPV journey from Orchestration callback Lambda

### DIFF
--- a/ci/terraform/oidc/authentication-callback.tf
+++ b/ci/terraform/oidc/authentication-callback.tf
@@ -9,6 +9,8 @@ module "oidc_api_authentication_callback_role" {
     aws_iam_policy.dynamo_authentication_callback_userinfo_read_policy.arn,
     aws_iam_policy.dynamo_authentication_callback_userinfo_write_access_policy.arn,
     aws_iam_policy.redis_parameter_policy.arn,
+    aws_iam_policy.ipv_token_auth_kms_policy.arn,
+    aws_iam_policy.ipv_public_encryption_key_parameter_policy.arn,
     module.oidc_txma_audit.access_policy_arn
   ]
 }
@@ -22,13 +24,16 @@ module "authentication_callback" {
   environment     = var.environment
 
   handler_environment_variables = {
-    REDIS_KEY               = local.redis_key
-    SUPPORT_AUTH_ORCH_SPLIT = var.support_auth_orch_split
-    DYNAMO_ENDPOINT         = var.use_localstack ? var.lambda_dynamo_endpoint : null
-    LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
-    ENVIRONMENT             = var.environment
-    TXMA_AUDIT_QUEUE_URL    = module.oidc_txma_audit.queue_url
-    INTERNAl_SECTOR_URI     = var.internal_sector_uri
+    ENVIRONMENT                 = var.environment
+    REDIS_KEY                   = local.redis_key
+    SUPPORT_AUTH_ORCH_SPLIT     = var.support_auth_orch_split
+    DYNAMO_ENDPOINT             = var.use_localstack ? var.lambda_dynamo_endpoint : null
+    LOCALSTACK_ENDPOINT         = var.use_localstack ? var.localstack_endpoint : null
+    TXMA_AUDIT_QUEUE_URL        = module.oidc_txma_audit.queue_url
+    INTERNAl_SECTOR_URI         = var.internal_sector_uri
+    IDENTITY_ENABLED            = var.ipv_api_enabled
+    IPV_AUTHORISATION_CLIENT_ID = var.ipv_authorisation_client_id
+    IPV_AUTHORISATION_URI       = var.ipv_authorisation_uri
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.AuthenticationCallbackHandler::handleRequest"
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.authentication.ipv.domain.IPVAuditableEvent;
-import uk.gov.di.authentication.ipv.entity.IPVAuthorisationResponse;
 import uk.gov.di.authentication.oidc.domain.OrchestrationAuditableEvent;
 import uk.gov.di.authentication.oidc.entity.AuthenticationUserInfo;
 import uk.gov.di.authentication.oidc.lambda.AuthenticationCallbackHandler;
@@ -256,12 +255,13 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
                                     Optional.of(buildSessionCookie(SESSION_ID, CLIENT_SESSION_ID))),
                             constructQueryStringParameters());
 
-            assertThat(response, hasStatus(200));
+            assertThat(response, hasStatus(302));
 
-            var body = objectMapper.readValue(response.getBody(), IPVAuthorisationResponse.class);
+            URI redirectLocationHeader =
+                    URI.create(response.getHeaders().get(ResponseHeaders.LOCATION));
 
             assertThat(
-                    body.getRedirectUri(),
+                    redirectLocationHeader.toString(),
                     startsWith(configurationService.getIPVAuthorisationURI().toString()));
 
             assertTxmaAuditEventsReceived(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
@@ -1,6 +1,5 @@
 package uk.gov.di.authentication.api;
 
-import com.nimbusds.jose.JOSEException;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import com.nimbusds.oauth2.sdk.OAuth2Error;
 import com.nimbusds.oauth2.sdk.ResponseType;
@@ -13,14 +12,19 @@ import com.nimbusds.openid.connect.sdk.Nonce;
 import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import org.apache.http.client.utils.URIBuilder;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.di.authentication.ipv.domain.IPVAuditableEvent;
+import uk.gov.di.authentication.ipv.entity.IPVAuthorisationResponse;
 import uk.gov.di.authentication.oidc.domain.OrchestrationAuditableEvent;
 import uk.gov.di.authentication.oidc.entity.AuthenticationUserInfo;
 import uk.gov.di.authentication.oidc.lambda.AuthenticationCallbackHandler;
 import uk.gov.di.authentication.oidc.services.AuthenticationAuthorizationService;
 import uk.gov.di.authentication.shared.entity.ClientSession;
 import uk.gov.di.authentication.shared.entity.ClientType;
+import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
+import uk.gov.di.authentication.shared.entity.LevelOfConfidence;
 import uk.gov.di.authentication.shared.entity.ResponseHeaders;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.shared.entity.VectorOfTrust;
@@ -36,7 +40,12 @@ import uk.gov.di.authentication.sharedtest.extensions.TokenSigningExtension;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
 import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -51,9 +60,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
+import static uk.gov.di.authentication.sharedtest.helper.JsonArrayHelper.jsonArrayOf;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
-class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
+public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     public static final String SESSION_ID = "some-session-id";
     public static final String CLIENT_SESSION_ID = "some-client-session-id";
@@ -62,11 +72,11 @@ class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHandlerInte
     public static final State ORCH_TO_AUTH_STATE = new State();
 
     @RegisterExtension
-    public static final AuthExternalApiStubExtension authExternalApiStub =
+    public final AuthExternalApiStubExtension authExternalApiStub =
             new AuthExternalApiStubExtension();
 
     @RegisterExtension
-    protected static final AuthenticationCallbackUserInfoStoreExtension userInfoStoreExtension =
+    protected final AuthenticationCallbackUserInfoStoreExtension userInfoStoreExtension =
             new AuthenticationCallbackUserInfoStoreExtension(180);
 
     protected final ConfigurationService configurationService =
@@ -86,10 +96,189 @@ class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHandlerInte
     private static final URI REDIRECT_URI = URI.create("http://localhost/redirect");
     private static final Subject SUBJECT_ID = new Subject();
 
-    @BeforeEach
-    void setup() throws JOSEException {
-        handler = new AuthenticationCallbackHandler(configurationService);
-        authExternalApiStub.init(SUBJECT_ID);
+    private static final String IPV_CLIENT_ID = "ipv-client-id";
+    private static final KeyPair keyPair = generateRsaKeyPair();
+    private static final String publicKey =
+            "-----BEGIN PUBLIC KEY-----\n"
+                    + Base64.getMimeEncoder().encodeToString(keyPair.getPublic().getEncoded())
+                    + "\n-----END PUBLIC KEY-----\n";
+
+    @Nested
+    class AuthJourney {
+
+        @BeforeEach()
+        void authSetup() throws Json.JsonException {
+            setupTest();
+            setupSession();
+            setupClientRegWithoutIdentityVerificationSupported();
+        }
+
+        @Test
+        void shouldStoreUserInfoAndRedirectToRpWhenSuccessfullyProcessedCallbackResponse() {
+            var response =
+                    makeRequest(
+                            Optional.empty(),
+                            constructHeaders(
+                                    Optional.of(buildSessionCookie(SESSION_ID, CLIENT_SESSION_ID))),
+                            constructQueryStringParameters());
+
+            assertThat(response, hasStatus(302));
+
+            URI redirectLocationHeader =
+                    URI.create(response.getHeaders().get(ResponseHeaders.LOCATION));
+            assertEquals(
+                    REDIRECT_URI.getAuthority() + REDIRECT_URI.getPath(),
+                    redirectLocationHeader.getAuthority() + redirectLocationHeader.getPath());
+
+            assertThat(redirectLocationHeader.getQuery(), containsString(RP_STATE.getValue()));
+
+            assertThat(redirectLocationHeader.getQuery(), containsString("code"));
+
+            assertTxmaAuditEventsReceived(
+                    txmaAuditQueue,
+                    List.of(
+                            OrchestrationAuditableEvent.AUTH_CALLBACK_RESPONSE_RECEIVED,
+                            OrchestrationAuditableEvent.AUTH_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
+                            OrchestrationAuditableEvent
+                                    .AUTH_SUCCESSFUL_USERINFO_RESPONSE_RECEIVED));
+
+            Optional<AuthenticationUserInfo> userInfoDbEntry =
+                    userInfoStoreExtension.getUserInfoBySubjectId(SUBJECT_ID.getValue());
+            assertTrue(userInfoDbEntry.isPresent());
+            assertEquals(SUBJECT_ID.getValue(), userInfoDbEntry.get().getSubjectID());
+            assertThat(userInfoDbEntry.get().getUserInfo(), containsString("new_account"));
+        }
+
+        @Test
+        void shouldRedirectToRpWithErrorWhenStateIsInvalid() {
+            var response =
+                    makeRequest(
+                            Optional.empty(),
+                            constructHeaders(
+                                    Optional.of(buildSessionCookie(SESSION_ID, CLIENT_SESSION_ID))),
+                            Map.of("code", "a-random-code", "state", new State().getValue()));
+
+            assertThat(response, hasStatus(302));
+            assertThat(
+                    response.getHeaders().get(ResponseHeaders.LOCATION),
+                    startsWith(REDIRECT_URI.toString()));
+            assertThat(
+                    response.getHeaders().get(ResponseHeaders.LOCATION),
+                    containsString(OAuth2Error.SERVER_ERROR.getCode()));
+            assertThat(
+                    response.getHeaders().get(ResponseHeaders.LOCATION),
+                    containsString(RP_STATE.getValue()));
+
+            assertTxmaAuditEventsReceived(
+                    txmaAuditQueue,
+                    List.of(
+                            OrchestrationAuditableEvent
+                                    .AUTH_UNSUCCESSFUL_CALLBACK_RESPONSE_RECEIVED));
+
+            Optional<AuthenticationUserInfo> userInfoDbEntry =
+                    userInfoStoreExtension.getUserInfoBySubjectId(SUBJECT_ID.getValue());
+            assertFalse(userInfoDbEntry.isPresent());
+        }
+
+        @Test
+        void shouldRedirectToFrontendErrorPageIfUnsuccessfulResponseReceivedFromTokenEndpoint() {
+            authExternalApiStub.register(
+                    "/token", 400, "application/json", "{\"error\": \"invalid_request\"}");
+
+            var response =
+                    makeRequest(
+                            Optional.empty(),
+                            constructHeaders(
+                                    Optional.of(buildSessionCookie(SESSION_ID, CLIENT_SESSION_ID))),
+                            constructQueryStringParameters());
+
+            assertThat(response, hasStatus(302));
+            assertThat(
+                    response.getHeaders().get(ResponseHeaders.LOCATION),
+                    startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
+            assertThat(response.getHeaders().get(ResponseHeaders.LOCATION), endsWith("error"));
+
+            assertTxmaAuditEventsReceived(
+                    txmaAuditQueue,
+                    List.of(
+                            OrchestrationAuditableEvent.AUTH_CALLBACK_RESPONSE_RECEIVED,
+                            OrchestrationAuditableEvent.AUTH_UNSUCCESSFUL_TOKEN_RESPONSE_RECEIVED));
+        }
+
+        @Test
+        void shouldRedirectToFrontendErrorPageIfUnsuccessfulResponseReceivedFromUserInfoEndpoint() {
+            authExternalApiStub.register(
+                    "/userinfo", 400, "application/json", "{\"error\": \"invalid_request\"}");
+
+            var response =
+                    makeRequest(
+                            Optional.empty(),
+                            constructHeaders(
+                                    Optional.of(buildSessionCookie(SESSION_ID, CLIENT_SESSION_ID))),
+                            constructQueryStringParameters());
+
+            assertThat(response, hasStatus(302));
+            assertThat(
+                    response.getHeaders().get(ResponseHeaders.LOCATION),
+                    startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
+            assertThat(response.getHeaders().get(ResponseHeaders.LOCATION), endsWith("error"));
+
+            assertTxmaAuditEventsReceived(
+                    txmaAuditQueue,
+                    List.of(
+                            OrchestrationAuditableEvent.AUTH_CALLBACK_RESPONSE_RECEIVED,
+                            OrchestrationAuditableEvent.AUTH_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
+                            OrchestrationAuditableEvent
+                                    .AUTH_UNSUCCESSFUL_USERINFO_RESPONSE_RECEIVED));
+        }
+
+        private void setupClientRegWithoutIdentityVerificationSupported() {
+            setupClientReg(false);
+        }
+    }
+
+    @Nested
+    class IPVJourney {
+
+        @BeforeEach()
+        void ipvSetup() throws Json.JsonException {
+            setupTest();
+            setupSession();
+            setupClientRegWithIdentityVerificationSupported();
+        }
+
+        @Test
+        void shouldRedirectToIPVWhenIdentityRequired() throws Json.JsonException {
+            var response =
+                    makeRequest(
+                            Optional.empty(),
+                            constructHeaders(
+                                    Optional.of(buildSessionCookie(SESSION_ID, CLIENT_SESSION_ID))),
+                            constructQueryStringParameters());
+
+            assertThat(response, hasStatus(200));
+
+            var body = objectMapper.readValue(response.getBody(), IPVAuthorisationResponse.class);
+
+            assertThat(
+                    body.getRedirectUri(),
+                    startsWith(configurationService.getIPVAuthorisationURI().toString()));
+
+            assertTxmaAuditEventsReceived(
+                    txmaAuditQueue,
+                    List.of(
+                            OrchestrationAuditableEvent.AUTH_CALLBACK_RESPONSE_RECEIVED,
+                            OrchestrationAuditableEvent.AUTH_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
+                            OrchestrationAuditableEvent.AUTH_SUCCESSFUL_USERINFO_RESPONSE_RECEIVED,
+                            IPVAuditableEvent.IPV_AUTHORISATION_REQUESTED));
+        }
+
+        private void setupClientRegWithIdentityVerificationSupported() {
+            setupClientReg(true);
+        }
+    }
+
+    private void setupClientReg(boolean identityVerificationSupport) {
         clientStore.registerClient(
                 CLIENT_ID,
                 "test-client",
@@ -103,149 +292,38 @@ class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHandlerInte
                 "https://test.com",
                 "pairwise",
                 true,
-                ClientType.APP);
+                ClientType.APP,
+                identityVerificationSupport);
+    }
+
+    private void setupTest() {
+        handler = new AuthenticationCallbackHandler(configurationService);
+        authExternalApiStub.init(SUBJECT_ID);
         txmaAuditQueue.clear();
     }
 
-    @Test
-    void shouldStoreUserInfoAndRedirectToRpWhenSuccessfullyProcessedCallbackResponse()
-            throws Json.JsonException {
-        setupSession();
-
-        var response =
-                makeRequest(
-                        Optional.empty(),
-                        constructHeaders(
-                                Optional.of(buildSessionCookie(SESSION_ID, CLIENT_SESSION_ID))),
-                        constructQueryStringParameters());
-
-        assertThat(response, hasStatus(302));
-
-        URI redirectLocationHeader =
-                URI.create(response.getHeaders().get(ResponseHeaders.LOCATION));
-        assertEquals(
-                REDIRECT_URI.getAuthority() + REDIRECT_URI.getPath(),
-                redirectLocationHeader.getAuthority() + redirectLocationHeader.getPath());
-
-        assertThat(redirectLocationHeader.getQuery(), containsString(RP_STATE.getValue()));
-
-        assertThat(redirectLocationHeader.getQuery(), containsString("code"));
-
-        assertTxmaAuditEventsReceived(
-                txmaAuditQueue,
-                List.of(
-                        OrchestrationAuditableEvent.AUTH_CALLBACK_RESPONSE_RECEIVED,
-                        OrchestrationAuditableEvent.AUTH_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
-                        OrchestrationAuditableEvent.AUTH_SUCCESSFUL_USERINFO_RESPONSE_RECEIVED));
-
-        Optional<AuthenticationUserInfo> userInfoDbEntry =
-                userInfoStoreExtension.getUserInfoBySubjectId(SUBJECT_ID.getValue());
-        assertTrue(userInfoDbEntry.isPresent());
-        assertEquals(SUBJECT_ID.getValue(), userInfoDbEntry.get().getSubjectID());
-        assertThat(userInfoDbEntry.get().getUserInfo(), containsString("new_account"));
-    }
-
-    @Test
-    void shouldRedirectToRpWithErrorWhenStateIsInvalid() throws Json.JsonException {
-        setupSession();
-
-        var response =
-                makeRequest(
-                        Optional.empty(),
-                        constructHeaders(
-                                Optional.of(buildSessionCookie(SESSION_ID, CLIENT_SESSION_ID))),
-                        Map.of("code", "a-random-code", "state", new State().getValue()));
-
-        assertThat(response, hasStatus(302));
-        assertThat(
-                response.getHeaders().get(ResponseHeaders.LOCATION),
-                startsWith(REDIRECT_URI.toString()));
-        assertThat(
-                response.getHeaders().get(ResponseHeaders.LOCATION),
-                containsString(OAuth2Error.SERVER_ERROR.getCode()));
-        assertThat(
-                response.getHeaders().get(ResponseHeaders.LOCATION),
-                containsString(RP_STATE.getValue()));
-
-        assertTxmaAuditEventsReceived(
-                txmaAuditQueue,
-                List.of(OrchestrationAuditableEvent.AUTH_UNSUCCESSFUL_CALLBACK_RESPONSE_RECEIVED));
-
-        Optional<AuthenticationUserInfo> userInfoDbEntry =
-                userInfoStoreExtension.getUserInfoBySubjectId(SUBJECT_ID.getValue());
-        assertFalse(userInfoDbEntry.isPresent());
-    }
-
-    @Test
-    void shouldRedirectToFrontendErrorPageIfUnsuccessfulResponseReceivedFromTokenEndpoint()
-            throws Json.JsonException {
-        setupSession();
-
-        authExternalApiStub.register(
-                "/token", 400, "application/json", "{\"error\": \"invalid_request\"}");
-
-        var response =
-                makeRequest(
-                        Optional.empty(),
-                        constructHeaders(
-                                Optional.of(buildSessionCookie(SESSION_ID, CLIENT_SESSION_ID))),
-                        constructQueryStringParameters());
-
-        assertThat(response, hasStatus(302));
-        assertThat(
-                response.getHeaders().get(ResponseHeaders.LOCATION),
-                startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
-        assertThat(response.getHeaders().get(ResponseHeaders.LOCATION), endsWith("error"));
-
-        assertTxmaAuditEventsReceived(
-                txmaAuditQueue,
-                List.of(
-                        OrchestrationAuditableEvent.AUTH_CALLBACK_RESPONSE_RECEIVED,
-                        OrchestrationAuditableEvent.AUTH_UNSUCCESSFUL_TOKEN_RESPONSE_RECEIVED));
-    }
-
-    @Test
-    void shouldRedirectToFrontendErrorPageIfUnsuccessfulResponseReceivedFromUserInfoEndpoint()
-            throws Json.JsonException {
-        setupSession();
-
-        authExternalApiStub.register(
-                "/userinfo", 400, "application/json", "{\"error\": \"invalid_request\"}");
-
-        var response =
-                makeRequest(
-                        Optional.empty(),
-                        constructHeaders(
-                                Optional.of(buildSessionCookie(SESSION_ID, CLIENT_SESSION_ID))),
-                        constructQueryStringParameters());
-
-        assertThat(response, hasStatus(302));
-        assertThat(
-                response.getHeaders().get(ResponseHeaders.LOCATION),
-                startsWith(TEST_CONFIGURATION_SERVICE.getLoginURI().toString()));
-        assertThat(response.getHeaders().get(ResponseHeaders.LOCATION), endsWith("error"));
-
-        assertTxmaAuditEventsReceived(
-                txmaAuditQueue,
-                List.of(
-                        OrchestrationAuditableEvent.AUTH_CALLBACK_RESPONSE_RECEIVED,
-                        OrchestrationAuditableEvent.AUTH_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
-                        OrchestrationAuditableEvent.AUTH_UNSUCCESSFUL_USERINFO_RESPONSE_RECEIVED));
-    }
-
     private void setupSession() throws Json.JsonException {
+        String vtrStr =
+                LevelOfConfidence.MEDIUM_LEVEL.getValue()
+                        + "."
+                        + CredentialTrustLevel.MEDIUM_LEVEL.getValue();
+        VectorOfTrust vot =
+                VectorOfTrust.parseFromAuthRequestAttribute(Arrays.asList("[\"" + vtrStr + "\"]"));
+
         var authRequestBuilder =
                 new AuthenticationRequest.Builder(
                                 ResponseType.CODE, SCOPE, new ClientID(CLIENT_ID), REDIRECT_URI)
                         .state(RP_STATE)
-                        .nonce(new Nonce());
+                        .nonce(new Nonce())
+                        .customParameter("vtr", jsonArrayOf(vtrStr));
         redis.createSession(SESSION_ID);
         var clientSession =
                 new ClientSession(
                         authRequestBuilder.build().toParameters(),
                         LocalDateTime.now(),
-                        VectorOfTrust.getDefaults(),
+                        vot,
                         CLIENT_NAME);
+
         redis.createClientSession(CLIENT_SESSION_ID, clientSession);
         redis.addStateToRedis(
                 AuthenticationAuthorizationService.AUTHENTICATION_STATE_STORAGE_PREFIX,
@@ -262,6 +340,17 @@ class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHandlerInte
                         "code",
                         new AuthorizationCode().getValue()));
         return queryStringParameters;
+    }
+
+    private static KeyPair generateRsaKeyPair() {
+        KeyPairGenerator kpg;
+        try {
+            kpg = KeyPairGenerator.getInstance("RSA");
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+        kpg.initialize(2048);
+        return kpg.generateKeyPair();
     }
 
     protected static class TestConfigurationService extends IntegrationTestConfigurationService {
@@ -325,6 +414,21 @@ class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHandlerInte
         @Override
         public String getOrchestrationToAuthenticationTokenSigningKeyAlias() {
             return orchestrationPrivateKeyJwtSigner.getKeyAlias();
+        }
+
+        @Override
+        public boolean isIdentityEnabled() {
+            return true;
+        }
+
+        @Override
+        public String getIPVAuthorisationClientId() {
+            return IPV_CLIENT_ID;
+        }
+
+        @Override
+        public String getIPVAuthEncryptionPublicKey() {
+            return publicKey;
         }
     }
 }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -273,33 +273,6 @@ public class AuthenticationCallbackHandler
                                 clientSession.getAuthRequestParams(),
                                 client.isIdentityVerificationSupported(),
                                 configurationService.isIdentityEnabled());
-                if (identityRequired) {
-                    return initiateIPVAuthorisationService.sendRequestToIPV(
-                            input,
-                            authenticationRequest,
-                            userInfo,
-                            userSession,
-                            client,
-                            clientId,
-                            clientSessionId,
-                            persistentSessionId);
-                }
-
-                URI clientRedirectURI = authenticationRequest.getRedirectionURI();
-                State state = authenticationRequest.getState();
-                ResponseMode responseMode = authenticationRequest.getResponseMode();
-
-                LOG.info("Redirecting to: {} with state: {}", clientRedirectURI, state);
-
-                VectorOfTrust requestedVectorOfTrust = clientSession.getEffectiveVectorOfTrust();
-                if (isNull(userSession.getCurrentCredentialStrength())
-                        || requestedVectorOfTrust
-                                        .getCredentialTrustLevel()
-                                        .compareTo(userSession.getCurrentCredentialStrength())
-                                > 0) {
-                    userSession.setCurrentCredentialStrength(
-                            requestedVectorOfTrust.getCredentialTrustLevel());
-                }
 
                 boolean isTestJourney = false;
                 if (nonNull(userInfo.getEmailAddress())) {
@@ -329,6 +302,34 @@ public class AuthenticationCallbackHandler
                 }
 
                 cloudwatchMetricsService.incrementCounter("AuthenticationCallback", dimensions);
+
+                if (identityRequired) {
+                    return initiateIPVAuthorisationService.sendRequestToIPV(
+                            input,
+                            authenticationRequest,
+                            userInfo,
+                            userSession,
+                            client,
+                            clientId,
+                            clientSessionId,
+                            persistentSessionId);
+                }
+
+                URI clientRedirectURI = authenticationRequest.getRedirectionURI();
+                State state = authenticationRequest.getState();
+                ResponseMode responseMode = authenticationRequest.getResponseMode();
+
+                LOG.info("Redirecting to: {} with state: {}", clientRedirectURI, state);
+
+                VectorOfTrust requestedVectorOfTrust = clientSession.getEffectiveVectorOfTrust();
+                if (isNull(userSession.getCurrentCredentialStrength())
+                        || requestedVectorOfTrust
+                                        .getCredentialTrustLevel()
+                                        .compareTo(userSession.getCurrentCredentialStrength())
+                                > 0) {
+                    userSession.setCurrentCredentialStrength(
+                            requestedVectorOfTrust.getCredentialTrustLevel());
+                }
 
                 var authCode =
                         authorisationCodeService.generateAndSaveAuthorisationCode(

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/InitiateIPVAuthorisationService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/InitiateIPVAuthorisationService.java
@@ -21,7 +21,6 @@ import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.serialization.Json.JsonException;
 import uk.gov.di.authentication.shared.services.AuditService;
-import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
@@ -39,19 +38,16 @@ public class InitiateIPVAuthorisationService {
     private static final Logger LOG = LogManager.getLogger(InitiateIPVAuthorisationService.class);
 
     private final ConfigurationService configurationService;
-    private final AuthenticationService authenticationService;
     private final AuditService auditService;
     private final IPVAuthorisationService authorisationService;
     private final CloudwatchMetricsService cloudwatchMetricsService;
 
     public InitiateIPVAuthorisationService(
             ConfigurationService configurationService,
-            AuthenticationService authenticationService,
             AuditService auditService,
             IPVAuthorisationService authorisationService,
             CloudwatchMetricsService cloudwatchMetricsService) {
         this.configurationService = configurationService;
-        this.authenticationService = authenticationService;
         this.auditService = auditService;
         this.authorisationService = authorisationService;
         this.cloudwatchMetricsService = cloudwatchMetricsService;

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandlerTest.java
@@ -1,6 +1,7 @@
 package uk.gov.di.authentication.oidc.lambda;
 
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
 import com.nimbusds.oauth2.sdk.AccessTokenResponse;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import com.nimbusds.oauth2.sdk.ErrorObject;
@@ -22,16 +23,22 @@ import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.ipv.entity.IPVAuthorisationResponse;
 import uk.gov.di.authentication.oidc.domain.OrchestrationAuditableEvent;
 import uk.gov.di.authentication.oidc.services.AuthenticationAuthorizationService;
 import uk.gov.di.authentication.oidc.services.AuthenticationTokenService;
 import uk.gov.di.authentication.oidc.services.AuthenticationUserInfoStorageService;
+import uk.gov.di.authentication.oidc.services.InitiateIPVAuthorisationService;
+import uk.gov.di.authentication.shared.conditions.IdentityHelper;
+import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ClientSession;
+import uk.gov.di.authentication.shared.entity.ClientType;
 import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.VectorOfTrust;
 import uk.gov.di.authentication.shared.exceptions.UnsuccessfulCredentialResponseException;
 import uk.gov.di.authentication.shared.helpers.CookieHelper;
+import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthorisationCodeService;
 import uk.gov.di.authentication.shared.services.ClientService;
@@ -48,16 +55,20 @@ import java.util.Map;
 import java.util.Optional;
 
 import static java.lang.String.format;
+import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 class AuthenticationCallbackHandlerTest {
@@ -75,6 +86,8 @@ class AuthenticationCallbackHandlerTest {
             mock(CloudwatchMetricsService.class);
     private static final AuthorisationCodeService authorisationCodeService =
             mock(AuthorisationCodeService.class);
+    private static final InitiateIPVAuthorisationService initiateIPVAuthorisationService =
+            mock(InitiateIPVAuthorisationService.class);
     private static final CookieHelper cookieHelper = mock(CookieHelper.class);
     private final ClientService clientService = mock(ClientService.class);
     private static final String TEST_FRONTEND_BASE_URL = "test.orchestration.frontend.url";
@@ -141,7 +154,8 @@ class AuthenticationCallbackHandlerTest {
                         cookieHelper,
                         cloudwatchMetricsService,
                         authorisationCodeService,
-                        clientService);
+                        clientService,
+                        initiateIPVAuthorisationService);
     }
 
     @Test
@@ -149,6 +163,7 @@ class AuthenticationCallbackHandlerTest {
             throws UnsuccessfulCredentialResponseException {
         usingValidSession();
         usingValidClientSession();
+        usingValidClient();
 
         var event = new APIGatewayProxyRequestEvent();
         setValidHeadersAndQueryParameters(event);
@@ -171,6 +186,39 @@ class AuthenticationCallbackHandlerTest {
                         OrchestrationAuditableEvent.AUTH_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
                         OrchestrationAuditableEvent.AUTH_SUCCESSFUL_USERINFO_RESPONSE_RECEIVED),
                 auditService);
+    }
+
+    @Test
+    void shouldRedirectToIPVWhenIdentityRequired()
+            throws Json.JsonException, UnsuccessfulCredentialResponseException {
+        mockStatic(IdentityHelper.class);
+
+        usingValidSession();
+        usingValidClientSession();
+        usingValidClient();
+
+        var event = new APIGatewayProxyRequestEvent();
+        setValidHeadersAndQueryParameters(event);
+
+        when(IdentityHelper.identityRequired(anyMap(), anyBoolean(), anyBoolean()))
+                .thenReturn(true);
+        when(initiateIPVAuthorisationService.sendRequestToIPV(
+                        any(), any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(createIPVApiResponse());
+        when(authorizationService.validateRequest(any(), any())).thenReturn(true);
+        when(tokenService.sendTokenRequest(any())).thenReturn(SUCCESSFUL_TOKEN_RESPONSE);
+        when(tokenService.sendUserInfoDataRequest(any(HTTPRequest.class))).thenReturn(USER_INFO);
+
+        var response = handler.handleRequest(event, null);
+
+        assertThat(response, hasStatus(302));
+        verify(initiateIPVAuthorisationService)
+                .sendRequestToIPV(any(), any(), any(), any(), any(), any(), any(), any());
+    }
+
+    private APIGatewayProxyResponseEvent createIPVApiResponse() throws Json.JsonException {
+        return generateApiGatewayProxyResponse(
+                302, new IPVAuthorisationResponse("redirect-ipv-url"));
     }
 
     @Test
@@ -280,6 +328,24 @@ class AuthenticationCallbackHandlerTest {
     private void usingValidClientSession() {
         when(clientSessionService.getClientSession(CLIENT_SESSION_ID))
                 .thenReturn(Optional.of(clientSession));
+    }
+
+    private void usingValidClient() {
+        when(clientService.getClient(CLIENT_ID.toString()))
+                .thenReturn(Optional.of(createClientRegistry()));
+    }
+
+    private ClientRegistry createClientRegistry() {
+        return new ClientRegistry()
+                .withClientName("client-name")
+                .withClientID(CLIENT_ID.toString())
+                .withPublicKey("public-key")
+                .withSubjectType("Public")
+                .withRedirectUrls(singletonList("http://localhost/redirect"))
+                .withContacts(singletonList("contant-name"))
+                .withPostLogoutRedirectUrls(singletonList("localhost/logout"))
+                .withClientType(ClientType.WEB.getValue())
+                .withClaims(List.of("claim"));
     }
 
     private static AuthenticationRequest generateRPAuthRequestForClientSession() {

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/InitiateIPVAuthorisationServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/InitiateIPVAuthorisationServiceTest.java
@@ -1,7 +1,14 @@
 package uk.gov.di.authentication.oidc.services;
 
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
-import com.nimbusds.jose.*;
+import com.nimbusds.jose.EncryptionMethod;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWEAlgorithm;
+import com.nimbusds.jose.JWEHeader;
+import com.nimbusds.jose.JWEObject;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.Payload;
 import com.nimbusds.jose.crypto.ECDSASigner;
 import com.nimbusds.jose.crypto.RSAEncrypter;
 import com.nimbusds.jose.jwk.Curve;
@@ -33,7 +40,6 @@ import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuditService;
-import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SerializationService;
@@ -50,7 +56,13 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.shared.services.AuditService.MetadataPair.pair;
 import static uk.gov.di.authentication.sharedtest.helper.RequestEventHelper.contextWithSourceIp;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
@@ -72,7 +84,6 @@ public class InitiateIPVAuthorisationServiceTest {
     private static final String IP_ADDRESS = "123.123.123.123";
 
     private final ConfigurationService configService = mock(ConfigurationService.class);
-    private final AuthenticationService authenticationService = mock(AuthenticationService.class);
     private final AuditService auditService = mock(AuditService.class);
     private final IPVAuthorisationService authorisationService =
             mock(IPVAuthorisationService.class);
@@ -105,7 +116,6 @@ public class InitiateIPVAuthorisationServiceTest {
         initiateAuthorisationService =
                 new InitiateIPVAuthorisationService(
                         configService,
-                        authenticationService,
                         auditService,
                         authorisationService,
                         cloudwatchMetricsService);


### PR DESCRIPTION
## What?
Initiate IPV journey from the Orchestration callback lambda if a user requires identity verification.
The new service (`InitiateIPVAuthorisationService`) will eventually replace `IPVAuthorisationHandler`.

## Why?

Authentication is being decoupled from Orchestration, so the Authentication frontend will no longer initiate the IPV journey. 

## Related PRs
First part of AUT-1498 which is already merged: https://github.com/alphagov/di-authentication-api/pull/3334
