### PR TITLE
ATO-109: Remove no longer needed moved blocks from endpoints

### DIFF
--- a/ci/terraform/account-management/authenticate.tf
+++ b/ci/terraform/account-management/authenticate.tf
@@ -59,8 +59,3 @@ module "authenticate" {
 
   use_localstack = var.use_localstack
 }
-
-moved {
-  from = module.authenticate.aws_api_gateway_method.endpoint_method
-  to   = module.authenticate.aws_api_gateway_method.endpoint_method["POST"]
-}

--- a/ci/terraform/account-management/remove-account.tf
+++ b/ci/terraform/account-management/remove-account.tf
@@ -61,8 +61,3 @@ module "delete_account" {
   lambda_env_vars_encryption_kms_key_arn = data.terraform_remote_state.shared.outputs.lambda_env_vars_encryption_kms_key_arn
 
 }
-
-moved {
-  from = module.delete_account.aws_api_gateway_method.endpoint_method
-  to   = module.delete_account.aws_api_gateway_method.endpoint_method["POST"]
-}

--- a/ci/terraform/account-management/send_otp_notification.tf
+++ b/ci/terraform/account-management/send_otp_notification.tf
@@ -73,8 +73,3 @@ module "send_otp_notification" {
     aws_elasticache_replication_group.account_management_sessions_store,
   ]
 }
-
-moved {
-  from = module.send_otp_notification.aws_api_gateway_method.endpoint_method
-  to   = module.send_otp_notification.aws_api_gateway_method.endpoint_method["POST"]
-}

--- a/ci/terraform/account-management/update-email.tf
+++ b/ci/terraform/account-management/update-email.tf
@@ -62,8 +62,3 @@ module "update_email" {
   lambda_env_vars_encryption_kms_key_arn = data.terraform_remote_state.shared.outputs.lambda_env_vars_encryption_kms_key_arn
 
 }
-
-moved {
-  from = module.update_email.aws_api_gateway_method.endpoint_method
-  to   = module.update_email.aws_api_gateway_method.endpoint_method["POST"]
-}

--- a/ci/terraform/account-management/update-password.tf
+++ b/ci/terraform/account-management/update-password.tf
@@ -60,8 +60,3 @@ module "update_password" {
   lambda_env_vars_encryption_kms_key_arn = data.terraform_remote_state.shared.outputs.lambda_env_vars_encryption_kms_key_arn
 
 }
-
-moved {
-  from = module.update_password.aws_api_gateway_method.endpoint_method
-  to   = module.update_password.aws_api_gateway_method.endpoint_method["POST"]
-}

--- a/ci/terraform/account-management/update-phone-number.tf
+++ b/ci/terraform/account-management/update-phone-number.tf
@@ -60,8 +60,3 @@ module "update_phone_number" {
   cloudwatch_log_retention               = var.cloudwatch_log_retention
   lambda_env_vars_encryption_kms_key_arn = data.terraform_remote_state.shared.outputs.lambda_env_vars_encryption_kms_key_arn
 }
-
-moved {
-  from = module.update_phone_number.aws_api_gateway_method.endpoint_method
-  to   = module.update_phone_number.aws_api_gateway_method.endpoint_method["POST"]
-}

--- a/ci/terraform/auth-external-api/token.tf
+++ b/ci/terraform/auth-external-api/token.tf
@@ -71,8 +71,3 @@ module "auth_token" {
     aws_api_gateway_rest_api.di_auth_ext_api,
   ]
 }
-
-moved {
-  from = module.auth_token.aws_api_gateway_method.endpoint_method
-  to   = module.auth_token.aws_api_gateway_method.endpoint_method["POST"]
-}

--- a/ci/terraform/auth-external-api/userinfo.tf
+++ b/ci/terraform/auth-external-api/userinfo.tf
@@ -66,7 +66,3 @@ module "auth_userinfo" {
     aws_api_gateway_rest_api.di_auth_ext_api,
   ]
 }
-moved {
-  from = module.auth_userinfo.aws_api_gateway_method.endpoint_method
-  to   = module.auth_userinfo.aws_api_gateway_method.endpoint_method["GET"]
-}

--- a/ci/terraform/delivery-receipts/notify-callback.tf
+++ b/ci/terraform/delivery-receipts/notify-callback.tf
@@ -53,7 +53,3 @@ module "notify_callback" {
     aws_api_gateway_rest_api.di_authentication_delivery_receipts_api,
   ]
 }
-moved {
-  from = module.notify_callback.aws_api_gateway_method.endpoint_method
-  to   = module.notify_callback.aws_api_gateway_method.endpoint_method["POST"]
-}

--- a/ci/terraform/oidc/account-recovery.tf
+++ b/ci/terraform/oidc/account-recovery.tf
@@ -66,7 +66,3 @@ module "account_recovery" {
 
   use_localstack = var.use_localstack
 }
-moved {
-  from = module.account_recovery.aws_api_gateway_method.endpoint_method
-  to   = module.account_recovery.aws_api_gateway_method.endpoint_method["POST"]
-}

--- a/ci/terraform/oidc/auth-code.tf
+++ b/ci/terraform/oidc/auth-code.tf
@@ -67,7 +67,3 @@ module "auth-code" {
     aws_api_gateway_resource.wellknown_resource,
   ]
 }
-moved {
-  from = module.auth-code.aws_api_gateway_method.endpoint_method
-  to   = module.auth-code.aws_api_gateway_method.endpoint_method["GET"]
-}

--- a/ci/terraform/oidc/authentication-auth-code.tf
+++ b/ci/terraform/oidc/authentication-auth-code.tf
@@ -72,7 +72,3 @@ module "orch_auth_code" {
     aws_api_gateway_resource.wellknown_resource,
   ]
 }
-moved {
-  from = module.orch_auth_code.aws_api_gateway_method.endpoint_method
-  to   = module.orch_auth_code.aws_api_gateway_method.endpoint_method["POST"]
-}

--- a/ci/terraform/oidc/authentication-callback.tf
+++ b/ci/terraform/oidc/authentication-callback.tf
@@ -77,8 +77,3 @@ module "authentication_callback" {
     aws_api_gateway_rest_api.di_authentication_api
   ]
 }
-
-moved {
-  from = module.authentication_callback.aws_api_gateway_method.endpoint_method
-  to   = module.authentication_callback.aws_api_gateway_method.endpoint_method["GET"]
-}

--- a/ci/terraform/oidc/authorize.tf
+++ b/ci/terraform/oidc/authorize.tf
@@ -91,8 +91,3 @@ module "authorize" {
     aws_api_gateway_resource.wellknown_resource,
   ]
 }
-
-moved {
-  from = module.authorize.aws_api_gateway_method.endpoint_method
-  to   = module.authorize.aws_api_gateway_method.endpoint_method["GET"]
-}

--- a/ci/terraform/oidc/doc-app-authorize.tf
+++ b/ci/terraform/oidc/doc-app-authorize.tf
@@ -76,8 +76,3 @@ module "doc-app-authorize" {
     aws_api_gateway_resource.wellknown_resource,
   ]
 }
-
-moved {
-  from = module.doc-app-authorize.aws_api_gateway_method.endpoint_method
-  to   = module.doc-app-authorize.aws_api_gateway_method.endpoint_method["POST"]
-}

--- a/ci/terraform/oidc/doc-app-callback.tf
+++ b/ci/terraform/oidc/doc-app-callback.tf
@@ -81,8 +81,3 @@ module "doc-app-callback" {
     aws_api_gateway_rest_api.di_authentication_api,
   ]
 }
-
-moved {
-  from = module.doc-app-callback.aws_api_gateway_method.endpoint_method
-  to   = module.doc-app-callback.aws_api_gateway_method.endpoint_method["GET"]
-}

--- a/ci/terraform/oidc/ipv-authorize.tf
+++ b/ci/terraform/oidc/ipv-authorize.tf
@@ -78,8 +78,3 @@ module "ipv-authorize" {
     aws_api_gateway_resource.wellknown_resource,
   ]
 }
-
-moved {
-  from = module.ipv-authorize.aws_api_gateway_method.endpoint_method
-  to   = module.ipv-authorize.aws_api_gateway_method.endpoint_method["POST"]
-}

--- a/ci/terraform/oidc/ipv-callback.tf
+++ b/ci/terraform/oidc/ipv-callback.tf
@@ -84,8 +84,3 @@ module "ipv-callback" {
     aws_api_gateway_resource.wellknown_resource,
   ]
 }
-
-moved {
-  from = module.ipv-callback.aws_api_gateway_method.endpoint_method
-  to   = module.ipv-callback.aws_api_gateway_method.endpoint_method["GET"]
-}

--- a/ci/terraform/oidc/ipv-capacity.tf
+++ b/ci/terraform/oidc/ipv-capacity.tf
@@ -68,8 +68,3 @@ module "ipv-capacity" {
     aws_api_gateway_resource.wellknown_resource,
   ]
 }
-
-moved {
-  from = module.ipv-capacity.aws_api_gateway_method.endpoint_method
-  to   = module.ipv-capacity.aws_api_gateway_method.endpoint_method["GET"]
-}

--- a/ci/terraform/oidc/jwks.tf
+++ b/ci/terraform/oidc/jwks.tf
@@ -61,8 +61,3 @@ module "jwks" {
     aws_api_gateway_resource.wellknown_resource,
   ]
 }
-
-moved {
-  from = module.jwks.aws_api_gateway_method.endpoint_method
-  to   = module.jwks.aws_api_gateway_method.endpoint_method["GET"]
-}

--- a/ci/terraform/oidc/login.tf
+++ b/ci/terraform/oidc/login.tf
@@ -68,8 +68,3 @@ module "login" {
 
   use_localstack = var.use_localstack
 }
-
-moved {
-  from = module.login.aws_api_gateway_method.endpoint_method
-  to   = module.login.aws_api_gateway_method.endpoint_method["POST"]
-}

--- a/ci/terraform/oidc/logout.tf
+++ b/ci/terraform/oidc/logout.tf
@@ -73,8 +73,3 @@ module "logout" {
     aws_api_gateway_resource.wellknown_resource,
   ]
 }
-
-moved {
-  from = module.logout.aws_api_gateway_method.endpoint_method
-  to   = module.logout.aws_api_gateway_method.endpoint_method["GET"]
-}

--- a/ci/terraform/oidc/mfa.tf
+++ b/ci/terraform/oidc/mfa.tf
@@ -74,8 +74,3 @@ module "mfa" {
     aws_sqs_queue.email_queue,
   ]
 }
-
-moved {
-  from = module.mfa.aws_api_gateway_method.endpoint_method
-  to   = module.mfa.aws_api_gateway_method.endpoint_method["POST"]
-}

--- a/ci/terraform/oidc/processing-identity.tf
+++ b/ci/terraform/oidc/processing-identity.tf
@@ -69,8 +69,3 @@ module "processing-identity" {
 
   use_localstack = var.use_localstack
 }
-
-moved {
-  from = module.processing-identity.aws_api_gateway_method.endpoint_method
-  to   = module.processing-identity.aws_api_gateway_method.endpoint_method["POST"]
-}

--- a/ci/terraform/oidc/register.tf
+++ b/ci/terraform/oidc/register.tf
@@ -65,8 +65,3 @@ module "register" {
     aws_api_gateway_resource.register_resource,
   ]
 }
-
-moved {
-  from = module.register[0].aws_api_gateway_method.endpoint_method
-  to   = module.register[0].aws_api_gateway_method.endpoint_method["POST"]
-}

--- a/ci/terraform/oidc/reset-password-request.tf
+++ b/ci/terraform/oidc/reset-password-request.tf
@@ -74,8 +74,3 @@ module "reset-password-request" {
     aws_sqs_queue.email_queue,
   ]
 }
-
-moved {
-  from = module.reset-password-request.aws_api_gateway_method.endpoint_method
-  to   = module.reset-password-request.aws_api_gateway_method.endpoint_method["POST"]
-}

--- a/ci/terraform/oidc/reset_password.tf
+++ b/ci/terraform/oidc/reset_password.tf
@@ -78,8 +78,3 @@ module "reset_password" {
     aws_api_gateway_resource.wellknown_resource,
   ]
 }
-
-moved {
-  from = module.reset_password.aws_api_gateway_method.endpoint_method
-  to   = module.reset_password.aws_api_gateway_method.endpoint_method["POST"]
-}

--- a/ci/terraform/oidc/send_notification.tf
+++ b/ci/terraform/oidc/send_notification.tf
@@ -73,8 +73,3 @@ module "send_notification" {
     aws_sqs_queue.email_queue,
   ]
 }
-
-moved {
-  from = module.send_notification.aws_api_gateway_method.endpoint_method
-  to   = module.send_notification.aws_api_gateway_method.endpoint_method["POST"]
-}

--- a/ci/terraform/oidc/signup.tf
+++ b/ci/terraform/oidc/signup.tf
@@ -72,7 +72,3 @@ module "signup" {
     aws_api_gateway_resource.wellknown_resource,
   ]
 }
-moved {
-  from = module.signup.aws_api_gateway_method.endpoint_method
-  to   = module.signup.aws_api_gateway_method.endpoint_method["POST"]
-}

--- a/ci/terraform/oidc/start.tf
+++ b/ci/terraform/oidc/start.tf
@@ -73,8 +73,3 @@ module "start" {
     aws_api_gateway_resource.wellknown_resource,
   ]
 }
-
-moved {
-  from = module.start.aws_api_gateway_method.endpoint_method
-  to   = module.start.aws_api_gateway_method.endpoint_method["GET"]
-}

--- a/ci/terraform/oidc/token.tf
+++ b/ci/terraform/oidc/token.tf
@@ -97,8 +97,3 @@ module "token" {
     aws_api_gateway_resource.wellknown_resource,
   ]
 }
-
-moved {
-  from = module.token.aws_api_gateway_method.endpoint_method
-  to   = module.token.aws_api_gateway_method.endpoint_method["POST"]
-}

--- a/ci/terraform/oidc/trustmarks.tf
+++ b/ci/terraform/oidc/trustmarks.tf
@@ -55,8 +55,3 @@ module "trustmarks" {
     aws_api_gateway_resource.wellknown_resource,
   ]
 }
-
-moved {
-  from = module.trustmarks.aws_api_gateway_method.endpoint_method
-  to   = module.trustmarks.aws_api_gateway_method.endpoint_method["GET"]
-}

--- a/ci/terraform/oidc/update.tf
+++ b/ci/terraform/oidc/update.tf
@@ -69,8 +69,3 @@ module "update" {
     aws_api_gateway_resource.register_resource,
   ]
 }
-
-moved {
-  from = module.update[0].aws_api_gateway_method.endpoint_method
-  to   = module.update[0].aws_api_gateway_method.endpoint_method["PUT"]
-}

--- a/ci/terraform/oidc/update_profile.tf
+++ b/ci/terraform/oidc/update_profile.tf
@@ -71,8 +71,3 @@ module "update_profile" {
     aws_api_gateway_resource.wellknown_resource,
   ]
 }
-
-moved {
-  from = module.update_profile.aws_api_gateway_method.endpoint_method
-  to   = module.update_profile.aws_api_gateway_method.endpoint_method["POST"]
-}

--- a/ci/terraform/oidc/userexists.tf
+++ b/ci/terraform/oidc/userexists.tf
@@ -70,8 +70,3 @@ module "userexists" {
     aws_api_gateway_resource.wellknown_resource,
   ]
 }
-
-moved {
-  from = module.userexists.aws_api_gateway_method.endpoint_method
-  to   = module.userexists.aws_api_gateway_method.endpoint_method["POST"]
-}

--- a/ci/terraform/oidc/userinfo.tf
+++ b/ci/terraform/oidc/userinfo.tf
@@ -73,8 +73,3 @@ module "userinfo" {
     aws_api_gateway_resource.wellknown_resource,
   ]
 }
-
-moved {
-  from = module.userinfo.aws_api_gateway_method.endpoint_method
-  to   = module.userinfo.aws_api_gateway_method.endpoint_method["GET"]
-}

--- a/ci/terraform/oidc/verify_code.tf
+++ b/ci/terraform/oidc/verify_code.tf
@@ -77,8 +77,3 @@ module "verify_code" {
     aws_sqs_queue.email_queue,
   ]
 }
-
-moved {
-  from = module.verify_code.aws_api_gateway_method.endpoint_method
-  to   = module.verify_code.aws_api_gateway_method.endpoint_method["POST"]
-}

--- a/ci/terraform/oidc/verify_mfa_code.tf
+++ b/ci/terraform/oidc/verify_mfa_code.tf
@@ -73,8 +73,3 @@ module "verify_mfa_code" {
     aws_api_gateway_rest_api.di_authentication_frontend_api,
   ]
 }
-
-moved {
-  from = module.verify_mfa_code.aws_api_gateway_method.endpoint_method
-  to   = module.verify_mfa_code.aws_api_gateway_method.endpoint_method["POST"]
-}

--- a/ci/terraform/oidc/wellknown.tf
+++ b/ci/terraform/oidc/wellknown.tf
@@ -55,8 +55,3 @@ module "openid_configuration_discovery" {
     module.openid_configuration_role
   ]
 }
-
-moved {
-  from = module.openid_configuration_discovery.aws_api_gateway_method.endpoint_method
-  to   = module.openid_configuration_discovery.aws_api_gateway_method.endpoint_method["GET"]
-}

--- a/ci/terraform/test-services/delete-synthetics-user.tf
+++ b/ci/terraform/test-services/delete-synthetics-user.tf
@@ -57,8 +57,3 @@ module "delete-synthetics-user" {
     aws_api_gateway_rest_api.di_authentication_test_services_api,
   ]
 }
-
-moved {
-  from = module.delete-synthetics-user.aws_api_gateway_method.endpoint_method
-  to   = module.delete-synthetics-user.aws_api_gateway_method.endpoint_method["DELETE"]
-}


### PR DESCRIPTION
## What?

Removing the moved blocks that were implemented as part of https://github.com/alphagov/di-authentication-api/pull/3443

## Why?

After deployment to all environments, moved blocks can be removed as they are no longer necessary
## Related PRs
https://github.com/alphagov/di-authentication-api/pull/3443
