### PR TITLE
AUT-1473: send next batch of 200,000 emails

### DIFF
--- a/ci/terraform/utils/production-overrides.tfvars
+++ b/ci/terraform/utils/production-overrides.tfvars
@@ -23,4 +23,4 @@ bulk_user_email_batch_query_limit     = 2500
 bulk_user_email_max_batch_count       = 1
 bulk_user_email_batch_pause_duration  = 0
 
-bulk_user_email_send_schedule_expression = "cron(0/06 10-13 26,27 SEP ? 2023)"
+bulk_user_email_send_schedule_expression = "cron(0/06 7-14 28 SEP ? 2023)"


### PR DESCRIPTION
DO NOT MERGE before 3pm today as it will overwrite the run for today.

This will send emails every 6 minutes on the hours between 7 and 14 UTC (inclusive) on 28 September. This effectively means it will run between 8am and 4pm BST at a rate of 25,000 an hour. This should mean 200,000 emails sent.

