### PR TITLE
AUT-1472: Tweak cron expression to use month name

### DIFF
--- a/ci/terraform/utils/production-overrides.tfvars
+++ b/ci/terraform/utils/production-overrides.tfvars
@@ -23,4 +23,4 @@ bulk_user_email_batch_query_limit     = 2500
 bulk_user_email_max_batch_count       = 1
 bulk_user_email_batch_pause_duration  = 0
 
-bulk_user_email_send_schedule_expression = "cron(0/10 14-17 20 8 ? 2023)"
+bulk_user_email_send_schedule_expression = "cron(0/10 14-17 20 SEP ? 2023)"


### PR DESCRIPTION

## What?

Tweak cron expression to use month name.

month 8 -> SEP

## Why?

Using 8 as a month was not passing validation in the Cloudwatch console.

## Related PRs

#3352 