### PR TITLE
ATO-2190 Update dynatrace layer in int and prod

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -229,8 +229,8 @@ Mappings:
       syncWaitForSpotTimeout: 20000
     integration:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
-      dynatraceLayerArn: arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_311_51_20250331-143707_with_collector_java:1
-      architecture: x86_64
+      dynatraceLayerArn: arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_331_39_20260206-150338_with_collector_java_arm:1
+      architecture: arm64
       authApiId: "k2skqhxed6"
       authExternalApiId: "5wcpjlfg3i"
       authAccountId: "761723964695"
@@ -256,8 +256,8 @@ Mappings:
       syncWaitForSpotTimeout: 5000
     production:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
-      dynatraceLayerArn: arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_311_51_20250331-143707_with_collector_java:1
-      architecture: x86_64
+      dynatraceLayerArn: arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_331_39_20260206-150338_with_collector_java_arm:1
+      architecture: arm64
       authApiId: "s4gj268zy6"
       authExternalApiId: "9k68v07tz7"
       authAccountId: "172348255554"
@@ -314,15 +314,6 @@ Globals:
                 !Ref Environment,
                 dynatraceSecretArn,
               ]
-        # Can be removed once all environments are using the new DT layer
-        DT_CLUSTER_ID: !Sub
-          - "{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CLUSTER_ID}}"
-          - SecretArn:
-              !FindInMap [
-                EnvironmentConfiguration,
-                !Ref Environment,
-                dynatraceSecretArn,
-              ]
         DT_LOG_COLLECTION_AUTH_TOKEN: !Sub
           - "{{resolve:secretsmanager:${SecretArn}:SecretString:DT_LOG_COLLECTION_AUTH_TOKEN}}"
           - SecretArn:
@@ -339,8 +330,6 @@ Globals:
                 !Ref Environment,
                 dynatraceSecretArn,
               ]
-        # Can be removed once all environments are using the new DT layer
-        DT_OPEN_TELEMETRY_ENABLE_INTEGRATION: "true"
         OTEL_INSTRUMENTATION_AWS_SDK_EXPERIMENTAL_USE_PROPAGATOR_FOR_MESSAGING: "true"
         JAVA_TOOL_OPTIONS: "-XX:+TieredCompilation -XX:TieredStopAtLevel=1 '--add-reads=jdk.jfr=ALL-UNNAMED'"
     MemorySize: 1536


### PR DESCRIPTION
### Wider context of change

Update Dynatrace layer to improve performance, tracing, and eliminate segfaults.

See: https://github.com/govuk-one-login/authentication-api/pull/8037

### What’s changed

- Dynatrace layer version in integration and production
- arm64 architecture in integration and production

### Manual testing

Deployed into non-prod environments and tested, including a perf test.

Cold start latency is increased, but other latency looks stable.
