### PR TITLE
AUT-4269: Bump terms_and_conditions version

### DIFF
--- a/ci/terraform/oidc/variables.tf
+++ b/ci/terraform/oidc/variables.tf
@@ -116,7 +116,7 @@ variable "custom_doc_app_claim_enabled" {
 
 variable "terms_and_conditions" {
   type    = string
-  default = "1.12"
+  default = "1.13"
 }
 
 variable "enable_api_gateway_execution_logging" {

--- a/ci/terraform/shared/variables.tf
+++ b/ci/terraform/shared/variables.tf
@@ -20,7 +20,7 @@ variable "aws_dynamodb_endpoint" {
 
 variable "terms_and_conditions" {
   type    = string
-  default = "1.12"
+  default = "1.13"
 }
 
 variable "logging_endpoint_arns" {

--- a/ci/terraform/utils/variables.tf
+++ b/ci/terraform/utils/variables.tf
@@ -53,7 +53,7 @@ variable "cloudwatch_log_retention" {
 
 variable "terms_and_conditions" {
   type        = string
-  default     = "1.12"
+  default     = "1.13"
   description = "The latest Terms and Conditions version number"
 }
 


### PR DESCRIPTION
## What

This ticket updates the privacy statement. Bumping this version number forces users to re-sign on their next visit to OL.

## How to review

1. Code Review
1. Deploy to an env running on the old version and ensure you see the consent banner appear

## Checklist

- [ ] Impact on orch and auth mutual dependencies has been checked.

## Related PRs

https://github.com/govuk-one-login/authentication-frontend/pull/2756