### PR TITLE
AUT-4196: Use common-passwords CMK on dev and staging environments

### DIFF
--- a/ci/terraform/shared/dynamodb.tf
+++ b/ci/terraform/shared/dynamodb.tf
@@ -362,7 +362,8 @@ resource "aws_dynamodb_table" "common_passwords_table" {
   }
 
   server_side_encryption {
-    enabled = true
+    enabled     = true
+    kms_key_arn = contains(["build", "integration", "production"], var.environment) ? null : aws_kms_key.common_passwords_table_encryption_key.arn
   }
 
   point_in_time_recovery {


### PR DESCRIPTION
## What

We want to switch to use a new CMK for encryption on the `common-passwords` table. We wish to control the promotion of this change.

This PR enables encryption with the new CMK on dev and staging environments (so not on build, integration, and production).

## Testing

Located the sandpit-common-passwords dynamo table on the gds-di-development account, observed that the encryption key was showing as "managed by AWS KMS".

Deployed to sandpit (with ./deploy-sandpit.sh -c -a), reviewed table again, now showing as a CMK, key ID matched expected CMK.

Added authdev1 to the list of environments that should not use the CMK, deployed TF to authdev1, the table encryption method had not updated (as expected) and continued using the AWS managed key.

Removed authdev1 from the list of environments that should not use the CMK, deployed TF to authdev1, the table encryption method had been updated (as expected) and this has switched to using the CMK.

Ran through an sign in journey successfully (login journey calls isPasswordResetRequired helper which in turn performs a lookup on this table).

Ran through password reset journey successfully.

Ran through account creation journey successfully.

## How to review

1. Code review
2. Deploy to dev env and check the encryption method on the `common-passwords` table

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked. **- N/A**

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [ ] No changes required or changes have been made to stub-orchestration. **- N/A**

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed. **- N/A**

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->

- Added to policy here: #3580