### PR TITLE
BAU: Make integration tests rerunnable after failures

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -262,7 +262,7 @@ spotless {
 
 dockerCompose {
     buildBeforeUp = true
-    forceRecreate = false
+    forceRecreate = true
 
     if (System.getProperty("os.arch") == "aarch64") {
         useComposeFiles = [

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,11 @@ services:
       - di-authentication-api-net
     ports:
       - 45678:45678
+    healthcheck:
+      test: curl -f http://localhost:45678/_localstack/health || exit 1
+      interval: 5s
+      timeout: 10s
+      retries: 5
 
   redis:
     image: redis:6.2.19-alpine@sha256:7fe72c486b910f6b1a9769c937dad5d63648ddee82e056f47417542dd40825bb

--- a/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/SqsQueueExtension.java
+++ b/shared-test/src/main/java/uk/gov/di/authentication/sharedtest/extensions/SqsQueueExtension.java
@@ -18,7 +18,6 @@ import uk.gov.di.authentication.shared.services.SerializationService;
 
 import java.net.URI;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static java.text.MessageFormat.format;
@@ -91,26 +90,30 @@ public class SqsQueueExtension extends BaseAwsResourceExtension implements Befor
                         context.getTestClass().map(Class::getSimpleName).orElse("unknown"),
                         queueNameSuffix);
         var truncatedQueueName = queueName.substring(0, Math.min(80, queueName.length()));
-        queueUrl =
-                getQueueUrlFor(truncatedQueueName).orElseGet(() -> createQueue(truncatedQueueName));
-        sqsClient.purgeQueue(PurgeQueueRequest.builder().queueUrl(queueUrl).build());
-    }
 
-    private Optional<String> getQueueUrlFor(String queueName) {
+        // Always create a fresh queue to handle container recreation
+        queueUrl = createQueueOrGetExisting(truncatedQueueName);
+
+        // Clear any existing messages
         try {
-            return Optional.of(
-                    sqsClient
-                            .getQueueUrl(GetQueueUrlRequest.builder().queueName(queueName).build())
-                            .toString());
-        } catch (QueueDoesNotExistException ignored) {
-            return Optional.empty();
+            sqsClient.purgeQueue(PurgeQueueRequest.builder().queueUrl(queueUrl).build());
+        } catch (Exception e) {
+            // Ignore purge errors as queue might be newly created
         }
     }
 
-    private String createQueue(String queueName) {
-        return sqsClient
-                .createQueue(CreateQueueRequest.builder().queueName(queueName).build())
-                .queueUrl();
+    private String createQueueOrGetExisting(String queueName) {
+        try {
+            // Try to get existing queue first
+            return sqsClient
+                    .getQueueUrl(GetQueueUrlRequest.builder().queueName(queueName).build())
+                    .queueUrl();
+        } catch (QueueDoesNotExistException e) {
+            // Create new queue if it doesn't exist
+            return sqsClient
+                    .createQueue(CreateQueueRequest.builder().queueName(queueName).build())
+                    .queueUrl();
+        }
     }
 
     private List<Message> getMessages(int numberOfMessages) {


### PR DESCRIPTION

## What

Refactor SqsQueueExtension to handle container recreation:
- Always create fresh queue to handle container restarts
- Improve queue creation logic with fallback handling
- Add error handling for queue purge operations
- Remove unused Optional import

<!-- Describe what you have changed and why -->

## How to review
1. Code Review
2. Make an integration test fail then check the next build does not require deleting or recreating docker containers.

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to sandpit with `./deploy-sandpit.sh -a`
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.sandpit.url/to/visit)
1. Log in
1. Ensure `x` message appears in a modal
-->

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
3. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Deployment of this PR will not break active user journeys

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] No changes required or changes have been made to stub-orchestration.

<!-- UCD Review
When a new feature or front-end change goes live, ensure that a review of it has been performed by UCD. The review may have already taken place, but it is important to check that it did before going live.

Think about if the change you are making here will enable a change UCD should review (i.e. toggling a feature flag).

Contact UCD colleagues in the Authentication team to identify the best way to approach the review.

Delete this item if this PR does not need a UCD review.
-->

- [ ] A UCD review has been performed.

## Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
