### PR TITLE
AUT-4413: Configure method management alerts

### DIFF
--- a/ci/terraform/account-management/mfa-methods-create.tf
+++ b/ci/terraform/account-management/mfa-methods-create.tf
@@ -54,5 +54,9 @@ module "mfa-methods-create" {
   slack_event_topic_arn = local.slack_event_sns_topic_arn
   dynatrace_secret      = local.dynatrace_secret
 
+  runbook_link                          = "https://govukverify.atlassian.net/wiki/x/HIHpRQE"
+  lambda_log_alarm_threshold            = 1
+  lambda_log_alarm_error_rate_threshold = 25
+
   depends_on = [module.account_management_api_mfa_methods_create_role]
 }

--- a/ci/terraform/account-management/mfa-methods-delete.tf
+++ b/ci/terraform/account-management/mfa-methods-delete.tf
@@ -53,5 +53,9 @@ module "mfa-methods-delete" {
   slack_event_topic_arn = local.slack_event_sns_topic_arn
   dynatrace_secret      = local.dynatrace_secret
 
+  runbook_link                          = "https://govukverify.atlassian.net/wiki/x/HIHpRQE"
+  lambda_log_alarm_threshold            = 1
+  lambda_log_alarm_error_rate_threshold = 25
+
   depends_on = [module.account_management_api_mfa_methods_delete_role]
 }

--- a/ci/terraform/account-management/mfa-methods-retrieve.tf
+++ b/ci/terraform/account-management/mfa-methods-retrieve.tf
@@ -52,5 +52,9 @@ module "mfa-methods-retrieve" {
   slack_event_topic_arn = local.slack_event_sns_topic_arn
   dynatrace_secret      = local.dynatrace_secret
 
+  runbook_link                          = "https://govukverify.atlassian.net/wiki/x/HIHpRQE"
+  lambda_log_alarm_threshold            = 1
+  lambda_log_alarm_error_rate_threshold = 25
+
   depends_on = [module.account_management_api_mfa_methods_retrieve_role]
 }

--- a/ci/terraform/account-management/mfa-methods-update.tf
+++ b/ci/terraform/account-management/mfa-methods-update.tf
@@ -54,5 +54,9 @@ module "mfa-methods-update" {
   slack_event_topic_arn = local.slack_event_sns_topic_arn
   dynatrace_secret      = local.dynatrace_secret
 
+  runbook_link                          = "https://govukverify.atlassian.net/wiki/x/HIHpRQE"
+  lambda_log_alarm_threshold            = 1
+  lambda_log_alarm_error_rate_threshold = 25
+
   depends_on = [module.account_management_api_mfa_methods_update_role]
 }


### PR DESCRIPTION

## What

Configure method management alerts in the account management api.

- Add runbook links to the alert descriptions
- Set log error threshold to 1 initially.  Lower threshold due to low volumes and to highlight errors.
- Set error rate threshold to 25%.  Set higher due false positives at low volumes.

## How to review

1. Code Review
1. Deploy to a test environment.
1. Go to the lambda console for each lambda and run a test with empty parameters to generate an error on the lambda.
1. Check the corresponding alarm in cloudwatch to see that the alarm is triggered.
1. Alarms are only wired to slack in integration and production so the actual alert messages will have to be tested in integration only.

## Checklist

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] No changes required or changes have been made to stub-orchestration.


## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
