### PR TITLE
BAU: Add missing AM write policy to send-otp-notification lambda

### DIFF
--- a/ci/terraform/account-management/send-otp-notification.tf
+++ b/ci/terraform/account-management/send-otp-notification.tf
@@ -15,6 +15,7 @@ module "account_management_api_send_notification_role" {
     local.pending_email_check_queue_access_policy_arn,
     local.email_check_results_encryption_policy_arn,
     aws_iam_policy.check_email_fraud_block_read_dynamo_read_access_policy.arn,
+    aws_iam_policy.dynamo_am_user_write_access_policy.arn,
   ]
   extra_tags = {
     Service = "send-otp-notification"


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

For a non-migrated user with only an auth app, a call to the `/send-otp-notification` lambda (e.g., as we're wanting to add an SMS backup method) can result in an `updateItem` call being made on the `user-credentials` table, which the lambda currently does not have permissions for.

See the stack trace below for the calls (originating from the `isPhoneAlreadyInUseAsAVerifiedMfa` method):

```
authdev2-send-otp-notification-lambda is not authorized to perform: dynamodb:UpdateItem on resource: arn:aws:dynamodb:eu-west-2:<ACCOUNT_NO>:table/authdev2-user-credentials

...

	at software.amazon.awssdk.enhanced.dynamodb.internal.client.DefaultDynamoDbTable.updateItem(DefaultDynamoDbTable.java:286)
	at uk.gov.di.authentication.shared.services.DynamoService.setMfaIdentifierForNonMigratedUserEnabledAuthApp(DynamoService.java:869)
	at uk.gov.di.authentication.shared.services.mfa.MFAMethodsService.getMfaMethodForNonMigratedUser(MFAMethodsService.java:141)
	at uk.gov.di.authentication.shared.services.mfa.MFAMethodsService.getMfaMethods(MFAMethodsService.java:92)
	at uk.gov.di.authentication.shared.services.mfa.MFAMethodsService.isPhoneAlreadyInUseAsAVerifiedMfa(MFAMethodsService.java:54)
	at uk.gov.di.accountmanagement.lambda.SendOtpNotificationHandler.sendOtpRequestHandler(SendOtpNotificationHandler.java:286)
	at uk.gov.di.accountmanagement.lambda.SendOtpNotificationHandler.lambda$handleRequest$0(SendOtpNotificationHandler.java:147)
	at uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall(InstrumentationHelper.java:21)
	at uk.gov.di.accountmanagement.lambda.SendOtpNotificationHandler.handleRequest(SendOtpNotificationHandler.java:145)
```

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

1. Code Review
1. Deploy to a dev env, send a request to the `/send-otp-notification` endpoint, should return a 2xx response.
1. Optionally, deploy main to a dev env (with `./deploy-authdevs.sh -b -a`), hit the `/send-otp-notification` endpoint with a non-migrated account with auth app as the only MFA method, should return 500. Then deploy this branch (which includes the policy change) and retry the same request, should return a 2xx response.

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked. **- N/A**

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [ ] No changes required or changes have been made to stub-orchestration. **- N/A**

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed. **- N/A**
