### PR TITLE
ATO-1691: use AuthSession isOneLoginService instead of client registry

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ClientSubjectHelper.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/helpers/ClientSubjectHelper.java
@@ -56,10 +56,7 @@ public class ClientSubjectHelper {
 
     public static String getSectorIdentifierForClient(
             ClientRegistry client, AuthSessionItem authSession, String internalSectorUri) {
-        LOG.info(
-                "isOneLoginService is equal on authSession and registry {}",
-                authSession.getIsOneLoginService() == client.isOneLoginService());
-        if (client.isOneLoginService()) {
+        if (authSession.getIsOneLoginService()) {
             return returnHost(internalSectorUri);
         }
         if (!hasValidClientConfig(client)) {

--- a/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ClientSubjectHelperTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/helpers/ClientSubjectHelperTest.java
@@ -71,14 +71,14 @@ class ClientSubjectHelperTest {
                 ClientSubjectHelper.getSubject(
                         userProfile,
                         clientRegistry1,
-                        AUTH_SESSION_FOR_CLIENT_1,
+                        AUTH_SESSION_FOR_CLIENT_1.withIsOneLoginService(false),
                         authenticationService,
                         INTERNAL_SECTOR_URI);
         Subject subject2 =
                 ClientSubjectHelper.getSubject(
                         userProfile,
                         clientRegistry2,
-                        AUTH_SESSION_FOR_CLIENT_2,
+                        AUTH_SESSION_FOR_CLIENT_2.withIsOneLoginService(false),
                         authenticationService,
                         INTERNAL_SECTOR_URI);
 
@@ -98,14 +98,14 @@ class ClientSubjectHelperTest {
                 ClientSubjectHelper.getSubject(
                         userProfile,
                         clientRegistry1,
-                        AUTH_SESSION_FOR_CLIENT_1,
+                        AUTH_SESSION_FOR_CLIENT_1.withIsOneLoginService(false),
                         authenticationService,
                         INTERNAL_SECTOR_URI);
         Subject subject2 =
                 ClientSubjectHelper.getSubject(
                         userProfile,
                         clientRegistry2,
-                        AUTH_SESSION_FOR_CLIENT_2,
+                        AUTH_SESSION_FOR_CLIENT_2.withIsOneLoginService(false),
                         authenticationService,
                         INTERNAL_SECTOR_URI);
 
@@ -125,14 +125,14 @@ class ClientSubjectHelperTest {
                 ClientSubjectHelper.getSubject(
                         userProfile,
                         clientRegistry1,
-                        AUTH_SESSION_FOR_CLIENT_1,
+                        AUTH_SESSION_FOR_CLIENT_1.withIsOneLoginService(false),
                         authenticationService,
                         INTERNAL_SECTOR_URI);
         Subject subject2 =
                 ClientSubjectHelper.getSubject(
                         userProfile,
                         clientRegistry2,
-                        AUTH_SESSION_FOR_CLIENT_2,
+                        AUTH_SESSION_FOR_CLIENT_2.withIsOneLoginService(false),
                         authenticationService,
                         INTERNAL_SECTOR_URI);
 
@@ -150,7 +150,7 @@ class ClientSubjectHelperTest {
                 ClientSubjectHelper.getSubject(
                         userProfile,
                         clientRegistry1,
-                        AUTH_SESSION_FOR_CLIENT_1,
+                        AUTH_SESSION_FOR_CLIENT_1.withIsOneLoginService(false),
                         authenticationService,
                         INTERNAL_SECTOR_URI);
 
@@ -170,14 +170,14 @@ class ClientSubjectHelperTest {
                 ClientSubjectHelper.getSubject(
                         userProfile,
                         clientRegistry1,
-                        AUTH_SESSION_FOR_CLIENT_1,
+                        AUTH_SESSION_FOR_CLIENT_1.withIsOneLoginService(true),
                         authenticationService,
                         INTERNAL_SECTOR_URI);
         var subject2 =
                 ClientSubjectHelper.getSubject(
                         userProfile,
                         clientRegistry2,
-                        AUTH_SESSION_FOR_CLIENT_2,
+                        AUTH_SESSION_FOR_CLIENT_2.withIsOneLoginService(false),
                         authenticationService,
                         INTERNAL_SECTOR_URI);
 
@@ -195,7 +195,7 @@ class ClientSubjectHelperTest {
                 ClientSubjectHelper.getSubject(
                         userProfile,
                         clientRegistry1,
-                        AUTH_SESSION_FOR_CLIENT_1,
+                        AUTH_SESSION_FOR_CLIENT_1.withIsOneLoginService(false),
                         authenticationService,
                         INTERNAL_SECTOR_URI);
 
@@ -211,7 +211,9 @@ class ClientSubjectHelperTest {
 
         var sectorId =
                 ClientSubjectHelper.getSectorIdentifierForClient(
-                        clientRegistry, AUTH_SESSION_FOR_CLIENT_1, INTERNAL_SECTOR_URI);
+                        clientRegistry,
+                        AUTH_SESSION_FOR_CLIENT_1.withIsOneLoginService(false),
+                        INTERNAL_SECTOR_URI);
 
         assertThat(sectorId, equalTo("test.com"));
     }
@@ -223,7 +225,9 @@ class ClientSubjectHelperTest {
 
         var sectorId =
                 ClientSubjectHelper.getSectorIdentifierForClient(
-                        clientRegistry, AUTH_SESSION_FOR_CLIENT_1, INTERNAL_SECTOR_URI);
+                        clientRegistry,
+                        AUTH_SESSION_FOR_CLIENT_1.withIsOneLoginService(true),
+                        INTERNAL_SECTOR_URI);
 
         assertThat(sectorId, equalTo("test.account.gov.uk"));
     }
@@ -236,7 +240,9 @@ class ClientSubjectHelperTest {
 
         var sectorId =
                 ClientSubjectHelper.getSectorIdentifierForClient(
-                        clientRegistry, AUTH_SESSION_FOR_CLIENT_1, INTERNAL_SECTOR_URI);
+                        clientRegistry,
+                        AUTH_SESSION_FOR_CLIENT_1.withIsOneLoginService(true),
+                        INTERNAL_SECTOR_URI);
 
         assertThat(sectorId, equalTo("test.account.gov.uk"));
     }
@@ -249,7 +255,9 @@ class ClientSubjectHelperTest {
 
         var sectorId =
                 ClientSubjectHelper.getSectorIdentifierForClient(
-                        clientRegistry, AUTH_SESSION_FOR_CLIENT_1, INTERNAL_SECTOR_URI);
+                        clientRegistry,
+                        AUTH_SESSION_FOR_CLIENT_1.withIsOneLoginService(false),
+                        INTERNAL_SECTOR_URI);
 
         assertThat(sectorId, equalTo("localhost"));
     }
@@ -269,7 +277,9 @@ class ClientSubjectHelperTest {
                 RuntimeException.class,
                 () ->
                         ClientSubjectHelper.getSectorIdentifierForClient(
-                                clientRegistry, AUTH_SESSION_FOR_CLIENT_1, INTERNAL_SECTOR_URI),
+                                clientRegistry,
+                                AUTH_SESSION_FOR_CLIENT_1.withIsOneLoginService(false),
+                                INTERNAL_SECTOR_URI),
                 "Expected to throw exception");
     }
 


### PR DESCRIPTION
### Wider context of change

We would like to move authentication away from using the ClientRegistry. To do this we need to pass information about the client from orch to auth, and store them on the auth session. A few fields we need have already been added as part of the client session migration.

### What’s changed

This PR swaps to using the is_one_login_service claim sent from orch (that's then set on AuthSession) instead of the ClientRegistry.isOneLoginService() method for ClientSubjectHelper

### Manual testing

Tested in authdev2, did a couple of journeys and all got the cookie from the frontend.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing. **N/A**
- [x] Impact on orch and auth mutual dependencies has been checked. **N/A**
- [x] Changes have been made to contract tests or not required. **N/A**
- [x] Changes have been made to the simulator or not required. **N/A**
- [x] Changes have been made to stubs or not required. **N/A**
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **N/A**
