### PR TITLE
AUT-4640: Publish new v2 alias on production

### DIFF
--- a/ci/terraform/oidc/mfa-reset-jar-jwk.tf
+++ b/ci/terraform/oidc/mfa-reset-jar-jwk.tf
@@ -29,8 +29,8 @@ module "mfa_reset_jar_signing_jwk" {
 
   handler_environment_variables = {
     ENVIRONMENT                                              = var.environment
-    IPV_REVERIFICATION_REQUESTS_SIGNING_KEY_ALIAS            = var.environment != "production" ? aws_kms_alias.ipv_reverification_request_signing_key_v2_alias.name : aws_kms_alias.ipv_reverification_request_signing_key_v1_alias.name
-    IPV_REVERIFICATION_REQUESTS_SIGNING_KEY_DEPRECATED_ALIAS = var.environment != "production" ? aws_kms_alias.ipv_reverification_request_signing_key_v1_alias.name : null
+    IPV_REVERIFICATION_REQUESTS_SIGNING_KEY_ALIAS            = aws_kms_alias.ipv_reverification_request_signing_key_v2_alias.name
+    IPV_REVERIFICATION_REQUESTS_SIGNING_KEY_DEPRECATED_ALIAS = aws_kms_alias.ipv_reverification_request_signing_key_v1_alias.name
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.MfaResetJarJwkHandler::handleRequest"
   runbook_link          = "https://govukverify.atlassian.net/l/cp/LfLKwP4s"


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

In integration and below we have deprecated the old "v1" signing key and have switched to using the new "v2" key. We now wish to do this on production. This requires that we first publish the new key on the JWKS endpoint on production, alongside the existing "v1" key. Also note that at this point we will still be signing with the "v1" key on production.

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

1. Code Review
1. Optionally:
    a. Review [the integration JWKS endpoint](https://auth.integration.account.gov.uk/.well-known/reverification-jwk.json) and ensure there are two keys present. This is the change that will be made in this PR, but for production, (publishing two keys rather than one).
    b. Test an MFA reset journey is working as expected in integration (same "publish then rotate" process was followed there)

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
3. After any sessions containing that data have expired, remove the value’s definition.
-->

- [ ] Deployment of this PR will not break active user journeys **- see notes below:**
    - Both signing keys (v1 and v2) will be published on JWKS endpoint in all environments. The v1 key will be identical to what is currently published. Worst case IPV will fallback to using their hardcoded public key for the v1 key.
    - We will still be signing using the v1 key.

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked. **- N/A**

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [ ] No changes required or changes have been made to stub-orchestration. **- N/A**

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed. **- N/A**

