### PR TITLE
AUT-1717 - Store state that Orchestration sends to Authentication

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -360,6 +360,8 @@ public class AuthorisationHandler
             var rpSectorIdentifierHost =
                     ClientSubjectHelper.getSectorIdentifierForClient(
                             client, configurationService.getInternalSectorUri());
+            var state = new State();
+            orchestrationAuthorizationService.storeState(session.getSessionId(), state);
             var claimsBuilder =
                     new JWTClaimsSet.Builder()
                             .issuer(configurationService.getOrchestrationClientId())
@@ -382,7 +384,7 @@ public class AuthorisationHandler
                                             .getEffectiveVectorOfTrust(authenticationRequest)
                                             .getCredentialTrustLevel()
                                             .getValue())
-                            .claim("state", new State().getValue())
+                            .claim("state", state.getValue())
                             .claim("client_id", configurationService.getOrchestrationClientId())
                             .claim(
                                     "redirect_uri",

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandlerTest.java
@@ -241,6 +241,8 @@ class AuthorisationHandlerTest {
 
         assertThat(response, hasStatus(302));
         var locationHeader = response.getHeaders().get(ResponseHeaders.LOCATION);
+        verify(orchestrationAuthorizationService)
+                .storeState(eq(session.getSessionId()), any(State.class));
         assertThat(locationHeader, containsString(TEST_ENCRYPTED_JWT.serialize()));
         assertThat(
                 splitQuery(locationHeader).get("request"), equalTo(TEST_ENCRYPTED_JWT.serialize()));


### PR DESCRIPTION
## What?

 - Store the state that Orchestration sends to Authentication

## Why?

- We need to store so we can validate it against the state returned in the redirect back from Authentication to Orchestration
