### PR TITLE
ATO-1658: Fix format of incoming event

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/GlobalLogoutMessage.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/entity/GlobalLogoutMessage.java
@@ -4,21 +4,39 @@ import com.google.gson.annotations.Expose;
 import uk.gov.di.orchestration.shared.validation.Required;
 
 public class GlobalLogoutMessage {
-    @Expose @Required private String internalCommonSubjectId;
+    @Expose @Required private String clientId;
+    @Expose @Required private String eventId;
     @Expose @Required private String sessionId;
     @Expose @Required private String clientSessionId;
+    @Expose @Required private String internalCommonSubjectId;
+    @Expose @Required private String persistentSessionId;
+    @Expose @Required private String ipAddress;
 
     public GlobalLogoutMessage() {}
 
     public GlobalLogoutMessage(
-            String internalCommonSubjectId, String sessionId, String clientSessionId) {
-        this.internalCommonSubjectId = internalCommonSubjectId;
+            String clientId,
+            String eventId,
+            String sessionId,
+            String clientSessionId,
+            String internalCommonSubjectId,
+            String persistentSessionId,
+            String ipAddress) {
+        this.clientId = clientId;
+        this.eventId = eventId;
         this.sessionId = sessionId;
         this.clientSessionId = clientSessionId;
+        this.internalCommonSubjectId = internalCommonSubjectId;
+        this.persistentSessionId = persistentSessionId;
+        this.ipAddress = ipAddress;
     }
 
-    public String getInternalCommonSubjectId() {
-        return internalCommonSubjectId;
+    public String getClientId() {
+        return clientId;
+    }
+
+    public String getEventId() {
+        return eventId;
     }
 
     public String getSessionId() {
@@ -27,5 +45,17 @@ public class GlobalLogoutMessage {
 
     public String getClientSessionId() {
         return clientSessionId;
+    }
+
+    public String getInternalCommonSubjectId() {
+        return internalCommonSubjectId;
+    }
+
+    public String getPersistentSessionId() {
+        return persistentSessionId;
+    }
+
+    public String getIpAddress() {
+        return ipAddress;
     }
 }

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/GlobalLogoutHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/GlobalLogoutHandlerTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -21,24 +20,7 @@ public class GlobalLogoutHandlerTest {
 
     private static Stream<Arguments> invalidMessages() {
         return Stream.of(
-                Arguments.of(
-                        Named.of(
-                                "Missing internal_common_subject_id",
-                                Map.ofEntries(
-                                        Map.entry("session_id", "sid"),
-                                        Map.entry("client_session_id", "csid")))),
-                Arguments.of(
-                        Named.of(
-                                "Missing session_id",
-                                Map.ofEntries(
-                                        Map.entry("internal_common_subject_id", "icsid"),
-                                        Map.entry("client_session_id", "csid")))),
-                Arguments.of(
-                        Named.of(
-                                "Missing client_session_id",
-                                Map.ofEntries(
-                                        Map.entry("session_id", "sid"),
-                                        Map.entry("internal_common_subject_id", "icsid")))),
+                Arguments.of(Named.of("Missing required fields", "{}")),
                 Arguments.of(Named.of("Invalid JSON", "{")));
     }
 


### PR DESCRIPTION
### Wider context of change

We were missing some fields needed for sending an audit message back to txma.

### What’s changed

The missing fields have been added to GlobalLogoutMessage. I've also updated the unit test to only test for missing fields once instead of 3 times.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.

