### PR TITLE
AUT-4544: Allow Dynamodb:DeleteItem cross account permission to authentication-attempt table

### DIFF
--- a/ci/cloudformation/auth/parent.yaml
+++ b/ci/cloudformation/auth/parent.yaml
@@ -422,6 +422,7 @@ Globals:
                 dynatraceSecretArn,
               ]
         DT_OPEN_TELEMETRY_ENABLE_INTEGRATION: "true"
+        OTEL_INSTRUMENTATION_AWS_SDK_EXPERIMENTAL_USE_PROPAGATOR_FOR_MESSAGING: "true"
         JAVA_TOOL_OPTIONS: "-XX:+TieredCompilation -XX:TieredStopAtLevel=1 '--add-reads=jdk.jfr=ALL-UNNAMED'"
     KmsKeyArn: !GetAtt MainKmsKey.Arn
     Layers:

--- a/ci/terraform/shared/dynamodb.tf
+++ b/ci/terraform/shared/dynamodb.tf
@@ -759,7 +759,7 @@ resource "aws_dynamodb_resource_policy" "email-check-result" {
 resource "aws_dynamodb_resource_policy" "authentication_attempt_table" {
   count        = local.allow_cross_account_access ? 1 : 0
   resource_arn = aws_dynamodb_table.authentication_attempt_table.arn
-  policy       = data.aws_iam_policy_document.auth_cross_account_table_resource_policy_document[0].json
+  policy       = data.aws_iam_policy_document.auth_cross_account_table_resource_combined_policy_document[0].json
 }
 
 resource "aws_dynamodb_resource_policy" "auth_session_table" {


### PR DESCRIPTION
## What

Allow Dynamodb:DeleteItem cross account permission to authentication-attempt table
Issue: [AUT-4544]



[AUT-4544]: https://govukverify.atlassian.net/browse/AUT-4544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ