### PR TITLE
BAU: Bump google-java-format

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -175,7 +175,7 @@ allprojects {
 spotless {
     java {
         target "**/*.java"
-        googleJavaFormat("1.13.0").aosp()
+        googleJavaFormat("1.18.0").aosp()
         importOrder "", "javax", "java", "\\#"
     }
 

--- a/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/services/DocAppCriServiceTest.java
+++ b/doc-checking-app-api/src/test/java/uk/gov/di/authentication/app/services/DocAppCriServiceTest.java
@@ -145,7 +145,9 @@ class DocAppCriServiceTest {
 
     @Test
     void shouldCallUserInfoEndpointAndReturn200()
-            throws IOException, JOSEException, NoSuchAlgorithmException,
+            throws IOException,
+                    JOSEException,
+                    NoSuchAlgorithmException,
                     UnsuccessfulCredentialResponseException {
         var keyPair = KeyPairGenerator.getInstance("EC").generateKeyPair();
         var signedJwtOne = generateSignedJWT(new JWTClaimsSet.Builder().build(), keyPair);
@@ -176,7 +178,9 @@ class DocAppCriServiceTest {
 
     @Test
     void shouldRetryCallToUserInfoAndReturn200IfFirstCallFails()
-            throws NoSuchAlgorithmException, JOSEException, IOException,
+            throws NoSuchAlgorithmException,
+                    JOSEException,
+                    IOException,
                     UnsuccessfulCredentialResponseException {
         var keyPair = KeyPairGenerator.getInstance("EC").generateKeyPair();
         var signedJwtOne = generateSignedJWT(new JWTClaimsSet.Builder().build(), keyPair);

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/KmsKeyExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/KmsKeyExtension.java
@@ -58,6 +58,7 @@ public class KmsKeyExtension extends BaseAwsResourceExtension implements BeforeA
             }
         }
     }
+
     // https://github.com/aws/aws-sdk/issues/125
     @SuppressWarnings("deprecation")
     protected void createTokenSigningKey(String keyAlias) {

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/TokenServiceTest.java
@@ -181,7 +181,9 @@ public class TokenServiceTest {
 
     @Test
     void shouldOnlyIncludeIdentityClaimsInAccessTokenWhenRequested()
-            throws ParseException, JOSEException, Json.JsonException,
+            throws ParseException,
+                    JOSEException,
+                    Json.JsonException,
                     com.nimbusds.oauth2.sdk.ParseException {
         var claimsSetRequest = new ClaimsSetRequest().add("nickname").add("birthdate");
         var oidcClaimsRequest = new OIDCClaimsRequest().withUserInfoClaimsRequest(claimsSetRequest);


### PR DESCRIPTION
## What?

- Upgrade google-java-format from v1.13.0 to v1.18.0.
- Format existing code (`spotlessApply`) with new google-java-format version.

## Why?

Fixes `spotlessApply` error due to `record` keyword in .../authentication/frontendapi/entity/AuthCodeResponse.java
