### PR TITLE
INC0015348: Increase delete-synthetics-user memory to support Dynatrace

### DIFF
--- a/ci/terraform/test-services/variables.tf
+++ b/ci/terraform/test-services/variables.tf
@@ -48,7 +48,7 @@ variable "cloudwatch_log_retention" {
 }
 
 variable "endpoint_memory_size" {
-  default = 512
+  default = 1536
   type    = number
 }
 


### PR DESCRIPTION
## What

Increase delete-synthetics-user memory to support Dynatrace

On a restart the lambda errored with the message

`Not enough memory allocated to the function.  The Dynatrace OneAgent will not be injected
(1500MB are required , but only 512 MB available)`

## How to review

1. Code Review

