### PR TITLE
AUT-4539: Use kms key alias in managed policies

### DIFF
--- a/ci/cloudformation/auth/parent.yaml
+++ b/ci/cloudformation/auth/parent.yaml
@@ -1915,8 +1915,14 @@ Resources:
               - kms:Sign
               - kms:GetPublicKey
             Resource: !Sub
-              - "{{resolve:secretsmanager:/deploy/${env}/ipv_reverification_request_signing_key}}"
-              - env:
+              - arn:aws:kms:${AWS::Region}:${DataStoreAccountId}:alias/${env}-ipv_reverification_request_signing_key
+              - DataStoreAccountId:
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    dataStoreAccountId,
+                  ]
+                env:
                   !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
 
   MfaResetTokenKmsSigningPolicy:
@@ -1935,8 +1941,14 @@ Resources:
               - kms:Sign
               - kms:GetPublicKey
             Resource: !Sub
-              - "{{resolve:secretsmanager:/deploy/${env}/mfa_reset_token_signing_key_ecc}}"
-              - env:
+              - arn:aws:kms:${AWS::Region}:${DataStoreAccountId}:alias/${env}-mfa-reset-token-signing-key-ecc-alias
+              - DataStoreAccountId:
+                  !FindInMap [
+                    EnvironmentConfiguration,
+                    !Ref Environment,
+                    dataStoreAccountId,
+                  ]
+                env:
                   !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
 
   PendingEmailCheckQueueAccessPolicy:


### PR DESCRIPTION
## What

Use kms alias in managed policies, instead of directly referencing a key id

