### PR TITLE
Aut 1253/orches modify userinfo and token endpoint

### DIFF
--- a/oidc-api/build.gradle
+++ b/oidc-api/build.gradle
@@ -23,7 +23,8 @@ dependencies {
             configurations.cloudwatch,
             project(":shared"),
             project(":client-registry-api"),
-            project(":doc-checking-app-api")
+            project(":doc-checking-app-api"),
+            project(":auth-external-api")
 
     testImplementation configurations.tests,
             configurations.lambda_tests,

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandler.java
@@ -38,7 +38,6 @@ public class UserInfoHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     private static final Logger LOG = LogManager.getLogger(UserInfoHandler.class);
-    private final AuthenticationUserInfoStorageService userInfoStorageService;
     private final ConfigurationService configurationService;
     private final UserInfoService userInfoService;
     private final AccessTokenService accessTokenService;
@@ -48,13 +47,11 @@ public class UserInfoHandler
             ConfigurationService configurationService,
             UserInfoService userInfoService,
             AccessTokenService accessTokenService,
-            AuditService auditService,
-            AuthenticationUserInfoStorageService userInfoStorageService) {
+            AuditService auditService) {
         this.configurationService = configurationService;
         this.userInfoService = userInfoService;
         this.accessTokenService = accessTokenService;
         this.auditService = auditService;
-        this.userInfoStorageService = userInfoStorageService;
     }
 
     public UserInfoHandler() {
@@ -81,8 +78,6 @@ public class UserInfoHandler
                                         new KmsConnectionService(configurationService)),
                                 configurationService));
         this.auditService = new AuditService(configurationService);
-        this.userInfoStorageService =
-                new AuthenticationUserInfoStorageService(configurationService);
     }
 
     @Override

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandler.java
@@ -13,6 +13,7 @@ import uk.gov.di.authentication.app.services.DynamoDocAppService;
 import uk.gov.di.authentication.oidc.domain.OidcAuditableEvent;
 import uk.gov.di.authentication.oidc.entity.AccessTokenInfo;
 import uk.gov.di.authentication.oidc.services.AccessTokenService;
+import uk.gov.di.authentication.oidc.services.AuthenticationUserInfoStorageService;
 import uk.gov.di.authentication.oidc.services.UserInfoService;
 import uk.gov.di.authentication.shared.exceptions.AccessTokenException;
 import uk.gov.di.authentication.shared.services.AuditService;
@@ -37,6 +38,7 @@ public class UserInfoHandler
         implements RequestHandler<APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent> {
 
     private static final Logger LOG = LogManager.getLogger(UserInfoHandler.class);
+    private final AuthenticationUserInfoStorageService userInfoStorageService;
     private final ConfigurationService configurationService;
     private final UserInfoService userInfoService;
     private final AccessTokenService accessTokenService;
@@ -46,11 +48,13 @@ public class UserInfoHandler
             ConfigurationService configurationService,
             UserInfoService userInfoService,
             AccessTokenService accessTokenService,
-            AuditService auditService) {
+            AuditService auditService,
+            AuthenticationUserInfoStorageService userInfoStorageService) {
         this.configurationService = configurationService;
         this.userInfoService = userInfoService;
         this.accessTokenService = accessTokenService;
         this.auditService = auditService;
+        this.userInfoStorageService = userInfoStorageService;
     }
 
     public UserInfoHandler() {
@@ -65,7 +69,8 @@ public class UserInfoHandler
                         new DynamoIdentityService(configurationService),
                         new DynamoDocAppService(configurationService),
                         new CloudwatchMetricsService(),
-                        configurationService);
+                        configurationService,
+                        new AuthenticationUserInfoStorageService(configurationService));
         this.accessTokenService =
                 new AccessTokenService(
                         new RedisConnectionService(configurationService),
@@ -76,6 +81,8 @@ public class UserInfoHandler
                                         new KmsConnectionService(configurationService)),
                                 configurationService));
         this.auditService = new AuditService(configurationService);
+        this.userInfoStorageService =
+                new AuthenticationUserInfoStorageService(configurationService);
     }
 
     @Override

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/UserInfoService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/UserInfoService.java
@@ -1,6 +1,8 @@
 package uk.gov.di.authentication.oidc.services;
 
 import com.nimbusds.oauth2.sdk.id.Subject;
+import com.nimbusds.oauth2.sdk.token.BearerTokenError;
+import com.nimbusds.oauth2.sdk.util.JSONObjectUtils;
 import com.nimbusds.openid.connect.sdk.OIDCScopeValue;
 import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import net.minidev.json.JSONArray;
@@ -11,6 +13,7 @@ import uk.gov.di.authentication.oidc.entity.AccessTokenInfo;
 import uk.gov.di.authentication.oidc.exceptions.UserInfoException;
 import uk.gov.di.authentication.shared.entity.CustomScopeValue;
 import uk.gov.di.authentication.shared.entity.ValidClaims;
+import uk.gov.di.authentication.shared.exceptions.AccessTokenException;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
@@ -23,7 +26,7 @@ import java.util.Map;
 import java.util.Objects;
 
 public class UserInfoService {
-
+    private final AuthenticationUserInfoStorageService userInfoStorageService;
     private final AuthenticationService authenticationService;
     private final DynamoIdentityService identityService;
     private final DynamoDocAppService dynamoDocAppService;
@@ -38,12 +41,14 @@ public class UserInfoService {
             DynamoIdentityService identityService,
             DynamoDocAppService dynamoDocAppService,
             CloudwatchMetricsService cloudwatchMetricsService,
-            ConfigurationService configurationService) {
+            ConfigurationService configurationService,
+            AuthenticationUserInfoStorageService userInfoStorageService) {
         this.authenticationService = authenticationService;
         this.identityService = identityService;
         this.dynamoDocAppService = dynamoDocAppService;
         this.cloudwatchMetricsService = cloudwatchMetricsService;
         this.configurationService = configurationService;
+        this.userInfoStorageService = userInfoStorageService;
     }
 
     public String calculateSubjectForAudit(AccessTokenInfo accessTokenInfo) {
@@ -64,30 +69,71 @@ public class UserInfoService {
         }
     }
 
-    public UserInfo populateUserInfo(AccessTokenInfo accessTokenInfo) {
+    public UserInfo populateUserInfo(AccessTokenInfo accessTokenInfo) throws AccessTokenException {
         LOG.info("Populating UserInfo");
-        var userInfo = new UserInfo(new Subject(accessTokenInfo.getSubject()));
+        UserInfo userInfo = new UserInfo(new Subject(accessTokenInfo.getSubject()));
         if (accessTokenInfo.getScopes().contains(CustomScopeValue.DOC_CHECKING_APP.getValue())) {
             return populateDocAppUserInfo(accessTokenInfo, userInfo);
         }
-        var userProfile =
-                authenticationService.getUserProfileFromSubject(
-                        accessTokenInfo.getAccessTokenStore().getInternalSubjectId());
 
-        if (accessTokenInfo.getScopes().contains(OIDCScopeValue.EMAIL.getValue())) {
-            userInfo.setEmailAddress(userProfile.getEmail());
-            userInfo.setEmailVerified(userProfile.isEmailVerified());
+        if (configurationService.isAuthOrchSplitEnabled()) {
+            UserInfo tmpUserInfo;
+            try {
+                var authUserInfo =
+                        userInfoStorageService.getAuthenticationUserInfoData(
+                                accessTokenInfo.getAccessTokenStore().getInternalSubjectId());
+
+                if (authUserInfo.isPresent()) {
+                    tmpUserInfo =
+                            new UserInfo(JSONObjectUtils.parse(authUserInfo.get().getUserInfo()));
+                } else {
+                    throw new AccessTokenException(
+                            "Unable to find subject", BearerTokenError.INVALID_TOKEN);
+                }
+            } catch (Exception e) {
+                throw new AccessTokenException(
+                        "Unable to get user info for Subject", BearerTokenError.INVALID_TOKEN);
+            }
+
+            if (accessTokenInfo.getScopes().contains(OIDCScopeValue.EMAIL.getValue())) {
+                userInfo.setEmailAddress(tmpUserInfo.getEmailAddress());
+                userInfo.setEmailVerified(tmpUserInfo.getEmailVerified());
+            }
+            if (accessTokenInfo.getScopes().contains(OIDCScopeValue.PHONE.getValue())) {
+                userInfo.setPhoneNumber(tmpUserInfo.getPhoneNumber());
+                userInfo.setPhoneNumberVerified(tmpUserInfo.getPhoneNumberVerified());
+            }
+            if (accessTokenInfo.getScopes().contains(CustomScopeValue.GOVUK_ACCOUNT.getValue())) {
+                userInfo.setClaim("legacy_subject_id", tmpUserInfo.getClaim("legacy_subject_id"));
+            }
+            if (accessTokenInfo
+                    .getScopes()
+                    .contains(CustomScopeValue.ACCOUNT_MANAGEMENT.getValue())) {
+                userInfo.setClaim("public_subject_id", tmpUserInfo.getClaim("public_subject_id"));
+            }
+        } else {
+            var userProfile =
+                    authenticationService.getUserProfileFromSubject(
+                            accessTokenInfo.getAccessTokenStore().getInternalSubjectId());
+
+            if (accessTokenInfo.getScopes().contains(OIDCScopeValue.EMAIL.getValue())) {
+                userInfo.setEmailAddress(userProfile.getEmail());
+                userInfo.setEmailVerified(userProfile.isEmailVerified());
+            }
+            if (accessTokenInfo.getScopes().contains(OIDCScopeValue.PHONE.getValue())) {
+                userInfo.setPhoneNumber(userProfile.getPhoneNumber());
+                userInfo.setPhoneNumberVerified(userProfile.isPhoneNumberVerified());
+            }
+            if (accessTokenInfo.getScopes().contains(CustomScopeValue.GOVUK_ACCOUNT.getValue())) {
+                userInfo.setClaim("legacy_subject_id", userProfile.getLegacySubjectID());
+            }
+            if (accessTokenInfo
+                    .getScopes()
+                    .contains(CustomScopeValue.ACCOUNT_MANAGEMENT.getValue())) {
+                userInfo.setClaim("public_subject_id", userProfile.getPublicSubjectID());
+            }
         }
-        if (accessTokenInfo.getScopes().contains(OIDCScopeValue.PHONE.getValue())) {
-            userInfo.setPhoneNumber(userProfile.getPhoneNumber());
-            userInfo.setPhoneNumberVerified(userProfile.isPhoneNumberVerified());
-        }
-        if (accessTokenInfo.getScopes().contains(CustomScopeValue.GOVUK_ACCOUNT.getValue())) {
-            userInfo.setClaim("legacy_subject_id", userProfile.getLegacySubjectID());
-        }
-        if (accessTokenInfo.getScopes().contains(CustomScopeValue.ACCOUNT_MANAGEMENT.getValue())) {
-            userInfo.setClaim("public_subject_id", userProfile.getPublicSubjectID());
-        }
+
         if (configurationService.isIdentityEnabled()
                 && Objects.nonNull(accessTokenInfo.getIdentityClaims())) {
             return populateIdentityInfo(accessTokenInfo, userInfo);

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandlerTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.oidc.domain.OidcAuditableEvent;
 import uk.gov.di.authentication.oidc.entity.AccessTokenInfo;
 import uk.gov.di.authentication.oidc.services.AccessTokenService;
+import uk.gov.di.authentication.oidc.services.AuthenticationUserInfoStorageService;
 import uk.gov.di.authentication.oidc.services.UserInfoService;
 import uk.gov.di.authentication.shared.exceptions.AccessTokenException;
 import uk.gov.di.authentication.shared.services.AuditService;
@@ -39,6 +40,8 @@ public class UserInfoHandlerTest {
     private static final String PHONE_NUMBER = "01234567890";
     private static final Subject SUBJECT = new Subject();
     private static final Subject AUDIT_SUBJECT_ID = new Subject();
+    private final AuthenticationUserInfoStorageService userInfoStorageService =
+            mock(AuthenticationUserInfoStorageService.class);
     private final Context context = mock(Context.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final UserInfoService userInfoService = mock(UserInfoService.class);
@@ -54,7 +57,11 @@ public class UserInfoHandlerTest {
     void setUp() {
         handler =
                 new UserInfoHandler(
-                        configurationService, userInfoService, accessTokenService, auditService);
+                        configurationService,
+                        userInfoService,
+                        accessTokenService,
+                        auditService,
+                        userInfoStorageService);
         when(context.getAwsRequestId()).thenReturn("aws-request-id");
         when(accessTokenInfo.getClientID()).thenReturn("client-id");
         when(accessTokenInfo.getSubject()).thenReturn(SUBJECT.getValue());

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandlerTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.Test;
 import uk.gov.di.authentication.oidc.domain.OidcAuditableEvent;
 import uk.gov.di.authentication.oidc.entity.AccessTokenInfo;
 import uk.gov.di.authentication.oidc.services.AccessTokenService;
-import uk.gov.di.authentication.oidc.services.AuthenticationUserInfoStorageService;
 import uk.gov.di.authentication.oidc.services.UserInfoService;
 import uk.gov.di.authentication.shared.exceptions.AccessTokenException;
 import uk.gov.di.authentication.shared.services.AuditService;
@@ -40,8 +39,6 @@ public class UserInfoHandlerTest {
     private static final String PHONE_NUMBER = "01234567890";
     private static final Subject SUBJECT = new Subject();
     private static final Subject AUDIT_SUBJECT_ID = new Subject();
-    private final AuthenticationUserInfoStorageService userInfoStorageService =
-            mock(AuthenticationUserInfoStorageService.class);
     private final Context context = mock(Context.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final UserInfoService userInfoService = mock(UserInfoService.class);
@@ -57,11 +54,7 @@ public class UserInfoHandlerTest {
     void setUp() {
         handler =
                 new UserInfoHandler(
-                        configurationService,
-                        userInfoService,
-                        accessTokenService,
-                        auditService,
-                        userInfoStorageService);
+                        configurationService, userInfoService, accessTokenService, auditService);
         when(context.getAwsRequestId()).thenReturn("aws-request-id");
         when(accessTokenInfo.getClientID()).thenReturn("client-id");
         when(accessTokenInfo.getSubject()).thenReturn(SUBJECT.getValue());


### PR DESCRIPTION
What?
Instead of populating the userinfo response with data from the UserProfile table, Orchestration will use the information returned from the Authentication /userinfo endpoint.

Why?
We want to restrict Orchestration having access to the User tables in DynamoDB.

Related PRs
https://github.com/alphagov/di-authentication-api/pull/3211 Orches: Create AuthCallbackHandler