### PR TITLE
AUT-4633: Fix SMS alarm routing

### DIFF
--- a/ci/terraform/utils/sms-quota-alarms.tf
+++ b/ci/terraform/utils/sms-quota-alarms.tf
@@ -8,7 +8,7 @@ resource "aws_cloudwatch_metric_alarm" "domestic_sms_quota_early_warning_alarm" 
   statistic           = "Sum"
   threshold           = "300000"
   alarm_description   = "Domestic SMS usage trending towards quota limit in ${var.environment}. ACCOUNT: ${local.aws_account_alias}"
-  alarm_actions       = ["arn:aws:sns:eu-west-2:653994557586:authdev1-slack-events"]
+  alarm_actions       = [var.environment == "production" ? "arn:aws:sns:eu-west-2:${data.aws_caller_identity.current.account_id}:production-pagerduty-p1-alerts" : local.slack_event_sns_topic_arn]
 
   dimensions = {
     Environment = var.environment
@@ -25,7 +25,7 @@ resource "aws_cloudwatch_metric_alarm" "international_sms_quota_early_warning_al
   statistic           = "Sum"
   threshold           = "3600"
   alarm_description   = "International SMS usage trending towards quota limit in ${var.environment}. ACCOUNT: ${local.aws_account_alias}"
-  alarm_actions       = ["arn:aws:sns:eu-west-2:653994557586:authdev1-slack-events"]
+  alarm_actions       = [var.environment == "production" ? "arn:aws:sns:eu-west-2:${data.aws_caller_identity.current.account_id}:production-pagerduty-p1-alerts" : local.slack_event_sns_topic_arn]
 
   dimensions = {
     Environment = var.environment


### PR DESCRIPTION
## What

SMS quota early warning alarms had hardcoded SNS topic ARNs pointing to 'authdev1-slack-events' for ALL environments.

Changes made:
- Replace hardcoded 'authdev1-slack-events' ARNs with environment- specific routing logic
- Production alarms now route to 'production-pagerduty-p1-alerts' (same as existing SMS limit exceeded alarms)
- Non-production alarms route to environment-specific slack topics (authdev1-slack-events, authdev2-slack-events, etc.)


<!-- Describe what you have changed and why -->

## How to review

1. Code Review

<!-- Describe the steps required to review this PR.
For example:

1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Deployment of this PR will not break active user journeys

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] No changes required or changes have been made to stub-orchestration.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
