### PR TITLE
ATO 1962/access token store and master key

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -1183,6 +1183,8 @@ Resources:
 
   AccessTokenTableEncryptionKey:
     Type: AWS::KMS::Key
+    DeletionPolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
+    UpdateReplacePolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
     Properties:
       Description: KMS encryption key for Access Token DynamoDB table
       EnableKeyRotation: true
@@ -1212,6 +1214,8 @@ Resources:
 
   AccessTokenTable:
     Type: AWS::DynamoDB::Table
+    DeletionPolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
+    UpdateReplacePolicy: !If [IsNotDevEnvironment, Retain, !Ref AWS::NoValue]
     Properties:
       TableName: !Sub ${Environment}-Access-Token
       AttributeDefinitions:


### PR DESCRIPTION
### Wider context of change

Migrating the access token store from redis to dynamoDb

### What’s changed

Created a access token store table with a composite key with clientId and rpPairwiseId. Also a global secondary index for AuthCode

Created the permissions policies for accessing the table and key

### Manual testing

(ToDo deploy to dev)

