### PR TITLE
AUT-4640: Stop publishing v1 key on JWKS endpoint on production

### DIFF
--- a/ci/terraform/oidc/mfa-reset-jar-jwk.tf
+++ b/ci/terraform/oidc/mfa-reset-jar-jwk.tf
@@ -28,9 +28,8 @@ module "mfa_reset_jar_signing_jwk" {
   environment     = var.environment
 
   handler_environment_variables = {
-    ENVIRONMENT                                              = var.environment
-    IPV_REVERIFICATION_REQUESTS_SIGNING_KEY_ALIAS            = aws_kms_alias.ipv_reverification_request_signing_key_v2_alias.name
-    IPV_REVERIFICATION_REQUESTS_SIGNING_KEY_DEPRECATED_ALIAS = var.environment == "production" ? aws_kms_alias.ipv_reverification_request_signing_key_v1_alias.name : null
+    ENVIRONMENT                                   = var.environment
+    IPV_REVERIFICATION_REQUESTS_SIGNING_KEY_ALIAS = aws_kms_alias.ipv_reverification_request_signing_key_v2_alias.name
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.MfaResetJarJwkHandler::handleRequest"
   runbook_link          = "https://govukverify.atlassian.net/l/cp/LfLKwP4s"


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

At this point we are signing with the v2 key on all environments. We now wish to stop publishing the v1 key on our JWKS endpoint on production, we have already stopped publishing the v1 key on integration and below (#7026).

Note that we can safely remove the `IPV_REVERIFICATION_REQUESTS_SIGNING_KEY_DEPRECATED_ALIAS` env var from this JWKS function as if there is no value defined then this is handled gracefully and only the main/primary signing key is published (the fallback/secondary is skipped).

Since #7026 has been merged, I've ran through the start of a MFA reset journey on integration (triggering the two lambdas doing the signing) and there have been no fallback errors on [integration](https://gds.splunkcloud.com/en-GB/app/gds-050-digital-Identity/search?earliest=1755676800&latest=1755817200&q=search%20(index%3D%22gds_di_production%22%20OR%20index%3D%22gds_di_development%22)%20source%3D%22*%3A%2Faws%2Flambda%2Fissue-client-access-token-*%22%20%22Key%20not%20found%20by%20key%20ID%2C%20returning%20key%20from%20config%22&display.page.search.mode=fast&dispatch.sample_ratio=1&workload_pool=&sid=1755701541.17499_EF514FC9-3E4E-4E40-A55A-64CE41D26AAF), meaning the signing key appears to be being retrieved successfully still.

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

1. Code Review

## Rollback

[Note that we shouldn't need to do this given we should be signing with the v2 key on prod].

1. Hotfix: On the `production-mfa-reset-authorize-lambda` lambda, add a new env var `IPV_REVERIFICATION_REQUESTS_SIGNING_KEY_DEPRECATED_ALIAS` with value `production-ipv_reverification_request_signing_key_v1`. Force container refresh for this to be picked up.
1. Revert this PR.

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
9. After any sessions containing that data have expired, remove the value’s definition.
-->

- [ ] Deployment of this PR will not break active user journeys **- see notes below:**
    - Should now be signing with the v2 key on all environments
    - Have tested this in integration under #7026

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked. **- N/A**

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [ ] No changes required or changes have been made to stub-orchestration. **- N/A**

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed. **- N/A**