### PR TITLE
AUT-4640: Publish secondary signing key on IPV MFA reset JWKS lambda (integration)

### DIFF
--- a/ci/terraform/oidc/mfa-reset-jar-jwk.tf
+++ b/ci/terraform/oidc/mfa-reset-jar-jwk.tf
@@ -30,7 +30,7 @@ module "mfa_reset_jar_signing_jwk" {
   handler_environment_variables = {
     ENVIRONMENT                                             = var.environment
     IPV_REVERIFICATION_REQUESTS_SIGNING_KEY_ALIAS           = aws_kms_alias.ipv_reverification_request_signing_key_alias.name
-    IPV_REVERIFICATION_REQUESTS_SIGNING_KEY_SECONDARY_ALIAS = var.environment != "integration" && var.environment != "production" ? aws_kms_alias.ipv_reverification_request_signing_key_secondary_alias.name : null
+    IPV_REVERIFICATION_REQUESTS_SIGNING_KEY_SECONDARY_ALIAS = var.environment != "production" ? aws_kms_alias.ipv_reverification_request_signing_key_secondary_alias.name : null
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.MfaResetJarJwkHandler::handleRequest"
   runbook_link          = "https://govukverify.atlassian.net/l/cp/LfLKwP4s"


### PR DESCRIPTION
# DO NOT MERGE - ALTERNATIVE APPROACH TAKEN

=====


We wish to rotate the IPV MFA reset signing key. At this point, this has been done in staging and below. We now wish to do this on integration.

The first step is to publish the new (current "secondary") key on the IPV MFA reset JWKS endpoint (`reverification-jwk`). A subsequent PR will switch to signing with this key on integration. A follow up PR will then stop publishing the old (current "primary") key once we have verified the rotation has been successful.

I have informed IPV core of this ([Slack link](https://gds.slack.com/archives/C068GQY76EL/p1754467777559209)).

**NOTE: We still want publishing and signing to be gated off for production.**

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

1. Code Review
    - Please double check that you are happy that this is gated off in production still

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
3. After any sessions containing that data have expired, remove the value’s definition.
-->

- [ ] Deployment of this PR will not break active user journeys **- JWKS lambda should pick up new secondary key at next invocation, IPV uses the key id in the payload to determine which key on the JWKS endpoint to use. Note that this is still gated off on production at this point.**

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked. **- N/A**

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [ ] No changes required or changes have been made to stub-orchestration. **- N/A**

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed. **- N/A**
