### PR TITLE
ATO-1644: remove auth redis session read reapply

### DIFF
--- a/auth-external-api/src/main/java/uk/gov/di/authentication/external/lambda/UserInfoHandler.java
+++ b/auth-external-api/src/main/java/uk/gov/di/authentication/external/lambda/UserInfoHandler.java
@@ -16,7 +16,6 @@ import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.external.services.UserInfoService;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
-import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.token.AccessTokenStore;
 import uk.gov.di.authentication.shared.exceptions.AccessTokenException;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
@@ -26,7 +25,6 @@ import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
-import uk.gov.di.authentication.shared.services.SessionService;
 
 import java.util.Map;
 import java.util.Optional;
@@ -47,7 +45,6 @@ public class UserInfoHandler
     private final UserInfoService userInfoService;
     private final AccessTokenService accessTokenService;
     private final AuditService auditService;
-    private final SessionService sessionService;
     private final AuthSessionService authSessionService;
 
     public UserInfoHandler(
@@ -55,13 +52,11 @@ public class UserInfoHandler
             UserInfoService userInfoService,
             AccessTokenService accessTokenService,
             AuditService auditService,
-            SessionService sessionService,
             AuthSessionService authSessionService) {
         this.configurationService = configurationService;
         this.userInfoService = userInfoService;
         this.accessTokenService = accessTokenService;
         this.auditService = auditService;
-        this.sessionService = sessionService;
         this.authSessionService = authSessionService;
     }
 
@@ -77,7 +72,6 @@ public class UserInfoHandler
                 new AccessTokenService(
                         configurationService, new CloudwatchMetricsService(configurationService));
         this.auditService = new AuditService(configurationService);
-        this.sessionService = new SessionService(configurationService);
         this.authSessionService = new AuthSessionService(configurationService);
     }
 
@@ -113,23 +107,6 @@ public class UserInfoHandler
                     new UserInfoErrorResponse(BearerTokenError.MISSING_TOKEN)
                             .toHTTPResponse()
                             .getHeaderMap());
-        }
-
-        try {
-
-            // ATO-982: We should remove this once auth is fully moved from
-            // using the shared session store
-            Optional<Session> optionalSession =
-                    sessionService.getSessionFromRequestHeaders(input.getHeaders());
-
-            if (optionalSession.isEmpty()) {
-                LOG.warn("Session cannot be found");
-                return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1000);
-            }
-
-        } catch (Exception e) {
-            LOG.error("Error retrieving session from redis: {}", e.getMessage());
-            throw new RuntimeException(e);
         }
 
         AuthSessionItem authSession;

--- a/auth-external-api/src/test/java/uk/gov/di/authentication/external/lambda/UserInfoHandlerTest.java
+++ b/auth-external-api/src/test/java/uk/gov/di/authentication/external/lambda/UserInfoHandlerTest.java
@@ -16,7 +16,6 @@ import uk.gov.di.authentication.external.services.UserInfoService;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
-import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.entity.token.AccessTokenStore;
 import uk.gov.di.authentication.shared.exceptions.AccessTokenException;
@@ -25,7 +24,6 @@ import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SerializationService;
-import uk.gov.di.authentication.shared.services.SessionService;
 
 import java.util.List;
 import java.util.Map;
@@ -52,14 +50,12 @@ class UserInfoHandlerTest {
     private UserInfoService userInfoService;
     private AccessTokenService accessTokenService;
     private UserInfoHandler userInfoHandler;
-    private SessionService sessionService;
     private AuthSessionService authSessionService;
     private static final AccessTokenStore accessTokenStore = mock(AccessTokenStore.class);
     private static final Subject TEST_SUBJECT = new Subject();
     private static final UserInfo TEST_SUBJECT_USER_INFO = new UserInfo(TEST_SUBJECT);
     private final AuditService auditService = mock(AuditService.class);
     private final String sessionId = "a-session-id";
-    private final Session testSession = new Session();
     private final AuthSessionItem authSession = new AuthSessionItem().withSessionId(sessionId);
     private final SerializationService objectMapper = SerializationService.getInstance();
     private final String testVerifiedMfaMethodType = MFAMethodType.AUTH_APP.getValue();
@@ -75,7 +71,6 @@ class UserInfoHandlerTest {
         configurationService = mock(ConfigurationService.class);
         userInfoService = mock(UserInfoService.class);
         accessTokenService = mock(AccessTokenService.class);
-        sessionService = mock(SessionService.class);
         authSessionService = mock(AuthSessionService.class);
         when(accessTokenService.getAccessTokenStore(any()))
                 .thenReturn(Optional.of(accessTokenStore));
@@ -85,7 +80,6 @@ class UserInfoHandlerTest {
                         userInfoService,
                         accessTokenService,
                         auditService,
-                        sessionService,
                         authSessionService);
 
         TEST_SUBJECT_USER_INFO.setEmailAddress("test@test.com");
@@ -108,8 +102,6 @@ class UserInfoHandlerTest {
                 .thenReturn(validToken);
         when(userInfoService.populateUserInfo(eq(accessTokenStore), any()))
                 .thenReturn(TEST_SUBJECT_USER_INFO);
-        when(sessionService.getSessionFromRequestHeaders(any()))
-                .thenReturn(Optional.of(testSession));
 
         APIGatewayProxyResponseEvent response = userInfoHandler.userInfoRequestHandler(request);
 
@@ -146,8 +138,6 @@ class UserInfoHandlerTest {
         when(accessTokenService.getAccessTokenFromAuthorizationHeader(any()))
                 .thenReturn(validToken);
         when(userInfoService.populateUserInfo(any(), any())).thenReturn(TEST_SUBJECT_USER_INFO);
-        when(sessionService.getSessionFromRequestHeaders(any()))
-                .thenReturn(Optional.of(testSession));
 
         APIGatewayProxyResponseEvent response = userInfoHandler.userInfoRequestHandler(request);
 
@@ -208,27 +198,7 @@ class UserInfoHandlerTest {
 
         assertEquals(400, response.getStatusCode());
         assertEquals(objectMapper.writeValueAsString(ErrorResponse.ERROR_1000), response.getBody());
-        verify(sessionService).getSessionFromRequestHeaders(request.getHeaders());
-        verifyNoInteractions(accessTokenService, userInfoService, auditService);
-    }
-
-    @Test
-    void shouldReturnNoSessionWhenSessionNotFound() throws ParseException, AccessTokenException {
-        APIGatewayProxyRequestEvent request = new APIGatewayProxyRequestEvent();
-        String validTokenHeader = "Bearer valid-token";
-        AccessToken validToken = AccessToken.parse(validTokenHeader, AccessTokenType.BEARER);
-        request.setHeaders(Map.of("Authorization", validTokenHeader, SESSION_ID_HEADER, sessionId));
-        when(accessTokenService.getAccessTokenFromAuthorizationHeader(any()))
-                .thenReturn(validToken);
-        when(userInfoService.populateUserInfo(accessTokenStore, authSession))
-                .thenReturn(TEST_SUBJECT_USER_INFO);
-        when(sessionService.getSessionFromRequestHeaders(any())).thenReturn(Optional.empty());
-
-        APIGatewayProxyResponseEvent response = userInfoHandler.userInfoRequestHandler(request);
-
-        assertEquals(400, response.getStatusCode());
-        assertEquals(objectMapper.writeValueAsString(ErrorResponse.ERROR_1000), response.getBody());
-        verify(sessionService).getSessionFromRequestHeaders(request.getHeaders());
+        verify(authSessionService).getSessionFromRequestHeaders(request.getHeaders());
         verifyNoInteractions(accessTokenService, userInfoService, auditService);
     }
 
@@ -242,8 +212,6 @@ class UserInfoHandlerTest {
                 .thenReturn(validToken);
         when(userInfoService.populateUserInfo(accessTokenStore, authSession))
                 .thenReturn(TEST_SUBJECT_USER_INFO);
-        when(sessionService.getSessionFromRequestHeaders(any()))
-                .thenReturn(Optional.of(testSession));
         APIGatewayProxyRequestEvent request = new APIGatewayProxyRequestEvent();
 
         request.setHeaders(Map.of("Authorization", validTokenHeader, SESSION_ID_HEADER, sessionId));
@@ -252,7 +220,7 @@ class UserInfoHandlerTest {
 
         assertEquals(400, response.getStatusCode());
         assertEquals(objectMapper.writeValueAsString(ErrorResponse.ERROR_1000), response.getBody());
-        verify(sessionService).getSessionFromRequestHeaders(request.getHeaders());
+        verify(authSessionService).getSessionFromRequestHeaders(request.getHeaders());
         verifyNoInteractions(accessTokenService, userInfoService, auditService);
     }
 
@@ -265,8 +233,6 @@ class UserInfoHandlerTest {
         request.setHeaders(Map.of("Authorization", invalidToken, SESSION_ID_HEADER, sessionId));
         when(accessTokenService.getAccessTokenFromAuthorizationHeader(any()))
                 .thenThrow(new AccessTokenException("test", BearerTokenError.INVALID_TOKEN));
-        when(sessionService.getSessionFromRequestHeaders(any()))
-                .thenReturn(Optional.of(testSession));
 
         APIGatewayProxyResponseEvent response = userInfoHandler.userInfoRequestHandler(request);
 
@@ -290,8 +256,6 @@ class UserInfoHandlerTest {
         when(accessTokenService.getAccessTokenFromAuthorizationHeader(any()))
                 .thenReturn(AccessToken.parse(invalidToken, AccessTokenType.BEARER));
         when(accessTokenService.getAccessTokenStore(any())).thenReturn(Optional.empty());
-        when(sessionService.getSessionFromRequestHeaders(any()))
-                .thenReturn(Optional.of(testSession));
 
         APIGatewayProxyResponseEvent response = userInfoHandler.userInfoRequestHandler(request);
 
@@ -314,8 +278,6 @@ class UserInfoHandlerTest {
         request.setHeaders(Map.of("Authorization", validToken, SESSION_ID_HEADER, sessionId));
         when(accessTokenService.getAccessTokenFromAuthorizationHeader(any()))
                 .thenReturn(AccessToken.parse(validToken, AccessTokenType.BEARER));
-        when(sessionService.getSessionFromRequestHeaders(any()))
-                .thenReturn(Optional.of(testSession));
 
         AccessTokenStore mockAccessTokenStore = mock(AccessTokenStore.class);
         when(mockAccessTokenStore.isUsed()).thenReturn(true);
@@ -343,8 +305,6 @@ class UserInfoHandlerTest {
         request.setHeaders(Map.of("Authorization", validToken, SESSION_ID_HEADER, sessionId));
         when(accessTokenService.getAccessTokenFromAuthorizationHeader(any()))
                 .thenReturn(AccessToken.parse(validToken, AccessTokenType.BEARER));
-        when(sessionService.getSessionFromRequestHeaders(any()))
-                .thenReturn(Optional.of(testSession));
 
         when(accessTokenStore.getTimeToExist()).thenReturn(0L);
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandler.java
@@ -33,8 +33,6 @@ import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.LambdaInvokerService;
-import uk.gov.di.authentication.shared.services.RedisConnectionService;
-import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.time.Clock;
@@ -97,7 +95,6 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
 
     protected AccountInterventionsHandler(
             ConfigurationService configurationService,
-            SessionService sessionService,
             ClientService clientService,
             AuthenticationService authenticationService,
             AccountInterventionsService accountInterventionsService,
@@ -109,7 +106,6 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
         super(
                 AccountInterventionsRequest.class,
                 configurationService,
-                sessionService,
                 clientService,
                 authenticationService,
                 authSessionService);
@@ -123,10 +119,8 @@ public class AccountInterventionsHandler extends BaseFrontendHandler<AccountInte
     }
 
     public AccountInterventionsHandler(
-            ConfigurationService configurationService,
-            RedisConnectionService redis,
-            LambdaInvokerService lambdaInvokerService) {
-        super(AccountInterventionsRequest.class, configurationService, redis);
+            ConfigurationService configurationService, LambdaInvokerService lambdaInvokerService) {
+        super(AccountInterventionsRequest.class, configurationService);
 
         this.lambdaInvoker = lambdaInvokerService;
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountRecoveryHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AccountRecoveryHandler.java
@@ -19,8 +19,6 @@ import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoAccountModifiersService;
-import uk.gov.di.authentication.shared.services.RedisConnectionService;
-import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
 import static uk.gov.di.audit.AuditContext.auditContextFromUserContext;
@@ -36,7 +34,6 @@ public class AccountRecoveryHandler extends BaseFrontendHandler<AccountRecoveryR
 
     protected AccountRecoveryHandler(
             ConfigurationService configurationService,
-            SessionService sessionService,
             ClientService clientService,
             AuthenticationService authenticationService,
             DynamoAccountModifiersService dynamoAccountModifiersService,
@@ -45,7 +42,6 @@ public class AccountRecoveryHandler extends BaseFrontendHandler<AccountRecoveryR
         super(
                 AccountRecoveryRequest.class,
                 configurationService,
-                sessionService,
                 clientService,
                 authenticationService,
                 authSessionService);
@@ -55,14 +51,6 @@ public class AccountRecoveryHandler extends BaseFrontendHandler<AccountRecoveryR
 
     public AccountRecoveryHandler(ConfigurationService configurationService) {
         super(AccountRecoveryRequest.class, configurationService);
-        this.dynamoAccountModifiersService =
-                new DynamoAccountModifiersService(configurationService);
-        this.auditService = new AuditService(configurationService);
-    }
-
-    public AccountRecoveryHandler(
-            ConfigurationService configurationService, RedisConnectionService redis) {
-        super(AccountRecoveryRequest.class, configurationService, redis);
         this.dynamoAccountModifiersService =
                 new DynamoAccountModifiersService(configurationService);
         this.auditService = new AuditService(configurationService);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandler.java
@@ -26,8 +26,6 @@ import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoAuthCodeService;
-import uk.gov.di.authentication.shared.services.RedisConnectionService;
-import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.net.URI;
@@ -51,7 +49,6 @@ public class AuthenticationAuthCodeHandler extends BaseFrontendHandler<AuthCodeR
     public AuthenticationAuthCodeHandler(
             DynamoAuthCodeService dynamoAuthCodeService,
             ConfigurationService configurationService,
-            SessionService sessionService,
             ClientService clientService,
             AuthenticationService authenticationService,
             AuditService auditService,
@@ -60,7 +57,6 @@ public class AuthenticationAuthCodeHandler extends BaseFrontendHandler<AuthCodeR
         super(
                 AuthCodeRequest.class,
                 configurationService,
-                sessionService,
                 clientService,
                 authenticationService,
                 authSessionService);
@@ -71,14 +67,6 @@ public class AuthenticationAuthCodeHandler extends BaseFrontendHandler<AuthCodeR
 
     public AuthenticationAuthCodeHandler(ConfigurationService configurationService) {
         super(AuthCodeRequest.class, configurationService);
-        this.dynamoAuthCodeService = new DynamoAuthCodeService(configurationService);
-        this.auditService = new AuditService(configurationService);
-        this.cloudwatchMetricsService = new CloudwatchMetricsService();
-    }
-
-    public AuthenticationAuthCodeHandler(
-            ConfigurationService configurationService, RedisConnectionService redis) {
-        super(AuthCodeRequest.class, configurationService, redis);
         this.dynamoAuthCodeService = new DynamoAuthCodeService(configurationService);
         this.auditService = new AuditService(configurationService);
         this.cloudwatchMetricsService = new CloudwatchMetricsService();

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckEmailFraudBlockHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckEmailFraudBlockHandler.java
@@ -24,8 +24,6 @@ import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoEmailCheckResultService;
-import uk.gov.di.authentication.shared.services.RedisConnectionService;
-import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.util.Optional;
@@ -42,7 +40,6 @@ public class CheckEmailFraudBlockHandler extends BaseFrontendHandler<CheckEmailF
 
     protected CheckEmailFraudBlockHandler(
             ConfigurationService configurationService,
-            SessionService sessionService,
             ClientService clientService,
             AuthenticationService authenticationService,
             DynamoEmailCheckResultService dynamoEmailCheckResultService,
@@ -51,7 +48,6 @@ public class CheckEmailFraudBlockHandler extends BaseFrontendHandler<CheckEmailF
         super(
                 CheckEmailFraudBlockRequest.class,
                 configurationService,
-                sessionService,
                 clientService,
                 authenticationService,
                 authSessionService);
@@ -61,14 +57,6 @@ public class CheckEmailFraudBlockHandler extends BaseFrontendHandler<CheckEmailF
 
     public CheckEmailFraudBlockHandler(ConfigurationService configurationService) {
         super(CheckEmailFraudBlockRequest.class, configurationService);
-        this.dynamoEmailCheckResultService =
-                new DynamoEmailCheckResultService(configurationService);
-        this.auditService = new AuditService(configurationService);
-    }
-
-    public CheckEmailFraudBlockHandler(
-            ConfigurationService configurationService, RedisConnectionService redis) {
-        super(CheckEmailFraudBlockRequest.class, configurationService, redis);
         this.dynamoEmailCheckResultService =
                 new DynamoEmailCheckResultService(configurationService);
         this.auditService = new AuditService(configurationService);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java
@@ -30,8 +30,6 @@ import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
-import uk.gov.di.authentication.shared.services.RedisConnectionService;
-import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.time.temporal.ChronoUnit;
@@ -61,7 +59,6 @@ public class CheckReAuthUserHandler extends BaseFrontendHandler<CheckReauthUserR
 
     public CheckReAuthUserHandler(
             ConfigurationService configurationService,
-            SessionService sessionService,
             ClientService clientService,
             AuthenticationService authenticationService,
             AuditService auditService,
@@ -71,7 +68,6 @@ public class CheckReAuthUserHandler extends BaseFrontendHandler<CheckReauthUserR
         super(
                 CheckReauthUserRequest.class,
                 configurationService,
-                sessionService,
                 clientService,
                 authenticationService,
                 authSessionService);
@@ -82,15 +78,6 @@ public class CheckReAuthUserHandler extends BaseFrontendHandler<CheckReauthUserR
 
     public CheckReAuthUserHandler(ConfigurationService configurationService) {
         super(CheckReauthUserRequest.class, configurationService);
-        this.auditService = new AuditService(configurationService);
-        this.authenticationAttemptsService =
-                new AuthenticationAttemptsService(configurationService);
-        this.cloudwatchMetricsService = new CloudwatchMetricsService();
-    }
-
-    public CheckReAuthUserHandler(
-            ConfigurationService configurationService, RedisConnectionService redis) {
-        super(CheckReauthUserRequest.class, configurationService, redis);
         this.auditService = new AuditService(configurationService);
         this.authenticationAttemptsService =
                 new AuthenticationAttemptsService(configurationService);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -29,7 +29,6 @@ import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
-import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.util.Optional;
@@ -52,7 +51,6 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
 
     public CheckUserExistsHandler(
             ConfigurationService configurationService,
-            SessionService sessionService,
             AuthSessionService authSessionService,
             ClientService clientService,
             AuthenticationService authenticationService,
@@ -61,7 +59,6 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
         super(
                 CheckUserExistsRequest.class,
                 configurationService,
-                sessionService,
                 clientService,
                 authenticationService,
                 authSessionService);
@@ -81,7 +78,7 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
 
     public CheckUserExistsHandler(
             ConfigurationService configurationService, RedisConnectionService redis) {
-        super(CheckUserExistsRequest.class, configurationService, redis);
+        super(CheckUserExistsRequest.class, configurationService);
         this.auditService = new AuditService(configurationService);
         this.codeStorageService = new CodeStorageService(configurationService, redis);
     }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandler.java
@@ -41,7 +41,6 @@ import uk.gov.di.authentication.shared.services.CommonPasswordsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
-import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
@@ -90,7 +89,6 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
 
     public LoginHandler(
             ConfigurationService configurationService,
-            SessionService sessionService,
             AuthenticationService authenticationService,
             ClientService clientService,
             CodeStorageService codeStorageService,
@@ -104,7 +102,6 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
         super(
                 LoginRequest.class,
                 configurationService,
-                sessionService,
                 clientService,
                 authenticationService,
                 true,
@@ -133,7 +130,7 @@ public class LoginHandler extends BaseFrontendHandler<LoginRequest>
     }
 
     public LoginHandler(ConfigurationService configurationService, RedisConnectionService redis) {
-        super(LoginRequest.class, configurationService, true, redis);
+        super(LoginRequest.class, configurationService, true);
         this.codeStorageService = new CodeStorageService(configurationService, redis);
         this.userMigrationService =
                 new UserMigrationService(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandler.java
@@ -33,7 +33,6 @@ import uk.gov.di.authentication.shared.services.CodeGeneratorService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
-import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
@@ -75,7 +74,6 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
 
     public MfaHandler(
             ConfigurationService configurationService,
-            SessionService sessionService,
             CodeGeneratorService codeGeneratorService,
             CodeStorageService codeStorageService,
             ClientService clientService,
@@ -87,7 +85,6 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
         super(
                 MfaRequest.class,
                 configurationService,
-                sessionService,
                 clientService,
                 authenticationService,
                 authSessionService);
@@ -101,7 +98,7 @@ public class MfaHandler extends BaseFrontendHandler<MfaRequest>
     public MfaHandler(
             ConfigurationService configurationService,
             RedisConnectionService redisConnectionService) {
-        super(MfaRequest.class, configurationService, redisConnectionService);
+        super(MfaRequest.class, configurationService);
         this.codeGeneratorService = new CodeGeneratorService();
         this.codeStorageService =
                 new CodeStorageService(configurationService, redisConnectionService);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetAuthorizeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetAuthorizeHandler.java
@@ -29,7 +29,6 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.IDReverificationStateService;
 import uk.gov.di.authentication.shared.services.KmsConnectionService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
-import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.services.TokenService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
@@ -52,7 +51,6 @@ public class MfaResetAuthorizeHandler extends BaseFrontendHandler<MfaResetReques
 
     public MfaResetAuthorizeHandler(
             ConfigurationService configurationService,
-            SessionService sessionService,
             ClientService clientService,
             AuthenticationService authenticationService,
             IPVReverificationService ipvReverificationService,
@@ -63,7 +61,6 @@ public class MfaResetAuthorizeHandler extends BaseFrontendHandler<MfaResetReques
         super(
                 MfaResetRequest.class,
                 configurationService,
-                sessionService,
                 clientService,
                 authenticationService,
                 authSessionService);
@@ -83,7 +80,7 @@ public class MfaResetAuthorizeHandler extends BaseFrontendHandler<MfaResetReques
 
     public MfaResetAuthorizeHandler(RedisConnectionService redisConnectionService)
             throws MalformedURLException {
-        super(MfaResetRequest.class, ConfigurationService.getInstance(), redisConnectionService);
+        super(MfaResetRequest.class, ConfigurationService.getInstance());
         KmsConnectionService kmsConnectionService = new KmsConnectionService(configurationService);
         JwtService jwtService = new JwtService(kmsConnectionService);
         TokenService tokenService =

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandler.java
@@ -38,7 +38,6 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoAccountModifiersService;
 import uk.gov.di.authentication.shared.services.DynamoService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
-import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.state.UserContext;
 import uk.gov.di.authentication.shared.validation.PasswordValidator;
 
@@ -70,7 +69,6 @@ public class ResetPasswordHandler extends BaseFrontendHandler<ResetPasswordCompl
             AwsSqsClient sqsClient,
             CodeStorageService codeStorageService,
             ConfigurationService configurationService,
-            SessionService sessionService,
             ClientService clientService,
             AuditService auditService,
             CommonPasswordsService commonPasswordsService,
@@ -80,7 +78,6 @@ public class ResetPasswordHandler extends BaseFrontendHandler<ResetPasswordCompl
         super(
                 ResetPasswordCompletionRequest.class,
                 configurationService,
-                sessionService,
                 clientService,
                 authenticationService,
                 authSessionService);
@@ -115,7 +112,7 @@ public class ResetPasswordHandler extends BaseFrontendHandler<ResetPasswordCompl
 
     public ResetPasswordHandler(
             ConfigurationService configurationService, RedisConnectionService redis) {
-        super(ResetPasswordCompletionRequest.class, configurationService, redis);
+        super(ResetPasswordCompletionRequest.class, configurationService);
         this.authenticationService = new DynamoService(configurationService);
         this.sqsClient =
                 new AwsSqsClient(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandler.java
@@ -33,7 +33,6 @@ import uk.gov.di.authentication.shared.services.CodeGeneratorService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
-import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
@@ -66,7 +65,6 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
 
     public ResetPasswordRequestHandler(
             ConfigurationService configurationService,
-            SessionService sessionService,
             ClientService clientService,
             AuthenticationService authenticationService,
             AwsSqsClient sqsClient,
@@ -78,7 +76,6 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
         super(
                 ResetPasswordRequest.class,
                 configurationService,
-                sessionService,
                 clientService,
                 authenticationService,
                 authSessionService);
@@ -108,7 +105,7 @@ public class ResetPasswordRequestHandler extends BaseFrontendHandler<ResetPasswo
 
     public ResetPasswordRequestHandler(
             ConfigurationService configurationService, RedisConnectionService redis) {
-        super(ResetPasswordRequest.class, configurationService, redis);
+        super(ResetPasswordRequest.class, configurationService);
         this.sqsClient =
                 new AwsSqsClient(
                         configurationService.getAwsRegion(),

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ReverificationResultHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/ReverificationResultHandler.java
@@ -27,8 +27,6 @@ import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.IDReverificationStateService;
-import uk.gov.di.authentication.shared.services.RedisConnectionService;
-import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.util.ArrayList;
@@ -55,7 +53,6 @@ public class ReverificationResultHandler extends BaseFrontendHandler<Reverificat
 
     public ReverificationResultHandler(
             ConfigurationService configurationService,
-            SessionService sessionService,
             ClientService clientService,
             AuthenticationService authenticationService,
             ReverificationResultService reverificationResultService,
@@ -66,7 +63,6 @@ public class ReverificationResultHandler extends BaseFrontendHandler<Reverificat
         super(
                 ReverificationResultRequest.class,
                 configurationService,
-                sessionService,
                 clientService,
                 authenticationService,
                 authSessionService);
@@ -78,17 +74,6 @@ public class ReverificationResultHandler extends BaseFrontendHandler<Reverificat
 
     public ReverificationResultHandler() {
         this(ConfigurationService.getInstance());
-    }
-
-    public ReverificationResultHandler(RedisConnectionService redisConnectionService) {
-        super(
-                ReverificationResultRequest.class,
-                ConfigurationService.getInstance(),
-                redisConnectionService);
-        this.reverificationResultService = new ReverificationResultService(configurationService);
-        this.auditService = new AuditService(configurationService);
-        this.idReverificationStateService = new IDReverificationStateService(configurationService);
-        this.cloudwatchMetricService = new CloudwatchMetricsService(configurationService);
     }
 
     public ReverificationResultHandler(ConfigurationService configurationService) {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandler.java
@@ -17,7 +17,6 @@ import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.NotifyRequest;
-import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.exceptions.ClientNotFoundException;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
@@ -37,7 +36,6 @@ import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoEmailCheckResultService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
-import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.util.List;
@@ -88,7 +86,6 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
 
     public SendNotificationHandler(
             ConfigurationService configurationService,
-            SessionService sessionService,
             ClientService clientService,
             AuthenticationService authenticationService,
             AwsSqsClient emailSqsClient,
@@ -101,7 +98,6 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
         super(
                 SendNotificationRequest.class,
                 configurationService,
-                sessionService,
                 clientService,
                 authenticationService,
                 authSessionService);
@@ -138,7 +134,7 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
 
     public SendNotificationHandler(
             ConfigurationService configurationService, RedisConnectionService redis) {
-        super(SendNotificationRequest.class, configurationService, redis);
+        super(SendNotificationRequest.class, configurationService);
         this.emailSqsClient =
                 new AwsSqsClient(
                         configurationService.getAwsRegion(),
@@ -205,7 +201,6 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
             Optional<ErrorResponse> userHasExceededMaximumAllowedCodeRequests =
                     isCodeRequestAttemptValid(
                             request.getEmail(),
-                            userContext.getSession(),
                             userContext.getAuthSession(),
                             request.getNotificationType(),
                             request.getJourneyType());
@@ -223,7 +218,6 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
             Optional<ErrorResponse> thisRequestExceedsMaxAllowed =
                     isCodeRequestAttemptValid(
                             request.getEmail(),
-                            userContext.getSession(),
                             userContext.getAuthSession(),
                             request.getNotificationType(),
                             request.getJourneyType());
@@ -409,7 +403,6 @@ public class SendNotificationHandler extends BaseFrontendHandler<SendNotificatio
 
     private Optional<ErrorResponse> isCodeRequestAttemptValid(
             String email,
-            Session session,
             AuthSessionItem authSession,
             NotificationType notificationType,
             JourneyType journeyType) {

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/SignUpHandler.java
@@ -22,8 +22,6 @@ import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.CommonPasswordsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
-import uk.gov.di.authentication.shared.services.RedisConnectionService;
-import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.state.UserContext;
 import uk.gov.di.authentication.shared.validation.PasswordValidator;
 
@@ -49,7 +47,6 @@ public class SignUpHandler extends BaseFrontendHandler<SignupRequest>
 
     public SignUpHandler(
             ConfigurationService configurationService,
-            SessionService sessionService,
             ClientService clientService,
             AuthenticationService authenticationService,
             AuditService auditService,
@@ -59,7 +56,6 @@ public class SignUpHandler extends BaseFrontendHandler<SignupRequest>
         super(
                 SignupRequest.class,
                 configurationService,
-                sessionService,
                 clientService,
                 authenticationService,
                 authSessionService);
@@ -74,13 +70,6 @@ public class SignUpHandler extends BaseFrontendHandler<SignupRequest>
 
     public SignUpHandler(ConfigurationService configurationService) {
         super(SignupRequest.class, configurationService);
-        this.auditService = new AuditService(configurationService);
-        this.commonPasswordsService = new CommonPasswordsService(configurationService);
-        this.passwordValidator = new PasswordValidator(commonPasswordsService);
-    }
-
-    public SignUpHandler(ConfigurationService configurationService, RedisConnectionService redis) {
-        super(SignupRequest.class, configurationService, redis);
         this.auditService = new AuditService(configurationService);
         this.commonPasswordsService = new CommonPasswordsService(configurationService);
         this.passwordValidator = new PasswordValidator(commonPasswordsService);

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/StartHandler.java
@@ -31,9 +31,7 @@ import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoClientService;
 import uk.gov.di.authentication.shared.services.DynamoService;
-import uk.gov.di.authentication.shared.services.RedisConnectionService;
 import uk.gov.di.authentication.shared.services.SerializationService;
-import uk.gov.di.authentication.shared.services.SessionService;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -69,7 +67,6 @@ public class StartHandler
     private static final Logger LOG = LogManager.getLogger(StartHandler.class);
 
     protected static final String REAUTHENTICATE_HEADER = "Reauthenticate";
-    private final SessionService sessionService;
     private final AuditService auditService;
     private final StartService startService;
     private final AuthSessionService authSessionService;
@@ -79,14 +76,12 @@ public class StartHandler
     private final Json objectMapper = SerializationService.getInstance();
 
     public StartHandler(
-            SessionService sessionService,
             AuditService auditService,
             StartService startService,
             AuthSessionService authSessionService,
             ConfigurationService configurationService,
             AuthenticationAttemptsService authenticationAttemptsService,
             CloudwatchMetricsService cloudwatchMetricsService) {
-        this.sessionService = sessionService;
         this.auditService = auditService;
         this.startService = startService;
         this.authSessionService = authSessionService;
@@ -96,30 +91,13 @@ public class StartHandler
     }
 
     public StartHandler(ConfigurationService configurationService) {
-        this.sessionService = new SessionService(configurationService);
         this.auditService = new AuditService(configurationService);
         this.authenticationAttemptsService =
                 new AuthenticationAttemptsService(configurationService);
         this.startService =
                 new StartService(
                         new DynamoClientService(configurationService),
-                        new DynamoService(configurationService),
-                        sessionService);
-        this.authSessionService = new AuthSessionService(configurationService);
-        this.configurationService = configurationService;
-        this.cloudwatchMetricsService = new CloudwatchMetricsService();
-    }
-
-    public StartHandler(ConfigurationService configurationService, RedisConnectionService redis) {
-        this.sessionService = new SessionService(configurationService, redis);
-        this.auditService = new AuditService(configurationService);
-        this.authenticationAttemptsService =
-                new AuthenticationAttemptsService(configurationService);
-        this.startService =
-                new StartService(
-                        new DynamoClientService(configurationService),
-                        new DynamoService(configurationService),
-                        sessionService);
+                        new DynamoService(configurationService));
         this.authSessionService = new AuthSessionService(configurationService);
         this.configurationService = configurationService;
         this.cloudwatchMetricsService = new CloudwatchMetricsService();
@@ -139,15 +117,13 @@ public class StartHandler
                         input.getHeaders(),
                         SESSION_ID_HEADER,
                         configurationService.getHeadersCaseInsensitive());
-        var sessionOpt = sessionIdOpt.flatMap(sessionService::getSession);
-        if (sessionIdOpt.isEmpty() || sessionOpt.isEmpty()) {
+        if (sessionIdOpt.isEmpty()) {
             return generateApiGatewayProxyErrorResponse(400, ErrorResponse.ERROR_1000);
         }
+
         var sessionId = sessionIdOpt.get();
-        var session = sessionOpt.get();
 
         attachSessionIdToLogs(sessionId);
-        LOG.info("Start session retrieved");
         attachLogFieldToLogs(
                 PERSISTENT_SESSION_ID, extractPersistentIdFromHeaders(input.getHeaders()));
 
@@ -178,6 +154,7 @@ public class StartHandler
             var authSession =
                     authSessionService.getUpdatedPreviousSessionOrCreateNew(
                             Optional.ofNullable(startRequest.previousSessionId()), sessionId);
+            LOG.info("Start session retrieved");
             var requestedCredentialTrustLevel =
                     retrieveCredentialTrustLevel(startRequest.requestedCredentialStrength());
             authSession.setRequestedCredentialStrength(requestedCredentialTrustLevel);
@@ -201,7 +178,7 @@ public class StartHandler
 
             authSessionService.addSession(authSession.withUpliftRequired(upliftRequired));
 
-            var userContext = startService.buildUserContext(session, authSession);
+            var userContext = startService.buildUserContext(authSession);
 
             var scopes = List.of(startRequest.scope().split(" "));
             var redirectURI = new URI(startRequest.redirectUri());

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandler.java
@@ -11,7 +11,6 @@ import uk.gov.di.authentication.frontendapi.entity.UpdateProfileRequest;
 import uk.gov.di.authentication.shared.domain.AuditableEvent;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
-import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.IpAddressHelper;
 import uk.gov.di.authentication.shared.helpers.LogLineHelper;
@@ -22,8 +21,6 @@ import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
-import uk.gov.di.authentication.shared.services.RedisConnectionService;
-import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.util.Optional;
@@ -46,7 +43,6 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
 
     protected UpdateProfileHandler(
             AuthenticationService authenticationService,
-            SessionService sessionService,
             ConfigurationService configurationService,
             AuditService auditService,
             ClientService clientService,
@@ -54,7 +50,6 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
         super(
                 UpdateProfileRequest.class,
                 configurationService,
-                sessionService,
                 clientService,
                 authenticationService,
                 authSessionService);
@@ -67,12 +62,6 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
 
     public UpdateProfileHandler(ConfigurationService configurationService) {
         super(UpdateProfileRequest.class, configurationService);
-        auditService = new AuditService(configurationService);
-    }
-
-    public UpdateProfileHandler(
-            ConfigurationService configurationService, RedisConnectionService redis) {
-        super(UpdateProfileRequest.class, configurationService, redis);
         auditService = new AuditService(configurationService);
     }
 
@@ -103,7 +92,6 @@ public class UpdateProfileHandler extends BaseFrontendHandler<UpdateProfileReque
             UpdateProfileRequest request,
             UserContext userContext) {
 
-        Session session = userContext.getSession();
         AuthSessionItem authSession = userContext.getAuthSession();
 
         String persistentSessionId =

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandler.java
@@ -42,7 +42,6 @@ import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoAccountModifiersService;
 import uk.gov.di.authentication.shared.services.RedisConnectionService;
-import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
@@ -89,7 +88,6 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
 
     protected VerifyCodeHandler(
             ConfigurationService configurationService,
-            SessionService sessionService,
             ClientService clientService,
             AuthenticationService authenticationService,
             CodeStorageService codeStorageService,
@@ -102,7 +100,6 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
         super(
                 VerifyCodeRequest.class,
                 configurationService,
-                sessionService,
                 clientService,
                 authenticationService,
                 authSessionService);
@@ -131,7 +128,7 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
 
     public VerifyCodeHandler(
             ConfigurationService configurationService, RedisConnectionService redis) {
-        super(VerifyCodeRequest.class, configurationService, redis);
+        super(VerifyCodeRequest.class, configurationService);
         this.codeStorageService = new CodeStorageService(configurationService, redis);
         this.auditService = new AuditService(configurationService);
         this.cloudwatchMetricsService = new CloudwatchMetricsService();
@@ -156,8 +153,6 @@ public class VerifyCodeHandler extends BaseFrontendHandler<VerifyCodeRequest>
         try {
             LOG.info("Processing request");
 
-            var session = userContext.getSession();
-            var sessionId = userContext.getAuthSession().getSessionId();
             AuthSessionItem authSession = userContext.getAuthSession();
 
             var notificationType = codeRequest.notificationType();

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/StartService.java
@@ -11,7 +11,6 @@ import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.LevelOfConfidence;
-import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
@@ -19,7 +18,6 @@ import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.exceptions.ClientNotFoundException;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.DynamoService;
-import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.net.URI;
@@ -34,23 +32,18 @@ public class StartService {
 
     private final ClientService clientService;
     private final DynamoService dynamoService;
-    private final SessionService sessionService;
     public static final String COOKIE_CONSENT_ACCEPT = "accept";
     public static final String COOKIE_CONSENT_REJECT = "reject";
     public static final String COOKIE_CONSENT_NOT_ENGAGED = "not-engaged";
     private static final Logger LOG = LogManager.getLogger(StartService.class);
 
-    public StartService(
-            ClientService clientService,
-            DynamoService dynamoService,
-            SessionService sessionService) {
+    public StartService(ClientService clientService, DynamoService dynamoService) {
         this.clientService = clientService;
         this.dynamoService = dynamoService;
-        this.sessionService = sessionService;
     }
 
-    public UserContext buildUserContext(Session session, AuthSessionItem authSession) {
-        var builder = UserContext.builder(session).withAuthSession(authSession);
+    public UserContext buildUserContext(AuthSessionItem authSession) {
+        var builder = UserContext.builder(authSession);
         UserContext userContext;
         try {
             var clientRegistry = getClient(authSession.getClientId());

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountInterventionsHandlerTest.java
@@ -25,7 +25,6 @@ import uk.gov.di.authentication.shared.entity.AuthSessionItem.ResetPasswordState
 import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.Intervention;
-import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.State;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
@@ -42,7 +41,6 @@ import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.LambdaInvokerService;
 import uk.gov.di.authentication.shared.services.SerializationService;
-import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.state.UserContext;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
@@ -100,7 +98,6 @@ class AccountInterventionsHandlerTest {
     private final Context context = mock(Context.class);
 
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
-    private final SessionService sessionService = mock(SessionService.class);
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
     private final AuditService auditService = mock(AuditService.class);
     private final UserContext userContext = mock(UserContext.class, Mockito.RETURNS_DEEP_STUBS);
@@ -112,7 +109,6 @@ class AccountInterventionsHandlerTest {
     private final LambdaInvokerService mockLambdaInvokerService = mock(LambdaInvokerService.class);
     private final AuthSessionService authSessionService = mock(AuthSessionService.class);
 
-    private final Session session = new Session();
     private final AuthSessionItem authSession =
             new AuthSessionItem()
                     .withSessionId(SESSION_ID)
@@ -141,8 +137,6 @@ class AccountInterventionsHandlerTest {
     @BeforeEach
     void setUp() throws URISyntaxException {
         when(context.getAwsRequestId()).thenReturn("aws-session-id");
-        when(sessionService.getSessionFromRequestHeaders(anyMap()))
-                .thenReturn(Optional.of(session));
         when(authSessionService.getSessionFromRequestHeaders(anyMap()))
                 .thenReturn(Optional.of(authSession));
         UserProfile userProfile = generateUserProfile();
@@ -155,7 +149,6 @@ class AccountInterventionsHandlerTest {
         when(configurationService.getAccountInterventionServiceURI())
                 .thenReturn(new URI("https://account-interventions.gov.uk/v1"));
         when(configurationService.getAwsRegion()).thenReturn("eu-west-2");
-        when(userContext.getSession()).thenReturn(session);
         when(userContext.getAuthSession()).thenReturn(authSession);
         when(userContext.getClientSessionId()).thenReturn(CommonTestVariables.CLIENT_SESSION_ID);
         when(userContext.getTxmaAuditEncoded())
@@ -167,7 +160,6 @@ class AccountInterventionsHandlerTest {
         handler =
                 new AccountInterventionsHandler(
                         configurationService,
-                        sessionService,
                         clientService,
                         authenticationService,
                         accountInterventionsService,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountRecoveryHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AccountRecoveryHandlerTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
-import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
@@ -16,7 +15,6 @@ import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoAccountModifiersService;
-import uk.gov.di.authentication.shared.services.SessionService;
 
 import java.util.Optional;
 
@@ -49,7 +47,6 @@ class AccountRecoveryHandlerTest {
     private final Context context = mock(Context.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
-    private final SessionService sessionService = mock(SessionService.class);
     private final DynamoAccountModifiersService dynamoAccountModifiersService =
             mock(DynamoAccountModifiersService.class);
     private final ClientService clientService = mock(ClientService.class);
@@ -60,7 +57,6 @@ class AccountRecoveryHandlerTest {
     private final String internalCommonSubjectId =
             ClientSubjectHelper.calculatePairwiseIdentifier(
                     INTERNAL_SUBJECT_ID.getValue(), "test.account.gov.uk", SALT);
-    private final Session session = new Session();
     private final AuthSessionItem authSession =
             new AuthSessionItem().withSessionId(SESSION_ID).withClientId(AuditService.UNKNOWN);
 
@@ -86,7 +82,6 @@ class AccountRecoveryHandlerTest {
         handler =
                 new AccountRecoveryHandler(
                         configurationService,
-                        sessionService,
                         clientService,
                         authenticationService,
                         dynamoAccountModifiersService,
@@ -145,8 +140,6 @@ class AccountRecoveryHandlerTest {
     }
 
     private void usingValidSession() {
-        when(sessionService.getSessionFromRequestHeaders(anyMap()))
-                .thenReturn(Optional.of(session));
         when(authSessionService.getSessionFromRequestHeaders(anyMap()))
                 .thenReturn(Optional.of(authSession));
     }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AuthenticationAuthCodeHandlerTest.java
@@ -14,7 +14,6 @@ import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.CountType;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
-import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.CommonTestVariables;
@@ -27,7 +26,6 @@ import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoAuthCodeService;
 import uk.gov.di.authentication.shared.services.SerializationService;
-import uk.gov.di.authentication.shared.services.SessionService;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -82,12 +80,10 @@ class AuthenticationAuthCodeHandlerTest {
     private final Context context = mock(Context.class);
     private final DynamoAuthCodeService dynamoAuthCodeService = mock(DynamoAuthCodeService.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
-    private final SessionService sessionService = mock(SessionService.class);
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
     private final ClientService clientService = mock(ClientService.class);
     private final CloudwatchMetricsService cloudwatchMetricsService =
             mock(CloudwatchMetricsService.class);
-    private Session session;
     private AuthSessionItem authSession;
     private final AuditService auditService = mock(AuditService.class);
     private final AuthSessionService authSessionService = mock(AuthSessionService.class);
@@ -106,7 +102,6 @@ class AuthenticationAuthCodeHandlerTest {
 
     @BeforeEach
     void setUp() throws Json.JsonException {
-        session = new Session();
         authSession =
                 new AuthSessionItem()
                         .withSessionId(SESSION_ID)
@@ -115,8 +110,6 @@ class AuthenticationAuthCodeHandlerTest {
         when(context.getAwsRequestId()).thenReturn("aws-session-id");
         when(clientService.getClient(CLIENT_ID))
                 .thenReturn(Optional.of(new ClientRegistry().withClientID(CLIENT_ID)));
-        when(sessionService.getSessionFromRequestHeaders(anyMap()))
-                .thenReturn(Optional.of(session));
         when(authSessionService.getSessionFromRequestHeaders(anyMap()))
                 .thenReturn(Optional.of(authSession));
         UserProfile userProfile = generateUserProfile();
@@ -127,7 +120,6 @@ class AuthenticationAuthCodeHandlerTest {
                 new AuthenticationAuthCodeHandler(
                         dynamoAuthCodeService,
                         configurationService,
-                        sessionService,
                         clientService,
                         authenticationService,
                         auditService,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckEmailFraudBlockHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckEmailFraudBlockHandlerTest.java
@@ -19,7 +19,6 @@ import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.EmailCheckResultStatus;
 import uk.gov.di.authentication.shared.entity.EmailCheckResultStore;
 import uk.gov.di.authentication.shared.entity.JourneyType;
-import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
@@ -29,7 +28,6 @@ import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoEmailCheckResultService;
-import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.util.Optional;
@@ -65,12 +63,10 @@ class CheckEmailFraudBlockHandlerTest {
     private static ConfigurationService configurationServiceMock;
     private static ClientService clientServiceMock;
     private static DynamoEmailCheckResultService dbMock;
-    private static SessionService sessionServiceMock;
     private static ClientRegistry clientRegistry;
     private static UserContext userContext;
     private static AuthSessionService authSessionServiceMock;
 
-    private final Session session = new Session();
     private final AuthSessionItem authSession =
             new AuthSessionItem().withSessionId(SESSION_ID).withClientId(CLIENT_ID);
     private CheckEmailFraudBlockHandler handler;
@@ -83,7 +79,6 @@ class CheckEmailFraudBlockHandlerTest {
         auditServiceMock = mock(AuditService.class);
         configurationServiceMock = mock(ConfigurationService.class);
         authenticationServiceMock = mock(AuthenticationService.class);
-        sessionServiceMock = mock(SessionService.class);
         clientRegistry = mock(ClientRegistry.class);
         userContext = mock(UserContext.class);
         authSessionServiceMock = mock(AuthSessionService.class);
@@ -93,9 +88,8 @@ class CheckEmailFraudBlockHandlerTest {
     void setup() {
         var userProfile = generateUserProfile();
         when(userContext.getClient()).thenReturn(Optional.of(clientRegistry));
-        when(userContext.getSession()).thenReturn(session);
-        when(userContext.getAuthSession()).thenReturn(authSession);
         when(userContext.getClientSessionId()).thenReturn(CLIENT_SESSION_ID);
+        when(userContext.getAuthSession()).thenReturn(authSession);
         when(userContext.getTxmaAuditEncoded()).thenReturn(ENCODED_DEVICE_DETAILS);
         when(configurationServiceMock.getInternalSectorUri()).thenReturn(INTERNAL_SECTOR_URI);
         when(configurationServiceMock.isEmailCheckEnabled()).thenReturn(true);
@@ -106,7 +100,6 @@ class CheckEmailFraudBlockHandlerTest {
         handler =
                 new CheckEmailFraudBlockHandler(
                         configurationServiceMock,
-                        sessionServiceMock,
                         clientServiceMock,
                         authenticationServiceMock,
                         dbMock,
@@ -199,8 +192,6 @@ class CheckEmailFraudBlockHandlerTest {
     }
 
     private void usingValidSession() {
-        when(sessionServiceMock.getSessionFromRequestHeaders(anyMap()))
-                .thenReturn(Optional.of(session));
         when(authSessionServiceMock.getSessionFromRequestHeaders(anyMap()))
                 .thenReturn(Optional.of(authSession));
     }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandlerTest.java
@@ -14,7 +14,6 @@ import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.CountType;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
-import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
@@ -25,7 +24,6 @@ import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
-import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.util.List;
@@ -58,7 +56,6 @@ class CheckReAuthUserHandlerTest {
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
     private final AuditService auditService = mock(AuditService.class);
     private final Context context = mock(Context.class);
-    private final SessionService sessionService = mock(SessionService.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final AuthenticationAttemptsService authenticationAttemptsService =
             mock(AuthenticationAttemptsService.class);
@@ -87,7 +84,6 @@ class CheckReAuthUserHandlerTest {
     private static final APIGatewayProxyRequestEvent API_REQUEST_EVENT_WITH_VALID_HEADERS =
             apiRequestEventWithHeadersAndBody(VALID_HEADERS, null);
 
-    private final Session session = new Session();
     private final AuthSessionItem authSession =
             new AuthSessionItem()
                     .withSessionId(SESSION_ID)
@@ -131,7 +127,6 @@ class CheckReAuthUserHandlerTest {
         when(authenticationService.getOrGenerateSalt(any(UserProfile.class))).thenReturn(SALT);
 
         when(userContext.getClient()).thenReturn(Optional.of(clientRegistry));
-        when(userContext.getSession()).thenReturn(session);
         when(userContext.getAuthSession()).thenReturn(authSession);
         when(userContext.getClientSessionId()).thenReturn(CLIENT_SESSION_ID);
         when(userContext.getTxmaAuditEncoded()).thenReturn(ENCODED_DEVICE_DETAILS);
@@ -156,7 +151,6 @@ class CheckReAuthUserHandlerTest {
         handler =
                 new CheckReAuthUserHandler(
                         configurationService,
-                        sessionService,
                         clientService,
                         authenticationService,
                         auditService,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
@@ -22,7 +22,6 @@ import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
-import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.TermsAndConditions;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
@@ -39,7 +38,6 @@ import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SerializationService;
-import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
 import java.nio.ByteBuffer;
@@ -60,7 +58,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
@@ -85,14 +82,12 @@ class CheckUserExistsHandlerTest {
     private final Context context = mock(Context.class);
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
     private final AuditService auditService = mock(AuditService.class);
-    private final SessionService sessionService = mock(SessionService.class);
     private final AuthSessionService authSessionService = mock(AuthSessionService.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final ClientService clientService = mock(ClientService.class);
     private final CodeStorageService codeStorageService = mock(CodeStorageService.class);
     private CheckUserExistsHandler handler;
     private static final Json objectMapper = SerializationService.getInstance();
-    private final Session session = new Session();
     private static final String CLIENT_ID = "test-client-id";
     private final AuthSessionItem authSession =
             new AuthSessionItem()
@@ -136,7 +131,6 @@ class CheckUserExistsHandlerTest {
         handler =
                 new CheckUserExistsHandler(
                         configurationService,
-                        sessionService,
                         authSessionService,
                         clientService,
                         authenticationService,
@@ -149,7 +143,6 @@ class CheckUserExistsHandlerTest {
     class WhenUserExists {
         @BeforeEach
         void setup() {
-            usingValidSession();
             authSessionExists();
             var userProfile =
                     generateUserProfile().withPhoneNumber(CommonTestVariables.UK_MOBILE_NUMBER);
@@ -347,7 +340,6 @@ class CheckUserExistsHandlerTest {
 
     @Test
     void shouldReturn200IfUserDoesNotExist() throws Json.JsonException {
-        usingValidSession();
         authSessionExists();
 
         setupUserProfileAndClient(Optional.empty());
@@ -370,7 +362,6 @@ class CheckUserExistsHandlerTest {
 
     @Test
     void shouldReturn400IfRequestIsMissingEmail() {
-        usingValidSession();
         authSessionExists();
 
         var event = new APIGatewayProxyRequestEvent().withHeaders(VALID_HEADERS).withBody("{ }");
@@ -394,7 +385,6 @@ class CheckUserExistsHandlerTest {
 
     @Test
     void shouldReturn400IfEmailAddressIsInvalid() {
-        usingValidSession();
         setupClient();
         authSessionExists();
 
@@ -410,7 +400,6 @@ class CheckUserExistsHandlerTest {
 
     @Test
     void shouldReturn400IfAuthSessionExpired() {
-        usingValidSession();
         authSessionMissing();
         setupClient();
 
@@ -418,11 +407,6 @@ class CheckUserExistsHandlerTest {
 
         assertThat(result, hasStatus(400));
         assertThat(result, hasJsonBody(ErrorResponse.ERROR_1000));
-    }
-
-    private void usingValidSession() {
-        when(sessionService.getSessionFromRequestHeaders(anyMap()))
-                .thenReturn(Optional.of(session));
     }
 
     private void authSessionExists() {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationRedisTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationRedisTest.java
@@ -18,7 +18,6 @@ import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
-import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.TermsAndConditions;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
@@ -36,7 +35,6 @@ import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.CommonPasswordsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
-import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
@@ -91,13 +89,11 @@ class LoginHandlerReauthenticationRedisTest {
                     .withMfaMethodType(MFAMethodType.AUTH_APP.getValue())
                     .withMethodVerified(true)
                     .withEnabled(true);
-    private static final Session session = new Session();
     private LoginHandler handler;
     private final Context context = mock(Context.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
     private final CodeStorageService codeStorageService = mock(CodeStorageService.class);
-    private final SessionService sessionService = mock(SessionService.class);
     private final ClientService clientService = mock(ClientService.class);
     private final UserMigrationService userMigrationService = mock(UserMigrationService.class);
     private final AuditService auditService = mock(AuditService.class);
@@ -155,7 +151,6 @@ class LoginHandlerReauthenticationRedisTest {
         handler =
                 new LoginHandler(
                         configurationService,
-                        sessionService,
                         authenticationService,
                         clientService,
                         codeStorageService,
@@ -183,7 +178,6 @@ class LoginHandlerReauthenticationRedisTest {
 
         when(configurationService.supportReauthSignoutEnabled()).thenReturn(true);
 
-        usingValidSession();
         usingValidAuthSession();
         usingApplicableUserCredentialsWithLogin(mfaMethodType, false);
 
@@ -223,7 +217,6 @@ class LoginHandlerReauthenticationRedisTest {
         usingApplicableUserCredentialsWithLogin(SMS, false);
         when(configurationService.supportReauthSignoutEnabled()).thenReturn(isReauthEnabled);
 
-        usingValidSession();
         usingValidAuthSession();
 
         var body = isReauthJourney ? validBodyWithReauthJourney : validBodyWithEmailAndPassword;
@@ -237,11 +230,6 @@ class LoginHandlerReauthenticationRedisTest {
         } else {
             verify(codeStorageService, atLeastOnce()).increaseIncorrectPasswordCount(EMAIL);
         }
-    }
-
-    private void usingValidSession() {
-        when(sessionService.getSessionFromRequestHeaders(anyMap()))
-                .thenReturn(Optional.of(session));
     }
 
     private void usingValidAuthSession() {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest.java
@@ -25,7 +25,6 @@ import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.CountType;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
-import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.TermsAndConditions;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
@@ -44,7 +43,6 @@ import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.CommonPasswordsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
-import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
@@ -112,7 +110,6 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
                     .withMfaMethodType(MFAMethodType.AUTH_APP.getValue())
                     .withMethodVerified(true)
                     .withEnabled(true);
-    private static final Session session = new Session();
     private final Context context = mock(Context.class);
     private final Subject subject = mock(Subject.class);
     private final String expectedCommonSubject =
@@ -140,7 +137,6 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
 
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
-    private final SessionService sessionService = mock(SessionService.class);
     private final ClientService clientService = mock(ClientService.class);
     private final UserMigrationService userMigrationService = mock(UserMigrationService.class);
     private final AuditService auditService = mock(AuditService.class);
@@ -182,7 +178,6 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
         handler =
                 new LoginHandler(
                         configurationService,
-                        sessionService,
                         authenticationService,
                         clientService,
                         codeStorageService,
@@ -219,7 +214,6 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
 
             when(configurationService.supportReauthSignoutEnabled()).thenReturn(true);
 
-            usingValidSession();
             usingValidAuthSession();
             usingApplicableUserCredentialsWithLogin(mfaMethodType, false);
 
@@ -325,7 +319,6 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
 
             when(configurationService.supportReauthSignoutEnabled()).thenReturn(true);
 
-            usingValidSession();
             usingValidAuthSession();
             usingApplicableUserCredentialsWithLogin(SMS, true);
 
@@ -379,7 +372,6 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
 
         when(configurationService.supportReauthSignoutEnabled()).thenReturn(true);
 
-        usingValidSession();
         usingValidAuthSession();
         usingApplicableUserCredentialsWithLogin(SMS, false);
 
@@ -426,7 +418,6 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
 
         when(configurationService.supportReauthSignoutEnabled()).thenReturn(true);
 
-        usingValidSession();
         usingValidAuthSession();
         usingApplicableUserCredentialsWithLogin(SMS, false);
 
@@ -470,7 +461,6 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
 
         when(authenticationAttemptsService.getCount(any(), any(), any())).thenReturn(1);
 
-        usingValidSession();
         usingValidAuthSession();
 
         var event = eventWithHeadersAndBody(VALID_HEADERS, validBodyWithReauthJourney);
@@ -511,7 +501,6 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
         when(authenticationAttemptsService.getCount(any(), any(), any()))
                 .thenReturn(MAX_ALLOWED_RETRIES - 1);
 
-        usingValidSession();
         usingValidAuthSession();
 
         var event = eventWithHeadersAndBody(VALID_HEADERS, validBodyWithReauthJourney);
@@ -537,11 +526,6 @@ class LoginHandlerReauthenticationUsingAuthenticationAttemptsServiceTest {
                                 }),
                         eq(REAUTHENTICATION),
                         eq(ENTER_PASSWORD));
-    }
-
-    private void usingValidSession() {
-        when(sessionService.getSessionFromRequestHeaders(anyMap()))
-                .thenReturn(Optional.of(session));
     }
 
     private void usingValidAuthSession() {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/LoginHandlerTest.java
@@ -50,7 +50,6 @@ import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.CommonPasswordsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SerializationService;
-import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
@@ -140,7 +139,6 @@ class LoginHandlerTest {
             mock(AuthenticationAttemptsService.class);
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
     private final CodeStorageService codeStorageService = mock(CodeStorageService.class);
-    private final SessionService sessionService = mock(SessionService.class);
     private final ClientService clientService = mock(ClientService.class);
     private final UserMigrationService userMigrationService = mock(UserMigrationService.class);
     private final AuditService auditService = mock(AuditService.class);
@@ -203,7 +201,6 @@ class LoginHandlerTest {
         handler =
                 new LoginHandler(
                         configurationService,
-                        sessionService,
                         authenticationService,
                         clientService,
                         codeStorageService,
@@ -223,7 +220,6 @@ class LoginHandlerTest {
         when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
                 .thenReturn(Optional.of(userProfile));
 
-        usingValidSession();
         usingApplicableUserCredentialsWithLogin(SMS, true);
         usingValidAuthSessionWithRequestedCredentialStrength(LOW_LEVEL);
 
@@ -269,7 +265,6 @@ class LoginHandlerTest {
         when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
                 .thenReturn(Optional.of(userProfile));
 
-        usingValidSession();
         usingApplicableUserCredentialsWithLogin(SMS, true);
         usingValidAuthSessionWithRequestedCredentialStrength(LOW_LEVEL);
 
@@ -322,7 +317,6 @@ class LoginHandlerTest {
         when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
                 .thenReturn(Optional.of(userProfile));
 
-        usingValidSession();
         usingApplicableUserCredentialsWithLogin(SMS, true);
         usingValidAuthSessionWithAchievedAndRequestedCredentialStrength(MEDIUM_LEVEL, LOW_LEVEL);
 
@@ -374,7 +368,6 @@ class LoginHandlerTest {
         when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
                 .thenReturn(Optional.of(userProfile));
 
-        usingValidSession();
         usingApplicableUserCredentialsWithLogin(SMS, true);
         usingValidAuthSessionWithAchievedAndRequestedCredentialStrength(LOW_LEVEL, LOW_LEVEL);
 
@@ -425,7 +418,6 @@ class LoginHandlerTest {
         when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
                 .thenReturn(Optional.of(userProfile));
 
-        usingValidSession();
         usingValidAuthSessionWithRequestedCredentialStrength(LOW_LEVEL);
         usingApplicableUserCredentialsWithLogin(SMS, true);
 
@@ -450,7 +442,6 @@ class LoginHandlerTest {
         UserProfile userProfile = generateUserProfile(null);
         when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
                 .thenReturn(Optional.of(userProfile));
-        usingValidSession();
         usingValidAuthSessionWithRequestedCredentialStrength(MEDIUM_LEVEL);
         usingApplicableUserCredentialsWithLogin(mfaMethodType, true);
 
@@ -472,7 +463,6 @@ class LoginHandlerTest {
         UserProfile userProfile = generateUserProfile(null);
         when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
                 .thenReturn(Optional.of(userProfile));
-        usingValidSession();
         usingValidAuthSession();
         usingApplicableUserCredentialsWithLogin(mfaMethodType, true);
 
@@ -510,7 +500,6 @@ class LoginHandlerTest {
                 .thenReturn(Optional.of(userProfile));
         when(authenticationService.getUserCredentialsFromEmail(EMAIL)).thenReturn(userCredentials);
         when(mfaMethodsService.getMfaMethods(EMAIL)).thenReturn(Result.success(List.of(mfaMethod)));
-        usingValidSession();
         usingValidAuthSessionWithRequestedCredentialStrength(MEDIUM_LEVEL);
 
         var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
@@ -583,7 +572,6 @@ class LoginHandlerTest {
         when(authenticationService.getUserCredentialsFromEmail(EMAIL))
                 .thenReturn(migratedUserCredentials);
         when(mfaMethodsService.getMfaMethods(EMAIL)).thenReturn(Result.success(List.of(mfaMethod)));
-        usingValidSession();
         usingValidAuthSessionWithRequestedCredentialStrength(MEDIUM_LEVEL);
 
         var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
@@ -696,7 +684,6 @@ class LoginHandlerTest {
         when(authenticationService.getUserCredentialsFromEmail(EMAIL))
                 .thenReturn(testUserCredentials);
         when(mfaMethodsService.getMfaMethods(EMAIL)).thenReturn(Result.success(mfaMethods));
-        usingValidSession();
         usingValidAuthSessionWithRequestedCredentialStrength(MEDIUM_LEVEL);
 
         // Act
@@ -718,7 +705,6 @@ class LoginHandlerTest {
         UserProfile userProfile = generateUserProfile(null);
         when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
                 .thenReturn(Optional.of(userProfile));
-        usingValidSession();
         usingValidAuthSession();
         usingApplicableUserCredentialsWithLogin(mfaMethodType, true);
 
@@ -753,7 +739,6 @@ class LoginHandlerTest {
         when(userMigrationService.processMigratedUser(
                         applicableUserCredentials, CommonTestVariables.PASSWORD))
                 .thenReturn(true);
-        usingValidSession();
         usingValidAuthSession();
 
         var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
@@ -778,7 +763,6 @@ class LoginHandlerTest {
 
         var maxRetriesAllowed = configurationService.getMaxPasswordRetries();
         when(codeStorageService.getIncorrectPasswordCount(EMAIL)).thenReturn(maxRetriesAllowed - 1);
-        usingValidSession();
         usingValidAuthSession();
         usingApplicableUserCredentialsWithLogin(mfaMethodType, false);
 
@@ -817,7 +801,6 @@ class LoginHandlerTest {
                 .thenReturn(maxRetriesAllowed - 1);
         when(configurationService.supportReauthSignoutEnabled()).thenReturn(true);
 
-        usingValidSession();
         usingValidAuthSession();
         usingApplicableUserCredentialsWithLogin(mfaMethodType, false);
 
@@ -857,7 +840,6 @@ class LoginHandlerTest {
         when(codeStorageService.getIncorrectPasswordCount(EMAIL))
                 .thenReturn(MAX_ALLOWED_PASSWORD_RETRIES);
         when(codeStorageService.isBlockedForEmail(any(), any())).thenReturn(true);
-        usingValidSession();
         usingValidAuthSession();
         usingApplicableUserCredentialsWithLogin(mfaMethodType, true);
 
@@ -898,7 +880,6 @@ class LoginHandlerTest {
                                                 ? DEFAULT_AUTH_APP_MFA_METHOD
                                                 : DEFAULT_SMS_MFA_METHOD)));
         when(codeStorageService.getIncorrectPasswordCount(EMAIL)).thenReturn(4);
-        usingValidSession();
         usingValidAuthSession();
 
         var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
@@ -922,7 +903,6 @@ class LoginHandlerTest {
                 .thenReturn(Optional.of(userProfile));
         usingApplicableUserCredentialsWithLogin(mfaMethodType, false);
 
-        usingValidSession();
         usingValidAuthSession();
 
         var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
@@ -953,7 +933,6 @@ class LoginHandlerTest {
         usingApplicableUserCredentialsWithLogin(SMS, false);
         when(configurationService.supportReauthSignoutEnabled()).thenReturn(isReauthEnabled);
 
-        usingValidSession();
         usingValidAuthSession();
 
         var body = isReauthJourney ? validBodyWithReauthJourney : validBodyWithEmailAndPassword;
@@ -982,7 +961,6 @@ class LoginHandlerTest {
         when(userMigrationService.processMigratedUser(
                         applicableUserCredentials, CommonTestVariables.PASSWORD))
                 .thenReturn(false);
-        usingValidSession();
         usingValidAuthSessionWithRequestedCredentialStrength(MEDIUM_LEVEL);
 
         var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
@@ -999,7 +977,6 @@ class LoginHandlerTest {
         var bodyWithoutEmail = format("{ \"password\": \"%s\"}", CommonTestVariables.PASSWORD);
         var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, bodyWithoutEmail);
 
-        usingValidSession();
         usingValidAuthSession();
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
 
@@ -1013,7 +990,7 @@ class LoginHandlerTest {
     void shouldReturn400IfSessionIdIsInvalid() {
         var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
 
-        when(sessionService.getSessionFromRequestHeaders(event.getHeaders()))
+        when(authSessionService.getSessionFromRequestHeaders(event.getHeaders()))
                 .thenReturn(Optional.empty());
 
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
@@ -1039,7 +1016,6 @@ class LoginHandlerTest {
     @Test
     void shouldReturn400IfUserDoesNotHaveAnAccount() {
         when(authenticationService.getUserProfileByEmailMaybe(EMAIL)).thenReturn(Optional.empty());
-        usingValidSession();
         usingValidAuthSession();
 
         var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, validBodyWithEmailAndPassword);
@@ -1062,7 +1038,6 @@ class LoginHandlerTest {
         UserProfile userProfile = generateUserProfile(null);
         when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
                 .thenReturn(Optional.of(userProfile));
-        usingValidSession();
         usingValidAuthSessionWithRequestedCredentialStrength(MEDIUM_LEVEL);
         usingApplicableUserCredentialsWithLogin(SMS, true);
         when(mfaMethodsService.getMfaMethods(EMAIL))
@@ -1083,7 +1058,6 @@ class LoginHandlerTest {
         UserProfile userProfile = generateUserProfile(null);
         when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
                 .thenReturn(Optional.of(userProfile));
-        usingValidSession();
         usingValidAuthSessionWithRequestedCredentialStrength(MEDIUM_LEVEL);
         usingApplicableUserCredentialsWithLogin(SMS, true);
         when(mfaMethodsService.getMfaMethods(EMAIL))
@@ -1113,7 +1087,6 @@ class LoginHandlerTest {
         UserProfile userProfile = generateUserProfile(null);
         when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
                 .thenReturn(Optional.of(userProfile));
-        usingValidSession();
         usingApplicableUserCredentialsWithLogin(SMS, true);
         usingValidAuthSessionInSmokeTest();
 
@@ -1138,7 +1111,6 @@ class LoginHandlerTest {
         when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
                 .thenReturn(Optional.of(userProfile));
 
-        usingValidSession();
         usingValidAuthSession();
         usingApplicableUserCredentialsWithLogin(SMS, true);
 
@@ -1157,7 +1129,6 @@ class LoginHandlerTest {
         when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
                 .thenReturn(Optional.of(userProfile));
 
-        usingValidSession();
         usingApplicableUserCredentialsWithLogin(SMS, true);
         usingValidAuthSession();
 
@@ -1167,11 +1138,6 @@ class LoginHandlerTest {
 
         assertThat(result, hasStatus(200));
         verifyAuthSessionIsSaved();
-    }
-
-    private void usingValidSession() {
-        when(sessionService.getSessionFromRequestHeaders(anyMap()))
-                .thenReturn(Optional.of(session));
     }
 
     private void usingValidAuthSessionWithAchievedCredentialStrength(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaHandlerTest.java
@@ -21,7 +21,6 @@ import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.NotifyRequest;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
 import uk.gov.di.authentication.shared.entity.Result;
-import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
@@ -35,7 +34,6 @@ import uk.gov.di.authentication.shared.services.CodeGeneratorService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SerializationService;
-import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
 import uk.gov.di.authentication.shared.services.mfa.MfaRetrieveFailureReason;
 import uk.gov.di.authentication.shared.state.UserContext;
@@ -90,7 +88,6 @@ class MfaHandlerTest {
     private static final String TEST_CLIENT_ID = "test-client-id";
 
     private final Context context = mock(Context.class);
-    private final SessionService sessionService = mock(SessionService.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final CodeGeneratorService codeGeneratorService = mock(CodeGeneratorService.class);
     private final CodeStorageService codeStorageService = mock(CodeStorageService.class);
@@ -145,7 +142,6 @@ class MfaHandlerTest {
                     DI_PERSISTENT_SESSION_ID,
                     Optional.of(ENCODED_DEVICE_DETAILS));
 
-    private final Session session = new Session();
     private final AuthSessionItem authSession =
             new AuthSessionItem()
                     .withSessionId(SESSION_ID)
@@ -202,7 +198,6 @@ class MfaHandlerTest {
         handler =
                 new MfaHandler(
                         configurationService,
-                        sessionService,
                         codeGeneratorService,
                         codeStorageService,
                         clientService,
@@ -439,10 +434,7 @@ class MfaHandlerTest {
         MfaRequest test = new MfaRequest(EMAIL, false, JourneyType.PASSWORD_RESET);
         APIGatewayProxyResponseEvent result =
                 handler.handleRequestWithUserContext(
-                        event,
-                        context,
-                        test,
-                        UserContext.builder(session).withAuthSession(authSession).build());
+                        event, context, test, UserContext.builder(authSession).build());
 
         assertThat(result, hasStatus(400));
 
@@ -451,7 +443,8 @@ class MfaHandlerTest {
 
     @Test
     void shouldReturn400WhenSessionIdIsInvalid() {
-        when(sessionService.getSessionFromRequestHeaders(anyMap())).thenReturn(Optional.empty());
+        when(authSessionService.getSessionFromRequestHeaders(anyMap()))
+                .thenReturn(Optional.empty());
         var body = format("{ \"email\": \"%s\"}", EMAIL);
         var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, body);
 
@@ -772,8 +765,6 @@ class MfaHandlerTest {
     }
 
     private void usingValidSession() {
-        when(sessionService.getSessionFromRequestHeaders(anyMap()))
-                .thenReturn(Optional.of(session));
         when(authSessionService.getSessionFromRequestHeaders(anyMap()))
                 .thenReturn(Optional.of(authSession));
     }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetAuthorizeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetAuthorizeHandlerTest.java
@@ -19,7 +19,6 @@ import uk.gov.di.authentication.frontendapi.services.IPVReverificationService;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.JourneyType;
-import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.CommonTestVariables;
 import uk.gov.di.authentication.shared.services.AuditService;
@@ -30,7 +29,6 @@ import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.IDReverificationStateService;
 import uk.gov.di.authentication.shared.services.SerializationService;
-import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.nio.charset.StandardCharsets;
@@ -73,9 +71,7 @@ class MfaResetAuthorizeHandlerTest {
     private static final ClientService clientService = mock(ClientService.class);
     private static final ClientRegistry clientRegistry = mock(ClientRegistry.class);
     private static final Context context = mock(Context.class);
-    private static final SessionService sessionService = mock(SessionService.class);
     private static final UserContext userContext = mock(UserContext.class);
-    private static final Session session = mock(Session.class);
     private static final AuditService auditService = mock(AuditService.class);
     private static final CloudwatchMetricsService cloudwatchMetricsService =
             mock(CloudwatchMetricsService.class);
@@ -113,18 +109,14 @@ class MfaResetAuthorizeHandlerTest {
     static void globalSetup() {
         userProfile.setSubjectID(INTERNAL_COMMON_SUBJECT_ID);
 
-        when(userContext.getSession()).thenReturn(new Session());
         when(userContext.getClientSessionId()).thenReturn(CLIENT_SESSION_ID);
         when(userContext.getAuthSession()).thenReturn(authSession);
         when(userContext.getUserProfile()).thenReturn(Optional.of(userProfile));
-        when(userContext.getSession()).thenReturn(session);
         when(userContext.getTxmaAuditEncoded()).thenReturn(ENCODED_DEVICE_DETAILS);
 
         when(clientRegistry.getSectorIdentifierUri()).thenReturn("htttps://gov.uk");
 
         when(userContext.getClient()).thenReturn(Optional.of(clientRegistry));
-        when(sessionService.getSessionFromRequestHeaders(anyMap()))
-                .thenReturn(Optional.of(session));
         when(authSessionService.getSessionFromRequestHeaders(anyMap()))
                 .thenReturn(Optional.of(authSession));
         when(authenticationService.getOrGenerateSalt(userProfile))
@@ -136,7 +128,6 @@ class MfaResetAuthorizeHandlerTest {
         handler =
                 new MfaResetAuthorizeHandler(
                         configurationService,
-                        sessionService,
                         clientService,
                         authenticationService,
                         ipvReverificationService,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordHandlerTest.java
@@ -16,7 +16,6 @@ import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.NotifyRequest;
-import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
@@ -38,7 +37,6 @@ import uk.gov.di.authentication.shared.services.CommonPasswordsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoAccountModifiersService;
 import uk.gov.di.authentication.shared.services.SerializationService;
-import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.validation.PasswordValidator;
 
 import java.time.temporal.ChronoUnit;
@@ -79,7 +77,6 @@ class ResetPasswordHandlerTest {
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
     private final AwsSqsClient sqsClient = mock(AwsSqsClient.class);
     private final CodeStorageService codeStorageService = mock(CodeStorageService.class);
-    private final SessionService sessionService = mock(SessionService.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final ClientService clientService = mock(ClientService.class);
     private final AuthSessionService authSessionService = mock(AuthSessionService.class);
@@ -129,7 +126,6 @@ class ResetPasswordHandlerTest {
                     Optional.of(ENCODED_DEVICE_DETAILS));
 
     private ResetPasswordHandler handler;
-    private final Session session = new Session();
     private final AuthSessionItem authSession =
             new AuthSessionItem()
                     .withSessionId(SESSION_ID)
@@ -161,7 +157,6 @@ class ResetPasswordHandlerTest {
                         sqsClient,
                         codeStorageService,
                         configurationService,
-                        sessionService,
                         clientService,
                         auditService,
                         commonPasswordsService,
@@ -404,7 +399,8 @@ class ResetPasswordHandlerTest {
 
     @Test
     void shouldReturn400WhenUserHasInvalidSession() {
-        when(sessionService.getSessionFromRequestHeaders(anyMap())).thenReturn(Optional.empty());
+        when(authSessionService.getSessionFromRequestHeaders(anyMap()))
+                .thenReturn(Optional.empty());
         APIGatewayProxyRequestEvent event = new APIGatewayProxyRequestEvent();
         event.setHeaders(Map.of("Session-Id", SESSION_ID));
         event.setBody(format("{ \"password\": \"%s\"}", NEW_PASSWORD));
@@ -507,8 +503,6 @@ class ResetPasswordHandlerTest {
     }
 
     private void usingValidSession() {
-        when(sessionService.getSessionFromRequestHeaders(anyMap()))
-                .thenReturn(Optional.of(session));
         when(authSessionService.getSessionFromRequestHeaders(anyMap()))
                 .thenReturn(Optional.of(authSession));
     }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ResetPasswordRequestHandlerTest.java
@@ -24,7 +24,6 @@ import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.NotifyRequest;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
 import uk.gov.di.authentication.shared.entity.Result;
-import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
 import uk.gov.di.authentication.shared.helpers.CommonTestVariables;
@@ -39,7 +38,6 @@ import uk.gov.di.authentication.shared.services.CodeGeneratorService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SerializationService;
-import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
@@ -101,7 +99,6 @@ class ResetPasswordRequestHandlerTest {
 
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final AwsSqsClient awsSqsClient = mock(AwsSqsClient.class);
-    private final SessionService sessionService = mock(SessionService.class);
     private final AuthSessionService authSessionService = mock(AuthSessionService.class);
     private final CodeGeneratorService codeGeneratorService = mock(CodeGeneratorService.class);
     private final CodeStorageService codeStorageService = mock(CodeStorageService.class);
@@ -122,7 +119,6 @@ class ResetPasswordRequestHandlerTest {
                                     CommonTestVariables.EMAIL,
                                     "jb2@digital.cabinet-office.gov.uk"));
 
-    private final Session session = new Session();
     private final AuthSessionItem authSession =
             new AuthSessionItem()
                     .withSessionId(SESSION_ID)
@@ -133,7 +129,6 @@ class ResetPasswordRequestHandlerTest {
     private final ResetPasswordRequestHandler handler =
             new ResetPasswordRequestHandler(
                     configurationService,
-                    sessionService,
                     clientService,
                     authenticationService,
                     awsSqsClient,
@@ -571,8 +566,8 @@ class ResetPasswordRequestHandlerTest {
         void shouldReturn400WhenNoEmailIsPresentInSession() {
             when(authenticationService.getPhoneNumber(CommonTestVariables.EMAIL))
                     .thenReturn(Optional.of(CommonTestVariables.UK_MOBILE_NUMBER));
-            when(sessionService.getSessionFromRequestHeaders(anyMap()))
-                    .thenReturn(Optional.of(new Session()));
+            when(authSessionService.getSessionFromRequestHeaders(anyMap()))
+                    .thenReturn(Optional.of(new AuthSessionItem().withSessionId(SESSION_ID)));
 
             APIGatewayProxyResponseEvent result = handler.handleRequest(validEvent, context);
 
@@ -627,8 +622,6 @@ class ResetPasswordRequestHandlerTest {
     }
 
     private void usingValidSession() {
-        when(sessionService.getSessionFromRequestHeaders(anyMap()))
-                .thenReturn(Optional.of(session));
         when(authSessionService.getSessionFromRequestHeaders(anyMap()))
                 .thenReturn(Optional.of(authSession));
     }
@@ -637,8 +630,6 @@ class ResetPasswordRequestHandlerTest {
         authSession.resetPasswordResetCount();
         IntStream.range(0, passwordResetCount)
                 .forEach((i) -> authSession.incrementPasswordResetCount());
-        when(sessionService.getSessionFromRequestHeaders(anyMap()))
-                .thenReturn(Optional.of(session));
         when(authSessionService.getSessionFromRequestHeaders(anyMap()))
                 .thenReturn(Optional.of(authSession));
     }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ReverificationResultHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/ReverificationResultHandlerTest.java
@@ -30,7 +30,6 @@ import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.IDReverificationStateService;
-import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.state.UserContext;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
@@ -92,7 +91,6 @@ class ReverificationResultHandlerTest {
     private ReverificationResultHandler handler;
     private final Context context = mock(Context.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
-    private final SessionService sessionService = mock(SessionService.class);
     private final AuthSessionService authSessionService = mock(AuthSessionService.class);
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
     private final AuditService auditService = mock(AuditService.class);
@@ -137,13 +135,10 @@ class ReverificationResultHandlerTest {
     @BeforeEach
     void setUp() throws URISyntaxException {
         when(context.getAwsRequestId()).thenReturn("aws-session-id");
-        when(sessionService.getSessionFromRequestHeaders(anyMap()))
-                .thenReturn(Optional.of(session));
         when(authSessionService.getSessionFromRequestHeaders(anyMap()))
                 .thenReturn(Optional.of(authSession));
         when(configurationService.getIPVBackendURI())
                 .thenReturn(new URI("https://api.identity.account.gov.uk/token"));
-        when(USER_CONTEXT.getSession()).thenReturn(session);
         when(USER_CONTEXT.getAuthSession()).thenReturn(authSession);
         when(USER_CONTEXT.getClientSessionId()).thenReturn(CLIENT_SESSION_ID);
         var userProfile = mock(UserProfile.class);
@@ -153,7 +148,6 @@ class ReverificationResultHandlerTest {
         handler =
                 new ReverificationResultHandler(
                         configurationService,
-                        sessionService,
                         clientService,
                         authenticationService,
                         reverificationResultService,

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/SendNotificationHandlerTest.java
@@ -22,7 +22,6 @@ import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.NotifyRequest;
-import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.helpers.CommonTestVariables;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
@@ -38,7 +37,6 @@ import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoEmailCheckResultService;
 import uk.gov.di.authentication.shared.services.SerializationService;
-import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
 import java.util.Date;
@@ -105,7 +103,6 @@ class SendNotificationHandlerTest {
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final AwsSqsClient emailSqsClient = mock(AwsSqsClient.class);
     private final AwsSqsClient pendingEmailCheckSqsClient = mock(AwsSqsClient.class);
-    private final SessionService sessionService = mock(SessionService.class);
     private final AuthSessionService authSessionService = mock(AuthSessionService.class);
     private final CodeGeneratorService codeGeneratorService = mock(CodeGeneratorService.class);
     private final CodeStorageService codeStorageService = mock(CodeStorageService.class);
@@ -125,7 +122,6 @@ class SendNotificationHandlerTest {
     private final Context context = mock(Context.class);
     private static final Json objectMapper = SerializationService.getInstance();
 
-    private final Session session = new Session();
     private final AuthSessionItem authSession =
             new AuthSessionItem()
                     .withSessionId(SESSION_ID)
@@ -148,7 +144,6 @@ class SendNotificationHandlerTest {
     private final SendNotificationHandler handler =
             new SendNotificationHandler(
                     configurationService,
-                    sessionService,
                     clientService,
                     authenticationService,
                     emailSqsClient,
@@ -1075,8 +1070,6 @@ class SendNotificationHandlerTest {
     }
 
     private void usingValidSession(String clientId) {
-        when(sessionService.getSessionFromRequestHeaders(anyMap()))
-                .thenReturn(Optional.of(session));
         when(authSessionService.getSessionFromRequestHeaders(anyMap()))
                 .thenReturn(Optional.of(authSession.withClientId(clientId)));
     }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/UpdateProfileHandlerTest.java
@@ -13,7 +13,6 @@ import uk.gov.di.audit.AuditContext;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
-import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.CommonTestVariables;
 import uk.gov.di.authentication.shared.services.AuditService;
@@ -21,7 +20,6 @@ import uk.gov.di.authentication.shared.services.AuthSessionService;
 import uk.gov.di.authentication.shared.services.AuthenticationService;
 import uk.gov.di.authentication.shared.services.ClientService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
-import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
 import java.util.Optional;
@@ -66,7 +64,6 @@ class UpdateProfileHandlerTest {
     private final Context context = mock(Context.class);
     private UpdateProfileHandler handler;
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
-    private final SessionService sessionService = mock(SessionService.class);
     private final AuthSessionService authSessionService = mock(AuthSessionService.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final ClientRegistry clientRegistry = mock(ClientRegistry.class);
@@ -75,7 +72,6 @@ class UpdateProfileHandlerTest {
 
     private final String TERMS_AND_CONDITIONS_VERSION =
             configurationService.getTermsAndConditionsVersion();
-    private final Session session = new Session();
     private final AuthSessionItem authSession =
             new AuthSessionItem()
                     .withSessionId(SESSION_ID)
@@ -131,7 +127,6 @@ class UpdateProfileHandlerTest {
         handler =
                 new UpdateProfileHandler(
                         authenticationService,
-                        sessionService,
                         configurationService,
                         auditService,
                         clientService,
@@ -237,8 +232,6 @@ class UpdateProfileHandlerTest {
     }
 
     private void usingValidSession() {
-        when(sessionService.getSessionFromRequestHeaders(anyMap()))
-                .thenReturn(Optional.of(session));
 
         when(authSessionService.getSessionFromRequestHeaders(anyMap()))
                 .thenReturn(Optional.of(authSession));

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyCodeHandlerTest.java
@@ -25,7 +25,6 @@ import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.Result;
-import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
@@ -40,7 +39,6 @@ import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoAccountModifiersService;
-import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.services.mfa.MFAMethodsService;
 import uk.gov.di.authentication.shared.services.mfa.MfaRetrieveFailureReason;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
@@ -118,14 +116,12 @@ class VerifyCodeHandlerTest {
     private static final long LOCKOUT_DURATION = 799;
     private static final int MAX_RETRIES = 6;
     private final Context context = mock(Context.class);
-    private final SessionService sessionService = mock(SessionService.class);
     private final CodeStorageService codeStorageService = mock(CodeStorageService.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final UserProfile userProfile = mock(UserProfile.class);
     private final String expectedPairwiseId =
             ClientSubjectHelper.calculatePairwiseIdentifier(
                     TEST_SUBJECT_ID, CLIENT_SECTOR_HOST, SALT);
-    private final Session session = new Session();
     private final AuthSessionItem authSession =
             new AuthSessionItem()
                     .withSessionId(SESSION_ID)
@@ -194,7 +190,6 @@ class VerifyCodeHandlerTest {
         handler =
                 new VerifyCodeHandler(
                         configurationService,
-                        sessionService,
                         clientService,
                         authenticationService,
                         codeStorageService,
@@ -227,9 +222,6 @@ class VerifyCodeHandlerTest {
     void shouldReturn400IfRequestIsMissingNotificationType() {
         var body = format("{ \"code\": \"%s\"}", CODE);
         var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, body);
-
-        when(sessionService.getSessionFromRequestHeaders(event.getHeaders()))
-                .thenReturn(Optional.of(session));
 
         APIGatewayProxyResponseEvent result = handler.handleRequest(event, context);
         assertThat(result, hasStatus(400));
@@ -305,8 +297,6 @@ class VerifyCodeHandlerTest {
                         "{ \"code\": \"%s\", \"notificationType\": \"%s\"  }",
                         CODE, emailNotificationType.toString());
         var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS_WITHOUT_AUDIT_ENCODED, body);
-        when(sessionService.getSessionFromRequestHeaders(event.getHeaders()))
-                .thenReturn(Optional.of(session));
         when(clientService.getClient(CLIENT_ID)).thenReturn(Optional.of(clientRegistry));
 
         var result = handler.handleRequest(event, context);
@@ -383,7 +373,7 @@ class VerifyCodeHandlerTest {
                 format(
                         "{ \"code\": \"%s\", \"notificationType\": \"%s\"  }",
                         TEST_CLIENT_CODE, VERIFY_EMAIL);
-        var result = makeCallWithCode(body, Optional.of(session));
+        var result = makeCallWithCode(body, Optional.of(authSession));
 
         assertThat(result, hasStatus(204));
         verifyNoInteractions(accountModifiersService);
@@ -419,7 +409,7 @@ class VerifyCodeHandlerTest {
         authSession.setClientId(TEST_CLIENT_ID);
         String body =
                 format("{ \"code\": \"%s\", \"notificationType\": \"%s\"  }", CODE, VERIFY_EMAIL);
-        var result = makeCallWithCode(body, Optional.of(session));
+        var result = makeCallWithCode(body, Optional.of(authSession));
 
         assertThat(result, hasStatus(204));
         verifyNoInteractions(accountModifiersService);
@@ -817,7 +807,7 @@ class VerifyCodeHandlerTest {
                 format(
                         "{ \"code\": \"%s\", \"notificationType\": \"%s\"  }",
                         TEST_CLIENT_CODE, RESET_PASSWORD_WITH_CODE);
-        APIGatewayProxyResponseEvent result = makeCallWithCode(body, Optional.of(session));
+        APIGatewayProxyResponseEvent result = makeCallWithCode(body, Optional.of(authSession));
 
         verifyNoInteractions(accountModifiersService);
         verify(codeStorageService).deleteOtpCode(TEST_CLIENT_EMAIL, RESET_PASSWORD_WITH_CODE);
@@ -981,7 +971,7 @@ class VerifyCodeHandlerTest {
                 format(
                         "{ \"code\": \"%s\", \"notificationType\": \"%s\"  }",
                         code, notificationType);
-        return makeCallWithCode(body, Optional.of(session));
+        return makeCallWithCode(body, Optional.of(authSession));
     }
 
     private APIGatewayProxyResponseEvent makeCallWithCode(
@@ -993,7 +983,7 @@ class VerifyCodeHandlerTest {
                 format(
                         "{ \"code\": \"%s\", \"notificationType\": \"%s\", \"journeyType\":\"%s\" }",
                         code, notificationType, journeyType.getValue());
-        return makeCallWithCode(body, Optional.of(session));
+        return makeCallWithCode(body, Optional.of(authSession));
     }
 
     private APIGatewayProxyResponseEvent makeCallWithCode(
@@ -1005,13 +995,15 @@ class VerifyCodeHandlerTest {
                 format(
                         "{ \"code\": \"%s\", \"notificationType\": \"%s\", \"journeyType\":\"%s\", \"mfaMethodId\":\"%s\" }",
                         code, notificationType, journeyType.getValue(), mfaMethodId);
-        return makeCallWithCode(body, Optional.of(session));
+        return makeCallWithCode(body, Optional.of(authSession));
     }
 
-    private APIGatewayProxyResponseEvent makeCallWithCode(String body, Optional<Session> session) {
+    private APIGatewayProxyResponseEvent makeCallWithCode(
+            String body, Optional<AuthSessionItem> session) {
         var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, body);
 
-        when(sessionService.getSessionFromRequestHeaders(event.getHeaders())).thenReturn(session);
+        when(authSessionService.getSessionFromRequestHeaders(event.getHeaders()))
+                .thenReturn(session);
         when(clientService.getClient(CLIENT_ID)).thenReturn(Optional.of(clientRegistry));
         when(clientService.getClient(TEST_CLIENT_ID)).thenReturn(Optional.of(testClientRegistry));
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/VerifyMfaCodeHandlerTest.java
@@ -30,7 +30,6 @@ import uk.gov.di.authentication.shared.entity.CountType;
 import uk.gov.di.authentication.shared.entity.CredentialTrustLevel;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
-import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
@@ -47,7 +46,6 @@ import uk.gov.di.authentication.shared.services.CloudwatchMetricsService;
 import uk.gov.di.authentication.shared.services.CodeStorageService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.SerializationService;
-import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.sharedtest.logging.CaptureLoggingExtension;
 
 import java.time.Instant;
@@ -118,7 +116,6 @@ class VerifyMfaCodeHandlerTest {
     private final String expectedRpPairwiseSubjectId =
             ClientSubjectHelper.calculatePairwiseIdentifier(
                     TEST_SUBJECT_ID, CLIENT_SECTOR_HOST, SALT);
-    private final Session session = new Session();
     private final AuthSessionItem authSession =
             new AuthSessionItem()
                     .withSessionId(SESSION_ID)
@@ -130,7 +127,6 @@ class VerifyMfaCodeHandlerTest {
     public VerifyMfaCodeHandler handler;
 
     private final Context context = mock(Context.class);
-    private final SessionService sessionService = mock(SessionService.class);
     private final CodeStorageService codeStorageService = mock(CodeStorageService.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final MfaCodeProcessorFactory mfaCodeProcessorFactory =
@@ -186,7 +182,6 @@ class VerifyMfaCodeHandlerTest {
         handler =
                 new VerifyMfaCodeHandler(
                         configurationService,
-                        sessionService,
                         clientService,
                         authenticationService,
                         codeStorageService,
@@ -268,8 +263,6 @@ class VerifyMfaCodeHandlerTest {
 
         var body = objectMapper.writeValueAsString(mfaCodeRequest);
         var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS_WITHOUT_AUDIT_ENCODED, body);
-        when(sessionService.getSessionFromRequestHeaders(event.getHeaders()))
-                .thenReturn(Optional.of(session));
 
         var result = handler.handleRequest(event, context);
 
@@ -1016,8 +1009,6 @@ class VerifyMfaCodeHandlerTest {
             throws Json.JsonException {
         var body = objectMapper.writeValueAsString(mfaCodeRequest);
         var event = apiRequestEventWithHeadersAndBody(VALID_HEADERS, body);
-        when(sessionService.getSessionFromRequestHeaders(event.getHeaders()))
-                .thenReturn(Optional.of(session));
         return handler.handleRequest(event, context);
     }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/StartServiceTest.java
@@ -37,7 +37,6 @@ import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.DynamoClientService;
 import uk.gov.di.authentication.shared.services.DynamoService;
-import uk.gov.di.authentication.shared.services.SessionService;
 import uk.gov.di.authentication.shared.state.UserContext;
 
 import java.net.URI;
@@ -85,13 +84,12 @@ class StartServiceTest {
 
     private final DynamoClientService dynamoClientService = mock(DynamoClientService.class);
     private final DynamoService dynamoService = mock(DynamoService.class);
-    private final SessionService sessionService = mock(SessionService.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private StartService startService;
 
     @BeforeEach
     void setup() {
-        startService = new StartService(dynamoClientService, dynamoService, sessionService);
+        startService = new StartService(dynamoClientService, dynamoService);
     }
 
     @Test
@@ -105,9 +103,8 @@ class StartServiceTest {
                 .thenReturn(Optional.of(mock(UserProfile.class)));
         when(dynamoService.getUserCredentialsFromEmail(EMAIL))
                 .thenReturn((mock(UserCredentials.class)));
-        var userContext = startService.buildUserContext(SESSION, AUTH_SESSION);
+        var userContext = startService.buildUserContext(AUTH_SESSION);
 
-        assertThat(userContext.getSession(), equalTo(SESSION));
         assertThat(userContext.getAuthSession(), equalTo(AUTH_SESSION));
     }
 
@@ -617,7 +614,7 @@ class StartServiceTest {
                         .withIdentityVerificationSupported(identityVerificationSupport)
                         .withOneLoginService(oneLoginService);
         serviceTypeOpt.ifPresent(clientRegistry::setServiceType);
-        return UserContext.builder(SESSION)
+        return UserContext.builder(AUTH_SESSION)
                 .withClient(clientRegistry)
                 .withUserCredentials(userCredentials)
                 .withUserProfile(userProfile)

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessorTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessorTest.java
@@ -99,7 +99,6 @@ class AuthAppCodeProcessorTest {
         this.mockAuditService = mock(AuditService.class);
         this.mockUserContext = mock(UserContext.class);
         this.mockAccountModifiersService = mock(DynamoAccountModifiersService.class);
-        when(mockUserContext.getSession()).thenReturn(session);
         when(mockUserContext.getAuthSession()).thenReturn(authSession);
         when(mockDynamoService.getUserProfileByEmail(EMAIL))
                 .thenReturn(new UserProfile().withMfaMethodsMigrated(false));
@@ -377,7 +376,6 @@ class AuthAppCodeProcessorTest {
 
     private void setUpSuccessfulCodeRequest(CodeRequest codeRequest) {
         when(mockUserContext.getClientSessionId()).thenReturn(CLIENT_SESSION_ID);
-        when(mockUserContext.getSession()).thenReturn(session);
         when(mockUserContext.getAuthSession()).thenReturn(authSession);
         when(mockUserContext.getTxmaAuditEncoded()).thenReturn(TXMA_ENCODED_HEADER_VALUE);
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessorTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/validation/PhoneNumberCodeProcessorTest.java
@@ -413,7 +413,6 @@ class PhoneNumberCodeProcessorTest {
     public void setupPhoneNumberCode(CodeRequest codeRequest, CodeRequestType codeRequestType) {
         var differentPhoneNumber = CommonTestVariables.UK_MOBILE_NUMBER.replace("789", "987");
         when(userContext.getClientSessionId()).thenReturn(CLIENT_SESSION_ID);
-        when(userContext.getSession()).thenReturn(session);
         when(userContext.getAuthSession()).thenReturn(authSession);
         when(userContext.getUserProfile()).thenReturn(Optional.of(userProfile));
         when(userProfile.isPhoneNumberVerified()).thenReturn(true);
@@ -445,7 +444,6 @@ class PhoneNumberCodeProcessorTest {
     public void setUpPhoneNumberCodeRetryLimitExceeded(CodeRequest codeRequest) {
         when(codeStorageService.getIncorrectMfaCodeAttemptsCount(CommonTestVariables.EMAIL))
                 .thenReturn(6);
-        when(userContext.getSession()).thenReturn(session);
         when(userContext.getAuthSession()).thenReturn(authSession);
         when(configurationService.isTestClientsEnabled()).thenReturn(false);
         when(codeStorageService.getOtpCode(
@@ -469,7 +467,6 @@ class PhoneNumberCodeProcessorTest {
 
     public void setUpBlockedPhoneNumberCode(
             CodeRequest codeRequest, CodeRequestType codeRequestType) {
-        when(userContext.getSession()).thenReturn(session);
         when(userContext.getAuthSession()).thenReturn(authSession);
         when(configurationService.isTestClientsEnabled()).thenReturn(false);
         when(codeStorageService.getOtpCode(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AccountInterventionsHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AccountInterventionsHandlerIntegrationTest.java
@@ -20,6 +20,7 @@ import uk.gov.di.authentication.shared.services.LambdaInvokerService;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.extensions.AccountInterventionsStubExtension;
 import uk.gov.di.authentication.sharedtest.extensions.AuthSessionExtension;
+import uk.gov.di.orchestration.shared.helpers.IdGenerator;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -73,7 +74,6 @@ public class AccountInterventionsHandlerIntegrationTest extends ApiGatewayHandle
         handler =
                 new AccountInterventionsHandler(
                         ACCOUNT_INTERVENTIONS_HANDLER_CONFIGURATION_SERVICE,
-                        redisConnectionService,
                         new LambdaInvokerService(mockLambdaClient));
         accountInterventionsStubExtension.initWithBlockedUserId(
                 setupUserAndRetrieveUserId(TEST_EMAIL_ADDRESS),
@@ -131,9 +131,9 @@ public class AccountInterventionsHandlerIntegrationTest extends ApiGatewayHandle
         assertThat(response, hasStatus(200));
     }
 
-    private Map<String, String> getHeadersForAuthenticatedSession() throws Json.JsonException {
+    private Map<String, String> getHeadersForAuthenticatedSession() {
         Map<String, String> headers = new HashMap<>();
-        var sessionId = redis.createSession();
+        var sessionId = IdGenerator.generate();
         authSessionServiceExtension.addSession(sessionId);
         headers.put("Session-Id", sessionId);
         headers.put(CLIENT_SESSION_ID_HEADER, "client-session-id");

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AccountRecoveryIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AccountRecoveryIntegrationTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.authentication.frontendapi.entity.AccountRecoveryResponse;
 import uk.gov.di.authentication.frontendapi.lambda.AccountRecoveryHandler;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
-import uk.gov.di.authentication.shared.serialization.Json;
+import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.extensions.AuthSessionExtension;
 
@@ -41,20 +41,18 @@ public class AccountRecoveryIntegrationTest extends ApiGatewayHandlerIntegration
 
     @BeforeEach
     void setup() {
-        handler =
-                new AccountRecoveryHandler(
-                        new AccountRecoveryTestConfigurationService(), redisConnectionService);
+        handler = new AccountRecoveryHandler(new AccountRecoveryTestConfigurationService());
         txmaAuditQueue.clear();
     }
 
     @Test
-    void shouldNotBePermittedForAccountRecoveryWhenBlockIsPresent() throws Json.JsonException {
+    void shouldNotBePermittedForAccountRecoveryWhenBlockIsPresent() {
         userStore.signUp(EMAIL, "password-1", SUBJECT);
         var salt = userStore.addSalt(EMAIL);
         var internalCommonSubjectId =
                 ClientSubjectHelper.calculatePairwiseIdentifier(
                         SUBJECT.getValue(), INTERNAl_SECTOR_HOST, salt);
-        var sessionId = redis.createSession();
+        var sessionId = IdGenerator.generate();
         authSessionServiceExtension.addSession(sessionId);
         accountModifiersStore.setAccountRecoveryBlock(internalCommonSubjectId);
         Map<String, String> headers = new HashMap<>();
@@ -71,8 +69,8 @@ public class AccountRecoveryIntegrationTest extends ApiGatewayHandlerIntegration
     }
 
     @Test
-    void shouldBePermittedForAccountRecoveryWhenNoBlockIsPresent() throws Json.JsonException {
-        var sessionId = redis.createSession();
+    void shouldBePermittedForAccountRecoveryWhenNoBlockIsPresent() {
+        var sessionId = IdGenerator.generate();
         authSessionServiceExtension.addSession(sessionId);
         userStore.signUp(EMAIL, "password-1", SUBJECT);
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthExternalApiUserInfoIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthExternalApiUserInfoIntegrationTest.java
@@ -74,7 +74,6 @@ class AuthExternalApiUserInfoIntegrationTest extends ApiGatewayHandlerIntegratio
                 };
         txmaAuditQueue.clear();
         handler = new UserInfoHandler(configurationService);
-        withRedisSession();
     }
 
     @Test
@@ -315,10 +314,6 @@ class AuthExternalApiUserInfoIntegrationTest extends ApiGatewayHandlerIntegratio
         userStore.signUp(TEST_EMAIL_ADDRESS, TEST_PASSWORD, TEST_SUBJECT);
         userStore.addVerifiedPhoneNumber(TEST_EMAIL_ADDRESS, TEST_PHONE_NUMBER);
         return userStore.getUserProfileFromEmail(TEST_EMAIL_ADDRESS).get();
-    }
-
-    private void withRedisSession() throws Json.JsonException {
-        redis.createSession(TEST_SESSION_ID);
     }
 
     private void withAuthSessionNewAccount() {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationAuthCodeHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationAuthCodeHandlerIntegrationTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.authentication.frontendapi.entity.AuthCodeRequest;
 import uk.gov.di.authentication.frontendapi.lambda.AuthenticationAuthCodeHandler;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.extensions.AuthCodeExtension;
@@ -43,9 +44,7 @@ class AuthenticationAuthCodeHandlerIntegrationTest extends ApiGatewayHandlerInte
 
     @BeforeEach
     void setup() throws Json.JsonException {
-        handler =
-                new AuthenticationAuthCodeHandler(
-                        TEST_CONFIGURATION_SERVICE, redisConnectionService);
+        handler = new AuthenticationAuthCodeHandler(TEST_CONFIGURATION_SERVICE);
         txmaAuditQueue.clear();
     }
 
@@ -140,8 +139,8 @@ class AuthenticationAuthCodeHandlerIntegrationTest extends ApiGatewayHandlerInte
         return headers;
     }
 
-    private String setupSession() throws Json.JsonException {
-        var sessionId = redis.createSession();
+    private String setupSession() {
+        var sessionId = IdGenerator.generate();
         authSessionExtension.addSession(sessionId);
         authSessionExtension.addEmailToSession(sessionId, TEST_EMAIL_ADDRESS);
         return sessionId;

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckEmailFraudBlockIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckEmailFraudBlockIntegrationTest.java
@@ -7,8 +7,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.authentication.frontendapi.entity.CheckEmailFraudBlockResponse;
 import uk.gov.di.authentication.frontendapi.lambda.CheckEmailFraudBlockHandler;
 import uk.gov.di.authentication.shared.entity.EmailCheckResultStatus;
+import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
-import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.DynamoEmailCheckResultService;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.extensions.AuthSessionExtension;
@@ -44,16 +44,14 @@ public class CheckEmailFraudBlockIntegrationTest extends ApiGatewayHandlerIntegr
 
     @BeforeEach
     void setup() {
-        handler =
-                new CheckEmailFraudBlockHandler(
-                        TXMA_ENABLED_CONFIGURATION_SERVICE, redisConnectionService);
+        handler = new CheckEmailFraudBlockHandler(TXMA_ENABLED_CONFIGURATION_SERVICE);
         txmaAuditQueue.clear();
     }
 
     @Test
-    void shouldReturnCorrectStatusBasedOnDbResult() throws Json.JsonException {
+    void shouldReturnCorrectStatusBasedOnDbResult() {
         userStore.signUp(EMAIL, "password-1", SUBJECT);
-        var sessionId = redis.createSession();
+        var sessionId = IdGenerator.generate();
         authSessionExtension.addSession(sessionId);
         dynamoEmailCheckResultService.saveEmailCheckResult(
                 EMAIL, EmailCheckResultStatus.ALLOW, unixTimePlusNDays(), "test-reference");

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckReAuthUserHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckReAuthUserHandlerIntegrationTest.java
@@ -13,6 +13,7 @@ import uk.gov.di.authentication.shared.entity.CountType;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
+import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.AuthenticationAttemptsService;
@@ -91,12 +92,12 @@ public class CheckReAuthUserHandlerIntegrationTest extends ApiGatewayHandlerInte
     @BeforeEach
     void setup() throws Json.JsonException {
 
-        var sessionId = redis.createSession();
+        var sessionId = IdGenerator.generate();
         authSessionExtension.addSession(sessionId);
         authSessionExtension.addEmailToSession(sessionId, TEST_EMAIL);
         authSessionExtension.addClientIdToSession(sessionId, CLIENT_ID.getValue());
         requestHeaders = createHeaders(sessionId);
-        handler = new CheckReAuthUserHandler(CONFIGURATION_SERVICE, redisConnectionService);
+        handler = new CheckReAuthUserHandler(CONFIGURATION_SERVICE);
         txmaAuditQueue.clear();
     }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckUserExistsIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/CheckUserExistsIntegrationTest.java
@@ -63,7 +63,7 @@ class CheckUserExistsIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     void shouldCallUserExistsEndpointAndReturnAuthenticationRequestStateWhenUserExists(
             MFAMethodType mfaMethodType) throws JsonException, URISyntaxException {
         var emailAddress = "joe.bloggs+1@digital.cabinet-office.gov.uk";
-        var sessionId = redis.createSession();
+        var sessionId = IdGenerator.generate();
         authSessionStore.addSession(sessionId);
         authSessionStore.addClientIdToSession(sessionId, CLIENT_ID.getValue());
         var clientSessionId = IdGenerator.generate();
@@ -116,7 +116,7 @@ class CheckUserExistsIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             throws JsonException {
         var emailAddress = "joe.bloggs+1@digital.cabinet-office.gov.uk";
 
-        String sessionId = redis.createSession();
+        String sessionId = IdGenerator.generate();
         authSessionStore.addSession(sessionId);
         authSessionStore.addClientIdToSession(sessionId, CLIENT_ID.getValue());
         var codeRequestType =
@@ -159,7 +159,7 @@ class CheckUserExistsIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     void shouldCallUserExistsEndpointAndReturnUserNotFoundStateWhenUserDoesNotExist()
             throws JsonException {
         String emailAddress = "joe.bloggs+2@digital.cabinet-office.gov.uk";
-        String sessionId = redis.createSession();
+        String sessionId = IdGenerator.generate();
         authSessionStore.addSession(sessionId);
         var clientSessionId = IdGenerator.generate();
         registerClient(emailAddress, CLIENT_ID, CLIENT_NAME, REDIRECT_URI);
@@ -187,7 +187,7 @@ class CheckUserExistsIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     void shouldCallUserExistsEndpointAndReturnErrorResponse1045WhenUserAccountIsLocked()
             throws JsonException {
         String emailAddress = "joe.bloggs+2@digital.cabinet-office.gov.uk";
-        String sessionId = redis.createSession();
+        String sessionId = IdGenerator.generate();
         authSessionStore.addSession(sessionId);
         redis.blockMfaCodesForEmail(
                 emailAddress,

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/MfaHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/MfaHandlerIntegrationTest.java
@@ -12,6 +12,7 @@ import uk.gov.di.authentication.shared.entity.NotificationType;
 import uk.gov.di.authentication.shared.entity.NotifyRequest;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
+import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
@@ -191,7 +192,7 @@ class MfaHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         @BeforeEach
         void setup() throws Json.JsonException {
-            SESSION_ID = redis.createSession();
+            SESSION_ID = IdGenerator.generate();
             authSessionStore.addSession(SESSION_ID);
             authSessionStore.addEmailToSession(SESSION_ID, USER_EMAIL);
             userStore.signUp(USER_EMAIL, USER_PASSWORD, new Subject("new-subject"));

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/MfaResetAuthorizeHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/MfaResetAuthorizeHandlerIntegrationTest.java
@@ -25,6 +25,7 @@ import uk.gov.di.authentication.frontendapi.entity.MfaResetRequest;
 import uk.gov.di.authentication.frontendapi.lambda.MfaResetAuthorizeHandler;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
+import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -168,6 +169,7 @@ class MfaResetAuthorizeHandlerIntegrationTest extends ApiGatewayHandlerIntegrati
 
     @BeforeEach
     void setup() throws Json.JsonException, MalformedURLException, NoSuchAlgorithmException {
+        sessionId = IdGenerator.generate();
         rsaKey =
                 new RSAKey.Builder((RSAPublicKey) keyPair.getPublic())
                         .privateKey(
@@ -191,14 +193,9 @@ class MfaResetAuthorizeHandlerIntegrationTest extends ApiGatewayHandlerIntegrati
                         "test.account.gov.uk",
                         SaltHelper.generateNewSalt());
 
-        setUpSession();
         addSessionToSessionStore(internalCommonSubjectId);
         registerClient();
         addUserToUserStore();
-    }
-
-    private void setUpSession() throws Json.JsonException {
-        sessionId = redis.createSession();
     }
 
     private void addSessionToSessionStore(String internalCommonSubjectId) {

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordIntegrationTest.java
@@ -11,7 +11,7 @@ import uk.gov.di.authentication.shared.entity.ErrorResponse;
 import uk.gov.di.authentication.shared.entity.NotifyRequest;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
-import uk.gov.di.authentication.shared.serialization.Json;
+import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.extensions.CommonPasswordsExtension;
 
@@ -75,8 +75,8 @@ public class ResetPasswordIntegrationTest extends ApiGatewayHandlerIntegrationTe
     }
 
     @Test
-    void shouldUpdatePasswordAndReturn204() throws Json.JsonException {
-        var sessionId = redis.createSession();
+    void shouldUpdatePasswordAndReturn204() {
+        var sessionId = IdGenerator.generate();
         authSessionStore.addSession(sessionId);
         userStore.signUp(EMAIL_ADDRESS, "password-1", SUBJECT);
         authSessionStore.addEmailToSession(sessionId, EMAIL_ADDRESS);
@@ -99,9 +99,9 @@ public class ResetPasswordIntegrationTest extends ApiGatewayHandlerIntegrationTe
     }
 
     @Test
-    void shouldUpdatePasswordSendSMSAndWriteToAccountModifiersTableWhenUserHasVerifiedPhoneNumber()
-            throws Json.JsonException {
-        var sessionId = redis.createSession();
+    void
+            shouldUpdatePasswordSendSMSAndWriteToAccountModifiersTableWhenUserHasVerifiedPhoneNumber() {
+        var sessionId = IdGenerator.generate();
         authSessionStore.addSession(sessionId);
         var phoneNumber = "+441234567890";
         userStore.signUp(EMAIL_ADDRESS, "password-1", SUBJECT);
@@ -137,9 +137,8 @@ public class ResetPasswordIntegrationTest extends ApiGatewayHandlerIntegrationTe
 
     @Test
     void
-            shouldUpdatePasswordSendSMSAndNotWriteToAccountModifiersTableWhenUserHasVerifiedPhoneNumberButRequestAllowsMfaReset()
-                    throws Json.JsonException {
-        var sessionId = redis.createSession();
+            shouldUpdatePasswordSendSMSAndNotWriteToAccountModifiersTableWhenUserHasVerifiedPhoneNumberButRequestAllowsMfaReset() {
+        var sessionId = IdGenerator.generate();
         authSessionStore.addSession(sessionId);
         var phoneNumber = "+441234567890";
         userStore.signUp(EMAIL_ADDRESS, "password-1", SUBJECT);
@@ -168,8 +167,8 @@ public class ResetPasswordIntegrationTest extends ApiGatewayHandlerIntegrationTe
     }
 
     @Test
-    void shouldReturn400ForRequestWithCommonPassword() throws Json.JsonException {
-        var sessionId = redis.createSession();
+    void shouldReturn400ForRequestWithCommonPassword() {
+        var sessionId = IdGenerator.generate();
         authSessionStore.addSession(sessionId);
         userStore.signUp(EMAIL_ADDRESS, "password-1", SUBJECT);
         authSessionStore.addEmailToSession(sessionId, EMAIL_ADDRESS);
@@ -192,9 +191,8 @@ public class ResetPasswordIntegrationTest extends ApiGatewayHandlerIntegrationTe
     }
 
     @Test
-    void shouldSendForcedResetJourneyAuditEventWhenForcedPasswordResetIsTrue()
-            throws Json.JsonException {
-        var sessionId = redis.createSession();
+    void shouldSendForcedResetJourneyAuditEventWhenForcedPasswordResetIsTrue() {
+        var sessionId = IdGenerator.generate();
         authSessionStore.addSession(sessionId);
         userStore.signUp(EMAIL_ADDRESS, "password-1", SUBJECT);
         authSessionStore.addEmailToSession(sessionId, EMAIL_ADDRESS);
@@ -225,8 +223,8 @@ public class ResetPasswordIntegrationTest extends ApiGatewayHandlerIntegrationTe
     @ParameterizedTest
     @MethodSource("phoneNumberVerified")
     void shouldUpdatePasswordAndWriteToAccountModifiersTableWithIfUserHasVerifiedPhoneNumber(
-            boolean phoneNumberVerified) throws Json.JsonException {
-        var sessionId = redis.createSession();
+            boolean phoneNumberVerified) {
+        var sessionId = IdGenerator.generate();
         authSessionStore.addSession(sessionId);
         var phoneNumber = "+441234567890";
         userStore.signUp(EMAIL_ADDRESS, "password-1", SUBJECT);
@@ -276,8 +274,8 @@ public class ResetPasswordIntegrationTest extends ApiGatewayHandlerIntegrationTe
     @ParameterizedTest
     @MethodSource("authAppVerified")
     void shouldUpdatePasswordAndWriteToAccountRecoveryTableWithIfUserHasVerifiedAuthApp(
-            boolean authAppVerified) throws Json.JsonException {
-        var sessionId = redis.createSession();
+            boolean authAppVerified) {
+        var sessionId = IdGenerator.generate();
         authSessionStore.addSession(sessionId);
         userStore.signUp(EMAIL_ADDRESS, "password-1", SUBJECT);
         byte[] salt = userStore.addSalt(EMAIL_ADDRESS);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordRequestIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ResetPasswordRequestIntegrationTest.java
@@ -7,7 +7,6 @@ import uk.gov.di.authentication.frontendapi.entity.ResetPasswordRequest;
 import uk.gov.di.authentication.frontendapi.lambda.ResetPasswordRequestHandler;
 import uk.gov.di.authentication.shared.entity.NotifyRequest;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
-import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 
 import java.net.URI;
@@ -40,14 +39,13 @@ public class ResetPasswordRequestIntegrationTest extends ApiGatewayHandlerIntegr
     }
 
     @Test
-    public void shouldCallResetPasswordEndpointAndReturn200ForCodeFlowRequest()
-            throws Json.JsonException {
+    public void shouldCallResetPasswordEndpointAndReturn200ForCodeFlowRequest() {
         String email = "joe.bloggs+3@digital.cabinet-office.gov.uk";
         String password = "password-1";
         String phoneNumber = "01234567890";
         userStore.signUp(email, password);
         userStore.addVerifiedPhoneNumber(email, phoneNumber);
-        String sessionId = redis.createSession();
+        String sessionId = IdGenerator.generate();
         authSessionStore.addSession(sessionId);
         authSessionStore.addEmailToSession(sessionId, email);
         String persistentSessionId = "test-persistent-id";

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/ReverificationResultHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/ReverificationResultHandlerIntegrationTest.java
@@ -15,6 +15,7 @@ import software.amazon.awssdk.services.kms.model.KeyUsageType;
 import uk.gov.di.authentication.frontendapi.entity.ReverificationResultRequest;
 import uk.gov.di.authentication.frontendapi.lambda.ReverificationResultHandler;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
+import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
@@ -113,9 +114,9 @@ class ReverificationResultHandlerIntegrationTest extends ApiGatewayHandlerIntegr
 
     @BeforeEach
     void setup() throws Json.JsonException {
-        handler = new ReverificationResultHandler(redisConnectionService);
+        handler = new ReverificationResultHandler();
 
-        sessionId = redis.createSession();
+        sessionId = IdGenerator.generate();
         internalCommonSubjectId =
                 ClientSubjectHelper.calculatePairwiseIdentifier(
                         new Subject().getValue(),

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/SendNotificationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/SendNotificationIntegrationTest.java
@@ -8,6 +8,7 @@ import uk.gov.di.authentication.frontendapi.entity.SendNotificationRequest;
 import uk.gov.di.authentication.frontendapi.lambda.SendNotificationHandler;
 import uk.gov.di.authentication.shared.entity.JourneyType;
 import uk.gov.di.authentication.shared.entity.NotificationType;
+import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.extensions.AuthSessionExtension;
@@ -38,14 +39,13 @@ class SendNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         handler =
                 new SendNotificationHandler(
                         TXMA_ENABLED_CONFIGURATION_SERVICE, redisConnectionService);
-        SESSION_ID = redis.createSession();
+        SESSION_ID = IdGenerator.generate();
         authSessionExtension.addSession(SESSION_ID);
         authSessionStore.addEmailToSession(SESSION_ID, USER_EMAIL);
     }
 
     @Test
-    void shouldCallSendNotificationEndpointAndPlaceSuccessMessageOnAuditQueueWhenSuccessful()
-            throws Json.JsonException {
+    void shouldCallSendNotificationEndpointAndPlaceSuccessMessageOnAuditQueueWhenSuccessful() {
         var response =
                 makeRequest(
                         Optional.of(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/SignupIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/SignupIntegrationTest.java
@@ -45,14 +45,13 @@ public class SignupIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @BeforeEach
     void setup() throws Json.JsonException {
-        handler = new SignUpHandler(TXMA_ENABLED_CONFIGURATION_SERVICE, redisConnectionService);
+        handler = new SignUpHandler(TXMA_ENABLED_CONFIGURATION_SERVICE);
         txmaAuditQueue.clear();
     }
 
     @Test
-    void shouldReturn200WhenValidSignUpRequest() throws Json.JsonException {
+    void shouldReturn200WhenValidSignUpRequest() {
         setUpTest();
-        redis.createSession(SESSION_ID);
         withAuthSession();
 
         Map<String, String> headers = new HashMap<>();

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/StartIntegrationTest.java
@@ -78,7 +78,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
     @BeforeEach
     void setup() {
-        handler = new StartHandler(new TestConfigurationService(), redisConnectionService);
+        handler = new StartHandler(new TestConfigurationService());
         txmaAuditQueue.clear();
     }
 
@@ -359,7 +359,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         @BeforeEach
         void setup() throws Json.JsonException {
-            handler = new StartHandler(new TestConfigurationService(), redisConnectionService);
+            handler = new StartHandler(new TestConfigurationService());
             txmaAuditQueue.clear();
             sessionId = redis.createSession();
             userStore.signUp(EMAIL, "password");
@@ -444,7 +444,7 @@ class StartIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         @BeforeEach
         void setup() throws Json.JsonException {
-            handler = new StartHandler(new TestConfigurationService(), redisConnectionService);
+            handler = new StartHandler(new TestConfigurationService());
             txmaAuditQueue.clear();
             sessionId = IdGenerator.generate();
             redis.createSession(sessionId);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateProfileIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/UpdateProfileIntegrationTest.java
@@ -6,7 +6,6 @@ import uk.gov.di.authentication.frontendapi.entity.UpdateProfileRequest;
 import uk.gov.di.authentication.frontendapi.lambda.UpdateProfileHandler;
 import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
-import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 
 import java.util.List;
@@ -28,16 +27,13 @@ public class UpdateProfileIntegrationTest extends ApiGatewayHandlerIntegrationTe
 
     @BeforeEach
     void setup() {
-        handler =
-                new UpdateProfileHandler(
-                        TXMA_ENABLED_CONFIGURATION_SERVICE, redisConnectionService);
+        handler = new UpdateProfileHandler(TXMA_ENABLED_CONFIGURATION_SERVICE);
         txmaAuditQueue.clear();
     }
 
     @Test
-    void shouldCallUpdateProfileToApproveTermsAndConditionsAndReturn204()
-            throws Json.JsonException {
-        String sessionId = redis.createSession();
+    void shouldCallUpdateProfileToApproveTermsAndConditionsAndReturn204() {
+        String sessionId = IdGenerator.generate();
         String clientSessionId = IdGenerator.generate();
         setUpTest(sessionId);
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyCodeIntegrationTest.java
@@ -17,6 +17,7 @@ import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
+import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
 import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
@@ -74,7 +75,7 @@ public class VerifyCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest 
                 new VerifyCodeHandler(
                         REAUTH_SIGNOUT_AND_TXMA_ENABLED_CONFIGUARION_SERVICE,
                         redisConnectionService);
-        this.sessionId = redis.createSession();
+        this.sessionId = IdGenerator.generate();
         authSessionExtension.addSession(this.sessionId);
         authSessionExtension.addClientIdToSession(this.sessionId, CLIENT_ID);
         authSessionExtension.addClientNameToSession(this.sessionId, CLIENT_NAME);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/VerifyMfaCodeIntegrationTest.java
@@ -20,9 +20,9 @@ import uk.gov.di.authentication.shared.entity.ServiceType;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethod;
 import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 import uk.gov.di.authentication.shared.helpers.ClientSubjectHelper;
+import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
 import uk.gov.di.authentication.shared.helpers.SaltHelper;
-import uk.gov.di.authentication.shared.serialization.Json;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
 import uk.gov.di.authentication.sharedtest.extensions.AuthSessionExtension;
@@ -91,7 +91,7 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     protected static final AuthSessionExtension authSessionExtension = new AuthSessionExtension();
 
     @BeforeEach
-    void beforeEachSetup() throws Json.JsonException {
+    void beforeEachSetup() {
         handler =
                 new VerifyMfaCodeHandler(
                         REAUTH_SIGNOUT_AND_TXMA_ENABLED_CONFIGUARION_SERVICE,
@@ -99,7 +99,7 @@ class VerifyMfaCodeIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         txmaAuditQueue.clear();
 
-        this.sessionId = redis.createSession();
+        this.sessionId = IdGenerator.generate();
         authSessionExtension.addSession(this.sessionId);
         authSessionExtension.addInternalCommonSubjectIdToSession(
                 this.sessionId, internalCommonSubjectId);

--- a/shared/src/main/java/uk/gov/di/authentication/shared/state/UserContext.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/state/UserContext.java
@@ -2,7 +2,6 @@ package uk.gov.di.authentication.shared.state;
 
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
-import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.entity.UserCredentials;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
@@ -10,7 +9,6 @@ import uk.gov.di.authentication.shared.helpers.LocaleHelper.SupportedLanguage;
 import java.util.Optional;
 
 public class UserContext {
-    private final Session session;
     private final AuthSessionItem authSession;
     private final Optional<UserProfile> userProfile;
     private final Optional<UserCredentials> userCredentials;
@@ -21,7 +19,6 @@ public class UserContext {
     private final String txmaAuditEncoded;
 
     protected UserContext(
-            Session session,
             Optional<UserProfile> userProfile,
             Optional<UserCredentials> userCredentials,
             boolean userAuthenticated,
@@ -30,7 +27,6 @@ public class UserContext {
             String clientSessionId,
             String txmaAuditEncoded,
             AuthSessionItem authSession) {
-        this.session = session;
         this.userProfile = userProfile;
         this.userCredentials = userCredentials;
         this.userAuthenticated = userAuthenticated;
@@ -39,10 +35,6 @@ public class UserContext {
         this.clientSessionId = clientSessionId;
         this.txmaAuditEncoded = txmaAuditEncoded;
         this.authSession = authSession;
-    }
-
-    public Session getSession() {
-        return session;
     }
 
     public Optional<UserProfile> getUserProfile() {
@@ -77,12 +69,11 @@ public class UserContext {
         return authSession;
     }
 
-    public static Builder builder(Session session) {
+    public static Builder builder(AuthSessionItem session) {
         return new Builder(session);
     }
 
     public static class Builder {
-        private Session session;
         private AuthSessionItem authSession;
         private Optional<UserProfile> userProfile = Optional.empty();
         private Optional<UserCredentials> userCredentials = Optional.empty();
@@ -92,12 +83,7 @@ public class UserContext {
         private String clientSessionId;
         private String txmaAuditEncoded;
 
-        protected Builder(Session session) {
-            this.session = session;
-        }
-
-        protected Builder(Session session, AuthSessionItem authSession) {
-            this.session = session;
+        protected Builder(AuthSessionItem authSession) {
             this.authSession = authSession;
         }
 
@@ -144,14 +130,8 @@ public class UserContext {
             return this;
         }
 
-        public Builder withAuthSession(AuthSessionItem authSession) {
-            this.authSession = authSession;
-            return this;
-        }
-
         public UserContext build() {
             return new UserContext(
-                    session,
                     userProfile,
                     userCredentials,
                     userAuthenticated,

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/TestClientHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/TestClientHelperTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.ClientRegistry;
-import uk.gov.di.authentication.shared.entity.Session;
 import uk.gov.di.authentication.shared.exceptions.ClientNotFoundException;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.state.UserContext;
@@ -136,11 +135,7 @@ class TestClientHelperTest {
                         .withClientName("some-client")
                         .withTestClient(isTestClient)
                         .withTestClientEmailAllowlist(allowedEmails);
-        var session = new Session();
         var authSession = new AuthSessionItem().withEmailAddress(TEST_EMAIL_ADDRESS);
-        return UserContext.builder(session)
-                .withClient(clientRegistry)
-                .withAuthSession(authSession)
-                .build();
+        return UserContext.builder(authSession).withClient(clientRegistry).build();
     }
 }


### PR DESCRIPTION
### Wider context of change:
- Re-applies this PR: https://github.com/govuk-one-login/authentication-api/pull/6573, the output of which is to remove reading the redis session from authentication

### What’s changed: 
See - https://github.com/govuk-one-login/authentication-api/pull/6573 for nicer commits

### Manual testing: 
See - https://github.com/govuk-one-login/authentication-api/pull/6573
### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [x] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [x] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [x] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [x] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [x] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [x] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs: 
- Must merge this PR before or shortly after: https://github.com/govuk-one-login/authentication-acceptance-tests/pull/673
