### PR TITLE
BAU: Pin jackson-core >= 2.15.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -139,8 +139,8 @@ subprojects {
                     because 'CVE-2022-42003 is fixed in 2.12.7.1 and above'
                 }
 
-                add(conf.name, 'com.fasterxml.jackson.core:jackson-core:[2.13.0,)') {
-                    because 'CVE-2025-49128 is fixed in 2.13.0 and above'
+                add(conf.name, 'com.fasterxml.jackson.core:jackson-core:[2.15.0,)') {
+                    because 'CVE-2025-52999 is fixed in com.fasterxml.jackson.core:jackson-core:2.15.0 and higher'
                 }
 
                 add(conf.name, 'com.google.protobuf:protobuf-java:[3.25.5,)') {


### PR DESCRIPTION
## What

This should resolve CVE-2025-52999. Pinning is required as our direct dependencies have not yet been updated to include the `jackson-core` update.

## How to review

1. Code Review

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [X] Deployment of this PR will not break active user journeys

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [X] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [X] No changes required or changes have been made to stub-orchestration.
