### PR TITLE
AUT-4287: Add secondary signing key to JWKS function CloudFormation

### DIFF
--- a/ci/cloudformation/auth/function/mfa-reset-jar-jwk.yaml
+++ b/ci/cloudformation/auth/function/mfa-reset-jar-jwk.yaml
@@ -21,6 +21,19 @@ Resources:
                 ]
               env:
                 !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+          IPV_REVERIFICATION_REQUESTS_SIGNING_KEY_SECONDARY_ALIAS: !If
+            - IsNotIntegrationOrProduction
+            - !Sub
+              - arn:aws:kms:${AWS::Region}:${DataStoreAccountId}:alias/${env}-ipv_reverification_request_signing_key_secondary
+              - DataStoreAccountId:
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    dataStoreAccountId,
+                  ]
+                env:
+                  !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+            - !Ref AWS::NoValue
       LoggingConfig:
         LogGroup: !Ref MfaResetJarJwkFunctionLogGroup
       Policies:

--- a/ci/cloudformation/auth/parent.yaml
+++ b/ci/cloudformation/auth/parent.yaml
@@ -98,6 +98,16 @@ Conditions:
           - !Ref Environment
           - production
 
+  IsNotIntegrationOrProduction:
+    Fn::Not:
+      - Fn::Or:
+          - Fn::Equals:
+              - !Ref Environment
+              - integration
+          - Fn::Equals:
+              - !Ref Environment
+              - production
+
   IsSplunkEnabled:
     Fn::Equals:
       - !FindInMap [EnvironmentConfiguration, !Ref Environment, IsSplunkEnabled]
@@ -1858,10 +1868,23 @@ Resources:
             Action:
               - kms:Sign
               - kms:GetPublicKey
-            Resource: !Sub
-              - "{{resolve:secretsmanager:/deploy/${env}/ipv_reverification_request_signing_key}}"
-              - env:
-                  !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+            Resource:
+              - !Sub
+                - "{{resolve:secretsmanager:/deploy/${env}/ipv_reverification_request_signing_key}}"
+                - env:
+                    !If [
+                      UseSubEnvironment,
+                      !Ref SubEnvironment,
+                      !Ref Environment,
+                    ]
+              - !Sub
+                - "{{resolve:secretsmanager:/deploy/${env}/ipv_reverification_request_signing_key_secondary_alias}}"
+                - env:
+                    !If [
+                      UseSubEnvironment,
+                      !Ref SubEnvironment,
+                      !Ref Environment,
+                    ]
 
   MfaResetTokenKmsSigningPolicy:
     Type: AWS::IAM::ManagedPolicy


### PR DESCRIPTION
**TODO BEFORE MERGE:**
- Dependent on merge of #6924
- The alias secret must be manually added through secrets manager in the `di-authentication-*` account for all environments (even if the env var isn't used on those envs, the policy is still defined).
    - _Note that we need #6924 to be merged before doing this so that the resource ARN's are stable (at present if we set these then someone else deploying before that is merged will remove these resources, meaning the next time they are created they will have a different ARN)_

## What

<!-- Describe what you have changed and why -->

Following on from #6924, we wish to add the CloudFormation changes to pass through the alias of the secondary key to the JWKS function for publishing. We also require policy changes to allow the public key of this resource to be accessed by the JWKS lambda.

As in #6924, the secondary key will not be published in integration and production (gated off).

Note that this is to keep things in sync with the TF changes.

**NOTE:** The `/deploy/${env}/ipv_reverification_request_signing_key_secondary_alias` secrets must be manually added through secrets manager in all of the `di-authentication-*` accounts, otherwise the CF deployment will fail with error: `Secrets Manager can't find the specified secret` ... `ResourceNotFoundException`.

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

1. Code Review
1. Optionally, deploy to a dev env (CF: ./sam-deploy-authdevs.sh -c -b -o -x authdev2), hit the `reverification-jwkjson-lambda` on the `di-authentication-development` account and ensure two keys are included in the JWKS response
    - This can be done by either hitting the lambda directly (e.g., through the test tab in the AWS web UI), or by making a request through the API gateway AWS web UI.
    - _Note that if this fails with `Secrets Manager can't find the specified secret` then the secret won't have been configured for that environment_

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
3. After any sessions containing that data have expired, remove the value’s definition.
-->

- [ ] Deployment of this PR will not break active user journeys **- N/A, `di-authentication-*` accounts not serving main traffic, secondary key won't be published past staging**

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked. **- N/A**

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [ ] No changes required or changes have been made to stub-orchestration. **- N/A**

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed. **- N/A**

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->

- #6924 - Terraform to create and publish MFA reset secondary signing key
