### PR TITLE
ATO-1882: Remove SnapStartEnabledSpotResponse feature flag

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -100,14 +100,6 @@ Conditions:
       !Equals [build, !Ref Environment],
       !Equals [staging, !Ref Environment],
     ]
-  SnapStartEnabledSpotResponse:
-    !Or [
-      !Equals [dev, !Ref Environment],
-      !Equals [build, !Ref Environment],
-      !Equals [staging, !Ref Environment],
-      !Equals [integration, !Ref Environment],
-      !Equals [production, !Ref Environment],
-    ]
   IsRpRateLimitingEnabled:
     !Or [
       !Equals [dev, !Ref Environment],
@@ -4604,10 +4596,8 @@ Resources:
         - !Ref OrchIdentityCredentialsTableDeleteAccessPolicy
         - !Ref TxmaQueueSendPermissionPolicy
         - !Ref SpotResponseQueueConsumePolicy
-      SnapStart: !If
-        - SnapStartEnabledSpotResponse
-        - ApplyOn: PublishedVersions
-        - !Ref AWS::NoValue
+      SnapStart:
+        ApplyOn: PublishedVersions
       Tags:
         CheckovRulesToSkip: CKV_AWS_115.CKV_AWS_116.CKV_AWS_173
 


### PR DESCRIPTION
### Wider context of change

We have a few feature flags that are enabled in all environments, so would like to clean them up.

### What’s changed

This PR removes the feature flag `SnapStartEnabledSpotResponse`, as it was enabled for all environments.

### Manual testing

Tested an identity journey in dev, the journey completed successfully. 

Also logged into the AWS console and confirmed that the SpotResponseFunction still had snapstart enabled.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.