### PR TITLE
AUT-4466: Enable the AM API V2 in Integration

### DIFF
--- a/ci/terraform/account-management/integration.tfvars
+++ b/ci/terraform/account-management/integration.tfvars
@@ -1,13 +1,7 @@
 common_state_bucket = "digital-identity-dev-tfstate"
 
-# FMS
-am_api_fms_tag_value = "accountmanagementint"
-
 # URIs
 internal_sector_uri = "https://identity.integration.account.gov.uk"
-
-# Logging
-logging_endpoint_arns = ["arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"]
 
 # Sizing
 redis_node_size        = "cache.t2.small"
@@ -17,8 +11,14 @@ lambda_min_concurrency = 1
 openapi_spec_filename = "openapi_v2.yaml"
 
 # Feature flags
-mfa_method_management_api_enabled = false
+mfa_method_management_api_enabled = true
 ais_call_in_authenticate_enabled  = true
+
+# Logging
+logging_endpoint_arns = ["arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"]
+
+# FMS
+am_api_fms_tag_value = "accountmanagementint"
 
 #Vpc endpoint IDs
 home_vpc_endpoint_id = "vpce-0e594accb3d775457"


### PR DESCRIPTION
## What

Switch on the AM API V2 in Integration.

The API is currently deployed but will not accept traffic without being switched on, and it needs to be switched on for proving the Integration environment.


## How to review

1. Code Review

## Related PRs

#6603 
