### PR TITLE
ATO-1878: Delete duplicated login role

### DIFF
--- a/ci/terraform/oidc/login.tf
+++ b/ci/terraform/oidc/login.tf
@@ -1,38 +1,3 @@
-// ATO-1878: This duplicate role will be deleted in a future PR.
-// We can only do this once we are sure it is completely unused
-// to prevent a ZDD issue during the deployment window
-module "frontend_api_login_role" {
-  source      = "../modules/lambda-role"
-  environment = var.environment
-  role_name   = "frontend-api-login-role"
-  vpc_arn     = local.authentication_vpc_arn
-
-  policies_to_attach = [
-    aws_iam_policy.audit_signing_key_lambda_kms_signing_policy.arn,
-    aws_iam_policy.dynamo_user_read_access_policy.arn,
-    aws_iam_policy.dynamo_user_write_access_policy.arn,
-    aws_iam_policy.dynamo_client_registry_read_access_policy.arn,
-    aws_iam_policy.lambda_sns_policy.arn,
-    aws_iam_policy.pepper_parameter_policy.arn,
-    aws_iam_policy.redis_parameter_policy.arn,
-    aws_iam_policy.dynamo_common_passwords_read_access_policy.arn,
-    module.oidc_txma_audit.access_policy_arn,
-    local.account_modifiers_encryption_policy_arn,
-    local.common_passwords_encryption_policy_arn,
-    local.client_registry_encryption_policy_arn,
-    local.user_credentials_encryption_policy_arn,
-    aws_iam_policy.dynamo_authentication_attempt_write_policy.arn,
-    aws_iam_policy.dynamo_authentication_attempt_read_policy.arn,
-    aws_iam_policy.dynamo_authentication_attempt_delete_policy.arn,
-    aws_iam_policy.dynamo_auth_session_read_write_policy.arn
-  ]
-  // The joint read/write policy above is required because we've reached the managed polices per role quota limit (20)
-  // Ticket raised to request quota increase (ATO-1056)
-  extra_tags = {
-    Service = "login"
-  }
-}
-
 module "frontend_api_login_role_with_combined_auth_attempts_table_policies" {
   source      = "../modules/lambda-role"
   environment = var.environment


### PR DESCRIPTION
### Wider context of change:
As part of consolidating the IAM policies attached to the login handler role, we have now left an unused role behind. This was left to ensure ZDD during the deployment window. Now we can clear it up.

### What’s changed:
- Removes the a unused login handler role 

### Manual testing
- Deployed to sandpit, saw the role destroyed.

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
