### PR TITLE
Updated govuk one org Auth team as codeowner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @alphagov/digital-identity-authentication @govuk-one-login/auth-team
+* @alphagov/digital-identity-authentication @dbes-gds

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @alphagov/digital-identity-authentication
+* @alphagov/digital-identity-authentication @govuk-one-login/auth-team


### PR DESCRIPTION
## What?
Updated govuk one org Auth team as codeowner

## Why?
We are moving repo to new org 


