### PR TITLE
AUT-4207: Apply Dynatrace lambda layer to email check results writer

### DIFF
--- a/ci/terraform/utils/dynatrace.tf
+++ b/ci/terraform/utils/dynatrace.tf
@@ -1,0 +1,14 @@
+locals {
+  dynatrace_production_secret    = "arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables"
+  dynatrace_nonproduction_secret = "arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables"
+
+  # tflint-ignore: terraform_unused_declarations
+  dynatrace_secret = jsondecode(data.aws_secretsmanager_secret_version.dynatrace_secret.secret_string)
+}
+
+data "aws_secretsmanager_secret" "dynatrace_secret" {
+  arn = var.environment == "production" ? local.dynatrace_production_secret : local.dynatrace_nonproduction_secret
+}
+data "aws_secretsmanager_secret_version" "dynatrace_secret" {
+  secret_id = data.aws_secretsmanager_secret.dynatrace_secret.id
+}

--- a/ci/terraform/utils/email_check_results_writer_lambda.tf
+++ b/ci/terraform/utils/email_check_results_writer_lambda.tf
@@ -1,12 +1,12 @@
 resource "aws_lambda_event_source_mapping" "lambda_sqs_mapping" {
   count                              = 1
   event_source_arn                   = var.email_check_results_sqs_queue_arn
-  function_name                      = aws_lambda_function.email_check_results_writer_lambda.arn
+  function_name                      = module.email_check_results_writer_lambda.endpoint_lambda_function.arn
   batch_size                         = 1
   maximum_batching_window_in_seconds = 0
 
   depends_on = [
-    aws_lambda_function.email_check_results_writer_lambda,
+    module.email_check_results_writer_lambda,
     aws_iam_policy.email_check_queue_policy,
   ]
 }
@@ -26,80 +26,36 @@ module "email_check_results_writer_role" {
   ]
 }
 
-resource "aws_lambda_function" "email_check_results_writer_lambda" {
-  #checkov:skip=CKV_AWS_116:No DLQ is required for this lambda, as it is SQS driven, and the SQS has a DLQ
-  function_name = "${var.environment}-email-check-writer"
-  role          = module.email_check_results_writer_role.arn
-  handler       = "uk.gov.di.authentication.utils.lambda.EmailCheckResultWriterHandler::handleRequest"
-  timeout       = 30
-  memory_size   = 512
-  runtime       = "java17"
-  publish       = true
+module "email_check_results_writer_lambda" {
+  source = "../modules/endpoint-lambda"
 
-  s3_bucket         = aws_s3_object.utils_release_zip.bucket
-  s3_key            = aws_s3_object.utils_release_zip.key
-  s3_object_version = aws_s3_object.utils_release_zip.version_id
+  endpoint_name = "email-check-writer"
+  handler_environment_variables = {
+    ENVIRONMENT = var.environment
+  }
+  handler_function_name = "uk.gov.di.authentication.utils.lambda.EmailCheckResultWriterHandler::handleRequest"
 
+  memory_size             = 2048
+  provisioned_concurrency = var.email_check_results_writer_provisioned_concurrency
+
+  source_bucket           = aws_s3_object.utils_release_zip.bucket
+  lambda_zip_file         = aws_s3_object.utils_release_zip.key
+  lambda_zip_file_version = aws_s3_object.utils_release_zip.version_id
   code_signing_config_arn = local.lambda_code_signing_configuration_arn
 
-  vpc_config {
-    security_group_ids = [local.authentication_egress_security_group_id]
-    subnet_ids         = local.authentication_private_subnet_ids
-  }
+  security_group_ids = [local.authentication_egress_security_group_id]
+  subnet_id          = local.authentication_private_subnet_ids
+  environment        = var.environment
+  lambda_role_arn    = module.email_check_results_writer_role.arn
 
-  tracing_config {
-    mode = "Active"
-  }
+  logging_endpoint_arns                  = var.logging_endpoint_arns
+  cloudwatch_key_arn                     = local.cloudwatch_encryption_key_arn
+  cloudwatch_log_retention               = var.cloudwatch_log_retention
+  lambda_env_vars_encryption_kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn
 
-  environment {
-    variables = {
-      JAVA_TOOL_OPTIONS = "-XX:+TieredCompilation -XX:TieredStopAtLevel=1 '--add-reads=jdk.jfr=ALL-UNNAMED'"
-      ENVIRONMENT       = var.environment
-    }
-  }
-  kms_key_arn = local.lambda_env_vars_encryption_kms_key_arn
-}
+  account_alias         = local.aws_account_alias
+  slack_event_topic_arn = local.slack_event_sns_topic_arn
+  dynatrace_secret      = local.dynatrace_secret
 
-resource "aws_lambda_alias" "email_check_results_writer_lambda" {
-  name             = replace("${aws_lambda_function.email_check_results_writer_lambda.function_name}-lambda-active", ".", "")
-  description      = "Alias pointing at active version of Lambda"
-  function_name    = aws_lambda_function.email_check_results_writer_lambda.arn
-  function_version = aws_lambda_function.email_check_results_writer_lambda.version
-}
-
-resource "aws_lambda_provisioned_concurrency_config" "endpoint_lambda_concurrency_config" {
-  count = var.email_check_results_writer_provisioned_concurrency == 0 ? 0 : 1
-
-  function_name = aws_lambda_function.email_check_results_writer_lambda.function_name
-  qualifier     = aws_lambda_alias.email_check_results_writer_lambda.name
-
-  provisioned_concurrent_executions = var.email_check_results_writer_provisioned_concurrency
-
-  lifecycle {
-    ignore_changes = [provisioned_concurrent_executions]
-  }
-
-}
-
-resource "aws_cloudwatch_log_group" "lambda_log_group" {
-  name       = "/aws/lambda/${aws_lambda_function.email_check_results_writer_lambda.function_name}"
-  kms_key_id = local.cloudwatch_encryption_key_arn
-  #checkov:skip=CKV_AWS_338:Cloudwatch logs do not need to be retained for a year, as they are shipped elsewhere (Splunk)
-  retention_in_days = var.cloudwatch_log_retention
-
-  depends_on = [
-    aws_lambda_function.email_check_results_writer_lambda
-  ]
-}
-
-resource "aws_cloudwatch_log_subscription_filter" "log_subscription" {
-  count           = length(var.logging_endpoint_arns)
-  name            = replace("${aws_lambda_function.email_check_results_writer_lambda.function_name}-log-subscription-${count.index}", ".", "")
-  log_group_name  = aws_cloudwatch_log_group.lambda_log_group.name
-  filter_pattern  = ""
-  destination_arn = var.logging_endpoint_arns[count.index]
-
-  lifecycle {
-    create_before_destroy = false
-  }
+  depends_on = [module.email_check_results_writer_role]
 }

--- a/ci/terraform/utils/email_check_results_writer_sqs_permissions.tf
+++ b/ci/terraform/utils/email_check_results_writer_sqs_permissions.tf
@@ -43,7 +43,7 @@ resource "aws_iam_policy" "email_check_sqs_kms_decrypt_policy" {
 resource "aws_lambda_permission" "allow_sqs_invoke" {
   statement_id  = "SQSInvokeFunction"
   action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.email_check_results_writer_lambda.function_name
+  function_name = module.email_check_results_writer_lambda.endpoint_lambda_function.function_name
 
   principal  = "sqs.amazonaws.com"
   source_arn = var.email_check_results_sqs_queue_arn


### PR DESCRIPTION
## What

- Apply Dynatrace lambda layer to email checks result writer
- This is included in the endpoint_lambda configuration, so the email check results writer .tf file has been refactored to source this configuration
- Bumped memory_size to 2048 as this is advised for DT lambda layer

## How to review

1. Code Review
2. Deploy to dev environment and see that SQS event sent to the pending email check results queue is processed successfully,

