### PR TITLE
AUT-1678: Add auth-orch split env var (terraform) and enable in Build

### DIFF
--- a/ci/terraform/auth-external-api/build.tfvars
+++ b/ci/terraform/auth-external-api/build.tfvars
@@ -9,6 +9,7 @@ lambda_min_concurrency = 1
 endpoint_memory_size   = 1024
 scaling_trigger        = 0.6
 
+support_auth_orch_split         = true
 orch_client_id                  = "orchestrationAuth"
 orch_to_auth_public_signing_key = <<-EOT
 -----BEGIN PUBLIC KEY-----
@@ -16,3 +17,4 @@ MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAENRdvNXHwk1TvrgFUsWXAE5oDTcPr
 CBp6HxbvYDLsqwNHiDFEzCwvbXKY2QQR/Rtel0o156CtU9k1lCZJGAsSIA==
 -----END PUBLIC KEY-----
 EOT
+

--- a/ci/terraform/auth-external-api/token.tf
+++ b/ci/terraform/auth-external-api/token.tf
@@ -32,6 +32,7 @@ module "auth_token" {
     ORCH_CLIENT_ID                            = var.orch_client_id
     AUTHENTICATION_BACKEND_URI                = var.authentication_backend_uri
     ORCH_TO_AUTH_TOKEN_SIGNING_PUBLIC_KEY     = var.orch_to_auth_public_signing_key
+    SUPPORT_AUTH_ORCH_SPLIT                   = var.support_auth_orch_split
   }
   handler_function_name = "uk.gov.di.authentication.external.lambda.TokenHandler::handleRequest"
   handler_runtime       = "java17"

--- a/ci/terraform/auth-external-api/userinfo.tf
+++ b/ci/terraform/auth-external-api/userinfo.tf
@@ -23,11 +23,12 @@ module "auth_userinfo" {
   environment     = var.environment
 
   handler_environment_variables = {
-    ENVIRONMENT          = var.environment
-    TXMA_AUDIT_QUEUE_URL = module.auth_ext_txma_audit.queue_url
-    LOCALSTACK_ENDPOINT  = null
-    DYNAMO_ENDPOINT      = null
-    INTERNAl_SECTOR_URI  = var.internal_sector_uri
+    ENVIRONMENT             = var.environment
+    TXMA_AUDIT_QUEUE_URL    = module.auth_ext_txma_audit.queue_url
+    LOCALSTACK_ENDPOINT     = null
+    DYNAMO_ENDPOINT         = null
+    INTERNAl_SECTOR_URI     = var.internal_sector_uri
+    SUPPORT_AUTH_ORCH_SPLIT = var.support_auth_orch_split
   }
   handler_function_name = "uk.gov.di.authentication.external.lambda.UserInfoHandler::handleRequest"
   handler_runtime       = "java17"

--- a/ci/terraform/auth-external-api/variables.tf
+++ b/ci/terraform/auth-external-api/variables.tf
@@ -110,6 +110,12 @@ variable "orch_to_auth_public_signing_key" {
   description = "A hardcoded value for the public key corresponding to the KMS created in the OIDC module. It is used to validate the signature of a client_assertion JWT (orch<->auth token endpoint)"
 }
 
+variable "support_auth_orch_split" {
+  default     = false
+  type        = bool
+  description = "Feature flag which toggles auth-orch split on and off"
+}
+
 locals {
   default_performance_parameters = {
     memory          = var.endpoint_memory_size

--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -43,6 +43,7 @@ module "authorize" {
     SUPPORT_LANGUAGE_CY                  = tostring(var.language_cy_enabled)
     INTERNAl_SECTOR_URI                  = var.internal_sector_uri
     ORCH_TO_AUTH_TOKEN_SIGNING_KEY_ALIAS = local.orch_to_auth_signing_key_alias_name
+    SUPPORT_AUTH_ORCH_SPLIT              = var.support_auth_orch_split
   }
   handler_function_name = "uk.gov.di.authentication.oidc.lambda.AuthorisationHandler::handleRequest"
   rest_api_id           = aws_api_gateway_rest_api.di_authentication_api.id


### PR DESCRIPTION
## What?
- Add auth-orch split env var (terraform) and enable in Build

## Why?
- Needed for testing

## Related PRs
- Amends: https://github.com/alphagov/di-authentication-api/pull/3367