### PR TITLE
BAU: Add decorator to client sessions list

### DIFF
--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchSessionItem.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/OrchSessionItem.java
@@ -21,7 +21,7 @@ public class OrchSessionItem {
     public static final String ATTRIBUTE_CURRENT_CREDENTIAL_STRENGTH = "CurrentCredentialStrength";
     public static final String ATTRIBUTE_PROCESSING_IDENTITY_ATTEMPTS =
             "ProcessingIdentityAttempts";
-    public static final String ATTRIBUTE_CLIENT_SESSIONS = "ClientSessions";
+    public static final String ATTRIBUTE_CLIENT_SESSIONS = "clientSessions";
 
     public enum AccountState {
         NEW,
@@ -227,6 +227,7 @@ public class OrchSessionItem {
         return processingIdentityAttempts;
     }
 
+    @DynamoDbAttribute(ATTRIBUTE_CLIENT_SESSIONS)
     public List<String> getClientSessions() {
         return clientSessions;
     }


### PR DESCRIPTION
### Wider context of change:

In previous work we did not add the usual DynamoDbAttribute decorator to the getter for this value. This meant it defaulted to using the the attribute name `clientSessions` instead of `ClientSessions` which was defined as a variable. This does not have any practical implications, as the list is still get/set normally, it just doesn't align with the pattern we've established.

Here we add this decorator but change the attribute to match what the current value is in Dynamo. This is required for the changes to be backwards compatible with existing session fields. Doing this now also prevents someone from doing this in the future with the existing attribute string, which might be breaking

### What’s changed

- Adds a decorator to the getter for clientSession list on the orch session.

### Manual testing

TODO: 
- Before deploying to dev, establish an orch session
- After deploying go back to the stub and go to auhtorize
- Observe two entries in the client session list and no additional attributes on the session 

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
