### PR TITLE
AUT-1695: Grant dynamo access rights to delivery receipts for bulk email

### DIFF
--- a/ci/terraform/delivery-receipts/delivery-receipts-dynamo-access.tf
+++ b/ci/terraform/delivery-receipts/delivery-receipts-dynamo-access.tf
@@ -1,0 +1,81 @@
+
+data "aws_dynamodb_table" "bulk_email_users_table" {
+  name = "${var.environment}-bulk-email-users"
+}
+
+data "aws_dynamodb_table" "user_profile_table" {
+  name = "${var.environment}-user-profile"
+}
+
+data "aws_iam_policy_document" "bulk_user_email_receipts_dynamo_write_access" {
+  statement {
+    sid    = "AllowAccessToDynamoTables"
+    effect = "Allow"
+
+    actions = [
+      "dynamodb:DescribeTable",
+      "dynamodb:UpdateItem",
+      "dynamodb:GetItem",
+    ]
+
+    resources = [
+      data.aws_dynamodb_table.bulk_email_users_table.arn,
+      "${data.aws_dynamodb_table.bulk_email_users_table.arn}/index/*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "bulk_user_email_receipts_dynamo_write_access" {
+  name_prefix = "dynamo-access-policy"
+  description = "IAM policy managing write access for the Bulk User Email Send lambda to the Dynamo Bulk Email Users table"
+
+  policy = data.aws_iam_policy_document.bulk_user_email_receipts_dynamo_write_access.json
+}
+
+data "aws_iam_policy_document" "bulk_user_email_receipts_user_profile_dynamo_read_access" {
+  statement {
+    sid    = "AllowAccessToDynamoTables"
+    effect = "Allow"
+
+    actions = [
+      "dynamodb:DescribeTable",
+      "dynamodb:Get*",
+    ]
+
+    resources = [
+      data.aws_dynamodb_table.user_profile_table.arn,
+      "${data.aws_dynamodb_table.user_profile_table.arn}/index/*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "bulk_user_email_receipts_user_profile_dynamo_read_access" {
+  name_prefix = "dynamo-access-policy"
+  description = "IAM policy managing read access for the Bulk User Email Send lambda to the Dynamo User Profile table"
+
+  policy = data.aws_iam_policy_document.bulk_user_email_receipts_user_profile_dynamo_read_access.json
+}
+
+data "aws_iam_policy_document" "bulk_user_email_dynamo_encryption_key_policy_document" {
+  statement {
+    sid    = "AllowAccessToBulkUserEmailTableKmsEncryptionKey"
+    effect = "Allow"
+
+    actions = [
+      "kms:Encrypt*",
+      "kms:Decrypt*",
+      "kms:GetPublicKey"
+    ]
+    resources = [
+      local.bulk_user_email_table_encryption_key_arn,
+    ]
+  }
+}
+
+resource "aws_iam_policy" "bulk_user_email_dynamo_encryption_key_kms_policy" {
+  name        = "${var.environment}-bulk-user-email-table-receipts-encryption-key-kms-policy"
+  path        = "/"
+  description = "IAM policy for managing KMS encryption of the bulk user email table"
+
+  policy = data.aws_iam_policy_document.bulk_user_email_dynamo_encryption_key_policy_document.json
+}

--- a/ci/terraform/delivery-receipts/notify-callback.tf
+++ b/ci/terraform/delivery-receipts/notify-callback.tf
@@ -6,6 +6,9 @@ module "delivery_receipts_api_notify_callback_role" {
 
   policies_to_attach = [
     aws_iam_policy.parameter_policy.arn,
+    aws_iam_policy.bulk_user_email_receipts_user_profile_dynamo_read_access.arn,
+    aws_iam_policy.bulk_user_email_receipts_dynamo_write_access.arn,
+    aws_iam_policy.bulk_user_email_dynamo_encryption_key_kms_policy.arn,
   ]
 }
 

--- a/ci/terraform/delivery-receipts/sandpit.tfvars
+++ b/ci/terraform/delivery-receipts/sandpit.tfvars
@@ -3,3 +3,8 @@ common_state_bucket = "digital-identity-dev-tfstate"
 
 logging_endpoint_enabled = false
 logging_endpoint_arns    = []
+
+notify_template_map = {
+  CHANGE_HOW_GET_SECURITY_CODES_CONFIRMATION_TEMPLATE_ID = "d253a170-8144-4471-b339-c35965c9298a"
+  TERMS_AND_CONDITIONS_BULK_EMAIL_TEMPLATE_ID            = "067548f2-420d-4da9-923f-ec9a941706cf"
+}

--- a/ci/terraform/delivery-receipts/shared.tf
+++ b/ci/terraform/delivery-receipts/shared.tf
@@ -15,6 +15,7 @@ data "terraform_remote_state" "shared" {
 }
 
 locals {
-  redis_key                             = "session"
-  lambda_code_signing_configuration_arn = data.terraform_remote_state.shared.outputs.lambda_code_signing_configuration_arn
+  redis_key                                = "session"
+  lambda_code_signing_configuration_arn    = data.terraform_remote_state.shared.outputs.lambda_code_signing_configuration_arn
+  bulk_user_email_table_encryption_key_arn = data.terraform_remote_state.shared.outputs.bulk_user_email_table_encryption_key_arn
 }


### PR DESCRIPTION
## What?

Grant dynamo access rights to delivery receipts for bulk email.

- Read access to the user-profile table
- Write access to the bulk-user-email table

## Why?

Adding a facility for delivery receipts to update the Notify the delivery status in the bulk-user-email table.  Allows us to know and store the delivery status for each email sent.  For failed emails we would then be able to schedule an additional run if required.

## Related PRs

See below for the PR changing the delivery receipts lambda to update the database.

#3343 

