### PR TITLE
AUT-1467: Bulk Email switch for delivery receipts lambda

### DIFF
--- a/ci/terraform/delivery-receipts/notify-callback.tf
+++ b/ci/terraform/delivery-receipts/notify-callback.tf
@@ -19,8 +19,9 @@ module "notify_callback" {
   environment     = var.environment
 
   handler_environment_variables = merge(var.notify_template_map, {
-    ENVIRONMENT         = var.environment
-    LOCALSTACK_ENDPOINT = var.use_localstack ? var.localstack_endpoint : null
+    ENVIRONMENT             = var.environment
+    LOCALSTACK_ENDPOINT     = var.use_localstack ? var.localstack_endpoint : null
+    BULK_USER_EMAIL_ENABLED = local.deploy_bulk_email_users_count
   })
   handler_function_name = "uk.gov.di.authentication.deliveryreceiptsapi.lambda.NotifyCallbackHandler::handleRequest"
 

--- a/delivery-receipts-api/src/main/java/uk/gov/di/authentication/deliveryreceiptsapi/lambda/NotifyCallbackHandler.java
+++ b/delivery-receipts-api/src/main/java/uk/gov/di/authentication/deliveryreceiptsapi/lambda/NotifyCallbackHandler.java
@@ -31,9 +31,9 @@ public class NotifyCallbackHandler
 
     private static final String AUTHORIZATION_HEADER = "Authorization";
     private final ConfigurationService configurationService;
-    private final DynamoService dynamoService;
+    private DynamoService dynamoService = null;
 
-    private final BulkEmailUsersService bulkEmailUsersService;
+    private BulkEmailUsersService bulkEmailUsersService = null;
     private final CloudwatchMetricsService cloudwatchMetricsService;
     private final Json objectMapper = SerializationService.getInstance();
 
@@ -46,15 +46,19 @@ public class NotifyCallbackHandler
             BulkEmailUsersService bulkEmailUsersService) {
         this.cloudwatchMetricsService = cloudwatchMetricsService;
         this.configurationService = configurationService;
-        this.dynamoService = dynamoService;
-        this.bulkEmailUsersService = bulkEmailUsersService;
+        if (configurationService.isBulkUserEmailEnabled()) {
+            this.dynamoService = dynamoService;
+            this.bulkEmailUsersService = bulkEmailUsersService;
+        }
     }
 
     public NotifyCallbackHandler(ConfigurationService configurationService) {
         this.cloudwatchMetricsService = new CloudwatchMetricsService();
         this.configurationService = configurationService;
-        this.dynamoService = new DynamoService(configurationService);
-        this.bulkEmailUsersService = new BulkEmailUsersService(configurationService);
+        if (configurationService.isBulkUserEmailEnabled()) {
+            this.dynamoService = new DynamoService(configurationService);
+            this.bulkEmailUsersService = new BulkEmailUsersService(configurationService);
+        }
     }
 
     public NotifyCallbackHandler() {
@@ -113,7 +117,9 @@ public class NotifyCallbackHandler
                                 configurationService.getEnvironment(),
                                 "NotifyStatus",
                                 deliveryReceipt.getStatus()));
-                if (templateName.equals(TERMS_AND_CONDITIONS_BULK_EMAIL.getTemplateAlias())) {
+                if (configurationService.isBulkUserEmailEnabled()
+                        && templateName.equals(
+                                TERMS_AND_CONDITIONS_BULK_EMAIL.getTemplateAlias())) {
                     LOG.info("Updating bulk email table for delivery receipt");
                     var maybeProfile =
                             dynamoService.getUserProfileByEmailMaybe(deliveryReceipt.getTo());

--- a/delivery-receipts-api/src/test/java/uk/gov/di/authentication/deliveryreceiptsapi/lambda/NotifyCallbackHandlerTest.java
+++ b/delivery-receipts-api/src/test/java/uk/gov/di/authentication/deliveryreceiptsapi/lambda/NotifyCallbackHandlerTest.java
@@ -44,6 +44,7 @@ class NotifyCallbackHandlerTest {
     private static final String BEARER_TOKEN = "1244656456457657566345";
     private static final String ENVIRONMENT = "test";
     private NotifyCallbackHandler handler;
+
     private final Context context = mock(Context.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final DynamoService dynamoService = mock(DynamoService.class);
@@ -157,6 +158,13 @@ class NotifyCallbackHandlerTest {
         var templateID = IdGenerator.generate();
         when(configurationService.getNotificationTypeFromTemplateId(templateID))
                 .thenReturn(Optional.of(TERMS_AND_CONDITIONS_BULK_EMAIL));
+        when(configurationService.isBulkUserEmailEnabled()).thenReturn(true);
+        NotifyCallbackHandler handlerBulkEmailOn =
+                new NotifyCallbackHandler(
+                        cloudwatchMetricsService,
+                        configurationService,
+                        dynamoService,
+                        bulkEmailUsersService);
         var deliveryReceipt = createDeliveryReceipt(email, "delivered", "email", templateID);
         var event = new APIGatewayProxyRequestEvent();
         event.setHeaders(Map.of("Authorization", "Bearer " + BEARER_TOKEN));
@@ -164,7 +172,7 @@ class NotifyCallbackHandlerTest {
         String subjectId = "subject-id-1";
         UserProfile userProfile = new UserProfile().withEmail(email).withSubjectID(subjectId);
         when(dynamoService.getUserProfileByEmailMaybe(email)).thenReturn(Optional.of(userProfile));
-        handler.handleRequest(event, context);
+        handlerBulkEmailOn.handleRequest(event, context);
 
         verify(dynamoService).getUserProfileByEmailMaybe(email);
 
@@ -172,17 +180,67 @@ class NotifyCallbackHandlerTest {
     }
 
     @Test
-    void shouldNotUpdateBulkEmailDeliveryReceiptsStatusForTermsAndConditionsEmailType()
-            throws Json.JsonException {
+    void
+            shouldNotUpdateBulkEmailDeliveryReceiptsStatusForTermsAndConditionsEmailTypeWhenBulkEmailSwitchedOn()
+                    throws Json.JsonException {
         String email = "jim@test.com";
         var templateID = IdGenerator.generate();
         when(configurationService.getNotificationTypeFromTemplateId(templateID))
                 .thenReturn(Optional.of(EMAIL_UPDATED));
+        NotifyCallbackHandler handlerBulkEmailOn =
+                new NotifyCallbackHandler(
+                        cloudwatchMetricsService,
+                        configurationService,
+                        dynamoService,
+                        bulkEmailUsersService);
+        var deliveryReceipt = createDeliveryReceipt(email, "delivered", "email", templateID);
+        var event = new APIGatewayProxyRequestEvent();
+        event.setHeaders(Map.of("Authorization", "Bearer " + BEARER_TOKEN));
+        event.setBody(objectMapper.writeValueAsString(deliveryReceipt));
+        handlerBulkEmailOn.handleRequest(event, context);
+
+        verify(dynamoService, never()).getUserProfileByEmailMaybe(anyString());
+        verify(bulkEmailUsersService, never())
+                .updateDeliveryReceiptStatus(anyString(), anyString());
+    }
+
+    @Test
+    void shouldNotUpdateBulkEmailDeliveryReceiptsStatusWhenBulkEmailSwitchedOff()
+            throws Json.JsonException {
+        String email = "jim@test.com";
+        var templateID = IdGenerator.generate();
+        when(configurationService.getNotificationTypeFromTemplateId(templateID))
+                .thenReturn(Optional.of(TERMS_AND_CONDITIONS_BULK_EMAIL));
         var deliveryReceipt = createDeliveryReceipt(email, "delivered", "email", templateID);
         var event = new APIGatewayProxyRequestEvent();
         event.setHeaders(Map.of("Authorization", "Bearer " + BEARER_TOKEN));
         event.setBody(objectMapper.writeValueAsString(deliveryReceipt));
         handler.handleRequest(event, context);
+
+        verify(dynamoService, never()).getUserProfileByEmailMaybe(anyString());
+        verify(bulkEmailUsersService, never())
+                .updateDeliveryReceiptStatus(anyString(), anyString());
+    }
+
+    @Test
+    void shouldNotUpdateBulkEmailDeliveryReceiptsStatusForEmailUpdatedEmailType()
+            throws Json.JsonException {
+        String email = "jim@test.com";
+        var templateID = IdGenerator.generate();
+        when(configurationService.getNotificationTypeFromTemplateId(templateID))
+                .thenReturn(Optional.of(EMAIL_UPDATED));
+        when(configurationService.isBulkUserEmailEnabled()).thenReturn(true);
+        NotifyCallbackHandler handlerBulkEmailOn =
+                new NotifyCallbackHandler(
+                        cloudwatchMetricsService,
+                        configurationService,
+                        dynamoService,
+                        bulkEmailUsersService);
+        var deliveryReceipt = createDeliveryReceipt(email, "delivered", "email", templateID);
+        var event = new APIGatewayProxyRequestEvent();
+        event.setHeaders(Map.of("Authorization", "Bearer " + BEARER_TOKEN));
+        event.setBody(objectMapper.writeValueAsString(deliveryReceipt));
+        handlerBulkEmailOn.handleRequest(event, context);
 
         verify(dynamoService, never()).getUserProfileByEmailMaybe(anyString());
         verify(bulkEmailUsersService, never())

--- a/delivery-receipts-integration-tests/src/test/java/uk/gov/di/deliveryreceipts/NotifyCallbackHandlerIntegrationTest.java
+++ b/delivery-receipts-integration-tests/src/test/java/uk/gov/di/deliveryreceipts/NotifyCallbackHandlerIntegrationTest.java
@@ -40,17 +40,34 @@ class NotifyCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
     private final Context context = mock(Context.class);
     private NotifyCallbackHandler handler;
 
+    private static final IntegrationTestConfigurationService CONFIGURATION_SERVICE =
+            new IntegrationTestConfigurationService(
+                    auditTopic,
+                    notificationsQueue,
+                    auditSigningKey,
+                    tokenSigner,
+                    ipvPrivateKeyJwtSigner,
+                    spotQueue,
+                    docAppPrivateKeyJwtSigner,
+                    configurationParameters,
+                    new SystemService()) {
+                @Override
+                public boolean isBulkUserEmailEnabled() {
+                    return true;
+                }
+            };
+
     @RegisterExtension
     protected static final BulkEmailUsersExtension bulkEmailUsersExtension =
             new BulkEmailUsersExtension();
 
     protected final BulkEmailUsersService bulkEmailUsersService =
-            new BulkEmailUsersService(TEST_CONFIGURATION_SERVICE);
+            new BulkEmailUsersService(CONFIGURATION_SERVICE);
 
     @BeforeEach
     void setup() {
-        TEST_CONFIGURATION_SERVICE.setSystemService(new SystemService());
-        handler = new NotifyCallbackHandler(TEST_CONFIGURATION_SERVICE);
+        CONFIGURATION_SERVICE.setSystemService(new SystemService());
+        handler = new NotifyCallbackHandler(CONFIGURATION_SERVICE);
     }
 
     @Test

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -124,6 +124,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return systemService.getOrDefault("BULK_USER_EMAIL_SEND_MODE", "PENDING");
     }
 
+    public boolean isBulkUserEmailEnabled() {
+        return systemService.getOrDefault("BULK_USER_EMAIL_ENABLED", "0").equals("1");
+    }
+
     public long getDefaultOtpCodeExpiry() {
         return Long.parseLong(System.getenv().getOrDefault("DEFAULT_OTP_CODE_EXPIRY", "900"));
     }


### PR DESCRIPTION
## What?

Bulk Email switch for delivery receipts lambda

Adds a switch to turn bulk email on and off in the NotifyCallbackHandler.

This PR should be merged before attempting to deploy #3431 again.

## Why?

This is so the lambda does not try to describe the user-profile table when the bulk email deployment switch is off (deploy_bulk_email_users_count).  If the deployment switch is off the NotifyCallbackHandler does not have the iam rights to access the user-profile table, so the lambda fails to start and throws errors.

## Related PRs

#3431 
