### PR TITLE
AUT-4390: Provide a userId for the AUTH_ACCOUNT_TEMPORARILY_LOCKED audit event

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandler.java
@@ -125,12 +125,21 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
 
             var userProfile = authenticationService.getUserProfileByEmailMaybe(emailAddress);
             var userExists = userProfile.isPresent();
+            var internalCommonSubjectId =
+                    userExists
+                            ? ClientSubjectHelper.getSubjectWithSectorIdentifier(
+                                            userProfile.get(),
+                                            configurationService.getInternalSectorUri(),
+                                            authenticationService)
+                                    .getValue()
+                            : AuditService.UNKNOWN;
             userContext.getAuthSession().setEmailAddress(emailAddress);
 
             if (codeStorageService.isBlockedForEmail(
                     emailAddress,
                     CodeStorageService.PASSWORD_BLOCKED_KEY_PREFIX + JourneyType.PASSWORD_RESET)) {
                 LOG.info("User account is locked");
+                auditContext = auditContext.withSubjectId(internalCommonSubjectId);
                 authSessionService.updateSession(userContext.getAuthSession());
 
                 auditService.submitAuditEvent(
@@ -158,12 +167,6 @@ public class CheckUserExistsHandler extends BaseFrontendHandler<CheckUserExistsR
                                         userContext.getAuthSession(),
                                         authenticationService,
                                         configurationService.getInternalSectorUri())
-                                .getValue();
-                var internalCommonSubjectId =
-                        ClientSubjectHelper.getSubjectWithSectorIdentifier(
-                                        userProfile.get(),
-                                        configurationService.getInternalSectorUri(),
-                                        authenticationService)
                                 .getValue();
 
                 LOG.info("Setting internal common subject identifier in user session");

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/CheckUserExistsHandlerTest.java
@@ -332,7 +332,7 @@ class CheckUserExistsHandlerTest {
             verify(auditService)
                     .submitAuditEvent(
                             AUTH_ACCOUNT_TEMPORARILY_LOCKED,
-                            AUDIT_CONTEXT,
+                            AUDIT_CONTEXT.withSubjectId(getExpectedInternalPairwiseId()),
                             AuditService.MetadataPair.pair(
                                     "number_of_attempts_user_allowed_to_login", 5));
         }


### PR DESCRIPTION
## What

Provide a userId for the AUTH_ACCOUNT_TEMPORARILY_LOCKED audit event

## How to review

1. Code Review
2. Review of unit test changes
3. End-to-end testing of the audit event itself can only be done in staging.

The change has been regression tested in sandpit.

### Test scenario to generate the event

1. Attempt to sign-in and lockout the account by getting the password wrong 6 times
2. Start a new session and attempt to login with the same user
3. Immediately after entering the email you should see the 'You cannot sign in at the moment' screen.  This means the event has been generated.

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] No changes required or changes have been made to stub-orchestration.


