### PR TITLE
AUT-4287: Sign with v2 IPV reverification signing key on staging and below

### DIFF
--- a/ci/terraform/oidc/ecc-signing-key.tf
+++ b/ci/terraform/oidc/ecc-signing-key.tf
@@ -134,7 +134,7 @@ resource "aws_kms_alias" "ipv_reverification_request_signing_key_v2_alias" {
 
 resource "aws_kms_alias" "ipv_reverification_request_signing_key_alias" {
   name          = "alias/${var.environment}-ipv_reverification_request_signing_key"
-  target_key_id = aws_kms_key.ipv_reverification_request_signing_key.key_id
+  target_key_id = var.environment != "integration" && var.environment != "production" ? aws_kms_key.ipv_reverification_request_signing_key_v2.key_id : aws_kms_key.ipv_reverification_request_signing_key.key_id
 }
 
 data "aws_iam_policy_document" "ipv_reverification_request_signing_key_access_policy" {


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

In staging and below we wish to deprecate the old "v1" key and switch to using the new "v2" key. At this point we are publishing on staging and below (#6977).

Point the `ipv_reverification_request_signing_key_alias` to the new v2 key on staging and below, on integration and production we want this to point to the original v1 key still (so same as what was there previously).

Note that the JWKS lambda does not use this alias (it uses the v1 and v2 aliases due to some caching concerns). The two lambdas (`mfa-reset-authorize` and `reverification-result`) that use this alias go directly to KMS for the signing operation without any key caching so that shouldn't be a concern.

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

1. Code Review
1. Optionally deploy to a dev environment and test

## Testing

Deployed this branch to authdev2 (`./deploy-authdevs.sh -c -b -o`) and ran through the start of MFA reset journey (enter email, enter password, click can't access MFA, see IPV stub, ran through "success" response) which triggers signing in both of the lambdas. Confirmed through CloudWatch that the `authdev2-reverification-result-lambda` and `
authdev2-mfa-reset-authorize-lambda` lambdas were both using the new v2 key. Also confirmed that both keys (v1 and v2) were still showing on the JWKS endpoint.

[Note that I was getting errors at first but had forgotten to redeploy the IPV stub to update the version of the secret being used for verification. Worked [after updating that](https://github.com/govuk-one-login/authentication-stubs/actions/runs/16963336230).]

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [ ] Deployment of this PR will not break active user journeys **- original ("v1") signing key still published on JWKS endpoint in all environments, "v2" signing key only being published on staging and below, "v2" signing key being used for signing on staging and below only**

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked. **- N/A**

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [ ] No changes required or changes have been made to stub-orchestration. **- N/A**

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed. **- N/A**