### PR TITLE
Configure one more batch at 11am on 5th October

### DIFF
--- a/ci/terraform/utils/production-overrides.tfvars
+++ b/ci/terraform/utils/production-overrides.tfvars
@@ -23,4 +23,4 @@ bulk_user_email_batch_query_limit     = 2500
 bulk_user_email_max_batch_count       = 1
 bulk_user_email_batch_pause_duration  = 0
 
-bulk_user_email_send_schedule_expression = "cron(0/06 8-15 2-4 OCT ? 2023)"
+bulk_user_email_send_schedule_expression = "cron(0 10 5 OCT ? 2023)"


### PR DESCRIPTION
Should run a single batch of bulk emails at 10am UTC / 11am BST

We have about 1500 left to get through, so a single batch of max 2,500 will see us through.