### PR TITLE
Aut 1768: Resend bulk email to users with notify errors

### DIFF
--- a/ci/terraform/utils/bulk_user_email_send_lambda.tf
+++ b/ci/terraform/utils/bulk_user_email_send_lambda.tf
@@ -52,6 +52,7 @@ resource "aws_lambda_function" "bulk_user_email_send_lambda" {
       BULK_USER_EMAIL_BATCH_PAUSE_DURATION          = var.bulk_user_email_batch_pause_duration
       BULK_USER_EMAIL_EMAIL_SENDING_ENABLED         = var.bulk_user_email_email_sending_enabled
       BULK_USER_EMAIL_INCLUDED_TERMS_AND_CONDITIONS = var.bulk_user_email_included_terms_and_conditions
+      BULK_USER_EMAIL_SEND_MODE                     = var.bulk_user_email_send_mode
     })
   }
 

--- a/ci/terraform/utils/production-overrides.tfvars
+++ b/ci/terraform/utils/production-overrides.tfvars
@@ -16,6 +16,7 @@ bulk_user_email_audience_loader_schedule_enabled  = false
 bulk_user_email_included_terms_and_conditions     = "1.0,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8"
 bulk_user_email_max_audience_load_user_batch_size = 0
 bulk_user_email_max_audience_load_user_count      = 0
+bulk_user_email_send_mode                         = "PENDING"
 
 bulk_user_email_send_schedule_enabled = true
 bulk_user_email_email_sending_enabled = true

--- a/ci/terraform/utils/variables.tf
+++ b/ci/terraform/utils/variables.tf
@@ -124,6 +124,11 @@ variable "bulk_user_email_included_terms_and_conditions" {
   default = null
 }
 
+variable "bulk_user_email_send_mode" {
+  type    = string
+  default = "PENDING"
+}
+
 variable "bulk_user_email_send_schedule_expression" {
   type        = string
   description = "Run at 15:00 every Friday in 2049.  Designed not to trigger, replace with desired expression."

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -120,6 +120,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         }
     }
 
+    public String getBulkEmailUserSendMode() {
+        return systemService.getOrDefault("BULK_USER_EMAIL_SEND_MODE", "PENDING");
+    }
+
     public long getDefaultOtpCodeExpiry() {
         return Long.parseLong(System.getenv().getOrDefault("DEFAULT_OTP_CODE_EXPIRY", "900"));
     }

--- a/utils/src/main/java/uk/gov/di/authentication/utils/exceptions/UnrecognisedSendModeException.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/exceptions/UnrecognisedSendModeException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.authentication.utils.exceptions;
+
+public class UnrecognisedSendModeException extends RuntimeException {
+    public UnrecognisedSendModeException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
When sending the bulk T&C emails, we record a status against the user, noting whether:

* The email was sent (but we may still have received a failed delivery receipt): EMAIL_SENT
* The user is still pending to send to: PENDING
* There was an error in the notify client: ERROR_SENDING_EMAIL
* The user has recently accepted the latest T&Cs: TERMS_ACCEPTED_RECENTLY
* The account has been recently deleted: ACCOUNT_NOT_FOUND

In the cases where there was an error in the Notify client (ERROR_SENDING_EMAIL), we want to retry. This was the case, for example, during an incident where Notify was experiencing degraded api service. This adds the ability to resend to these users, based on the value of a feature flag being set to `NOTIFY_ERROR_RETRIES`
