### PR TITLE
BAU: Attach redis parameter policy to authentication callback lambda 

### DIFF
--- a/ci/terraform/oidc/authentication-callback.tf
+++ b/ci/terraform/oidc/authentication-callback.tf
@@ -8,6 +8,7 @@ module "oidc_api_authentication_callback_role" {
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.dynamo_authentication_callback_userinfo_read_policy.arn,
     aws_iam_policy.dynamo_authentication_callback_userinfo_write_access_policy.arn,
+    aws_iam_policy.redis_parameter_policy.arn,
     module.oidc_txma_audit.access_policy_arn
   ]
 }
@@ -21,6 +22,7 @@ module "authentication_callback" {
   environment     = var.environment
 
   handler_environment_variables = {
+    REDIS_KEY               = local.redis_key
     SUPPORT_AUTH_ORCH_SPLIT = var.support_auth_orch_split
     DYNAMO_ENDPOINT         = var.use_localstack ? var.lambda_dynamo_endpoint : null
     LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null


### PR DESCRIPTION
## What?

Attach `redis_parameter_policy` to the `oidc_api_authentication_callback_role` module

## Why?

To fix error:

````
User: arn:aws:sts::xxxxxx:assumed-role/execution-role20230920085053532800000004/build-orchestration-redirect-lambda is not authorized to perform: ssm:GetParameters on resource: arn:aws:ssm:eu-west-2:761723964695:parameter/build-null-redis-master-host because no identity-based policy allows the ssm:GetParameters action (Service: Ssm, Status Code: 400, Request ID: a71296e6-c18c-48f3-8c6e-ae94cbba3fa6): 
````

## Related PRs

https://github.com/alphagov/di-authentication-api/pull/3339
