### PR TITLE
ATO-37: Add nino claim

### DIFF
--- a/ci/terraform/shared/stub-rp-clients.tf
+++ b/ci/terraform/shared/stub-rp-clients.tf
@@ -63,6 +63,9 @@ resource "aws_dynamodb_table_item" "stub_rp_client" {
         {
           S = "https://vocab.account.gov.uk/v1/drivingPermit"
         },
+        {
+          S = "https://vocab.account.gov.uk/v1/nino"
+        },
       ]
     }
     PublicKey = {

--- a/ci/terraform/shared/stub-rp-clients.tf
+++ b/ci/terraform/shared/stub-rp-clients.tf
@@ -64,7 +64,7 @@ resource "aws_dynamodb_table_item" "stub_rp_client" {
           S = "https://vocab.account.gov.uk/v1/drivingPermit"
         },
         {
-          S = "https://vocab.account.gov.uk/v1/nino"
+          S = "https://vocab.account.gov.uk/v1/socialSecurityRecord"
         },
       ]
     }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
@@ -184,7 +184,7 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
         assertTrue(
                 identityCredentials
                         .map(IdentityCredentials::getAdditionalClaims)
-                        .map(t -> t.get(ValidClaims.NINO.getValue()))
+                        .map(t -> t.get(ValidClaims.SOCIAL_SECURITY_RECORD.getValue()))
                         .isPresent());
 
         var addressClaim =
@@ -214,14 +214,14 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                         JSONArray.class);
         assertThat(((LinkedTreeMap) drivingPermit.get(0)).size(), equalTo(6));
 
-        var nino =
+        var socialSecurityRecord =
                 objectMapper.readValue(
                         identityCredentials
                                 .get()
                                 .getAdditionalClaims()
-                                .get(ValidClaims.NINO.getValue()),
+                                .get(ValidClaims.SOCIAL_SECURITY_RECORD.getValue()),
                         JSONArray.class);
-        assertThat(((LinkedTreeMap) nino.get(0)).size(), equalTo(1));
+        assertThat(((LinkedTreeMap) socialSecurityRecord.get(0)).size(), equalTo(1));
     }
 
     @Test

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
@@ -176,11 +176,15 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                         .map(IdentityCredentials::getAdditionalClaims)
                         .map(t -> t.get(ValidClaims.PASSPORT.getValue()))
                         .isPresent());
-
         assertTrue(
                 identityCredentials
                         .map(IdentityCredentials::getAdditionalClaims)
                         .map(t -> t.get(ValidClaims.DRIVING_PERMIT.getValue()))
+                        .isPresent());
+        assertTrue(
+                identityCredentials
+                        .map(IdentityCredentials::getAdditionalClaims)
+                        .map(t -> t.get(ValidClaims.NINO.getValue()))
                         .isPresent());
 
         var addressClaim =
@@ -209,6 +213,15 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
                                 .get(ValidClaims.DRIVING_PERMIT.getValue()),
                         JSONArray.class);
         assertThat(((LinkedTreeMap) drivingPermit.get(0)).size(), equalTo(6));
+
+        var nino =
+                objectMapper.readValue(
+                        identityCredentials
+                                .get()
+                                .getAdditionalClaims()
+                                .get(ValidClaims.NINO.getValue()),
+                        JSONArray.class);
+        assertThat(((LinkedTreeMap) nino.get(0)).size(), equalTo(1));
     }
 
     @Test

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UserInfoIntegrationTest.java
@@ -62,8 +62,8 @@ import static uk.gov.di.authentication.sharedtest.helper.AuditAssertionsHelper.a
 import static uk.gov.di.authentication.sharedtest.helper.IdentityTestData.ADDRESS_CLAIM;
 import static uk.gov.di.authentication.sharedtest.helper.IdentityTestData.CORE_IDENTITY_CLAIM;
 import static uk.gov.di.authentication.sharedtest.helper.IdentityTestData.DRIVING_PERMIT;
-import static uk.gov.di.authentication.sharedtest.helper.IdentityTestData.NINO;
 import static uk.gov.di.authentication.sharedtest.helper.IdentityTestData.PASSPORT_CLAIM;
+import static uk.gov.di.authentication.sharedtest.helper.IdentityTestData.SOCIAL_SECURITY_RECORD;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
@@ -186,8 +186,8 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         PASSPORT_CLAIM,
                         ValidClaims.DRIVING_PERMIT.getValue(),
                         DRIVING_PERMIT,
-                        ValidClaims.NINO.getValue(),
-                        NINO),
+                        ValidClaims.SOCIAL_SECURITY_RECORD.getValue(),
+                        SOCIAL_SECURITY_RECORD),
                 180,
                 true);
 
@@ -205,11 +205,13 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var passportClaim = (JSONArray) userInfoResponse.getClaim(ValidClaims.PASSPORT.getValue());
         var drivingPermitClaim =
                 (JSONArray) userInfoResponse.getClaim(ValidClaims.DRIVING_PERMIT.getValue());
-        var ninoClaim = (JSONArray) userInfoResponse.getClaim(ValidClaims.NINO.getValue());
+        var socialSecurityRecordClaim =
+                (JSONArray)
+                        userInfoResponse.getClaim(ValidClaims.SOCIAL_SECURITY_RECORD.getValue());
         assertThat(((JSONObject) addressClaim.get(0)).size(), equalTo(7));
         assertThat(((JSONObject) passportClaim.get(0)).size(), equalTo(2));
         assertThat(((JSONObject) drivingPermitClaim.get(0)).size(), equalTo(6));
-        assertThat(((JSONObject) ninoClaim.get(0)).size(), equalTo(1));
+        assertThat(((JSONObject) socialSecurityRecordClaim.get(0)).size(), equalTo(1));
 
         assertThat(
                 userInfoResponse.getClaim(ValidClaims.CORE_IDENTITY_JWT.getValue()),
@@ -335,7 +337,7 @@ public class UserInfoIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                         .add(ValidClaims.ADDRESS.getValue())
                         .add(ValidClaims.PASSPORT.getValue())
                         .add(ValidClaims.DRIVING_PERMIT.getValue())
-                        .add(ValidClaims.NINO.getValue());
+                        .add(ValidClaims.SOCIAL_SECURITY_RECORD.getValue());
         var oidcValidClaimsRequest =
                 new OIDCClaimsRequest().withUserInfoClaimsRequest(claimsSetRequest);
         var claimsSet =

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AccessTokenServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AccessTokenServiceTest.java
@@ -72,7 +72,7 @@ class AccessTokenServiceTest {
                     .add(ValidClaims.ADDRESS.getValue())
                     .add(ValidClaims.PASSPORT.getValue())
                     .add(ValidClaims.DRIVING_PERMIT.getValue())
-                    .add(ValidClaims.NINO.getValue())
+                    .add(ValidClaims.SOCIAL_SECURITY_RECORD.getValue())
                     .add(ValidClaims.CORE_IDENTITY_JWT.getValue());
     private final OIDCClaimsRequest oidcValidClaimsRequest =
             new OIDCClaimsRequest().withUserInfoClaimsRequest(claimsSetRequest);

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AccessTokenServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AccessTokenServiceTest.java
@@ -49,7 +49,6 @@ import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.sharedtest.logging.LogEventMatcher.withMessageContaining;
 
 class AccessTokenServiceTest {
-
     private AccessTokenService validationService;
     private final RedisConnectionService redisConnectionService =
             mock(RedisConnectionService.class);
@@ -68,12 +67,12 @@ class AccessTokenServiceTest {
     private static final String KEY_ID = "14342354354353";
     private static final String ACCESS_TOKEN_PREFIX = "ACCESS_TOKEN:";
     private static final Json objectMapper = SerializationService.getInstance();
-
     private final ClaimsSetRequest claimsSetRequest =
             new ClaimsSetRequest()
                     .add(ValidClaims.ADDRESS.getValue())
                     .add(ValidClaims.PASSPORT.getValue())
                     .add(ValidClaims.DRIVING_PERMIT.getValue())
+                    .add(ValidClaims.NINO.getValue())
                     .add(ValidClaims.CORE_IDENTITY_JWT.getValue());
     private final OIDCClaimsRequest oidcValidClaimsRequest =
             new OIDCClaimsRequest().withUserInfoClaimsRequest(claimsSetRequest);
@@ -83,18 +82,18 @@ class AccessTokenServiceTest {
     public final CaptureLoggingExtension logging =
             new CaptureLoggingExtension(AccessTokenService.class);
 
-    @AfterEach
-    void tearDown() {
-        assertThat(
-                logging.events(),
-                not(hasItem(withMessageContaining(CLIENT_ID, SUBJECT.toString()))));
-    }
-
     @BeforeEach
     void setUp() {
         validationService =
                 new AccessTokenService(
                         redisConnectionService, clientService, tokenValidationService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        assertThat(
+                logging.events(),
+                not(hasItem(withMessageContaining(CLIENT_ID, SUBJECT.toString()))));
     }
 
     private static Stream<Boolean> identityEnabled() {
@@ -183,6 +182,7 @@ class AccessTokenServiceTest {
     @MethodSource("identityEnabled")
     void shouldThrowExceptionWhenTokenHasExpired(boolean identityEndpoint) {
         accessToken = createSignedAccessToken(null, true);
+
         var accessTokenException =
                 assertThrows(
                         AccessTokenException.class,

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
@@ -16,6 +16,7 @@ import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import net.minidev.json.JSONArray;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.authentication.app.entity.DocAppCredential;
@@ -55,6 +56,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.sharedtest.helper.IdentityTestData.ADDRESS_CLAIM;
+import static uk.gov.di.authentication.sharedtest.helper.IdentityTestData.DRIVING_PERMIT;
 import static uk.gov.di.authentication.sharedtest.helper.IdentityTestData.PASSPORT_CLAIM;
 import static uk.gov.di.authentication.sharedtest.logging.LogEventMatcher.withMessageContaining;
 
@@ -98,13 +100,6 @@ class UserInfoServiceTest {
     public final CaptureLoggingExtension logging =
             new CaptureLoggingExtension(UserInfoService.class);
 
-    @AfterEach
-    void tearDown() {
-        assertThat(
-                logging.events(),
-                not(hasItem(withMessageContaining(CLIENT_ID, SUBJECT.toString()))));
-    }
-
     @BeforeEach
     void setUp() {
         userInfoService =
@@ -117,6 +112,13 @@ class UserInfoServiceTest {
                         userInfoStorageService);
         when(configurationService.getInternalSectorUri()).thenReturn(INTERNAL_SECTOR_URI);
         when(configurationService.getEnvironment()).thenReturn("test");
+    }
+
+    @AfterEach
+    void tearDown() {
+        assertThat(
+                logging.events(),
+                not(hasItem(withMessageContaining(CLIENT_ID, SUBJECT.toString()))));
     }
 
     @Test
@@ -133,6 +135,7 @@ class UserInfoServiceTest {
                 new AccessTokenInfo(accessTokenStore, SUBJECT.getValue(), SCOPES, null, CLIENT_ID);
 
         var userInfo = userInfoService.populateUserInfo(accessTokenInfo);
+
         assertThat(userInfo.getEmailAddress(), equalTo(EMAIL));
         assertThat(userInfo.getEmailVerified(), equalTo(true));
         assertThat(userInfo.getPhoneNumber(), equalTo(PHONE_NUMBER));
@@ -154,15 +157,15 @@ class UserInfoServiceTest {
                 new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
         var accessTokenInfo =
                 new AccessTokenInfo(accessTokenStore, SUBJECT.getValue(), SCOPES, null, CLIENT_ID);
-
-        AuthenticationUserInfo testUserInfo =
+        var testUserInfo =
                 new AuthenticationUserInfo().withUserInfo(generateUserInfo().toJSONString());
 
         when(userInfoStorageService.getAuthenticationUserInfoData(
-                        accessTokenInfo.getAccessTokenStore().getInternalSubjectId()))
+                accessTokenInfo.getAccessTokenStore().getInternalSubjectId()))
                 .thenReturn(Optional.of(testUserInfo));
 
         var userInfo = userInfoService.populateUserInfo(accessTokenInfo);
+
         assertThat(userInfo.getEmailAddress(), equalTo(EMAIL));
         assertThat(userInfo.getEmailVerified(), equalTo(true));
         assertThat(userInfo.getPhoneNumber(), equalTo(PHONE_NUMBER));
@@ -173,444 +176,456 @@ class UserInfoServiceTest {
         assertNull(userInfo.getClaim(ValidClaims.DRIVING_PERMIT.getValue()));
     }
 
-    @Test
-    void shouldJustPopulateEmailClaimWhenOnlyEmailScopeIsPresentAndIdentityNotEnabled()
-            throws JOSEException, AccessTokenException {
-        when(configurationService.isIdentityEnabled()).thenReturn(false);
-        accessToken = createSignedAccessToken(null);
-        var scopes = List.of(OIDCScopeValue.OPENID.getValue(), OIDCScopeValue.EMAIL.getValue());
-        when(authenticationService.getUserProfileFromSubject(INTERNAL_SUBJECT.getValue()))
-                .thenReturn(generateUserprofile());
+    @Nested
+    class userInfoClaimsTests {
+        @Test
+        void shouldJustPopulateUserInfoWhenIdentityEnabledButNoIdentityClaimsPresent()
+                throws JOSEException, AccessTokenException {
+            when(configurationService.isIdentityEnabled()).thenReturn(true);
+            accessToken = createSignedAccessToken(null);
+            when(authenticationService.getUserProfileFromSubject(INTERNAL_SUBJECT.getValue()))
+                    .thenReturn(generateUserprofile());
 
-        var accessTokenStore =
-                new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
-        var accessTokenInfo =
-                new AccessTokenInfo(accessTokenStore, SUBJECT.getValue(), scopes, null, CLIENT_ID);
+            var accessTokenStore =
+                    new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
+            var accessTokenInfo =
+                    new AccessTokenInfo(accessTokenStore, SUBJECT.getValue(), SCOPES, null, CLIENT_ID);
 
-        var userInfo = userInfoService.populateUserInfo(accessTokenInfo);
-        assertThat(userInfo.getEmailAddress(), equalTo(EMAIL));
-        assertThat(userInfo.getEmailVerified(), equalTo(true));
-        assertNull(userInfo.getPhoneNumber());
-        assertNull(userInfo.getPhoneNumberVerified());
-        assertNull(userInfo.getClaim(ValidClaims.ADDRESS.getValue()));
-        assertNull(userInfo.getClaim(ValidClaims.PASSPORT.getValue()));
-        assertNull(userInfo.getClaim(ValidClaims.DRIVING_PERMIT.getValue()));
-        assertNull(userInfo.getClaim(ValidClaims.CORE_IDENTITY_JWT.getValue()));
+            var userInfo = userInfoService.populateUserInfo(accessTokenInfo);
+
+            assertThat(userInfo.getEmailAddress(), equalTo(EMAIL));
+            assertThat(userInfo.getEmailVerified(), equalTo(true));
+            assertThat(userInfo.getPhoneNumber(), equalTo(PHONE_NUMBER));
+            assertThat(userInfo.getPhoneNumberVerified(), equalTo(true));
+            assertNull(userInfo.getClaim(ValidClaims.ADDRESS.getValue()));
+            assertNull(userInfo.getClaim(ValidClaims.PASSPORT.getValue()));
+            assertNull(userInfo.getClaim(ValidClaims.DRIVING_PERMIT.getValue()));
+            assertNull(userInfo.getClaim(ValidClaims.CORE_IDENTITY_JWT.getValue()));
+        }
+
+        @Test
+        void shouldJustPopulateUserInfoWhenIdentityEnabledButNoIdentityClaimsPresentOrchSplitEnabled()
+                throws JOSEException, AccessTokenException {
+            when(configurationService.isIdentityEnabled()).thenReturn(true);
+            when(configurationService.isAuthOrchSplitEnabled()).thenReturn(true);
+
+            accessToken = createSignedAccessToken(null);
+            var accessTokenStore =
+                    new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
+            var accessTokenInfo =
+                    new AccessTokenInfo(accessTokenStore, SUBJECT.getValue(), SCOPES, null, CLIENT_ID);
+            var testUserInfo =
+                    new AuthenticationUserInfo().withUserInfo(generateUserInfo().toJSONString());
+
+            when(userInfoStorageService.getAuthenticationUserInfoData(
+                    accessTokenInfo.getAccessTokenStore().getInternalSubjectId()))
+                    .thenReturn(Optional.of(testUserInfo));
+
+            var userInfo = userInfoService.populateUserInfo(accessTokenInfo);
+
+            assertThat(userInfo.getEmailAddress(), equalTo(EMAIL));
+            assertThat(userInfo.getEmailVerified(), equalTo(true));
+            assertThat(userInfo.getPhoneNumber(), equalTo(PHONE_NUMBER));
+            assertThat(userInfo.getPhoneNumberVerified(), equalTo(true));
+            assertNull(userInfo.getClaim(ValidClaims.ADDRESS.getValue()));
+            assertNull(userInfo.getClaim(ValidClaims.PASSPORT.getValue()));
+            assertNull(userInfo.getClaim(ValidClaims.DRIVING_PERMIT.getValue()));
+            assertNull(userInfo.getClaim(ValidClaims.CORE_IDENTITY_JWT.getValue()));
+        }
+
+        @Test
+        void shouldPopulateIdentityClaimsWhenClaimsArePresentAndIdentityIsEnabled()
+                throws JOSEException, AccessTokenException {
+            when(configurationService.isIdentityEnabled()).thenReturn(true);
+            var identityCredentials =
+                    new IdentityCredentials()
+                            .withSubjectID(SUBJECT.getValue())
+                            .withCoreIdentityJWT(coreIdentityJWT)
+                            .withAdditionalClaims(
+                                    Map.of(
+                                            ValidClaims.ADDRESS.getValue(),
+                                            ADDRESS_CLAIM,
+                                            ValidClaims.PASSPORT.getValue(),
+                                            PASSPORT_CLAIM,
+                                            ValidClaims.DRIVING_PERMIT.getValue(),
+                                            DRIVING_PERMIT));
+            accessToken = createSignedAccessToken(oidcValidClaimsRequest);
+            when(authenticationService.getUserProfileFromSubject(INTERNAL_SUBJECT.getValue()))
+                    .thenReturn(generateUserprofile());
+            when(identityService.getIdentityCredentials(SUBJECT.getValue()))
+                    .thenReturn(Optional.of(identityCredentials));
+
+            var accessTokenStore =
+                    new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
+            var accessTokenInfo =
+                    new AccessTokenInfo(
+                            accessTokenStore,
+                            SUBJECT.getValue(),
+                            SCOPES,
+                            oidcValidClaimsRequest.getUserInfoClaimsRequest().getEntries().stream()
+                                    .map(ClaimsSetRequest.Entry::getClaimName)
+                                    .collect(Collectors.toList()),
+                            CLIENT_ID);
+
+            var userInfo = userInfoService.populateUserInfo(accessTokenInfo);
+
+            assertThat(userInfo.getEmailAddress(), equalTo(EMAIL));
+            assertThat(userInfo.getEmailVerified(), equalTo(true));
+            assertThat(userInfo.getPhoneNumber(), equalTo(PHONE_NUMBER));
+            assertThat(userInfo.getPhoneNumberVerified(), equalTo(true));
+            assertThat(
+                    userInfo.getClaim(ValidClaims.CORE_IDENTITY_JWT.getValue()),
+                    equalTo(coreIdentityJWT));
+            var addressClaim = (JSONArray) userInfo.getClaim(ValidClaims.ADDRESS.getValue());
+            assertThat(((LinkedTreeMap) addressClaim.get(0)).size(), equalTo(7));
+            var passportClaim = (JSONArray) userInfo.getClaim(ValidClaims.PASSPORT.getValue());
+            assertThat(((LinkedTreeMap) passportClaim.get(0)).size(), equalTo(2));
+
+            assertClaimMetricPublished("https://vocab.account.gov.uk/v1/coreIdentityJWT");
+            assertClaimMetricPublished("https://vocab.account.gov.uk/v1/address");
+            assertClaimMetricPublished("https://vocab.account.gov.uk/v1/passport");
+        }
+
+        @Test
+        void shouldPopulateIdentityClaimsWhenClaimsArePresentAndIdentityIsEnabledOrchSplitEnabled()
+                throws JOSEException, AccessTokenException {
+            when(configurationService.isIdentityEnabled()).thenReturn(true);
+            when(configurationService.isAuthOrchSplitEnabled()).thenReturn(true);
+            var identityCredentials =
+                    new IdentityCredentials()
+                            .withSubjectID(SUBJECT.getValue())
+                            .withCoreIdentityJWT(coreIdentityJWT)
+                            .withAdditionalClaims(
+                                    Map.of(
+                                            ValidClaims.ADDRESS.getValue(),
+                                            ADDRESS_CLAIM,
+                                            ValidClaims.PASSPORT.getValue(),
+                                            PASSPORT_CLAIM,
+                                            ValidClaims.DRIVING_PERMIT.getValue(),
+                                            PASSPORT_CLAIM));
+            accessToken = createSignedAccessToken(oidcValidClaimsRequest);
+
+            when(identityService.getIdentityCredentials(SUBJECT.getValue()))
+                    .thenReturn(Optional.of(identityCredentials));
+
+            var accessTokenStore =
+                    new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
+            var accessTokenInfo =
+                    new AccessTokenInfo(
+                            accessTokenStore,
+                            SUBJECT.getValue(),
+                            SCOPES,
+                            oidcValidClaimsRequest.getUserInfoClaimsRequest().getEntries().stream()
+                                    .map(ClaimsSetRequest.Entry::getClaimName)
+                                    .collect(Collectors.toList()),
+                            CLIENT_ID);
+            var testUserInfo =
+                    new AuthenticationUserInfo().withUserInfo(generateUserInfo().toJSONString());
+
+            when(userInfoStorageService.getAuthenticationUserInfoData(
+                    accessTokenInfo.getAccessTokenStore().getInternalSubjectId()))
+                    .thenReturn(Optional.of(testUserInfo));
+
+            var userInfo = userInfoService.populateUserInfo(accessTokenInfo);
+
+            assertThat(userInfo.getEmailAddress(), equalTo(EMAIL));
+            assertThat(userInfo.getEmailVerified(), equalTo(true));
+            assertThat(userInfo.getPhoneNumber(), equalTo(PHONE_NUMBER));
+            assertThat(userInfo.getPhoneNumberVerified(), equalTo(true));
+            assertThat(
+                    userInfo.getClaim(ValidClaims.CORE_IDENTITY_JWT.getValue()),
+                    equalTo(coreIdentityJWT));
+            var addressClaim = (JSONArray) userInfo.getClaim(ValidClaims.ADDRESS.getValue());
+            assertThat(((LinkedTreeMap) addressClaim.get(0)).size(), equalTo(7));
+            var passportClaim = (JSONArray) userInfo.getClaim(ValidClaims.PASSPORT.getValue());
+            assertThat(((LinkedTreeMap) passportClaim.get(0)).size(), equalTo(2));
+
+            assertClaimMetricPublished("https://vocab.account.gov.uk/v1/coreIdentityJWT");
+            assertClaimMetricPublished("https://vocab.account.gov.uk/v1/address");
+            assertClaimMetricPublished("https://vocab.account.gov.uk/v1/passport");
+        }
+
+        @Test
+        void shouldJustPopulateEmailClaimWhenOnlyEmailScopeIsPresentAndIdentityNotEnabled()
+                throws JOSEException, AccessTokenException {
+            when(configurationService.isIdentityEnabled()).thenReturn(false);
+            accessToken = createSignedAccessToken(null);
+            var scopes = List.of(OIDCScopeValue.OPENID.getValue(), OIDCScopeValue.EMAIL.getValue());
+            when(authenticationService.getUserProfileFromSubject(INTERNAL_SUBJECT.getValue()))
+                    .thenReturn(generateUserprofile());
+
+            var accessTokenStore =
+                    new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
+            var accessTokenInfo =
+                    new AccessTokenInfo(accessTokenStore, SUBJECT.getValue(), scopes, null, CLIENT_ID);
+
+            var userInfo = userInfoService.populateUserInfo(accessTokenInfo);
+
+            assertThat(userInfo.getEmailAddress(), equalTo(EMAIL));
+            assertThat(userInfo.getEmailVerified(), equalTo(true));
+            assertNull(userInfo.getPhoneNumber());
+            assertNull(userInfo.getPhoneNumberVerified());
+            assertNull(userInfo.getClaim(ValidClaims.ADDRESS.getValue()));
+            assertNull(userInfo.getClaim(ValidClaims.PASSPORT.getValue()));
+            assertNull(userInfo.getClaim(ValidClaims.DRIVING_PERMIT.getValue()));
+            assertNull(userInfo.getClaim(ValidClaims.CORE_IDENTITY_JWT.getValue()));
+        }
+
+        @Test
+        void shouldJustPopulateEmailClaimWhenOnlyEmailScopeIsPresentAndIdentityNotEnabledOrchSplitEnabled()
+                throws JOSEException, AccessTokenException {
+            when(configurationService.isIdentityEnabled()).thenReturn(false);
+            when(configurationService.isAuthOrchSplitEnabled()).thenReturn(true);
+            accessToken = createSignedAccessToken(null);
+            var scopes = List.of(OIDCScopeValue.OPENID.getValue(), OIDCScopeValue.EMAIL.getValue());
+
+            var accessTokenStore =
+                    new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
+            var accessTokenInfo =
+                    new AccessTokenInfo(accessTokenStore, SUBJECT.getValue(), scopes, null, CLIENT_ID);
+            var testUserInfo =
+                    new AuthenticationUserInfo().withUserInfo(generateUserInfo().toJSONString());
+
+            when(userInfoStorageService.getAuthenticationUserInfoData(
+                    accessTokenInfo.getAccessTokenStore().getInternalSubjectId()))
+                    .thenReturn(Optional.of(testUserInfo));
+
+            var userInfo = userInfoService.populateUserInfo(accessTokenInfo);
+
+            assertThat(userInfo.getEmailAddress(), equalTo(EMAIL));
+            assertThat(userInfo.getEmailVerified(), equalTo(true));
+            assertNull(userInfo.getPhoneNumber());
+            assertNull(userInfo.getPhoneNumberVerified());
+            assertNull(userInfo.getClaim(ValidClaims.ADDRESS.getValue()));
+            assertNull(userInfo.getClaim(ValidClaims.PASSPORT.getValue()));
+            assertNull(userInfo.getClaim(ValidClaims.DRIVING_PERMIT.getValue()));
+            assertNull(userInfo.getClaim(ValidClaims.CORE_IDENTITY_JWT.getValue()));
+        }
+
+        @Test
+        void shouldPopulateIdentityClaimsWhenClaimsArePresentButNoAdditionalClaimsArePresent()
+                throws JOSEException, AccessTokenException {
+            when(configurationService.isIdentityEnabled()).thenReturn(true);
+            var identityCredentials =
+                    new IdentityCredentials()
+                            .withSubjectID(SUBJECT.getValue())
+                            .withCoreIdentityJWT(coreIdentityJWT);
+            accessToken = createSignedAccessToken(oidcValidClaimsRequest);
+            when(authenticationService.getUserProfileFromSubject(INTERNAL_SUBJECT.getValue()))
+                    .thenReturn(generateUserprofile());
+            when(identityService.getIdentityCredentials(SUBJECT.getValue()))
+                    .thenReturn(Optional.of(identityCredentials));
+
+            var accessTokenStore =
+                    new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
+            var accessTokenInfo =
+                    new AccessTokenInfo(
+                            accessTokenStore,
+                            SUBJECT.getValue(),
+                            SCOPES,
+                            oidcValidClaimsRequest.getUserInfoClaimsRequest().getEntries().stream()
+                                    .map(ClaimsSetRequest.Entry::getClaimName)
+                                    .collect(Collectors.toList()),
+                            CLIENT_ID);
+
+            var userInfo = userInfoService.populateUserInfo(accessTokenInfo);
+            assertThat(userInfo.getEmailAddress(), equalTo(EMAIL));
+            assertThat(userInfo.getEmailVerified(), equalTo(true));
+            assertThat(userInfo.getPhoneNumber(), equalTo(PHONE_NUMBER));
+            assertThat(userInfo.getPhoneNumberVerified(), equalTo(true));
+            assertThat(
+                    userInfo.getClaim(ValidClaims.CORE_IDENTITY_JWT.getValue()),
+                    equalTo(coreIdentityJWT));
+
+            assertClaimMetricPublished("https://vocab.account.gov.uk/v1/coreIdentityJWT");
+        }
+
+        @Test
+        void
+        shouldPopulateIdentityClaimsWhenClaimsArePresentButNoAdditionalClaimsArePresentOrchSplitEnabled()
+                throws JOSEException, AccessTokenException {
+            when(configurationService.isIdentityEnabled()).thenReturn(true);
+            when(configurationService.isAuthOrchSplitEnabled()).thenReturn(true);
+            var identityCredentials =
+                    new IdentityCredentials()
+                            .withSubjectID(SUBJECT.getValue())
+                            .withCoreIdentityJWT(coreIdentityJWT);
+            accessToken = createSignedAccessToken(oidcValidClaimsRequest);
+
+            when(identityService.getIdentityCredentials(SUBJECT.getValue()))
+                    .thenReturn(Optional.of(identityCredentials));
+
+            var accessTokenStore =
+                    new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
+            var accessTokenInfo =
+                    new AccessTokenInfo(
+                            accessTokenStore,
+                            SUBJECT.getValue(),
+                            SCOPES,
+                            oidcValidClaimsRequest.getUserInfoClaimsRequest().getEntries().stream()
+                                    .map(ClaimsSetRequest.Entry::getClaimName)
+                                    .collect(Collectors.toList()),
+                            CLIENT_ID);
+            var testUserInfo =
+                    new AuthenticationUserInfo().withUserInfo(generateUserInfo().toJSONString());
+
+            when(userInfoStorageService.getAuthenticationUserInfoData(
+                    accessTokenInfo.getAccessTokenStore().getInternalSubjectId()))
+                    .thenReturn(Optional.of(testUserInfo));
+
+            var userInfo = userInfoService.populateUserInfo(accessTokenInfo);
+
+            assertThat(userInfo.getEmailAddress(), equalTo(EMAIL));
+            assertThat(userInfo.getEmailVerified(), equalTo(true));
+            assertThat(userInfo.getPhoneNumber(), equalTo(PHONE_NUMBER));
+            assertThat(userInfo.getPhoneNumberVerified(), equalTo(true));
+            assertThat(
+                    userInfo.getClaim(ValidClaims.CORE_IDENTITY_JWT.getValue()),
+                    equalTo(coreIdentityJWT));
+
+            assertClaimMetricPublished("https://vocab.account.gov.uk/v1/coreIdentityJWT");
+        }
     }
 
-    @Test
-    void
-            shouldJustPopulateEmailClaimWhenOnlyEmailScopeIsPresentAndIdentityNotEnabledOrchSplitEnabled()
-                    throws JOSEException, AccessTokenException {
-        when(configurationService.isIdentityEnabled()).thenReturn(false);
-        when(configurationService.isAuthOrchSplitEnabled()).thenReturn(true);
-        accessToken = createSignedAccessToken(null);
-        var scopes = List.of(OIDCScopeValue.OPENID.getValue(), OIDCScopeValue.EMAIL.getValue());
+    @Nested
+    class docAppTests {
+        @Test
+        void shouldPopulateUserInfoWithDocAppCredentialWhenDocAppScopeIsPresent()
+                throws JOSEException, AccessTokenException {
+            var docAppScope =
+                    List.of(
+                            OIDCScopeValue.OPENID.getValue(),
+                            CustomScopeValue.DOC_CHECKING_APP.getValue());
+            var accessToken = createSignedAccessToken(null, docAppScope);
+            var docAppCredential =
+                    new DocAppCredential()
+                            .withSubjectID(SUBJECT.getValue())
+                            .withCredential(List.of(docAppCredentialJWT));
+            when(dynamoDocAppService.getDocAppCredential(SUBJECT.getValue()))
+                    .thenReturn(Optional.of(docAppCredential));
 
-        var accessTokenStore =
-                new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
-        var accessTokenInfo =
-                new AccessTokenInfo(accessTokenStore, SUBJECT.getValue(), scopes, null, CLIENT_ID);
+            var accessTokenStore =
+                    new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
+            var accessTokenInfo =
+                    new AccessTokenInfo(
+                            accessTokenStore, SUBJECT.getValue(), docAppScope, null, CLIENT_ID);
 
-        AuthenticationUserInfo testUserInfo =
-                new AuthenticationUserInfo().withUserInfo(generateUserInfo().toJSONString());
+            var userInfo = userInfoService.populateUserInfo(accessTokenInfo);
 
-        when(userInfoStorageService.getAuthenticationUserInfoData(
-                        accessTokenInfo.getAccessTokenStore().getInternalSubjectId()))
-                .thenReturn(Optional.of(testUserInfo));
+            assertThat(userInfo.getClaim("doc-app-credential"), equalTo(List.of(docAppCredentialJWT)));
+            assertClaimMetricPublished("doc-app-credential");
+        }
 
-        var userInfo = userInfoService.populateUserInfo(accessTokenInfo);
-        assertThat(userInfo.getEmailAddress(), equalTo(EMAIL));
-        assertThat(userInfo.getEmailVerified(), equalTo(true));
-        assertNull(userInfo.getPhoneNumber());
-        assertNull(userInfo.getPhoneNumberVerified());
-        assertNull(userInfo.getClaim(ValidClaims.ADDRESS.getValue()));
-        assertNull(userInfo.getClaim(ValidClaims.PASSPORT.getValue()));
-        assertNull(userInfo.getClaim(ValidClaims.DRIVING_PERMIT.getValue()));
-        assertNull(userInfo.getClaim(ValidClaims.CORE_IDENTITY_JWT.getValue()));
-    }
+        @Test
+        void shouldPopulateUserInfoWithDocAppCredentialWhenDocAppScopeIsPresentOrchSplitEnabled()
+                throws JOSEException, AccessTokenException {
+            when(configurationService.isAuthOrchSplitEnabled()).thenReturn(true);
+            var docAppScope =
+                    List.of(
+                            OIDCScopeValue.OPENID.getValue(),
+                            CustomScopeValue.DOC_CHECKING_APP.getValue());
+            var accessToken = createSignedAccessToken(null, docAppScope);
+            var docAppCredential =
+                    new DocAppCredential()
+                            .withSubjectID(SUBJECT.getValue())
+                            .withCredential(List.of(docAppCredentialJWT));
+            when(dynamoDocAppService.getDocAppCredential(SUBJECT.getValue()))
+                    .thenReturn(Optional.of(docAppCredential));
 
-    @Test
-    void shouldJustPopulateUserInfoWhenIdentityEnabledButNoIdentityClaimsPresent()
-            throws JOSEException, AccessTokenException {
-        when(configurationService.isIdentityEnabled()).thenReturn(true);
-        accessToken = createSignedAccessToken(null);
-        when(authenticationService.getUserProfileFromSubject(INTERNAL_SUBJECT.getValue()))
-                .thenReturn(generateUserprofile());
+            var accessTokenStore =
+                    new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
+            var accessTokenInfo =
+                    new AccessTokenInfo(
+                            accessTokenStore, SUBJECT.getValue(), docAppScope, null, CLIENT_ID);
 
-        var accessTokenStore =
-                new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
-        var accessTokenInfo =
-                new AccessTokenInfo(accessTokenStore, SUBJECT.getValue(), SCOPES, null, CLIENT_ID);
+            var userInfo = userInfoService.populateUserInfo(accessTokenInfo);
 
-        var userInfo = userInfoService.populateUserInfo(accessTokenInfo);
-        assertThat(userInfo.getEmailAddress(), equalTo(EMAIL));
-        assertThat(userInfo.getEmailVerified(), equalTo(true));
-        assertThat(userInfo.getPhoneNumber(), equalTo(PHONE_NUMBER));
-        assertThat(userInfo.getPhoneNumberVerified(), equalTo(true));
-        assertNull(userInfo.getClaim(ValidClaims.ADDRESS.getValue()));
-        assertNull(userInfo.getClaim(ValidClaims.PASSPORT.getValue()));
-        assertNull(userInfo.getClaim(ValidClaims.DRIVING_PERMIT.getValue()));
-        assertNull(userInfo.getClaim(ValidClaims.CORE_IDENTITY_JWT.getValue()));
-    }
+            assertThat(userInfo.getClaim("doc-app-credential"), equalTo(List.of(docAppCredentialJWT)));
+            assertClaimMetricPublished("doc-app-credential");
+        }
 
-    @Test
-    void shouldJustPopulateUserInfoWhenIdentityEnabledButNoIdentityClaimsPresentOrchSplitEnabled()
-            throws JOSEException, AccessTokenException {
-        when(configurationService.isIdentityEnabled()).thenReturn(false);
-        when(configurationService.isAuthOrchSplitEnabled()).thenReturn(true);
+        @Test
+        void shouldReturnDocAppSubjectIdWhenDocAppScopeIsPresent() throws JOSEException {
+            accessToken = createSignedAccessToken(null);
+            var docAppScope =
+                    List.of(
+                            OIDCScopeValue.OPENID.getValue(),
+                            CustomScopeValue.DOC_CHECKING_APP.getValue());
+            var accessTokenStore =
+                    new AccessTokenStore(accessToken.getValue(), DOC_APP_SUBJECT.getValue());
+            var accessTokenInfo =
+                    new AccessTokenInfo(
+                            accessTokenStore, DOC_APP_SUBJECT.getValue(), docAppScope, null, CLIENT_ID);
 
-        accessToken = createSignedAccessToken(null);
-        var accessTokenStore =
-                new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
-        var accessTokenInfo =
-                new AccessTokenInfo(accessTokenStore, SUBJECT.getValue(), SCOPES, null, CLIENT_ID);
+            var subjectForAudit = userInfoService.calculateSubjectForAudit(accessTokenInfo);
 
-        AuthenticationUserInfo testUserInfo =
-                new AuthenticationUserInfo().withUserInfo(generateUserInfo().toJSONString());
+            assertThat(subjectForAudit, equalTo(DOC_APP_SUBJECT.getValue()));
+        }
 
-        when(userInfoStorageService.getAuthenticationUserInfoData(
-                        accessTokenInfo.getAccessTokenStore().getInternalSubjectId()))
-                .thenReturn(Optional.of(testUserInfo));
+        @Test
+        void shouldReturnDocAppSubjectIdWhenDocAppScopeIsPresentOrchSplitEnabled()
+                throws JOSEException {
+            when(configurationService.isAuthOrchSplitEnabled()).thenReturn(true);
+            accessToken = createSignedAccessToken(null);
+            var docAppScope =
+                    List.of(
+                            OIDCScopeValue.OPENID.getValue(),
+                            CustomScopeValue.DOC_CHECKING_APP.getValue());
+            var accessTokenStore =
+                    new AccessTokenStore(accessToken.getValue(), DOC_APP_SUBJECT.getValue());
+            var accessTokenInfo =
+                    new AccessTokenInfo(
+                            accessTokenStore, DOC_APP_SUBJECT.getValue(), docAppScope, null, CLIENT_ID);
 
-        var userInfo = userInfoService.populateUserInfo(accessTokenInfo);
-        assertThat(userInfo.getEmailAddress(), equalTo(EMAIL));
-        assertThat(userInfo.getEmailVerified(), equalTo(true));
-        assertThat(userInfo.getPhoneNumber(), equalTo(PHONE_NUMBER));
-        assertThat(userInfo.getPhoneNumberVerified(), equalTo(true));
-        assertNull(userInfo.getClaim(ValidClaims.ADDRESS.getValue()));
-        assertNull(userInfo.getClaim(ValidClaims.PASSPORT.getValue()));
-        assertNull(userInfo.getClaim(ValidClaims.DRIVING_PERMIT.getValue()));
-        assertNull(userInfo.getClaim(ValidClaims.CORE_IDENTITY_JWT.getValue()));
-    }
+            var subjectForAudit = userInfoService.calculateSubjectForAudit(accessTokenInfo);
 
-    @Test
-    void shouldPopulateIdentityClaimsWhenClaimsArePresentAndIdentityIsEnabled()
-            throws JOSEException, AccessTokenException {
-        when(configurationService.isIdentityEnabled()).thenReturn(true);
-        var identityCredentials =
-                new IdentityCredentials()
-                        .withSubjectID(SUBJECT.getValue())
-                        .withCoreIdentityJWT(coreIdentityJWT)
-                        .withAdditionalClaims(
-                                Map.of(
-                                        ValidClaims.ADDRESS.getValue(),
-                                        ADDRESS_CLAIM,
-                                        ValidClaims.PASSPORT.getValue(),
-                                        PASSPORT_CLAIM,
-                                        ValidClaims.DRIVING_PERMIT.getValue(),
-                                        PASSPORT_CLAIM));
-        accessToken = createSignedAccessToken(oidcValidClaimsRequest);
-        when(authenticationService.getUserProfileFromSubject(INTERNAL_SUBJECT.getValue()))
-                .thenReturn(generateUserprofile());
-        when(identityService.getIdentityCredentials(SUBJECT.getValue()))
-                .thenReturn(Optional.of(identityCredentials));
+            assertThat(subjectForAudit, equalTo(DOC_APP_SUBJECT.getValue()));
+        }
 
-        var accessTokenStore =
-                new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
-        var accessTokenInfo =
-                new AccessTokenInfo(
-                        accessTokenStore,
-                        SUBJECT.getValue(),
-                        SCOPES,
-                        oidcValidClaimsRequest.getUserInfoClaimsRequest().getEntries().stream()
-                                .map(ClaimsSetRequest.Entry::getClaimName)
-                                .collect(Collectors.toList()),
-                        CLIENT_ID);
+        @Test
+        void shouldReturnInternalCommonSubjectIdentifierWhenDocAppScopeIsNotPresent()
+                throws JOSEException {
+            var salt = SaltHelper.generateNewSalt();
+            var expectedCommonSubject =
+                    ClientSubjectHelper.calculatePairwiseIdentifier(
+                            INTERNAL_SUBJECT.getValue(), "test.account.gov.uk", salt);
+            accessToken = createSignedAccessToken(null);
+            var userProfile = generateUserprofile();
+            when(authenticationService.getUserProfileFromSubject(INTERNAL_SUBJECT.getValue()))
+                    .thenReturn(userProfile);
+            when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(salt);
+            var accessTokenStore =
+                    new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
+            var accessTokenInfo =
+                    new AccessTokenInfo(accessTokenStore, SUBJECT.getValue(), SCOPES, null, CLIENT_ID);
 
-        var userInfo = userInfoService.populateUserInfo(accessTokenInfo);
-        assertThat(userInfo.getEmailAddress(), equalTo(EMAIL));
-        assertThat(userInfo.getEmailVerified(), equalTo(true));
-        assertThat(userInfo.getPhoneNumber(), equalTo(PHONE_NUMBER));
-        assertThat(userInfo.getPhoneNumberVerified(), equalTo(true));
-        assertThat(
-                userInfo.getClaim(ValidClaims.CORE_IDENTITY_JWT.getValue()),
-                equalTo(coreIdentityJWT));
-        var addressClaim = (JSONArray) userInfo.getClaim(ValidClaims.ADDRESS.getValue());
-        assertThat(((LinkedTreeMap) addressClaim.get(0)).size(), equalTo(7));
-        var passportClaim = (JSONArray) userInfo.getClaim(ValidClaims.PASSPORT.getValue());
-        assertThat(((LinkedTreeMap) passportClaim.get(0)).size(), equalTo(2));
+            var subjectForAudit = userInfoService.calculateSubjectForAudit(accessTokenInfo);
 
-        assertClaimMetricPublished("https://vocab.account.gov.uk/v1/coreIdentityJWT");
-        assertClaimMetricPublished("https://vocab.account.gov.uk/v1/address");
-        assertClaimMetricPublished("https://vocab.account.gov.uk/v1/passport");
-    }
+            assertThat(subjectForAudit, equalTo(expectedCommonSubject));
+        }
 
-    @Test
-    void shouldPopulateIdentityClaimsWhenClaimsArePresentAndIdentityIsEnabledOrchSplitEnabled()
-            throws JOSEException, AccessTokenException {
-        when(configurationService.isIdentityEnabled()).thenReturn(true);
-        when(configurationService.isAuthOrchSplitEnabled()).thenReturn(true);
-        var identityCredentials =
-                new IdentityCredentials()
-                        .withSubjectID(SUBJECT.getValue())
-                        .withCoreIdentityJWT(coreIdentityJWT)
-                        .withAdditionalClaims(
-                                Map.of(
-                                        ValidClaims.ADDRESS.getValue(),
-                                        ADDRESS_CLAIM,
-                                        ValidClaims.PASSPORT.getValue(),
-                                        PASSPORT_CLAIM,
-                                        ValidClaims.DRIVING_PERMIT.getValue(),
-                                        PASSPORT_CLAIM));
-        accessToken = createSignedAccessToken(oidcValidClaimsRequest);
+        @Test
+        void shouldReturnInternalCommonSubjectIdentifierWhenDocAppScopeIsNotPresentOrchSplitEnabled()
+                throws JOSEException {
+            when(configurationService.isAuthOrchSplitEnabled()).thenReturn(true);
+            var salt = SaltHelper.generateNewSalt();
+            var expectedCommonSubject =
+                    ClientSubjectHelper.calculatePairwiseIdentifier(
+                            INTERNAL_SUBJECT.getValue(), "test.account.gov.uk", salt);
+            accessToken = createSignedAccessToken(null);
+            var userProfile = generateUserprofile();
+            when(authenticationService.getUserProfileFromSubject(INTERNAL_SUBJECT.getValue()))
+                    .thenReturn(userProfile);
+            when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(salt);
+            var accessTokenStore =
+                    new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
+            var accessTokenInfo =
+                    new AccessTokenInfo(accessTokenStore, SUBJECT.getValue(), SCOPES, null, CLIENT_ID);
 
-        when(identityService.getIdentityCredentials(SUBJECT.getValue()))
-                .thenReturn(Optional.of(identityCredentials));
+            var subjectForAudit = userInfoService.calculateSubjectForAudit(accessTokenInfo);
 
-        var accessTokenStore =
-                new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
-        var accessTokenInfo =
-                new AccessTokenInfo(
-                        accessTokenStore,
-                        SUBJECT.getValue(),
-                        SCOPES,
-                        oidcValidClaimsRequest.getUserInfoClaimsRequest().getEntries().stream()
-                                .map(ClaimsSetRequest.Entry::getClaimName)
-                                .collect(Collectors.toList()),
-                        CLIENT_ID);
-
-        AuthenticationUserInfo testUserInfo =
-                new AuthenticationUserInfo().withUserInfo(generateUserInfo().toJSONString());
-
-        when(userInfoStorageService.getAuthenticationUserInfoData(
-                        accessTokenInfo.getAccessTokenStore().getInternalSubjectId()))
-                .thenReturn(Optional.of(testUserInfo));
-
-        var userInfo = userInfoService.populateUserInfo(accessTokenInfo);
-        assertThat(userInfo.getEmailAddress(), equalTo(EMAIL));
-        assertThat(userInfo.getEmailVerified(), equalTo(true));
-        assertThat(userInfo.getPhoneNumber(), equalTo(PHONE_NUMBER));
-        assertThat(userInfo.getPhoneNumberVerified(), equalTo(true));
-        assertThat(
-                userInfo.getClaim(ValidClaims.CORE_IDENTITY_JWT.getValue()),
-                equalTo(coreIdentityJWT));
-        var addressClaim = (JSONArray) userInfo.getClaim(ValidClaims.ADDRESS.getValue());
-        assertThat(((LinkedTreeMap) addressClaim.get(0)).size(), equalTo(7));
-        var passportClaim = (JSONArray) userInfo.getClaim(ValidClaims.PASSPORT.getValue());
-        assertThat(((LinkedTreeMap) passportClaim.get(0)).size(), equalTo(2));
-
-        assertClaimMetricPublished("https://vocab.account.gov.uk/v1/coreIdentityJWT");
-        assertClaimMetricPublished("https://vocab.account.gov.uk/v1/address");
-        assertClaimMetricPublished("https://vocab.account.gov.uk/v1/passport");
-    }
-
-    @Test
-    void shouldPopulateIdentityClaimsWhenClaimsArePresentButNoAdditionalClaimsArePresent()
-            throws JOSEException, AccessTokenException {
-        when(configurationService.isIdentityEnabled()).thenReturn(true);
-        var identityCredentials =
-                new IdentityCredentials()
-                        .withSubjectID(SUBJECT.getValue())
-                        .withCoreIdentityJWT(coreIdentityJWT);
-        accessToken = createSignedAccessToken(oidcValidClaimsRequest);
-        when(authenticationService.getUserProfileFromSubject(INTERNAL_SUBJECT.getValue()))
-                .thenReturn(generateUserprofile());
-        when(identityService.getIdentityCredentials(SUBJECT.getValue()))
-                .thenReturn(Optional.of(identityCredentials));
-
-        var accessTokenStore =
-                new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
-        var accessTokenInfo =
-                new AccessTokenInfo(
-                        accessTokenStore,
-                        SUBJECT.getValue(),
-                        SCOPES,
-                        oidcValidClaimsRequest.getUserInfoClaimsRequest().getEntries().stream()
-                                .map(ClaimsSetRequest.Entry::getClaimName)
-                                .collect(Collectors.toList()),
-                        CLIENT_ID);
-
-        var userInfo = userInfoService.populateUserInfo(accessTokenInfo);
-        assertThat(userInfo.getEmailAddress(), equalTo(EMAIL));
-        assertThat(userInfo.getEmailVerified(), equalTo(true));
-        assertThat(userInfo.getPhoneNumber(), equalTo(PHONE_NUMBER));
-        assertThat(userInfo.getPhoneNumberVerified(), equalTo(true));
-        assertThat(
-                userInfo.getClaim(ValidClaims.CORE_IDENTITY_JWT.getValue()),
-                equalTo(coreIdentityJWT));
-
-        assertClaimMetricPublished("https://vocab.account.gov.uk/v1/coreIdentityJWT");
-    }
-
-    @Test
-    void
-            shouldPopulateIdentityClaimsWhenClaimsArePresentButNoAdditionalClaimsArePresentOrchSplitEnabled()
-                    throws JOSEException, AccessTokenException {
-        when(configurationService.isIdentityEnabled()).thenReturn(true);
-        when(configurationService.isAuthOrchSplitEnabled()).thenReturn(true);
-        var identityCredentials =
-                new IdentityCredentials()
-                        .withSubjectID(SUBJECT.getValue())
-                        .withCoreIdentityJWT(coreIdentityJWT);
-        accessToken = createSignedAccessToken(oidcValidClaimsRequest);
-
-        when(identityService.getIdentityCredentials(SUBJECT.getValue()))
-                .thenReturn(Optional.of(identityCredentials));
-
-        var accessTokenStore =
-                new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
-        var accessTokenInfo =
-                new AccessTokenInfo(
-                        accessTokenStore,
-                        SUBJECT.getValue(),
-                        SCOPES,
-                        oidcValidClaimsRequest.getUserInfoClaimsRequest().getEntries().stream()
-                                .map(ClaimsSetRequest.Entry::getClaimName)
-                                .collect(Collectors.toList()),
-                        CLIENT_ID);
-
-        AuthenticationUserInfo testUserInfo =
-                new AuthenticationUserInfo().withUserInfo(generateUserInfo().toJSONString());
-
-        when(userInfoStorageService.getAuthenticationUserInfoData(
-                        accessTokenInfo.getAccessTokenStore().getInternalSubjectId()))
-                .thenReturn(Optional.of(testUserInfo));
-
-        var userInfo = userInfoService.populateUserInfo(accessTokenInfo);
-        assertThat(userInfo.getEmailAddress(), equalTo(EMAIL));
-        assertThat(userInfo.getEmailVerified(), equalTo(true));
-        assertThat(userInfo.getPhoneNumber(), equalTo(PHONE_NUMBER));
-        assertThat(userInfo.getPhoneNumberVerified(), equalTo(true));
-        assertThat(
-                userInfo.getClaim(ValidClaims.CORE_IDENTITY_JWT.getValue()),
-                equalTo(coreIdentityJWT));
-
-        assertClaimMetricPublished("https://vocab.account.gov.uk/v1/coreIdentityJWT");
-    }
-
-    @Test
-    void shouldPopulateUserInfoWithDocAppCredentialWhenDocAppScopeIsPresent()
-            throws JOSEException, AccessTokenException {
-        var docAppScope =
-                List.of(
-                        OIDCScopeValue.OPENID.getValue(),
-                        CustomScopeValue.DOC_CHECKING_APP.getValue());
-        var accessToken = createSignedAccessToken(null, docAppScope);
-        var docAppCredential =
-                new DocAppCredential()
-                        .withSubjectID(SUBJECT.getValue())
-                        .withCredential(List.of(docAppCredentialJWT));
-        when(dynamoDocAppService.getDocAppCredential(SUBJECT.getValue()))
-                .thenReturn(Optional.of(docAppCredential));
-
-        var accessTokenStore =
-                new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
-        var accessTokenInfo =
-                new AccessTokenInfo(
-                        accessTokenStore, SUBJECT.getValue(), docAppScope, null, CLIENT_ID);
-
-        var userInfo = userInfoService.populateUserInfo(accessTokenInfo);
-        assertThat(userInfo.getClaim("doc-app-credential"), equalTo(List.of(docAppCredentialJWT)));
-        assertClaimMetricPublished("doc-app-credential");
-    }
-
-    @Test
-    void shouldPopulateUserInfoWithDocAppCredentialWhenDocAppScopeIsPresentOrchSplitEnabled()
-            throws JOSEException, AccessTokenException {
-        when(configurationService.isAuthOrchSplitEnabled()).thenReturn(true);
-        var docAppScope =
-                List.of(
-                        OIDCScopeValue.OPENID.getValue(),
-                        CustomScopeValue.DOC_CHECKING_APP.getValue());
-        var accessToken = createSignedAccessToken(null, docAppScope);
-        var docAppCredential =
-                new DocAppCredential()
-                        .withSubjectID(SUBJECT.getValue())
-                        .withCredential(List.of(docAppCredentialJWT));
-        when(dynamoDocAppService.getDocAppCredential(SUBJECT.getValue()))
-                .thenReturn(Optional.of(docAppCredential));
-
-        var accessTokenStore =
-                new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
-        var accessTokenInfo =
-                new AccessTokenInfo(
-                        accessTokenStore, SUBJECT.getValue(), docAppScope, null, CLIENT_ID);
-
-        var userInfo = userInfoService.populateUserInfo(accessTokenInfo);
-        assertThat(userInfo.getClaim("doc-app-credential"), equalTo(List.of(docAppCredentialJWT)));
-        assertClaimMetricPublished("doc-app-credential");
-    }
-
-    @Test
-    void shouldReturnInternalCommonSubjectIdentifierWhenDocAppScopeIsNotPresent()
-            throws JOSEException {
-        var salt = SaltHelper.generateNewSalt();
-        var expectedCommonSubject =
-                ClientSubjectHelper.calculatePairwiseIdentifier(
-                        INTERNAL_SUBJECT.getValue(), "test.account.gov.uk", salt);
-        accessToken = createSignedAccessToken(null);
-        var userProfile = generateUserprofile();
-        when(authenticationService.getUserProfileFromSubject(INTERNAL_SUBJECT.getValue()))
-                .thenReturn(userProfile);
-        when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(salt);
-        var accessTokenStore =
-                new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
-        var accessTokenInfo =
-                new AccessTokenInfo(accessTokenStore, SUBJECT.getValue(), SCOPES, null, CLIENT_ID);
-
-        var subjectForAudit = userInfoService.calculateSubjectForAudit(accessTokenInfo);
-
-        assertThat(subjectForAudit, equalTo(expectedCommonSubject));
-    }
-
-    @Test
-    void shouldReturnInternalCommonSubjectIdentifierWhenDocAppScopeIsNotPresentOrchSplitEnabled()
-            throws JOSEException {
-        when(configurationService.isAuthOrchSplitEnabled()).thenReturn(true);
-        var salt = SaltHelper.generateNewSalt();
-        var expectedCommonSubject =
-                ClientSubjectHelper.calculatePairwiseIdentifier(
-                        INTERNAL_SUBJECT.getValue(), "test.account.gov.uk", salt);
-        accessToken = createSignedAccessToken(null);
-        var userProfile = generateUserprofile();
-        when(authenticationService.getUserProfileFromSubject(INTERNAL_SUBJECT.getValue()))
-                .thenReturn(userProfile);
-        when(authenticationService.getOrGenerateSalt(userProfile)).thenReturn(salt);
-        var accessTokenStore =
-                new AccessTokenStore(accessToken.getValue(), INTERNAL_SUBJECT.getValue());
-        var accessTokenInfo =
-                new AccessTokenInfo(accessTokenStore, SUBJECT.getValue(), SCOPES, null, CLIENT_ID);
-
-        var subjectForAudit = userInfoService.calculateSubjectForAudit(accessTokenInfo);
-
-        assertThat(subjectForAudit, equalTo(expectedCommonSubject));
-    }
-
-    @Test
-    void shouldReturnDocAppSubjectIdWhenDocAppScopeIsPresent() throws JOSEException {
-        accessToken = createSignedAccessToken(null);
-        var docAppScope =
-                List.of(
-                        OIDCScopeValue.OPENID.getValue(),
-                        CustomScopeValue.DOC_CHECKING_APP.getValue());
-        var accessTokenStore =
-                new AccessTokenStore(accessToken.getValue(), DOC_APP_SUBJECT.getValue());
-        var accessTokenInfo =
-                new AccessTokenInfo(
-                        accessTokenStore, DOC_APP_SUBJECT.getValue(), docAppScope, null, CLIENT_ID);
-        var subjectForAudit = userInfoService.calculateSubjectForAudit(accessTokenInfo);
-
-        assertThat(subjectForAudit, equalTo(DOC_APP_SUBJECT.getValue()));
-    }
-
-    @Test
-    void shouldReturnDocAppSubjectIdWhenDocAppScopeIsPresentOrchSplitEnabled()
-            throws JOSEException {
-        when(configurationService.isAuthOrchSplitEnabled()).thenReturn(true);
-        accessToken = createSignedAccessToken(null);
-        var docAppScope =
-                List.of(
-                        OIDCScopeValue.OPENID.getValue(),
-                        CustomScopeValue.DOC_CHECKING_APP.getValue());
-        var accessTokenStore =
-                new AccessTokenStore(accessToken.getValue(), DOC_APP_SUBJECT.getValue());
-        var accessTokenInfo =
-                new AccessTokenInfo(
-                        accessTokenStore, DOC_APP_SUBJECT.getValue(), docAppScope, null, CLIENT_ID);
-        var subjectForAudit = userInfoService.calculateSubjectForAudit(accessTokenInfo);
-
-        assertThat(subjectForAudit, equalTo(DOC_APP_SUBJECT.getValue()));
+            assertThat(subjectForAudit, equalTo(expectedCommonSubject));
+        }
     }
 
     private AccessToken createSignedAccessToken(OIDCClaimsRequest identityClaims)
@@ -618,8 +633,8 @@ class UserInfoServiceTest {
         return createSignedAccessToken(identityClaims, SCOPES);
     }
 
-    private AccessToken createSignedAccessToken(
-            OIDCClaimsRequest identityClaims, List<String> scopes) throws JOSEException {
+    private AccessToken createSignedAccessToken(OIDCClaimsRequest identityClaims, List<String> scopes)
+            throws JOSEException {
         var expiryDate = NowHelper.nowPlus(3, ChronoUnit.MINUTES);
         var ecSigningKey =
                 new ECKeyGenerator(Curve.P_256)

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
@@ -57,8 +57,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.di.authentication.sharedtest.helper.IdentityTestData.ADDRESS_CLAIM;
 import static uk.gov.di.authentication.sharedtest.helper.IdentityTestData.DRIVING_PERMIT;
-import static uk.gov.di.authentication.sharedtest.helper.IdentityTestData.NINO;
 import static uk.gov.di.authentication.sharedtest.helper.IdentityTestData.PASSPORT_CLAIM;
+import static uk.gov.di.authentication.sharedtest.helper.IdentityTestData.SOCIAL_SECURITY_RECORD;
 import static uk.gov.di.authentication.sharedtest.logging.LogEventMatcher.withMessageContaining;
 
 class UserInfoServiceTest {
@@ -91,7 +91,7 @@ class UserInfoServiceTest {
                     .add(ValidClaims.ADDRESS.getValue())
                     .add(ValidClaims.PASSPORT.getValue())
                     .add(ValidClaims.DRIVING_PERMIT.getValue())
-                    .add(ValidClaims.NINO.getValue());
+                    .add(ValidClaims.SOCIAL_SECURITY_RECORD.getValue());
     private final OIDCClaimsRequest oidcValidClaimsRequest =
             new OIDCClaimsRequest().withUserInfoClaimsRequest(claimsSetRequest);
     private final String coreIdentityJWT = SignedCredentialHelper.generateCredential().serialize();
@@ -147,7 +147,7 @@ class UserInfoServiceTest {
         assertNull(userInfo.getClaim(ValidClaims.ADDRESS.getValue()));
         assertNull(userInfo.getClaim(ValidClaims.PASSPORT.getValue()));
         assertNull(userInfo.getClaim(ValidClaims.DRIVING_PERMIT.getValue()));
-        assertNull(userInfo.getClaim(ValidClaims.NINO.getValue()));
+        assertNull(userInfo.getClaim(ValidClaims.SOCIAL_SECURITY_RECORD.getValue()));
     }
 
     @Test
@@ -178,7 +178,7 @@ class UserInfoServiceTest {
         assertNull(userInfo.getClaim(ValidClaims.ADDRESS.getValue()));
         assertNull(userInfo.getClaim(ValidClaims.PASSPORT.getValue()));
         assertNull(userInfo.getClaim(ValidClaims.DRIVING_PERMIT.getValue()));
-        assertNull(userInfo.getClaim(ValidClaims.NINO.getValue()));
+        assertNull(userInfo.getClaim(ValidClaims.SOCIAL_SECURITY_RECORD.getValue()));
     }
 
     @Nested
@@ -206,7 +206,7 @@ class UserInfoServiceTest {
             assertNull(userInfo.getClaim(ValidClaims.ADDRESS.getValue()));
             assertNull(userInfo.getClaim(ValidClaims.PASSPORT.getValue()));
             assertNull(userInfo.getClaim(ValidClaims.DRIVING_PERMIT.getValue()));
-            assertNull(userInfo.getClaim(ValidClaims.NINO.getValue()));
+            assertNull(userInfo.getClaim(ValidClaims.SOCIAL_SECURITY_RECORD.getValue()));
             assertNull(userInfo.getClaim(ValidClaims.CORE_IDENTITY_JWT.getValue()));
         }
 
@@ -239,7 +239,7 @@ class UserInfoServiceTest {
             assertNull(userInfo.getClaim(ValidClaims.ADDRESS.getValue()));
             assertNull(userInfo.getClaim(ValidClaims.PASSPORT.getValue()));
             assertNull(userInfo.getClaim(ValidClaims.DRIVING_PERMIT.getValue()));
-            assertNull(userInfo.getClaim(ValidClaims.NINO.getValue()));
+            assertNull(userInfo.getClaim(ValidClaims.SOCIAL_SECURITY_RECORD.getValue()));
             assertNull(userInfo.getClaim(ValidClaims.CORE_IDENTITY_JWT.getValue()));
         }
 
@@ -259,8 +259,8 @@ class UserInfoServiceTest {
                                             PASSPORT_CLAIM,
                                             ValidClaims.DRIVING_PERMIT.getValue(),
                                             DRIVING_PERMIT,
-                                            ValidClaims.NINO.getValue(),
-                                            NINO));
+                                            ValidClaims.SOCIAL_SECURITY_RECORD.getValue(),
+                                            SOCIAL_SECURITY_RECORD));
             accessToken = createSignedAccessToken(oidcValidClaimsRequest);
             when(authenticationService.getUserProfileFromSubject(INTERNAL_SUBJECT.getValue()))
                     .thenReturn(generateUserprofile());
@@ -289,20 +289,21 @@ class UserInfoServiceTest {
                     userInfo.getClaim(ValidClaims.CORE_IDENTITY_JWT.getValue()),
                     equalTo(coreIdentityJWT));
             var addressClaim = (JSONArray) userInfo.getClaim(ValidClaims.ADDRESS.getValue());
-            assertThat(((LinkedTreeMap) addressClaim.get(0)).size(), equalTo(7));
             var passportClaim = (JSONArray) userInfo.getClaim(ValidClaims.PASSPORT.getValue());
-            assertThat(((LinkedTreeMap) passportClaim.get(0)).size(), equalTo(2));
             var drivingPermitClaim =
                     (JSONArray) userInfo.getClaim(ValidClaims.DRIVING_PERMIT.getValue());
+            var socialSecurityRecordClaim =
+                    (JSONArray) userInfo.getClaim(ValidClaims.SOCIAL_SECURITY_RECORD.getValue());
+            assertThat(((LinkedTreeMap) addressClaim.get(0)).size(), equalTo(7));
+            assertThat(((LinkedTreeMap) passportClaim.get(0)).size(), equalTo(2));
             assertThat(((LinkedTreeMap) drivingPermitClaim.get(0)).size(), equalTo(6));
-            var ninoClaim = (JSONArray) userInfo.getClaim(ValidClaims.NINO.getValue());
-            assertThat(((LinkedTreeMap) ninoClaim.get(0)).size(), equalTo(1));
+            assertThat(((LinkedTreeMap) socialSecurityRecordClaim.get(0)).size(), equalTo(1));
 
             assertClaimMetricPublished("https://vocab.account.gov.uk/v1/coreIdentityJWT");
             assertClaimMetricPublished("https://vocab.account.gov.uk/v1/address");
             assertClaimMetricPublished("https://vocab.account.gov.uk/v1/passport");
             assertClaimMetricPublished("https://vocab.account.gov.uk/v1/drivingPermit");
-            assertClaimMetricPublished("https://vocab.account.gov.uk/v1/nino");
+            assertClaimMetricPublished("https://vocab.account.gov.uk/v1/socialSecurityRecord");
         }
 
         @Test
@@ -322,8 +323,8 @@ class UserInfoServiceTest {
                                             PASSPORT_CLAIM,
                                             ValidClaims.DRIVING_PERMIT.getValue(),
                                             DRIVING_PERMIT,
-                                            ValidClaims.NINO.getValue(),
-                                            NINO));
+                                            ValidClaims.SOCIAL_SECURITY_RECORD.getValue(),
+                                            SOCIAL_SECURITY_RECORD));
             accessToken = createSignedAccessToken(oidcValidClaimsRequest);
 
             when(identityService.getIdentityCredentials(SUBJECT.getValue()))
@@ -357,20 +358,21 @@ class UserInfoServiceTest {
                     userInfo.getClaim(ValidClaims.CORE_IDENTITY_JWT.getValue()),
                     equalTo(coreIdentityJWT));
             var addressClaim = (JSONArray) userInfo.getClaim(ValidClaims.ADDRESS.getValue());
-            assertThat(((LinkedTreeMap) addressClaim.get(0)).size(), equalTo(7));
             var passportClaim = (JSONArray) userInfo.getClaim(ValidClaims.PASSPORT.getValue());
-            assertThat(((LinkedTreeMap) passportClaim.get(0)).size(), equalTo(2));
             var drivingPermitClaim =
                     (JSONArray) userInfo.getClaim(ValidClaims.DRIVING_PERMIT.getValue());
+            var socialSecurityRecordClaim =
+                    (JSONArray) userInfo.getClaim(ValidClaims.SOCIAL_SECURITY_RECORD.getValue());
+            assertThat(((LinkedTreeMap) addressClaim.get(0)).size(), equalTo(7));
+            assertThat(((LinkedTreeMap) passportClaim.get(0)).size(), equalTo(2));
             assertThat(((LinkedTreeMap) drivingPermitClaim.get(0)).size(), equalTo(6));
-            var ninoClaim = (JSONArray) userInfo.getClaim(ValidClaims.NINO.getValue());
-            assertThat(((LinkedTreeMap) ninoClaim.get(0)).size(), equalTo(1));
+            assertThat(((LinkedTreeMap) socialSecurityRecordClaim.get(0)).size(), equalTo(1));
 
             assertClaimMetricPublished("https://vocab.account.gov.uk/v1/coreIdentityJWT");
             assertClaimMetricPublished("https://vocab.account.gov.uk/v1/address");
             assertClaimMetricPublished("https://vocab.account.gov.uk/v1/passport");
             assertClaimMetricPublished("https://vocab.account.gov.uk/v1/drivingPermit");
-            assertClaimMetricPublished("https://vocab.account.gov.uk/v1/nino");
+            assertClaimMetricPublished("https://vocab.account.gov.uk/v1/socialSecurityRecord");
         }
 
         @Test
@@ -397,7 +399,7 @@ class UserInfoServiceTest {
             assertNull(userInfo.getClaim(ValidClaims.ADDRESS.getValue()));
             assertNull(userInfo.getClaim(ValidClaims.PASSPORT.getValue()));
             assertNull(userInfo.getClaim(ValidClaims.DRIVING_PERMIT.getValue()));
-            assertNull(userInfo.getClaim(ValidClaims.NINO.getValue()));
+            assertNull(userInfo.getClaim(ValidClaims.SOCIAL_SECURITY_RECORD.getValue()));
             assertNull(userInfo.getClaim(ValidClaims.CORE_IDENTITY_JWT.getValue()));
         }
 
@@ -431,7 +433,7 @@ class UserInfoServiceTest {
             assertNull(userInfo.getClaim(ValidClaims.ADDRESS.getValue()));
             assertNull(userInfo.getClaim(ValidClaims.PASSPORT.getValue()));
             assertNull(userInfo.getClaim(ValidClaims.DRIVING_PERMIT.getValue()));
-            assertNull(userInfo.getClaim(ValidClaims.NINO.getValue()));
+            assertNull(userInfo.getClaim(ValidClaims.SOCIAL_SECURITY_RECORD.getValue()));
             assertNull(userInfo.getClaim(ValidClaims.CORE_IDENTITY_JWT.getValue()));
         }
 
@@ -472,7 +474,7 @@ class UserInfoServiceTest {
             assertNull(userInfo.getClaim(ValidClaims.ADDRESS.getValue()));
             assertNull(userInfo.getClaim(ValidClaims.PASSPORT.getValue()));
             assertNull(userInfo.getClaim(ValidClaims.DRIVING_PERMIT.getValue()));
-            assertNull(userInfo.getClaim(ValidClaims.NINO.getValue()));
+            assertNull(userInfo.getClaim(ValidClaims.SOCIAL_SECURITY_RECORD.getValue()));
 
             assertClaimMetricPublished("https://vocab.account.gov.uk/v1/coreIdentityJWT");
         }
@@ -522,7 +524,7 @@ class UserInfoServiceTest {
             assertNull(userInfo.getClaim(ValidClaims.ADDRESS.getValue()));
             assertNull(userInfo.getClaim(ValidClaims.PASSPORT.getValue()));
             assertNull(userInfo.getClaim(ValidClaims.DRIVING_PERMIT.getValue()));
-            assertNull(userInfo.getClaim(ValidClaims.NINO.getValue()));
+            assertNull(userInfo.getClaim(ValidClaims.SOCIAL_SECURITY_RECORD.getValue()));
 
             assertClaimMetricPublished("https://vocab.account.gov.uk/v1/coreIdentityJWT");
         }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/IPVStubExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/IPVStubExtension.java
@@ -40,6 +40,7 @@ public class IPVStubExtension extends HttpStubExtension {
                         + "  \"https://vocab.account.gov.uk/v1/coreIdentity\": {\"name\":[{\"nameParts\":[{\"type\":\"GivenName\",\"value\":\"kenneth\"},{\"type\":\"FamilyName\",\"value\":\"decerqueira\"}]}],\"birthDate\":[{\"value\":\"1964-11-07\"}]},"
                         + "  \"https://vocab.account.gov.uk/v1/address\": [{\"addressCountry\":\"GB\",\"uprn\":null,\"buildingName\":\"\",\"streetName\":\"HADLEY ROAD\",\"postalCode\":\"BA2 5AA\",\"buildingNumber\":\"8\",\"addressLocality\":\"BATH\",\"validFrom\":\"2000-01-01\"}],"
                         + "  \"https://vocab.account.gov.uk/v1/drivingPermit\": [{\"personalNumber\":\"DOE99802085J99KV\",\"fullAddress\":\"122 BURNS CRESCENT EDINBURGH EH1 9GP\",\"issueNumber\":\"16\",\"issuedBy\":\"DVLA\",\"issueDate\":\"2019-01-23\",\"expiryDate\":\"2023-01-18\"}],"
+                        + "  \"https://vocab.account.gov.uk/v1/nino\": [{\"socialSecurityRecord\":[{\"personalNumber\":\"LR850265D\"}]}],"
                         + "  \"https://vocab.account.gov.uk/v1/passport\": [{\"documentNumber\":\"1223456\",\"expiryDate\":\"2022-02-02\"}]"
                         + "}");
     }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/IPVStubExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/IPVStubExtension.java
@@ -40,7 +40,7 @@ public class IPVStubExtension extends HttpStubExtension {
                         + "  \"https://vocab.account.gov.uk/v1/coreIdentity\": {\"name\":[{\"nameParts\":[{\"type\":\"GivenName\",\"value\":\"kenneth\"},{\"type\":\"FamilyName\",\"value\":\"decerqueira\"}]}],\"birthDate\":[{\"value\":\"1964-11-07\"}]},"
                         + "  \"https://vocab.account.gov.uk/v1/address\": [{\"addressCountry\":\"GB\",\"uprn\":null,\"buildingName\":\"\",\"streetName\":\"HADLEY ROAD\",\"postalCode\":\"BA2 5AA\",\"buildingNumber\":\"8\",\"addressLocality\":\"BATH\",\"validFrom\":\"2000-01-01\"}],"
                         + "  \"https://vocab.account.gov.uk/v1/drivingPermit\": [{\"personalNumber\":\"DOE99802085J99KV\",\"fullAddress\":\"122 BURNS CRESCENT EDINBURGH EH1 9GP\",\"issueNumber\":\"16\",\"issuedBy\":\"DVLA\",\"issueDate\":\"2019-01-23\",\"expiryDate\":\"2023-01-18\"}],"
-                        + "  \"https://vocab.account.gov.uk/v1/nino\": [{\"socialSecurityRecord\":[{\"personalNumber\":\"LR850265D\"}]}],"
+                        + "  \"https://vocab.account.gov.uk/v1/socialSecurityRecord\": [{\"socialSecurityRecord\":[{\"personalNumber\":\"LR850265D\"}]}],"
                         + "  \"https://vocab.account.gov.uk/v1/passport\": [{\"documentNumber\":\"1223456\",\"expiryDate\":\"2022-02-02\"}]"
                         + "}");
     }

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/IdentityTestData.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/IdentityTestData.java
@@ -12,7 +12,7 @@ public final class IdentityTestData {
     public static final String DRIVING_PERMIT =
             "[{\"personalNumber\":\"DOE99802085J99KV\",\"fullAddress\":\"122 BURNS CRESCENT EDINBURGH EH1 9GP\",\"issueNumber\":\"16\",\"issuedBy\":\"DVLA\",\"issueDate\":\"2019-01-23\",\"expiryDate\":\"2023-01-18\"}]";
 
-    public static final String NINO =
+    public static final String SOCIAL_SECURITY_RECORD =
             "[{\"socialSecurityRecord\":[{\"personalNumber\":\"LR850265D\"}]}]";
 
     public static final String CORE_IDENTITY_CLAIM =

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/IdentityTestData.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/helper/IdentityTestData.java
@@ -12,6 +12,9 @@ public final class IdentityTestData {
     public static final String DRIVING_PERMIT =
             "[{\"personalNumber\":\"DOE99802085J99KV\",\"fullAddress\":\"122 BURNS CRESCENT EDINBURGH EH1 9GP\",\"issueNumber\":\"16\",\"issuedBy\":\"DVLA\",\"issueDate\":\"2019-01-23\",\"expiryDate\":\"2023-01-18\"}]";
 
+    public static final String NINO =
+            "[{\"socialSecurityRecord\":[{\"personalNumber\":\"LR850265D\"}]}]";
+
     public static final String CORE_IDENTITY_CLAIM =
             "{\"name\":[{\"nameParts\":[{\"type\":\"GivenName\",\"value\":\"kenneth\"},{\"type\":\"FamilyName\",\"value\":\"decerqueira\"}]}],\"birthDate\":[{\"value\":\"1964-11-07\"}]}";
 

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ValidClaims.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ValidClaims.java
@@ -12,7 +12,7 @@ public enum ValidClaims {
     ADDRESS("https://vocab.account.gov.uk/v1/address"),
     PASSPORT("https://vocab.account.gov.uk/v1/passport"),
     DRIVING_PERMIT("https://vocab.account.gov.uk/v1/drivingPermit"),
-    NINO("https://vocab.account.gov.uk/v1/nino"),
+    SOCIAL_SECURITY_RECORD("https://vocab.account.gov.uk/v1/socialSecurityRecord"),
     CORE_IDENTITY_JWT("https://vocab.account.gov.uk/v1/coreIdentityJWT");
 
     private final String value;

--- a/shared/src/main/java/uk/gov/di/authentication/shared/entity/ValidClaims.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/entity/ValidClaims.java
@@ -12,6 +12,7 @@ public enum ValidClaims {
     ADDRESS("https://vocab.account.gov.uk/v1/address"),
     PASSPORT("https://vocab.account.gov.uk/v1/passport"),
     DRIVING_PERMIT("https://vocab.account.gov.uk/v1/drivingPermit"),
+    NINO("https://vocab.account.gov.uk/v1/nino"),
     CORE_IDENTITY_JWT("https://vocab.account.gov.uk/v1/coreIdentityJWT");
 
     private final String value;

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/ValidClaimsTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/ValidClaimsTest.java
@@ -19,7 +19,7 @@ class ValidClaimsTest {
                 "https://vocab.account.gov.uk/v1/passport",
                 "https://vocab.account.gov.uk/v1/coreIdentityJWT",
                 "https://vocab.account.gov.uk/v1/drivingPermit",
-                "https://vocab.account.gov.uk/v1/nino");
+                "https://vocab.account.gov.uk/v1/socialSecurityRecord");
     }
 
     static Stream<String> unsupportedClaims() {

--- a/shared/src/test/java/uk/gov/di/authentication/shared/entity/ValidClaimsTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/entity/ValidClaimsTest.java
@@ -18,7 +18,8 @@ class ValidClaimsTest {
                 "https://vocab.account.gov.uk/v1/address",
                 "https://vocab.account.gov.uk/v1/passport",
                 "https://vocab.account.gov.uk/v1/coreIdentityJWT",
-                "https://vocab.account.gov.uk/v1/drivingPermit");
+                "https://vocab.account.gov.uk/v1/drivingPermit",
+                "https://vocab.account.gov.uk/v1/nino");
     }
 
     static Stream<String> unsupportedClaims() {
@@ -29,7 +30,7 @@ class ValidClaimsTest {
 
     @Test
     void shouldReturnCorrectNumberOfClaimsSupported() {
-        assertThat(ValidClaims.getAllValidClaims().size(), equalTo(4));
+        assertThat(ValidClaims.getAllValidClaims().size(), equalTo(5));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
## What

Adding a new claim for NINO, so that HMRC can request it from One Login. 

## Why

So that they can see if the user has a HMRC account. It would prevent HMRC from having to collect the NINO from the user after creating a [GOV.UK](http://gov.uk/) One Login account

## Who

Orchestration

Dev Notes
Agree claim name and payload structure with Identity team, will be of the form https://vocab.account.gov.uk/v1/<something> 

## Related PRs

[AUT-763 - Support drivingPermit claim · alphagov/di-authentication-api@2356517](https://github.com/alphagov/di-authentication-api/commit/23565179dd002f2224d00367c94e7420c8f87202) Previous pull request to add driving Permit