### PR TITLE
BAU: Fixes profile name to match the sso script output

### DIFF
--- a/sam-deploy-authdevs.sh
+++ b/sam-deploy-authdevs.sh
@@ -45,7 +45,7 @@ fi
 
 function sso_login() {
   export AWS_ACCOUNT=di-authentication-development
-  export AWS_PROFILE=di-authentication-development-AWSAdministratorAccess
+  export AWS_PROFILE=di-authentication-development-admin
   export AWS_REGION="eu-west-2"
 
   if ! aws sts get-caller-identity &> /dev/null; then


### PR DESCRIPTION
## What

Changes the name of the profile used to match the one created by [_set_up_sso.py line 278](https://github.com/govuk-one-login/authentication-api/blob/main/scripts/_set_up_sso.py#L278)

## How to review

Run ./scripts/set-up-sso.sh and then ./sam-deploy-authdevs.sh