### PR TITLE
Cache SSM parameter and configure next email batch

### DIFF
--- a/ci/terraform/utils/production-overrides.tfvars
+++ b/ci/terraform/utils/production-overrides.tfvars
@@ -23,4 +23,4 @@ bulk_user_email_batch_query_limit     = 2500
 bulk_user_email_max_batch_count       = 1
 bulk_user_email_batch_pause_duration  = 0
 
-bulk_user_email_send_schedule_expression = "cron(0/06 10-11 25 SEP ? 2023)"
+bulk_user_email_send_schedule_expression = "cron(0/06 10-13 26,27 SEP ? 2023)"

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -43,6 +43,8 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
     private SsmClient ssmClient;
     private Map<String, String> ssmRedisParameters;
     private Optional<String> passwordPepper;
+
+    private String notifyCallbackBearerToken;
     protected SystemService systemService;
 
     public ConfigurationService() {}
@@ -402,13 +404,18 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
     }
 
     public String getNotifyCallbackBearerToken() {
-        var request =
-                GetParameterRequest.builder()
-                        .withDecryption(true)
-                        .name(format("{0}-notify-callback-bearer-token", getEnvironment()))
-                        .build();
+        if (notifyCallbackBearerToken == null) {
 
-        return getSsmClient().getParameter(request).parameter().value();
+            var request =
+                    GetParameterRequest.builder()
+                            .withDecryption(true)
+                            .name(format("{0}-notify-callback-bearer-token", getEnvironment()))
+                            .build();
+
+            notifyCallbackBearerToken = getSsmClient().getParameter(request).parameter().value();
+        }
+
+        return notifyCallbackBearerToken;
     }
 
     public List<String> getNotifyTestDestinations() {


### PR DESCRIPTION
## What?

* Cache a parameter we read from ssm, so we do not hit aws rate limiting while processing delivery receipts, which we [saw today](https://gds.splunkcloud.com/en-GB/app/gds-050-digital-Identity/search?q=search%20index%3Dgds_di_production%20%22*exception*%22%20sourcetype%3D%22aws%3Alambda%3Aproduction%3Anotify-callback-lambda%22%20%7C%20sort%20-_time&display.page.search.mode=smart&dispatch.sample_ratio=1&workload_pool=standard_perf&earliest=1695207600&latest=1695639900&sid=1695649750.684596)
* Also configure the next batch of emails for today and tomorrow

## Questions for reviewer 

**Edit - I've fixed this now :-)** I did want to test the changes to the configuration service, but this would involve mocking a private method. If someone has a suggestion as to how to do this that is quick, I'd appreciate it (I saw some ways via adding a new dependency, but wasn't keen)
