### PR TITLE
ATO-1756: Enable feature flag up to staging

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -133,7 +133,11 @@ Conditions:
       !Equals [production, !Ref Environment],
     ]
   UseAnyKeyFromDocAppJwks:
-    !Or [!Equals [dev, !Ref Environment], !Equals [build, !Ref Environment]]
+    !Or [
+      !Equals [dev, !Ref Environment],
+      !Equals [build, !Ref Environment],
+      !Equals [staging, !Ref Environment],
+    ]
 
 Mappings:
   EnvironmentConfiguration:


### PR DESCRIPTION
### Wider context of change

This feature flag is to stop using the hardcoded encryption key ID to get an encryption key from the doc app jwks endpoint, and instead use the first available encryption key on the endpoint, sending the key ID of the key we have used in the JWE headers.

This feature flag is enabled on dev and build at the moment. We would like to slowly introduce this in higher environments.

### What’s changed

This PR enables this feature flag up to staging. This *should* be fine as the JWKS endpoint only has 1 RSA encryption key on it in staging, so it should still use the key it was using before

### Checklist

- [ ] Lambdas have correct permissions for the resources they're accessing.
- [ ] Impact on orch and auth mutual dependencies has been checked.
- [ ] Changes have been made to contract tests or not required.
- [ ] Changes have been made to the simulator or not required.
- [ ] Changes have been made to stubs or not required.
- [ ] Successfully deployed to authdev or not required.
- [ ] Successfully run Authentication acceptance tests against sandpit or not required.
