### PR TITLE
AUT-1467: Remove bulk email infrastructure in build and sandpit

### DIFF
--- a/ci/terraform/shared/site.tf
+++ b/ci/terraform/shared/site.tf
@@ -59,7 +59,7 @@ locals {
   }
 
   request_tracing_allowed       = contains(["build", "sandpit"], var.environment)
-  deploy_bulk_email_users_count = 1
+  deploy_bulk_email_users_count = contains(["build", "sandpit"], var.environment) ? 0 : 1
 }
 
 data "aws_caller_identity" "current" {}


### PR DESCRIPTION
This sets the counts for:
* The bulk-email-users table;
* The bulk-email-sender;
* The bulk-email-loader

to 0. This will mean that the lambdas are no longer deployed in build and sandpit, and the table (including data) is destroyed.