### PR TITLE
BAU: Bump jetty-http to 12.0.12+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -183,6 +183,10 @@ subprojects {
                     version { strictly '[4.1.124.Final,4.2.0)' }
                     because 'CVE-2025-55163 is fixed in io.netty:netty-codec-http2:4.1.124.Final and higher'
                 }
+
+                add(conf.name, 'org.eclipse.jetty:jetty-http:[12.0.12,)') {
+                    because 'CVE-2024-6763 is fixed in org.eclipse.jetty:jetty-http:12.0.12 and higher'
+                }
             }
         }
 


### PR DESCRIPTION
## What

Bumps jetty-http (a dependency of Javalin) to 12.0.12. There wasn't a Javalin update available, so needed to add a constraint.

Resolves CVE-2024-6763

## How to review

1. Code Review