### PR TITLE
ATO-2292: force empty client locs when sse registering

### DIFF
--- a/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandler.java
+++ b/client-registry-api/src/main/java/uk/gov/di/authentication/clientregistry/lambda/UpdateClientConfigHandler.java
@@ -11,6 +11,7 @@ import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.clientregistry.entity.ClientRegistrationResponse;
 import uk.gov.di.authentication.clientregistry.services.ClientConfigValidationService;
 import uk.gov.di.orchestration.audit.TxmaAuditUser;
+import uk.gov.di.orchestration.shared.dynamodb.SelfServiceClientRegistryExtension;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.UpdateClientConfigRequest;
 import uk.gov.di.orchestration.shared.helpers.IpAddressHelper;
@@ -56,7 +57,11 @@ public class UpdateClientConfigHandler
     }
 
     public UpdateClientConfigHandler(ConfigurationService configurationService) {
-        this.clientService = new DynamoClientService(configurationService);
+        this.clientService =
+                new DynamoClientService(
+                        configurationService,
+                        // HACK! See commit message
+                        new SelfServiceClientRegistryExtension());
         this.validationService = new ClientConfigValidationService();
         this.auditService = new AuditService(configurationService);
     }

--- a/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandlerTest.java
+++ b/client-registry-api/src/test/java/uk/gov/di/authentication/clientregistry/lambda/ClientRegistrationHandlerTest.java
@@ -47,8 +47,6 @@ import static uk.gov.di.authentication.clientregistry.domain.ClientRegistryAudit
 import static uk.gov.di.authentication.clientregistry.services.ClientConfigValidationService.INVALID_PUBLIC_KEY;
 import static uk.gov.di.authentication.clientregistry.services.ClientConfigValidationService.INVALID_SCOPE;
 import static uk.gov.di.orchestration.audit.TxmaAuditUser.user;
-import static uk.gov.di.orchestration.shared.entity.LevelOfConfidence.MEDIUM_LEVEL;
-import static uk.gov.di.orchestration.shared.entity.LevelOfConfidence.NONE;
 import static uk.gov.di.orchestration.shared.entity.ServiceType.MANDATORY;
 import static uk.gov.di.orchestration.sharedtest.logging.LogEventMatcher.withMessageContaining;
 import static uk.gov.di.orchestration.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
@@ -141,7 +139,7 @@ class ClientRegistrationHandlerTest {
     }
 
     @Test
-    void shouldRegisterWithLOCs() throws Json.JsonException {
+    void shouldIgnoreTheProvidedLOCsInTheRequest() throws Json.JsonException {
         when(configValidationService.validateClientRegistrationConfig(
                         any(ClientRegistrationRequest.class)))
                 .thenReturn(Optional.empty());
@@ -183,7 +181,7 @@ class ClientRegistrationHandlerTest {
                         null,
                         ClientAuthenticationMethod.PRIVATE_KEY_JWT.getValue(),
                         "ES256",
-                        List.of(NONE.getValue(), MEDIUM_LEVEL.getValue()),
+                        emptyList(),
                         Channel.WEB.getValue(),
                         false,
                         false,

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/dynamodb/DynamoClientHelper.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/dynamodb/DynamoClientHelper.java
@@ -2,6 +2,7 @@ package uk.gov.di.orchestration.shared.dynamodb;
 
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClientExtension;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
@@ -26,5 +27,14 @@ public class DynamoClientHelper {
             ConfigurationService configurationService) {
         var dynamoDbClient = createDynamoClient(configurationService);
         return DynamoDbEnhancedClient.builder().dynamoDbClient(dynamoDbClient).build();
+    }
+
+    public static DynamoDbEnhancedClient createDynamoEnhancedClient(
+            ConfigurationService configurationService, DynamoDbEnhancedClientExtension extension) {
+        var dynamoDbClient = createDynamoClient(configurationService);
+        return DynamoDbEnhancedClient.builder()
+                .dynamoDbClient(dynamoDbClient)
+                .extensions(extension)
+                .build();
     }
 }

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/dynamodb/SelfServiceClientRegistryExtension.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/dynamodb/SelfServiceClientRegistryExtension.java
@@ -1,0 +1,40 @@
+package uk.gov.di.orchestration.shared.dynamodb;
+
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClientExtension;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbExtensionContext;
+import software.amazon.awssdk.enhanced.dynamodb.extensions.WriteModification;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
+import static uk.gov.di.orchestration.shared.entity.LevelOfConfidence.HIGH_LEVEL;
+import static uk.gov.di.orchestration.shared.entity.LevelOfConfidence.LOW_LEVEL;
+
+public class SelfServiceClientRegistryExtension implements DynamoDbEnhancedClientExtension {
+    private static final List<String> manuallyConfiguredLocValues =
+            List.of(LOW_LEVEL.getValue(), HIGH_LEVEL.getValue());
+
+    @Override
+    public WriteModification beforeWrite(DynamoDbExtensionContext.BeforeWrite context) {
+        var clientItem = context.items();
+
+        if (clientItem == null) {
+            return WriteModification.builder().build();
+        }
+
+        if (!clientItem.containsKey("ClientLoCs")) {
+            return WriteModification.builder().build();
+        }
+
+        if (clientItem.get("ClientLoCs").l().stream()
+                .anyMatch(loc -> manuallyConfiguredLocValues.contains(loc.s()))) {
+            // Do not modify if the client contains manually configured values
+            return WriteModification.builder().build();
+        }
+        var modifiedClient = new HashMap<>(clientItem);
+        modifiedClient.put("ClientLoCs", AttributeValue.fromL(Collections.emptyList()));
+        return WriteModification.builder().transformedItem(modifiedClient).build();
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/DynamoClientService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/DynamoClientService.java
@@ -2,6 +2,7 @@ package uk.gov.di.orchestration.shared.services;
 
 import com.nimbusds.oauth2.sdk.id.ClientID;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClientExtension;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
@@ -21,6 +22,19 @@ public class DynamoClientService implements ClientService {
 
     private static final String CLIENT_REGISTRY_TABLE = "client-registry";
     private final DynamoDbTable<ClientRegistry> dynamoClientRegistryTable;
+
+    public DynamoClientService(
+            ConfigurationService configurationService, DynamoDbEnhancedClientExtension extension) {
+        var tableName = configurationService.getEnvironment() + "-" + CLIENT_REGISTRY_TABLE;
+
+        // This is for processing identity handler
+        if (configurationService.getOrchDynamoArnPrefix().isPresent()) {
+            tableName = configurationService.getOrchDynamoArnPrefix().get() + CLIENT_REGISTRY_TABLE;
+        }
+        var dynamoDBEnhanced = createDynamoEnhancedClient(configurationService, extension);
+        this.dynamoClientRegistryTable =
+                dynamoDBEnhanced.table(tableName, TableSchema.fromBean(ClientRegistry.class));
+    }
 
     public DynamoClientService(ConfigurationService configurationService) {
         var tableName = configurationService.getEnvironment() + "-" + CLIENT_REGISTRY_TABLE;

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/dynamoDb/SelfServiceClientRegistryExtensionTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/dynamoDb/SelfServiceClientRegistryExtensionTest.java
@@ -1,0 +1,156 @@
+package uk.gov.di.orchestration.shared.dynamoDb;
+
+import com.nimbusds.openid.connect.sdk.SubjectType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbExtensionContext;
+import software.amazon.awssdk.enhanced.dynamodb.extensions.WriteModification;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import uk.gov.di.orchestration.shared.dynamodb.SelfServiceClientRegistryExtension;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static java.util.Collections.emptyList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static uk.gov.di.orchestration.shared.entity.LevelOfConfidence.HIGH_LEVEL;
+import static uk.gov.di.orchestration.shared.entity.LevelOfConfidence.LOW_LEVEL;
+import static uk.gov.di.orchestration.shared.entity.LevelOfConfidence.MEDIUM_LEVEL;
+import static uk.gov.di.orchestration.shared.entity.LevelOfConfidence.NONE;
+
+class SelfServiceClientRegistryExtensionTest {
+
+    private SelfServiceClientRegistryExtension selfServiceClientRegistryExtension;
+    DynamoDbExtensionContext.BeforeWrite mockContext =
+            mock(DynamoDbExtensionContext.BeforeWrite.class);
+
+    @BeforeEach
+    void setup() {
+        selfServiceClientRegistryExtension = new SelfServiceClientRegistryExtension();
+    }
+
+    @Test
+    void itReturnsImmediatelyIfNullItem() {
+        when(mockContext.items()).thenReturn(null);
+
+        WriteModification writeModification =
+                selfServiceClientRegistryExtension.beforeWrite(mockContext);
+
+        assertNull(writeModification.transformedItem());
+    }
+
+    @Test
+    void itDoesNotModifyAnItemThatDoesNotContainTheClientLOCsField() {
+        var client = generateRawClientRegistryEntry(null);
+        when(mockContext.items()).thenReturn(client);
+
+        WriteModification writeModification =
+                selfServiceClientRegistryExtension.beforeWrite(mockContext);
+
+        assertNull(writeModification.transformedItem());
+    }
+
+    @Test
+    void itReturnsAnEmptyLOCIfTheClientContainsAP0LocValue() {
+        var client = new HashMap<>(generateRawClientRegistryEntry(List.of(NONE.getValue())));
+        when(mockContext.items()).thenReturn(client);
+
+        WriteModification writeModification =
+                selfServiceClientRegistryExtension.beforeWrite(mockContext);
+
+        var expectedModifiedClient = new HashMap<>(client);
+        expectedModifiedClient.put("ClientLoCs", AttributeValue.fromL(emptyList()));
+
+        assertEquals(expectedModifiedClient, writeModification.transformedItem());
+    }
+
+    @Test
+    void itReturnsAnEmptyLOCIfTheClientContainsAP2LocValue() {
+        var client =
+                new HashMap<>(generateRawClientRegistryEntry(List.of(MEDIUM_LEVEL.getValue())));
+        when(mockContext.items()).thenReturn(client);
+
+        WriteModification writeModification =
+                selfServiceClientRegistryExtension.beforeWrite(mockContext);
+
+        var expectedModifiedClient = new HashMap<>(client);
+        expectedModifiedClient.put("ClientLoCs", AttributeValue.fromL(emptyList()));
+
+        assertEquals(expectedModifiedClient, writeModification.transformedItem());
+    }
+
+    @Test
+    void itReturnsDoesNotModifyAClientIfTheClientContainsAP1LocValue() {
+        var client = new HashMap<>(generateRawClientRegistryEntry(List.of(LOW_LEVEL.getValue())));
+        when(mockContext.items()).thenReturn(client);
+
+        WriteModification writeModification =
+                selfServiceClientRegistryExtension.beforeWrite(mockContext);
+
+        assertNull(writeModification.transformedItem());
+    }
+
+    @Test
+    void itReturnsDoesNotModifyAClientIfTheClientContainsAP3LocValue() {
+        var client = new HashMap<>(generateRawClientRegistryEntry(List.of(HIGH_LEVEL.getValue())));
+        when(mockContext.items()).thenReturn(client);
+
+        WriteModification writeModification =
+                selfServiceClientRegistryExtension.beforeWrite(mockContext);
+
+        assertNull(writeModification.transformedItem());
+    }
+
+    private Map<String, AttributeValue> generateRawClientRegistryEntry(List<String> clientLocs) {
+        var client =
+                new HashMap<>(
+                        Map.ofEntries(
+                                Map.entry("ClientID", AttributeValue.fromS("test-client")),
+                                Map.entry("ClientName", AttributeValue.fromS("test-client")),
+                                Map.entry("PublicKey", AttributeValue.fromS("example-key")),
+                                Map.entry(
+                                        "Scopes",
+                                        AttributeValue.fromL(
+                                                List.of(
+                                                        AttributeValue.fromS("openid"),
+                                                        AttributeValue.fromS("email"),
+                                                        AttributeValue.fromS("phone")))),
+                                Map.entry(
+                                        "RedirectUrls",
+                                        AttributeValue.fromL(
+                                                List.of(
+                                                        AttributeValue.fromS(
+                                                                "https://example.com")))),
+                                Map.entry(
+                                        "Contacts",
+                                        AttributeValue.fromL(
+                                                List.of(
+                                                        AttributeValue.fromS(
+                                                                "example@example.com")))),
+                                Map.entry(
+                                        "PostLogoutRedirectUrls",
+                                        AttributeValue.fromL(
+                                                List.of(
+                                                        AttributeValue.fromS(
+                                                                "https://example.com/post-logout")))),
+                                Map.entry("ServiceType", AttributeValue.fromS("MANDATORY")),
+                                Map.entry(
+                                        "SectorIdentifierUri",
+                                        AttributeValue.fromS("https://example.com")),
+                                Map.entry(
+                                        "SubjectType",
+                                        AttributeValue.fromS(SubjectType.PAIRWISE.toString()))));
+
+        if (Objects.nonNull(clientLocs)) {
+            client.put(
+                    "ClientLoCs",
+                    AttributeValue.fromL(clientLocs.stream().map(AttributeValue::fromS).toList()));
+        }
+        return client;
+    }
+}


### PR DESCRIPTION
### Wider context of change:

We previously removed setting the client LOCs value in SSE, because it was doing  it in a slightly wrong way and ran the risk of overwriting values which we manually configured for clients. So we decided to remove this and allow or runtime defaulting using the `IsIdentityVerificationEnabled` flag to determine the permitted Levels of Confidence, which would also allow us to persist manually updated values. 

### What’s changed:
- Uses the DynamoEnhancedClientExtension's beforeWrite hook to override the value of ClientLoCs on creation and updating the DB. This is **only** applied in the SSE create and update handlers.
- Includes an exclusion for clients using manually configured values (`P1` or `P3`)

### Manual testing

TODO: Deployed to dev:
- registered a new client - saw empty LOCs in dynamo ✅ 
- updated an existing client configured with `[P0]` - saw empty LOCs in dynamo ✅
- updated an existing client configured with `[P0]` to turn on identity verification - saw empty LOCs in dynamo and made a P2 request successfully ✅
- Updated a client manually configured with `P3` and saw the the client locs unaffected ✅


### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
