### PR TITLE
ATO-1891: turn on RP rate limiting for all envs and remove feature flag

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/AuthorisationHandler.java
@@ -385,24 +385,22 @@ public class AuthorisationHandler
                     user);
         }
 
-        if (configurationService.isRpRateLimitingEnabled()) {
-            var rateLimitDecision =
-                    rateLimitService.getClientRateLimitDecision(
-                            ClientRateLimitConfig.fromClientRegistry(client));
+        var rateLimitDecision =
+                rateLimitService.getClientRateLimitDecision(
+                        ClientRateLimitConfig.fromClientRegistry(client));
 
-            if (rateLimitDecision.hasExceededRateLimit()) {
-                switch (rateLimitDecision.getAction()) {
-                    case RETURN_TO_RP -> {
-                        authRequestError =
-                                Optional.of(
-                                        new AuthRequestError(
-                                                OAuth2Error.TEMPORARILY_UNAVAILABLE,
-                                                authRequest.getRedirectionURI(),
-                                                authRequest.getState()));
-                    }
-                    case NONE -> {
-                        // continue
-                    }
+        if (rateLimitDecision.hasExceededRateLimit()) {
+            switch (rateLimitDecision.getAction()) {
+                case RETURN_TO_RP -> {
+                    authRequestError =
+                            Optional.of(
+                                    new AuthRequestError(
+                                            OAuth2Error.TEMPORARILY_UNAVAILABLE,
+                                            authRequest.getRedirectionURI(),
+                                            authRequest.getState()));
+                }
+                case NONE -> {
+                    // continue
                 }
             }
         }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -398,10 +398,6 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return getFlagOrFalse("TEST_CLIENTS_ENABLED");
     }
 
-    public boolean isRpRateLimitingEnabled() {
-        return getFlagOrFalse("RP_RATE_LIMITING_ENABLED");
-    }
-
     public String getExternalTokenSigningKeyAlias() {
         return System.getenv("EXTERNAL_TOKEN_SIGNING_KEY_ALIAS");
     }

--- a/template.yaml
+++ b/template.yaml
@@ -89,12 +89,6 @@ Conditions:
       !Equals [build, !Ref Environment],
       !Equals [staging, !Ref Environment],
     ]
-  IsRpRateLimitingEnabled:
-    !Or [
-      !Equals [dev, !Ref Environment],
-      !Equals [staging, !Ref Environment],
-      !Equals [production, !Ref Environment],
-    ]
   UseGlobalLogoutTxmaQueue: !Equals [staging, !Ref Environment]
 
 Mappings:
@@ -3497,10 +3491,6 @@ Resources:
               orchToAuthKeyArn,
             ]
           REDIS_KEY: session
-          RP_RATE_LIMITING_ENABLED: !If
-            - IsRpRateLimitingEnabled
-            - true
-            - false
           TXMA_AUDIT_QUEUE_URL:
             Fn::ImportValue: !Sub orchestration-${Environment}-txma-QueueURL
           TXMA_AUDIT_ENCODED_ENABLED: true


### PR DESCRIPTION
### Wider context of change

RP rate limiting is already turned on for dev, staging, and prod. This is turning it on for build and integration as well as removing the feature flag outright.

### What’s changed

Removes the RP rate limiting feature flag.

### Manual testing

N/A

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing. **N/A**
- [x] Impact on orch and auth mutual dependencies has been checked. **N/A**
- [x] Changes have been made to contract tests or not required. **N/A**
- [x] Changes have been made to the simulator or not required. **N/A**
- [x] Changes have been made to stubs or not required. **N/A**
- [x] Successfully deployed to authdev or not required. **N/A**
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **N/A**