### PR TITLE
AUT-4633: Fix SMS quota monitoring and alarm testing

### DIFF
--- a/ci/terraform/utils/authdev2.tfvars
+++ b/ci/terraform/utils/authdev2.tfvars
@@ -24,6 +24,6 @@ performance_tuning = {
 email_check_results_writer_provisioned_concurrency = 0
 
 # SMS Quota Monitoring
-sms_quota_monitor_schedule_rate   = "rate(5 minutes)"
+sms_quota_monitor_schedule_rate   = "rate(1 minute)"
 domestic_sms_quota_threshold      = "300000"
 international_sms_quota_threshold = "3600"

--- a/ci/terraform/utils/sms-quota-alarms.tf
+++ b/ci/terraform/utils/sms-quota-alarms.tf
@@ -6,8 +6,8 @@ resource "aws_cloudwatch_metric_alarm" "domestic_sms_quota_early_warning_alarm" 
   namespace           = "Authentication"
   period              = "60"
   statistic           = "Sum"
-  threshold           = "300000"
-  alarm_description   = "Domestic SMS usage trending towards quota limit in ${var.environment}. ACCOUNT: ${local.aws_account_alias}"
+  threshold           = "1"
+  alarm_description   = "Domestic SMS usage trending towards quota limit in ${var.environment}. ACCOUNT: ${local.aws_account_alias}. Runbook: https://govukverify.atlassian.net/wiki/x/qIBJTQE"
   alarm_actions       = [var.environment == "production" ? "arn:aws:sns:eu-west-2:${data.aws_caller_identity.current.account_id}:production-pagerduty-p1-alerts" : local.slack_event_sns_topic_arn]
 
   dimensions = {
@@ -23,8 +23,8 @@ resource "aws_cloudwatch_metric_alarm" "international_sms_quota_early_warning_al
   namespace           = "Authentication"
   period              = "60"
   statistic           = "Sum"
-  threshold           = "3600"
-  alarm_description   = "International SMS usage trending towards quota limit in ${var.environment}. ACCOUNT: ${local.aws_account_alias}"
+  threshold           = "1"
+  alarm_description   = "International SMS usage trending towards quota limit in ${var.environment}. ACCOUNT: ${local.aws_account_alias}. Runbook: https://govukverify.atlassian.net/wiki/x/qIBJTQE"
   alarm_actions       = [var.environment == "production" ? "arn:aws:sns:eu-west-2:${data.aws_caller_identity.current.account_id}:production-pagerduty-p1-alerts" : local.slack_event_sns_topic_arn]
 
   dimensions = {

--- a/utils/src/main/java/uk/gov/di/authentication/utils/lambda/SmsQuotaMonitorHandler.java
+++ b/utils/src/main/java/uk/gov/di/authentication/utils/lambda/SmsQuotaMonitorHandler.java
@@ -68,7 +68,10 @@ public class SmsQuotaMonitorHandler implements RequestHandler<ScheduledEvent, Vo
     }
 
     private double getSmsCountSinceMidnight(String metricName, Instant start, Instant end) {
-        var periodSeconds = (int) java.time.Duration.between(start, end).getSeconds();
+        var durationSeconds = (int) java.time.Duration.between(start, end).getSeconds();
+        var periodSeconds =
+                ((durationSeconds + 59) / 60) * 60; // Round up to nearest multiple of 60
+
         var request =
                 GetMetricStatisticsRequest.builder()
                         .namespace("Authentication")

--- a/utils/src/test/java/uk/gov/di/authentication/utils/lambda/SmsQuotaMonitorHandlerTest.java
+++ b/utils/src/test/java/uk/gov/di/authentication/utils/lambda/SmsQuotaMonitorHandlerTest.java
@@ -3,6 +3,7 @@ package uk.gov.di.authentication.utils.lambda;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.ScheduledEvent;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
 import software.amazon.awssdk.services.cloudwatch.model.Datapoint;
 import software.amazon.awssdk.services.cloudwatch.model.GetMetricStatisticsRequest;
@@ -11,10 +12,14 @@ import software.amazon.awssdk.services.cloudwatch.model.PutMetricDataRequest;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
 import java.time.Instant;
+import java.util.Collections;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -24,43 +29,129 @@ class SmsQuotaMonitorHandlerTest {
     private final CloudWatchClient cloudWatchClient = mock(CloudWatchClient.class);
 
     @Test
-    void shouldEmitCorrectValuesBasedOnThresholds() {
+    void shouldEmitWarningWhenDomesticThresholdExceeded() {
         when(configurationService.getEnvironment()).thenReturn("test");
-        when(configurationService.getDomesticSmsQuotaThreshold()).thenReturn(500.0);
-        when(configurationService.getInternationalSmsQuotaThreshold()).thenReturn(200.0);
+        when(configurationService.getDomesticSmsQuotaThreshold()).thenReturn(300000.0);
+        when(configurationService.getInternationalSmsQuotaThreshold()).thenReturn(3600.0);
 
         var handler = new SmsQuotaMonitorHandler(configurationService, cloudWatchClient);
 
-        // Domestic: 600 exceeds threshold of 500, International: 150 below threshold of 200
         when(cloudWatchClient.getMetricStatistics(any(GetMetricStatisticsRequest.class)))
-                .thenReturn(createMetricResponse(600.0))
-                .thenReturn(createMetricResponse(150.0));
+                .thenReturn(createMetricResponse(300100.0))
+                .thenReturn(createMetricResponse(100.0));
 
         handler.handleRequest(mock(ScheduledEvent.class), mock(Context.class));
 
-        // Should emit metrics for both domestic (value 1) and international (value 0)
-        verify(cloudWatchClient, org.mockito.Mockito.times(2))
-                .putMetricData(any(PutMetricDataRequest.class));
+        var captor = ArgumentCaptor.forClass(PutMetricDataRequest.class);
+        verify(cloudWatchClient, times(2)).putMetricData(captor.capture());
+
+        var requests = captor.getAllValues();
+        assertEquals(1.0, requests.get(0).metricData().get(0).value()); // Domestic warning
+        assertEquals(0.0, requests.get(1).metricData().get(0).value()); // International OK
     }
 
     @Test
-    void shouldEmitZeroWhenBothThresholdsNotExceeded() {
+    void shouldEmitWarningWhenInternationalThresholdExceeded() {
         when(configurationService.getEnvironment()).thenReturn("test");
-        when(configurationService.getDomesticSmsQuotaThreshold()).thenReturn(800.0);
-        when(configurationService.getInternationalSmsQuotaThreshold()).thenReturn(200.0);
+        when(configurationService.getDomesticSmsQuotaThreshold()).thenReturn(300000.0);
+        when(configurationService.getInternationalSmsQuotaThreshold()).thenReturn(3600.0);
 
         var handler = new SmsQuotaMonitorHandler(configurationService, cloudWatchClient);
 
-        // Domestic: 300 below threshold of 800, International: 150 below threshold of 200
         when(cloudWatchClient.getMetricStatistics(any(GetMetricStatisticsRequest.class)))
-                .thenReturn(createMetricResponse(300.0))
-                .thenReturn(createMetricResponse(150.0));
+                .thenReturn(createMetricResponse(100.0))
+                .thenReturn(createMetricResponse(4000.0));
 
         handler.handleRequest(mock(ScheduledEvent.class), mock(Context.class));
 
-        // Should emit value 0 for both metrics when below thresholds
-        verify(cloudWatchClient, org.mockito.Mockito.times(2))
-                .putMetricData(any(PutMetricDataRequest.class));
+        var captor = ArgumentCaptor.forClass(PutMetricDataRequest.class);
+        verify(cloudWatchClient, times(2)).putMetricData(captor.capture());
+
+        var requests = captor.getAllValues();
+        assertEquals(0.0, requests.get(0).metricData().get(0).value()); // Domestic OK
+        assertEquals(1.0, requests.get(1).metricData().get(0).value()); // International warning
+    }
+
+    @Test
+    void shouldUseCorrectPeriodCalculation() {
+        when(configurationService.getEnvironment()).thenReturn("test");
+        when(configurationService.getDomesticSmsQuotaThreshold()).thenReturn(300000.0);
+        when(configurationService.getInternationalSmsQuotaThreshold()).thenReturn(3600.0);
+
+        var handler = new SmsQuotaMonitorHandler(configurationService, cloudWatchClient);
+
+        when(cloudWatchClient.getMetricStatistics(any(GetMetricStatisticsRequest.class)))
+                .thenReturn(createMetricResponse(0.0));
+
+        handler.handleRequest(mock(ScheduledEvent.class), mock(Context.class));
+
+        var captor = ArgumentCaptor.forClass(GetMetricStatisticsRequest.class);
+        verify(cloudWatchClient, times(2)).getMetricStatistics(captor.capture());
+
+        // Period should be multiple of 60
+        for (var request : captor.getAllValues()) {
+            assertTrue(request.period() % 60 == 0, "Period must be multiple of 60 seconds");
+        }
+    }
+
+    @Test
+    void shouldHandleNoDataScenario() {
+        when(configurationService.getEnvironment()).thenReturn("test");
+        when(configurationService.getDomesticSmsQuotaThreshold()).thenReturn(300000.0);
+        when(configurationService.getInternationalSmsQuotaThreshold()).thenReturn(3600.0);
+
+        var handler = new SmsQuotaMonitorHandler(configurationService, cloudWatchClient);
+
+        when(cloudWatchClient.getMetricStatistics(any(GetMetricStatisticsRequest.class)))
+                .thenReturn(createEmptyMetricResponse());
+
+        handler.handleRequest(mock(ScheduledEvent.class), mock(Context.class));
+
+        var captor = ArgumentCaptor.forClass(PutMetricDataRequest.class);
+        verify(cloudWatchClient, times(2)).putMetricData(captor.capture());
+
+        // Should emit 0.0 when no data available
+        var requests = captor.getAllValues();
+        assertEquals(0.0, requests.get(0).metricData().get(0).value());
+        assertEquals(0.0, requests.get(1).metricData().get(0).value());
+    }
+
+    @Test
+    void shouldUseCorrectMetricNamesAndDimensions() {
+        when(configurationService.getEnvironment()).thenReturn("production");
+        when(configurationService.getDomesticSmsQuotaThreshold()).thenReturn(300000.0);
+        when(configurationService.getInternationalSmsQuotaThreshold()).thenReturn(3600.0);
+
+        var handler = new SmsQuotaMonitorHandler(configurationService, cloudWatchClient);
+
+        when(cloudWatchClient.getMetricStatistics(any(GetMetricStatisticsRequest.class)))
+                .thenReturn(createMetricResponse(0.0));
+
+        handler.handleRequest(mock(ScheduledEvent.class), mock(Context.class));
+
+        var getCaptor = ArgumentCaptor.forClass(GetMetricStatisticsRequest.class);
+        var putCaptor = ArgumentCaptor.forClass(PutMetricDataRequest.class);
+        verify(cloudWatchClient, times(2)).getMetricStatistics(getCaptor.capture());
+        verify(cloudWatchClient, times(2)).putMetricData(putCaptor.capture());
+
+        // Verify input metric names
+        var getRequests = getCaptor.getAllValues();
+        assertEquals("DomesticSmsSent", getRequests.get(0).metricName());
+        assertEquals("InternationalSmsSent", getRequests.get(1).metricName());
+
+        // Verify output metric names
+        var putRequests = putCaptor.getAllValues();
+        assertEquals(
+                "DomesticSmsQuotaEarlyWarning",
+                putRequests.get(0).metricData().get(0).metricName());
+        assertEquals(
+                "InternationalSmsQuotaEarlyWarning",
+                putRequests.get(1).metricData().get(0).metricName());
+
+        // Verify environment dimension
+        for (var request : getRequests) {
+            assertEquals("production", request.dimensions().get(0).value());
+        }
     }
 
     private GetMetricStatisticsResponse createMetricResponse(double value) {
@@ -68,5 +159,9 @@ class SmsQuotaMonitorHandlerTest {
                 .datapoints(
                         List.of(Datapoint.builder().sum(value).timestamp(Instant.now()).build()))
                 .build();
+    }
+
+    private GetMetricStatisticsResponse createEmptyMetricResponse() {
+        return GetMetricStatisticsResponse.builder().datapoints(Collections.emptyList()).build();
     }
 }


### PR DESCRIPTION
## What

- Fix alarm thresholds to 1 for binary warning metrics (0/1)
- Fix CloudWatch period calculation (must be multiple of 60s)
- Reduce monitoring frequency to 1 minute for faster detection
- Enhance alarm testing script for lambda-processed metrics
- Add comprehensive test coverage for edge cases
- Add runbook links to alarm descriptions


<!-- Describe what you have changed and why -->

## How to review
1. Code Review

<!-- Describe the steps required to review this PR.
For example:

1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Deployment of this PR will not break active user journeys

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] No changes required or changes have been made to stub-orchestration.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
