### PR TITLE
AUT-4633: Add VPC permissions to quota monitor role

### DIFF
--- a/ci/terraform/utils/sms_quota_monitor_lambda.tf
+++ b/ci/terraform/utils/sms_quota_monitor_lambda.tf
@@ -24,6 +24,7 @@ module "sms_quota_monitor_lambda_role" {
 
   environment = var.environment
   role_name   = "sms-quota-monitor-lambda-role"
+  vpc_arn     = local.authentication_vpc_arn
 
   policies_to_attach = [
     aws_iam_policy.sms_quota_monitor_cloudwatch_access.arn,


### PR DESCRIPTION
## What

The SMS quota monitor Lambda is configured to run in a VPC but the IAM role was missing the required VPC permissions
(CreateNetworkInterface, DescribeNetworkInterfaces, DeleteNetworkInterface). This caused deployment failures in build environment with error: "The provided execution role does not have permissions to call CreateNetworkInterface on EC2"

Dev environments worked because they were deployed before VPC config was added, so the Lambda existed without VPC constraints. Build environment failed because it's a fresh deployment with VPC config requiring proper permissions from the start.

Fixed by adding vpc_arn parameter to the lambda-role module call, which enables the conditional VPC permissions policy in the module.


<!-- Describe what you have changed and why -->

## How to review

1. Code Review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Deployment of this PR will not break active user journeys

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] No changes required or changes have been made to stub-orchestration.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
