### PR TITLE
ATO-1674: Use service_type claim in StartHandler

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/StartRequest.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/StartRequest.java
@@ -17,4 +17,5 @@ public record StartRequest(
         @Expose @SerializedName("client_id") String clientId,
         @Expose @SerializedName("redirect_uri") String redirectUri,
         @Expose @SerializedName("scope") String scope,
-        @Expose @SerializedName("client_name") String clientName) {}
+        @Expose @SerializedName("client_name") String clientName,
+        @Expose @SerializedName("service_type") String serviceType) {}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -206,7 +206,11 @@ public class StartHandler
             attachLogFieldToLogs(CLIENT_ID, authSession.getClientId());
             var clientStartInfo =
                     startService.buildClientStartInfo(
-                            userContext.getClient().orElseThrow(), scopes, redirectURI, state);
+                            userContext.getClient().orElseThrow(),
+                            startRequest.serviceType(),
+                            scopes,
+                            redirectURI,
+                            state);
 
             var cookieConsent =
                     startService.getCookieConsentValue(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
@@ -76,12 +76,16 @@ public class StartService {
     }
 
     public ClientStartInfo buildClientStartInfo(
-            ClientRegistry clientRegistry, List<String> scopes, URI redirectURI, State state) {
+            ClientRegistry clientRegistry,
+            String serviceType,
+            List<String> scopes,
+            URI redirectURI,
+            State state) {
         var clientInfo =
                 new ClientStartInfo(
                         clientRegistry.getClientName(),
                         scopes,
-                        clientRegistry.getServiceType(),
+                        serviceType,
                         clientRegistry.isCookieConsentShared(),
                         redirectURI,
                         state,
@@ -90,7 +94,7 @@ public class StartService {
                 "Found ClientStartInfo for ClientName: {} Scopes: {} ServiceType: {}",
                 clientRegistry.getClientName(),
                 scopes,
-                clientRegistry.getServiceType());
+                serviceType);
 
         return clientInfo;
     }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/StartHandlerTest.java
@@ -26,6 +26,7 @@ import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.LevelOfConfidence;
+import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.serialization.Json;
@@ -501,7 +502,7 @@ class StartHandlerTest {
             UserContext userContext, ClientStartInfo clientStartInfo, UserStartInfo userStartInfo) {
         when(startService.buildUserContext(eq(session), any(AuthSessionItem.class)))
                 .thenReturn(userContext);
-        when(startService.buildClientStartInfo(eq(clientRegistry), any(), any(), any()))
+        when(startService.buildClientStartInfo(eq(clientRegistry), any(), any(), any(), any()))
                 .thenReturn(clientStartInfo);
         when(startService.buildUserStartInfo(
                         eq(userContext),
@@ -551,6 +552,7 @@ class StartHandlerTest {
                         TEST_CLIENT_ID,
                         REDIRECT_URL.toString(),
                         SCOPE.toString(),
-                        CLIENT_NAME));
+                        CLIENT_NAME,
+                        ServiceType.MANDATORY.toString()));
     }
 }

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
@@ -533,7 +533,9 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                                 "redirect_uri",
                                 redirectUri,
                                 "client_name",
-                                TEST_CLIENT_NAME));
+                                TEST_CLIENT_NAME,
+                                "service_type",
+                                ServiceType.MANDATORY.toString()));
         previousSessionIdOpt.ifPresent(
                 previousSessionId -> requestBodyMap.put("previous-session-id", previousSessionId));
         requestedLevelOfConfidenceOpt.ifPresent(


### PR DESCRIPTION
### Wider context of change

We would like to move authentication away from using the ClientRegistry. To do this we need to pass information about the client from orch to auth, and store them on the auth session. A few fields we need have already been added as part of the client session migration.

### What’s changed

This PR swaps to using the service_type claim sent from orch instead of the ClientRegistry.getServiceType() method.

### Manual testing

Tested in sandpit. Did an auth only journey and identity journey. Both were successful

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing. n/a
- [x] Impact on orch and auth mutual dependencies has been checked. n/a
- [x] Changes have been made to contract tests or not required. n/a
- [x] Changes have been made to the simulator or not required. n/a
- [x] Changes have been made to stubs or not required. n/a
- [x] Successfully deployed to authdev or not required. See above
- [x] Successfully run Authentication acceptance tests against sandpit or not required. See above
