### PR TITLE
AUT-1767: Add Auth_Code_Issued Audit Event to AuthCallBack Lambda

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.authentication.ipv.domain.IPVAuditableEvent;
+import uk.gov.di.authentication.oidc.domain.OidcAuditableEvent;
 import uk.gov.di.authentication.oidc.domain.OrchestrationAuditableEvent;
 import uk.gov.di.authentication.oidc.entity.AuthenticationUserInfo;
 import uk.gov.di.authentication.oidc.lambda.AuthenticationCallbackHandler;
@@ -138,8 +139,8 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
                     List.of(
                             OrchestrationAuditableEvent.AUTH_CALLBACK_RESPONSE_RECEIVED,
                             OrchestrationAuditableEvent.AUTH_SUCCESSFUL_TOKEN_RESPONSE_RECEIVED,
-                            OrchestrationAuditableEvent
-                                    .AUTH_SUCCESSFUL_USERINFO_RESPONSE_RECEIVED));
+                            OrchestrationAuditableEvent.AUTH_SUCCESSFUL_USERINFO_RESPONSE_RECEIVED,
+                            OidcAuditableEvent.AUTH_CODE_ISSUED));
 
             Optional<AuthenticationUserInfo> userInfoDbEntry =
                     userInfoStoreExtension.getUserInfoBySubjectId(SUBJECT_ID.getValue());


### PR DESCRIPTION
## What?

Add Auth_Code_Issued Audit Event to AuthCallBack Lambda

## Why?

There is an audit event which is triggered when we generate an auth code for an RP - [https://github.com/alphagov/di-authentication-api/blob/main/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java#L2[…]01](https://github.com/alphagov/di-authentication-api/blob/main/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java#L287-L301)

We will also need this audit event on the AuthenticationCallbackHandler as the place where we will generate Auth Codes for RPs would have moved once we enable the split, so not to replicate it would mean the new journey is not fully equivalent in audit terms.

