### PR TITLE
AUT-4503: New auth cross-acct permissions for signing keys, dynamodb and api tests

### DIFF
--- a/ci/terraform/shared/iam.tf
+++ b/ci/terraform/shared/iam.tf
@@ -86,6 +86,42 @@ data "aws_iam_policy_document" "dynamo_access_policy" {
       aws_kms_key.account_modifiers_table_encryption_key.arn
     ]
   }
+
+  statement {
+    sid    = "AllowAccessToKmsSigningKeys"
+    effect = "Allow"
+    actions = [
+      "kms:GetPublicKey",
+      "kms:Sign"
+    ]
+    resources = [
+      aws_kms_key.id_token_signing_key.arn
+    ]
+  }
+
+  statement {
+    sid    = "AllowAPITests"
+    effect = "Allow"
+    actions = [
+      "apigateway:GET",
+      "lambda:InvokeFunction",
+      "s3:ListBucket",
+      "s3:GetObject",
+      "s3:DeleteObject"
+    ]
+    resources = [
+      "arn:aws:apigateway:eu-west-2::/restapis",
+      "arn:aws:apigateway:eu-west-2::/restapis/*",
+      "arn:aws:lambda:eu-west-2:${data.aws_caller_identity.current.account_id}:function:${var.environment}-api_gateway_authorizer",
+      "arn:aws:lambda:eu-west-2:${data.aws_caller_identity.current.account_id}:function:${var.environment}-authenticate-lambda",
+      "arn:aws:lambda:eu-west-2:${data.aws_caller_identity.current.account_id}:function:${var.environment}-mfa-methods-create-lambda",
+      "arn:aws:lambda:eu-west-2:${data.aws_caller_identity.current.account_id}:function:${var.environment}-mfa-methods-retrieve-lambda",
+      "arn:aws:lambda:eu-west-2:${data.aws_caller_identity.current.account_id}:function:${var.environment}-mfa-methods-update-lambda",
+      "arn:aws:lambda:eu-west-2:${data.aws_caller_identity.current.account_id}:function:${var.environment}-send-otp-notification-lambda",
+      "arn:aws:s3:::${var.environment}-am-api-acceptance-tests-otp",
+      "arn:aws:s3:::${var.environment}-am-api-acceptance-tests-otp/*"
+    ]
+  }
 }
 
 # Create  policy to the role


### PR DESCRIPTION
## What

New auth cross-acct permissions for signing keys, dynamodb and api tests. Changes include:

1. Allow `dynamodb:DeleteItem` permission given only to auth-session table
2. CrossAccountRole (applicable only to dev, build and staging) permission update. This role is assumed by pipeline test stage

Issue: [AUT-4503]

## How to review

1. Apply the changes in the PR in dev environment (via dev-auth-deploy-pipeline deploy shared stage)
3. Temporarily edit `authentication-acceptance-tests/rundocker.sh` file, `-e SAM_STACK_NAME="authentication-api"` added to the docker run command for UI tests
4. Run acceptance tests locally: `./rundocker.sh dev-ui`

[AUT-4503]: https://govukverify.atlassian.net/browse/AUT-4503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ