### PR TITLE
AUT-1678: Remove unused AUTH_AUDIENCE env var in authorize endpoint

### DIFF
--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -26,7 +26,6 @@ module "authorize" {
   environment     = var.environment
 
   handler_environment_variables = {
-    AUTH_AUDIENCE                        = var.auth_audience
     DOMAIN_NAME                          = local.service_domain
     DOC_APP_API_ENABLED                  = var.doc_app_api_enabled
     DYNAMO_ENDPOINT                      = var.use_localstack ? var.lambda_dynamo_endpoint : null

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -464,11 +464,6 @@ variable "orch_client_id" {
   default = ""
 }
 
-variable "auth_audience" {
-  type    = string
-  default = ""
-}
-
 locals {
   default_performance_parameters = {
     memory          = var.endpoint_memory_size


### PR DESCRIPTION
## What?
- Remove unused AUTH_AUDIENCE env var in authorize endpoint

## Why?
- A previous commit decided to use the Login URI as the audience value
- We therefore no longer need to pass the environment variable separately as the ConfigurationService no longer tries to read it

## Related PRs
- Cleanup after: https://github.com/alphagov/di-authentication-api/pull/3370
