### PR TITLE
BAU: Handle null userProfile in error helper

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/CheckReAuthUserHandler.java
@@ -201,14 +201,15 @@ public class CheckReAuthUserHandler extends BaseFrontendHandler<CheckReauthUserR
             String userSuppliedEmail,
             Optional<UserProfile> userProfileOfSuppliedEmail) {
 
-        String uniqueUserIdentifier;
+        String uniqueUserIdentifier = rpPairwiseId;
         Optional<String> additionalIdentifier = Optional.empty();
         if (emailUserIsSignedInWith != null) {
             var userProfile = authenticationService.getUserProfileByEmail(emailUserIsSignedInWith);
-            uniqueUserIdentifier = userProfile.getSubjectID();
-            additionalIdentifier = Optional.of(rpPairwiseId);
-        } else {
-            uniqueUserIdentifier = rpPairwiseId;
+
+            if (userProfile != null) {
+                uniqueUserIdentifier = userProfile.getSubjectID();
+                additionalIdentifier = Optional.of(rpPairwiseId);
+            }
         }
 
         authenticationAttemptsService.createOrIncrementCount(


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

When an error occurs in the `CheckReAuthUserHandler`, we increment an authentication attempt count. The key we use for the count is an identifier for the user.

- If the email the user is signed in with is provided, then the subject id on the user profile will be used as the primary key and the rp pairwise id is used as a secondary key.
- Otherwise, only the rp pairwise id is used as a key.

In the first case, we are performing an unsafe method call on the userProfile object at present which can lead to a NullPointerException if the user profile can't be found. We should fall back to the default user identifier if userProfile is null.

A small number of errors have been observed due to this - see [this Slack thread](https://gds.slack.com/archives/C02HCLREVV5/p1753258718196739?thread_ts=1753213261.189319&cid=C02HCLREVV5) for more details.

Truncated error stack trace:

```
java.lang.NullPointerException: Cannot invoke "uk.gov.di.authentication.shared.entity.UserProfile.getSubjectID()" because "userProfile" is null
	at uk.gov.di.authentication.frontendapi.lambda.CheckReAuthUserHandler.generateErrorResponse(CheckReAuthUserHandler.java:208)
```

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

1. Code Review
1. Deploy to a dev env
    - TF: `./deploy-authdevs.sh -c -b -o` 
    - CF: `./sam-deploy-authdevs.sh -c -b -x authdev1`
1. Test a successful reauth journey (make one request from the orch stub, copy the rp_pairwise_id value, navigate back to the orch stub, enter the copied value, sign in again using the same email)
1. Test an error path (e.g., on the second sign in above try a different email)

## Testing

Deployed to authdev1. Ran through a reauth journey successfully (same email on reauth). Ran through an error path successfully (used a different email on reauth) - confirmed in the logs that 404 `USER_NOT_FOUND` was returned - note my auth session should've still been active at this point so `emailUserIsSignedInWith` should've been defined (meaning we entered the if block with the condition `emailUserIsSignedInWith != null`).

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
4. After any sessions containing that data have expired, remove the value’s definition.
-->

- [ ] Deployment of this PR will not break active user journeys **- N/A, should only affect new invocations of the lambda**

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked. **- N/A**

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [ ] No changes required or changes have been made to stub-orchestration. **- N/A**

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed. **- N/A**
