### PR TITLE
AUT-2434: decrease default retry limit for auth app codes during sign up

### DIFF
--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/MfaCodeProcessorFactoryTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/MfaCodeProcessorFactoryTest.java
@@ -37,7 +37,7 @@ class MfaCodeProcessorFactoryTest {
     @BeforeEach
     void setUp() {
         when(configurationService.getCodeMaxRetries()).thenReturn(5);
-        when(configurationService.getCodeMaxRetriesRegistration()).thenReturn(999999);
+        when(configurationService.getCodeMaxRetriesRegistration()).thenReturn(5);
 
         when(userContext.getSession()).thenReturn(session);
     }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
@@ -599,7 +599,7 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     @EnumSource(
             value = JourneyType.class,
             names = {"REGISTRATION", "ACCOUNT_RECOVERY"})
-    void whenAuthAppCodeRetriesExceedFiveDontBlockAndReturn400(JourneyType journeyType) {
+    void whenAuthAppCodeRetriesExceedFiveBlockAndReturn400(JourneyType journeyType) {
         for (int i = 0; i < 5; i++) {
             redis.increaseMfaCodeAttemptsCount(EMAIL_ADDRESS, MFAMethodType.AUTH_APP);
         }
@@ -619,8 +619,8 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         var codeBlockedKeyPrefix = CODE_BLOCKED_KEY_PREFIX + codeRequestType;
 
         assertThat(response, hasStatus(400));
-        assertThat(response, hasJsonBody(ErrorResponse.ERROR_1043));
-        assertFalse(redis.isBlockedMfaCodesForEmail(EMAIL_ADDRESS, codeBlockedKeyPrefix));
+        assertThat(response, hasJsonBody(ErrorResponse.ERROR_1042));
+        assertTrue(redis.isBlockedMfaCodesForEmail(EMAIL_ADDRESS, codeBlockedKeyPrefix));
     }
 
     @Test

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -146,8 +146,7 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
     }
 
     public int getCodeMaxRetriesRegistration() {
-        return Integer.parseInt(
-                System.getenv().getOrDefault("CODE_MAX_RETRIES_REGISTRATION", "999999"));
+        return Integer.parseInt(System.getenv().getOrDefault("CODE_MAX_RETRIES_REGISTRATION", "5"));
     }
 
     public int getAuthAppCodeWindowLength() {


### PR DESCRIPTION
## What?

Change retry limit default for auth app codes during sign up to 5 from 999999.

## Why?

This was noticed during 2hr lockout unit testing and as it's a production issue should be addressed separately and quickly.

original decision to effectively remove retry limit in this [ticket](https://govukverify.atlassian.net/browse/AUT-1322).

Latest decision from security is to restore the retry limit.