### PR TITLE
BAU: Bump Wiremock from v3.12.1 to v3.13.0

### DIFF
--- a/frontend-api/build.gradle
+++ b/frontend-api/build.gradle
@@ -40,7 +40,7 @@ dependencies {
             configurations.kms,
             configurations.dynamodb,
             configurations.pact_consumer,
-            'org.wiremock:wiremock-jetty12:3.12.1'
+            'org.wiremock:wiremock-jetty12:3.13.0'
 
     testRuntimeOnly configurations.test_runtime
 }

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:${dependencyVersions.junit}"
     testImplementation("uk.org.webcompere:system-stubs-jupiter:2.1.8")
     testImplementation("org.awaitility:awaitility:4.3.0")
-    testImplementation('org.wiremock:wiremock-jetty12:3.12.1')
+    testImplementation('org.wiremock:wiremock-jetty12:3.13.0')
 }
 
 test {


### PR DESCRIPTION
## What

Dependabot spotted a vulnerability with org.apache.httpcomponents.client5:httpclient5 v5.4.2 (a dependency of Wiremock). This bumps Wiremock to use httpclient v5.4.3

https://github.com/govuk-one-login/authentication-api/security/dependabot/36

This only affects a testing dependency, so the tests will be able to validate it.

## How to review

1. Code Review