### PR TITLE
Ato 81/modify authorize terraform to allow post requests

### DIFF
--- a/ci/terraform/account-management/authenticate.tf
+++ b/ci/terraform/account-management/authenticate.tf
@@ -17,7 +17,7 @@ module "authenticate" {
 
   endpoint_name   = "authenticate"
   path_part       = "authenticate"
-  endpoint_method = "POST"
+  endpoint_method = ["POST"]
   handler_environment_variables = {
     ENVIRONMENT          = var.environment
     DYNAMO_ENDPOINT      = var.use_localstack ? var.lambda_dynamo_endpoint : null

--- a/ci/terraform/account-management/authenticate.tf
+++ b/ci/terraform/account-management/authenticate.tf
@@ -59,3 +59,8 @@ module "authenticate" {
 
   use_localstack = var.use_localstack
 }
+
+moved {
+  from = module.authenticate.aws_api_gateway_method.endpoint_method
+  to   = module.authenticate.aws_api_gateway_method.endpoint_method["POST"]
+}

--- a/ci/terraform/account-management/remove-account.tf
+++ b/ci/terraform/account-management/remove-account.tf
@@ -19,7 +19,7 @@ module "delete_account" {
 
   endpoint_name   = "delete-account"
   path_part       = "delete-account"
-  endpoint_method = "POST"
+  endpoint_method = ["POST"]
   handler_environment_variables = {
     ENVIRONMENT          = var.environment
     DYNAMO_ENDPOINT      = var.use_localstack ? var.lambda_dynamo_endpoint : null

--- a/ci/terraform/account-management/remove-account.tf
+++ b/ci/terraform/account-management/remove-account.tf
@@ -61,3 +61,8 @@ module "delete_account" {
   lambda_env_vars_encryption_kms_key_arn = data.terraform_remote_state.shared.outputs.lambda_env_vars_encryption_kms_key_arn
 
 }
+
+moved {
+  from = module.delete_account.aws_api_gateway_method.endpoint_method
+  to   = module.delete_account.aws_api_gateway_method.endpoint_method["POST"]
+}

--- a/ci/terraform/account-management/send_otp_notification.tf
+++ b/ci/terraform/account-management/send_otp_notification.tf
@@ -18,7 +18,7 @@ module "send_otp_notification" {
 
   endpoint_name   = "send-otp-notification"
   path_part       = "send-otp-notification"
-  endpoint_method = "POST"
+  endpoint_method = ["POST"]
   environment     = var.environment
 
   handler_environment_variables = {

--- a/ci/terraform/account-management/send_otp_notification.tf
+++ b/ci/terraform/account-management/send_otp_notification.tf
@@ -73,3 +73,8 @@ module "send_otp_notification" {
     aws_elasticache_replication_group.account_management_sessions_store,
   ]
 }
+
+moved {
+  from = module.send_otp_notification.aws_api_gateway_method.endpoint_method
+  to   = module.send_otp_notification.aws_api_gateway_method.endpoint_method["POST"]
+}

--- a/ci/terraform/account-management/update-email.tf
+++ b/ci/terraform/account-management/update-email.tf
@@ -62,3 +62,8 @@ module "update_email" {
   lambda_env_vars_encryption_kms_key_arn = data.terraform_remote_state.shared.outputs.lambda_env_vars_encryption_kms_key_arn
 
 }
+
+moved {
+  from = module.update_email.aws_api_gateway_method.endpoint_method
+  to   = module.update_email.aws_api_gateway_method.endpoint_method["POST"]
+}

--- a/ci/terraform/account-management/update-email.tf
+++ b/ci/terraform/account-management/update-email.tf
@@ -19,7 +19,7 @@ module "update_email" {
 
   endpoint_name   = "update-email"
   path_part       = "update-email"
-  endpoint_method = "POST"
+  endpoint_method = ["POST"]
   handler_environment_variables = {
     ENVIRONMENT          = var.environment
     DYNAMO_ENDPOINT      = var.use_localstack ? var.lambda_dynamo_endpoint : null

--- a/ci/terraform/account-management/update-password.tf
+++ b/ci/terraform/account-management/update-password.tf
@@ -18,7 +18,7 @@ module "update_password" {
 
   endpoint_name   = "update-password"
   path_part       = "update-password"
-  endpoint_method = "POST"
+  endpoint_method = ["POST"]
   handler_environment_variables = {
     ENVIRONMENT          = var.environment
     DYNAMO_ENDPOINT      = var.use_localstack ? var.lambda_dynamo_endpoint : null

--- a/ci/terraform/account-management/update-password.tf
+++ b/ci/terraform/account-management/update-password.tf
@@ -60,3 +60,8 @@ module "update_password" {
   lambda_env_vars_encryption_kms_key_arn = data.terraform_remote_state.shared.outputs.lambda_env_vars_encryption_kms_key_arn
 
 }
+
+moved {
+  from = module.update_password.aws_api_gateway_method.endpoint_method
+  to   = module.update_password.aws_api_gateway_method.endpoint_method["POST"]
+}

--- a/ci/terraform/account-management/update-phone-number.tf
+++ b/ci/terraform/account-management/update-phone-number.tf
@@ -60,3 +60,8 @@ module "update_phone_number" {
   cloudwatch_log_retention               = var.cloudwatch_log_retention
   lambda_env_vars_encryption_kms_key_arn = data.terraform_remote_state.shared.outputs.lambda_env_vars_encryption_kms_key_arn
 }
+
+moved {
+  from = module.update_phone_number.aws_api_gateway_method.endpoint_method
+  to   = module.update_phone_number.aws_api_gateway_method.endpoint_method["POST"]
+}

--- a/ci/terraform/account-management/update-phone-number.tf
+++ b/ci/terraform/account-management/update-phone-number.tf
@@ -18,7 +18,7 @@ module "update_phone_number" {
 
   endpoint_name   = "update-phone-number"
   path_part       = "update-phone-number"
-  endpoint_method = "POST"
+  endpoint_method = ["POST"]
   handler_environment_variables = {
     ENVIRONMENT          = var.environment
     DYNAMO_ENDPOINT      = var.use_localstack ? var.lambda_dynamo_endpoint : null

--- a/ci/terraform/auth-external-api/token.tf
+++ b/ci/terraform/auth-external-api/token.tf
@@ -71,3 +71,8 @@ module "auth_token" {
     aws_api_gateway_rest_api.di_auth_ext_api,
   ]
 }
+
+moved {
+  from = module.auth_token.aws_api_gateway_method.endpoint_method
+  to   = module.auth_token.aws_api_gateway_method.endpoint_method["POST"]
+}

--- a/ci/terraform/auth-external-api/token.tf
+++ b/ci/terraform/auth-external-api/token.tf
@@ -22,7 +22,7 @@ module "auth_token" {
 
   endpoint_name   = "auth-token"
   path_part       = "token"
-  endpoint_method = "POST"
+  endpoint_method = ["POST"]
   environment     = var.environment
 
   handler_environment_variables = {

--- a/ci/terraform/auth-external-api/userinfo.tf
+++ b/ci/terraform/auth-external-api/userinfo.tf
@@ -66,3 +66,7 @@ module "auth_userinfo" {
     aws_api_gateway_rest_api.di_auth_ext_api,
   ]
 }
+moved {
+  from = module.auth_userinfo.aws_api_gateway_method.endpoint_method
+  to   = module.auth_userinfo.aws_api_gateway_method.endpoint_method["GET"]
+}

--- a/ci/terraform/auth-external-api/userinfo.tf
+++ b/ci/terraform/auth-external-api/userinfo.tf
@@ -20,7 +20,7 @@ module "auth_userinfo" {
 
   endpoint_name   = "auth-userinfo"
   path_part       = "userinfo"
-  endpoint_method = "GET"
+  endpoint_method = ["GET"]
   environment     = var.environment
 
   handler_environment_variables = {

--- a/ci/terraform/delivery-receipts/notify-callback.tf
+++ b/ci/terraform/delivery-receipts/notify-callback.tf
@@ -53,3 +53,7 @@ module "notify_callback" {
     aws_api_gateway_rest_api.di_authentication_delivery_receipts_api,
   ]
 }
+moved {
+  from = module.notify_callback.aws_api_gateway_method.endpoint_method
+  to   = module.notify_callback.aws_api_gateway_method.endpoint_method["POST"]
+}

--- a/ci/terraform/delivery-receipts/notify-callback.tf
+++ b/ci/terraform/delivery-receipts/notify-callback.tf
@@ -15,7 +15,7 @@ module "notify_callback" {
 
   endpoint_name   = "notify-callback"
   path_part       = "notify-callback"
-  endpoint_method = "POST"
+  endpoint_method = ["POST"]
   environment     = var.environment
 
   handler_environment_variables = merge(var.notify_template_map, {

--- a/ci/terraform/modules/endpoint-module/api-gateway.tf
+++ b/ci/terraform/modules/endpoint-module/api-gateway.tf
@@ -6,9 +6,10 @@ resource "aws_api_gateway_resource" "endpoint_resource" {
 }
 
 resource "aws_api_gateway_method" "endpoint_method" {
+  for_each    = toset(var.endpoint_method)
   rest_api_id = var.rest_api_id
   resource_id = var.create_endpoint ? aws_api_gateway_resource.endpoint_resource[0].id : var.root_resource_id
-  http_method = var.endpoint_method
+  http_method = each.key
 
   authorization = var.authorizer_id == null ? "NONE" : "CUSTOM"
   authorizer_id = var.authorizer_id
@@ -21,9 +22,10 @@ resource "aws_api_gateway_method" "endpoint_method" {
 }
 
 resource "aws_api_gateway_integration" "endpoint_integration" {
+  for_each           = toset(var.endpoint_method)
   rest_api_id        = var.rest_api_id
   resource_id        = var.create_endpoint ? aws_api_gateway_resource.endpoint_resource[0].id : var.root_resource_id
-  http_method        = aws_api_gateway_method.endpoint_method.http_method
+  http_method        = aws_api_gateway_method.endpoint_method[each.key].http_method
   request_parameters = var.integration_request_parameters
 
   integration_http_method = "POST"

--- a/ci/terraform/modules/endpoint-module/variables.tf
+++ b/ci/terraform/modules/endpoint-module/variables.tf
@@ -27,7 +27,7 @@ variable "integration_request_parameters" {
 }
 
 variable "endpoint_method" {
-  type = string
+  type = list(string)
 }
 
 variable "source_bucket" {

--- a/ci/terraform/oidc/account-recovery.tf
+++ b/ci/terraform/oidc/account-recovery.tf
@@ -22,7 +22,7 @@ module "account_recovery" {
 
   endpoint_name   = "account-recovery"
   path_part       = "account-recovery"
-  endpoint_method = "POST"
+  endpoint_method = ["POST"]
   environment     = var.environment
 
   handler_environment_variables = {

--- a/ci/terraform/oidc/account-recovery.tf
+++ b/ci/terraform/oidc/account-recovery.tf
@@ -66,3 +66,7 @@ module "account_recovery" {
 
   use_localstack = var.use_localstack
 }
+moved {
+  from = module.account_recovery.aws_api_gateway_method.endpoint_method
+  to   = module.account_recovery.aws_api_gateway_method.endpoint_method["POST"]
+}

--- a/ci/terraform/oidc/auth-code.tf
+++ b/ci/terraform/oidc/auth-code.tf
@@ -67,3 +67,7 @@ module "auth-code" {
     aws_api_gateway_resource.wellknown_resource,
   ]
 }
+moved {
+  from = module.auth-code.aws_api_gateway_method.endpoint_method
+  to   = module.auth-code.aws_api_gateway_method.endpoint_method["GET"]
+}

--- a/ci/terraform/oidc/auth-code.tf
+++ b/ci/terraform/oidc/auth-code.tf
@@ -19,7 +19,7 @@ module "auth-code" {
 
   endpoint_name   = "auth-code"
   path_part       = "auth-code"
-  endpoint_method = "GET"
+  endpoint_method = ["GET"]
 
   handler_environment_variables = {
     TXMA_AUDIT_QUEUE_URL     = module.oidc_txma_audit.queue_url

--- a/ci/terraform/oidc/authentication-auth-code.tf
+++ b/ci/terraform/oidc/authentication-auth-code.tf
@@ -22,7 +22,7 @@ module "orch_auth_code" {
 
   endpoint_name   = "orch-auth-code"
   path_part       = "orch-auth-code"
-  endpoint_method = "POST"
+  endpoint_method = ["POST"]
   environment     = var.environment
 
   handler_environment_variables = {

--- a/ci/terraform/oidc/authentication-auth-code.tf
+++ b/ci/terraform/oidc/authentication-auth-code.tf
@@ -72,3 +72,7 @@ module "orch_auth_code" {
     aws_api_gateway_resource.wellknown_resource,
   ]
 }
+moved {
+  from = module.orch_auth_code.aws_api_gateway_method.endpoint_method
+  to   = module.orch_auth_code.aws_api_gateway_method.endpoint_method["POST"]
+}

--- a/ci/terraform/oidc/authentication-callback.tf
+++ b/ci/terraform/oidc/authentication-callback.tf
@@ -22,7 +22,7 @@ module "authentication_callback" {
 
   endpoint_name   = "orchestration-redirect"
   path_part       = "orchestration-redirect"
-  endpoint_method = "GET"
+  endpoint_method = ["GET"]
   environment     = var.environment
 
   handler_environment_variables = {

--- a/ci/terraform/oidc/authentication-callback.tf
+++ b/ci/terraform/oidc/authentication-callback.tf
@@ -77,3 +77,8 @@ module "authentication_callback" {
     aws_api_gateway_rest_api.di_authentication_api
   ]
 }
+
+moved {
+  from = module.authentication_callback.aws_api_gateway_method.endpoint_method
+  to   = module.authentication_callback.aws_api_gateway_method.endpoint_method["GET"]
+}

--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -23,7 +23,7 @@ module "authorize" {
 
   endpoint_name   = "authorize"
   path_part       = "authorize"
-  endpoint_method = "GET"
+  endpoint_method = ["GET", "POST"]
   environment     = var.environment
 
   handler_environment_variables = {

--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -91,3 +91,8 @@ module "authorize" {
     aws_api_gateway_resource.wellknown_resource,
   ]
 }
+
+moved {
+  from = module.authorize.aws_api_gateway_method.endpoint_method
+  to   = module.authorize.aws_api_gateway_method.endpoint_method["GET"]
+}

--- a/ci/terraform/oidc/doc-app-authorize.tf
+++ b/ci/terraform/oidc/doc-app-authorize.tf
@@ -19,7 +19,7 @@ module "doc-app-authorize" {
 
   endpoint_name   = "doc-app-authorize"
   path_part       = "doc-app-authorize"
-  endpoint_method = "POST"
+  endpoint_method = ["POST"]
   environment     = var.environment
 
   handler_environment_variables = {

--- a/ci/terraform/oidc/doc-app-authorize.tf
+++ b/ci/terraform/oidc/doc-app-authorize.tf
@@ -76,3 +76,8 @@ module "doc-app-authorize" {
     aws_api_gateway_resource.wellknown_resource,
   ]
 }
+
+moved {
+  from = module.doc-app-authorize.aws_api_gateway_method.endpoint_method
+  to   = module.doc-app-authorize.aws_api_gateway_method.endpoint_method["POST"]
+}

--- a/ci/terraform/oidc/doc-app-callback.tf
+++ b/ci/terraform/oidc/doc-app-callback.tf
@@ -81,3 +81,8 @@ module "doc-app-callback" {
     aws_api_gateway_rest_api.di_authentication_api,
   ]
 }
+
+moved {
+  from = module.doc-app-callback.aws_api_gateway_method.endpoint_method
+  to   = module.doc-app-callback.aws_api_gateway_method.endpoint_method["GET"]
+}

--- a/ci/terraform/oidc/doc-app-callback.tf
+++ b/ci/terraform/oidc/doc-app-callback.tf
@@ -21,7 +21,7 @@ module "doc-app-callback" {
 
   endpoint_name   = "doc-app-callback"
   path_part       = "doc-app-callback"
-  endpoint_method = "GET"
+  endpoint_method = ["GET"]
   environment     = var.environment
 
   handler_environment_variables = {

--- a/ci/terraform/oidc/ipv-authorize.tf
+++ b/ci/terraform/oidc/ipv-authorize.tf
@@ -22,7 +22,7 @@ module "ipv-authorize" {
 
   endpoint_name   = "ipv-authorize"
   path_part       = "ipv-authorize"
-  endpoint_method = "POST"
+  endpoint_method = ["POST"]
   environment     = var.environment
 
   handler_environment_variables = {

--- a/ci/terraform/oidc/ipv-authorize.tf
+++ b/ci/terraform/oidc/ipv-authorize.tf
@@ -78,3 +78,8 @@ module "ipv-authorize" {
     aws_api_gateway_resource.wellknown_resource,
   ]
 }
+
+moved {
+  from = module.ipv-authorize.aws_api_gateway_method.endpoint_method
+  to   = module.ipv-authorize.aws_api_gateway_method.endpoint_method["POST"]
+}

--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -24,7 +24,7 @@ module "ipv-callback" {
 
   endpoint_name   = "ipv-callback"
   path_part       = "ipv-callback"
-  endpoint_method = "GET"
+  endpoint_method = ["GET"]
   environment     = var.environment
 
   handler_environment_variables = {

--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -84,3 +84,8 @@ module "ipv-callback" {
     aws_api_gateway_resource.wellknown_resource,
   ]
 }
+
+moved {
+  from = module.ipv-callback.aws_api_gateway_method.endpoint_method
+  to   = module.ipv-callback.aws_api_gateway_method.endpoint_method["GET"]
+}

--- a/ci/terraform/oidc/ipv-capacity.tf
+++ b/ci/terraform/oidc/ipv-capacity.tf
@@ -68,3 +68,8 @@ module "ipv-capacity" {
     aws_api_gateway_resource.wellknown_resource,
   ]
 }
+
+moved {
+  from = module.ipv-capacity.aws_api_gateway_method.endpoint_method
+  to   = module.ipv-capacity.aws_api_gateway_method.endpoint_method["GET"]
+}

--- a/ci/terraform/oidc/ipv-capacity.tf
+++ b/ci/terraform/oidc/ipv-capacity.tf
@@ -17,7 +17,7 @@ module "ipv-capacity" {
 
   endpoint_name   = "ipv-capacity"
   path_part       = "ipv-capacity"
-  endpoint_method = "GET"
+  endpoint_method = ["GET"]
   environment     = var.environment
 
   handler_environment_variables = {

--- a/ci/terraform/oidc/jwks.tf
+++ b/ci/terraform/oidc/jwks.tf
@@ -61,3 +61,8 @@ module "jwks" {
     aws_api_gateway_resource.wellknown_resource,
   ]
 }
+
+moved {
+  from = module.jwks.aws_api_gateway_method.endpoint_method
+  to   = module.jwks.aws_api_gateway_method.endpoint_method["GET"]
+}

--- a/ci/terraform/oidc/jwks.tf
+++ b/ci/terraform/oidc/jwks.tf
@@ -15,7 +15,7 @@ module "jwks" {
 
   endpoint_name   = "jwks.json"
   path_part       = "jwks.json"
-  endpoint_method = "GET"
+  endpoint_method = ["GET"]
   environment     = var.environment
 
   handler_environment_variables = {

--- a/ci/terraform/oidc/login.tf
+++ b/ci/terraform/oidc/login.tf
@@ -23,7 +23,7 @@ module "login" {
 
   endpoint_name   = "login"
   path_part       = "login"
-  endpoint_method = "POST"
+  endpoint_method = ["POST"]
   environment     = var.environment
 
   handler_environment_variables = {

--- a/ci/terraform/oidc/login.tf
+++ b/ci/terraform/oidc/login.tf
@@ -68,3 +68,8 @@ module "login" {
 
   use_localstack = var.use_localstack
 }
+
+moved {
+  from = module.login.aws_api_gateway_method.endpoint_method
+  to   = module.login.aws_api_gateway_method.endpoint_method["POST"]
+}

--- a/ci/terraform/oidc/logout.tf
+++ b/ci/terraform/oidc/logout.tf
@@ -20,7 +20,7 @@ module "logout" {
 
   endpoint_name   = "logout"
   path_part       = "logout"
-  endpoint_method = "GET"
+  endpoint_method = ["GET"]
   environment     = var.environment
 
   handler_environment_variables = {

--- a/ci/terraform/oidc/logout.tf
+++ b/ci/terraform/oidc/logout.tf
@@ -73,3 +73,8 @@ module "logout" {
     aws_api_gateway_resource.wellknown_resource,
   ]
 }
+
+moved {
+  from = module.logout.aws_api_gateway_method.endpoint_method
+  to   = module.logout.aws_api_gateway_method.endpoint_method["GET"]
+}

--- a/ci/terraform/oidc/mfa.tf
+++ b/ci/terraform/oidc/mfa.tf
@@ -19,7 +19,7 @@ module "mfa" {
 
   endpoint_name   = "mfa"
   path_part       = "mfa"
-  endpoint_method = "POST"
+  endpoint_method = ["POST"]
   environment     = var.environment
 
   handler_environment_variables = {

--- a/ci/terraform/oidc/mfa.tf
+++ b/ci/terraform/oidc/mfa.tf
@@ -74,3 +74,8 @@ module "mfa" {
     aws_sqs_queue.email_queue,
   ]
 }
+
+moved {
+  from = module.mfa.aws_api_gateway_method.endpoint_method
+  to   = module.mfa.aws_api_gateway_method.endpoint_method["POST"]
+}

--- a/ci/terraform/oidc/processing-identity.tf
+++ b/ci/terraform/oidc/processing-identity.tf
@@ -69,3 +69,8 @@ module "processing-identity" {
 
   use_localstack = var.use_localstack
 }
+
+moved {
+  from = module.processing-identity.aws_api_gateway_method.endpoint_method
+  to   = module.processing-identity.aws_api_gateway_method.endpoint_method["POST"]
+}

--- a/ci/terraform/oidc/processing-identity.tf
+++ b/ci/terraform/oidc/processing-identity.tf
@@ -21,7 +21,7 @@ module "processing-identity" {
 
   endpoint_name   = "processing-identity"
   path_part       = "processing-identity"
-  endpoint_method = "POST"
+  endpoint_method = ["POST"]
   environment     = var.environment
 
   handler_environment_variables = {

--- a/ci/terraform/oidc/register.tf
+++ b/ci/terraform/oidc/register.tf
@@ -19,7 +19,7 @@ module "register" {
 
   endpoint_name   = "register"
   path_part       = "register"
-  endpoint_method = "POST"
+  endpoint_method = ["POST"]
 
   handler_environment_variables = {
     ENVIRONMENT          = var.environment

--- a/ci/terraform/oidc/register.tf
+++ b/ci/terraform/oidc/register.tf
@@ -65,3 +65,8 @@ module "register" {
     aws_api_gateway_resource.register_resource,
   ]
 }
+
+moved {
+  from = module.register[0].aws_api_gateway_method.endpoint_method
+  to   = module.register[0].aws_api_gateway_method.endpoint_method["POST"]
+}

--- a/ci/terraform/oidc/reset-password-request.tf
+++ b/ci/terraform/oidc/reset-password-request.tf
@@ -74,3 +74,8 @@ module "reset-password-request" {
     aws_sqs_queue.email_queue,
   ]
 }
+
+moved {
+  from = module.reset-password-request.aws_api_gateway_method.endpoint_method
+  to   = module.reset-password-request.aws_api_gateway_method.endpoint_method["POST"]
+}

--- a/ci/terraform/oidc/reset-password-request.tf
+++ b/ci/terraform/oidc/reset-password-request.tf
@@ -19,7 +19,7 @@ module "reset-password-request" {
 
   endpoint_name   = "reset-password-request"
   path_part       = "reset-password-request"
-  endpoint_method = "POST"
+  endpoint_method = ["POST"]
   environment     = var.environment
 
   handler_environment_variables = {

--- a/ci/terraform/oidc/reset_password.tf
+++ b/ci/terraform/oidc/reset_password.tf
@@ -23,7 +23,7 @@ module "reset_password" {
 
   endpoint_name   = "reset-password"
   path_part       = "reset-password"
-  endpoint_method = "POST"
+  endpoint_method = ["POST"]
   environment     = var.environment
 
   handler_environment_variables = {

--- a/ci/terraform/oidc/reset_password.tf
+++ b/ci/terraform/oidc/reset_password.tf
@@ -78,3 +78,8 @@ module "reset_password" {
     aws_api_gateway_resource.wellknown_resource,
   ]
 }
+
+moved {
+  from = module.reset_password.aws_api_gateway_method.endpoint_method
+  to   = module.reset_password.aws_api_gateway_method.endpoint_method["POST"]
+}

--- a/ci/terraform/oidc/send_notification.tf
+++ b/ci/terraform/oidc/send_notification.tf
@@ -73,3 +73,8 @@ module "send_notification" {
     aws_sqs_queue.email_queue,
   ]
 }
+
+moved {
+  from = module.send_notification.aws_api_gateway_method.endpoint_method
+  to   = module.send_notification.aws_api_gateway_method.endpoint_method["POST"]
+}

--- a/ci/terraform/oidc/send_notification.tf
+++ b/ci/terraform/oidc/send_notification.tf
@@ -19,7 +19,7 @@ module "send_notification" {
 
   endpoint_name   = "send-notification"
   path_part       = "send-notification"
-  endpoint_method = "POST"
+  endpoint_method = ["POST"]
   environment     = var.environment
 
   handler_environment_variables = {

--- a/ci/terraform/oidc/signup.tf
+++ b/ci/terraform/oidc/signup.tf
@@ -21,7 +21,7 @@ module "signup" {
 
   endpoint_name   = "signup"
   path_part       = "signup"
-  endpoint_method = "POST"
+  endpoint_method = ["POST"]
   environment     = var.environment
 
   handler_environment_variables = {

--- a/ci/terraform/oidc/signup.tf
+++ b/ci/terraform/oidc/signup.tf
@@ -72,3 +72,7 @@ module "signup" {
     aws_api_gateway_resource.wellknown_resource,
   ]
 }
+moved {
+  from = module.signup.aws_api_gateway_method.endpoint_method
+  to   = module.signup.aws_api_gateway_method.endpoint_method["POST"]
+}

--- a/ci/terraform/oidc/start.tf
+++ b/ci/terraform/oidc/start.tf
@@ -73,3 +73,8 @@ module "start" {
     aws_api_gateway_resource.wellknown_resource,
   ]
 }
+
+moved {
+  from = module.start.aws_api_gateway_method.endpoint_method
+  to   = module.start.aws_api_gateway_method.endpoint_method["GET"]
+}

--- a/ci/terraform/oidc/start.tf
+++ b/ci/terraform/oidc/start.tf
@@ -19,7 +19,7 @@ module "start" {
 
   endpoint_name   = "start"
   path_part       = "start"
-  endpoint_method = "GET"
+  endpoint_method = ["GET"]
   environment     = var.environment
 
   handler_environment_variables = {

--- a/ci/terraform/oidc/token.tf
+++ b/ci/terraform/oidc/token.tf
@@ -44,7 +44,7 @@ module "token" {
 
   endpoint_name   = "token"
   path_part       = "token"
-  endpoint_method = "POST"
+  endpoint_method = ["POST"]
   environment     = var.environment
 
   handler_environment_variables = {

--- a/ci/terraform/oidc/token.tf
+++ b/ci/terraform/oidc/token.tf
@@ -97,3 +97,8 @@ module "token" {
     aws_api_gateway_resource.wellknown_resource,
   ]
 }
+
+moved {
+  from = module.token.aws_api_gateway_method.endpoint_method
+  to   = module.token.aws_api_gateway_method.endpoint_method["POST"]
+}

--- a/ci/terraform/oidc/trustmarks.tf
+++ b/ci/terraform/oidc/trustmarks.tf
@@ -11,7 +11,7 @@ module "trustmarks" {
 
   endpoint_name   = "trustmark"
   path_part       = "trustmark"
-  endpoint_method = "GET"
+  endpoint_method = ["GET"]
   environment     = var.environment
 
   handler_environment_variables = {

--- a/ci/terraform/oidc/trustmarks.tf
+++ b/ci/terraform/oidc/trustmarks.tf
@@ -55,3 +55,8 @@ module "trustmarks" {
     aws_api_gateway_resource.wellknown_resource,
   ]
 }
+
+moved {
+  from = module.trustmarks.aws_api_gateway_method.endpoint_method
+  to   = module.trustmarks.aws_api_gateway_method.endpoint_method["GET"]
+}

--- a/ci/terraform/oidc/update.tf
+++ b/ci/terraform/oidc/update.tf
@@ -69,3 +69,8 @@ module "update" {
     aws_api_gateway_resource.register_resource,
   ]
 }
+
+moved {
+  from = module.update[0].aws_api_gateway_method.endpoint_method
+  to   = module.update[0].aws_api_gateway_method.endpoint_method["PUT"]
+}

--- a/ci/terraform/oidc/update.tf
+++ b/ci/terraform/oidc/update.tf
@@ -19,7 +19,7 @@ module "update" {
 
   path_part                      = "{clientId}"
   endpoint_name                  = "update-client-info"
-  endpoint_method                = "PUT"
+  endpoint_method                = ["PUT"]
   method_request_parameters      = { "method.request.path.clientId" = true }
   integration_request_parameters = { "integration.request.path.clientId" = "method.request.path.clientId" }
 

--- a/ci/terraform/oidc/update_profile.tf
+++ b/ci/terraform/oidc/update_profile.tf
@@ -71,3 +71,8 @@ module "update_profile" {
     aws_api_gateway_resource.wellknown_resource,
   ]
 }
+
+moved {
+  from = module.update_profile.aws_api_gateway_method.endpoint_method
+  to   = module.update_profile.aws_api_gateway_method.endpoint_method["POST"]
+}

--- a/ci/terraform/oidc/update_profile.tf
+++ b/ci/terraform/oidc/update_profile.tf
@@ -20,7 +20,7 @@ module "update_profile" {
 
   endpoint_name   = "update-profile"
   path_part       = "update-profile"
-  endpoint_method = "POST"
+  endpoint_method = ["POST"]
   environment     = var.environment
 
   handler_environment_variables = {

--- a/ci/terraform/oidc/userexists.tf
+++ b/ci/terraform/oidc/userexists.tf
@@ -20,7 +20,7 @@ module "userexists" {
 
   endpoint_name   = "user-exists"
   path_part       = "user-exists"
-  endpoint_method = "POST"
+  endpoint_method = ["POST"]
   environment     = var.environment
 
   handler_environment_variables = {

--- a/ci/terraform/oidc/userexists.tf
+++ b/ci/terraform/oidc/userexists.tf
@@ -70,3 +70,8 @@ module "userexists" {
     aws_api_gateway_resource.wellknown_resource,
   ]
 }
+
+moved {
+  from = module.userexists.aws_api_gateway_method.endpoint_method
+  to   = module.userexists.aws_api_gateway_method.endpoint_method["POST"]
+}

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -22,7 +22,7 @@ module "userinfo" {
 
   endpoint_name   = "userinfo"
   path_part       = "userinfo"
-  endpoint_method = "GET"
+  endpoint_method = ["GET"]
   environment     = var.environment
 
   handler_environment_variables = {

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -73,3 +73,8 @@ module "userinfo" {
     aws_api_gateway_resource.wellknown_resource,
   ]
 }
+
+moved {
+  from = module.userinfo.aws_api_gateway_method.endpoint_method
+  to   = module.userinfo.aws_api_gateway_method.endpoint_method["GET"]
+}

--- a/ci/terraform/oidc/verify_code.tf
+++ b/ci/terraform/oidc/verify_code.tf
@@ -22,7 +22,7 @@ module "verify_code" {
 
   endpoint_name   = "verify-code"
   path_part       = "verify-code"
-  endpoint_method = "POST"
+  endpoint_method = ["POST"]
   environment     = var.environment
 
   handler_environment_variables = {

--- a/ci/terraform/oidc/verify_code.tf
+++ b/ci/terraform/oidc/verify_code.tf
@@ -77,3 +77,8 @@ module "verify_code" {
     aws_sqs_queue.email_queue,
   ]
 }
+
+moved {
+  from = module.verify_code.aws_api_gateway_method.endpoint_method
+  to   = module.verify_code.aws_api_gateway_method.endpoint_method["POST"]
+}

--- a/ci/terraform/oidc/verify_mfa_code.tf
+++ b/ci/terraform/oidc/verify_mfa_code.tf
@@ -22,7 +22,7 @@ module "verify_mfa_code" {
 
   endpoint_name   = "verify-mfa-code"
   path_part       = "verify-mfa-code"
-  endpoint_method = "POST"
+  endpoint_method = ["POST"]
   environment     = var.environment
 
   handler_environment_variables = {

--- a/ci/terraform/oidc/verify_mfa_code.tf
+++ b/ci/terraform/oidc/verify_mfa_code.tf
@@ -73,3 +73,8 @@ module "verify_mfa_code" {
     aws_api_gateway_rest_api.di_authentication_frontend_api,
   ]
 }
+
+moved {
+  from = module.verify_mfa_code.aws_api_gateway_method.endpoint_method
+  to   = module.verify_mfa_code.aws_api_gateway_method.endpoint_method["POST"]
+}

--- a/ci/terraform/oidc/wellknown.tf
+++ b/ci/terraform/oidc/wellknown.tf
@@ -11,7 +11,7 @@ module "openid_configuration_discovery" {
 
   endpoint_name   = "openid-configuration"
   path_part       = "openid-configuration"
-  endpoint_method = "GET"
+  endpoint_method = ["GET"]
   environment     = var.environment
 
   handler_environment_variables = {

--- a/ci/terraform/oidc/wellknown.tf
+++ b/ci/terraform/oidc/wellknown.tf
@@ -55,3 +55,8 @@ module "openid_configuration_discovery" {
     module.openid_configuration_role
   ]
 }
+
+moved {
+  from = module.openid_configuration_discovery.aws_api_gateway_method.endpoint_method
+  to   = module.openid_configuration_discovery.aws_api_gateway_method.endpoint_method["GET"]
+}

--- a/ci/terraform/test-services/delete-synthetics-user.tf
+++ b/ci/terraform/test-services/delete-synthetics-user.tf
@@ -57,3 +57,8 @@ module "delete-synthetics-user" {
     aws_api_gateway_rest_api.di_authentication_test_services_api,
   ]
 }
+
+moved {
+  from = module.delete-synthetics-user.aws_api_gateway_method.endpoint_method
+  to   = module.delete-synthetics-user.aws_api_gateway_method.endpoint_method["DELETE"]
+}

--- a/ci/terraform/test-services/delete-synthetics-user.tf
+++ b/ci/terraform/test-services/delete-synthetics-user.tf
@@ -16,7 +16,7 @@ module "delete-synthetics-user" {
 
   endpoint_name   = "synthetics-user"
   path_part       = "synthetics-user"
-  endpoint_method = "DELETE"
+  endpoint_method = ["DELETE"]
   environment     = var.environment
 
   handler_environment_variables = {


### PR DESCRIPTION
## What?

Allow post requests to authorize endpoint

## Why?

Standard authorise request uses a GET request and has a string limit. 
We currently don’t know what our current string limit is or if it’s a problem. 
This will remove risk of hitting query string limits with the full encrypted and signed HMRC payload

## Related PRs

[Parent Ticket](https://govukverify.atlassian.net/jira/software/c/projects/ATO/boards/390?selectedIssue=ATO-22)