### PR TITLE
AUT-4640: Teardown - remove v1 MFA reset signing key resource and alias

### DIFF
--- a/ci/terraform/oidc/ecc-signing-key.tf
+++ b/ci/terraform/oidc/ecc-signing-key.tf
@@ -91,25 +91,6 @@ data "aws_iam_policy_document" "mfa_reset_signing_key_access_policy" {
   }
 }
 
-## ipv_reverification_request_signing_key - V1 ##
-# NOTE: Before deleting these V1 resources, ensure they are no longer being used on higher environments such as production.
-
-resource "aws_kms_key" "ipv_reverification_request_signing_key" {
-  description              = "KMS signing key (ECC) for JARs sent from Authentication to IPV for MFA reset"
-  deletion_window_in_days  = 30
-  key_usage                = "SIGN_VERIFY"
-  customer_master_key_spec = "ECC_NIST_P256"
-
-  policy = data.aws_iam_policy_document.ipv_reverification_request_signing_key_access_policy.json
-}
-
-resource "aws_kms_alias" "ipv_reverification_request_signing_key_v1_alias" {
-  name          = "alias/${var.environment}-ipv_reverification_request_signing_key_v1"
-  target_key_id = aws_kms_key.ipv_reverification_request_signing_key.key_id
-}
-
-## / ipv_reverification_request_signing_key - V1 ##
-
 ## ipv_reverification_request_signing_key - V2 ##
 
 resource "aws_kms_key" "ipv_reverification_request_signing_key_v2" {


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

At this point we are only publishing and signing with the v2 key on all environments.

We now wish to tear down the old v1 key resources. The policies have already been removed.

The v1 alias resource is not referenced anywhere (also searched for references in the CF files and can't see any) and the v1 key resource is only referenced by that alias.

The lambdas now use the v2 signing key for both publishing and signing.

It should be safe to remove both of these resources at the same time, I believe TF should understand the dependency between these.

Note that the alias will be deleted immediately and the key resource should respect the `deletion_window_in_days` attribute that was set on it (30 days) and be marked for deletion to allow for recovery within this period.

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

1. Code review
1. Optionally, deploy to a dev env and run through an MFA reset journey

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
3. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Deployment of this PR will not break active user journeys
    - Key should not be used by any lambdas now

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked. **- N/A**

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [ ] No changes required or changes have been made to stub-orchestration. **- N/A**

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed. **- N/A**
