### PR TITLE
BAU: Switch off Dynatrace in build

### DIFF
--- a/ci/terraform/modules/endpoint-module/lambda.tf
+++ b/ci/terraform/modules/endpoint-module/lambda.tf
@@ -120,6 +120,6 @@ resource "aws_appautoscaling_policy" "provisioned-concurrency-policy" {
 }
 
 locals {
-  deploy_dynatrace = var.environment != "production"
+  deploy_dynatrace = contains(["integration", "staging"], var.environment)
   lambda_layers    = flatten(local.deploy_dynatrace ? [local.dynatrace_layer_arn] : [])
 }


### PR DESCRIPTION
## What?

Switch off Dynatrace in build.

## Why?

And keep switched-off in production.
To see if Dynatrace is causing acceptance test issues in build.

## Related PRs

#3414 
