### PR TITLE
AUT-4449: Remove unneeded Redis configuration

### DIFF
--- a/ci/terraform/account-management/authenticate.tf
+++ b/ci/terraform/account-management/authenticate.tf
@@ -25,7 +25,6 @@ module "authenticate" {
     ENVIRONMENT                                               = var.environment
     INTERNAl_SECTOR_URI                                       = var.internal_sector_uri
     TXMA_AUDIT_QUEUE_URL                                      = module.account_management_txma_audit.queue_url
-    REDIS_KEY                                                 = var.environment == "production" ? local.redis_key : null
     ACCOUNT_INTERVENTION_SERVICE_URI                          = var.account_intervention_service_uri
     ACCOUNT_INTERVENTION_SERVICE_CALL_IN_AUTHENTICATE_ENABLED = var.ais_call_in_authenticate_enabled
   }
@@ -46,9 +45,9 @@ module "authenticate" {
   lambda_zip_file_version = aws_s3_object.account_management_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
-  security_group_ids = concat([
+  security_group_ids = [
     local.allow_aws_service_access_security_group_id,
-  ], var.environment == "production" ? [aws_security_group.allow_access_to_am_redis.id] : [])
+  ]
 
   subnet_id                              = local.private_subnet_ids
   environment                            = var.environment

--- a/ci/terraform/account-management/mfa-methods-delete.tf
+++ b/ci/terraform/account-management/mfa-methods-delete.tf
@@ -21,7 +21,6 @@ module "mfa-methods-delete" {
   endpoint_name = "mfa-methods-delete"
   handler_environment_variables = {
     ENVIRONMENT                       = var.environment
-    REDIS_KEY                         = var.environment == "production" ? local.redis_key : null
     EMAIL_QUEUE_URL                   = aws_sqs_queue.email_queue.id
     TXMA_AUDIT_QUEUE_URL              = module.account_management_txma_audit.queue_url
     INTERNAl_SECTOR_URI               = var.internal_sector_uri
@@ -39,9 +38,9 @@ module "mfa-methods-delete" {
   lambda_zip_file_version = aws_s3_object.account_management_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
-  security_group_ids = concat([
+  security_group_ids = [
     local.allow_aws_service_access_security_group_id,
-  ], var.environment == "production" ? [aws_security_group.allow_access_to_am_redis.id] : [])
+  ]
 
   subnet_id                              = local.private_subnet_ids
   environment                            = var.environment

--- a/ci/terraform/account-management/mfa-methods-retrieve.tf
+++ b/ci/terraform/account-management/mfa-methods-retrieve.tf
@@ -19,7 +19,6 @@ module "mfa-methods-retrieve" {
   endpoint_name = "mfa-methods-retrieve"
   handler_environment_variables = {
     ENVIRONMENT                       = var.environment
-    REDIS_KEY                         = var.environment == "production" ? local.redis_key : null
     TXMA_AUDIT_QUEUE_URL              = module.account_management_txma_audit.queue_url
     INTERNAl_SECTOR_URI               = var.internal_sector_uri
     MFA_METHOD_MANAGEMENT_API_ENABLED = var.mfa_method_management_api_enabled
@@ -36,9 +35,9 @@ module "mfa-methods-retrieve" {
   lambda_zip_file_version = aws_s3_object.account_management_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
-  security_group_ids = concat([
+  security_group_ids = [
     local.allow_aws_service_access_security_group_id,
-  ], var.environment == "production" ? [aws_security_group.allow_access_to_am_redis.id] : [])
+  ]
 
   subnet_id                              = local.private_subnet_ids
   environment                            = var.environment

--- a/ci/terraform/auth-external-api/userinfo.tf
+++ b/ci/terraform/auth-external-api/userinfo.tf
@@ -33,7 +33,6 @@ module "auth_userinfo" {
   handler_environment_variables = {
     ENVIRONMENT          = var.environment
     TXMA_AUDIT_QUEUE_URL = module.auth_ext_txma_audit.queue_url
-    REDIS_KEY            = var.environment == "production" ? local.redis_key : null
     INTERNAl_SECTOR_URI  = var.internal_sector_uri
   }
   handler_function_name = "uk.gov.di.authentication.external.lambda.UserInfoHandler::handleRequest"
@@ -55,9 +54,9 @@ module "auth_userinfo" {
   lambda_zip_file_version = aws_s3_object.auth_ext_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
-  security_group_ids = concat([
+  security_group_ids = [
     local.authentication_security_group_id,
-  ], var.environment == "production" ? [local.authentication_oidc_redis_security_group_id] : [])
+  ]
 
   subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.auth_userinfo_role.arn

--- a/ci/terraform/oidc/account-interventions.tf
+++ b/ci/terraform/oidc/account-interventions.tf
@@ -37,7 +37,6 @@ module "account_interventions" {
     ENVIRONMENT                                 = var.environment
     TXMA_AUDIT_QUEUE_URL                        = module.oidc_txma_audit.queue_url
     INTERNAl_SECTOR_URI                         = var.internal_sector_uri
-    REDIS_KEY                                   = var.environment == "production" ? local.redis_key : null
     ACCOUNT_INTERVENTION_SERVICE_URI            = var.account_intervention_service_uri
     ACCOUNT_INTERVENTION_SERVICE_ABORT_ON_ERROR = var.account_intervention_service_abort_on_error
     ACCOUNT_INTERVENTION_SERVICE_CALL_TIMEOUT   = var.account_intervention_service_call_timeout
@@ -64,9 +63,9 @@ module "account_interventions" {
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
 
-  security_group_ids = concat([
+  security_group_ids = [
     local.authentication_security_group_id,
-  ], var.environment == "production" ? [local.authentication_oidc_redis_security_group_id] : [])
+  ]
 
   subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.frontend_api_account_interventions_role[count.index].arn

--- a/ci/terraform/oidc/account-recovery.tf
+++ b/ci/terraform/oidc/account-recovery.tf
@@ -35,7 +35,6 @@ module "account_recovery" {
   handler_environment_variables = {
     ENVIRONMENT              = var.environment
     TXMA_AUDIT_QUEUE_URL     = module.oidc_txma_audit.queue_url
-    REDIS_KEY                = var.environment == "production" ? local.redis_key : null
     HEADERS_CASE_INSENSITIVE = "false"
     INTERNAl_SECTOR_URI      = var.internal_sector_uri
   }
@@ -56,9 +55,9 @@ module "account_recovery" {
   lambda_zip_file_version = aws_s3_object.frontend_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
-  security_group_ids = concat([
+  security_group_ids = [
     local.authentication_security_group_id,
-  ], var.environment == "production" ? [local.authentication_oidc_redis_security_group_id] : [])
+  ]
 
   subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.frontend_api_account_recovery_role.arn

--- a/ci/terraform/oidc/auth-code.tf
+++ b/ci/terraform/oidc/auth-code.tf
@@ -29,7 +29,6 @@ module "auth-code" {
 
   handler_environment_variables = {
     TXMA_AUDIT_QUEUE_URL     = module.oidc_txma_audit.queue_url
-    REDIS_KEY                = var.environment == "production" ? local.redis_key : null
     ENVIRONMENT              = var.environment
     HEADERS_CASE_INSENSITIVE = "false"
     INTERNAl_SECTOR_URI      = var.internal_sector_uri
@@ -47,9 +46,9 @@ module "auth-code" {
   lambda_zip_file_version = aws_s3_object.oidc_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
-  security_group_ids = concat([
+  security_group_ids = [
     local.authentication_security_group_id,
-  ], var.environment == "production" ? [local.authentication_oidc_redis_security_group_id] : [])
+  ]
 
   subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.oidc_auth_code_role.arn

--- a/ci/terraform/oidc/authentication-auth-code.tf
+++ b/ci/terraform/oidc/authentication-auth-code.tf
@@ -39,7 +39,6 @@ module "orch_auth_code" {
     ENVIRONMENT                    = var.environment
     TXMA_AUDIT_QUEUE_URL           = module.oidc_txma_audit.queue_url
     INTERNAl_SECTOR_URI            = var.internal_sector_uri
-    REDIS_KEY                      = var.environment == "production" ? local.redis_key : null
     SUPPORT_REAUTH_SIGNOUT_ENABLED = var.support_reauth_signout_enabled
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.AuthenticationAuthCodeHandler::handleRequest"
@@ -58,9 +57,9 @@ module "orch_auth_code" {
   lambda_zip_file_version = aws_s3_object.frontend_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
-  security_group_ids = concat([
+  security_group_ids = [
     local.authentication_security_group_id,
-  ], var.environment == "production" ? [local.authentication_oidc_redis_security_group_id] : [])
+  ]
 
   subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.frontend_api_orch_auth_code_role.arn

--- a/ci/terraform/oidc/check-email-fraud-block.tf
+++ b/ci/terraform/oidc/check-email-fraud-block.tf
@@ -34,7 +34,6 @@ module "check_email_fraud_block" {
     ENVIRONMENT                   = var.environment
     TXMA_AUDIT_QUEUE_URL          = module.oidc_txma_audit.queue_url
     INTERNAl_SECTOR_URI           = var.internal_sector_uri
-    REDIS_KEY                     = var.environment == "production" ? local.redis_key : null
     LOCKOUT_DURATION              = var.lockout_duration
     LOCKOUT_COUNT_TTL             = var.lockout_count_ttl
     SUPPORT_EMAIL_CHECK_ENABLED   = var.support_email_check_enabled
@@ -57,9 +56,9 @@ module "check_email_fraud_block" {
   lambda_zip_file_version = aws_s3_object.frontend_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
-  security_group_ids = concat([
+  security_group_ids = [
     local.authentication_security_group_id,
-  ], var.environment == "production" ? [local.authentication_oidc_redis_security_group_id] : [])
+  ]
 
   subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.frontend_api_check_email_fraud_block_role[0].arn

--- a/ci/terraform/oidc/check-reauth-user.tf
+++ b/ci/terraform/oidc/check-reauth-user.tf
@@ -36,7 +36,6 @@ module "check_reauth_user" {
     ENVIRONMENT                             = var.environment
     TXMA_AUDIT_QUEUE_URL                    = module.oidc_txma_audit.queue_url
     INTERNAl_SECTOR_URI                     = var.internal_sector_uri
-    REDIS_KEY                               = var.environment == "production" ? local.redis_key : null
     LOCKOUT_DURATION                        = var.lockout_duration
     LOCKOUT_COUNT_TTL                       = var.lockout_count_ttl
     SUPPORT_REAUTH_SIGNOUT_ENABLED          = var.support_reauth_signout_enabled
@@ -61,9 +60,9 @@ module "check_reauth_user" {
   lambda_zip_file_version = aws_s3_object.frontend_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
-  security_group_ids = concat([
+  security_group_ids = [
     local.authentication_security_group_id,
-  ], var.environment == "production" ? [local.authentication_oidc_redis_security_group_id] : [])
+  ]
 
   subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.frontend_api_check_reauth_user_role[0].arn

--- a/ci/terraform/oidc/identity-progress.tf
+++ b/ci/terraform/oidc/identity-progress.tf
@@ -31,7 +31,6 @@ module "identity_progress" {
     TXMA_AUDIT_QUEUE_URL     = module.oidc_txma_audit.queue_url
     ENVIRONMENT              = var.environment
     HEADERS_CASE_INSENSITIVE = "false"
-    REDIS_KEY                = var.environment == "production" ? local.redis_key : null
     OIDC_API_BASE_URL        = local.api_base_url,
     ORCH_DYNAMO_ARN_PREFIX   = "arn:aws:dynamodb:eu-west-2:${var.orch_account_id}:table/${var.orch_environment}-"
   }
@@ -52,9 +51,9 @@ module "identity_progress" {
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
 
-  security_group_ids = concat([
+  security_group_ids = [
     local.authentication_security_group_id,
-  ], var.environment == "production" ? [local.authentication_oidc_redis_security_group_id] : [])
+  ]
 
   subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.identity_progress_role_2.arn

--- a/ci/terraform/oidc/ipv-capacity.tf
+++ b/ci/terraform/oidc/ipv-capacity.tf
@@ -26,7 +26,6 @@ module "ipv-capacity" {
   handler_environment_variables = {
     ENVIRONMENT                    = var.environment
     TXMA_AUDIT_QUEUE_URL           = module.oidc_txma_audit.queue_url
-    REDIS_KEY                      = var.environment == "production" ? local.redis_key : null
     IPV_AUTHORISATION_URI          = var.ipv_authorisation_uri
     IPV_AUTHORISATION_CALLBACK_URI = var.ipv_authorisation_callback_uri
     IPV_AUTHORISATION_CLIENT_ID    = var.ipv_authorisation_client_id
@@ -49,9 +48,9 @@ module "ipv-capacity" {
   lambda_zip_file_version = aws_s3_object.ipv_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
-  security_group_ids = concat([
+  security_group_ids = [
     local.authentication_security_group_id,
-  ], var.environment == "production" ? [local.authentication_oidc_redis_security_group_id] : [])
+  ]
 
   subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.ipv_capacity_role.arn

--- a/ci/terraform/oidc/logout.tf
+++ b/ci/terraform/oidc/logout.tf
@@ -31,7 +31,6 @@ module "logout" {
 
   handler_environment_variables = {
     TXMA_AUDIT_QUEUE_URL                 = module.oidc_txma_audit.queue_url
-    REDIS_KEY                            = var.environment == "production" ? local.redis_key : null
     ENVIRONMENT                          = var.environment
     EXTERNAL_TOKEN_SIGNING_KEY_ALIAS     = local.id_token_signing_key_alias_name
     EXTERNAL_TOKEN_SIGNING_KEY_RSA_ALIAS = aws_kms_alias.id_token_signing_key_alias.name
@@ -52,9 +51,9 @@ module "logout" {
   lambda_zip_file_version = aws_s3_object.oidc_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
-  security_group_ids = concat([
+  security_group_ids = [
     local.authentication_security_group_id,
-  ], var.environment == "production" ? [local.authentication_oidc_redis_security_group_id] : [])
+  ]
 
   subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.oidc_logout_role.arn

--- a/ci/terraform/oidc/processing-identity.tf
+++ b/ci/terraform/oidc/processing-identity.tf
@@ -59,7 +59,6 @@ module "processing-identity" {
   handler_environment_variables = {
     TXMA_AUDIT_QUEUE_URL                        = module.oidc_txma_audit.queue_url
     ENVIRONMENT                                 = var.environment
-    REDIS_KEY                                   = var.environment == "production" ? local.redis_key : null
     INTERNAl_SECTOR_URI                         = var.internal_sector_uri
     ACCOUNT_INTERVENTION_SERVICE_ACTION_ENABLED = var.account_intervention_service_action_enabled
     ACCOUNT_INTERVENTION_SERVICE_CALL_ENABLED   = var.account_intervention_service_call_enabled
@@ -87,9 +86,9 @@ module "processing-identity" {
   lambda_zip_file_version = aws_s3_object.ipv_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
-  security_group_ids = concat([
+  security_group_ids = [
     local.authentication_security_group_id,
-  ], var.environment == "production" ? [local.authentication_oidc_redis_security_group_id] : [])
+  ]
 
   subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = var.is_orch_stubbed ? module.ipv_processing_identity_role_2.arn : module.ipv_processing_identity_role_with_orch_session_table_read_write_delete_access_2[0].arn

--- a/ci/terraform/oidc/reverification-result.tf
+++ b/ci/terraform/oidc/reverification-result.tf
@@ -30,7 +30,6 @@ module "reverification_result" {
   handler_environment_variables = {
     TXMA_AUDIT_QUEUE_URL                          = module.oidc_txma_audit.queue_url
     INTERNAl_SECTOR_URI                           = var.internal_sector_uri
-    REDIS_KEY                                     = var.environment == "production" ? local.redis_key : null
     IPV_AUDIENCE                                  = var.ipv_audience
     IPV_AUTHORISATION_CALLBACK_URI                = var.ipv_auth_authorize_callback_uri
     IPV_AUTHORISATION_CLIENT_ID                   = var.ipv_auth_authorize_client_id
@@ -57,9 +56,9 @@ module "reverification_result" {
   lambda_zip_file_version = aws_s3_object.frontend_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
-  security_group_ids = concat([
+  security_group_ids = [
     local.authentication_egress_security_group_id,
-  ], var.environment == "production" ? [local.authentication_oidc_redis_security_group_id] : [])
+  ]
 
   subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.reverification_result_role.arn

--- a/ci/terraform/oidc/signup.tf
+++ b/ci/terraform/oidc/signup.tf
@@ -36,7 +36,6 @@ module "signup" {
   handler_environment_variables = {
     ENVIRONMENT                   = var.environment
     TXMA_AUDIT_QUEUE_URL          = module.oidc_txma_audit.queue_url
-    REDIS_KEY                     = var.environment == "production" ? local.redis_key : null
     TERMS_CONDITIONS_VERSION      = var.terms_and_conditions
     INTERNAl_SECTOR_URI           = var.internal_sector_uri
     USE_STRONGLY_CONSISTENT_READS = var.use_strongly_consistent_reads
@@ -57,9 +56,9 @@ module "signup" {
   lambda_zip_file_version = aws_s3_object.frontend_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
-  security_group_ids = concat([
+  security_group_ids = [
     local.authentication_security_group_id,
-  ], var.environment == "production" ? [local.authentication_oidc_redis_security_group_id] : [])
+  ]
 
   subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.frontend_api_signup_role.arn

--- a/ci/terraform/oidc/start.tf
+++ b/ci/terraform/oidc/start.tf
@@ -36,7 +36,6 @@ module "start" {
     TXMA_AUDIT_QUEUE_URL                    = module.oidc_txma_audit.queue_url
     CUSTOM_DOC_APP_CLAIM_ENABLED            = var.custom_doc_app_claim_enabled
     DOC_APP_DOMAIN                          = var.doc_app_domain
-    REDIS_KEY                               = var.environment == "production" ? local.redis_key : null
     ENVIRONMENT                             = var.environment
     HEADERS_CASE_INSENSITIVE                = "false"
     IDENTITY_ENABLED                        = var.ipv_api_enabled
@@ -60,9 +59,9 @@ module "start" {
   lambda_zip_file_version = aws_s3_object.frontend_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
-  security_group_ids = concat([
+  security_group_ids = [
     local.authentication_security_group_id,
-  ], var.environment == "production" ? [local.authentication_oidc_redis_security_group_id] : [])
+  ]
 
   subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.frontend_api_start_role.arn

--- a/ci/terraform/oidc/update_profile.tf
+++ b/ci/terraform/oidc/update_profile.tf
@@ -33,7 +33,6 @@ module "update_profile" {
   handler_environment_variables = {
     ENVIRONMENT                   = var.environment
     TXMA_AUDIT_QUEUE_URL          = module.oidc_txma_audit.queue_url
-    REDIS_KEY                     = var.environment == "production" ? local.redis_key : null
     TERMS_CONDITIONS_VERSION      = var.terms_and_conditions
     HEADERS_CASE_INSENSITIVE      = "false"
     INTERNAl_SECTOR_URI           = var.internal_sector_uri
@@ -55,9 +54,9 @@ module "update_profile" {
   lambda_zip_file_version = aws_s3_object.frontend_api_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
-  security_group_ids = concat([
+  security_group_ids = [
     local.authentication_security_group_id,
-  ], var.environment == "production" ? [local.authentication_oidc_redis_security_group_id] : [])
+  ]
 
   subnet_id                              = local.authentication_private_subnet_ids
   lambda_role_arn                        = module.frontend_api_update_profile_role.arn


### PR DESCRIPTION
## What

Redis config is no longer required for these lambdas, so the envars and
security groups related to Redis have been removed.

The policy attachment has been retained in production, as removing it
will likely cause a brief outage while the role is updated. This can be
removed in a future PR.

## How to review

- Check that the right configuration has been removed (those modified via #6824)
- Check that policies have not been modified
