### PR TITLE
AUT-1707: Refactor AuthCodeHandler response to contain redirect URI

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/AuthCodeResponse.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/AuthCodeResponse.java
@@ -1,28 +1,6 @@
 package uk.gov.di.authentication.frontendapi.entity;
 
-public class AuthCodeResponse {
+import com.google.gson.annotations.Expose;
+import org.apache.logging.log4j.core.config.plugins.validation.constraints.Required;
 
-    private String code;
-    private String state;
-
-    public AuthCodeResponse(String code, String state) {
-        this.code = code;
-        this.state = state;
-    }
-
-    public String getCode() {
-        return code;
-    }
-
-    public void setCode(String code) {
-        this.code = code;
-    }
-
-    public String getState() {
-        return state;
-    }
-
-    public void setState(String state) {
-        this.state = state;
-    }
-}
+public record AuthCodeResponse(@Expose @Required String location) {}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandler.java
@@ -9,6 +9,7 @@ import com.nimbusds.oauth2.sdk.id.State;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.frontendapi.entity.AuthCodeRequest;
+import uk.gov.di.authentication.frontendapi.entity.AuthCodeResponse;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.lambda.BaseFrontendHandler;
 import uk.gov.di.authentication.shared.serialization.Json.JsonException;
@@ -86,7 +87,8 @@ public class AuthenticationAuthCodeHandler extends BaseFrontendHandler<AuthCodeR
                         new AuthorizationSuccessResponse(
                                 redirectUri, authorisationCode, null, state, null);
 
-                return generateApiGatewayProxyResponse(200, authorizationResponse);
+                return generateApiGatewayProxyResponse(
+                        200, new AuthCodeResponse(authorizationResponse.toURI().toString()));
             } catch (JsonException ex) {
                 return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1001);
             }


### PR DESCRIPTION
## What?

- Prior to the change, the handler returned the `authorization` response object
- The response now returns a json body with "location" denoting the redirect uri with appropriate query params

## Why?

To behave similarly to the existing auth code handler, which returns the `authentication` response as a URI with the query params already constructed.