### PR TITLE
AUT-4640: Sign with v2 IPV reverification signing key on integration

### DIFF
--- a/ci/terraform/oidc/ecc-signing-key.tf
+++ b/ci/terraform/oidc/ecc-signing-key.tf
@@ -134,7 +134,7 @@ resource "aws_kms_alias" "ipv_reverification_request_signing_key_v2_alias" {
 
 resource "aws_kms_alias" "ipv_reverification_request_signing_key_alias" {
   name          = "alias/${var.environment}-ipv_reverification_request_signing_key"
-  target_key_id = var.environment != "integration" && var.environment != "production" ? aws_kms_key.ipv_reverification_request_signing_key_v2.key_id : aws_kms_key.ipv_reverification_request_signing_key.key_id
+  target_key_id = var.environment != "production" ? aws_kms_key.ipv_reverification_request_signing_key_v2.key_id : aws_kms_key.ipv_reverification_request_signing_key.key_id
 }
 
 data "aws_iam_policy_document" "ipv_reverification_request_signing_key_access_policy" {


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

In integration and below we wish to deprecate the old "v1" key and switch to using the new "v2" key. At this point we are:
- Publishing and signing with the new "v2" key on staging and below (#6977, #6978)
- Publishing the new "v2" key (alongside the "v1" key) on integration (#6990)

We now wish to point the `ipv_reverification_request_signing_key_alias` to the new "v2" key on integration, on production we want this to point to the original v1 key still (so same as what was there previously).

Note that the JWKS lambda does not use this alias (it uses the v1 and v2 aliases due to some caching concerns). The two lambdas (`mfa-reset-authorize` and `reverification-result`) that use this alias go directly to KMS for the signing operation without any key caching so that shouldn't be a concern.

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

1. Code Review
1. Review [the integration JWKS endpoint](https://auth.integration.account.gov.uk/.well-known/reverification-jwk.json) and ensure there are two keys present.
1. Optionally, test an MFA reset journey is working as expected in staging (same "publish then rotate" process was followed there)

## Testing

[Note that the keys below contain public data only and are accessible externally, so ok to publish here.]

Reviewed [the integration JWKS endpoint](https://auth.integration.account.gov.uk/.well-known/reverification-jwk.json) before merging the publish PR (#6977), confirmed only one key being published (expected):

```json
{"keys":[{"kty":"EC","use":"sig","crv":"P-256","kid":"c144467496bf68d6c6c2cacd999ccdbef754c0566c7e07412150c2eeea296d72","x":"cL0uhc1iTxZw18K2EPWjP73UHIhLKawoK2xLfET2Y7Q","y":"piUb9UPrWkYnzP79NvxS3PmPMZmDFekqBn-A4PUJaKM","alg":"ES256"}]}
```

Reviewed [the integration JWKS endpoint](https://auth.integration.account.gov.uk/.well-known/reverification-jwk.json) after merging the publish PR (#6977), confirmed two keys are now being published (expected), and that the original key (above) is still being published the exact same (note that this is now the second key as the deprecated key is added to the list second).

```json
{"keys":[{"kty":"EC","use":"sig","crv":"P-256","kid":"5ad8cb51eed37340f0bdb576d036613442a55f67ed03b61ad148502cbc7682b2","x":"wuEQZIzjZ-wXYO7bu3xCJNh3dlOAAjt1WSu3COBj774","y":"dsTLy-BwPXnHh9H0a_0SimJRssyF0yYQK_K79es1zNI","alg":"ES256"},{"kty":"EC","use":"sig","crv":"P-256","kid":"c144467496bf68d6c6c2cacd999ccdbef754c0566c7e07412150c2eeea296d72","x":"cL0uhc1iTxZw18K2EPWjP73UHIhLKawoK2xLfET2Y7Q","y":"piUb9UPrWkYnzP79NvxS3PmPMZmDFekqBn-A4PUJaKM","alg":"ES256"}]}
```

So IPV should be able to retrieve the new key when we start signing with it (this PR).

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
3. After any sessions containing that data have expired, remove the value’s definition.
-->

- [ ] Deployment of this PR will not break active user journeys **- original ("v1") signing key still published on JWKS endpoint in all environments, "v2" signing key only being published on integration and below, "v2" signing key being used for signing on integration and below only**

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked. **- N/A**

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [ ] No changes required or changes have been made to stub-orchestration. **- N/A**

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed. **- N/A**