### PR TITLE
ATO-1757: Enable UseAnyKeyFromDocAppJwks in integration

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -137,6 +137,7 @@ Conditions:
       !Equals [dev, !Ref Environment],
       !Equals [build, !Ref Environment],
       !Equals [staging, !Ref Environment],
+      !Equals [integration, !Ref Environment],
     ]
 
 Mappings:


### PR DESCRIPTION
### Wider context of change

This feature flag is to stop using the hardcoded encryption key ID to get an encryption key from the doc app jwks endpoint, and instead use the first available encryption key on the endpoint, sending the key ID of the key we have used in the JWE headers, as implemented in https://github.com/govuk-one-login/authentication-api/pull/6707.

This feature flag is enabled on dev, build and staging at the moment. We would like to slowly introduce this in higher environments.

### What’s changed

This PR enables this feature flag up to integration.

### Checklist

- [ ] Lambdas have correct permissions for the resources they're accessing.
- [ ] Impact on orch and auth mutual dependencies has been checked.
- [ ] Changes have been made to contract tests or not required.
- [ ] Changes have been made to the simulator or not required.
- [ ] Changes have been made to stubs or not required.
- [ ] Successfully deployed to authdev or not required.
- [ ] Successfully run Authentication acceptance tests against sandpit or not required.
