### PR TITLE
Deploy dynatrace to all environments but production.

### DIFF
--- a/ci/terraform/modules/endpoint-module/lambda.tf
+++ b/ci/terraform/modules/endpoint-module/lambda.tf
@@ -120,6 +120,6 @@ resource "aws_appautoscaling_policy" "provisioned-concurrency-policy" {
 }
 
 locals {
-  deploy_dynatrace = contains(["staging"], var.environment)
+  deploy_dynatrace = var.environment != "production"
   lambda_layers    = flatten(local.deploy_dynatrace ? [local.dynatrace_layer_arn] : [])
 }


### PR DESCRIPTION
## What?

Deploy dynatrace to all environments but production.

## Why?

Dynatrace java lambda layer issue has been resolved and testing in sandpit and staging. Now deploying to all environments apart from production.
