### PR TITLE
ATO-251: Remove parse vtr set logic

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -60,6 +60,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import static com.nimbusds.oauth2.sdk.http.HTTPRequest.Method.GET;
+import static java.lang.String.format;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 import static uk.gov.di.orchestration.shared.conditions.DocAppUserHelper.isDocCheckingAppUserWithSubjectId;
@@ -491,11 +492,13 @@ public class AuthenticationCallbackHandler
                         .getCredentialTrustLevel()
                         .equals(CredentialTrustLevel.LOW_LEVEL);
         var levelOfConfidence = LevelOfConfidence.NONE.getValue();
+        // Assumption: Requested vectors of trust will either all be for identity or none, and so we
+        // can check just the first
         if (orderedVtrList.get(0).containsLevelOfConfidence()) {
-            levelOfConfidence = orderedVtrList.get(0).getLevelOfConfidence().getValue();
+            levelOfConfidence = VectorOfTrust.stringifyLevelsOfConfidence(orderedVtrList);
         }
         dimensions.put("MfaRequired", mfaRequired ? "Yes" : "No");
-        dimensions.put("RequestedLevelOfConfidence", levelOfConfidence);
+        dimensions.put("RequestedLevelOfConfidence", format("%s", levelOfConfidence));
         return dimensions;
     }
 

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/entity/VectorOfTrustTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/entity/VectorOfTrustTest.java
@@ -43,15 +43,6 @@ class VectorOfTrustTest {
     }
 
     @Test
-    void shouldReturnLowestVectorWhenMultipleSetsAreIsPassedIn() {
-        var jsonArray = jsonArrayOf("Cl.Cm", "Cl");
-        VectorOfTrust vectorOfTrust =
-                VectorOfTrust.parseFromAuthRequestAttribute(Collections.singletonList(jsonArray));
-        assertThat(vectorOfTrust.getCredentialTrustLevel(), equalTo(LOW_LEVEL));
-        assertNull(vectorOfTrust.getLevelOfConfidence());
-    }
-
-    @Test
     void shouldParseValidStringWithMultipleVectors() {
         var jsonArray = jsonArrayOf("Cl");
         VectorOfTrust vectorOfTrust =
@@ -87,7 +78,7 @@ class VectorOfTrustTest {
         assertThat(lowestCredentialLevel, equalTo(expected));
     }
 
-    public static Stream<Arguments> vtrListsWithLowestCredentialTrustVtrs() {
+    private static Stream<Arguments> vtrListsWithLowestCredentialTrustVtrs() {
         return Stream.of(
                 Arguments.of(
                         List.of(
@@ -111,7 +102,7 @@ class VectorOfTrustTest {
         assertThat(orderedList, equalTo(expected));
     }
 
-    public static Stream<Arguments> vtrListsToOrder() {
+    private static Stream<Arguments> vtrListsToOrder() {
         return Stream.of(
                 Arguments.of(
                         List.of(


### PR DESCRIPTION
## What?

- Remove logic from parseVtrSet to only return a list
- Add stringification of vtrList for logging

## Why?

Want to return the list of vtrs, this is a step in doing that

## Related PRs

Branched off from https://github.com/govuk-one-login/authentication-api/pull/3887