### PR TITLE
ATO-1942: Adjust alarm sensitivity to reduce noise

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -35,6 +35,10 @@ Parameters:
   LambdaDeploymentPreference:
     Type: String
     Description: Specifies the configuration to enable gradual Lambda deployments
+  MinErrorThreshold:
+    Type: Number
+    Description: Minimum number of errors before error rate alarms can be triggered
+    Default: 4
 
 Conditions:
   UsePermissionsBoundary:
@@ -1100,7 +1104,7 @@ Resources:
       Metrics:
         - Id: e1
           ReturnData: true
-          Expression: m2/m1*100
+          Expression: !Sub "IF(m2 >= ${MinErrorThreshold}, m2/m1*100, 0)"
           Label: Error Rate
         - Id: m1
           ReturnData: false
@@ -1261,7 +1265,7 @@ Resources:
       Metrics:
         - Id: e1
           ReturnData: true
-          Expression: m2/m1*100
+          Expression: !Sub "IF(m2 >= ${MinErrorThreshold}, m2/m1*100, 0)"
           Label: Error Rate
         - Id: m1
           ReturnData: false
@@ -1413,7 +1417,7 @@ Resources:
       Metrics:
         - Id: e1
           ReturnData: true
-          Expression: m2/m1*100
+          Expression: !Sub "IF(m2 >= ${MinErrorThreshold}, m2/m1*100, 0)"
           Label: Error Rate
         - Id: m1
           ReturnData: false
@@ -1561,7 +1565,7 @@ Resources:
       Metrics:
         - Id: e1
           ReturnData: true
-          Expression: m2/m1*100
+          Expression: !Sub "IF(m2 >= ${MinErrorThreshold}, m2/m1*100, 0)"
           Label: Error Rate
         - Id: m1
           ReturnData: false
@@ -1806,7 +1810,7 @@ Resources:
       Metrics:
         - Id: e1
           ReturnData: true
-          Expression: m2/m1*100
+          Expression: !Sub "IF(m2 >= ${MinErrorThreshold}, m2/m1*100, 0)"
           Label: Error Rate
         - Id: m1
           ReturnData: false
@@ -2013,7 +2017,7 @@ Resources:
       Metrics:
         - Id: e1
           ReturnData: true
-          Expression: m2/m1*100
+          Expression: !Sub "IF(m2 >= ${MinErrorThreshold}, m2/m1*100, 0)"
           Label: Error Rate
         - Id: m1
           ReturnData: false
@@ -2227,7 +2231,7 @@ Resources:
       Metrics:
         - Id: e1
           ReturnData: true
-          Expression: m2/m1*100
+          Expression: !Sub "IF(m2 >= ${MinErrorThreshold}, m2/m1*100, 0)"
           Label: Error Rate
         - Id: m1
           ReturnData: false
@@ -2388,7 +2392,7 @@ Resources:
       Metrics:
         - Id: e1
           ReturnData: true
-          Expression: m2/m1*100
+          Expression: !Sub "IF(m2 >= ${MinErrorThreshold}, m2/m1*100, 0)"
           Label: Error Rate
         - Id: m1
           ReturnData: false
@@ -2788,7 +2792,7 @@ Resources:
       Metrics:
         - Id: e1
           ReturnData: true
-          Expression: m2/m1*100
+          Expression: !Sub "IF(m2 >= ${MinErrorThreshold}, m2/m1*100, 0)"
           Label: Error Rate
         - Id: m1
           ReturnData: false
@@ -3009,7 +3013,7 @@ Resources:
       Metrics:
         - Id: e1
           ReturnData: true
-          Expression: m2/m1*100
+          Expression: !Sub "IF(m2 >= ${MinErrorThreshold}, m2/m1*100, 0)"
           Label: Error Rate
         - Id: m1
           ReturnData: false
@@ -3139,7 +3143,7 @@ Resources:
       Metrics:
         - Id: e1
           ReturnData: true
-          Expression: m2/m1*100
+          Expression: !Sub "IF(m2 >= ${MinErrorThreshold}, m2/m1*100, 0)"
           Label: Error Rate
         - Id: m1
           ReturnData: false
@@ -3432,7 +3436,7 @@ Resources:
       Metrics:
         - Id: e1
           ReturnData: true
-          Expression: m2/m1*100
+          Expression: !Sub "IF(m2 >= ${MinErrorThreshold}, m2/m1*100, 0)"
           Label: Error Rate
         - Id: m1
           ReturnData: false
@@ -3636,7 +3640,7 @@ Resources:
       Metrics:
         - Id: e1
           ReturnData: true
-          Expression: m2/m1*100
+          Expression: !Sub "IF(m2 >= ${MinErrorThreshold}, m2/m1*100, 0)"
           Label: Error Rate
         - Id: m1
           ReturnData: false
@@ -3827,7 +3831,7 @@ Resources:
       Metrics:
         - Id: e1
           ReturnData: true
-          Expression: m2/m1*100
+          Expression: !Sub "IF(m2 >= ${MinErrorThreshold}, m2/m1*100, 0)"
           Label: Error Rate
         - Id: m1
           ReturnData: false
@@ -4004,7 +4008,7 @@ Resources:
       Metrics:
         - Id: e1
           ReturnData: true
-          Expression: m2/m1*100
+          Expression: !Sub "IF(m2 >= ${MinErrorThreshold}, m2/m1*100, 0)"
           Label: Error Rate
         - Id: m1
           ReturnData: false
@@ -4179,7 +4183,7 @@ Resources:
       Metrics:
         - Id: e1
           ReturnData: true
-          Expression: m2/m1*100
+          Expression: !Sub "IF(m2 >= ${MinErrorThreshold}, m2/m1*100, 0)"
           Label: Error Rate
         - Id: m1
           ReturnData: false
@@ -4511,7 +4515,7 @@ Resources:
       Metrics:
         - Id: e1
           ReturnData: true
-          Expression: m2/m1*100
+          Expression: !Sub "IF(m2 >= ${MinErrorThreshold}, m2/m1*100, 0)"
           Label: Error Rate
         - Id: m1
           ReturnData: false
@@ -4710,7 +4714,7 @@ Resources:
       Metrics:
         - Id: e1
           ReturnData: true
-          Expression: m2/m1*100
+          Expression: !Sub "IF(m2 >= ${MinErrorThreshold}, m2/m1*100, 0)"
           Label: Error Rate
         - Id: m1
           ReturnData: false
@@ -4918,7 +4922,7 @@ Resources:
       Metrics:
         - Id: e1
           ReturnData: true
-          Expression: m2/m1*100
+          Expression: !Sub "IF(m2 >= ${MinErrorThreshold}, m2/m1*100, 0)"
           Label: Error Rate
         - Id: m1
           ReturnData: false


### PR DESCRIPTION
Context: error rate alarms are currently firing when errors exceed 10% of invocations in a 60 second period. This means that for low-volume services, you only need a couple of errors to cause the alarm, which means lots of false positives.

- adjust error rate alarms so that as well as exceeding the allowed rate of 10% of invocations in a 60 second period, there must be more than 3 errors in that period.

Tested in dev environment using `aws cloudwatch put-metric-data` to check that alarms are triggered under certain conditions. Confirmed that following the change, 4 or more errors in 10 invocations would trigger the alarm, as would 11 in 100, but 3 in 10 would not.