### PR TITLE
Increase default memory size to 1.5GiB

### DIFF
--- a/ci/terraform/account-management/build-overrides.tfvars
+++ b/ci/terraform/account-management/build-overrides.tfvars
@@ -2,7 +2,7 @@ internal_sector_uri = "https://identity.build.account.gov.uk"
 
 lambda_max_concurrency = 0
 lambda_min_concurrency = 1
-endpoint_memory_size   = 1024
+endpoint_memory_size   = 1536
 scaling_trigger        = 0.6
 
 logging_endpoint_arns = [

--- a/ci/terraform/account-management/integration-overrides.tfvars
+++ b/ci/terraform/account-management/integration-overrides.tfvars
@@ -2,7 +2,7 @@ internal_sector_uri = "https://identity.integration.account.gov.uk"
 
 lambda_max_concurrency = 0
 lambda_min_concurrency = 1
-endpoint_memory_size   = 1024
+endpoint_memory_size   = 1536
 scaling_trigger        = 0.6
 
 logging_endpoint_arns = [

--- a/ci/terraform/account-management/production-overrides.tfvars
+++ b/ci/terraform/account-management/production-overrides.tfvars
@@ -22,7 +22,7 @@ performance_tuning = {
 
 lambda_max_concurrency = 10
 lambda_min_concurrency = 3
-endpoint_memory_size   = 1024
+endpoint_memory_size   = 1536
 scaling_trigger        = 0.6
 
 logging_endpoint_arns = [

--- a/ci/terraform/account-management/sandpit.tfvars
+++ b/ci/terraform/account-management/sandpit.tfvars
@@ -8,7 +8,7 @@ dns_state_role      = null
 logging_endpoint_enabled = false
 logging_endpoint_arns    = []
 
-endpoint_memory_size   = 1024
+endpoint_memory_size   = 1536
 lambda_max_concurrency = 0
 lambda_min_concurrency = 0
 

--- a/ci/terraform/account-management/staging-overrides.tfvars
+++ b/ci/terraform/account-management/staging-overrides.tfvars
@@ -1,7 +1,7 @@
 internal_sector_uri    = "https://identity.staging.account.gov.uk"
 lambda_max_concurrency = 3
 lambda_min_concurrency = 1
-endpoint_memory_size   = 1024
+endpoint_memory_size   = 1536
 scaling_trigger        = 0.6
 
 logging_endpoint_arns = [

--- a/ci/terraform/account-management/variables.tf
+++ b/ci/terraform/account-management/variables.tf
@@ -162,7 +162,7 @@ variable "localstack_endpoint" {
 }
 
 variable "endpoint_memory_size" {
-  default = 1024
+  default = 1536
   type    = number
 }
 

--- a/ci/terraform/auth-external-api/build.tfvars
+++ b/ci/terraform/auth-external-api/build.tfvars
@@ -6,7 +6,7 @@ logging_endpoint_arns = [
 internal_sector_uri    = "https://identity.build.account.gov.uk"
 lambda_max_concurrency = 0
 lambda_min_concurrency = 1
-endpoint_memory_size   = 1024
+endpoint_memory_size   = 1536
 scaling_trigger        = 0.6
 
 orch_client_id                  = "orchestrationAuth"

--- a/ci/terraform/auth-external-api/integration.tfvars
+++ b/ci/terraform/auth-external-api/integration.tfvars
@@ -6,7 +6,7 @@ logging_endpoint_arns = [
 internal_sector_uri    = "https://identity.integration.account.gov.uk"
 lambda_max_concurrency = 0
 lambda_min_concurrency = 1
-endpoint_memory_size   = 1024
+endpoint_memory_size   = 1536
 scaling_trigger        = 0.6
 
 orch_client_id                  = "orchestrationAuth"

--- a/ci/terraform/auth-external-api/production.tfvars
+++ b/ci/terraform/auth-external-api/production.tfvars
@@ -7,7 +7,7 @@ logging_endpoint_arns = [
 internal_sector_uri    = "https://identity.account.gov.uk"
 lambda_max_concurrency = 10
 lambda_min_concurrency = 3
-endpoint_memory_size   = 1024
+endpoint_memory_size   = 1536
 scaling_trigger        = 0.6
 
 orch_client_id                  = "orchestrationAuth"

--- a/ci/terraform/auth-external-api/sandpit.tfvars
+++ b/ci/terraform/auth-external-api/sandpit.tfvars
@@ -5,7 +5,7 @@ logging_endpoint_arns  = []
 internal_sector_uri    = "https://identity.sandpit.account.gov.uk"
 lambda_max_concurrency = 0
 lambda_min_concurrency = 0
-endpoint_memory_size   = 1024
+endpoint_memory_size   = 1536
 
 orch_client_id                  = "orchestrationAuth"
 orch_to_auth_public_signing_key = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAESyWJU5s5F4jSovHsh9y133/Ogf5Px78OrfDJqiMMI2p8Warbq0ppcbWvbihK6rAXTH7bPIeOHOeU9cKAEl5NdQ=="

--- a/ci/terraform/auth-external-api/staging.tfvars
+++ b/ci/terraform/auth-external-api/staging.tfvars
@@ -6,7 +6,7 @@ logging_endpoint_arns = [
 internal_sector_uri    = "https://identity.staging.account.gov.uk"
 lambda_max_concurrency = 10
 lambda_min_concurrency = 3
-endpoint_memory_size   = 1024
+endpoint_memory_size   = 1536
 scaling_trigger        = 0.6
 
 orch_client_id                  = "orchestrationAuth"

--- a/ci/terraform/auth-external-api/variables.tf
+++ b/ci/terraform/auth-external-api/variables.tf
@@ -82,7 +82,7 @@ variable "lambda_min_concurrency" {
 }
 
 variable "endpoint_memory_size" {
-  default = 1024
+  default = 1536
   type    = number
 }
 

--- a/ci/terraform/delivery-receipts/variables.tf
+++ b/ci/terraform/delivery-receipts/variables.tf
@@ -79,7 +79,7 @@ variable "cloudwatch_log_retention" {
 }
 
 variable "endpoint_memory_size" {
-  default = 1024
+  default = 1536
   type    = number
 }
 

--- a/ci/terraform/oidc/build-overrides.tfvars
+++ b/ci/terraform/oidc/build-overrides.tfvars
@@ -54,5 +54,5 @@ performance_tuning = {
 }
 lambda_max_concurrency = 0
 lambda_min_concurrency = 1
-endpoint_memory_size   = 1024
+endpoint_memory_size   = 1536
 scaling_trigger        = 0.6

--- a/ci/terraform/oidc/integration-overrides.tfvars
+++ b/ci/terraform/oidc/integration-overrides.tfvars
@@ -72,5 +72,5 @@ performance_tuning = {
 }
 lambda_max_concurrency = 0
 lambda_min_concurrency = 1
-endpoint_memory_size   = 1024
+endpoint_memory_size   = 1536
 scaling_trigger        = 0.6

--- a/ci/terraform/oidc/production-overrides.tfvars
+++ b/ci/terraform/oidc/production-overrides.tfvars
@@ -96,7 +96,7 @@ performance_tuning = {
 }
 lambda_max_concurrency = 10
 lambda_min_concurrency = 3
-endpoint_memory_size   = 1024
+endpoint_memory_size   = 1536
 scaling_trigger        = 0.6
 
 logging_endpoint_arns = [

--- a/ci/terraform/oidc/sandpit.tfvars
+++ b/ci/terraform/oidc/sandpit.tfvars
@@ -35,7 +35,7 @@ spot_enabled                                 = false
 
 lambda_max_concurrency = 0
 lambda_min_concurrency = 0
-endpoint_memory_size   = 1024
+endpoint_memory_size   = 1536
 
 blocked_email_duration                    = 30
 otp_code_ttl_duration                     = 120

--- a/ci/terraform/oidc/staging-overrides.tfvars
+++ b/ci/terraform/oidc/staging-overrides.tfvars
@@ -82,7 +82,7 @@ performance_tuning = {
 }
 lambda_max_concurrency = 10
 lambda_min_concurrency = 3
-endpoint_memory_size   = 1024
+endpoint_memory_size   = 1536
 scaling_trigger        = 0.6
 
 logging_endpoint_arns = [

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -304,7 +304,7 @@ variable "internal_sector_uri" {
 }
 
 variable "endpoint_memory_size" {
-  default = 1024
+  default = 1536
   type    = number
 }
 


### PR DESCRIPTION
## What?

Increase default memory size to 1.5GiB to provide enough CPU for the Dynatrace instrumentation library.

## Why?

The Dynatrace instrumentation library won't run if a Java Lambda function has less than 1500MB RAM because it requires enough CPU to run.
