### PR TITLE
BAU: Simplify phone number redaction

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/FrontendApiPhoneNumberHelper.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/helpers/FrontendApiPhoneNumberHelper.java
@@ -5,12 +5,11 @@ import uk.gov.di.authentication.shared.entity.mfa.MFAMethodType;
 
 public class FrontendApiPhoneNumberHelper {
     public static final int NUMBER_OF_LAST_DIGITS = 3;
+    public static final int NUMBER_OF_UNREDACTED_DIGITS = 4;
 
     public static String redactPhoneNumber(String phoneNumber) {
-        String substring = phoneNumber.substring(phoneNumber.length() - 4);
-        String newString = phoneNumber.substring(0, phoneNumber.length() - 4);
-        String concat = "*".repeat(newString.length());
-        return concat + substring;
+        int redactLength = phoneNumber.length() - NUMBER_OF_UNREDACTED_DIGITS;
+        return "*".repeat(redactLength) + phoneNumber.substring(redactLength);
     }
 
     public static String getLastDigitsOfPhoneNumber(UserMfaDetail userMfaDetail) {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/helpers/FrontendApiPhoneNumberHelperTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/helpers/FrontendApiPhoneNumberHelperTest.java
@@ -11,6 +11,7 @@ import java.util.stream.Stream;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static uk.gov.di.authentication.frontendapi.helpers.FrontendApiPhoneNumberHelper.getLastDigitsOfPhoneNumber;
+import static uk.gov.di.authentication.frontendapi.helpers.FrontendApiPhoneNumberHelper.redactPhoneNumber;
 
 class FrontendApiPhoneNumberHelperTest {
 
@@ -30,5 +31,21 @@ class FrontendApiPhoneNumberHelperTest {
                 Arguments.of(
                         new UserMfaDetail(false, false, MFAMethodType.SMS, "123456789"), "789"),
                 Arguments.of(new UserMfaDetail(false, false, MFAMethodType.SMS, "12"), null));
+    }
+
+    @ParameterizedTest
+    @MethodSource("phoneNumberRedactionCases")
+    void shouldRedactPhoneNumber(String phoneNumber, String expected) {
+        var result = redactPhoneNumber(phoneNumber);
+        assertThat(result, equalTo(expected));
+    }
+
+    private static Stream<Arguments> phoneNumberRedactionCases() {
+        return Stream.of(
+                Arguments.of("+447123456789", "*********6789"),
+                Arguments.of("07987654321", "*******4321"),
+                Arguments.of("1234", "1234"),
+                Arguments.of("123456789", "*****6789"),
+                Arguments.of("+11234567890", "********7890"));
     }
 }


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

- Simplified the `redactPhoneNumber` method for conciseness and reduced complexity
- Added missing unit tests

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

1. Code review
1. Optionally deploy

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
3. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Deployment of this PR will not break active user journeys **- internal string generation change only**

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked. **- N/A, auth frontend change only**

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] No changes required or changes have been made to stub-orchestration. **- N/A, technical refactor only**

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [x] A UCD review has been performed. **- N/A, technical refactor only, same functionality and views**
