### PR TITLE
BAU: Make required checks run on merge queue

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -6,6 +6,7 @@ on:
       - reopened
       - ready_for_review
       - synchronize
+  merge_group:
 
 jobs:
   style-checks:


### PR DESCRIPTION
## What?

Ensure the pre merge checks also run when a PR is added to the merge queue.

## Why?

We want to make sure the code that ends up on main passes all the tests. Therefore we're going to try out merge queues. You must make this change to all required checks when enabling merge queues.
