### PR TITLE
AUT-1678: Align auth external api state key in sandpit

### DIFF
--- a/ci/terraform/auth-external-api/sandpit.hcl
+++ b/ci/terraform/auth-external-api/sandpit.hcl
@@ -1,4 +1,4 @@
 bucket  = "digital-identity-dev-tfstate"
-key     = "sandpit-auth-ext-api-terraform.tfstate"
+key     = "sandpit-auth-external-api-terraform.tfstate"
 encrypt = true
 region  = "eu-west-2"

--- a/ci/terraform/oidc/integration.tfvars
+++ b/ci/terraform/oidc/integration.tfvars
@@ -29,4 +29,4 @@ AZUx4RCDu+VWAZpPi1NaF5XWvkFNFwH+MyLkATh90UEJDe+ayKW6AXFcRQ==
 EOT
 
 orch_client_id          = "orchestrationAuth"
-support_auth_orch_split = true
+support_auth_orch_split = false

--- a/ci/terraform/oidc/shared.tf
+++ b/ci/terraform/oidc/shared.tf
@@ -18,7 +18,7 @@ data "terraform_remote_state" "auth-ext-api" {
   backend = "s3"
   config = {
     bucket                      = var.shared_state_bucket
-    key                         = "${var.environment}-auth-ext-api-terraform.tfstate"
+    key                         = "${var.environment}-auth-external-api-terraform.tfstate"
     role_arn                    = var.deployer_role_arn
     region                      = var.aws_region
     endpoint                    = var.use_localstack ? "http://localhost:45678" : null


### PR DESCRIPTION
## What?

Align sandpit auth-external-api terraform state key with the other environments to avoid build pipeline errors.

## Why?

Pipeline is creating auth-external-api state keys as enn-auth-external-api-terraform.tfstate, whereas sandpit was using env-auth-ext-api-terraform.tfstate. 

