### PR TITLE
AUT-4682: Enable IPV JWKS call on production

### DIFF
--- a/ci/terraform/oidc/production.tfvars
+++ b/ci/terraform/oidc/production.tfvars
@@ -176,3 +176,6 @@ performance_tuning = {
 }
 lambda_max_concurrency = 10
 lambda_min_concurrency = 3
+
+ipv_jwks_call_enabled = true
+ipv_jwks_url          = "https://api.identity.account.gov.uk/.well-known/jwks.json"


### PR DESCRIPTION
~~**MERGE NOTE: DEPENDENT ON https://github.com/govuk-one-login/authentication-api/pull/7033 BEING MERGED FIRST**~~

## What

<!-- Describe what you have changed and why -->

As part of MFA reset reverification, we send a signed and encrypted JWT to IPV from authentication. We use IPV's public key to encrypt this JWT before sending. IPV publish a JWK for their RSA encryption on their JWKS endpoint (e.g., [prod](https://api.identity.account.gov.uk/.well-known/jwks.json)).

At this point we are generating the public key from their JWKS endpoint on both staging and integration. We wish to do this on production. Currently on production we use a hardcoded variable which holds the public key.

A fallback was added under #7030 for if our JWKS call fails, the fallback was tested on dev under that PR (see testing notes in the description for #7030).

I have verified that the public key of the RSA JWK being published on the [IPV JWKS endpoint on production](https://api.identity.account.gov.uk/.well-known/jwks.json) is the same as the hardcoded value in the oidc production.tfvars.

#7033 enabled this on integration, this is working as expected (ran through the start of an MFA reset journey successfully and then reviewed the logs to ensure we were not using the fallback).

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

1. Code Review
1. Optionally, ensure the value for the `ipv_jwks_url` in the diff is for production, visit this url and ensure there is an RSA key being published
1. Optionally, verify the PEM generated from [the published RSA JWK](https://api.identity.account.gov.uk/.well-known/jwks.json) is the same as the hardcoded public key value in the tfvars.
    - Note I have verified this already (see above), this would just be a double check

## Testing

- Ran through MFA reset journey on integration where this is already enabled
    - Reviewed the logs to ensure we weren't using the fallback and the public key was being generated from the RSA JWK being published on the IPV JWKS endpoint 
- Tested the fallback path on dev as part of #7030

## Rollback

[Hopefully this isn't needed due to a fallback being in place (see #7030) which switches to using the old env var method if there are any JWKS retrieval issues].

There are no key changes under this PR, only the source of where these are retrieved from.

If there are any issues with this PR:
- On the lambda (`production-mfa-reset-authorize-lambda`), update the `IPV_JWKS_CALL_ENABLED` env var to have value `false` and force a lambda container refresh to ensure this is picked up.
    - This should force us down the fallback path and skip any JWKS retrieval.
- Revert this PR

This is not a tier 1 journey, but we still get a decent amount of traffic through this lambda - for exact numbers [see this Splunk query](https://gds.splunkcloud.com/en-GB/app/gds-050-digital-Identity/search?earliest=-60m%40m&latest=now&q=search%20index%3D%22gds_di_production%22%20source%3D%22*%3A%2Faws%2Flambda%2Fproduction-mfa-reset-authorize-lambda%3A*%22%20%22MFA%20Reset%20Authorization%20request%20received%22&display.page.search.mode=fast&dispatch.sample_ratio=1&workload_pool=&sid=1755700432.17201_EF514FC9-3E4E-4E40-A55A-64CE41D26AAF).

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
9. After any sessions containing that data have expired, remove the value’s definition.
-->

- [ ] Deployment of this PR will not break active user journeys **- see notes below:**
    - Fallback (to the old approach using env vars) is in place in the case where the JWKS retrieval fails 

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked. **- N/A**

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [ ] No changes required or changes have been made to stub-orchestration. **- N/A**

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed. **- N/A**