### PR TITLE
AUT-4722: Fix `userProfile` retrieval failure exception message

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoServiceIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/authentication/services/DynamoServiceIntegrationTest.java
@@ -707,7 +707,7 @@ class DynamoServiceIntegrationTest {
         assertThrows(
                 RuntimeException.class,
                 () -> dynamoService.getUserProfileFromSubject("NonExistentUser"),
-                "No userCredentials found with query search");
+                "No userProfile found with query search");
     }
 
     @Test

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/DynamoService.java
@@ -541,7 +541,7 @@ public class DynamoService implements AuthenticationService {
     public UserProfile getUserProfileFromSubject(String subject) {
         Optional<UserProfile> userProfile = getOptionalUserProfileFromSubject(subject);
         if (userProfile.isEmpty()) {
-            throw new RuntimeException("No userCredentials found with query search");
+            throw new RuntimeException("No userProfile found with query search");
         }
         return userProfile.get();
     }
@@ -563,6 +563,9 @@ public class DynamoService implements AuthenticationService {
     public Optional<UserProfile> getOptionalUserProfileFromSubject(String subject) {
         QueryConditional q =
                 QueryConditional.keyEqualTo(Key.builder().partitionValue(subject).build());
+
+        // NOTE: We can't perform a strongly consistent read here as we are operating on a global
+        // secondary index (which is eventually consistent).
         QueryEnhancedRequest queryEnhancedRequest =
                 QueryEnhancedRequest.builder().consistentRead(false).queryConditional(q).build();
         return dynamoUserProfileTable.index("SubjectIDIndex").query(queryEnhancedRequest).stream()


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

Exception message refers to the wrong item. This was likely copied from the `userCredentials` retrieval op, we are searching for a `userProfile` item here.

Also added a small comment about why we're performing an eventually consistent read on this item.

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

1. Code Review

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [ ] Deployment of this PR will not break active user journeys **- N/A, exception message change only**

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked. **- N/A**

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [ ] No changes required or changes have been made to stub-orchestration. **- N/A**

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed. **- N/A**