### PR TITLE
AUT 1678 load secrets from secretsmanager in sandpit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,6 @@ build
 .java-version
 **/terraform.log
 ci/terraform/**/*.plan
+ci/terraform/**/*.tfstate*
 logs/
 .vscode/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.DEFAULT_GOAL := help
+
+.PHONY: help
+help:
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+READ_SECRETS_SCRIPTS_IN_MODULES=$(shell find ci/terraform -type f -name read_secrets.sh)
+.PHONY: update_read_secrets_scripts
+update_read_secrets_scripts: ## Update read_secrets.sh in all terraform modules from scripts/read_secrets__main.sh
+update_read_secrets_scripts: $(READ_SECRETS_SCRIPTS_IN_MODULES)
+
+$(READ_SECRETS_SCRIPTS_IN_MODULES): scripts/read_secrets__main.sh
+	@cp -pvf $< $@

--- a/ci/terraform/account-management/read_secrets.sh
+++ b/ci/terraform/account-management/read_secrets.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
+[[ "${BASH_SOURCE[0]}" != "${0}" ]] || {
+  echo "Error: Script must be sourced, not executed"
+  exit 1
+}
+
 ENVIRONMENT="${1}"
 
 if [ "$ENVIRONMENT" = "dev" ]; then
@@ -12,6 +17,11 @@ secrets="$(
     --filter "Key=\"name\",Values=\"/deploy/${ENVIRONMENT}/\"" --region eu-west-2 |
     jq -r '.SecretList[]|[.ARN,(.Name|split("/")|last)]|@tsv'
 )"
+
+if [ -z "${secrets}" ]; then
+  printf '!! ERROR: No secrets found for environment %s. Exiting.\n' "${ENVIRONMENT}" >&2
+  exit 1
+fi
 
 while IFS=$'\t' read -r arn name; do
   value=$(aws secretsmanager get-secret-value --secret-id "${arn}" | jq -r '.SecretString')

--- a/ci/terraform/auth-external-api/read_secrets.sh
+++ b/ci/terraform/auth-external-api/read_secrets.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
+[[ "${BASH_SOURCE[0]}" != "${0}" ]] || {
+  echo "Error: Script must be sourced, not executed"
+  exit 1
+}
+
 ENVIRONMENT="${1}"
 
 if [ "$ENVIRONMENT" = "dev" ]; then
@@ -12,6 +17,11 @@ secrets="$(
     --filter "Key=\"name\",Values=\"/deploy/${ENVIRONMENT}/\"" --region eu-west-2 |
     jq -r '.SecretList[]|[.ARN,(.Name|split("/")|last)]|@tsv'
 )"
+
+if [ -z "${secrets}" ]; then
+  printf '!! ERROR: No secrets found for environment %s. Exiting.\n' "${ENVIRONMENT}" >&2
+  exit 1
+fi
 
 while IFS=$'\t' read -r arn name; do
   value=$(aws secretsmanager get-secret-value --secret-id "${arn}" | jq -r '.SecretString')

--- a/ci/terraform/oidc/dns.tf
+++ b/ci/terraform/oidc/dns.tf
@@ -100,6 +100,10 @@ output "oidc_api_name_servers" {
 
 resource "aws_route53_zone" "frontend_api_zone" {
   name = local.frontend_api_fqdn
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "aws_acm_certificate" "frontend_api" {

--- a/ci/terraform/oidc/read_secrets.sh
+++ b/ci/terraform/oidc/read_secrets.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
+[[ "${BASH_SOURCE[0]}" != "${0}" ]] || {
+  echo "Error: Script must be sourced, not executed"
+  exit 1
+}
+
 ENVIRONMENT="${1}"
 
 if [ "$ENVIRONMENT" = "dev" ]; then
@@ -12,6 +17,11 @@ secrets="$(
     --filter "Key=\"name\",Values=\"/deploy/${ENVIRONMENT}/\"" --region eu-west-2 |
     jq -r '.SecretList[]|[.ARN,(.Name|split("/")|last)]|@tsv'
 )"
+
+if [ -z "${secrets}" ]; then
+  printf '!! ERROR: No secrets found for environment %s. Exiting.\n' "${ENVIRONMENT}" >&2
+  exit 1
+fi
 
 while IFS=$'\t' read -r arn name; do
   value=$(aws secretsmanager get-secret-value --secret-id "${arn}" | jq -r '.SecretString')

--- a/ci/terraform/oidc/sandpit.tfvars
+++ b/ci/terraform/oidc/sandpit.tfvars
@@ -41,7 +41,6 @@ blocked_email_duration                    = 30
 otp_code_ttl_duration                     = 120
 email_acct_creation_otp_code_ttl_duration = 60
 
-txma_account_id                = "12345678"
 extended_feature_flags_enabled = true
 
 orch_client_id = "orchestrationAuth"

--- a/ci/terraform/shared/read_secrets.sh
+++ b/ci/terraform/shared/read_secrets.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
+[[ "${BASH_SOURCE[0]}" != "${0}" ]] || {
+  echo "Error: Script must be sourced, not executed"
+  exit 1
+}
+
 ENVIRONMENT="${1}"
 
 if [ "$ENVIRONMENT" = "dev" ]; then
@@ -12,6 +17,11 @@ secrets="$(
     --filter "Key=\"name\",Values=\"/deploy/${ENVIRONMENT}/\"" --region eu-west-2 |
     jq -r '.SecretList[]|[.ARN,(.Name|split("/")|last)]|@tsv'
 )"
+
+if [ -z "${secrets}" ]; then
+  printf '!! ERROR: No secrets found for environment %s. Exiting.\n' "${ENVIRONMENT}" >&2
+  exit 1
+fi
 
 while IFS=$'\t' read -r arn name; do
   value=$(aws secretsmanager get-secret-value --secret-id "${arn}" | jq -r '.SecretString')

--- a/ci/terraform/test-services/read_secrets.sh
+++ b/ci/terraform/test-services/read_secrets.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
+[[ "${BASH_SOURCE[0]}" != "${0}" ]] || {
+  echo "Error: Script must be sourced, not executed"
+  exit 1
+}
+
 ENVIRONMENT="${1}"
 
 if [ "$ENVIRONMENT" = "dev" ]; then
@@ -12,6 +17,11 @@ secrets="$(
     --filter "Key=\"name\",Values=\"/deploy/${ENVIRONMENT}/\"" --region eu-west-2 |
     jq -r '.SecretList[]|[.ARN,(.Name|split("/")|last)]|@tsv'
 )"
+
+if [ -z "${secrets}" ]; then
+  printf '!! ERROR: No secrets found for environment %s. Exiting.\n' "${ENVIRONMENT}" >&2
+  exit 1
+fi
 
 while IFS=$'\t' read -r arn name; do
   value=$(aws secretsmanager get-secret-value --secret-id "${arn}" | jq -r '.SecretString')

--- a/ci/terraform/utils/read_secrets.sh
+++ b/ci/terraform/utils/read_secrets.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
+[[ "${BASH_SOURCE[0]}" != "${0}" ]] || {
+  echo "Error: Script must be sourced, not executed"
+  exit 1
+}
+
 ENVIRONMENT="${1}"
 
 if [ "$ENVIRONMENT" = "dev" ]; then
@@ -12,6 +17,11 @@ secrets="$(
     --filter "Key=\"name\",Values=\"/deploy/${ENVIRONMENT}/\"" --region eu-west-2 |
     jq -r '.SecretList[]|[.ARN,(.Name|split("/")|last)]|@tsv'
 )"
+
+if [ -z "${secrets}" ]; then
+  printf '!! ERROR: No secrets found for environment %s. Exiting.\n' "${ENVIRONMENT}" >&2
+  exit 1
+fi
 
 while IFS=$'\t' read -r arn name; do
   value=$(aws secretsmanager get-secret-value --secret-id "${arn}" | jq -r '.SecretString')

--- a/scripts/create_update_sandpit_secret.sh
+++ b/scripts/create_update_sandpit_secret.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+FORCE="${FORCE:-false}"
+
+name="${1}"
+incoming_value="${2:-}"
+value=""
+
+if [[ ${name} =~ ^[a-zA-Z0-9_]+= ]]; then
+    name="${1%=*}"
+    value="${1#*=}"
+fi
+if [[ ${name} =~ [^a-zA-Z0-9_] ]]; then
+    printf '\e[31m!\e[0m Secret name must match /^[a-zA-Z0-9_]$/'
+    exit 1
+fi
+
+if [ -n "${incoming_value}" ]; then
+    value="${incoming_value}"
+fi
+
+[ -z "${value}" ] && read -rp "Enter value for ${name}: " value
+
+secret_name="/deploy/sandpit/${name}"
+
+printf '\e[36m*\e[0m Secret Name: "\e[33m%s\e[0m", Value: "\e[36m%s\e[0m"\n\n' "${secret_name}" "${value}"
+
+if [[ "${FORCE}" != "true" ]]; then
+    read -r -p "Press enter to continue, Ctrl+C to abort..."
+fi
+
+verb="created"
+
+create="$(aws secretsmanager create-secret \
+    --name "${secret_name}" \
+    --description "${name}" \
+    --secret-string "${value}" \
+    --region eu-west-2 \
+    --tags '[{"Key": "Name", "Value": "'"${name}"'"}, {"Key": "Environment", "Value": "sandpit"}]' 2>&1)" ||
+    {
+        if [[ ${create} =~ 'already exists.'$ ]]; then
+            verb="updated"
+        else
+            printf '\e[31m!\e[0m Failed to create secret "%s"\n%s' "${secret_name}" "${create}"
+            exit 1
+        fi
+    }
+
+if [[ "${verb}" == "updated" ]]; then
+    secret_arn="$(aws secretsmanager list-secrets \
+        --filter "Key=\"name\",Values=\"${secret_name}\"" --region eu-west-2 |
+        jq -r '.SecretList[0].ARN')"
+    if [ -z "${secret_arn}" ]; then
+        exit 1
+    fi
+    existing_value="$(aws secretsmanager get-secret-value \
+        --secret-id "${secret_arn}" --region eu-west-2 |
+        jq -r '.SecretString')"
+
+    printf '\e[36m*\e[0m Secret "\e[33m%s\e[0m" already exists with value "\e[36m%s\e[0m". Updating it with the provided value.\n' "${secret_name}" "${existing_value}"
+
+    update="$(aws secretsmanager update-secret \
+        --secret-id "${secret_arn}" \
+        --description "${name}" \
+        --secret-string "${value}" \
+        --region eu-west-2 2>&1)" ||
+        {
+            printf '\e[31m!\e[0m Failed to update secret "%s"\n%s' "${secret_name}" "${update}"
+            exit 1
+        }
+    printf '\e[36m*\e[0m Updated secret value\n'
+
+    tag="$(aws secretsmanager tag-resource \
+        --secret-id "${secret_arn}" \
+        --tags '[{"Key": "Name", "Value": "'"${name}"'"}, {"Key": "Environment", "Value": "sandpit"}]' 2>&1)" ||
+        {
+            printf '\e[31m!\e[0m Failed to tag secret "%s"\n%s' "${secret_name}" "${tag}"
+            exit 1
+        }
+    printf '\e[36m*\e[0m Updated secret tags\n'
+fi
+
+printf '\e[32m✓\e[0m Secret "\e[33m%s\e[0m" %s successfully\n' "${secret_name}" "${verb}"

--- a/scripts/read_secrets__main.sh
+++ b/scripts/read_secrets__main.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -euo pipefail
+
+[[ "${BASH_SOURCE[0]}" != "${0}" ]] || {
+  echo "Error: Script must be sourced, not executed"
+  exit 1
+}
+
+ENVIRONMENT="${1}"
+
+if [ "$ENVIRONMENT" = "dev" ]; then
+  ENVIRONMENT="build"
+fi
+
+secrets="$(
+  aws secretsmanager list-secrets \
+    --filter "Key=\"name\",Values=\"/deploy/${ENVIRONMENT}/\"" --region eu-west-2 |
+    jq -r '.SecretList[]|[.ARN,(.Name|split("/")|last)]|@tsv'
+)"
+
+if [ -z "${secrets}" ]; then
+  printf '!! ERROR: No secrets found for environment %s. Exiting.\n' "${ENVIRONMENT}" >&2
+  exit 1
+fi
+
+while IFS=$'\t' read -r arn name; do
+  value=$(aws secretsmanager get-secret-value --secret-id "${arn}" | jq -r '.SecretString')
+  export "TF_VAR_${name}"="${value}"
+done <<<"${secrets}"


### PR DESCRIPTION
## What?

- AUT-1678: If no secrets are found, exit with error
- chore: add Makefile for performing common tasks
- chore: add delete protection to auth. hosted zone
- chore: Pull sandpit tfvars from secrets manager
- chore: ignore files generated by terraform

## Why?

This brings sandpit into alignment with the other environments.

Also, `auth.x` hosted zones should have deletion protection now we have dns correctly delegated to us.

## Related PRs

Please include links to PRs in other repositories relevant to this PR.
Delete this section if not needed.
