### PR TITLE
AUT-1720: don't try to export invalid tfvars

### DIFF
--- a/ci/terraform/account-management/read_secrets.sh
+++ b/ci/terraform/account-management/read_secrets.sh
@@ -24,6 +24,10 @@ if [ -z "${secrets}" ]; then
 fi
 
 while IFS=$'\t' read -r arn name; do
+  if [[ ! ${name} =~ ^[a-zA-Z0-9_]+$ ]]; then
+    printf '!! Invalid secret name: %s. Secret name must match /^[a-zA-Z0-9_]+/. Exiting' "${name}" >&2
+    exit 1
+  fi
   value=$(aws secretsmanager get-secret-value --secret-id "${arn}" | jq -r '.SecretString')
   export "TF_VAR_${name}"="${value}"
 done <<<"${secrets}"

--- a/ci/terraform/auth-external-api/read_secrets.sh
+++ b/ci/terraform/auth-external-api/read_secrets.sh
@@ -24,6 +24,10 @@ if [ -z "${secrets}" ]; then
 fi
 
 while IFS=$'\t' read -r arn name; do
+  if [[ ! ${name} =~ ^[a-zA-Z0-9_]+$ ]]; then
+    printf '!! Invalid secret name: %s. Secret name must match /^[a-zA-Z0-9_]+/. Exiting' "${name}" >&2
+    exit 1
+  fi
   value=$(aws secretsmanager get-secret-value --secret-id "${arn}" | jq -r '.SecretString')
   export "TF_VAR_${name}"="${value}"
 done <<<"${secrets}"

--- a/ci/terraform/oidc/read_secrets.sh
+++ b/ci/terraform/oidc/read_secrets.sh
@@ -24,6 +24,10 @@ if [ -z "${secrets}" ]; then
 fi
 
 while IFS=$'\t' read -r arn name; do
+  if [[ ! ${name} =~ ^[a-zA-Z0-9_]+$ ]]; then
+    printf '!! Invalid secret name: %s. Secret name must match /^[a-zA-Z0-9_]+/. Exiting' "${name}" >&2
+    exit 1
+  fi
   value=$(aws secretsmanager get-secret-value --secret-id "${arn}" | jq -r '.SecretString')
   export "TF_VAR_${name}"="${value}"
 done <<<"${secrets}"

--- a/ci/terraform/shared/read_secrets.sh
+++ b/ci/terraform/shared/read_secrets.sh
@@ -24,6 +24,10 @@ if [ -z "${secrets}" ]; then
 fi
 
 while IFS=$'\t' read -r arn name; do
+  if [[ ! ${name} =~ ^[a-zA-Z0-9_]+$ ]]; then
+    printf '!! Invalid secret name: %s. Secret name must match /^[a-zA-Z0-9_]+/. Exiting' "${name}" >&2
+    exit 1
+  fi
   value=$(aws secretsmanager get-secret-value --secret-id "${arn}" | jq -r '.SecretString')
   export "TF_VAR_${name}"="${value}"
 done <<<"${secrets}"

--- a/ci/terraform/test-services/read_secrets.sh
+++ b/ci/terraform/test-services/read_secrets.sh
@@ -24,6 +24,10 @@ if [ -z "${secrets}" ]; then
 fi
 
 while IFS=$'\t' read -r arn name; do
+  if [[ ! ${name} =~ ^[a-zA-Z0-9_]+$ ]]; then
+    printf '!! Invalid secret name: %s. Secret name must match /^[a-zA-Z0-9_]+/. Exiting' "${name}" >&2
+    exit 1
+  fi
   value=$(aws secretsmanager get-secret-value --secret-id "${arn}" | jq -r '.SecretString')
   export "TF_VAR_${name}"="${value}"
 done <<<"${secrets}"

--- a/ci/terraform/utils/read_secrets.sh
+++ b/ci/terraform/utils/read_secrets.sh
@@ -24,6 +24,10 @@ if [ -z "${secrets}" ]; then
 fi
 
 while IFS=$'\t' read -r arn name; do
+  if [[ ! ${name} =~ ^[a-zA-Z0-9_]+$ ]]; then
+    printf '!! Invalid secret name: %s. Secret name must match /^[a-zA-Z0-9_]+/. Exiting' "${name}" >&2
+    exit 1
+  fi
   value=$(aws secretsmanager get-secret-value --secret-id "${arn}" | jq -r '.SecretString')
   export "TF_VAR_${name}"="${value}"
 done <<<"${secrets}"

--- a/scripts/read_secrets__main.sh
+++ b/scripts/read_secrets__main.sh
@@ -24,6 +24,10 @@ if [ -z "${secrets}" ]; then
 fi
 
 while IFS=$'\t' read -r arn name; do
+  if [[ ! ${name} =~ ^[a-zA-Z0-9_]+$ ]]; then
+    printf '!! Invalid secret name: %s. Secret name must match /^[a-zA-Z0-9_]+/. Exiting' "${name}" >&2
+    exit 1
+  fi
   value=$(aws secretsmanager get-secret-value --secret-id "${arn}" | jq -r '.SecretString')
   export "TF_VAR_${name}"="${value}"
 done <<<"${secrets}"


### PR DESCRIPTION
## What?

Error and exit if an attempt would be made to export an envar with an invalid name.

## Why?

We shouldn't try to export a variable with an invalid character in the name (eg. `-`), as we know before trying that it will fail.

The secrets namespace we are parsing is exclusively for the consumption of this script, so invalid secrets are cause to fail to deploy.
