### PR TITLE
ATO-1129: delete temporary logs

### DIFF
--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/services/UserInfoService.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/services/UserInfoService.java
@@ -63,30 +63,6 @@ public class UserInfoService {
                 AuthUserInfoClaims.NEW_ACCOUNT.getValue(), accessTokenInfo.getIsNewAccount());
         userInfo.setClaim("password_reset_time", accessTokenInfo.getPasswordResetTime());
 
-        // TODO: ATO-1129: delete temporary logs
-        LOG.info(
-                "is email a requested claim: {}",
-                accessTokenInfo.getClaims().contains(AuthUserInfoClaims.EMAIL.getValue()));
-        LOG.info(
-                "is verified_mfa a requested claim: {}",
-                accessTokenInfo
-                        .getClaims()
-                        .contains(AuthUserInfoClaims.VERIFIED_MFA_METHOD_TYPE.getValue()));
-        LOG.info(
-                "is current_credential_strength a requested claim: {}",
-                accessTokenInfo
-                        .getClaims()
-                        .contains(AuthUserInfoClaims.CURRENT_CREDENTIAL_STRENGTH.getValue()));
-        LOG.info(
-                "is uplift_required a requested claim: {}",
-                accessTokenInfo
-                        .getClaims()
-                        .contains(AuthUserInfoClaims.UPLIFT_REQUIRED.getValue()));
-        LOG.info(
-                "is salt a requested claim: {}",
-                accessTokenInfo.getClaims().contains(AuthUserInfoClaims.SALT.getValue()));
-        //
-
         if (accessTokenInfo.getClaims().contains(AuthUserInfoClaims.LEGACY_SUBJECT_ID.getValue())) {
             userInfo.setClaim("legacy_subject_id", userProfile.getLegacySubjectID());
         }


### PR DESCRIPTION
### Wider context of change
Log cleanup

### What’s changed
Removes temporary logs

### Manual testing
n/a

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [x] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [x] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [x] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [x] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [x] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [x] Successfully run Authentication acceptance tests against sandpit or not required.