### PR TITLE
ATO-2464: Reject non P0 requests for non identity clients

### DIFF
--- a/integration-tests/src/test/java/uk/gov/di/orchestration/oidc/lambda/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/orchestration/oidc/lambda/AuthorisationIntegrationTest.java
@@ -663,8 +663,8 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             setupForAuthJourney();
             String sessionId = givenAnExistingSession();
 
-            var queryParams = constructQueryStringParameters(
-                    CLIENT_ID, null, "openid", "[P2.Cl.Cm,Cl.Cm]");
+            var queryParams =
+                    constructQueryStringParameters(CLIENT_ID, null, "openid ", "[P2.Cl.Cm,Cl.Cm]");
             queryParams.put("vtr", jsonArrayOf("P2.Cl.Cm", "Cl.Cm"));
             var response =
                     makeRequest(
@@ -688,19 +688,18 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         @Test
         void
-        shouldReturnRequestVtrNotValidErrorToRPWhenIdentityLoCRequestedAndIdentityNotSupported() {
+                shouldReturnRequestVtrNotValidErrorToRPWhenIdentityLoCRequestedAndIdentityNotSupported() {
             setupForAuthJourney(false);
             String sessionId = givenAnExistingSession();
 
-            var queryParams = constructQueryStringParameters(
-                    CLIENT_ID, null, "openid", "P2.Cl.Cm");
+            var queryParams = constructQueryStringParameters(CLIENT_ID, null, "openid", "P2.Cl.Cm");
             var response =
                     makeRequest(
                             Optional.empty(),
                             constructHeaders(
-                                    new HttpCookie[]{
-                                            buildSessionCookie(sessionId, DUMMY_CLIENT_SESSION_ID),
-                                            new HttpCookie("bsid", BROWSER_SESSION_ID)
+                                    new HttpCookie[] {
+                                        buildSessionCookie(sessionId, DUMMY_CLIENT_SESSION_ID),
+                                        new HttpCookie("bsid", BROWSER_SESSION_ID)
                                     }),
                             queryParams,
                             Optional.of("GET"));
@@ -2197,6 +2196,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         return queryStringParameters;
     }
+
     private void setupForAuthJourney() {
         setupForAuthJourney(true);
     }

--- a/integration-tests/src/test/java/uk/gov/di/orchestration/oidc/lambda/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/orchestration/oidc/lambda/AuthorisationIntegrationTest.java
@@ -663,6 +663,9 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
             setupForAuthJourney();
             String sessionId = givenAnExistingSession();
 
+            var queryParams = constructQueryStringParameters(
+                    CLIENT_ID, null, "openid", "[P2.Cl.Cm,Cl.Cm]");
+            queryParams.put("vtr", jsonArrayOf("P2.Cl.Cm", "Cl.Cm"));
             var response =
                     makeRequest(
                             Optional.empty(),
@@ -671,8 +674,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                                         buildSessionCookie(sessionId, DUMMY_CLIENT_SESSION_ID),
                                         new HttpCookie("bsid", BROWSER_SESSION_ID)
                                     }),
-                            constructQueryStringParameters(
-                                    CLIENT_ID, null, "openid", "[P2.Cl.Cm,Cl.Cm]"),
+                            queryParams,
                             Optional.of("GET"));
 
             assertThat(response, hasStatus(302));

--- a/integration-tests/src/test/java/uk/gov/di/orchestration/oidc/lambda/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/orchestration/oidc/lambda/AuthorisationIntegrationTest.java
@@ -1163,6 +1163,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                     .withPublicKey(
                             Base64.getMimeEncoder()
                                     .encodeToString(RP_KEY_PAIR.getPublic().getEncoded()))
+                    .withIdentityVerificationSupported(true)
                     .saveToDynamo();
             handler = new AuthorisationHandler(configuration);
             txmaAuditQueue.clear();
@@ -1341,6 +1342,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                     .withPublicKey(
                             Base64.getMimeEncoder()
                                     .encodeToString(RP_KEY_PAIR.getPublic().getEncoded()))
+                    .withIdentityVerificationSupported(true)
                     .saveToDynamo();
             handler = new AuthorisationHandler(configuration);
             txmaAuditQueue.clear();
@@ -2178,6 +2180,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 .withPublicKey(
                         Base64.getMimeEncoder()
                                 .encodeToString(RP_KEY_PAIR.getPublic().getEncoded()))
+                .withIdentityVerificationSupported(true)
                 .saveToDynamo();
         handler = new AuthorisationHandler(configuration);
         txmaAuditQueue.clear();

--- a/integration-tests/src/test/java/uk/gov/di/orchestration/oidc/lambda/AuthorisationIntegrationTest.java
+++ b/integration-tests/src/test/java/uk/gov/di/orchestration/oidc/lambda/AuthorisationIntegrationTest.java
@@ -687,6 +687,34 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
         }
 
         @Test
+        void
+        shouldReturnRequestVtrNotValidErrorToRPWhenIdentityLoCRequestedAndIdentityNotSupported() {
+            setupForAuthJourney(false);
+            String sessionId = givenAnExistingSession();
+
+            var queryParams = constructQueryStringParameters(
+                    CLIENT_ID, null, "openid", "P2.Cl.Cm");
+            var response =
+                    makeRequest(
+                            Optional.empty(),
+                            constructHeaders(
+                                    new HttpCookie[]{
+                                            buildSessionCookie(sessionId, DUMMY_CLIENT_SESSION_ID),
+                                            new HttpCookie("bsid", BROWSER_SESSION_ID)
+                                    }),
+                            queryParams,
+                            Optional.of("GET"));
+
+            assertThat(response, hasStatus(302));
+            var redirectUri = getLocationResponseHeader(response);
+            assertThat(redirectUri, startsWith(RP_REDIRECT_URI.toString()));
+            assertThat(URI.create(redirectUri).getQuery(), containsString("error=invalid_request"));
+            assertThat(
+                    URI.create(redirectUri).getQuery(),
+                    containsString("error_description=Request+vtr+is+not+permitted"));
+        }
+
+        @Test
         void shouldRedirectToFrontendWhenPromptNoneAndUserUnauthenticated() {
             setupForAuthJourney();
             var response =
@@ -2169,8 +2197,11 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
 
         return queryStringParameters;
     }
-
     private void setupForAuthJourney() {
+        setupForAuthJourney(true);
+    }
+
+    private void setupForAuthJourney(boolean identityVerificationSupported) {
         clientStore
                 .createClient()
                 .withClientId(CLIENT_ID)
@@ -2182,7 +2213,7 @@ class AuthorisationIntegrationTest extends ApiGatewayHandlerIntegrationTest {
                 .withPublicKey(
                         Base64.getMimeEncoder()
                                 .encodeToString(RP_KEY_PAIR.getPublic().getEncoded()))
-                .withIdentityVerificationSupported(true)
+                .withIdentityVerificationSupported(identityVerificationSupported)
                 .saveToDynamo();
         handler = new AuthorisationHandler(configuration);
         txmaAuditQueue.clear();

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/BaseAuthorizeValidator.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/BaseAuthorizeValidator.java
@@ -149,6 +149,41 @@ public abstract class BaseAuthorizeValidator {
         return Optional.empty();
     }
 
+    protected Optional<ErrorObject> validateVtr(List<String> authRequestVtr, ClientRegistry client) {
+        try {
+            var vtrList = VectorOfTrust.parseFromAuthRequestAttribute(authRequestVtr);
+            var levelOfConfidenceValues = VectorOfTrust.getRequestedLevelsOfConfidence(vtrList);
+            if (!client.getClientLoCs().containsAll(levelOfConfidenceValues)) {
+                logErrorInProdElseWarn(
+                        String.format(
+                                "Level of confidence values have been requested which this client is not permitted to request. Level of confidence values in request: %s",
+                                levelOfConfidenceValues));
+                return Optional.of(
+                        new ErrorObject(
+                                OAuth2Error.INVALID_REQUEST_CODE,
+                                "Request vtr is not permitted"));
+            }
+            var vtrError = errorIfIdentityLoCAndIdentityUnsupported(vtrList, client);
+            if (vtrError.isPresent()) {
+                return vtrError;
+            }
+            if (vtrList.get(0).containsLevelOfConfidence()
+                    && !ipvCapacityService.isIPVCapacityAvailable()
+                    && !client.isTestClient()) {
+                return Optional.of(OAuth2Error.TEMPORARILY_UNAVAILABLE);
+            }
+        } catch (IllegalArgumentException e) {
+            logErrorInProdElseWarn(
+                    String.format(
+                            "vtr in AuthRequest is not valid. vtr in request: %s. IllegalArgumentException: %s",
+                            authRequestVtr, e));
+            return Optional.of(
+                    new ErrorObject(
+                            OAuth2Error.INVALID_REQUEST_CODE, "Request vtr not valid"));
+        }
+        return Optional.empty();
+    }
+
     protected Optional<ErrorObject> errorIfIdentityLoCAndIdentityUnsupported(
             List<VectorOfTrust> vtrList, ClientRegistry client) {
         List<LevelOfConfidence> identityLoCs =

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/BaseAuthorizeValidator.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/BaseAuthorizeValidator.java
@@ -149,7 +149,7 @@ public abstract class BaseAuthorizeValidator {
         return Optional.empty();
     }
 
-    protected void logIfIdentityLoCAndIdentityUnsupported(
+    protected Optional<ErrorObject> errorIfIdentityLoCAndIdentityUnsupported(
             List<VectorOfTrust> vtrList, ClientRegistry client) {
         List<LevelOfConfidence> identityLoCs =
                 List.of(
@@ -163,9 +163,13 @@ public abstract class BaseAuthorizeValidator {
                         .filter(Objects::nonNull)
                         .anyMatch(identityLoCs::contains);
         if (hasRequestedIdentityLoC && !client.isIdentityVerificationSupported()) {
-            LOG.info(
+            logErrorInProdElseWarn(
                     "Level of confidence values for an identity journey have been requested, but identity is not supported for this client.");
+            return Optional.of(
+                    new ErrorObject(
+                            OAuth2Error.INVALID_REQUEST_CODE, "Request vtr is not permitted"));
         }
+        return Optional.empty();
     }
 
     protected void validateResponseMode(String responseMode) throws InvalidResponseModeException {

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/BaseAuthorizeValidator.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/BaseAuthorizeValidator.java
@@ -149,7 +149,8 @@ public abstract class BaseAuthorizeValidator {
         return Optional.empty();
     }
 
-    protected Optional<ErrorObject> validateVtr(List<String> authRequestVtr, ClientRegistry client) {
+    protected Optional<ErrorObject> validateVtr(
+            List<String> authRequestVtr, ClientRegistry client) {
         try {
             var vtrList = VectorOfTrust.parseFromAuthRequestAttribute(authRequestVtr);
             var levelOfConfidenceValues = VectorOfTrust.getRequestedLevelsOfConfidence(vtrList);
@@ -160,8 +161,7 @@ public abstract class BaseAuthorizeValidator {
                                 levelOfConfidenceValues));
                 return Optional.of(
                         new ErrorObject(
-                                OAuth2Error.INVALID_REQUEST_CODE,
-                                "Request vtr is not permitted"));
+                                OAuth2Error.INVALID_REQUEST_CODE, "Request vtr is not permitted"));
             }
             var vtrError = errorIfIdentityLoCAndIdentityUnsupported(vtrList, client);
             if (vtrError.isPresent()) {
@@ -178,8 +178,7 @@ public abstract class BaseAuthorizeValidator {
                             "vtr in AuthRequest is not valid. vtr in request: %s. IllegalArgumentException: %s",
                             authRequestVtr, e));
             return Optional.of(
-                    new ErrorObject(
-                            OAuth2Error.INVALID_REQUEST_CODE, "Request vtr not valid"));
+                    new ErrorObject(OAuth2Error.INVALID_REQUEST_CODE, "Request vtr not valid"));
         }
         return Optional.empty();
     }

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/QueryParamsAuthorizeValidator.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/QueryParamsAuthorizeValidator.java
@@ -9,7 +9,6 @@ import uk.gov.di.authentication.oidc.entity.AuthRequestError;
 import uk.gov.di.authentication.oidc.services.IPVCapacityService;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.ValidScopes;
-import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.exceptions.ClientRedirectUriValidationException;
 import uk.gov.di.orchestration.shared.exceptions.InvalidResponseModeException;
 import uk.gov.di.orchestration.shared.services.ConfigurationService;
@@ -162,41 +161,6 @@ public class QueryParamsAuthorizeValidator extends BaseAuthorizeValidator {
             }
         }
 
-        return Optional.empty();
-    }
-
-    private Optional<ErrorObject> validateVtr(List<String> authRequestVtr, ClientRegistry client) {
-        try {
-            var vtrList = VectorOfTrust.parseFromAuthRequestAttribute(authRequestVtr);
-            var levelOfConfidenceValues = VectorOfTrust.getRequestedLevelsOfConfidence(vtrList);
-            if (!client.getClientLoCs().containsAll(levelOfConfidenceValues)) {
-                logErrorInProdElseWarn(
-                        String.format(
-                                "Level of confidence values have been requested which this client is not permitted to request. Level of confidence values in request: %s",
-                                levelOfConfidenceValues));
-                return Optional.of(
-                        new ErrorObject(
-                                OAuth2Error.INVALID_REQUEST_CODE,
-                                "Request vtr is not permitted"));
-            }
-            var vtrError = errorIfIdentityLoCAndIdentityUnsupported(vtrList, client);
-            if (vtrError.isPresent()) {
-                return vtrError;
-            }
-            if (vtrList.get(0).containsLevelOfConfidence()
-                    && !ipvCapacityService.isIPVCapacityAvailable()
-                    && !client.isTestClient()) {
-                return Optional.of(OAuth2Error.TEMPORARILY_UNAVAILABLE);
-            }
-        } catch (IllegalArgumentException e) {
-            logErrorInProdElseWarn(
-                    String.format(
-                            "vtr in AuthRequest is not valid. vtr in request: %s. IllegalArgumentException: %s",
-                            authRequestVtr, e));
-            return Optional.of(
-                    new ErrorObject(
-                            OAuth2Error.INVALID_REQUEST_CODE, "Request vtr not valid"));
-        }
         return Optional.empty();
     }
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/QueryParamsAuthorizeValidator.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/QueryParamsAuthorizeValidator.java
@@ -126,44 +126,9 @@ public class QueryParamsAuthorizeValidator extends BaseAuthorizeValidator {
         }
 
         List<String> authRequestVtr = authRequest.getCustomParameter(VTR_PARAM);
-        try {
-            var vtrList = VectorOfTrust.parseFromAuthRequestAttribute(authRequestVtr);
-            var levelOfConfidenceValues = VectorOfTrust.getRequestedLevelsOfConfidence(vtrList);
-            if (!client.getClientLoCs().containsAll(levelOfConfidenceValues)) {
-                logErrorInProdElseWarn(
-                        String.format(
-                                "Level of confidence values have been requested which this client is not permitted to request. Level of confidence values in request: %s",
-                                levelOfConfidenceValues));
-                return Optional.of(
-                        new AuthRequestError(
-                                new ErrorObject(
-                                        OAuth2Error.INVALID_REQUEST_CODE,
-                                        "Request vtr is not permitted"),
-                                redirectURI,
-                                state));
-            }
-            var vtrError = errorIfIdentityLoCAndIdentityUnsupported(vtrList, client);
-            if (vtrError.isPresent()) {
-                return Optional.of(new AuthRequestError(vtrError.get(), redirectURI, state));
-            }
-            if (vtrList.get(0).containsLevelOfConfidence()
-                    && !ipvCapacityService.isIPVCapacityAvailable()
-                    && !client.isTestClient()) {
-                return Optional.of(
-                        new AuthRequestError(
-                                OAuth2Error.TEMPORARILY_UNAVAILABLE, redirectURI, state));
-            }
-        } catch (IllegalArgumentException e) {
-            logErrorInProdElseWarn(
-                    String.format(
-                            "vtr in AuthRequest is not valid. vtr in request: %s. IllegalArgumentException: %s",
-                            authRequestVtr, e));
-            return Optional.of(
-                    new AuthRequestError(
-                            new ErrorObject(
-                                    OAuth2Error.INVALID_REQUEST_CODE, "Request vtr not valid"),
-                            redirectURI,
-                            state));
+        var vtrError = validateVtr(authRequestVtr, client);
+        if (vtrError.isPresent()) {
+            return Optional.of(new AuthRequestError(vtrError.get(), redirectURI, state));
         }
         if (!client.getMaxAgeEnabled() && authRequest.getMaxAge() != -1) {
             LOG.warn(
@@ -197,6 +162,41 @@ public class QueryParamsAuthorizeValidator extends BaseAuthorizeValidator {
             }
         }
 
+        return Optional.empty();
+    }
+
+    private Optional<ErrorObject> validateVtr(List<String> authRequestVtr, ClientRegistry client) {
+        try {
+            var vtrList = VectorOfTrust.parseFromAuthRequestAttribute(authRequestVtr);
+            var levelOfConfidenceValues = VectorOfTrust.getRequestedLevelsOfConfidence(vtrList);
+            if (!client.getClientLoCs().containsAll(levelOfConfidenceValues)) {
+                logErrorInProdElseWarn(
+                        String.format(
+                                "Level of confidence values have been requested which this client is not permitted to request. Level of confidence values in request: %s",
+                                levelOfConfidenceValues));
+                return Optional.of(
+                        new ErrorObject(
+                                OAuth2Error.INVALID_REQUEST_CODE,
+                                "Request vtr is not permitted"));
+            }
+            var vtrError = errorIfIdentityLoCAndIdentityUnsupported(vtrList, client);
+            if (vtrError.isPresent()) {
+                return vtrError;
+            }
+            if (vtrList.get(0).containsLevelOfConfidence()
+                    && !ipvCapacityService.isIPVCapacityAvailable()
+                    && !client.isTestClient()) {
+                return Optional.of(OAuth2Error.TEMPORARILY_UNAVAILABLE);
+            }
+        } catch (IllegalArgumentException e) {
+            logErrorInProdElseWarn(
+                    String.format(
+                            "vtr in AuthRequest is not valid. vtr in request: %s. IllegalArgumentException: %s",
+                            authRequestVtr, e));
+            return Optional.of(
+                    new ErrorObject(
+                            OAuth2Error.INVALID_REQUEST_CODE, "Request vtr not valid"));
+        }
         return Optional.empty();
     }
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/QueryParamsAuthorizeValidator.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/QueryParamsAuthorizeValidator.java
@@ -142,7 +142,10 @@ public class QueryParamsAuthorizeValidator extends BaseAuthorizeValidator {
                                 redirectURI,
                                 state));
             }
-            logIfIdentityLoCAndIdentityUnsupported(vtrList, client);
+            var vtrError = errorIfIdentityLoCAndIdentityUnsupported(vtrList, client);
+            if (vtrError.isPresent()) {
+                return Optional.of(new AuthRequestError(vtrError.get(), redirectURI, state));
+            }
             if (vtrList.get(0).containsLevelOfConfidence()
                     && !ipvCapacityService.isIPVCapacityAvailable()
                     && !client.isTestClient()) {

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/RequestObjectAuthorizeValidator.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/RequestObjectAuthorizeValidator.java
@@ -327,14 +327,16 @@ public class RequestObjectAuthorizeValidator extends BaseAuthorizeValidator {
         throw new ParseException("vtr is in an invalid format. Could not be parsed.", 0);
     }
 
-    private Optional<ErrorObject> parseAndValidateVtr(JWTClaimsSet jwtClaimsSet, ClientRegistry client){
+    private Optional<ErrorObject> parseAndValidateVtr(
+            JWTClaimsSet jwtClaimsSet, ClientRegistry client) {
         try {
             var authRequestVtr = getRequestObjectVtrAsList(jwtClaimsSet);
             return validateVtr(authRequestVtr, client);
         } catch (ParseException | Json.JsonException e) {
             logErrorInProdElseWarn(
                     String.format("Parse exception thrown when validating vtr: %s", e));
-            return Optional.of(new ErrorObject(OAuth2Error.INVALID_REQUEST_CODE, "Request vtr not valid"));
+            return Optional.of(
+                    new ErrorObject(OAuth2Error.INVALID_REQUEST_CODE, "Request vtr not valid"));
         }
     }
 

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/RequestObjectAuthorizeValidator.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/RequestObjectAuthorizeValidator.java
@@ -15,7 +15,6 @@ import uk.gov.di.orchestration.shared.api.OidcAPI;
 import uk.gov.di.orchestration.shared.entity.ClientRegistry;
 import uk.gov.di.orchestration.shared.entity.ClientType;
 import uk.gov.di.orchestration.shared.entity.ValidScopes;
-import uk.gov.di.orchestration.shared.entity.VectorOfTrust;
 import uk.gov.di.orchestration.shared.exceptions.ClientRedirectUriValidationException;
 import uk.gov.di.orchestration.shared.exceptions.ClientSignatureValidationException;
 import uk.gov.di.orchestration.shared.exceptions.JwksException;
@@ -27,7 +26,6 @@ import uk.gov.di.orchestration.shared.services.SerializationService;
 
 import java.net.URI;
 import java.text.ParseException;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -204,10 +202,18 @@ public class RequestObjectAuthorizeValidator extends BaseAuthorizeValidator {
                 return errorResponse(redirectURI, codeChallengeError.get(), state);
             }
 
-            var vtrError = validateVtr(jwtClaimsSet, client);
-            if (vtrError.isPresent()) {
-                return errorResponse(redirectURI, vtrError.get(), state);
+            try {
+                var authRequestVtr = getRequestObjectVtrAsList(jwtClaimsSet);
+                var vtrError = validateVtr(authRequestVtr, client);
+                if (vtrError.isPresent()) {
+                    return errorResponse(redirectURI, vtrError.get(), state);
+                }
+            } catch (ParseException | Json.JsonException e) {
+                logErrorInProdElseWarn(
+                        String.format("Parse exception thrown when validating vtr: %s", e));
+                return errorResponse(redirectURI, new ErrorObject(OAuth2Error.INVALID_REQUEST_CODE, "Request vtr not valid"), state);
             }
+
             if (Objects.nonNull(jwtClaimsSet.getClaim("ui_locales"))) {
                 try {
                     String uiLocales = (String) jwtClaimsSet.getClaim("ui_locales");
@@ -264,45 +270,6 @@ public class RequestObjectAuthorizeValidator extends BaseAuthorizeValidator {
     private boolean requestContainsInvalidScopes(Scope scopes, ClientRegistry client) {
         return !ValidScopes.areScopesValid(scopes.toStringList())
                 || !client.getScopes().containsAll(scopes.toStringList());
-    }
-
-    private Optional<ErrorObject> validateVtr(JWTClaimsSet jwtClaimsSet, ClientRegistry client) {
-        List<String> authRequestVtr = new ArrayList<>();
-        try {
-            authRequestVtr = getRequestObjectVtrAsList(jwtClaimsSet);
-            var vtrList = VectorOfTrust.parseFromAuthRequestAttribute(authRequestVtr);
-            var levelOfConfidenceValues = VectorOfTrust.getRequestedLevelsOfConfidence(vtrList);
-            if (!client.getClientLoCs().containsAll(levelOfConfidenceValues)) {
-                logErrorInProdElseWarn(
-                        String.format(
-                                "Level of confidence values have been requested which this client is not permitted to request. Level of confidence values in request: %s",
-                                levelOfConfidenceValues));
-                return Optional.of(
-                        new ErrorObject(
-                                OAuth2Error.INVALID_REQUEST_CODE, "Request vtr is not permitted"));
-            }
-            var vtrError = errorIfIdentityLoCAndIdentityUnsupported(vtrList, client);
-            if (vtrError.isPresent()) {
-                return vtrError;
-            }
-            if (vtrList.get(0).containsLevelOfConfidence()
-                    && !ipvCapacityService.isIPVCapacityAvailable()) {
-                return Optional.of(OAuth2Error.TEMPORARILY_UNAVAILABLE);
-            }
-        } catch (IllegalArgumentException e) {
-            logErrorInProdElseWarn(
-                    String.format(
-                            "vtr in AuthRequest is not valid. vtr in request: %s. IllegalArgumentException: %s",
-                            authRequestVtr, e));
-            return Optional.of(
-                    new ErrorObject(OAuth2Error.INVALID_REQUEST_CODE, "Request vtr not valid"));
-        } catch (ParseException | Json.JsonException e) {
-            logErrorInProdElseWarn(
-                    String.format("Parse exception thrown when validating vtr: %s", e));
-            return Optional.of(
-                    new ErrorObject(OAuth2Error.INVALID_REQUEST_CODE, "Request vtr not valid"));
-        }
-        return Optional.empty();
     }
 
     private Optional<ErrorObject> validateMaxAge(JWTClaimsSet jwtClaimsSet, ClientRegistry client)

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/RequestObjectAuthorizeValidator.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/RequestObjectAuthorizeValidator.java
@@ -281,7 +281,10 @@ public class RequestObjectAuthorizeValidator extends BaseAuthorizeValidator {
                         new ErrorObject(
                                 OAuth2Error.INVALID_REQUEST_CODE, "Request vtr is not permitted"));
             }
-            logIfIdentityLoCAndIdentityUnsupported(vtrList, client);
+            var vtrError = errorIfIdentityLoCAndIdentityUnsupported(vtrList, client);
+            if (vtrError.isPresent()) {
+                return vtrError;
+            }
             if (vtrList.get(0).containsLevelOfConfidence()
                     && !ipvCapacityService.isIPVCapacityAvailable()) {
                 return Optional.of(OAuth2Error.TEMPORARILY_UNAVAILABLE);

--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/RequestObjectAuthorizeValidator.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/validators/RequestObjectAuthorizeValidator.java
@@ -202,16 +202,9 @@ public class RequestObjectAuthorizeValidator extends BaseAuthorizeValidator {
                 return errorResponse(redirectURI, codeChallengeError.get(), state);
             }
 
-            try {
-                var authRequestVtr = getRequestObjectVtrAsList(jwtClaimsSet);
-                var vtrError = validateVtr(authRequestVtr, client);
-                if (vtrError.isPresent()) {
-                    return errorResponse(redirectURI, vtrError.get(), state);
-                }
-            } catch (ParseException | Json.JsonException e) {
-                logErrorInProdElseWarn(
-                        String.format("Parse exception thrown when validating vtr: %s", e));
-                return errorResponse(redirectURI, new ErrorObject(OAuth2Error.INVALID_REQUEST_CODE, "Request vtr not valid"), state);
+            var vtrError = parseAndValidateVtr(jwtClaimsSet, client);
+            if (vtrError.isPresent()) {
+                return errorResponse(redirectURI, vtrError.get(), state);
             }
 
             if (Objects.nonNull(jwtClaimsSet.getClaim("ui_locales"))) {
@@ -332,6 +325,17 @@ public class RequestObjectAuthorizeValidator extends BaseAuthorizeValidator {
         }
 
         throw new ParseException("vtr is in an invalid format. Could not be parsed.", 0);
+    }
+
+    private Optional<ErrorObject> parseAndValidateVtr(JWTClaimsSet jwtClaimsSet, ClientRegistry client){
+        try {
+            var authRequestVtr = getRequestObjectVtrAsList(jwtClaimsSet);
+            return validateVtr(authRequestVtr, client);
+        } catch (ParseException | Json.JsonException e) {
+            logErrorInProdElseWarn(
+                    String.format("Parse exception thrown when validating vtr: %s", e));
+            return Optional.of(new ErrorObject(OAuth2Error.INVALID_REQUEST_CODE, "Request vtr not valid"));
+        }
     }
 
     private static Optional<AuthRequestError> errorResponse(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/QueryParamsAuthorizeValidatorTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/QueryParamsAuthorizeValidatorTest.java
@@ -406,7 +406,8 @@ class QueryParamsAuthorizeValidatorTest {
     void shouldSuccessfullyValidateWhenNonceNotExpectedAndMissing() {
         var clientRegitry =
                 generateClientRegistry(REDIRECT_URI.toString(), CLIENT_ID.toString())
-                        .withPermitMissingNonce(true);
+                        .withPermitMissingNonce(true)
+                        .withIdentityVerificationSupported(false);
 
         when(dynamoClientService.getClient(CLIENT_ID.toString()))
                 .thenReturn(Optional.of(clientRegitry));
@@ -495,7 +496,7 @@ class QueryParamsAuthorizeValidatorTest {
     }
 
     @Test
-    void validatorLogsTheConflictWhenIdentityLoCInRequestAndIdentityVerificationFlagIsFalse() {
+    void validatorReturnsErrorWhenIdentityLoCInRequestAndIdentityVerificationFlagIsFalse() {
         when(ipvCapacityService.isIPVCapacityAvailable()).thenReturn(true);
         List<String> clientLoCs = List.of("P0", "P2");
         var vtr = jsonArrayOf("Cl.Cm.P2");
@@ -516,7 +517,14 @@ class QueryParamsAuthorizeValidatorTest {
                         .build();
         var errorObject = queryParamsAuthorizeValidator.validate(authRequest);
 
-        assertFalse(errorObject.isPresent());
+        assertTrue(errorObject.isPresent());
+        assertThat(
+                errorObject.get().errorObject().toJSONObject(),
+                equalTo(
+                        new ErrorObject(
+                                        OAuth2Error.INVALID_REQUEST_CODE,
+                                        "Request vtr is not permitted")
+                                .toJSONObject()));
         String expectedLogMessage =
                 "Level of confidence values for an identity journey have been requested, but identity is not supported for this client.";
         assertThat(baseClassLogging.events(), hasItem(withMessageContaining(expectedLogMessage)));
@@ -828,7 +836,8 @@ class QueryParamsAuthorizeValidatorTest {
                 .withPublicKey(null)
                 .withTestClient(testClient)
                 .withClientLoCs(clientLoCs)
-                .withScopes(scopes);
+                .withScopes(scopes)
+                .withIdentityVerificationSupported(true);
     }
 
     private AuthenticationRequest generateAuthRequest(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RequestObjectAuthorizeValidatorTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RequestObjectAuthorizeValidatorTest.java
@@ -161,7 +161,29 @@ class RequestObjectAuthorizeValidatorTest {
         }
 
         @Test
-        void validatorLogsTheConflictWhenIdentityLoCInRequestAndIdentityVerificationFlagIsFalse()
+        void validatorReturnsErrorWhenCannotParseVtr()
+            throws JOSEException, JwksException, ClientSignatureValidationException {
+                var invalidVtr = false;
+                var jwtClaimsSet =
+                    getDefaultJWTClaimsSetBuilder()
+                        .claim("vtr", invalidVtr).build();
+
+                var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet, keyPair));
+                var requestObjectError = validator.validate(authRequest);
+
+                assertTrue(requestObjectError.isPresent());
+                assertThat(
+                    requestObjectError.get().errorObject().toJSONObject(),
+                    equalTo(
+                            new ErrorObject(
+                                            OAuth2Error.INVALID_REQUEST_CODE,
+                                            "Request vtr not valid")
+                                    .toJSONObject()));
+            assertThat(requestObjectError.get().redirectURI().toString(), equalTo(REDIRECT_URI));
+        }
+
+        @Test
+        void validatorReturnsErrorWhenIdentityLoCInRequestAndIdentityVerificationFlagIsFalse()
                 throws JOSEException, JwksException, ClientSignatureValidationException {
             var jwtClaimsSet =
                     getDefaultJWTClaimsSetBuilder().claim("vtr", jsonArrayOf("Cl.Cm.P2")).build();

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RequestObjectAuthorizeValidatorTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RequestObjectAuthorizeValidatorTest.java
@@ -162,17 +162,15 @@ class RequestObjectAuthorizeValidatorTest {
 
         @Test
         void validatorReturnsErrorWhenCannotParseVtr()
-            throws JOSEException, JwksException, ClientSignatureValidationException {
-                var invalidVtr = false;
-                var jwtClaimsSet =
-                    getDefaultJWTClaimsSetBuilder()
-                        .claim("vtr", invalidVtr).build();
+                throws JOSEException, JwksException, ClientSignatureValidationException {
+            var invalidVtr = false;
+            var jwtClaimsSet = getDefaultJWTClaimsSetBuilder().claim("vtr", invalidVtr).build();
 
-                var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet, keyPair));
-                var requestObjectError = validator.validate(authRequest);
+            var authRequest = generateAuthRequest(generateSignedJWT(jwtClaimsSet, keyPair));
+            var requestObjectError = validator.validate(authRequest);
 
-                assertTrue(requestObjectError.isPresent());
-                assertThat(
+            assertTrue(requestObjectError.isPresent());
+            assertThat(
                     requestObjectError.get().errorObject().toJSONObject(),
                     equalTo(
                             new ErrorObject(

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RequestObjectAuthorizeValidatorTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/RequestObjectAuthorizeValidatorTest.java
@@ -179,8 +179,14 @@ class RequestObjectAuthorizeValidatorTest {
                     .thenReturn(Optional.of(clientRegistry));
 
             var requestObjectError = validator.validate(authRequest);
-
-            assertFalse(requestObjectError.isPresent());
+            assertTrue(requestObjectError.isPresent());
+            assertThat(
+                    requestObjectError.get().errorObject().toJSONObject(),
+                    equalTo(
+                            new ErrorObject(
+                                            OAuth2Error.INVALID_REQUEST_CODE,
+                                            "Request vtr is not permitted")
+                                    .toJSONObject()));
             String expectedLogMessage =
                     "Level of confidence values for an identity journey have been requested, but identity is not supported for this client.";
             assertThat(
@@ -916,7 +922,7 @@ class RequestObjectAuthorizeValidatorTest {
                         .claim("scope", SCOPE)
                         .claim("state", STATE.toString())
                         .claim("client_id", CLIENT_ID.getValue())
-                        .claim("vtr", List.of("P2.Cl.Cm"))
+                        .claim("vtr", List.of("Cl.Cm"))
                         .issuer(CLIENT_ID.getValue())
                         .build();
         var signedJWT = generateSignedJWT(jwtClaimsSet, keyPair);
@@ -993,7 +999,8 @@ class RequestObjectAuthorizeValidatorTest {
                                 ValidClaims.ADDRESS.getValue(),
                                 ValidClaims.CORE_IDENTITY_JWT.getValue(),
                                 ValidClaims.PASSPORT.getValue(),
-                                ValidClaims.RETURN_CODE.getValue()));
+                                ValidClaims.RETURN_CODE.getValue()))
+                .withIdentityVerificationSupported(true);
     }
 
     private AuthenticationRequest generateAuthRequest(SignedJWT signedJWT) {


### PR DESCRIPTION
### Wider context of change

Currently you are able to request an identity LoC even if identityVerificationSupported is set to false for your client, provided the ClientLoCs allow it (you will be forced onto a normal auth journey). We would like to change this so that these invalid requests are rejected.

### What’s changed

This PR returns an `invalid_request` with message `Request vtr is not permitted` if a client tries to request a non P0 LoC when identity is disabled for that client.

### Manual testing

Added unit and integration tests for this case

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing.
- [x] Impact on orch and auth mutual dependencies has been checked.
- [x] Changes have been made to contract tests or not required.
- [x] Changes have been made to the simulator or not required.
- [x] Changes have been made to stubs or not required.
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required.

