### PR TITLE
AUT-4207: optimise email check results writer

### DIFF
--- a/ci/terraform/utils/email_check_results_writer_lambda.tf
+++ b/ci/terraform/utils/email_check_results_writer_lambda.tf
@@ -1,7 +1,9 @@
 resource "aws_lambda_event_source_mapping" "lambda_sqs_mapping" {
-  count            = 1
-  event_source_arn = var.email_check_results_sqs_queue_arn
-  function_name    = aws_lambda_function.email_check_results_writer_lambda.arn
+  count                              = 1
+  event_source_arn                   = var.email_check_results_sqs_queue_arn
+  function_name                      = aws_lambda_function.email_check_results_writer_lambda.arn
+  batch_size                         = 1
+  maximum_batching_window_in_seconds = 0
 
   depends_on = [
     aws_lambda_function.email_check_results_writer_lambda,


### PR DESCRIPTION
## What

- Remove batching window to eliminate 5s delay in SQS message processing
- Set batch_size=1 for immediate message handling

Currently we're not doing batch processing in the email check repo. This aligns the results writer with that. It might be good down the line the implement batch processing for the full process, but that goes outside the scope of this ticket.

## How to review

1. Code Review

