### PR TITLE
AUT-1467: Remove bulk email infrastructure in build and sandpit

### DIFF
--- a/ci/terraform/delivery-receipts/delivery-receipts-dynamo-access.tf
+++ b/ci/terraform/delivery-receipts/delivery-receipts-dynamo-access.tf
@@ -1,6 +1,7 @@
 
 data "aws_dynamodb_table" "bulk_email_users_table" {
-  name = "${var.environment}-bulk-email-users"
+  count = local.deploy_bulk_email_users_count
+  name  = "${var.environment}-bulk-email-users"
 }
 
 data "aws_dynamodb_table" "user_profile_table" {

--- a/ci/terraform/delivery-receipts/site.tf
+++ b/ci/terraform/delivery-receipts/site.tf
@@ -45,7 +45,8 @@ locals {
     application = "delivery-receipts-api"
   }
 
-  request_tracing_allowed = contains(["build", "sandpit"], var.environment)
+  request_tracing_allowed       = contains(["build", "sandpit"], var.environment)
+  deploy_bulk_email_users_count = contains(["build", "sandpit"], var.environment) ? 0 : 1
 
   access_logging_template = jsonencode({
     requestId            = "$context.requestId"

--- a/ci/terraform/shared/site.tf
+++ b/ci/terraform/shared/site.tf
@@ -59,7 +59,7 @@ locals {
   }
 
   request_tracing_allowed       = contains(["build", "sandpit"], var.environment)
-  deploy_bulk_email_users_count = 1
+  deploy_bulk_email_users_count = contains(["build", "sandpit"], var.environment) ? 0 : 1
 }
 
 data "aws_caller_identity" "current" {}

--- a/ci/terraform/utils/site.tf
+++ b/ci/terraform/utils/site.tf
@@ -52,7 +52,7 @@ locals {
   }
 
   request_tracing_allowed                     = contains(["build", "sandpit"], var.environment)
-  deploy_bulk_email_users_count               = 1
+  deploy_bulk_email_users_count               = contains(["build", "sandpit"], var.environment) ? 0 : 1
   bulk_user_email_audience_loader_lambda_name = "${var.environment}-bulk-user-email-audience-loader-lambda"
 }
 


### PR DESCRIPTION
This sets the counts for:
* The bulk-email-users table;
* The bulk-email-sender;
* The bulk-email-loader

to 0 in build and sandpit. It also adds this count in for the delivery receipts api. This will mean that the lambdas are no longer deployed in these environments, and the table (including data) is destroyed.

This was previously reverted as we had pipeline failures due to not setting all the counts to 0 - I think this should fix.