### PR TITLE
AUT-1472: Set up next batch of email sending 

### DIFF
--- a/ci/terraform/utils/production-overrides.tfvars
+++ b/ci/terraform/utils/production-overrides.tfvars
@@ -17,10 +17,10 @@ bulk_user_email_included_terms_and_conditions     = "1.0,1.1,1.2,1.3,1.4,1.5,1.6
 bulk_user_email_max_audience_load_user_batch_size = 0
 bulk_user_email_max_audience_load_user_count      = 0
 
-bulk_user_email_send_schedule_enabled = false
-bulk_user_email_email_sending_enabled = false
+bulk_user_email_send_schedule_enabled = true
+bulk_user_email_email_sending_enabled = true
 bulk_user_email_batch_query_limit     = 2500
 bulk_user_email_max_batch_count       = 1
 bulk_user_email_batch_pause_duration  = 0
 
-bulk_user_email_send_schedule_expression = "cron(30,36 15 21 SEP ? 2023)"
+bulk_user_email_send_schedule_expression = "cron(0/06 10-11 25 SEP ? 2023)"


### PR DESCRIPTION
TO BE MERGED MONDAY MORNING - shouldn't do anything bad before then since it's sending on a cron schedule for Monday, but I've disabled sending over the weekend for peace of mind so this will override that.

AUT-1472: Set up next batch of email sending
    
This should send 50,000 emails (a rate of 2,500 every 6 minutes between 11am and 1pm BST).

Cron expression breaks down as follows:
* 0/06 - run every 6 minutes with 0 offset (so on the hour, 6 minutes past, 12 minutes past etc)
* 10-11 - run on the hours of 10am and 11am UTC. This actually has a duration of two hours, so it'll run during the hours of 10 and 11. Since it's UTC and we're ccurrently on BST, this will actually be on the hours of 11am and 12pm, meaning that in effect we're running between 11am and 1pm in local time.
* 25 SEP ? 2023 - run it just on the 25th September