### PR TITLE
AUT-3904: Turn on calls to TICF CRI in prod

### DIFF
--- a/ci/terraform/oidc/authdev1.tfvars
+++ b/ci/terraform/oidc/authdev1.tfvars
@@ -11,7 +11,6 @@ account_intervention_service_call_enabled   = true
 account_intervention_service_action_enabled = true
 account_intervention_service_abort_on_error = true
 send_storage_token_to_ipv_enabled           = true
-call_ticf_cri                               = true
 support_reauth_signout_enabled              = true
 authentication_attempts_service_enabled     = true
 

--- a/ci/terraform/oidc/authdev2.tfvars
+++ b/ci/terraform/oidc/authdev2.tfvars
@@ -11,7 +11,6 @@ account_intervention_service_call_enabled   = true
 account_intervention_service_action_enabled = true
 account_intervention_service_abort_on_error = true
 send_storage_token_to_ipv_enabled           = true
-call_ticf_cri                               = true
 support_reauth_signout_enabled              = true
 authentication_attempts_service_enabled     = true
 

--- a/ci/terraform/oidc/build.tfvars
+++ b/ci/terraform/oidc/build.tfvars
@@ -9,7 +9,6 @@ shared_state_bucket                  = "digital-identity-dev-tfstate"
 test_clients_enabled                 = true
 internal_sector_uri                  = "https://identity.build.account.gov.uk"
 ipv_api_enabled                      = true
-call_ticf_cri                        = true
 
 # lockout config
 lockout_duration                          = 60

--- a/ci/terraform/oidc/dev.tfvars
+++ b/ci/terraform/oidc/dev.tfvars
@@ -8,7 +8,6 @@ logging_endpoint_arns                = []
 shared_state_bucket                  = "di-auth-development-tfstate"
 test_clients_enabled                 = true
 internal_sector_uri                  = "https://identity.dev.account.gov.uk"
-call_ticf_cri                        = true
 ipv_authorisation_callback_uri       = "https://signin.dev.account.gov.uk/ipv/callback/authorize"
 ipv_authorisation_client_id          = "authTestClient"
 ipv_authorisation_uri                = "https://ipvstub.signin.dev.account.gov.uk/authorize/"

--- a/ci/terraform/oidc/integration.tfvars
+++ b/ci/terraform/oidc/integration.tfvars
@@ -8,7 +8,6 @@ logging_endpoint_arns                   = []
 shared_state_bucket                     = "digital-identity-dev-tfstate"
 test_clients_enabled                    = false
 internal_sector_uri                     = "https://identity.integration.account.gov.uk"
-call_ticf_cri                           = true
 support_reauth_signout_enabled          = true
 authentication_attempts_service_enabled = true
 

--- a/ci/terraform/oidc/sandpit.tfvars
+++ b/ci/terraform/oidc/sandpit.tfvars
@@ -11,7 +11,6 @@ account_intervention_service_call_enabled   = true
 account_intervention_service_action_enabled = true
 account_intervention_service_abort_on_error = true
 send_storage_token_to_ipv_enabled           = true
-call_ticf_cri                               = true
 support_reauth_signout_enabled              = true
 authentication_attempts_service_enabled     = true
 auth_frontend_public_encryption_key         = <<-EOT

--- a/ci/terraform/oidc/staging.tfvars
+++ b/ci/terraform/oidc/staging.tfvars
@@ -14,7 +14,6 @@ lockout_duration                        = 7200
 reduced_lockout_duration                = 900
 incorrect_password_lockout_count_ttl    = 7200
 support_account_creation_count_ttl      = true
-call_ticf_cri                           = true
 ticf_cri_service_call_timeout           = 10000
 support_reauth_signout_enabled          = true
 authentication_attempts_service_enabled = true

--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -720,7 +720,7 @@ variable "authentication_attempts_service_enabled" {
 
 variable "call_ticf_cri" {
   type        = bool
-  default     = false
+  default     = true
   description = "Feature flag to switch on invoking TICF CRI lambda."
 }
 


### PR DESCRIPTION
## What

This is done by making calls to the API default to enabled and removing the env specific configuration for all other envs.

## How to review

1. Code Review

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->
- [X] Impact on orch and auth mutual dependencies has been checked.
