### PR TITLE
BAU: Upgrade to latest gradle docker-compose plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 
 plugins {
     id "com.diffplug.spotless" version "6.22.0"
-    id "com.avast.gradle.docker-compose" version "0.16.12"
+    id "com.avast.gradle.docker-compose" version "0.17.5"
     id "org.sonarqube" version "4.0.0.2929"
     id "jacoco"
 }


### PR DESCRIPTION
## What?

Upgrade to latest gradle docker-compose plugin.

## Why?

docker-compose up fails when running integration tests on the latest version of Docker Desktop without this upgrade.

