### PR TITLE
OLH-2751: Enable ACCOUNT_INTERVENTION_SERVICE_CALL_IN_AUTHENTICATE_ENABLED in prod [DO NOT MERGE]

### DIFF
--- a/ci/terraform/account-management/production.tfvars
+++ b/ci/terraform/account-management/production.tfvars
@@ -38,6 +38,7 @@ openapi_spec_filename = "openapi_v2.yaml"
 
 # Feature flags
 mfa_method_management_api_enabled = true
+ais_call_in_authenticate_enabled  = true
 
 # Logging
 cloudwatch_log_retention = 30


### PR DESCRIPTION
# authentication-api PR template picker
Enable ACCOUNT_INTERVENTION_SERVICE_CALL_IN_AUTHENTICATE_ENABLED in prod as part of Data Integrity go-live prep

DO NOT MERGE until [this PR is merged AND deployed](https://github.com/govuk-one-login/di-account-management-frontend/pull/2347)

> [!TIP]
> Please go to the `Preview` tab and select the appropriate sub-template

## Templates

- [Auth Team](?expand=1&template=auth_template.md)
- [Orchestration Team](?expand=1&template=orch_template.md)
