### PR TITLE
ATO-1945: Add new dimension to existing metric

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -427,8 +427,16 @@ public class AuthorisationHandler
             LOG.warn("Error recording state length, continuing: ", e);
         }
 
+        var isDocAppJourney =
+                DocAppUserHelper.isDocCheckingAppUser(
+                        authRequest.toParameters(), Optional.of(client));
         cloudwatchMetricsService.incrementCounter(
-                "orchAuthorizeRequestCount", Map.of("clientName", client.getClientName()));
+                "orchAuthorizeRequestCount",
+                Map.of(
+                        "clientName",
+                        client.getClientName(),
+                        "isDocAppJourney",
+                        Boolean.toString(isDocAppJourney)));
 
         boolean reauthRequested =
                 getCustomParameterOpt(authRequest, "id_token_hint").isPresent()
@@ -453,9 +461,7 @@ public class AuthorisationHandler
                         vtrList,
                         client.getClientName());
 
-        if (DocAppUserHelper.isDocCheckingAppUser(
-                authRequest.toParameters(), Optional.of(client))) {
-
+        if (isDocAppJourney) {
             return handleDocAppJourney(
                     orchSessionOptional,
                     orchClientSession,


### PR DESCRIPTION
### Wider context of change

We recently added a metric to measure when an RP makes a valid authorize request. The next dashboard we want to add is for number of successful auth or IPV journeys. Since we do not want to count doc app journeys in this dashboard, we need to add a new dimension to the metric we added in the previous PR. 

### What’s changed

This PR adds the `isDocAppJourney` dimension to the `orchAuthorizeRequestCount` metric.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.

