### PR TITLE
AUT-1689: Add rp-sector-uri and is-new-account params in AuthCodeStore table

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/AuthCodeRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/AuthCodeRequest.java
@@ -23,10 +23,27 @@ public class AuthCodeRequest {
     @Required
     private List<String> claims;
 
-    public AuthCodeRequest(String redirectUri, String state, List<String> claims) {
+    @SerializedName("rp-sector-uri")
+    @Expose
+    @Required
+    private String sectorIdentifier;
+
+    @SerializedName("is-new-account")
+    @Expose
+    @Required
+    private boolean isNewAccount;
+
+    public AuthCodeRequest(
+            String redirectUri,
+            String state,
+            List<String> claims,
+            String sectorIdentifier,
+            boolean isNewAccount) {
         this.redirectUri = redirectUri;
         this.state = state;
         this.claims = claims;
+        this.sectorIdentifier = sectorIdentifier;
+        this.isNewAccount = isNewAccount;
     }
 
     public String getRedirectUri() {
@@ -51,5 +68,21 @@ public class AuthCodeRequest {
 
     public void setClaims(List<String> claims) {
         this.claims = claims;
+    }
+
+    public String getSectorIdentifier() {
+        return sectorIdentifier;
+    }
+
+    public void setSectorIdentifier(String sectorIdentifier) {
+        this.sectorIdentifier = sectorIdentifier;
+    }
+
+    public boolean isNewAccount() {
+        return isNewAccount;
+    }
+
+    public void setNewAccount(boolean newAccount) {
+        isNewAccount = newAccount;
     }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandler.java
@@ -76,7 +76,9 @@ public class AuthenticationAuthCodeHandler extends BaseFrontendHandler<AuthCodeR
                         userProfile.get().getSubjectID(),
                         authorisationCode.getValue(),
                         authCodeRequest.getClaims(),
-                        false);
+                        false,
+                        authCodeRequest.getSectorIdentifier(),
+                        authCodeRequest.isNewAccount());
 
                 var state = State.parse(authCodeRequest.getState());
                 var redirectUri = URI.create(authCodeRequest.getRedirectUri());

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandlerTest.java
@@ -43,6 +43,7 @@ class AuthenticationAuthCodeHandlerTest {
     private static final String TEST_STATE = "xyz";
     private static final String TEST_AUTHORIZATION_CODE = "SplxlOBeZQQYbYS6WxSbIA";
     private static final String TEST_SUBJECT_ID = "subject-id";
+    private static final String TEST_SECTOR_IDENTIFIER = "sectorIdentifier";
 
     private AuthenticationAuthCodeHandler handler;
     private static final Json objectMapper = SerializationService.getInstance();
@@ -151,7 +152,13 @@ class AuthenticationAuthCodeHandlerTest {
         var result = handler.handleRequest(event, context);
 
         verify(dynamoAuthCodeService, times(1))
-                .saveAuthCode(eq(userProfile.getSubjectID()), anyString(), anyList(), eq(false));
+                .saveAuthCode(
+                        eq(userProfile.getSubjectID()),
+                        anyString(),
+                        anyList(),
+                        eq(false),
+                        anyString(),
+                        eq(false));
         assertThat(result, hasStatus(200));
         var authorizationResponse = new AuthCodeResponse(TEST_AUTHORIZATION_CODE, TEST_STATE);
         assertThat(result, hasBody(objectMapper.writeValueAsString(authorizationResponse)));
@@ -162,11 +169,13 @@ class AuthenticationAuthCodeHandlerTest {
         event.setHeaders(getHeaders());
         event.setBody(
                 format(
-                        "{ \"email\": \"%s\", \"redirect-uri\": \"%s\", \"state\": \"%s\", \"claims\": [\"%s\"] }",
+                        "{ \"email\": \"%s\", \"redirect-uri\": \"%s\", \"state\": \"%s\", \"claims\": [\"%s\"], \"rp-sector-uri\": \"%s\",  \"is-new-account\": \"%s\" }",
                         TEST_EMAIL_ADDRESS,
                         TEST_REDIRECT_URI,
                         TEST_STATE,
-                        List.of("email-verified", "email")));
+                        List.of("email-verified", "email"),
+                        TEST_SECTOR_IDENTIFIER,
+                        false));
         return event;
     }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationAuthCodeHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationAuthCodeHandlerIntegrationTest.java
@@ -27,6 +27,7 @@ class AuthenticationAuthCodeHandlerIntegrationTest extends ApiGatewayHandlerInte
     private static final String TEST_REDIRECT_URI = "https://redirect_uri.com";
     private static final String TEST_STATE = "xyz";
     private static final String TEST_AUTHORIZATION_CODE = "SplxlOBeZQQYbYS6WxSbIA";
+    private static final String TEST_SECTOR_IDENTIFIER = "sectorIdentifier";
     private static final String TEST_SUBJECT_ID = "subject-id";
 
     @RegisterExtension
@@ -44,6 +45,8 @@ class AuthenticationAuthCodeHandlerIntegrationTest extends ApiGatewayHandlerInte
                 TEST_SUBJECT_ID,
                 TEST_AUTHORIZATION_CODE,
                 List.of(EMAIL_VERIFIED.getValue(), EMAIL.getValue()),
+                false,
+                TEST_SECTOR_IDENTIFIER,
                 false);
         userStore.signUp(TEST_EMAIL_ADDRESS, TEST_PASSWORD);
     }
@@ -56,7 +59,9 @@ class AuthenticationAuthCodeHandlerIntegrationTest extends ApiGatewayHandlerInte
                 new AuthCodeRequest(
                         TEST_REDIRECT_URI,
                         TEST_STATE,
-                        List.of(EMAIL_VERIFIED.getValue(), EMAIL.getValue()));
+                        List.of(EMAIL_VERIFIED.getValue(), EMAIL.getValue()),
+                        TEST_SECTOR_IDENTIFIER,
+                        false);
         var response = makeRequest(Optional.of(authRequest), getHeaders(), Map.of());
         assertThat(response, hasStatus(200));
     }
@@ -66,7 +71,11 @@ class AuthenticationAuthCodeHandlerIntegrationTest extends ApiGatewayHandlerInte
         setUpDynamo();
         var authRequest =
                 new AuthCodeRequest(
-                        null, TEST_STATE, List.of(EMAIL_VERIFIED.getValue(), EMAIL.getValue()));
+                        null,
+                        TEST_STATE,
+                        List.of(EMAIL_VERIFIED.getValue(), EMAIL.getValue()),
+                        TEST_SECTOR_IDENTIFIER,
+                        false);
         var response = makeRequest(Optional.of(authRequest), getHeaders(), Map.of());
         assertThat(response, hasStatus(400));
         assertThat(response, hasBody(objectMapper.writeValueAsString(ErrorResponse.ERROR_1001)));
@@ -79,7 +88,9 @@ class AuthenticationAuthCodeHandlerIntegrationTest extends ApiGatewayHandlerInte
                 new AuthCodeRequest(
                         TEST_REDIRECT_URI,
                         null,
-                        List.of(EMAIL_VERIFIED.getValue(), EMAIL.getValue()));
+                        List.of(EMAIL_VERIFIED.getValue(), EMAIL.getValue()),
+                        TEST_SECTOR_IDENTIFIER,
+                        false);
         var response = makeRequest(Optional.of(authRequest), getHeaders(), Map.of());
         assertThat(response, hasStatus(400));
         assertThat(response, hasBody(objectMapper.writeValueAsString(ErrorResponse.ERROR_1001)));
@@ -88,7 +99,9 @@ class AuthenticationAuthCodeHandlerIntegrationTest extends ApiGatewayHandlerInte
     @Test
     void shouldReturn400StatusForInvalidRequestedScopeClaims() throws Json.JsonException {
         setUpDynamo();
-        var authRequest = new AuthCodeRequest(TEST_REDIRECT_URI, TEST_STATE, null);
+        var authRequest =
+                new AuthCodeRequest(
+                        TEST_REDIRECT_URI, TEST_STATE, null, TEST_SECTOR_IDENTIFIER, false);
         var response = makeRequest(Optional.of(authRequest), getHeaders(), Map.of());
         assertThat(response, hasStatus(400));
         assertThat(response, hasBody(objectMapper.writeValueAsString(ErrorResponse.ERROR_1001)));

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationTokenHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationTokenHandlerIntegrationTest.java
@@ -48,6 +48,7 @@ class AuthenticationTokenHandlerIntegrationTest extends ApiGatewayHandlerIntegra
     private static final URI AUTH_BACKEND_URI = URI.create("http://auth-backend");
     private static final Subject TEST_SUBJECT = new Subject();
     private static final List<String> TEST_CLAIMS = List.of("test-claim-1");
+    private static final String TEST_SECTOR_IDENTIFIER = "sectorIdentifier";
 
     @RegisterExtension
     protected static final AuthCodeExtension authCodeStoreExtension = new AuthCodeExtension(180);
@@ -71,7 +72,12 @@ class AuthenticationTokenHandlerIntegrationTest extends ApiGatewayHandlerIntegra
         handler = new TokenHandler(configurationService);
 
         authCodeStoreExtension.saveAuthCode(
-                TEST_SUBJECT.getValue(), VALID_AUTH_CODE, TEST_CLAIMS, false);
+                TEST_SUBJECT.getValue(),
+                VALID_AUTH_CODE,
+                TEST_CLAIMS,
+                false,
+                TEST_SECTOR_IDENTIFIER,
+                false);
 
         txmaAuditQueue.clear();
     }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoAuthCodeServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoAuthCodeServiceIntegrationTest.java
@@ -20,6 +20,8 @@ class DynamoAuthCodeServiceIntegrationTest {
     private static final String SUBJECT_ID = "test-subject-id";
     private static final String AUTH_CODE = "test-auth-code";
     private static final boolean HAS_BEEN_USED = false;
+    private static final boolean IS_NEW_ACCOUNT = false;
+    private static final String TEST_SECTOR_IDENTIFIER = "sectorIdentifier";
 
     @RegisterExtension
     protected static final AuthCodeExtension authCodeExtension = new AuthCodeExtension(180);
@@ -32,7 +34,9 @@ class DynamoAuthCodeServiceIntegrationTest {
                 SUBJECT_ID,
                 AUTH_CODE,
                 List.of(EMAIL_VERIFIED.getValue(), EMAIL.getValue()),
-                HAS_BEEN_USED);
+                HAS_BEEN_USED,
+                TEST_SECTOR_IDENTIFIER,
+                IS_NEW_ACCOUNT);
     }
 
     @Test

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthCodeExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/AuthCodeExtension.java
@@ -60,9 +60,15 @@ public class AuthCodeExtension extends DynamoExtension implements AfterEachCallb
     }
 
     public void saveAuthCode(
-            String subjectID, String authCode, List<String> claims, boolean hasBeenUsed) {
+            String subjectID,
+            String authCode,
+            List<String> claims,
+            boolean hasBeenUsed,
+            String sectorIdentifier,
+            boolean isNewAccount) {
 
-        dynamoAuthCodeService.saveAuthCode(subjectID, authCode, claims, hasBeenUsed);
+        dynamoAuthCodeService.saveAuthCode(
+                subjectID, authCode, claims, hasBeenUsed, sectorIdentifier, isNewAccount);
     }
 
     private void createAuthCodeStoreTable() {

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoAuthCodeService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoAuthCodeService.java
@@ -40,7 +40,12 @@ public class DynamoAuthCodeService extends BaseDynamoService<AuthCodeStore> {
     }
 
     public void saveAuthCode(
-            String subjectID, String authCode, List<String> claims, boolean hasBeenUsed) {
+            String subjectID,
+            String authCode,
+            List<String> claims,
+            boolean hasBeenUsed,
+            String sectorIdentifier,
+            boolean isNewAccount) {
         if (isAuthOrchSplitEnabled) {
             var authCodeStore =
                     new AuthCodeStore()
@@ -48,6 +53,8 @@ public class DynamoAuthCodeService extends BaseDynamoService<AuthCodeStore> {
                             .withAuthCode(authCode)
                             .withClaims(claims)
                             .withHasBeenUsed(hasBeenUsed)
+                            .withSectorIdentifier(sectorIdentifier)
+                            .withIsNewAccount(isNewAccount)
                             .withTimeToExist(
                                     NowHelper.nowPlus(timeToExist, ChronoUnit.SECONDS)
                                             .toInstant()


### PR DESCRIPTION
## What?
Add two new params to the AuthCodeStore table `SectorIdentifier` (rp-sector-uri) and `IsNewAccount` as these parameters  are required to be reflected in the AuthCodeStore table parsed from `/userinfo` endpoint
- `SectorIdentifier` (rp-sector-uri): value already being passed as a claim from the OIDC API under the field name rp_sector_host
- Modify AuthCodeRequest to parse the new params
- Save the new params into the table via DynamoAuthCodeService

## Why?

For the userinfo ticket `AUT-1250` there were a couple of fields were not reflected in anything passed by frontend to /orch-auth-code and therefore not stored in the auth code store
