### PR TITLE
AUT-1473: Send 200,000 emails a day Mon - Weds next week

### DIFF
--- a/ci/terraform/utils/production-overrides.tfvars
+++ b/ci/terraform/utils/production-overrides.tfvars
@@ -23,4 +23,4 @@ bulk_user_email_batch_query_limit     = 2500
 bulk_user_email_max_batch_count       = 1
 bulk_user_email_batch_pause_duration  = 0
 
-bulk_user_email_send_schedule_expression = "cron(0/06 7-14 28 SEP ? 2023)"
+bulk_user_email_send_schedule_expression = "cron(0/06 8-15 2-4 OCT ? 2023)"


### PR DESCRIPTION
This will send emails every 6 minutes on the hours between 8 and 15 UTC (inclusive) on 2nd, 3rd and 4th October. This effectively means it will run between 9am and 5pm BST at a rate of 25,000 an hour. This should mean 200,000 emails sent on each day.