### PR TITLE
Revert "AUT-1467: Remove bulk email infrastructure in build and sandpit"

### DIFF
--- a/ci/terraform/shared/site.tf
+++ b/ci/terraform/shared/site.tf
@@ -59,7 +59,7 @@ locals {
   }
 
   request_tracing_allowed       = contains(["build", "sandpit"], var.environment)
-  deploy_bulk_email_users_count = contains(["build", "sandpit"], var.environment) ? 0 : 1
+  deploy_bulk_email_users_count = 1
 }
 
 data "aws_caller_identity" "current" {}


### PR DESCRIPTION
This reverts commit 127f8ecc932534b71982b1b7da8028bc074b975f and sets the count for deploy_bulk_email_users_count back to 1, to fix a problem in the pipeline while we work out the better way of doing this.

Thee