### PR TITLE
AUT-1678: Add no args constructor to Auth Code handler

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandler.java
@@ -56,6 +56,10 @@ public class AuthenticationAuthCodeHandler extends BaseFrontendHandler<AuthCodeR
         this.dynamoAuthCodeService = new DynamoAuthCodeService(configurationService);
     }
 
+    public AuthenticationAuthCodeHandler() {
+        this(ConfigurationService.getInstance());
+    }
+
     @Override
     public APIGatewayProxyResponseEvent handleRequestWithUserContext(
             APIGatewayProxyRequestEvent input,


### PR DESCRIPTION
## What?
- Add no args constructor to Auth Code handler

## Why?
- The lambda cannot be invoked without a no-args constructor leading to the following exception:

```Class uk.gov.di.authentication.frontendapi.lambda.AuthenticationAuthCodeHandler has no public zero-argument constructor: java.lang.Exception
java.lang.Exception: Class uk.gov.di.authentication.frontendapi.lambda.AuthenticationAuthCodeHandler has no public zero-argument constructor
Caused by: java.lang.NoSuchMethodException: uk.gov.di.authentication.frontendapi.lambda.AuthenticationAuthCodeHandler.<init>()
	at java.base/java.lang.Class.getConstructor0(Unknown Source)
	at java.base/java.lang.Class.getConstructor(Unknown Source)
```

- Auth Code Handler is the handler deployed via internal Auth API
- This will only be used once the auth-orch split occurs
- Until that point, the OIDC API auth code lambda is the only auth code lambda in use in production

## Related PRs
- Part of work to get orch-auth split working in Build:
    - https://github.com/alphagov/di-authentication-api/pull/3371
    - https://github.com/alphagov/di-authentication-api/pull/3370
    - https://github.com/alphagov/di-authentication-api/pull/3368
    - https://github.com/alphagov/di-authentication-api/pull/3367    
