### PR TITLE
BAU: Default 'accountVerified' to 0 on sign up

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
@@ -81,7 +81,7 @@ public class DynamoService implements AuthenticationService {
     @Override
     public User signUp(
             String email, String password, Subject subject, TermsAndConditions termsAndConditions) {
-        return signUp(email, password, subject, termsAndConditions, false, 1);
+        return signUp(email, password, subject, termsAndConditions, false, 0);
     }
 
     public User signUp(


### PR DESCRIPTION

## What?

Default 'accountVerified' to 0 on sign up.

## Why?

Fixes an error with account metrics that reports on this field.

Reverts a change made to set the default to 1: [AUT-1567: Only return users with verified accounts](https://github.com/alphagov/di-authentication-api/pull/3264/commits/9316794533bae3bee43cfcefd8f433d8d4bd6a6a)

## Related PRs

#3264 