### PR TITLE
AUT-1472: Send two extra batches of emails

### DIFF
--- a/ci/terraform/utils/production-overrides.tfvars
+++ b/ci/terraform/utils/production-overrides.tfvars
@@ -23,4 +23,4 @@ bulk_user_email_batch_query_limit     = 2500
 bulk_user_email_max_batch_count       = 1
 bulk_user_email_batch_pause_duration  = 0
 
-bulk_user_email_send_schedule_expression = "cron(0/6 10-11 21 SEP ? 2023)"
+bulk_user_email_send_schedule_expression = "cron(30,36 15 21 SEP ? 2023)"


### PR DESCRIPTION
## What?

Modify cron expression to send two batches of emails - 15:30 and 15:36 on 21/09/2023

## Why?

Previous run of sending emails ended 5,000 emails (two batches) short of 50,000 target. This was due to not all jobs being run.

## Related PRs

[Previous scheduled run](https://github.com/alphagov/di-authentication-api/pull/3359)
