### PR TITLE
BAU: Log session id when hitting no redis session error

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -258,9 +258,13 @@ public class AuthenticationCallbackHandler
                     sessionService
                             .getSession(sessionId)
                             .orElseThrow(
-                                    () ->
-                                            new AuthenticationCallbackException(
-                                                    "Shared session not found in Redis"));
+                                    () -> {
+                                        LOG.warn(
+                                                "Shared session not found in redis for ID: {}",
+                                                sessionId);
+                                        return new AuthenticationCallbackException(
+                                                "Shared session not found in Redis");
+                                    });
             var orchSession =
                     orchSessionService
                             .getSession(sessionId)


### PR DESCRIPTION
# authentication-api PR template picker

> [!TIP]
> Please go to the `Preview` tab and select the appropriate sub-template

## Templates

- [Auth Team](?expand=1&template=auth_template.md)
- [Orchestration Team](?expand=1&template=orch_template.md)
