### PR TITLE
Revert "Revert "ATO-1946: Add clientName to token metric""

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/lambda/TokenHandler.java
@@ -62,6 +62,7 @@ import static com.nimbusds.oauth2.sdk.OAuth2Error.INVALID_GRANT_CODE;
 import static java.lang.String.format;
 import static uk.gov.di.orchestration.shared.conditions.DocAppUserHelper.isDocCheckingAppUserWithSubjectId;
 import static uk.gov.di.orchestration.shared.domain.CloudwatchMetricDimensions.CLIENT;
+import static uk.gov.di.orchestration.shared.domain.CloudwatchMetricDimensions.CLIENT_NAME;
 import static uk.gov.di.orchestration.shared.domain.CloudwatchMetricDimensions.ENVIRONMENT;
 import static uk.gov.di.orchestration.shared.domain.CloudwatchMetrics.SUCCESSFUL_TOKEN_ISSUED;
 import static uk.gov.di.orchestration.shared.domain.TokenGeneratedAuditableEvent.OIDC_TOKEN_GENERATED;
@@ -283,7 +284,8 @@ public class TokenHandler
                 new HashMap<>(
                         Map.of(
                                 ENVIRONMENT.getValue(), configurationService.getEnvironment(),
-                                CLIENT.getValue(), clientRegistry.getClientID()));
+                                CLIENT.getValue(), clientRegistry.getClientID(),
+                                CLIENT_NAME.getValue(), clientRegistry.getClientName()));
         cloudwatchMetricsService.incrementCounter(SUCCESSFUL_TOKEN_ISSUED.getValue(), dimensions);
 
         LOG.info("Successfully generated tokens");

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/lambda/TokenHandlerTest.java
@@ -50,6 +50,7 @@ import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import uk.gov.di.orchestration.audit.TxmaAuditUser;
+import uk.gov.di.orchestration.shared.domain.CloudwatchMetricDimensions;
 import uk.gov.di.orchestration.shared.entity.AuthCodeExchangeData;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.OrchClientSessionItem;
@@ -257,7 +258,9 @@ public class TokenHandlerTest {
                                 ENVIRONMENT.getValue(),
                                 configurationService.getEnvironment(),
                                 CLIENT.getValue(),
-                                CLIENT_ID));
+                                CLIENT_ID,
+                                CloudwatchMetricDimensions.CLIENT_NAME.getValue(),
+                                CLIENT_NAME));
         verify(auditService)
                 .submitAuditEvent(
                         OIDC_TOKEN_GENERATED,
@@ -390,7 +393,9 @@ public class TokenHandlerTest {
                                 ENVIRONMENT.getValue(),
                                 configurationService.getEnvironment(),
                                 CLIENT.getValue(),
-                                CLIENT_ID));
+                                CLIENT_ID,
+                                CloudwatchMetricDimensions.CLIENT_NAME.getValue(),
+                                CLIENT_NAME));
         verify(auditService)
                 .submitAuditEvent(
                         OIDC_TOKEN_GENERATED,
@@ -796,7 +801,9 @@ public class TokenHandlerTest {
                                     ENVIRONMENT.getValue(),
                                     configurationService.getEnvironment(),
                                     CLIENT.getValue(),
-                                    CLIENT_ID));
+                                    CLIENT_ID,
+                                    CloudwatchMetricDimensions.CLIENT_NAME.getValue(),
+                                    CLIENT_NAME));
             verify(auditService)
                     .submitAuditEvent(
                             OIDC_TOKEN_GENERATED,
@@ -843,7 +850,9 @@ public class TokenHandlerTest {
                                     ENVIRONMENT.getValue(),
                                     configurationService.getEnvironment(),
                                     CLIENT.getValue(),
-                                    CLIENT_ID));
+                                    CLIENT_ID,
+                                    CloudwatchMetricDimensions.CLIENT_NAME.getValue(),
+                                    CLIENT_NAME));
             verify(auditService, never())
                     .submitAuditEvent(eq(OIDC_TOKEN_GENERATED), anyString(), any());
 
@@ -1113,7 +1122,9 @@ public class TokenHandlerTest {
                                     ENVIRONMENT.getValue(),
                                     configurationService.getEnvironment(),
                                     CLIENT.getValue(),
-                                    CLIENT_ID));
+                                    CLIENT_ID,
+                                    CloudwatchMetricDimensions.CLIENT_NAME.getValue(),
+                                    CLIENT_NAME));
             verify(auditService)
                     .submitAuditEvent(
                             OIDC_TOKEN_GENERATED,
@@ -1253,7 +1264,9 @@ public class TokenHandlerTest {
                                 ENVIRONMENT.getValue(),
                                 configurationService.getEnvironment(),
                                 CLIENT.getValue(),
-                                DOC_APP_CLIENT_ID.getValue()));
+                                DOC_APP_CLIENT_ID.getValue(),
+                                CloudwatchMetricDimensions.CLIENT_NAME.getValue(),
+                                CLIENT_NAME));
         verify(auditService)
                 .submitAuditEvent(
                         OIDC_TOKEN_GENERATED,
@@ -1529,7 +1542,7 @@ public class TokenHandlerTest {
     private ClientRegistry generateClientRegistry(KeyPair keyPair, String clientID) {
         return new ClientRegistry()
                 .withClientID(clientID)
-                .withClientName("test-client")
+                .withClientName(CLIENT_NAME)
                 .withRedirectUrls(singletonList(REDIRECT_URI))
                 .withScopes(SCOPES.toStringList())
                 .withContacts(singletonList(TEST_EMAIL))


### PR DESCRIPTION
Reverts govuk-one-login/authentication-api#7116

Client Name was added to the dimensions of the successfulTokenIssued metric but this caused TSD's dashboard to fail, so the change was reverted. We now have agreed with TSD that we will go ahead with this change, and they will be able to correct their dashboard as required.