### PR TITLE
BAU: Bump netty-codec-http2 to 4.1.124+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -178,6 +178,11 @@ subprojects {
                 add(conf.name, 'org.apache.commons:commons-lang3:[3.18.0,)') {
                     because 'CVE-2025-48924 is fixed in org.apache.commons:commons-lang3:3.18.0 and higher'
                 }
+
+                add(conf.name, 'io.netty:netty-codec-http2') {
+                    version { strictly '[4.1.124.Final,4.2.0)' }
+                    because 'CVE-2025-55163 is fixed in io.netty:netty-codec-http2:4.1.124.Final and higher'
+                }
             }
         }
 


### PR DESCRIPTION
## What

Requires netty-codec-http2 from 4.1.118 Final to use 4.1.124 Final or above.

Resolving CVE-2025-55163

## How to review

1. Code Review