### PR TITLE
AUT-1489: Add terraform for auth token endpoint

### DIFF
--- a/ci/terraform/auth-external-api/build.tfvars
+++ b/ci/terraform/auth-external-api/build.tfvars
@@ -8,3 +8,11 @@ lambda_max_concurrency = 0
 lambda_min_concurrency = 1
 endpoint_memory_size   = 1024
 scaling_trigger        = 0.6
+
+orch_client_id                  = "orchestrationAuth"
+orch_to_auth_public_signing_key = <<-EOT
+-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAENRdvNXHwk1TvrgFUsWXAE5oDTcPr
+CBp6HxbvYDLsqwNHiDFEzCwvbXKY2QQR/Rtel0o156CtU9k1lCZJGAsSIA==
+-----END PUBLIC KEY-----
+EOT

--- a/ci/terraform/auth-external-api/dynamo-policies.tf
+++ b/ci/terraform/auth-external-api/dynamo-policies.tf
@@ -10,6 +10,10 @@ data "aws_dynamodb_table" "access_token_store_table" {
   name = "${var.environment}-access-token-store"
 }
 
+data "aws_dynamodb_table" "auth_code_store" {
+  name = "${var.environment}-auth-code-store"
+}
+
 data "aws_iam_policy_document" "dynamo_user_write_policy_document" {
   statement {
     sid    = "AllowAccessToDynamoTables"
@@ -88,6 +92,41 @@ data "aws_iam_policy_document" "dynamo_access_token_store_read_policy_document" 
   }
 }
 
+data "aws_iam_policy_document" "dynamo_auth_code_store_write_access_policy_document" {
+  statement {
+    sid    = "AllowAccessToDynamoTables"
+    effect = "Allow"
+
+    actions = [
+      "dynamodb:BatchWriteItem",
+      "dynamodb:UpdateItem",
+      "dynamodb:PutItem",
+    ]
+    resources = [
+      data.aws_dynamodb_table.auth_code_store.arn,
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "dynamo_auth_code_store_read_access_policy_document" {
+  statement {
+    sid    = "AllowAccessToDynamoTables"
+    effect = "Allow"
+
+    actions = [
+      "dynamodb:BatchGetItem",
+      "dynamodb:DescribeStream",
+      "dynamodb:DescribeTable",
+      "dynamodb:Get*",
+      "dynamodb:Query",
+      "dynamodb:Scan",
+    ]
+    resources = [
+      data.aws_dynamodb_table.auth_code_store.arn,
+    ]
+  }
+}
+
 resource "aws_iam_policy" "dynamo_access_token_store_read_access_policy" {
   name_prefix = "dynamo-access-token-store-read-policy"
   path        = "/${var.environment}/auth-ext/"
@@ -119,4 +158,20 @@ resource "aws_iam_policy" "dynamo_user_write_access_policy" {
   description = "IAM policy for managing write permissions to the Dynamo User tables"
 
   policy = data.aws_iam_policy_document.dynamo_user_write_policy_document.json
+}
+
+resource "aws_iam_policy" "dynamo_auth_code_store_write_access_policy" {
+  name_prefix = "dynamo-auth-code-write-policy"
+  path        = "/${var.environment}/auth-ext/"
+  description = "IAM policy for managing write permissions to the Dynamo Auth Code table (code used orch<->auth NOT RP<->orch)"
+
+  policy = data.aws_iam_policy_document.dynamo_auth_code_store_write_access_policy_document.json
+}
+
+resource "aws_iam_policy" "dynamo_auth_code_store_read_access_policy" {
+  name_prefix = "dynamo-auth-code-read-policy"
+  path        = "/${var.environment}/auth-ext/"
+  description = "IAM policy for managing read permissions to the Dynamo Auth Code table (code used orch<->auth NOT RP<->orch)"
+
+  policy = data.aws_iam_policy_document.dynamo_auth_code_store_read_access_policy_document.json
 }

--- a/ci/terraform/auth-external-api/integration.tfvars
+++ b/ci/terraform/auth-external-api/integration.tfvars
@@ -8,3 +8,11 @@ lambda_max_concurrency = 0
 lambda_min_concurrency = 1
 endpoint_memory_size   = 1024
 scaling_trigger        = 0.6
+
+orch_client_id                  = "orchestrationAuth"
+orch_to_auth_public_signing_key = <<-EOT
+-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEzzwKLypUL89WVaeTbfBZu0Fws8T7
+ppx89XLVfgXIoCs2P//N5qdghvzgNIgVehQ7CkzyorO/lnRlWPfjCG4Oxw==
+-----END PUBLIC KEY-----
+EOT

--- a/ci/terraform/auth-external-api/production.tfvars
+++ b/ci/terraform/auth-external-api/production.tfvars
@@ -9,3 +9,11 @@ lambda_max_concurrency = 10
 lambda_min_concurrency = 3
 endpoint_memory_size   = 1024
 scaling_trigger        = 0.6
+
+orch_client_id                  = "orchestrationAuth"
+orch_to_auth_public_signing_key = <<-EOT
+-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE5iJXSuxgbfM6ADQVtNNDi7ED5ly5
++3VZPbjHv+v0AjQ5Ps+avkXWKwOeScG9sS0cDf0utEXi3fN3cEraa9WuKQ==
+-----END PUBLIC KEY-----
+EOT

--- a/ci/terraform/auth-external-api/sandpit.tfvars
+++ b/ci/terraform/auth-external-api/sandpit.tfvars
@@ -7,3 +7,11 @@ internal_sector_uri    = "https://identity.sandpit.account.gov.uk"
 lambda_max_concurrency = 0
 lambda_min_concurrency = 0
 endpoint_memory_size   = 1024
+
+orch_client_id                  = "orchestrationAuth"
+orch_to_auth_public_signing_key = <<-EOT
+-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAESyWJU5s5F4jSovHsh9y133/Ogf5P
+x78OrfDJqiMMI2p8Warbq0ppcbWvbihK6rAXTH7bPIeOHOeU9cKAEl5NdQ==
+-----END PUBLIC KEY-----
+EOT

--- a/ci/terraform/auth-external-api/staging.tfvars
+++ b/ci/terraform/auth-external-api/staging.tfvars
@@ -8,3 +8,11 @@ lambda_max_concurrency = 10
 lambda_min_concurrency = 3
 endpoint_memory_size   = 1024
 scaling_trigger        = 0.6
+
+orch_client_id                  = "orchestrationAuth"
+orch_to_auth_public_signing_key = <<-EOT
+-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE5PP1PZmhiuHR57ZEfZXARt9/uiG+
+KKF+S7us4zEEEmEXZFR1H+kWP5RrLHQy9esxsul9X7V4pygDTY1I6QbMGg==
+-----END PUBLIC KEY-----
+EOT

--- a/ci/terraform/auth-external-api/token.tf
+++ b/ci/terraform/auth-external-api/token.tf
@@ -1,0 +1,70 @@
+module "auth_token_role" {
+  source      = "../modules/lambda-role"
+  environment = var.environment
+  role_name   = "auth-ext-token-role"
+  vpc_arn     = local.authentication_vpc_arn
+
+  policies_to_attach = [
+    module.auth_ext_txma_audit.access_policy_arn,
+    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
+    aws_iam_policy.audit_events_sns_policy.arn,
+    aws_iam_policy.dynamo_auth_code_store_read_access_policy.arn,
+    aws_iam_policy.dynamo_auth_code_store_write_access_policy.arn,
+    aws_iam_policy.dynamo_access_token_store_read_access_policy.arn,
+    aws_iam_policy.dynamo_access_token_store_write_access_policy.arn,
+  ]
+}
+
+module "auth_token" {
+  source = "../modules/endpoint-module"
+
+  endpoint_name   = "auth-token"
+  path_part       = "token"
+  endpoint_method = "POST"
+  environment     = var.environment
+
+  handler_environment_variables = {
+    ENVIRONMENT                               = var.environment
+    TXMA_AUDIT_QUEUE_URL                      = module.auth_ext_txma_audit.queue_url
+    LOCALSTACK_ENDPOINT                       = null
+    DYNAMO_ENDPOINT                           = null
+    AUTHENTICATION_AUTHORIZATION_CALLBACK_URI = var.authentication_auth_callback_uri
+    ORCH_CLIENT_ID                            = var.orch_client_id
+    AUTHENTICATION_BACKEND_URI                = var.authentication_backend_uri
+    ORCH_TO_AUTH_TOKEN_SIGNING_PUBLIC_KEY     = var.orch_to_auth_public_signing_key
+  }
+  handler_function_name = "uk.gov.di.authentication.external.lambda.TokenHandler::handleRequest"
+  handler_runtime       = "java17"
+
+  rest_api_id      = aws_api_gateway_rest_api.di_auth_ext_api.id
+  root_resource_id = aws_api_gateway_rest_api.di_auth_ext_api.root_resource_id
+  execution_arn    = aws_api_gateway_rest_api.di_auth_ext_api.execution_arn
+
+  memory_size                 = lookup(var.performance_tuning, "auth-token", local.default_performance_parameters).memory
+  provisioned_concurrency     = lookup(var.performance_tuning, "auth-token", local.default_performance_parameters).concurrency
+  max_provisioned_concurrency = lookup(var.performance_tuning, "auth-token", local.default_performance_parameters).max_concurrency
+  scaling_trigger             = lookup(var.performance_tuning, "auth-token", local.default_performance_parameters).scaling_trigger
+
+  source_bucket           = aws_s3_bucket.auth_ext_source_bucket.bucket
+  lambda_zip_file         = aws_s3_object.auth_ext_api_release_zip.key
+  lambda_zip_file_version = aws_s3_object.auth_ext_api_release_zip.version_id
+  code_signing_config_arn = local.lambda_code_signing_configuration_arn
+
+  authentication_vpc_arn = local.authentication_vpc_arn
+  security_group_ids = [
+    local.authentication_security_group_id,
+  ]
+  subnet_id                              = local.authentication_subnet_ids
+  lambda_role_arn                        = module.auth_token_role.arn
+  logging_endpoint_arns                  = var.logging_endpoint_arns
+  cloudwatch_key_arn                     = data.terraform_remote_state.shared.outputs.cloudwatch_encryption_key_arn
+  cloudwatch_log_retention               = var.cloudwatch_log_retention
+  lambda_env_vars_encryption_kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn
+  default_tags                           = local.default_tags
+
+  use_localstack = false
+
+  depends_on = [
+    aws_api_gateway_rest_api.di_auth_ext_api,
+  ]
+}

--- a/ci/terraform/auth-external-api/variables.tf
+++ b/ci/terraform/auth-external-api/variables.tf
@@ -86,6 +86,30 @@ variable "endpoint_memory_size" {
   type    = number
 }
 
+variable "authentication_auth_callback_uri" {
+  default     = ""
+  type        = string
+  description = "The redirect URI used by the orchestrator's auth callback lambda when calling the token endpoint. N.B. there is no actual redirect in the orchestration <-> authentication flow, but it is a part of OAuth2 formalities"
+}
+
+variable "orch_client_id" {
+  default     = ""
+  type        = string
+  description = "The client ID used by the orchestrator in two situations: 1) when passing an authorize request to the authentication frontend - see OIDC module 2) when calling the authentication token endpoint - in this second case there is no real client registry or defined scopes, but it is a part of OAuth2 formalities."
+}
+
+variable "authentication_backend_uri" {
+  default     = ""
+  type        = string
+  description = "The base URL for the authentication API (all endpoints). This is not used for HTTP(S) routing within the context of this module, but is used to calculate the expected 'aud(ience)' in the signed client_assertion JWT in the orchestrator's token request to authentication's token endpoint"
+}
+
+variable "orch_to_auth_public_signing_key" {
+  default     = ""
+  type        = string
+  description = "A hardcoded value for the public key corresponding to the KMS created in the OIDC module. It is used to validate the signature of a client_assertion JWT (orch<->auth token endpoint)"
+}
+
 locals {
   default_performance_parameters = {
     memory          = var.endpoint_memory_size

--- a/ci/terraform/oidc/authentication-auth-code.tf
+++ b/ci/terraform/oidc/authentication-auth-code.tf
@@ -9,6 +9,7 @@ module "frontend_api_orch_auth_code_role" {
     aws_iam_policy.dynamo_user_read_access_policy.arn,
     aws_iam_policy.dynamo_user_write_access_policy.arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
+    aws_iam_policy.dynamo_auth_code_store_write_access_policy.arn,
     module.oidc_txma_audit.access_policy_arn
   ]
 }

--- a/ci/terraform/oidc/build-overrides.tfvars
+++ b/ci/terraform/oidc/build-overrides.tfvars
@@ -16,6 +16,7 @@ custom_doc_app_claim_enabled        = true
 ipv_no_session_response_enabled     = true
 doc_app_cri_data_v2_endpoint        = "credentials/issue"
 doc_app_use_cri_data_v2_endpoint    = true
+orch_client_id                      = "orchestrationAuth"
 auth_frontend_public_encryption_key = <<-EOT
 -----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApLJWOHz7uHLinSJr8XM0

--- a/ci/terraform/oidc/dev.tfvars
+++ b/ci/terraform/oidc/dev.tfvars
@@ -8,3 +8,4 @@ logging_endpoint_arns                = []
 shared_state_bucket                  = "digital-identity-dev-tfstate"
 test_clients_enabled                 = true
 internal_sector_uri                  = "https://identity.dev.account.gov.uk"
+orch_client_id                       = "orchestrationAuth"

--- a/ci/terraform/oidc/dynamo-policies.tf
+++ b/ci/terraform/oidc/dynamo-policies.tf
@@ -26,6 +26,10 @@ data "aws_dynamodb_table" "account_modifiers_table" {
   name = "${var.environment}-account-modifiers"
 }
 
+data "aws_dynamodb_table" "auth_code_store" {
+  name = "${var.environment}-auth-code-store"
+}
+
 data "aws_dynamodb_table" "access_token_store" {
   name = "${var.environment}-access-token-store"
 }
@@ -208,6 +212,7 @@ data "aws_iam_policy_document" "dynamo_common_passwords_read_access_policy_docum
   }
 }
 
+
 data "aws_iam_policy_document" "dynamo_account_modifiers_read_access_policy_document" {
   statement {
     sid    = "AllowAccessToDynamoTables"
@@ -334,6 +339,22 @@ data "aws_iam_policy_document" "dynamo_authentication_callback_userinfo_read_pol
     resources = [
       data.aws_dynamodb_table.authentication_callback_userinfo_table.arn,
       "${data.aws_dynamodb_table.authentication_callback_userinfo_table.arn}/index/*",
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "dynamo_auth_code_store_write_access_policy_document" {
+  statement {
+    sid    = "AllowAccessToDynamoTables"
+    effect = "Allow"
+
+    actions = [
+      "dynamodb:BatchWriteItem",
+      "dynamodb:UpdateItem",
+      "dynamodb:PutItem",
+    ]
+    resources = [
+      data.aws_dynamodb_table.auth_code_store.arn,
     ]
   }
 }
@@ -481,4 +502,12 @@ resource "aws_iam_policy" "dynamo_authentication_callback_userinfo_write_access_
   description = "IAM policy for managing write permissions to the Dynamo Callback User Info table"
 
   policy = data.aws_iam_policy_document.dynamo_authentication_callback_userinfo_write_policy_document.json
+}
+
+resource "aws_iam_policy" "dynamo_auth_code_store_write_access_policy" {
+  name_prefix = "dynamo-auth-code-write-policy"
+  path        = "/${var.environment}/oidc-shared/"
+  description = "IAM policy for managing write permissions to the Dynamo Auth Code table (code used orch<->auth NOT RP<->orch)"
+
+  policy = data.aws_iam_policy_document.dynamo_auth_code_store_write_access_policy_document.json
 }

--- a/ci/terraform/oidc/integration-overrides.tfvars
+++ b/ci/terraform/oidc/integration-overrides.tfvars
@@ -24,6 +24,7 @@ extended_feature_flags_enabled  = true
 support_auth_orch_split         = false
 custom_doc_app_claim_enabled    = true
 ipv_no_session_response_enabled = true
+orch_client_id                  = "orchestrationAuth"
 
 auth_frontend_public_encryption_key = <<-EOT
 -----BEGIN PUBLIC KEY-----

--- a/ci/terraform/oidc/production-overrides.tfvars
+++ b/ci/terraform/oidc/production-overrides.tfvars
@@ -49,6 +49,8 @@ swIDAQAB
 -----END PUBLIC KEY-----
 EOT
 
+orch_client_id = "orchestrationAuth"
+
 auth_frontend_public_encryption_key = <<-EOT
 -----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAppKCOhyLiKs5QTB1L+XK

--- a/ci/terraform/oidc/sandpit.tfvars
+++ b/ci/terraform/oidc/sandpit.tfvars
@@ -43,3 +43,5 @@ email_acct_creation_otp_code_ttl_duration = 60
 
 txma_account_id                = "12345678"
 extended_feature_flags_enabled = true
+
+orch_client_id = "orchestrationAuth"


### PR DESCRIPTION
## What?
- Add terraform for auth token endpoint
- This is the token endpoint for orchestration<->authentication
- Not to be confused with the token endpoint for RP<->orchestration

## Why?
- Required in order to deploy the new token lambda as part of auth-external-api module

## Related PRs
- The code for the lambda which is being deployed via this terraform: https://github.com/alphagov/di-authentication-api/pull/3337
