### PR TITLE
AUT-1824: turned off xxs sec header

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ApiGatewayResponseHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ApiGatewayResponseHelper.java
@@ -18,7 +18,7 @@ import java.util.stream.Collectors;
 public class ApiGatewayResponseHelper {
 
     public enum SecurityHeaders {
-        XSS_PROTECTION("X-XSS-Protection", "1; mode=block"),
+        XSS_PROTECTION("X-XSS-Protection", "0"),
         CONTENT_TYPE_OPTIONS("X-Content-Type-Options", "nosniff"),
         CONTENT_SECURITY_POLICY("Content-Security-Policy", "frame-ancestors 'none'"),
         STRICT_TRANSPORT_SECURITY(

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ApiGatewayResponseHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ApiGatewayResponseHelperTest.java
@@ -18,7 +18,7 @@ public class ApiGatewayResponseHelperTest {
 
         assertThat(result.getHeaders(), hasEntry(HttpHeaders.CACHE_CONTROL, "no-cache, no-store"));
         assertThat(result.getHeaders(), hasEntry(HttpHeaders.PRAGMA, "no-cache"));
-        assertThat(result.getHeaders(), hasEntry("X-XSS-Protection", "1; mode=block"));
+        assertThat(result.getHeaders(), hasEntry("X-XSS-Protection", "0"));
         assertThat(result.getHeaders(), hasEntry("X-Content-Type-Options", "nosniff"));
         assertThat(
                 result.getHeaders(), hasEntry("Content-Security-Policy", "frame-ancestors 'none'"));
@@ -37,7 +37,7 @@ public class ApiGatewayResponseHelperTest {
 
         assertThat(result.getHeaders(), hasEntry(HttpHeaders.CACHE_CONTROL, "no-cache, no-store"));
         assertThat(result.getHeaders(), hasEntry(HttpHeaders.PRAGMA, "no-cache"));
-        assertThat(result.getHeaders(), hasEntry("X-XSS-Protection", "1; mode=block"));
+        assertThat(result.getHeaders(), hasEntry("X-XSS-Protection", "0"));
         assertThat(result.getHeaders(), hasEntry("X-Content-Type-Options", "nosniff"));
         assertThat(
                 result.getHeaders(), hasEntry("Content-Security-Policy", "frame-ancestors 'none'"));
@@ -56,7 +56,7 @@ public class ApiGatewayResponseHelperTest {
 
         assertThat(result.getHeaders(), hasEntry(HttpHeaders.CACHE_CONTROL, "no-cache, no-store"));
         assertThat(result.getHeaders(), hasEntry(HttpHeaders.PRAGMA, "no-cache"));
-        assertThat(result.getHeaders(), hasEntry("X-XSS-Protection", "1; mode=block"));
+        assertThat(result.getHeaders(), hasEntry("X-XSS-Protection", "0"));
         assertThat(result.getHeaders(), hasEntry("X-Content-Type-Options", "nosniff"));
         assertThat(
                 result.getHeaders(), hasEntry("Content-Security-Policy", "frame-ancestors 'none'"));


### PR DESCRIPTION
## What?

Turned off X-XXS-Security protection header

## Why?

The X XSS Protection header is designed to detect and assist in protecting against cross-site scripting (“XSS”) attacks. However, most modern browsers ignore this header now as having it on can introduce additional security issues.


