### PR TITLE
ATO-NONE: update BackChannelLogoutDLQAlarm Statistic to be Maximum instead of Sum

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -4789,7 +4789,7 @@ Resources:
             Fn::GetAtt:
               - BackChannelLogoutDeadLetterQueue
               - QueueName
-      Statistic: Sum
+      Statistic: Maximum
       Period: 300
       EvaluationPeriods: 1
       Threshold: 5


### PR DESCRIPTION
### Wider context of change

We were seeing the cloudwatch alarm show way higher message counts than actual messages in the DLQ. This is because the statistic for the alarm was Sum, meaning for every minute in the period, it multiplied by the number of messages (i.e. it's a five min period, so for every 1 message it returns 5). Maximum will take the maximum number of messages received (i.e. for a five min period, if the number of messages found for each minute is [2,4,6,5,0] it'll return 6). This is obviously still not ideal but the best solution to find the total number of messages and the solution suggested by AWS.

### What’s changed

Statistic is now Maximum.

### Manual testing

Have not tested in auth but don't think it's necessary as it's done for other alarms.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing. **N/A**
- [x] Impact on orch and auth mutual dependencies has been checked. **N/A**
- [x] Changes have been made to contract tests or not required. **N/A**
- [x] Changes have been made to the simulator or not required. **N/A**
- [x] Changes have been made to stubs or not required. **N/A**
- [x] Successfully deployed to authdev or not required. **N/A**
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **N/A**
