### PR TITLE
Redeploy "AUT-4466: Enable AM API V2 in Production""

### DIFF
--- a/ci/terraform/account-management/openapi_v2.yaml
+++ b/ci/terraform/account-management/openapi_v2.yaml
@@ -323,7 +323,7 @@ paths:
                 post-when-default-method-already-exists-new-one-cannot-be-created:
                   value:
                     code: 1080
-                    message: "Default method already exists, new one cannot be created"
+                    message: "Default method already exists, new one cannot be created."
                 post-when-invalid-otp-code:
                   value:
                     code: 1020

--- a/ci/terraform/account-management/production.tfvars
+++ b/ci/terraform/account-management/production.tfvars
@@ -37,7 +37,7 @@ lambda_min_concurrency = 3
 openapi_spec_filename = "openapi_v2.yaml"
 
 # Feature flags
-mfa_method_management_api_enabled = false
+mfa_method_management_api_enabled = true
 
 # Logging
 cloudwatch_log_retention = 30


### PR DESCRIPTION
Reverts govuk-one-login/authentication-api#6783

Redeploys https://github.com/govuk-one-login/authentication-api/pull/6702 enabling the Method Management API in production following a rollback of the implementation on Thu 3 July 2025.