### PR TITLE
AUT-4642: Increase alarm threshold on TICF CRI alarm

### DIFF
--- a/ci/cloudformation/auth/function/ticf-cri.yaml
+++ b/ci/cloudformation/auth/function/ticf-cri.yaml
@@ -139,7 +139,7 @@ Resources:
               EnvironmentConfiguration,
               !Ref Environment,
               lambdaLogAlarmThreshold,
-              DefaultValue: 5,
+              DefaultValue: 20,
             ]
           Env: !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
           RunbookLink:

--- a/ci/terraform/oidc/ticf-cri.tf
+++ b/ci/terraform/oidc/ticf-cri.tf
@@ -21,7 +21,9 @@ module "ticf_cri_lambda" {
   source = "../modules/endpoint-lambda"
 
   endpoint_name = "ticf-cri"
-  runbook_link  = "https://govukverify.atlassian.net/l/cp/UzdQFFH1"
+
+  runbook_link               = "https://govukverify.atlassian.net/l/cp/UzdQFFH1"
+  lambda_log_alarm_threshold = 20
 
   environment = var.environment
 


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

We are receiving a large number of false positives from this lambda. The lambda fails gracefully on error and failures do not impact the user journey.

This change should reduce the number of false positives being observed.

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

1. Code Review
1. Optionally, deploy to a dev environment and review the CloudWatch alarm through the AWS UI to check that the threshold has been updated

## Testing

Deployed using CF (`./sam-deploy-authdevs.sh -c -b -o -x authdev2`) and TF (`./deploy-authdevs.sh -c -b -o`), checked the `di-authentication-dev` and `di-auth-dev` accounts and observed the alarm threshold had increased to 20.

<img width="1016" height="450" alt="Screenshot 2025-08-07 at 16 48 01" src="https://github.com/user-attachments/assets/4e47cf2a-27bc-4503-97c8-bfc18d1d95e9" />
<img width="1015" height="416" alt="Screenshot 2025-08-07 at 16 47 51" src="https://github.com/user-attachments/assets/2e8fafab-7ddd-4350-9372-68a55688395b" />

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
3. After any sessions containing that data have expired, remove the value’s definition.
-->

- [ ] Deployment of this PR will not break active user journeys **- N/A**

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked. **- N/A**

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [ ] No changes required or changes have been made to stub-orchestration. **- N/A**

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed. **- N/A**