### PR TITLE
AUT-4287: Rotate MFA reset signing key to secondary on staging and below

### DIFF
--- a/ci/terraform/oidc/mfa-reset-authorize.tf
+++ b/ci/terraform/oidc/mfa-reset-authorize.tf
@@ -38,7 +38,7 @@ module "mfa_reset_authorize" {
     IPV_AUTHORISATION_CLIENT_ID                   = var.ipv_auth_authorize_client_id,
     IPV_AUTHORIZATION_URI                         = var.ipv_authorisation_uri,
     MFA_RESET_CALLBACK_URI                        = var.ipv_auth_authorize_callback_uri,
-    IPV_REVERIFICATION_REQUESTS_SIGNING_KEY_ALIAS = aws_kms_alias.ipv_reverification_request_signing_key_alias.arn,
+    IPV_REVERIFICATION_REQUESTS_SIGNING_KEY_ALIAS = var.environment != "integration" && var.environment != "production" ? aws_kms_alias.ipv_reverification_request_signing_key_secondary_alias.arn : aws_kms_alias.ipv_reverification_request_signing_key_alias.arn
     MFA_RESET_STORAGE_TOKEN_SIGNING_KEY_ALIAS     = aws_kms_alias.mfa_reset_token_signing_key_alias.arn,
     REDIS_KEY                                     = local.redis_key,
     TXMA_AUDIT_QUEUE_URL                          = module.oidc_txma_audit.queue_url

--- a/ci/terraform/oidc/reverification-result.tf
+++ b/ci/terraform/oidc/reverification-result.tf
@@ -35,7 +35,7 @@ module "reverification_result" {
     IPV_AUTHORISATION_CALLBACK_URI                = var.ipv_auth_authorize_callback_uri
     IPV_AUTHORISATION_CLIENT_ID                   = var.ipv_auth_authorize_client_id
     ENVIRONMENT                                   = var.environment
-    IPV_REVERIFICATION_REQUESTS_SIGNING_KEY_ALIAS = aws_kms_alias.ipv_reverification_request_signing_key_alias.arn
+    IPV_REVERIFICATION_REQUESTS_SIGNING_KEY_ALIAS = var.environment != "integration" && var.environment != "production" ? aws_kms_alias.ipv_reverification_request_signing_key_secondary_alias.arn : aws_kms_alias.ipv_reverification_request_signing_key_alias.arn
     IPV_BACKEND_URI                               = var.ipv_backend_uri
     USE_STRONGLY_CONSISTENT_READS                 = var.use_strongly_consistent_reads
   }


### PR DESCRIPTION
## What

We wish to rotate the IPV MFA reset signing key in staging and below.

Both a primary and secondary key are being published on the reverification-jwk JWKS endpoint in staging and below - [staging link](https://auth.staging.account.gov.uk/.well-known/reverification-jwk.json). Both keys are showing as type EC, for signing, using `P-256` and using `ES256`. Previously this endpoint was only showing one key - see current [integration](https://auth.integration.account.gov.uk/.well-known/reverification-jwk.json) and [production](https://auth.account.gov.uk/.well-known/reverification-jwk.json) JWKS endpoints which both have a single signing key.

This PR performs the actual rotation, switching the primary and secondary keys in staging and below and keeping the existing key in integration and production.

The old key resource will be removed in a subsequent PR once rotation has occurred on staging.

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

1. Code Review
1. Optionally, deploy to a dev env, run through an MFA reset journey

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
3. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Deployment of this PR will not break active user journeys **- N/A, rotation will not be performed past staging under this PR**, both keys are being published on the JWKS endpoint so new invocations should switch to using the new key/kid.

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked. **- N/A**

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [ ] No changes required or changes have been made to stub-orchestration. **- N/A**

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed. **- N/A**
