### PR TITLE
ATO-1315: stop publishing old orch to ipv key on production

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -128,7 +128,6 @@ Conditions:
       !Equals [integration, !Ref Environment],
       !Equals [production, !Ref Environment],
     ]
-  IsAuthIpvTokenSigningKeyPublishEnabled: !Equals [production, !Ref Environment]
   IsOrchIpvTokenSigningKeyPublishEnabled:
     !Or [
       !Equals [dev, !Ref Environment],
@@ -2679,10 +2678,7 @@ Resources:
               !Ref Environment,
               ipvTokenKeyArn,
             ]
-          AUTH_IPV_TOKEN_SIGNING_KEY_PUBLISH_ENABLED: !If
-            - IsAuthIpvTokenSigningKeyPublishEnabled
-            - true
-            - false
+          AUTH_IPV_TOKEN_SIGNING_KEY_PUBLISH_ENABLED: false
           ORCH_IPV_TOKEN_SIGNING_KEY_PUBLISH_ENABLED: !If
             - IsOrchIpvTokenSigningKeyPublishEnabled
             - true


### PR DESCRIPTION
### Wider context of change

<!-- Short explanation of why this change is required and how it fits into larger initiatives. For example:

As part of the max age initiative, Orch need to return the auth_time claim in the ID token to RPs. This is so that RPs can compare max_age, auth_time and the current time, to determine if the ID token is valid.
-->

Previously orch was signs requests to IPV with a private key residing in the `gds-di-*` AWS accounts. We have migrated to signing with a new key residing in the `di-orchestration-*` AWS accounts. To achieve this migration we had to publish the old and new keys alongside one another on the IPV JWKS endpoint.

Now we are only using the new key, we wish to stop publishing the old key on the IPV JWKS endpoint. We wish to control promotion of this change. We have already stopped publishing on the dev, build, staging, and integration environments (#6432, #6435).

This PR stops publishing the old key on **production**.

Note that we will clean up the `AUTH_IPV_TOKEN_SIGNING_KEY_PUBLISH_ENABLED` env var in a subsequent PR.

### What’s changed

<!-- What’s changed in this PR. For example:

The auth_time claim is retrieved from the auth code exchange data store, and then added to all token responses (not just when the RP includes max age in the authorize request). Implementation is feature flagged and enabled in all envs except production. As this change is RP facing, it needs to be tested in integration and RPs made aware of the changes before releasing to production.
-->

- Disabled publishing the old key on production using the flag introduced in #6432.

### Manual testing

<!-- Describe the manual testing completed. For example:

Deployed to Orch dev and observed the following succesful test cases:
- max age not set, sign in 2FA journey, claims returned
- max age not set, no sign in journey, claims returned
- max age 0 forces reauthentication
- max age 1234 does not force reauthentication
- max age 5 forces reauthentication
- max age -3 fails with appropriate error message
- max age “abc” fails with appropriate error message
-->

Ran through identity (P2) and auth only journeys on integration (with the changes from #6435 were live) successfully.

Navigated to the IPV JWKS endpoint on integration (one below production) (https://oidc.integration.account.gov.uk/.well-known/ipv-jwks.json) where publishing of the old key was previously disabled (#6432) - confirmed there was a single key in the response, reviewed logs for this lambda and observed that this was for the new key ID `alias/integration-orch-ipv-token-auth-kms-key-alias` - all as expected.

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [x] Lambdas have correct permissions for the resources they're accessing.
  - No permission changes.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked. **- N/A**

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required. **- N/A**

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required. **- N/A**

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required. **- N/A**

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required. **- N/A**

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required. **- N/A**

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->

- #6432 - disable publishing of the old key on the dev, build and staging environments
- #6435 - disable publishing on integration