### PR TITLE
AUT-4196: Add user-credentials CMK to account management policies

### DIFF
--- a/ci/terraform/account-management/dynamo-policies.tf
+++ b/ci/terraform/account-management/dynamo-policies.tf
@@ -66,7 +66,10 @@ data "aws_iam_policy_document" "dynamo_user_write_policy_document" {
       "kms:CreateGrant",
       "kms:DescribeKey",
     ]
-    resources = [local.user_profile_kms_key_arn]
+    resources = [
+      local.user_profile_kms_key_arn,
+      local.user_credentials_kms_key_arn,
+    ]
   }
 }
 
@@ -102,7 +105,10 @@ data "aws_iam_policy_document" "dynamo_user_read_policy_document" {
       "kms:CreateGrant",
       "kms:DescribeKey",
     ]
-    resources = [local.user_profile_kms_key_arn]
+    resources = [
+      local.user_profile_kms_key_arn,
+      local.user_credentials_kms_key_arn,
+    ]
   }
 }
 

--- a/ci/terraform/account-management/shared.tf
+++ b/ci/terraform/account-management/shared.tf
@@ -14,6 +14,7 @@ locals {
   common_passwords_encryption_policy_arn      = data.terraform_remote_state.shared.outputs.common_passwords_encryption_policy_arn
   client_registry_encryption_policy_arn       = data.terraform_remote_state.shared.outputs.client_registry_encryption_policy_arn
   user_profile_encryption_policy_arn          = data.terraform_remote_state.shared.outputs.user_profile_encryption_policy_arn
+  user_credentials_kms_key_arn                = data.terraform_remote_state.shared.outputs.user_credentials_kms_key_arn
   pending_email_check_queue_id                = data.terraform_remote_state.shared.outputs.pending_email_check_queue_id
   pending_email_check_queue_access_policy_arn = data.terraform_remote_state.shared.outputs.pending_email_check_queue_access_policy_arn
   client_registry_encryption_key_arn          = data.terraform_remote_state.shared.outputs.client_registry_encryption_key_arn


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

Give dynamo user roles in account management access to the `user-credentials` CMK.

## Testing

Deployed to sandpit, checked through the AWS UI that the `sandpit-mfa-methods-retrieve-lambda` lambda has access to the CMK.

## How to review

1. Code Review
1. Apply to a dev environment to observe terraform plan

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked. **-N/A**

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [ ] No changes required or changes have been made to stub-orchestration. **-N/A**

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed. **-N/A**

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->

- adding permissions for OIDC resources - #6445