### PR TITLE
ATO-1878: use new role with condensed policy

### DIFF
--- a/ci/terraform/oidc/login.tf
+++ b/ci/terraform/oidc/login.tf
@@ -1,3 +1,6 @@
+// ATO-1878: This duplicate role will be deleted in a future PR.
+// We can only do this once we are sure it is completely unused
+// to prevent a ZDD issue during the deployment window
 module "frontend_api_login_role" {
   source      = "../modules/lambda-role"
   environment = var.environment
@@ -30,8 +33,6 @@ module "frontend_api_login_role" {
   }
 }
 
-# ATO-1878: This is a duplicate of the above role however it has a combined
-# read/write/delete policy for the authentication attempts table
 module "frontend_api_login_role_with_combined_auth_attempts_table_policies" {
   source      = "../modules/lambda-role"
   environment = var.environment
@@ -55,8 +56,8 @@ module "frontend_api_login_role_with_combined_auth_attempts_table_policies" {
     aws_iam_policy.dynamo_authentication_attempt_read_write_delete_policy.arn,
     aws_iam_policy.dynamo_auth_session_read_write_policy.arn
   ]
-  // The joint read/write policy above is required because we've reached the managed polices per role quota limit (20)
-  // Ticket raised to request quota increase (ATO-1056)
+  // The joint read/write policy above is required because we've reached the managed polices per role quota limit (20).
+  // This also applies for the combined read/write/delete policy for the authentication attempts table
   extra_tags = {
     Service = "login"
   }


### PR DESCRIPTION
### Wider context of change

AWS IAM has a hard limit of [20 policies per role](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html#:~:text=Managed%20policies%20per%20role). The login handler is at this limit, and we need to free up some slots for future work. In a previous PR we added the new role with the condensed policy. Now we swap to the already created role. We leave the previous role in place as we will delete this in a followup to ensure ZDD.

### What’s changed:
- Swaps the login handler role to the one with combined policy for `authentication-attempts-*` table
- Should be effectively a no-op change

### Manual testing:
- Deployed to sandpit:
- Ran through a re-auth journey and saw no errors
- Specifically a re-auth journey as that seems to be where in the code we exercise the permissions

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
