### PR TITLE
ATO-1315: enable signing with new key on staging

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -137,7 +137,11 @@ Conditions:
       !Equals [production, !Ref Environment],
     ]
   UseOrchIpvTokenSigningKey:
-    !Or [!Equals [dev, !Ref Environment], !Equals [build, !Ref Environment]]
+    !Or [
+      !Equals [dev, !Ref Environment],
+      !Equals [build, !Ref Environment],
+      !Equals [staging, !Ref Environment],
+    ]
 
 Mappings:
   EnvironmentConfiguration:


### PR DESCRIPTION
### Wider context of change

<!-- Short explanation of why this change is required and how it fits into larger initiatives. For example:

As part of the max age initiative, Orch need to return the auth_time claim in the ID token to RPs. This is so that RPs can compare max_age, auth_time and the current time, to determine if the ID token is valid.
-->

At present, orch signs requests to IPV with the private key `IPV_TOKEN_SIGNING_KEY_ALIAS` which is resides in the `gds-di-*` AWS accounts. We wish to move this into the `di-orchestration-*` AWS accounts.

At this point, the new key is being published to the IPV JWKS endpoint alongside the old/existing key (that is currently the active signing key). We wish to switch over to signing using this new key.

Promotion up to production is being controlled. At present signing with the new key is enabled in the dev and build environments. This PR enables signing in staging.

[The IPV team will be informed before we promote this change to staging and upwards in subsequent PRs.]

### What’s changed

<!-- What’s changed in this PR. For example:

The auth_time claim is retrieved from the auth code exchange data store, and then added to all token responses (not just when the RP includes max age in the authorize request). Implementation is feature flagged and enabled in all envs except production. As this change is RP facing, it needs to be tested in integration and RPs made aware of the changes before releasing to production.
-->

- Switch to signing with the new key pair on staging.

### Manual testing

<!-- Describe the manual testing completed. For example:

Deployed to Orch dev and observed the following succesful test cases:
- max age not set, sign in 2FA journey, claims returned
- max age not set, no sign in journey, claims returned
- max age 0 forces reauthentication
- max age 1234 does not force reauthentication
- max age 5 forces reauthentication
- max age -3 fails with appropriate error message
- max age “abc” fails with appropriate error message
-->

Ran through an identity journey (P2) on build successfully.
Reviewed the build env IPV Callback lambda logs and observed the following logs (logs and KeyId as expected):

> Calling KMS with SignRequest and KeyId alias/build-orch-ipv-token-auth-kms-key-alias

> PrivateKeyJWT has been signed successfully

Also ran through a standalone auth only journey just as a double check due to the changes in Authentication Callback - journey successful.

Reviewed IPV JWKS endpoint on [dev](https://oidc.sandpit.account.gov.uk/.well-known/ipv-jwks.json) and [build](https://oidc.build.account.gov.uk/.well-known/ipv-jwks.json) and confirmed two keys are still showing in the JWKS response.

Bulk of testing previously completed under #6405.

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [x] Lambdas have correct permissions for the resources they're accessing.
  - Using the existing `IpvTokenSigningKmsAccessPolicy` permissions policy (new key added to this policy under #6405) - this was already added to the three lambdas using the new key. No permission errors when triggering these lambdas.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked. **- N/A**

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required. **- N/A**

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required. **- N/A**

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required. **- N/A**

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required. **- N/A**

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required. **- N/A**

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->

- #6405 - sign on dev and build