### PR TITLE
ATO-1580: check if current rp pairwise id is null

### DIFF
--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/BackChannelLogoutService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/BackChannelLogoutService.java
@@ -73,6 +73,8 @@ public class BackChannelLogoutService {
                 LOGGER.info(
                         "rpPairwiseId on client session is null, client-id = {}",
                         clientRegistry.getClientID());
+            } else if (subjectId == null) {
+                LOGGER.info("subjectId is null, client-id = {}", clientRegistry.getClientID());
             } else {
                 LOGGER.info(
                         "calculated and given rpPairwiseId are different, client-id = {}",


### PR DESCRIPTION
### Wider context of change
Part of the rpPairwiseId migration work. I still haven't identified why rpPairwiseId on the clientSession is out of sync with the calculated subjectId. I have figured out two reasons (publicSubjectId and journeys which don't reach authCallback), but I'm still seeing logs where they are out of sync. I'm adding this to rule out that the current value is null somehow.

### What’s changed
Adds a log to see if subjectId is null

### Manual testing
N/A

### Checklist
- [x] Lambdas have correct permissions for the resources they're accessing. **No change**
- [x] Impact on orch and auth mutual dependencies has been checked. **No change**
- [x] Changes have been made to contract tests or not required. **N/A**
- [x] Changes have been made to the simulator or not required. **N/A**
- [x] Changes have been made to stubs or not required. **N/A**
- [x] Successfully deployed to authdev or not required. **N/A**
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **N/A**