### PR TITLE
AUT-1742: Add audit event to auth external API token lambda

### DIFF
--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/domain/AuthExternalApiAuditableEvent.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/domain/AuthExternalApiAuditableEvent.java
@@ -1,0 +1,11 @@
+package uk.gov.di.authentication.external.domain;
+
+import uk.gov.di.authentication.shared.domain.AuditableEvent;
+
+public enum AuthExternalApiAuditableEvent implements AuditableEvent {
+    TOKEN_SENT_TO_ORCHESTRATION;
+
+    public AuditableEvent parseFromName(String name) {
+        return valueOf(name);
+    }
+}

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationTokenHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationTokenHandlerIntegrationTest.java
@@ -36,7 +36,9 @@ import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static uk.gov.di.authentication.external.domain.AuthExternalApiAuditableEvent.TOKEN_SENT_TO_ORCHESTRATION;
 import static uk.gov.di.authentication.shared.helpers.ConstructUriHelper.buildURI;
+import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.assertTxmaAuditEventsReceived;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 class AuthenticationTokenHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -117,6 +119,8 @@ class AuthenticationTokenHandlerIntegrationTest extends ApiGatewayHandlerIntegra
         var authCodeStorePostHanderExecution = authCodeStoreExtension.getAuthCode(VALID_AUTH_CODE);
         assertTrue(authCodeStorePostHanderExecution.isPresent());
         assertTrue(authCodeStorePostHanderExecution.get().isHasBeenUsed());
+
+        assertTxmaAuditEventsReceived(txmaAuditQueue, List.of(TOKEN_SENT_TO_ORCHESTRATION));
     }
 
     @Test


### PR DESCRIPTION
## What?
- Add audit event to auth external API token lambda

## Why?
- This lambda issues a token to orchestration
- It is not meant for use by any RP (not to be confused with OIDC API token endpoint which is for RPs)
- There is a corresponding audit event on the orchestration side when the token response is successfuly received
- This is only code logic, but the Terraform work already seems to be in place ref getting SQS created and the relevant env var passed via the configuration service (see token.tf)

## Note on testing
- It is inherently quite hard to test these as events need to pass via TxMA so the proof of the pudding is only much later when TxMA processes things (which involves some admin steps that haven't been done yet). However, I have deployed to sandpit and put a test event through which is showing in the correct queue `sandpit-auth-external-api-txma-audit-queue` which at least implies the IaC is more or less fine:
<img width="658" alt="image" src="https://github.com/alphagov/di-authentication-api/assets/106964077/0d2bcc94-03d3-4215-a485-4e80d4a09689">


## Related PRs
- Queue itself was created here: https://github.com/alphagov/di-authentication-api/pull/3321
