### PR TITLE
AUT-4444: Add notificationIdentifier to OpenAPI spec for PUT request

### DIFF
--- a/ci/terraform/account-management/openapi_v2.yaml
+++ b/ci/terraform/account-management/openapi_v2.yaml
@@ -407,6 +407,7 @@ paths:
               $ref: "#/components/schemas/MfaMethodUpdateRequest"
             examples:
               update-sms:
+                summary: a user with a default mfa method of SMS before update who has changed their phone number
                 value:
                   {
                     "mfaMethod":
@@ -420,9 +421,27 @@ paths:
                           },
                       },
                   }
-              update-auth-app:
+              change-default-mfa:
+                summary: a user with a default mfa method of auth app before update who is changing their default to SMS
                 value:
                   {
+                    "notificationIdentifier": "CHANGED_DEFAULT_MFA",
+                    "mfaMethod":
+                      {
+                        "priorityIdentifier": "DEFAULT",
+                        "method":
+                          {
+                            "mfaMethodType": "SMS",
+                            "phoneNumber": "070",
+                            "otp": "123456",
+                          },
+                      },
+                  }
+              change-auth-app:
+                summary: a user with a default mfa method of auth app before update who is changing to a new auth app
+                value:
+                  {
+                    "notificationIdentifier": "CHANGED_AUTHENTICATOR_APP",
                     "mfaMethod":
                       {
                         "priorityIdentifier": "DEFAULT",
@@ -434,7 +453,12 @@ paths:
                       },
                   }
               swap-backup-with-default:
-                value: { "mfaMethod": { "priorityIdentifier": "DEFAULT" } }
+                value:
+                  {
+                    "notificationIdentifier": "SWITCHED_MFA_METHODS",
+                    "mfaMethod": { "priorityIdentifier": "DEFAULT" },
+                  }
+
         required: true
       responses:
         "200":
@@ -763,14 +787,25 @@ components:
             mfaMethodType: AUTH_APP
             credential: "AAAABBBBCCCCCDDDDD55551111EEEE2222FFFF3333GGGG4444"
 
+    MfaMethodUpdateNotificationEnum:
+      type: string
+      enum:
+        - CHANGED_AUTHENTICATOR_APP
+        - CHANGED_DEFAULT_MFA
+        - SWITCHED_MFA_METHODS
+
     MfaMethodUpdateRequest:
       required:
         - mfaMethod
       type: object
       properties:
+        notificationIdentifier:
+          $ref: "#/components/schemas/MfaMethodUpdateNotificationEnum"
+          description: "Identifier for the confirmation notification to be sent."
         mfaMethod:
           $ref: "#/components/schemas/MfaMethodCreate"
       example:
+        notificationIdentifier: CHANGED_AUTHENTICATOR_APP
         mfaMethod:
           priorityIdentifier: DEFAULT
           method:


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

As part of the method management confirmation email work, we’re having difficulty differentiating between the calls to the method management PUT endpoint in order to send the correct notification email.

We wish to add a new optional parameter to the payload of the PUT requests to specify which confirmation email should be sent.

The method management OpenAPI spec needs to be updated prior to code changes.

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

1. Code Review

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked. **- N/A**

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [ ] No changes required or changes have been made to stub-orchestration. **- N/A**

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed. **- N/A**