### PR TITLE
ATO-1866: Add resource policies to PII containing tables

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -558,6 +558,25 @@ Resources:
         Enabled: true
       PointInTimeRecoverySpecification:
         PointInTimeRecoveryEnabled: true
+      ResourcePolicy: !If
+        - IsNotDevEnvironment
+        - PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Deny
+                Principal:
+                  AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+                NotAction:
+                  - dynamodb:DescribeTable
+                  - dynamodb:DescribeTimeToLive
+                  - dynamodb:ListTagsOfResource
+                Resource: "*"
+                Condition:
+                  StringNotLike:
+                    aws:PrincipalARN: !Sub arn:aws:iam::${AWS::AccountId}:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_ApprovedAdministrator*
+                  StringLike:
+                    aws:PrincipalARN: !Sub arn:aws:iam::${AWS::AccountId}:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_*
+        - !Ref AWS::NoValue
       Tags:
         - Key: Name
           Value: AuthUserInfoTable
@@ -846,6 +865,62 @@ Resources:
                         !Ref Environment,
                         authAccountId,
                       ]
+            - !If
+              - IsNotDevEnvironment
+              - Sid: DenyNonAdminTeamRolesAccess
+                Effect: Deny
+                Principal:
+                  AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+                NotAction:
+                  - dynamodb:DescribeTable
+                  - dynamodb:DescribeTimeToLive
+                  - dynamodb:ListTagsOfResource
+                Resource: "*"
+                Condition:
+                  StringNotLike:
+                    aws:PrincipalARN: !Sub arn:aws:iam::${AWS::AccountId}:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_ApprovedAdministrator*
+                  StringLike:
+                    aws:PrincipalARN: !Sub arn:aws:iam::${AWS::AccountId}:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_*
+              - !Ref AWS::NoValue
+            - !If
+              - IsNotDevEnvironment
+              - Sid: DenyAuthAccountNonAdminTeamRolesAccess
+                Effect: Deny
+                Principal:
+                  AWS: !Sub
+                    - arn:aws:iam::${AuthAccountId}:root
+                    - AuthAccountId:
+                        !FindInMap [
+                          EnvironmentConfiguration,
+                          !Ref Environment,
+                          authAccountId,
+                        ]
+                NotAction:
+                  - dynamodb:DescribeTable
+                  - dynamodb:DescribeTimeToLive
+                  - dynamodb:ListTagsOfResource
+                Resource: "*"
+                Condition:
+                  StringNotLike:
+                    aws:PrincipalARN: !Sub
+                      - arn:aws:iam::${AuthAccountId}:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_ApprovedAdministrator*
+                      - AuthAccountId:
+                          !FindInMap [
+                            EnvironmentConfiguration,
+                            !Ref Environment,
+                            authAccountId,
+                          ]
+                  StringLike:
+                    aws:PrincipalARN: !Sub
+                      - arn:aws:iam::${AuthAccountId}:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_*
+                      - AuthAccountId:
+                          !FindInMap [
+                            EnvironmentConfiguration,
+                            !Ref Environment,
+                            authAccountId,
+                          ]
+
+              - !Ref AWS::NoValue
   #endregion
 
   #region RP Public Key DynamoDB Table
@@ -1016,6 +1091,25 @@ Resources:
         Enabled: true
       PointInTimeRecoverySpecification:
         PointInTimeRecoveryEnabled: true
+      ResourcePolicy: !If
+        - IsNotDevEnvironment
+        - PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Deny
+                Principal:
+                  AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+                NotAction:
+                  - dynamodb:DescribeTable
+                  - dynamodb:DescribeTimeToLive
+                  - dynamodb:ListTagsOfResource
+                Resource: "*"
+                Condition:
+                  StringNotLike:
+                    aws:PrincipalARN: !Sub arn:aws:iam::${AWS::AccountId}:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_ApprovedAdministrator*
+                  StringLike:
+                    aws:PrincipalARN: !Sub arn:aws:iam::${AWS::AccountId}:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_*
+        - !Ref AWS::NoValue
       Tags:
         - Key: Name
           Value: DocAppCredentialTable


### PR DESCRIPTION
### Wider context of change

TEAM power user roles allow full access to PII containing resources. We would like to lock down this access to approved admin only roles.

In dev we do not need to reduce this access, so the resource policies are not necessary

### What’s changed

<!-- What’s changed in this PR. For example:

The auth_time claim is retrieved from the auth code exchange data store, and then added to all token responses (not just when the RP includes max age in the authorize request). Implementation is feature flagged and enabled in all envs except production. As this change is RP facing, it needs to be tested in integration and RPs made aware of the changes before releasing to production.
-->

### Manual testing
Deployed to dev in this format, and checked it does not add a resource policy.
Deployed to dev with the role arn syntax in the form of admin for dev, and check that
a) Can successfully run a journey
b) Admin role still has access
c) Non admin roles do not have access

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [x] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [x] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [x] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [x] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [x] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
