### PR TITLE
AUT-1678: Add redis permissions to auth code lambda

### DIFF
--- a/ci/terraform/oidc/authentication-auth-code.tf
+++ b/ci/terraform/oidc/authentication-auth-code.tf
@@ -10,6 +10,7 @@ module "frontend_api_orch_auth_code_role" {
     aws_iam_policy.dynamo_user_write_access_policy.arn,
     aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
     aws_iam_policy.dynamo_auth_code_store_write_access_policy.arn,
+    aws_iam_policy.redis_parameter_policy.arn,
     module.oidc_txma_audit.access_policy_arn
   ]
 }
@@ -29,6 +30,7 @@ module "orch_auth_code" {
     ENVIRONMENT             = var.environment
     TXMA_AUDIT_QUEUE_URL    = module.oidc_txma_audit.queue_url
     INTERNAl_SECTOR_URI     = var.internal_sector_uri
+    REDIS_KEY               = local.redis_key
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.AuthenticationAuthCodeHandler::handleRequest"
 


### PR DESCRIPTION
- Relates to the auth code lambda for the internal Auth API, which is orchestration-facing
- This is NOT to be confused with the auth code lambda for OIDC API which is RP-facing

## What?

Please include a summary of the change.

## Why?

Please include reason for the change and any other relevant context.

## Related PRs

Please include links to PRs in other repositories relevant to this PR.
Delete this section if not needed.
