### PR TITLE
ATO-1945: Add new orch metrics

### DIFF
--- a/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
+++ b/ipv-api/src/main/java/uk/gov/di/authentication/ipv/helpers/IPVCallbackHelper.java
@@ -222,6 +222,11 @@ public class IPVCallbackHelper {
 
         cloudwatchMetricsService.incrementSignInByClient(
                 orchSession.getIsNewAccount(), clientId, clientName, isTestJourney);
+        cloudwatchMetricsService.incrementCounter(
+                "orchIdentityJourneyCompleted",
+                Map.of(
+                        "clientName", clientName,
+                        "clientId", clientId));
 
         authCodeResponseService.saveSession(false, orchSessionService, orchSession);
         return authenticationResponse;

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandler.java
@@ -42,6 +42,7 @@ import uk.gov.di.orchestration.shared.services.OrchClientSessionService;
 import uk.gov.di.orchestration.shared.services.OrchSessionService;
 
 import java.util.ArrayList;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -312,6 +313,11 @@ public class AuthCodeHandler
                     clientID.getValue(),
                     orchClientSession.getClientName(),
                     isTestJourney);
+            cloudwatchMetricsService.incrementCounter(
+                    "orchIdentityJourneyCompleted",
+                    Map.of(
+                            "clientName", client.getClientName(),
+                            "clientId", clientID.getValue()));
             authCodeResponseService.saveSession(isDocAppJourney, orchSessionService, orchSession);
 
             LOG.info("Generating successful auth code response");

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthenticationCallbackHandler.java
@@ -530,6 +530,9 @@ public class AuthenticationCallbackHandler
                         clientId,
                         orchClientSession.getClientName(),
                         isTestJourney);
+                cloudwatchMetricsService.incrementCounter(
+                        "orchAuthJourneyCompleted",
+                        Map.of("clientName", client.getClientName(), "clientId", clientId));
 
                 LOG.info("Successfully processed request");
 

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/AuthCodeHandlerTest.java
@@ -197,7 +197,8 @@ class AuthCodeHandlerTest {
                         Optional.of(
                                 new ClientRegistry()
                                         .withClientID(CLIENT_ID.getValue())
-                                        .withSubjectType("pairwise")));
+                                        .withSubjectType("pairwise")
+                                        .withClientName(CLIENT_NAME)));
     }
 
     private static Stream<Arguments> upliftTestParameters() {


### PR DESCRIPTION
### Wider context of change

To make it easier to calculate % of successful journeys from orch's perspective, we would like to add some new metrics to indicate when certain journeys have finished 

### What’s changed

Added metrics for when auth only journeys finish and for when identity journeys finish. These metrics will be used to calculate number of successful auth only and identity journeys.

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.

