### PR TITLE
BAU: store state in dynamo

### DIFF
--- a/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
+++ b/doc-checking-app-api/src/main/java/uk/gov/di/authentication/app/lambda/DocAppCallbackHandler.java
@@ -42,6 +42,7 @@ import uk.gov.di.orchestration.shared.services.OrchSessionService;
 import uk.gov.di.orchestration.shared.services.RedirectService;
 import uk.gov.di.orchestration.shared.services.RedisConnectionService;
 import uk.gov.di.orchestration.shared.services.SerializationService;
+import uk.gov.di.orchestration.shared.services.StateStorageService;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -119,7 +120,8 @@ public class DocAppCallbackHandler
                         configurationService,
                         new RedisConnectionService(configurationService),
                         kmsConnectionService,
-                        new JwksService(configurationService, kmsConnectionService));
+                        new JwksService(configurationService, kmsConnectionService),
+                        new StateStorageService(configurationService));
         this.tokenService =
                 new DocAppCriService(configurationService, kmsConnectionService, this.docAppCriApi);
         this.orchClientSessionService = new OrchClientSessionService(configurationService);
@@ -143,7 +145,8 @@ public class DocAppCallbackHandler
                         configurationService,
                         redis,
                         kmsConnectionService,
-                        new JwksService(configurationService, kmsConnectionService));
+                        new JwksService(configurationService, kmsConnectionService),
+                        new StateStorageService(configurationService));
         this.tokenService =
                 new DocAppCriService(configurationService, kmsConnectionService, this.docAppCriApi);
         this.orchClientSessionService = new OrchClientSessionService(configurationService);

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthenticationCallbackHandlerIntegrationTest.java
@@ -59,6 +59,7 @@ import uk.gov.di.orchestration.sharedtest.extensions.OrchClientSessionExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.OrchSessionExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.SnsTopicExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.SqsQueueExtension;
+import uk.gov.di.orchestration.sharedtest.extensions.StateStorageExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.TokenSigningExtension;
 
 import java.net.URI;
@@ -138,6 +139,9 @@ public class AuthenticationCallbackHandlerIntegrationTest extends ApiGatewayHand
 
     @RegisterExtension
     public static final OrchAuthCodeExtension orchAuthCodeExtension = new OrchAuthCodeExtension();
+
+    @RegisterExtension
+    public static final StateStorageExtension stateStorageExtension = new StateStorageExtension();
 
     protected static ConfigurationService configurationService;
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/AuthorisationIntegrationTest.java
@@ -53,6 +53,7 @@ import uk.gov.di.orchestration.sharedtest.extensions.KmsKeyExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.OrchClientSessionExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.OrchSessionExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.RpPublicKeyCacheExtension;
+import uk.gov.di.orchestration.sharedtest.extensions.StateStorageExtension;
 import uk.gov.di.orchestration.sharedtest.helper.KeyPairHelper;
 
 import java.net.HttpCookie;
@@ -94,6 +95,7 @@ import static uk.gov.di.authentication.oidc.domain.OidcAuditableEvent.AUTHORISAT
 import static uk.gov.di.authentication.oidc.domain.OidcAuditableEvent.AUTHORISATION_REQUEST_ERROR;
 import static uk.gov.di.authentication.oidc.domain.OidcAuditableEvent.AUTHORISATION_REQUEST_PARSED;
 import static uk.gov.di.authentication.oidc.domain.OidcAuditableEvent.AUTHORISATION_REQUEST_RECEIVED;
+import static uk.gov.di.authentication.oidc.services.OrchestrationAuthorizationService.AUTHENTICATION_STATE_STORAGE_PREFIX;
 import static uk.gov.di.orchestration.shared.entity.CredentialTrustLevel.LOW_LEVEL;
 import static uk.gov.di.orchestration.shared.entity.CredentialTrustLevel.MEDIUM_LEVEL;
 import static uk.gov.di.orchestration.shared.entity.ValidClaims.ADDRESS;
@@ -142,6 +144,9 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
     @RegisterExtension
     public static final OrchClientSessionExtension orchClientSessionExtention =
             new OrchClientSessionExtension();
+
+    @RegisterExtension
+    public static final StateStorageExtension stateStorageExtension = new StateStorageExtension();
 
     private static final String ENCRYPTION_KEY_ID = UUID.randomUUID().toString();
 
@@ -241,6 +246,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                             AUTHORISATION_REQUEST_RECEIVED,
                             AUTHORISATION_REQUEST_PARSED,
                             AUTHORISATION_INITIATED));
+            assertStateSavedInRedisAndDynamo(response);
         }
 
         @Test
@@ -273,6 +279,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                             AUTHORISATION_REQUEST_RECEIVED,
                             AUTHORISATION_REQUEST_PARSED,
                             AUTHORISATION_INITIATED));
+            assertStateSavedInRedisAndDynamo(response);
         }
 
         @Test
@@ -320,6 +327,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                             AUTHORISATION_REQUEST_RECEIVED,
                             AUTHORISATION_REQUEST_PARSED,
                             AUTHORISATION_INITIATED));
+            assertStateSavedInRedisAndDynamo(response);
         }
 
         @Test
@@ -373,6 +381,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                             AUTHORISATION_REQUEST_RECEIVED,
                             AUTHORISATION_REQUEST_PARSED,
                             AUTHORISATION_INITIATED));
+            assertStateSavedInRedisAndDynamo(response);
         }
 
         @Test
@@ -412,6 +421,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                             AUTHORISATION_REQUEST_RECEIVED,
                             AUTHORISATION_REQUEST_PARSED,
                             AUTHORISATION_INITIATED));
+            assertStateSavedInRedisAndDynamo(response);
         }
 
         @Test
@@ -475,6 +485,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                             AUTHORISATION_REQUEST_RECEIVED,
                             AUTHORISATION_REQUEST_PARSED,
                             AUTHORISATION_INITIATED));
+            assertStateSavedInRedisAndDynamo(response);
         }
 
         @Test
@@ -517,6 +528,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                             AUTHORISATION_REQUEST_RECEIVED,
                             AUTHORISATION_REQUEST_PARSED,
                             AUTHORISATION_INITIATED));
+            assertStateSavedInRedisAndDynamo(response);
         }
 
         @Test
@@ -573,6 +585,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                             AUTHORISATION_REQUEST_RECEIVED,
                             AUTHORISATION_REQUEST_PARSED,
                             AUTHORISATION_INITIATED));
+            assertStateSavedInRedisAndDynamo(response);
         }
 
         @Test
@@ -619,6 +632,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                             AUTHORISATION_REQUEST_RECEIVED,
                             AUTHORISATION_REQUEST_PARSED,
                             AUTHORISATION_INITIATED));
+            assertStateSavedInRedisAndDynamo(response);
         }
 
         @Test
@@ -664,6 +678,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                             AUTHORISATION_REQUEST_RECEIVED,
                             AUTHORISATION_REQUEST_PARSED,
                             AUTHORISATION_INITIATED));
+            assertStateSavedInRedisAndDynamo(response);
         }
 
         @Test
@@ -718,6 +733,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                             AUTHORISATION_REQUEST_RECEIVED,
                             AUTHORISATION_REQUEST_PARSED,
                             AUTHORISATION_INITIATED));
+            assertStateSavedInRedisAndDynamo(response);
         }
 
         @Test
@@ -766,6 +782,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                             AUTHORISATION_REQUEST_RECEIVED,
                             AUTHORISATION_REQUEST_PARSED,
                             AUTHORISATION_INITIATED));
+            assertStateSavedInRedisAndDynamo(response);
         }
 
         @Test
@@ -816,6 +833,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                             AUTHORISATION_REQUEST_RECEIVED,
                             AUTHORISATION_REQUEST_PARSED,
                             AUTHORISATION_INITIATED));
+            assertStateSavedInRedisAndDynamo(response);
         }
 
         @Test
@@ -866,6 +884,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                             AUTHORISATION_REQUEST_RECEIVED,
                             AUTHORISATION_REQUEST_PARSED,
                             AUTHORISATION_INITIATED));
+            assertStateSavedInRedisAndDynamo(response);
         }
 
         @Test
@@ -932,6 +951,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                             .get(ADDRESS.getValue())
                             .getClaimRequirement(),
                     equalTo(ClaimRequirement.ESSENTIAL));
+            assertStateSavedInRedisAndDynamo(response);
         }
 
         @ParameterizedTest
@@ -976,6 +996,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             }
             assertResponseJarHasClaimsWithValues(response, expectedClaims);
             assertResponseJarHasClaims(response, List.of("state"));
+            assertStateSavedInRedisAndDynamo(response);
         }
 
         @ParameterizedTest
@@ -1050,6 +1071,20 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                             MEDIUM_LEVEL,
                             LevelOfConfidence.HMRC200),
                     Arguments.of(null, MEDIUM_LEVEL, null));
+        }
+
+        private void assertStateSavedInRedisAndDynamo(APIGatewayProxyResponseEvent response) {
+            var sessionCookie =
+                    getHttpCookieFromMultiValueResponseHeaders(
+                            response.getMultiValueHeaders(), "gs");
+            var sid = sessionCookie.get().getValue().split("\\.")[0];
+
+            var redisState = redis.getFromRedis(AUTHENTICATION_STATE_STORAGE_PREFIX + sid);
+            assertNotNull(redisState);
+            var dynamoState =
+                    stateStorageExtension.getStateFromDyamo(
+                            AUTHENTICATION_STATE_STORAGE_PREFIX + sid);
+            assertTrue(dynamoState.isPresent());
         }
     }
 

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/DocAppCallbackHandlerIntegrationTest.java
@@ -38,6 +38,7 @@ import uk.gov.di.orchestration.sharedtest.extensions.OrchAuthCodeExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.OrchClientSessionExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.OrchSessionExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.SqsQueueExtension;
+import uk.gov.di.orchestration.sharedtest.extensions.StateStorageExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.TokenSigningExtension;
 
 import java.net.URI;
@@ -103,6 +104,9 @@ class DocAppCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationT
 
     @RegisterExtension
     public static final OrchAuthCodeExtension orchAuthCodeExtension = new OrchAuthCodeExtension();
+
+    @RegisterExtension
+    public static final StateStorageExtension stateStorageExtension = new StateStorageExtension();
 
     protected static final ConfigurationService configurationService =
             new DocAppCallbackHandlerIntegrationTest.TestConfigurationService(

--- a/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/api/IPVCallbackHandlerIntegrationTest.java
@@ -50,6 +50,7 @@ import uk.gov.di.orchestration.sharedtest.extensions.OrchClientSessionExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.OrchSessionExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.SnsTopicExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.SqsQueueExtension;
+import uk.gov.di.orchestration.sharedtest.extensions.StateStorageExtension;
 import uk.gov.di.orchestration.sharedtest.extensions.TokenSigningExtension;
 
 import java.net.URI;
@@ -101,6 +102,10 @@ class IPVCallbackHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest
     @RegisterExtension
     protected static final AuthenticationCallbackUserInfoStoreExtension userInfoStorageExtension =
             new AuthenticationCallbackUserInfoStoreExtension(180);
+
+    @RegisterExtension
+    protected static final StateStorageExtension stateStorageExtension =
+            new StateStorageExtension();
 
     @RegisterExtension
     public static final OrchAuthCodeExtension orchAuthCodeExtension = new OrchAuthCodeExtension();

--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/StateStorageServiceTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/StateStorageServiceTest.java
@@ -1,0 +1,51 @@
+package uk.gov.di.authentication.services;
+
+import com.nimbusds.oauth2.sdk.id.State;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import uk.gov.di.authentication.shared.helpers.IdGenerator;
+import uk.gov.di.orchestration.sharedtest.extensions.StateStorageExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class StateStorageServiceTest {
+    private static final State STATE = new State();
+    private static final String SESSION_ID = "Session-ID";
+    private static final String PREFIX = "TEST_STATE:";
+
+    @RegisterExtension
+    protected static final StateStorageExtension stateStorageExtension =
+            new StateStorageExtension();
+
+    @Test
+    void itShouldFetchStateFromDynamo() {
+        withExistingState();
+        var state = stateStorageExtension.getStateFromDyamo(PREFIX + SESSION_ID);
+        assertTrue(state.isPresent());
+        assertEquals(STATE, state.get());
+    }
+
+    @Test
+    void itReturnsEmptyForUnknownSessionId() {
+        var state = stateStorageExtension.getStateFromDyamo(PREFIX + IdGenerator.generate());
+        assertFalse(state.isPresent());
+    }
+
+    @Test
+    void itPutsStateIntoDynamo() {
+        var sessionId = IdGenerator.generate();
+        var state = new State();
+
+        stateStorageExtension.addStateToDynamo(PREFIX + sessionId, state);
+
+        var fetchedState = stateStorageExtension.getStateFromDyamo(PREFIX + sessionId);
+        assertTrue(fetchedState.isPresent());
+        assertEquals(state, fetchedState.get());
+    }
+
+    private void withExistingState() {
+        stateStorageExtension.addStateToDynamo(PREFIX + SESSION_ID, STATE);
+    }
+}

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/lambda/IPVCallbackHandler.java
@@ -57,6 +57,7 @@ import uk.gov.di.orchestration.shared.services.RedirectService;
 import uk.gov.di.orchestration.shared.services.RedisConnectionService;
 import uk.gov.di.orchestration.shared.services.SerializationService;
 import uk.gov.di.orchestration.shared.services.SessionService;
+import uk.gov.di.orchestration.shared.services.StateStorageService;
 
 import java.util.List;
 import java.util.Map;
@@ -138,7 +139,8 @@ public class IPVCallbackHandler
                 new IPVAuthorisationService(
                         configurationService,
                         new RedisConnectionService(configurationService),
-                        kmsConnectionService);
+                        kmsConnectionService,
+                        new StateStorageService(configurationService));
         this.ipvTokenService = new IPVTokenService(configurationService, kmsConnectionService);
         this.sessionService = new SessionService(configurationService);
         this.orchSessionService = new OrchSessionService(configurationService);
@@ -164,7 +166,11 @@ public class IPVCallbackHandler
         var kmsConnectionService = new KmsConnectionService(configurationService);
         this.configurationService = configurationService;
         this.ipvAuthorisationService =
-                new IPVAuthorisationService(configurationService, redis, kmsConnectionService);
+                new IPVAuthorisationService(
+                        configurationService,
+                        redis,
+                        kmsConnectionService,
+                        new StateStorageService(configurationService));
         this.ipvTokenService = new IPVTokenService(configurationService, kmsConnectionService);
         this.sessionService = new SessionService(configurationService, redis);
         this.orchSessionService = new OrchSessionService(configurationService);

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationService.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationService.java
@@ -132,6 +132,8 @@ public class IPVAuthorisationService {
                     STATE_STORAGE_PREFIX + sessionId,
                     objectMapper.writeValueAsString(state),
                     configurationService.getSessionExpiry());
+
+            stateStorageService.storeState(STATE_STORAGE_PREFIX + sessionId, state);
         } catch (JsonException e) {
             LOG.error("Unable to save state to Redis");
             throw new RuntimeException(e);

--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationService.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationService.java
@@ -38,6 +38,7 @@ import uk.gov.di.orchestration.shared.services.JwksService;
 import uk.gov.di.orchestration.shared.services.KmsConnectionService;
 import uk.gov.di.orchestration.shared.services.RedisConnectionService;
 import uk.gov.di.orchestration.shared.services.SerializationService;
+import uk.gov.di.orchestration.shared.services.StateStorageService;
 
 import java.nio.charset.StandardCharsets;
 import java.security.interfaces.RSAPublicKey;
@@ -54,6 +55,7 @@ public class IPVAuthorisationService {
     private final ConfigurationService configurationService;
     private final RedisConnectionService redisConnectionService;
     private final KmsConnectionService kmsConnectionService;
+    private final StateStorageService stateStorageService;
     private final JwksService jwksService;
     private final NowClock nowClock;
     public static final String STATE_STORAGE_PREFIX = "state:";
@@ -63,13 +65,15 @@ public class IPVAuthorisationService {
     public IPVAuthorisationService(
             ConfigurationService configurationService,
             RedisConnectionService redisConnectionService,
-            KmsConnectionService kmsConnectionService) {
+            KmsConnectionService kmsConnectionService,
+            StateStorageService stateStorageService) {
         this(
                 configurationService,
                 redisConnectionService,
                 kmsConnectionService,
                 new JwksService(configurationService, kmsConnectionService),
-                new NowClock(Clock.systemUTC()));
+                new NowClock(Clock.systemUTC()),
+                stateStorageService);
     }
 
     public IPVAuthorisationService(
@@ -77,12 +81,14 @@ public class IPVAuthorisationService {
             RedisConnectionService redisConnectionService,
             KmsConnectionService kmsConnectionService,
             JwksService jwksService,
-            NowClock nowClock) {
+            NowClock nowClock,
+            StateStorageService stateStorageService) {
         this.configurationService = configurationService;
         this.redisConnectionService = redisConnectionService;
         this.kmsConnectionService = kmsConnectionService;
         this.jwksService = jwksService;
         this.nowClock = nowClock;
+        this.stateStorageService = stateStorageService;
     }
 
     public Optional<ErrorObject> validateResponse(Map<String, String> headers, String sessionId) {

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationServiceTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationServiceTest.java
@@ -238,6 +238,14 @@ class IPVAuthorisationServiceTest {
                         SESSION_EXPIRY);
     }
 
+    @Test
+    void shouldSaveStateToDynamo() throws Json.JsonException {
+        var sessionId = "session-id";
+        authorisationService.storeState(sessionId, STATE);
+
+        verify(stateStorageService).storeState(STATE_STORAGE_PREFIX + sessionId, STATE);
+    }
+
     @Nested
     class SignedJwtRequest {
         @BeforeEach

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationServiceTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationServiceTest.java
@@ -227,6 +227,21 @@ class IPVAuthorisationServiceTest {
     }
 
     @Test
+    void shouldReadDynamoStateButDoNothingWithIt() throws Json.JsonException {
+        ;
+        when(redisConnectionService.getValue(STATE_STORAGE_PREFIX + SESSION_ID))
+                .thenReturn(objectMapper.writeValueAsString(STATE));
+        Map<String, String> responseHeaders = new HashMap<>();
+        responseHeaders.put("state", STATE.getValue());
+        responseHeaders.put("code", AUTH_CODE.getValue());
+
+        assertThat(
+                authorisationService.validateResponse(responseHeaders, SESSION_ID),
+                equalTo(Optional.empty()));
+        verify(stateStorageService).getState(STATE_STORAGE_PREFIX + SESSION_ID);
+    }
+
+    @Test
     void shouldSaveStateToRedis() throws Json.JsonException {
         var sessionId = "session-id";
         authorisationService.storeState(sessionId, STATE);

--- a/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationServiceTest.java
+++ b/ipv-api/src/test/java/uk/gov/di/authentication/ipv/services/IPVAuthorisationServiceTest.java
@@ -42,6 +42,7 @@ import uk.gov.di.orchestration.shared.services.JwksService;
 import uk.gov.di.orchestration.shared.services.KmsConnectionService;
 import uk.gov.di.orchestration.shared.services.RedisConnectionService;
 import uk.gov.di.orchestration.shared.services.SerializationService;
+import uk.gov.di.orchestration.shared.services.StateStorageService;
 import uk.gov.di.orchestration.sharedtest.helper.TestClockHelper;
 
 import java.net.MalformedURLException;
@@ -96,13 +97,15 @@ class IPVAuthorisationServiceTest {
             mock(RedisConnectionService.class);
     private final KmsConnectionService kmsConnectionService = mock(KmsConnectionService.class);
     private final JwksService jwksService = mock(JwksService.class);
+    private final StateStorageService stateStorageService = mock(StateStorageService.class);
     private final IPVAuthorisationService authorisationService =
             new IPVAuthorisationService(
                     configurationService,
                     redisConnectionService,
                     kmsConnectionService,
                     jwksService,
-                    TestClockHelper.getInstance());
+                    TestClockHelper.getInstance(),
+                    stateStorageService);
     private PrivateKey privateKey;
 
     @BeforeEach

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -65,6 +65,7 @@ import uk.gov.di.orchestration.shared.services.OrchSessionService;
 import uk.gov.di.orchestration.shared.services.RedirectService;
 import uk.gov.di.orchestration.shared.services.RedisConnectionService;
 import uk.gov.di.orchestration.shared.services.SessionService;
+import uk.gov.di.orchestration.shared.services.StateStorageService;
 import uk.gov.di.orchestration.shared.services.TokenService;
 
 import java.net.URI;
@@ -124,9 +125,11 @@ public class AuthenticationCallbackHandler
     public AuthenticationCallbackHandler(ConfigurationService configurationService) {
         var kmsConnectionService = new KmsConnectionService(configurationService);
         var redisConnectionService = new RedisConnectionService(configurationService);
+        var stateStorageService = new StateStorageService(configurationService);
         var oidcApi = new OidcAPI(configurationService);
         this.configurationService = configurationService;
-        this.authorisationService = new AuthenticationAuthorizationService(redisConnectionService);
+        this.authorisationService =
+                new AuthenticationAuthorizationService(redisConnectionService, stateStorageService);
         this.tokenService =
                 new AuthenticationTokenService(configurationService, kmsConnectionService);
         this.sessionService = new SessionService(configurationService);
@@ -166,8 +169,10 @@ public class AuthenticationCallbackHandler
             RedisConnectionService redisConnectionService) {
 
         var kmsConnectionService = new KmsConnectionService(configurationService);
+        var stateStorageService = new StateStorageService(configurationService);
         this.configurationService = configurationService;
-        this.authorisationService = new AuthenticationAuthorizationService(redisConnectionService);
+        this.authorisationService =
+                new AuthenticationAuthorizationService(redisConnectionService, stateStorageService);
         this.tokenService =
                 new AuthenticationTokenService(configurationService, kmsConnectionService);
         this.sessionService = new SessionService(configurationService, redisConnectionService);

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -147,7 +147,10 @@ public class AuthenticationCallbackHandler
                         configurationService,
                         auditService,
                         new IPVAuthorisationService(
-                                configurationService, redisConnectionService, kmsConnectionService),
+                                configurationService,
+                                redisConnectionService,
+                                kmsConnectionService,
+                                stateStorageService),
                         cloudwatchMetricsService,
                         new NoSessionOrchestrationService(configurationService),
                         new TokenService(
@@ -189,7 +192,10 @@ public class AuthenticationCallbackHandler
                         configurationService,
                         auditService,
                         new IPVAuthorisationService(
-                                configurationService, redisConnectionService, kmsConnectionService),
+                                configurationService,
+                                redisConnectionService,
+                                kmsConnectionService,
+                                stateStorageService),
                         cloudwatchMetricsService,
                         new NoSessionOrchestrationService(
                                 configurationService, redisConnectionService),

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -77,6 +77,7 @@ import uk.gov.di.orchestration.shared.services.OrchClientSessionService;
 import uk.gov.di.orchestration.shared.services.OrchSessionService;
 import uk.gov.di.orchestration.shared.services.RedisConnectionService;
 import uk.gov.di.orchestration.shared.services.SessionService;
+import uk.gov.di.orchestration.shared.services.StateStorageService;
 import uk.gov.di.orchestration.shared.services.TokenValidationService;
 
 import java.net.URI;
@@ -192,7 +193,8 @@ public class AuthorisationHandler
                         configurationService,
                         new RedisConnectionService(configurationService),
                         kmsConnectionService,
-                        jwksService);
+                        jwksService,
+                        new StateStorageService(configurationService));
         this.cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);
         this.noSessionOrchestrationService =
                 new NoSessionOrchestrationService(configurationService);
@@ -219,7 +221,11 @@ public class AuthorisationHandler
         var jwksService = new JwksService(configurationService, kmsConnectionService);
         this.docAppAuthorisationService =
                 new DocAppAuthorisationService(
-                        configurationService, redis, kmsConnectionService, jwksService);
+                        configurationService,
+                        redis,
+                        kmsConnectionService,
+                        jwksService,
+                        new StateStorageService(configurationService));
         this.cloudwatchMetricsService = new CloudwatchMetricsService(configurationService);
         this.noSessionOrchestrationService =
                 new NoSessionOrchestrationService(configurationService, redis);

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/StateStorageExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/StateStorageExtension.java
@@ -1,0 +1,77 @@
+package uk.gov.di.orchestration.sharedtest.extensions;
+
+import com.nimbusds.oauth2.sdk.id.State;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
+import software.amazon.awssdk.services.dynamodb.model.BillingMode;
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.KeyType;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
+import uk.gov.di.orchestration.shared.services.ConfigurationService;
+import uk.gov.di.orchestration.shared.services.StateStorageService;
+import uk.gov.di.orchestration.sharedtest.basetest.DynamoTestConfiguration;
+
+import java.util.Optional;
+
+public class StateStorageExtension extends DynamoExtension implements AfterEachCallback {
+
+    public static final String TABLE_NAME = "local-State-Storage";
+    public static final String PREFIXED_SESSION_ID = "PrefixedSessionId";
+    private StateStorageService stateStorageService;
+    private final ConfigurationService configurationService;
+
+    public StateStorageExtension() {
+        createInstance();
+        this.configurationService =
+                new DynamoTestConfiguration(REGION, ENVIRONMENT, DYNAMO_ENDPOINT);
+        stateStorageService = new StateStorageService(configurationService);
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+        super.beforeAll(context);
+
+        stateStorageService = new StateStorageService(configurationService);
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) throws Exception {
+        clearDynamoTable(dynamoDB, TABLE_NAME, PREFIXED_SESSION_ID);
+    }
+
+    @Override
+    protected void createTables() {
+        if (!tableExists(TABLE_NAME)) {
+            createOrchSessionTable();
+        }
+    }
+
+    private void createOrchSessionTable() {
+        CreateTableRequest request =
+                CreateTableRequest.builder()
+                        .tableName(TABLE_NAME)
+                        .keySchema(
+                                KeySchemaElement.builder()
+                                        .keyType(KeyType.HASH)
+                                        .attributeName(PREFIXED_SESSION_ID)
+                                        .build())
+                        .billingMode(BillingMode.PAY_PER_REQUEST)
+                        .attributeDefinitions(
+                                AttributeDefinition.builder()
+                                        .attributeName(PREFIXED_SESSION_ID)
+                                        .attributeType(ScalarAttributeType.S)
+                                        .build())
+                        .build();
+        dynamoDB.createTable(request);
+    }
+
+    public void addStateToDynamo(String prefixedSessionId, State state) {
+        stateStorageService.storeState(prefixedSessionId, state);
+    }
+
+    public Optional<State> getStateFromDyamo(String prefixedSessionId) {
+        return stateStorageService.getState(prefixedSessionId);
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/StoredState.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/entity/StoredState.java
@@ -1,0 +1,65 @@
+package uk.gov.di.orchestration.shared.entity;
+
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbAttribute;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+
+@DynamoDbBean
+public class StoredState {
+    private static final String ATTRIBUTE_PREFIXED_SESSION_ID = "PrefixedSessionId";
+    private static final String ATTRIBUTE_STATE = "State";
+    private static final String ATTRIBUTE_TIME_TO_LIVE = "ttl";
+
+    private String prefixedSessionId;
+    private String state;
+    private long ttl;
+
+    public StoredState() {}
+
+    public StoredState(String prefixedSessionId) {
+        this.prefixedSessionId = prefixedSessionId;
+    }
+
+    @DynamoDbPartitionKey
+    @DynamoDbAttribute(ATTRIBUTE_PREFIXED_SESSION_ID)
+    public String getPrefixedSessionId() {
+        return this.prefixedSessionId;
+    }
+
+    public void setPrefixedSessionId(String prefixedSessionId) {
+        this.prefixedSessionId = prefixedSessionId;
+    }
+
+    public StoredState withPrefixedSessionId(String prefixedSessionId) {
+        this.prefixedSessionId = prefixedSessionId;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_STATE)
+    public String getState() {
+        return state;
+    }
+
+    public void setState(String state) {
+        this.state = state;
+    }
+
+    public StoredState withState(String state) {
+        this.state = state;
+        return this;
+    }
+
+    @DynamoDbAttribute(ATTRIBUTE_TIME_TO_LIVE)
+    public long getTtl() {
+        return ttl;
+    }
+
+    public void setTtl(long ttl) {
+        this.ttl = ttl;
+    }
+
+    public StoredState withTtl(long ttl) {
+        this.ttl = ttl;
+        return this;
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/exceptions/StateStorageException.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/exceptions/StateStorageException.java
@@ -1,0 +1,7 @@
+package uk.gov.di.orchestration.shared.exceptions;
+
+public class StateStorageException extends RuntimeException {
+    public StateStorageException(String message) {
+        super(message);
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/DocAppAuthorisationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/DocAppAuthorisationService.java
@@ -51,6 +51,7 @@ public class DocAppAuthorisationService {
     private final RedisConnectionService redisConnectionService;
     private final KmsConnectionService kmsConnectionService;
     private final JwksService jwksService;
+    private final StateStorageService stateStorageService;
     public static final String STATE_STORAGE_PREFIX = "state:";
 
     public static final String STATE_PARAM = "state";
@@ -62,11 +63,13 @@ public class DocAppAuthorisationService {
             ConfigurationService configurationService,
             RedisConnectionService redisConnectionService,
             KmsConnectionService kmsConnectionService,
-            JwksService jwksService) {
+            JwksService jwksService,
+            StateStorageService stateStorageService) {
         this.configurationService = configurationService;
         this.redisConnectionService = redisConnectionService;
         this.kmsConnectionService = kmsConnectionService;
         this.jwksService = jwksService;
+        this.stateStorageService = stateStorageService;
     }
 
     public Optional<ErrorObject> validateResponse(Map<String, String> headers, String sessionId) {
@@ -112,6 +115,8 @@ public class DocAppAuthorisationService {
                     STATE_STORAGE_PREFIX + sessionId,
                     objectMapper.writeValueAsString(state),
                     configurationService.getSessionExpiry());
+
+            stateStorageService.storeState(STATE_STORAGE_PREFIX + sessionId, state);
         } catch (JsonException e) {
             LOG.error("Unable to save state to Redis");
             throw new DocAppAuthorisationServiceException(e);

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/DocAppAuthorisationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/DocAppAuthorisationService.java
@@ -127,6 +127,9 @@ public class DocAppAuthorisationService {
         var value =
                 Optional.ofNullable(
                         redisConnectionService.getValue(STATE_STORAGE_PREFIX + sessionId));
+        var dynamoState = stateStorageService.getState(STATE_STORAGE_PREFIX + sessionId);
+        logComparisonBetweenStateValues(value, dynamoState);
+
         if (value.isEmpty()) {
             LOG.info("No Doc Checking App state found in Redis");
             return false;
@@ -261,6 +264,38 @@ public class DocAppAuthorisationService {
         } catch (MalformedURLException e) {
             LOG.error("Invalid JWKs URL", e);
             throw new DocAppAuthorisationServiceException(e);
+        }
+    }
+
+    private void logComparisonBetweenStateValues(
+            Optional<String> redisStateOpt, Optional<State> dynamoStateOpt) {
+        try {
+            if (redisStateOpt.isEmpty() && dynamoStateOpt.isEmpty()) {
+                LOG.info("Both redis and dynamo state are empty");
+                return;
+            }
+            if (redisStateOpt.isPresent() && dynamoStateOpt.isEmpty()
+                    || redisStateOpt.isEmpty() && dynamoStateOpt.isPresent()) {
+                LOG.info(
+                        "Either one of redis or Dynamo state is not present. Redis present: {}, Dynamo present: {}",
+                        redisStateOpt.isPresent(),
+                        dynamoStateOpt.isPresent());
+                return;
+            }
+
+            var redisState = objectMapper.readValue(redisStateOpt.get(), State.class);
+            var dyanmoState = dynamoStateOpt.get();
+
+            LOG.info(
+                    "Dynamo state: {} and redis state: {}. Are equal: {}",
+                    dyanmoState.getValue(),
+                    redisState.getValue(),
+                    dyanmoState.getValue().equals(redisState.getValue()));
+
+        } catch (Exception e) {
+            LOG.warn(
+                    "Exception when comparing redis and dynamo state: {}. Continuing as normal",
+                    e.getMessage());
         }
     }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/StateStorageService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/StateStorageService.java
@@ -1,0 +1,69 @@
+package uk.gov.di.orchestration.shared.services;
+
+import com.nimbusds.oauth2.sdk.id.State;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import uk.gov.di.orchestration.shared.entity.StoredState;
+import uk.gov.di.orchestration.shared.exceptions.StateStorageException;
+import uk.gov.di.orchestration.shared.helpers.NowHelper;
+
+import java.time.Clock;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+
+public class StateStorageService extends BaseDynamoService<StoredState> {
+    private static final Logger LOG = LogManager.getLogger(StateStorageService.class);
+    private final long timeToLive;
+    private final NowHelper.NowClock nowClock;
+
+    public StateStorageService(ConfigurationService configurationService) {
+        super(StoredState.class, "State-Storage", configurationService, true);
+        this.timeToLive = configurationService.getSessionExpiry();
+        this.nowClock = new NowHelper.NowClock(Clock.systemUTC());
+    }
+
+    public StateStorageService(
+            DynamoDbClient dynamoDbClient,
+            DynamoDbTable<StoredState> dynamoDbTable,
+            ConfigurationService configurationService,
+            Clock clock) {
+        super(dynamoDbTable, dynamoDbClient, configurationService);
+        this.timeToLive = configurationService.getSessionExpiry();
+        this.nowClock = new NowHelper.NowClock(clock);
+    }
+
+    public void storeState(String prefixedSessionId, State state) {
+        LOG.info("Storing State in dynamo");
+
+        try {
+            put(
+                    new StoredState(prefixedSessionId)
+                            .withState(state.getValue())
+                            .withTtl(
+                                    nowClock.nowPlus(timeToLive, ChronoUnit.SECONDS)
+                                            .toInstant()
+                                            .getEpochSecond()));
+        } catch (Exception e) {
+            LOG.error("Failed to store state in Dynamo: {}", e.getMessage());
+            throw new StateStorageException("Failed to store state in Dynamo");
+        }
+    }
+
+    public Optional<State> getState(String prefixedSessionId) {
+        Optional<StoredState> storedState;
+
+        try {
+            storedState = get(prefixedSessionId);
+        } catch (Exception e) {
+            LOG.error("Failed to fetch state from Dynamo: {}", e.getMessage());
+            throw new StateStorageException("Failed to fetch state from Dynamo");
+        }
+
+        return storedState
+                .filter(s -> s.getTtl() > nowClock.now().toInstant().getEpochSecond())
+                .map(StoredState::getState)
+                .map(State::parse);
+    }
+}

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/DocAppAuthorisationServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/DocAppAuthorisationServiceTest.java
@@ -129,6 +129,18 @@ class DocAppAuthorisationServiceTest {
     }
 
     @Test
+    void shouldCallDynamoToCheckIfStateIsPresentButDoNothingWithIt() {
+        Map<String, String> responseHeaders = new HashMap<>();
+        responseHeaders.put("code", AUTH_CODE.getValue());
+        responseHeaders.put("state", STATE.getValue());
+
+        assertThat(
+                authorisationService.validateResponse(responseHeaders, SESSION_ID),
+                equalTo(Optional.empty()));
+        verify(stateStorageService).getState(STATE_STORAGE_PREFIX + SESSION_ID);
+    }
+
+    @Test
     void shouldReturnErrorObjectWhenResponseContainsError() {
         ErrorObject errorObject =
                 new ErrorObject(

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/DocAppAuthorisationServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/DocAppAuthorisationServiceTest.java
@@ -82,12 +82,14 @@ class DocAppAuthorisationServiceTest {
             mock(RedisConnectionService.class);
     private final KmsConnectionService kmsConnectionService = mock(KmsConnectionService.class);
     private final JwksService jwksService = mock(JwksService.class);
+    private final StateStorageService stateStorageService = mock(StateStorageService.class);
     private final DocAppAuthorisationService authorisationService =
             new DocAppAuthorisationService(
                     configurationService,
                     redisConnectionService,
                     kmsConnectionService,
-                    jwksService);
+                    jwksService,
+                    stateStorageService);
     private PrivateKey privateKey;
 
     private final ClientRegistry clientRegistry = mock(ClientRegistry.class);
@@ -209,6 +211,14 @@ class DocAppAuthorisationServiceTest {
                         STATE_STORAGE_PREFIX + sessionId,
                         objectMapper.writeValueAsString(STATE),
                         SESSION_EXPIRY);
+    }
+
+    @Test
+    void shouldSaveStateToDynamo() {
+        var sessionId = "session-id";
+        authorisationService.storeState(sessionId, STATE);
+
+        verify(stateStorageService).storeState(STATE_STORAGE_PREFIX + sessionId, STATE);
     }
 
     @ParameterizedTest

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/StateStorageServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/StateStorageServiceTest.java
@@ -1,0 +1,146 @@
+package uk.gov.di.orchestration.shared.services;
+
+import com.nimbusds.oauth2.sdk.id.State;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.enhanced.dynamodb.model.GetItemEnhancedRequest;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.DynamoDbException;
+import uk.gov.di.orchestration.shared.entity.StoredState;
+import uk.gov.di.orchestration.shared.exceptions.StateStorageException;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+
+import static java.time.Clock.fixed;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class StateStorageServiceTest {
+    private static final State TEST_STATE = new State("TEST_STATE");
+    private static final String TEST_SESSION_ID = "TEST_SESSION_ID";
+    private static final String TEST_SESSION_ID_PREFIX = "SOME_STATE:";
+    private static final String TEST_SESSION_ID_WITH_PREFIX =
+            TEST_SESSION_ID_PREFIX + TEST_SESSION_ID;
+    // 2025-05-27T14:21:28Z
+    private static final long FIXED_TIMESTAMP = 1748355688L;
+    private static final long MOCKED_TTL = 86400L;
+    private static final Clock TEST_CLOCK =
+            fixed(Instant.ofEpochSecond(FIXED_TIMESTAMP), ZoneId.systemDefault());
+    private static final long VALID_TTL =
+            Instant.ofEpochSecond(FIXED_TIMESTAMP).plusSeconds(100).getEpochSecond();
+    private static final long EXPIRED_TTL = Instant.now().minusSeconds(100).getEpochSecond();
+    private static final Key PREFIXED_SESSION_ID_PARTITION_KEY =
+            Key.builder().partitionValue(TEST_SESSION_ID_WITH_PREFIX).build();
+    private static final GetItemEnhancedRequest SESSION_GET_REQUEST =
+            GetItemEnhancedRequest.builder()
+                    .key(PREFIXED_SESSION_ID_PARTITION_KEY)
+                    .consistentRead(false)
+                    .build();
+
+    private final DynamoDbTable<StoredState> table = mock(DynamoDbTable.class);
+    private final DynamoDbClient dynamoDbClient = mock(DynamoDbClient.class);
+    private final ConfigurationService configurationService = mock(ConfigurationService.class);
+
+    private StateStorageService stateStorageService;
+
+    @BeforeEach
+    void setup() {
+        when(configurationService.getSessionExpiry()).thenReturn(MOCKED_TTL);
+        stateStorageService =
+                new StateStorageService(dynamoDbClient, table, configurationService, TEST_CLOCK);
+    }
+
+    @Test
+    void itCallsPutWithTheExpectedItemWhenCallingStoreState() {
+        stateStorageService.storeState(TEST_SESSION_ID_PREFIX + TEST_SESSION_ID, TEST_STATE);
+        var expectedItem =
+                new StoredState(TEST_SESSION_ID_PREFIX + TEST_SESSION_ID)
+                        .withState(TEST_STATE.getValue())
+                        .withTtl(FIXED_TIMESTAMP + MOCKED_TTL);
+
+        var putItemCaptor = ArgumentCaptor.forClass(StoredState.class);
+        verify(table).putItem(putItemCaptor.capture());
+        assertEquals(
+                expectedItem.getPrefixedSessionId(),
+                putItemCaptor.getValue().getPrefixedSessionId());
+        assertEquals(expectedItem.getState(), putItemCaptor.getValue().getState());
+        assertEquals(expectedItem.getTtl(), putItemCaptor.getValue().getTtl());
+    }
+
+    @Test
+    void itReturnsTheStateValueWhenThereIsAValidItemStored() {
+        withValidStoredState();
+
+        var storedState = stateStorageService.getState(TEST_SESSION_ID_WITH_PREFIX);
+        assertTrue(storedState.isPresent());
+        assertEquals(TEST_STATE.getValue(), storedState.get().getValue());
+    }
+
+    @Test
+    void itReturnsEmptyWhenExpiredStateStored() {
+        withExpiredStoredState();
+
+        var storedState = stateStorageService.getState(TEST_SESSION_ID_WITH_PREFIX);
+        assertTrue(storedState.isPresent());
+        assertEquals(TEST_STATE.getValue(), storedState.get().getValue());
+    }
+
+    @Test
+    void itRethrowsErrorsWhenGettingAsStateStorageException() {
+        withFailedGet();
+        assertThrows(
+                StateStorageException.class,
+                () -> stateStorageService.getState(TEST_SESSION_ID_WITH_PREFIX));
+    }
+
+    @Test
+    void itRethrowsErrorsWhenPuttingAsStateStorageException() {
+        withFailedPut();
+        assertThrows(
+                StateStorageException.class,
+                () -> stateStorageService.storeState(TEST_SESSION_ID_WITH_PREFIX, TEST_STATE));
+    }
+
+    private void withValidStoredState() {
+        when(table.getItem(SESSION_GET_REQUEST)).thenReturn(getValidStoredState());
+    }
+
+    private void withExpiredStoredState() {
+        when(table.getItem(SESSION_GET_REQUEST)).thenReturn(getExpiredStoredState());
+    }
+
+    private void withFailedPut() {
+        doThrow(DynamoDbException.builder().message("Failed to put item in table").build())
+                .when(table)
+                .putItem(any(StoredState.class));
+    }
+
+    private void withFailedGet() {
+        doThrow(DynamoDbException.builder().message("Failed to get from table").build())
+                .when(table)
+                .getItem(any(GetItemEnhancedRequest.class));
+    }
+
+    private StoredState getValidStoredState() {
+        return new StoredState(TEST_SESSION_ID_WITH_PREFIX)
+                .withState(TEST_STATE.getValue())
+                .withTtl(VALID_TTL);
+    }
+
+    private StoredState getExpiredStoredState() {
+        return new StoredState(TEST_SESSION_ID_WITH_PREFIX)
+                .withState(TEST_STATE.getValue())
+                .withTtl(EXPIRED_TTL);
+    }
+}

--- a/template.yaml
+++ b/template.yaml
@@ -849,6 +849,63 @@ Resources:
 
   #endregion
 
+  #region State Storage Table
+
+  StateStorageTableEncryptionKey:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: KMS encryption key for Orchestration State storage DynamoDB table
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowIamManagement
+            Effect: Allow
+            Principal:
+              AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+            Action: kms:*
+            Resource: "*"
+          - Sid: AllowDynamodbAccessToEncryptionKey
+            Effect: Allow
+            Principal:
+              Service: dynamodb.amazonaws.com
+            Action:
+              - kms:Encrypt
+              - kms:Decrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+              - kms:DescribeKey
+            Resource: "*"
+            Condition:
+              ArnLike:
+                kms:EncryptionContext:aws:dynamodb:table/arn: !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/*
+
+  StateStorageTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: !Sub ${Environment}-State-Storage
+      AttributeDefinitions:
+        - AttributeName: PrefixedSessionId
+          AttributeType: S
+      KeySchema:
+        - AttributeName: PrefixedSessionId
+          KeyType: HASH
+      BillingMode: PAY_PER_REQUEST
+      SSESpecification:
+        SSEEnabled: true
+        KMSMasterKeyId: !GetAtt StateStorageTableEncryptionKey.Arn
+        SSEType: KMS
+      TimeToLiveSpecification:
+        AttributeName: ttl
+        Enabled: true
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: true
+      Tags:
+        - Key: Name
+          Value: StateStorageTable
+
+  #endregion
+
   #region Fetch JWKS Lambda
 
   FetchJwksFunction:

--- a/template.yaml
+++ b/template.yaml
@@ -3012,6 +3012,7 @@ Resources:
         - !Ref OrchSessionTableReadAndWriteAccessPolicy
         - !Ref OrchSessionTableDeleteAccessPolicy
         - !Ref ClientSessionTableWriteAccessPolicy
+        - !Ref StateStorageTableWriteAccessPolicy
       Tags:
         CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_116.CKV_AWS_173
 
@@ -5329,6 +5330,55 @@ Resources:
               - kms:CreateGrant
               - kms:DescribeKey
             Resource: !GetAtt RpPublicKeyTableEncryptionKey.Arn
+
+  #region State Storage policies #
+
+  StateStorageTableReadAccessPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowStateStorageTableReadAccess
+            Effect: Allow
+            Action:
+              - dynamodb:DescribeTable
+              - dynamodb:Get*
+            Resource: !GetAtt StateStorageTable.Arn
+          - Sid: AllowStateStorageTableKeyAccess
+            Effect: Allow
+            Action:
+              - kms:Encrypt
+              - kms:Decrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+              - kms:CreateGrant
+              - kms:DescribeKey
+            Resource: !GetAtt StateStorageTableEncryptionKey.Arn
+
+  StateStorageTableWriteAccessPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowStateStorageTableWriteAccess
+            Effect: Allow
+            Action:
+              - dynamodb:PutItem #We won't be updating items, only getting and putting
+            Resource: !GetAtt StateStorageTable.Arn
+          - Sid: AllowStateStorageTableKeyAccess
+            Effect: Allow
+            Action:
+              - kms:Encrypt
+              - kms:Decrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+              - kms:CreateGrant
+              - kms:DescribeKey
+            Resource: !GetAtt StateStorageTableEncryptionKey.Arn
+
+  #endregion
 
   TxmaQueueSendPermissionPolicy:
     Type: AWS::IAM::ManagedPolicy

--- a/template.yaml
+++ b/template.yaml
@@ -4088,6 +4088,7 @@ Resources:
         - !Ref ClientSessionTableReadAccessPolicy
         - !Ref ClientSessionTableDeleteAccessPolicy
         - !Ref OrchAuthCodeTableWriteAccessPolicy
+        - !Ref StateStorageTableReadAccessPolicy
       Tags:
         CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_116.CKV_AWS_173
 

--- a/template.yaml
+++ b/template.yaml
@@ -1605,6 +1605,7 @@ Resources:
         - !Ref OrchSessionTableReadAccessPolicy
         - !Ref ClientSessionTableReadAccessPolicy
         - !Ref OrchAuthCodeTableWriteAccessPolicy
+        - !Ref StateStorageTableReadAccessPolicy
       Tags:
         CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_116.CKV_AWS_173
 

--- a/template.yaml
+++ b/template.yaml
@@ -2365,6 +2365,7 @@ Resources:
         - !Ref OrchSessionTableReadWriteAndDeleteAccessPolicy
         - !Ref ClientSessionTableReadWriteAndDeleteAccessPolicy
         - !Ref OrchAuthCodeTableWriteAccessPolicy
+        - !Ref StateStorageTableReadWriteAccessPolicy
       Tags:
         CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_116.CKV_AWS_173
 
@@ -5378,6 +5379,29 @@ Resources:
               - kms:DescribeKey
             Resource: !GetAtt StateStorageTableEncryptionKey.Arn
 
+  StateStorageTableReadWriteAccessPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowStateStorageTableWriteAccess
+            Effect: Allow
+            Action:
+              - dynamodb:PutItem
+              - dynamodb:DescribeTable
+              - dynamodb:Get*
+            Resource: !GetAtt StateStorageTable.Arn
+          - Sid: AllowStateStorageTableKeyAccess
+            Effect: Allow
+            Action:
+              - kms:Encrypt
+              - kms:Decrypt
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+              - kms:CreateGrant
+              - kms:DescribeKey
+            Resource: !GetAtt StateStorageTableEncryptionKey.Arn
   #endregion
 
   TxmaQueueSendPermissionPolicy:


### PR DESCRIPTION
### Wider context of change:

We want to migrate away from using redis where possible. We currently use redis to store the state we use when redirecting to different components. To move away from this we must firstly start storing state in the new table. This PR does that and also starts to fetch the state and log a comparison between the stores.

### What’s changed:
- Creates a new State Storage table alongside a CMK for encryption
- Writes to the new state storage table at Authorize and Authentication callback
- Reads from new state storage table at our callback lambdas

### Manual testing: 
- TODO: Deploy to dev and run through a:
- Auth only journey
- Identity journey
- Doc app journey

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
