### PR TITLE
AUT-4196: Switch user-credentials table encryption to a CMK

### DIFF
--- a/ci/terraform/shared/dynamodb.tf
+++ b/ci/terraform/shared/dynamodb.tf
@@ -56,7 +56,7 @@ resource "aws_dynamodb_table" "user_credentials_table" {
 
   server_side_encryption {
     enabled     = true
-    kms_key_arn = contains(["build", "integration", "production"], var.environment) ? null : aws_kms_key.user_credentials_table_encryption_key.arn
+    kms_key_arn = aws_kms_key.user_credentials_table_encryption_key.arn
   }
 
   point_in_time_recovery {


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

- User credentials DynamoDB table switched from using an AWS managed key to using a CMK on all environments. 

## Testing

**Prior to #6465:**

Located the `sandpit-user-credentials` dynamo table on the `gds-di-development` account, observed that the encryption key was showing as "managed by AWS KMS".

Deployed to sandpit (with `./deploy-sandpit.sh -c -a`), reviewed table again, now showing as a CMK, key ID matched expected CMK.

Ran through an identity (P2) journey successfully.

**After enabled on lower envs (changes from #6465)**

- Redeployed to sandpit, confirmed TF deployment successful and that the table was still showing as a CMK.
- Tested on staging (CMK enabled on there under #6465) - see comment [below](https://github.com/govuk-one-login/authentication-api/pull/6459#issuecomment-2862943897)

## How to review

1. Code Review
1. (Optionally) Run through identity (P2) journey on sandpit (already deployed with `./deploy-sandpit.sh -c -a`)

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.
  - [Discussed in this slack thread](https://gds.slack.com/archives/C060UE8NSP4/p1744111440904699) - orch dependency (processing identity handler) is still in the auth accounts (`gds-di-*`). Ran through identity journey on sandpit to confirm ok (see above).

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [ ] No changes required or changes have been made to stub-orchestration. **- N/A**

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed. **- N/A**

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->

- #6445
- adding to AM policies - #6462
- enabling on lower envs - #6465