### PR TITLE
ATO-1745: swap read for dynamoDb doc app table

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/UserInfoHandler.java
@@ -9,7 +9,7 @@ import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
-import uk.gov.di.authentication.app.services.DynamoDocAppService;
+import uk.gov.di.authentication.app.services.DynamoDocAppCriService;
 import uk.gov.di.authentication.oidc.domain.OidcAuditableEvent;
 import uk.gov.di.authentication.oidc.entity.AccessTokenInfo;
 import uk.gov.di.authentication.oidc.services.AccessTokenService;
@@ -84,7 +84,7 @@ public class UserInfoHandler
                         new DynamoService(configurationService),
                         new DynamoIdentityService(configurationService),
                         new DynamoClientService(configurationService),
-                        new DynamoDocAppService(configurationService),
+                        new DynamoDocAppCriService(configurationService),
                         new CloudwatchMetricsService(),
                         configurationService,
                         new AuthenticationUserInfoStorageService(configurationService));
@@ -109,7 +109,7 @@ public class UserInfoHandler
                         new DynamoService(configurationService),
                         new DynamoIdentityService(configurationService),
                         new DynamoClientService(configurationService),
-                        new DynamoDocAppService(configurationService),
+                        new DynamoDocAppCriService(configurationService),
                         new CloudwatchMetricsService(),
                         configurationService,
                         new AuthenticationUserInfoStorageService(configurationService));

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/UserInfoService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/UserInfoService.java
@@ -8,7 +8,7 @@ import com.nimbusds.openid.connect.sdk.claims.UserInfo;
 import net.minidev.json.JSONArray;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import uk.gov.di.authentication.app.services.DynamoDocAppService;
+import uk.gov.di.authentication.app.services.DynamoDocAppCriService;
 import uk.gov.di.authentication.oidc.entity.AccessTokenInfo;
 import uk.gov.di.authentication.oidc.exceptions.UserInfoException;
 import uk.gov.di.orchestration.shared.entity.AuthUserInfoClaims;
@@ -35,7 +35,7 @@ public class UserInfoService {
     private final AuthenticationService authenticationService;
     private final DynamoIdentityService identityService;
     private final DynamoClientService dynamoClientService;
-    private final DynamoDocAppService dynamoDocAppService;
+    private final DynamoDocAppCriService dynamoDocAppCriService;
     private final CloudwatchMetricsService cloudwatchMetricsService;
     private final ConfigurationService configurationService;
     protected final Json objectMapper = SerializationService.getInstance();
@@ -45,14 +45,14 @@ public class UserInfoService {
             AuthenticationService authenticationService,
             DynamoIdentityService identityService,
             DynamoClientService dynamoClientService,
-            DynamoDocAppService dynamoDocAppService,
+            DynamoDocAppCriService dynamoDocAppCriService,
             CloudwatchMetricsService cloudwatchMetricsService,
             ConfigurationService configurationService,
             AuthenticationUserInfoStorageService userInfoStorageService) {
         this.authenticationService = authenticationService;
         this.identityService = identityService;
         this.dynamoClientService = dynamoClientService;
-        this.dynamoDocAppService = dynamoDocAppService;
+        this.dynamoDocAppCriService = dynamoDocAppCriService;
         this.cloudwatchMetricsService = cloudwatchMetricsService;
         this.configurationService = configurationService;
         this.userInfoStorageService = userInfoStorageService;
@@ -188,7 +188,7 @@ public class UserInfoService {
 
     private UserInfo populateDocAppUserInfo(AccessTokenInfo accessTokenInfo, UserInfo userInfo) {
         LOG.info("Populating DocAppUserInfo");
-        return dynamoDocAppService
+        return dynamoDocAppCriService
                 .getDocAppCredential(accessTokenInfo.getSubject())
                 .map(
                         docAppCredential -> {

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/UserInfoServiceTest.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.authentication.app.entity.DocAppCredential;
-import uk.gov.di.authentication.app.services.DynamoDocAppService;
+import uk.gov.di.authentication.app.services.DynamoDocAppCriService;
 import uk.gov.di.authentication.oidc.entity.AccessTokenInfo;
 import uk.gov.di.orchestration.shared.entity.AccessTokenStore;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
@@ -70,7 +70,8 @@ class UserInfoServiceTest {
     private final AuthenticationService authenticationService = mock(AuthenticationService.class);
     private final DynamoClientService dynamoClientService = mock(DynamoClientService.class);
     private final DynamoIdentityService identityService = mock(DynamoIdentityService.class);
-    private final DynamoDocAppService dynamoDocAppService = mock(DynamoDocAppService.class);
+    private final DynamoDocAppCriService dynamoDocAppCriService =
+            mock(DynamoDocAppCriService.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
     private final CloudwatchMetricsService cloudwatchMetricsService =
             mock(CloudwatchMetricsService.class);
@@ -115,7 +116,7 @@ class UserInfoServiceTest {
                         authenticationService,
                         identityService,
                         dynamoClientService,
-                        dynamoDocAppService,
+                        dynamoDocAppCriService,
                         cloudwatchMetricsService,
                         configurationService,
                         userInfoStorageService);
@@ -444,7 +445,7 @@ class UserInfoServiceTest {
                     new DocAppCredential()
                             .withSubjectID(SUBJECT.getValue())
                             .withCredential(List.of(docAppCredentialJWT));
-            when(dynamoDocAppService.getDocAppCredential(SUBJECT.getValue()))
+            when(dynamoDocAppCriService.getDocAppCredential(SUBJECT.getValue()))
                     .thenReturn(Optional.of(docAppCredential));
 
             var accessTokenStore =

--- a/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/DocumentAppCredentialStoreExtension.java
+++ b/orchestration-shared-test/src/main/java/uk/gov/di/orchestration/sharedtest/extensions/DocumentAppCredentialStoreExtension.java
@@ -89,6 +89,7 @@ public class DocumentAppCredentialStoreExtension extends DynamoExtension
 
     public void addCredential(String subjectId, List<String> credentials) {
         dynamoDocAppService.addDocAppCredential(subjectId, credentials);
+        dynamoDocAppCriService.addDocAppCredential(subjectId, credentials);
     }
 
     public Optional<DocAppCredential> getCredential(String subjectId) {


### PR DESCRIPTION
### Wider context of change

Migrating the doc App credential table from Auth to Orch

 - Merge in again as the first PR switched the permissions for the userInfo instead of appending which caused errors in Prod

### What’s changed

Added read permissions to new table for userInfo table

### Manual testing
