### PR TITLE
AUT-1678: Make aud value equal login URI value

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -365,7 +365,7 @@ public class AuthorisationHandler
             var claimsBuilder =
                     new JWTClaimsSet.Builder()
                             .issuer(configurationService.getOrchestrationClientId())
-                            .audience(configurationService.getAuthAudience())
+                            .audience(configurationService.getLoginURI().toString())
                             .expirationTime(expiryDate)
                             .issueTime(NowHelper.now())
                             .notBeforeTime(NowHelper.now())

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -148,10 +148,6 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return Integer.parseInt(System.getenv().getOrDefault("CODE_AUTH_APP_ALLOWED_WINDOWS", "9"));
     }
 
-    public String getAuthAudience() {
-        return System.getenv().getOrDefault("AUTH_AUDIENCE", "UNKNOWN");
-    }
-
     public boolean isAuthOrchSplitEnabled() {
         return System.getenv().getOrDefault("SUPPORT_AUTH_ORCH_SPLIT", "false").equals("true");
     }


### PR DESCRIPTION
## What?
- Make `aud` value equal login URI value in the authorize lambda when it passes it within the JWT to authentication frontend

## Why?
- These were previously two separate config values
- However, the Login URI is always an acceptable value for aud and it simplifies our configuration approach
