### PR TITLE
AUT-4196: Use common-passwords CMK on build and integration

### DIFF
--- a/ci/terraform/shared/dynamodb.tf
+++ b/ci/terraform/shared/dynamodb.tf
@@ -363,7 +363,7 @@ resource "aws_dynamodb_table" "common_passwords_table" {
 
   server_side_encryption {
     enabled     = true
-    kms_key_arn = contains(["build", "integration", "production"], var.environment) ? null : aws_kms_key.common_passwords_table_encryption_key.arn
+    kms_key_arn = var.environment != "production" ? aws_kms_key.common_passwords_table_encryption_key.arn : null
   }
 
   point_in_time_recovery {


### PR DESCRIPTION
~~**DO NOT MERGE, DEPENDENCIES:**~~
- ~~#6476~~
- ~~Complete testing below on staging~~ - done

## What

We want to switch to use a new CMK for encryption on the `common-passwords` table. We wish to control the promotion of this change. This has already been enabled on the dev and staging environments (see #6476) and we are happy with this (see testing notes below).

This PR enables encryption with the new CMK on the integration environment (so we will still be using the AWS managed key on production).

## Testing

Ran through the following journeys successfully on staging (all via home):
- Sign in journey (login journey calls isPasswordResetRequired helper which in turn performs a lookup on this table).
- Password reset journey (from sign in flow).
- Password reset journey (from account management).
- Account creation journey.

## How to review

1. Code review
2. Optionally run through the above journeys on the staging environment.

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked. **- N/A**

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [ ] No changes required or changes have been made to stub-orchestration. **- N/A**

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed. **- N/A**

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->

- Added to policy here: #3580
- Enable on dev and staging: #6476