### PR TITLE
BAU: Sign using hashed kid in ipv token contract test

### DIFF
--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/contract/IpvTokenTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/contract/IpvTokenTest.java
@@ -32,6 +32,7 @@ import uk.gov.di.authentication.shared.services.ConfigurationService;
 import uk.gov.di.authentication.shared.services.KmsConnectionService;
 
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Base64;
@@ -51,6 +52,7 @@ class IpvTokenTest {
     private final ConfigurationService configService = mock(ConfigurationService.class);
     private final KmsConnectionService kmsConnectionService = mock(KmsConnectionService.class);
     private ReverificationResultService reverificationResultService;
+    private static final Base64.Encoder ENCODER = Base64.getUrlEncoder().withoutPadding();
 
     private static final String IPV_AUD = "http://ipv/";
     private static final URI IPV_URI = URI.create(IPV_AUD);
@@ -77,13 +79,25 @@ class IpvTokenTest {
                     .toBase64URL()
                     .toString();
     private static final String CLIENT_ASSERTION_BODY =
-            "eyJzdWIiOiJhdXRoT3JjaGVzdHJhdG9yIiwiYXVkIjoiaHR0cDovL2lwdi8iLCJuYmYiOjk0NjY4NDgwMCwiaXNzIjoiYXV0aE9yY2hlc3RyYXRvciIsImV4cCI6NDA3MDkwODgwMCwiaWF0Ijo5NDY2ODQ4MDAsImp0aSI6IjEifQ";
+            ENCODER.encodeToString(
+                    String.format(
+                                    "{"
+                                            + "\"sub\":\"%s\","
+                                            + "\"aud\":\"%s\","
+                                            + "\"nbf\":946684800,"
+                                            + "\"iss\":\"%s\","
+                                            + "\"exp\":4070908800,"
+                                            + "\"iat\":946684800,"
+                                            + "\"jti\":\"1\""
+                                            + "}",
+                                    CLIENT_ID.getValue(), IPV_URI, CLIENT_ID.getValue())
+                            .getBytes(StandardCharsets.UTF_8));
 
     // Generated using the "JWT Encoder" on jwt.io, providing the above header and body and by using
     // the PRIVATE_JWT_KEY above.
     // Note that this signature needs to be updated whenever the header or body are updated.
     private static final String CLIENT_ASSERTION_SIGNATURE =
-            "EAQJjtb57sPyjiKQpT8YBShPlXXRNO8SQzO83Dc_RSLauhyEEaRcZQIgRKIFyhRQKOAOqtqFfLkhSUAgCOROPg";
+            "V_ocBG_qBVQH9pULox_Wxf8OuuL7Be3WUnrP5wR2lkJO29CwEz746Gdz1R2qRMRT-yOexfPdHb3vodfb_Da6kw";
 
     @BeforeEach
     void setUp() {


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

At present, the IPV-auth contract tests are failing. This is likely related to us fixing a bug where the key id was not being hashed ([PR](https://github.com/govuk-one-login/authentication-api/pull/6946/files#diff-c7472e0832361b0f4b756eb3b0da2b1f5a9c8c02cd0a60ffcc667f680311de1a)).

The hashed key id is being passed through in the headers, but the signature is invalid as it was not updated. Recomputing the signature allows us to pass signature validation.

We also want to align the hashing of the key id across these tests. The key id has been updated in the JWK already on IPV side, and this PR does it on our side. This updated JWK is then used for signature generation.

Verified the changes are as expected by outputting each component of the JWT (see below) and entering these into https://www.jwt.io/ (note that all this info is public anyway, including the JWT):

```
public static void main(String[] args) {
        System.out.println(CLIENT_ASSERTION_HEADER);
        System.out.println(CLIENT_ASSERTION_BODY);
        System.out.println(CLIENT_ASSERTION_SIGNATURE);
        System.out.println(PRIVATE_JWT_KEY);
}
```

Output:
```
eyJraWQiOiJmMTdkYTg2NjlhOTUxYWZjM2ZiNDk5ZTkwMTE4NmQ3N2U5OWFmMjNiNWQxOTYyZDNjZTg1ZTlkNmM4MmQzYTY5IiwiYWxnIjoiRVMyNTYifQ
eyJzdWIiOiJhdXRoT3JjaGVzdHJhdG9yIiwiYXVkIjoiaHR0cDovL2lwdi8iLCJuYmYiOjk0NjY4NDgwMCwiaXNzIjoiYXV0aE9yY2hlc3RyYXRvciIsImV4cCI6NDA3MDkwODgwMCwiaWF0Ijo5NDY2ODQ4MDAsImp0aSI6IjEifQ
V_ocBG_qBVQH9pULox_Wxf8OuuL7Be3WUnrP5wR2lkJO29CwEz746Gdz1R2qRMRT-yOexfPdHb3vodfb_Da6kw
{"kty":"EC","d":"4NLo4B5Oj5E_ga6-eYjTSehss85p_mL799NRQqmll64","crv":"P-256","kid":"f17da8669a951afc3fb499e901186d77e99af23b5d1962d3ce85e9d6c82d3a69","x":"emDeRQ0KISC_TdfkoAZdd4lWm2Nk5UOtmmboLEab850","y":"-Ua4zzSzMG5lgpMyZoURg6Au60mHSxgnnf9pDtJmE2w","alg":"ES256"}
```

This output can be put into a JWT decoder to verify the signature (good signature).

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

1. Code Review

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
3. After any sessions containing that data have expired, remove the value’s definition.
-->

- [ ] Deployment of this PR will not break active user journeys **- N/A, contract tests only**

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked. **- N/A**

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [ ] No changes required or changes have been made to stub-orchestration. **- N/A**

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed. **- N/A**