### PR TITLE
ATO-NONE: Fix default deployer role arn for newer versions of terraform

### DIFF
--- a/ci/terraform/account-management/variables.tf
+++ b/ci/terraform/account-management/variables.tf
@@ -1,5 +1,5 @@
 variable "deployer_role_arn" {
-  default     = ""
+  default     = null
   description = "The name of the AWS role to assume, leave blank when running locally"
   type        = string
 }

--- a/ci/terraform/audit-processors/variables.tf
+++ b/ci/terraform/audit-processors/variables.tf
@@ -1,5 +1,5 @@
 variable "deployer_role_arn" {
-  default     = ""
+  default     = null
   description = "The name of the AWS role to assume, leave blank when running locally"
   type        = string
 }

--- a/ci/terraform/auth-external-api/variables.tf
+++ b/ci/terraform/auth-external-api/variables.tf
@@ -8,7 +8,7 @@ variable "environment" {
 }
 
 variable "deployer_role_arn" {
-  default     = ""
+  default     = null
   description = "The name of the AWS role to assume, leave blank when running locally"
   type        = string
 }

--- a/ci/terraform/delivery-receipts/variables.tf
+++ b/ci/terraform/delivery-receipts/variables.tf
@@ -1,5 +1,5 @@
 variable "deployer_role_arn" {
-  default     = ""
+  default     = null
   description = "The name of the AWS role to assume, leave blank when running locally"
   type        = string
 }

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -53,7 +53,7 @@ variable "doc_app_p1_alarm_error_time_period" {
 }
 
 variable "deployer_role_arn" {
-  default     = ""
+  default     = null
   description = "The name of the AWS role to assume, leave blank when running locally"
   type        = string
 }

--- a/ci/terraform/shared/variables.tf
+++ b/ci/terraform/shared/variables.tf
@@ -1,5 +1,5 @@
 variable "deployer_role_arn" {
-  default     = ""
+  default     = null
   description = "The name of the AWS role to assume, leave blank when running locally"
   type        = string
 }

--- a/ci/terraform/test-services/variables.tf
+++ b/ci/terraform/test-services/variables.tf
@@ -1,5 +1,5 @@
 variable "deployer_role_arn" {
-  default     = ""
+  default     = null
   description = "The name of the AWS role to assume, leave blank when running locally"
   type        = string
 }

--- a/ci/terraform/utils/variables.tf
+++ b/ci/terraform/utils/variables.tf
@@ -3,7 +3,7 @@ variable "aws_region" {
 }
 
 variable "deployer_role_arn" {
-  default     = ""
+  default     = null
   description = "The name of the AWS role to assume, leave blank when running locally"
   type        = string
 }


### PR DESCRIPTION
## What?

Change default deploy role arn to null from empty string

## Why?

New versions of terraform error on deployment if the deploy arn is empty string. This is backwards compatible with version 1.3.1

