### PR TITLE
AUT-4640: Sign with v2 IPV reverification signing key on production

### DIFF
--- a/ci/terraform/oidc/ecc-signing-key.tf
+++ b/ci/terraform/oidc/ecc-signing-key.tf
@@ -130,7 +130,7 @@ resource "aws_kms_alias" "ipv_reverification_request_signing_key_v2_alias" {
 
 resource "aws_kms_alias" "ipv_reverification_request_signing_key_alias" {
   name          = "alias/${var.environment}-ipv_reverification_request_signing_key"
-  target_key_id = var.environment != "production" ? aws_kms_key.ipv_reverification_request_signing_key_v2.key_id : aws_kms_key.ipv_reverification_request_signing_key.key_id
+  target_key_id = aws_kms_key.ipv_reverification_request_signing_key_v2.key_id
 }
 
 data "aws_iam_policy_document" "ipv_reverification_request_signing_key_access_policy" {


### PR DESCRIPTION
Confirmed deployed to prod: ~~**DO NOT MERGE UNTIL WE HAVE CONFIRMED THE NEW KEY IS ALSO BEING PUBLISHED - #7004**~~

## What

<!-- Describe what you have changed and why -->

In production and below we wish to deprecate the old "v1" key and switch to using the new "v2" key. At this point we are:
- Publishing and signing with the new "v2" key on integration and below (#6977, #6978, #6990, #6992)
- Publishing the new "v2" key (alongside the "v1" key) on production (#7004)

We now wish to point the `ipv_reverification_request_signing_key_alias` to the new "v2" key on production.

Note that the JWKS lambda does not use this alias (it uses the v1 and v2 aliases due to some caching concerns). The two lambdas (`mfa-reset-authorize` and `reverification-result`) that use this alias go directly to KMS for the signing operation without any key caching so that shouldn't be a concern.

See counts for users going through this journey [through this Splunk query (counting page visits)](https://gds.splunkcloud.com/en-GB/app/gds-050-digital-Identity/search?earliest=-60m%40m&latest=now&q=search%20index%3D%22gds_di_production%22%20source%3D%22075701497069%3A%2Faws%2Fecs%2Fcore-front-production-CoreFront-ECS%3Acore-front-production%2Fapp%2F*%22%20%22req.url%22%3D%22%2Fipv%2Fpage%2Fyou-can-change-security-code-method%22%20%22req.method%22%3D%22GET%22%20message%3D%22REQUEST%20RECEIVED%3A%20GET%22&display.page.search.mode=fast&dispatch.sample_ratio=1&workload_pool=&sid=1755519772.56171_EF514FC9-3E4E-4E40-A55A-64CE41D26AAF) and [this Splunk query (counting key accesses)](https://gds.splunkcloud.com/en-GB/app/gds-050-digital-Identity/search?earliest=-60m%40m&latest=now&q=search%20index%3D%22gds_di_production%22%20source%3D%22*%3A%2Faws%2F*%2Fproduction-*%22%20%22ipv_reverification_request_signing_key%22%20%0A%7C%20stats%20count%20by%20message&display.page.search.mode=fast&dispatch.sample_ratio=1&workload_pool=&display.page.search.tab=statistics&display.general.type=statistics&sid=1755521239.56688_EF514FC9-3E4E-4E40-A55A-64CE41D26AAF).

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

1. Code Review
1. Review [the production JWKS endpoint](https://auth.account.gov.uk/.well-known/reverification-jwk.json) and ensure there are two keys present.
1. Optionally, test an MFA reset journey is working as expected in integration (same "publish then rotate" process was followed there)

## Testing

- Ran through expected journey using new v2 signing key on several envs integration and lower

### Key ID bug:
- Confirmed that we are no longer experiencing `Key not found by key ID, returning key from config` errors on prod [Splunk query to double check](https://gds.splunkcloud.com/en-GB/app/gds-050-digital-Identity/search?earliest=1754434800&latest=1755558000&q=search%20index%3D%22gds_di_production%22%20%22Key%20not%20found%20by%20key%20ID%2C%20returning%20key%20from%20config%22&display.page.search.mode=fast&dispatch.sample_ratio=1&workload_pool=&sid=1755515635.55100_EF514FC9-3E4E-4E40-A55A-64CE41D26AAF)

### JWKS endpoint checks:

[Note that the keys below contain public data only and are accessible externally, so ok to publish here.]

Reviewed [th JWKS endpoint](https://auth.account.gov.uk/.well-known/reverification-jwk.json) before merging the publish PR (#7004), confirmed only one key being published (expected):

```json
{"keys":[{"kty":"EC","use":"sig","crv":"P-256","kid":"abc9e77d9f71a7657f7fca8a1caa1985dc8955e7d8e9f8d594d4fdee6c3d7266","x":"dIL1zohbM-8qwBkflFJfBKwaiV9FT_qQXSGPP0UxrVk","y":"_Lr3zmF7QtiUXLqK776qRWguK22n7a8bB1j_eNVoybI","alg":"ES256"}]}
```

Reviewed [the JWKS endpoint](https://auth.account.gov.uk/.well-known/reverification-jwk.json) after merging the publish PR (#7004), confirmed two keys are now being published (expected), and that the original key (above) is still being published the exact same (note that this is now the second key as the deprecated key is added to the list second).

```json
{"keys":[{"kty":"EC","use":"sig","crv":"P-256","kid":"e5685debb7549784aec7ebadd079d28efd0614b011e393b734888902729a2ec4","x":"XgPhahXfbiG9pHO817TGxhpY6kGJsMb4T7cK4vDsI_A","y":"yyjNQYIZpl8WVMBMDkRgFc4BXIh7prVLvCHt6bLZL00","alg":"ES256"},{"kty":"EC","use":"sig","crv":"P-256","kid":"abc9e77d9f71a7657f7fca8a1caa1985dc8955e7d8e9f8d594d4fdee6c3d7266","x":"dIL1zohbM-8qwBkflFJfBKwaiV9FT_qQXSGPP0UxrVk","y":"_Lr3zmF7QtiUXLqK776qRWguK22n7a8bB1j_eNVoybI","alg":"ES256"}]}
```

So IPV should be able to retrieve the new key when we start signing with it (this PR).

## Revert Strategy

[Note that this shouldn't be needed based on what we've observed by following the same rotation process on integration and below].

1. Sign in to the prod AWS account (`gds-di-production`)
1. Open KMS
1. Locate the CMK associated with the alias `production-ipv_reverification_request_signing_key`
1. On the `aliases` tab, DELETE this alias `production-ipv_reverification_request_signing_key`
    - Note that this may cause different errors temporarily for new requests as the key isn't present, but if we have to revert then we will be getting failed journeys anyway
1. Locate the CMK associated with the alias `production-ipv_reverification_request_signing_key_v1`
1. On the `aliases` tab, ADD this alias `production-ipv_reverification_request_signing_key`
    - This will sign new requests with the v1 key
1. The two lambdas (`mfa-reset-authorize` and `reverification-result`) that need the change will switch back to the v1 key automatically as part of their signing operations. We should see this change immediately - there is no caching within these lambdas (vs JWKS where there is).
1. Raise a PR to revert this branch's changes

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
9. After any sessions containing that data have expired, remove the value’s definition.
-->

- [ ] Deployment of this PR will not break active user journeys **- see notes below:**
    - Both signing keys (v1 and v2) will be published on JWKS endpoint in all environments.
    - After this change is deployed to prod, new lambda invocations / new MFA reset journeys will use the new v2 signing key, IPV should be able to locate this key [on our JWKS endpoint](https://auth.account.gov.uk/.well-known/reverification-jwk.json).
    - Existing journeys signed using the old v1 key should continue as normal, IPV will lookup this key ID in their cache (or use our JWKS endpoing where it will still be published) and signature verification should work as normal
    - Note that MFA reset is not a tier 1 journey and it is likely that only a few users will be going through this journey

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked. **- N/A**

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [ ] No changes required or changes have been made to stub-orchestration. **- N/A**

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed. **- N/A**