### PR TITLE
BAU: Log notification reference upon notification sending failure

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/NotificationHandler.java
@@ -150,12 +150,13 @@ public class NotificationHandler implements RequestHandler<SQSEvent, SQSBatchRes
             return;
         }
 
+        var reference =
+                String.format(
+                        "%s/%s",
+                        request.getUniqueNotificationReference(), request.getClientSessionId());
+
         try {
             var personalisation = getPersonalisation(request);
-            var reference =
-                    String.format(
-                            "%s/%s",
-                            request.getUniqueNotificationReference(), request.getClientSessionId());
 
             if (request.getNotificationType().isEmail()) {
                 notificationService.sendEmail(
@@ -174,8 +175,9 @@ public class NotificationHandler implements RequestHandler<SQSEvent, SQSBatchRes
                     request.getNotificationType(), request.getCode(), request.getDestination());
         } catch (NotificationClientException e) {
             LOG.error(
-                    "Error sending with Notify using NotificationType: {}",
-                    request.getNotificationType());
+                    "Error sending with Notify using NotificationType: {}, reference: {}",
+                    request.getNotificationType(),
+                    reference);
 
             if (isPhoneNotification(request.getNotificationType())) {
                 String countryCode =
@@ -183,15 +185,15 @@ public class NotificationHandler implements RequestHandler<SQSEvent, SQSBatchRes
                                 .orElse("unable to parse country");
                 throw new RuntimeException(
                         String.format(
-                                "Error sending Notify SMS with NotificationType: %s and country code: %s",
-                                request.getNotificationType(), countryCode),
+                                "Error sending Notify SMS with NotificationType: %s and country code: %s, reference: %s",
+                                request.getNotificationType(), countryCode, reference),
                         e);
             }
 
             throw new RuntimeException(
                     String.format(
-                            "Error sending Notify email with NotificationType: %s",
-                            request.getNotificationType()),
+                            "Error sending Notify email with NotificationType: %s, reference: %s",
+                            request.getNotificationType(), reference),
                     e);
         }
     }


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

This reference is auto-generated upon NotifyRequest instantiation and is currently logged within those handlers. This addition will help us track errors across lambdas more easily and help determine user impact metrics if we encounter any issues sending notifications.

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

1. Code Review
1. Optionally, deploy to a dev environment (e.g., using `./deploy-authdevs.sh -c -b -o`)

## Testing

Deployed to authdev2 (`./deploy-authdevs.sh -c -b -o`), checked the `authdev2-email-notification-sqs-lambda` resource had updated through the AWS UI, ran through a sign in journey for an account with SMS MFA, received SMS message, found the invocation through the UI and reviewed logs, reference value that was pulled out in this PR was present in the `Sending SMS using Notify, reference` log. As expected.

Note that this doesn't test the failure case but shows that the `reference` variable has a value. The unit tests only test the gateway result so the exception messages aren't tested.

Worst case if the updates to the catch block don't work, these will be handled by the calling method (`notificationRequestHandler`) anyway and things should fail gracefully.

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
4. After any sessions containing that data have expired, remove the value’s definition.
-->

- [ ] Deployment of this PR will not break active user journeys **- N/A, should only affect new invocations of the lambda**

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked. **- N/A**

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [ ] No changes required or changes have been made to stub-orchestration. **- N/A**

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed. **- N/A**