### PR TITLE
BAU: use main KMS alias to resolve Terraform dependency cycle

### DIFF
--- a/ci/terraform/oidc/mfa-reset-jar-jwk.tf
+++ b/ci/terraform/oidc/mfa-reset-jar-jwk.tf
@@ -29,7 +29,7 @@ module "mfa_reset_jar_signing_jwk" {
 
   handler_environment_variables = {
     ENVIRONMENT                                   = var.environment
-    IPV_REVERIFICATION_REQUESTS_SIGNING_KEY_ALIAS = aws_kms_alias.ipv_reverification_request_signing_key_v2_alias.name
+    IPV_REVERIFICATION_REQUESTS_SIGNING_KEY_ALIAS = aws_kms_alias.ipv_reverification_request_signing_key_alias.name
   }
   handler_function_name = "uk.gov.di.authentication.frontendapi.lambda.MfaResetJarJwkHandler::handleRequest"
   runbook_link          = "https://govukverify.atlassian.net/l/cp/LfLKwP4s"


### PR DESCRIPTION
## What

Use ipv_reverification_request_signing_key_alias instead of v2_alias to break circular dependency during resource destruction

## How to review

1. Code Review
