### PR TITLE
AUT-4184: Enable ticf call in production

### DIFF
--- a/ci/terraform/oidc/production.tfvars
+++ b/ci/terraform/oidc/production.tfvars
@@ -9,6 +9,7 @@ shared_state_bucket                  = "digital-identity-prod-tfstate"
 # App-specific
 internal_sector_uri  = "https://identity.account.gov.uk"
 test_clients_enabled = false
+call_ticf_cri        = true
 
 evcs_audience              = "https://credential-store.account.gov.uk"
 auth_issuer_claim_for_evcs = "https://signin.account.gov.uk"

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
@@ -264,7 +264,6 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
             return;
         }
 
-        LOG.info("Invoking TICF CRI with payload: {}", payload);
         lambdaInvoker.invokeAsyncWithPayload(
                 payload, configurationService.getTicfCRILambdaIdentifier());
     }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/TicfCriHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/TicfCriHandler.java
@@ -89,7 +89,6 @@ public class TicfCriHandler implements RequestHandler<InternalTICFCRIRequest, Vo
             throws IOException, InterruptedException {
         var externalRequest = ExternalTICFCRIRequest.fromInternalRequest(internalTICFCRIRequest);
         var body = serialisationService.writeValueAsStringNoNulls(externalRequest);
-        LOG.info("Serialized request to TICF CRI: {}", body);
         var timeoutInMilliseconds =
                 Duration.ofMillis(configurationService.getTicfCriServiceCallTimeout());
         var request =

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
@@ -68,7 +68,6 @@ import static java.lang.String.format;
 import static java.time.Clock.fixed;
 import static java.time.ZoneId.systemDefault;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItem;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
@@ -87,7 +86,6 @@ import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.C
 import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.EMAIL;
 import static uk.gov.di.authentication.frontendapi.helpers.CommonTestVariables.SESSION_ID;
 import static uk.gov.di.authentication.frontendapi.lambda.LoginHandler.INTERNAL_SUBJECT_ID;
-import static uk.gov.di.authentication.sharedtest.logging.LogEventMatcher.withMessageContaining;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
@@ -612,12 +610,6 @@ class AccountInterventionsHandlerTest {
         vtr.add(CredentialTrustLevel.LOW_LEVEL.getValue());
         assertEquals(ticfRequest.vtr(), vtr);
         verify(auditService).submitAuditEvent(expectedEvent, AUDIT_CONTEXT);
-
-        assertThat(
-                logging.events(),
-                hasItem(
-                        withMessageContaining(
-                                "Invoking TICF CRI with payload: %s".formatted(capturedPayload))));
     }
 
     @Test


### PR DESCRIPTION
## What
- Enable TICF calls in production. This should not impact user journeys: it's configured with a fairly short timeout
- Remove log lines which include subject ID

## How to review

code review

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] No changes required or changes have been made to stub-orchestration.



