### PR TITLE
ATO-1721: Enable SnapStart for ClientRegistrationHandler

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -3862,6 +3862,8 @@ Resources:
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdA
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdB
           - Fn::ImportValue: !Sub ${VpcStackName}-PrivateSubnetIdC
+      SnapStart:
+        ApplyOn: PublishedVersions
       Environment:
         Variables:
           # checkov:skip=CKV_AWS_173: These environment variables do not require encryption.


### PR DESCRIPTION
### Wider context of change

We would like to enable SnapStart on most of our lambdas, to decrease response time.

### What’s changed

This PR turns on SnapStart for the `ClientRegistrationHandler` lambda

### Manual testing

Tested by updating client config with and without snapstart

Without snapstart: Took **5 seconds** for the lambda to initialise
With snapstart:      Took **1 second** for the lambda to initialise

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.
