### PR TITLE
BAU: Changed alarm count to not deploy to integration and production

### DIFF
--- a/ci/terraform/oidc/account-interventions-alerts.tf
+++ b/ci/terraform/oidc/account-interventions-alerts.tf
@@ -31,12 +31,12 @@ resource "aws_cloudwatch_metric_alarm" "account_interventions_p1_cloudwatch_alar
 }
 
 data "aws_cloudwatch_log_group" "auth_account_interventions_lambda_log_group" {
-  count = var.use_localstack ? 0 : 1
+  count = var.environment == "production" || var.environment == "integration" ? 0 : 1
   name  = replace("/aws/lambda/${var.environment}-account-interventions-lambda", ".", "")
 }
 
 resource "aws_cloudwatch_log_metric_filter" "auth_account_interventions_metric_filter" {
-  count          = var.use_localstack ? 0 : 1
+  count          = var.environment == "production" || var.environment == "integration" ? 0 : 1
   name           = replace("${var.environment}-auth-account-interventions-errors-responses", ".", "")
   pattern        = "{($.${var.account_interventions_error_metric_name} = 1)}"
   log_group_name = data.aws_cloudwatch_log_group.auth_account_interventions_lambda_log_group[0].name
@@ -49,7 +49,7 @@ resource "aws_cloudwatch_log_metric_filter" "auth_account_interventions_metric_f
 }
 
 resource "aws_cloudwatch_metric_alarm" "auth_account_interventions_cloudwatch_alarm" {
-  count               = var.use_localstack ? 0 : 1
+  count               = var.environment == "production" || var.environment == "integration" ? 0 : 1
   alarm_name          = replace("${var.environment}-auth-account-interventions-cloudwatch-alarm", ".", "")
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
@@ -63,7 +63,7 @@ resource "aws_cloudwatch_metric_alarm" "auth_account_interventions_cloudwatch_al
 }
 
 resource "aws_cloudwatch_metric_alarm" "account_interventions_error_rate_p1_cloudwatch_alarm" {
-  count               = var.use_localstack ? 0 : 1
+  count               = var.environment == "production" || var.environment == "integration" ? 0 : 1
   alarm_name          = replace("${var.environment}-P1-auth-account-interventions-alarm", ".", "")
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"


### PR DESCRIPTION
## What?

Changed count for new account interventions alarms to be 0 in integration and production, and 1 in other test environments.

## Why?

Deployment of the alarms caused pipeline failures


## Related PRs

https://github.com/govuk-one-login/authentication-api/pull/3997
https://github.com/govuk-one-login/authentication-api/pull/4005

## Orchestration and Authentication mutual dependencies

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.

- [ ] Impact on orch and auth mutual dependencies has been checked.