### PR TITLE
AUT-5323: Build AMAPI-to-ADAPI passkey proxy endpoints

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/PasskeysDeleteProxyHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/PasskeysDeleteProxyHandler.java
@@ -7,8 +7,12 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
+import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.exceptions.UnsuccessfulAccountDataApiResponseException;
+import uk.gov.di.authentication.shared.services.AccountDataApiService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
+import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
 
@@ -17,6 +21,7 @@ public class PasskeysDeleteProxyHandler
 
     private static final Logger LOG = LogManager.getLogger(PasskeysDeleteProxyHandler.class);
     private final ConfigurationService configurationService;
+    private final AccountDataApiService accountDataApiService;
 
     public PasskeysDeleteProxyHandler() {
         this(ConfigurationService.getInstance());
@@ -24,6 +29,14 @@ public class PasskeysDeleteProxyHandler
 
     public PasskeysDeleteProxyHandler(ConfigurationService configurationService) {
         this.configurationService = configurationService;
+        this.accountDataApiService = new AccountDataApiService(configurationService);
+    }
+
+    public PasskeysDeleteProxyHandler(
+            ConfigurationService configurationService,
+            AccountDataApiService accountDataApiService) {
+        this.configurationService = configurationService;
+        this.accountDataApiService = accountDataApiService;
     }
 
     @Override
@@ -39,6 +52,18 @@ public class PasskeysDeleteProxyHandler
             APIGatewayProxyRequestEvent input, Context context) {
         LOG.info("PasskeysDeleteProxyHandler invoked");
 
-        return generateApiGatewayProxyResponse(501, "Not implemented");
+        var publicSubjectId = input.getPathParameters().getOrDefault("publicSubjectId", "");
+        var passkeyIdentifier = input.getPathParameters().getOrDefault("passkeyIdentifier", "");
+
+        try {
+            var response = accountDataApiService.deletePasskey(publicSubjectId, passkeyIdentifier);
+            return generateApiGatewayProxyResponse(response.statusCode(), response.body());
+        } catch (UnsuccessfulAccountDataApiResponseException e) {
+            LOG.warn(
+                    "Attempted to delete passkey with ID '{}' but failed due to '{}'",
+                    passkeyIdentifier,
+                    e.getMessage());
+            return generateApiGatewayProxyErrorResponse(500, ErrorResponse.INTERNAL_SERVER_ERROR);
+        }
     }
 }

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/PasskeysRetrieveProxyHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/PasskeysRetrieveProxyHandler.java
@@ -7,8 +7,12 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.ThreadContext;
+import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.exceptions.UnsuccessfulAccountDataApiResponseException;
+import uk.gov.di.authentication.shared.services.AccountDataApiService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
 
+import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyErrorResponse;
 import static uk.gov.di.authentication.shared.helpers.ApiGatewayResponseHelper.generateApiGatewayProxyResponse;
 import static uk.gov.di.authentication.shared.helpers.InstrumentationHelper.segmentedFunctionCall;
 
@@ -17,6 +21,7 @@ public class PasskeysRetrieveProxyHandler
 
     private static final Logger LOG = LogManager.getLogger(PasskeysRetrieveProxyHandler.class);
     private final ConfigurationService configurationService;
+    private final AccountDataApiService accountDataApiService;
 
     public PasskeysRetrieveProxyHandler() {
         this(ConfigurationService.getInstance());
@@ -24,6 +29,14 @@ public class PasskeysRetrieveProxyHandler
 
     public PasskeysRetrieveProxyHandler(ConfigurationService configurationService) {
         this.configurationService = configurationService;
+        this.accountDataApiService = new AccountDataApiService(configurationService);
+    }
+
+    public PasskeysRetrieveProxyHandler(
+            ConfigurationService configurationService,
+            AccountDataApiService accountDataApiService) {
+        this.configurationService = configurationService;
+        this.accountDataApiService = accountDataApiService;
     }
 
     @Override
@@ -39,6 +52,16 @@ public class PasskeysRetrieveProxyHandler
             APIGatewayProxyRequestEvent input, Context context) {
         LOG.info("PasskeysRetrieveProxyHandler invoked");
 
-        return generateApiGatewayProxyResponse(501, "Not implemented");
+        var publicSubjectId = input.getPathParameters().getOrDefault("publicSubjectId", "");
+
+        try {
+            var response = accountDataApiService.retrievePasskeys(publicSubjectId);
+            return generateApiGatewayProxyResponse(response.statusCode(), response.body());
+        } catch (UnsuccessfulAccountDataApiResponseException e) {
+            LOG.warn(
+                    "Attempted retrieving passkeys for user but failed due to '{}'",
+                    e.getMessage());
+            return generateApiGatewayProxyErrorResponse(500, ErrorResponse.INTERNAL_SERVER_ERROR);
+        }
     }
 }

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/PasskeysDeleteProxyHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/PasskeysDeleteProxyHandlerTest.java
@@ -3,35 +3,88 @@ package uk.gov.di.accountmanagement.lambda;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.exceptions.UnsuccessfulAccountDataApiResponseException;
+import uk.gov.di.authentication.shared.services.AccountDataApiService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+import java.net.http.HttpResponse;
+import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static uk.gov.di.accountmanagement.helpers.CommonTestVariables.VALID_HEADERS;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.IP_ADDRESS;
+import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.PUBLIC_SUBJECT_ID;
 import static uk.gov.di.authentication.sharedtest.helper.RequestEventHelper.contextWithSourceIp;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class PasskeysDeleteProxyHandlerTest {
     private final Context context = mock(Context.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private final AccountDataApiService accountDataApiService = mock(AccountDataApiService.class);
 
     private PasskeysDeleteProxyHandler handler;
 
     @BeforeEach
     void setUp() {
-        handler = new PasskeysDeleteProxyHandler(configurationService);
+        handler = new PasskeysDeleteProxyHandler(configurationService, accountDataApiService);
     }
 
-    @Test
-    void shouldReturn501NotImplemented() {
-        var result = handler.handleRequest(passkeysDeleteProxyRequest(), context);
-        assertThat(result, hasStatus(501));
+    private static final String PASSKEY_IDENTIFIER = "test-passkey-id";
+
+    @Nested
+    class SuccessfulRequest {
+        @Test
+        void shouldProxyResponseFromService() throws UnsuccessfulAccountDataApiResponseException {
+            // Arrange
+            var mockHttpResponse = mock(HttpResponse.class);
+            when(mockHttpResponse.statusCode()).thenReturn(200);
+            when(mockHttpResponse.body()).thenReturn("{\"deleted\": true}");
+            when(accountDataApiService.deletePasskey(PUBLIC_SUBJECT_ID, PASSKEY_IDENTIFIER))
+                    .thenReturn(mockHttpResponse);
+
+            // Act
+            var result = handler.handleRequest(passkeysDeleteProxyRequest(), context);
+
+            // Assert
+            assertThat(result, hasStatus(200));
+            assertThat(result, hasBody("{\"deleted\": true}"));
+            verify(accountDataApiService).deletePasskey(PUBLIC_SUBJECT_ID, PASSKEY_IDENTIFIER);
+        }
+    }
+
+    @Nested
+    class FailedRequest {
+        @Test
+        void shouldReturn500IfServiceThrowsException()
+                throws UnsuccessfulAccountDataApiResponseException {
+            // Arrange
+            when(accountDataApiService.deletePasskey(PUBLIC_SUBJECT_ID, PASSKEY_IDENTIFIER))
+                    .thenThrow(new UnsuccessfulAccountDataApiResponseException("service error", 0));
+
+            // Act
+            var result = handler.handleRequest(passkeysDeleteProxyRequest(), context);
+
+            // Assert
+            assertThat(result, hasStatus(500));
+            assertThat(result, hasJsonBody(ErrorResponse.INTERNAL_SERVER_ERROR));
+            verify(accountDataApiService).deletePasskey(PUBLIC_SUBJECT_ID, PASSKEY_IDENTIFIER);
+        }
     }
 
     private APIGatewayProxyRequestEvent passkeysDeleteProxyRequest() {
         return new APIGatewayProxyRequestEvent()
+                .withPathParameters(
+                        Map.of(
+                                "publicSubjectId", PUBLIC_SUBJECT_ID,
+                                "passkeyIdentifier", PASSKEY_IDENTIFIER))
                 .withHeaders(VALID_HEADERS)
                 .withRequestContext(contextWithSourceIp(IP_ADDRESS));
     }

--- a/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/PasskeysRetrieveProxyHandlerTest.java
+++ b/account-management-api/src/test/java/uk/gov/di/accountmanagement/lambda/PasskeysRetrieveProxyHandlerTest.java
@@ -3,35 +3,83 @@ package uk.gov.di.accountmanagement.lambda;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.shared.entity.ErrorResponse;
+import uk.gov.di.authentication.shared.exceptions.UnsuccessfulAccountDataApiResponseException;
+import uk.gov.di.authentication.shared.services.AccountDataApiService;
 import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+import java.net.http.HttpResponse;
+import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static uk.gov.di.accountmanagement.helpers.CommonTestVariables.VALID_HEADERS;
 import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.IP_ADDRESS;
+import static uk.gov.di.authentication.sharedtest.helper.CommonTestVariables.PUBLIC_SUBJECT_ID;
 import static uk.gov.di.authentication.sharedtest.helper.RequestEventHelper.contextWithSourceIp;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasBody;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasJsonBody;
 import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
 
 public class PasskeysRetrieveProxyHandlerTest {
     private final Context context = mock(Context.class);
     private final ConfigurationService configurationService = mock(ConfigurationService.class);
+    private final AccountDataApiService accountDataApiService = mock(AccountDataApiService.class);
 
     private PasskeysRetrieveProxyHandler handler;
 
     @BeforeEach
     void setUp() {
-        handler = new PasskeysRetrieveProxyHandler(configurationService);
+        handler = new PasskeysRetrieveProxyHandler(configurationService, accountDataApiService);
     }
 
-    @Test
-    void shouldReturn501NotImplemented() {
-        var result = handler.handleRequest(passkeysRetrieveProxyRequest(), context);
-        assertThat(result, hasStatus(501));
+    @Nested
+    class SuccessfulRequest {
+        @Test
+        void shouldProxyResponseFromService() throws UnsuccessfulAccountDataApiResponseException {
+            // Arrange
+            var mockHttpResponse = mock(HttpResponse.class);
+            when(mockHttpResponse.statusCode()).thenReturn(200);
+            when(mockHttpResponse.body()).thenReturn("{\"passkeys\": []}");
+            when(accountDataApiService.retrievePasskeys(PUBLIC_SUBJECT_ID))
+                    .thenReturn(mockHttpResponse);
+
+            // Act
+            var result = handler.handleRequest(passkeysRetrieveProxyRequest(), context);
+
+            // Assert
+            assertThat(result, hasStatus(200));
+            assertThat(result, hasBody("{\"passkeys\": []}"));
+            verify(accountDataApiService).retrievePasskeys(PUBLIC_SUBJECT_ID);
+        }
+    }
+
+    @Nested
+    class FailedRequest {
+        @Test
+        void shouldReturn500IfServiceThrowsException()
+                throws UnsuccessfulAccountDataApiResponseException {
+            // Arrange
+            when(accountDataApiService.retrievePasskeys(PUBLIC_SUBJECT_ID))
+                    .thenThrow(new UnsuccessfulAccountDataApiResponseException("service error", 0));
+
+            // Act
+            var result = handler.handleRequest(passkeysRetrieveProxyRequest(), context);
+
+            // Assert
+            assertThat(result, hasStatus(500));
+            assertThat(result, hasJsonBody(ErrorResponse.INTERNAL_SERVER_ERROR));
+            verify(accountDataApiService).retrievePasskeys(PUBLIC_SUBJECT_ID);
+        }
     }
 
     private APIGatewayProxyRequestEvent passkeysRetrieveProxyRequest() {
         return new APIGatewayProxyRequestEvent()
+                .withPathParameters((Map.of("publicSubjectId", PUBLIC_SUBJECT_ID)))
                 .withHeaders(VALID_HEADERS)
                 .withRequestContext(contextWithSourceIp(IP_ADDRESS));
     }

--- a/account-management-integration-tests/build.gradle
+++ b/account-management-integration-tests/build.gradle
@@ -18,7 +18,8 @@ dependencies {
             libs.bundles.awsDynamoDb,
             libs.bundles.awsLambda,
             libs.bundles.lettuce,
-            libs.libphonenumber
+            libs.libphonenumber,
+            libs.wiremock
 
     implementation project(':audit-events')
 

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/PasskeysDeleteProxyHandlerIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/PasskeysDeleteProxyHandlerIntegrationTest.java
@@ -1,0 +1,157 @@
+package uk.gov.di.accountmanagement.api;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import uk.gov.di.accountmanagement.lambda.PasskeysDeleteProxyHandler;
+import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.delete;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
+
+@ExtendWith(SystemStubsExtension.class)
+class PasskeysDeleteProxyHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
+    private static WireMockServer accountDataApiWireMockServer;
+
+    @SystemStub static EnvironmentVariables environment = new EnvironmentVariables();
+
+    @BeforeEach
+    void setUp() {
+        accountDataApiWireMockServer =
+                new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
+        accountDataApiWireMockServer.start();
+
+        environment.set(
+                "ACCOUNT_DATA_API_URI", "http://localhost:" + accountDataApiWireMockServer.port());
+    }
+
+    @AfterAll
+    static void tearDown() {
+        if (accountDataApiWireMockServer != null) {
+            accountDataApiWireMockServer.stop();
+        }
+    }
+
+    @Test
+    void shouldProxy204ResponseFromAccountDataApi() {
+        // Arrange
+        handler = new PasskeysDeleteProxyHandler(TEST_CONFIGURATION_SERVICE);
+
+        var publicSubjectId = "abc";
+        var passkeyId = "def";
+
+        accountDataApiWireMockServer.stubFor(
+                delete(
+                                urlPathMatching(
+                                        "/accounts/"
+                                                + publicSubjectId
+                                                + "/authenticators/passkeys/"
+                                                + passkeyId))
+                        .willReturn(aResponse().withStatus(204)));
+
+        // Act
+        var response =
+                makeRequest(
+                        Optional.empty(),
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        Map.of("publicSubjectId", publicSubjectId, "passkeyIdentifier", passkeyId),
+                        Collections.emptyMap(),
+                        Optional.of("delete"));
+
+        // Assert
+        assertThat(response, hasStatus(204));
+    }
+
+    @Test
+    void shouldProxy404ResponseFromAccountDataApi() {
+        // Arrange
+        handler = new PasskeysDeleteProxyHandler(TEST_CONFIGURATION_SERVICE);
+
+        var publicSubjectId = "abc";
+        var passkeyId = "def";
+        var adapiResponse =
+                """
+                {
+                  "code": 4040,
+                  "message": "Passkey not found"
+                }
+                """;
+
+        accountDataApiWireMockServer.stubFor(
+                delete(
+                                urlPathMatching(
+                                        "/accounts/"
+                                                + publicSubjectId
+                                                + "/authenticators/passkeys/"
+                                                + passkeyId))
+                        .willReturn(aResponse().withStatus(404).withBody(adapiResponse)));
+
+        // Act
+        var response =
+                makeRequest(
+                        Optional.empty(),
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        Map.of("publicSubjectId", publicSubjectId, "passkeyIdentifier", passkeyId),
+                        Collections.emptyMap(),
+                        Optional.of("delete"));
+
+        // Assert
+        assertThat(response, hasStatus(404));
+        assertThat(response.getBody(), equalTo(adapiResponse));
+    }
+
+    @Test
+    void shouldProxy500ResponseFromAccountDataApi() {
+        // Arrange
+        handler = new PasskeysDeleteProxyHandler(TEST_CONFIGURATION_SERVICE);
+
+        var publicSubjectId = "abc";
+        var passkeyId = "def";
+        var adapiResponse =
+                """
+                {
+                  "code": 5000,
+                  "message": "Internal server error"
+                }
+                """;
+
+        accountDataApiWireMockServer.stubFor(
+                delete(
+                                urlPathMatching(
+                                        "/accounts/"
+                                                + publicSubjectId
+                                                + "/authenticators/passkeys/"
+                                                + passkeyId))
+                        .willReturn(aResponse().withStatus(500).withBody(adapiResponse)));
+
+        // Act
+        var response =
+                makeRequest(
+                        Optional.empty(),
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        Map.of("publicSubjectId", publicSubjectId, "passkeyIdentifier", passkeyId),
+                        Collections.emptyMap(),
+                        Optional.of("delete"));
+
+        // Assert
+        assertThat(response, hasStatus(500));
+        assertThat(response.getBody(), equalTo(adapiResponse));
+    }
+}

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/PasskeysRetrieveProxyHandlerIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/PasskeysRetrieveProxyHandlerIntegrationTest.java
@@ -1,0 +1,122 @@
+package uk.gov.di.accountmanagement.api;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import uk.gov.di.accountmanagement.lambda.PasskeysRetrieveProxyHandler;
+import uk.gov.di.authentication.sharedtest.basetest.ApiGatewayHandlerIntegrationTest;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static uk.gov.di.authentication.sharedtest.matchers.APIGatewayProxyResponseEventMatcher.hasStatus;
+
+@ExtendWith(SystemStubsExtension.class)
+class PasskeysRetrieveProxyHandlerIntegrationTest extends ApiGatewayHandlerIntegrationTest {
+    private static WireMockServer accountDataApiWireMockServer;
+
+    @SystemStub static EnvironmentVariables environment = new EnvironmentVariables();
+
+    @BeforeEach
+    void setup() {
+        accountDataApiWireMockServer =
+                new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
+        accountDataApiWireMockServer.start();
+
+        environment.set(
+                "ACCOUNT_DATA_API_URI", "http://localhost:" + accountDataApiWireMockServer.port());
+    }
+
+    @AfterAll
+    static void tearDown() {
+        if (accountDataApiWireMockServer != null) {
+            accountDataApiWireMockServer.stop();
+        }
+    }
+
+    @Test
+    void shouldProxy200ResponseFromAccountDataApi() {
+        // Arrange
+        handler = new PasskeysRetrieveProxyHandler(TEST_CONFIGURATION_SERVICE);
+
+        var publicSubjectId = "abc";
+        var adapiResponse =
+                """
+                {
+                  "passkeys": [
+                    {
+                      "id": "123456",
+                      "credential": "credential1",
+                      "aaguid": "some-aaguid",
+                      "isAttested": true,
+                      "signCount": 1,
+                      "transports": [],
+                      "isBackupEligible": true,
+                      "isBackedUp": true,
+                      "createdAt": "some-timestamp",
+                      "lastUsedAt": "another-timestamp"
+                    }
+                  ]
+                }
+                """;
+
+        accountDataApiWireMockServer.stubFor(
+                get(urlPathMatching("/accounts/" + publicSubjectId + "/authenticators/passkeys"))
+                        .willReturn(aResponse().withStatus(200).withBody(adapiResponse)));
+
+        // Act
+        var response =
+                makeRequest(
+                        Optional.empty(),
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        Map.of("publicSubjectId", publicSubjectId));
+
+        // Assert
+        assertThat(response, hasStatus(200));
+        assertThat(response.getBody(), equalTo(adapiResponse));
+    }
+
+    @Test
+    void shouldProxy500ResponseFromAccountDataApi() {
+        // Arrange
+        handler = new PasskeysRetrieveProxyHandler(TEST_CONFIGURATION_SERVICE);
+
+        var publicSubjectId = "abc";
+        var adapiResponse =
+                """
+                {
+                  "code": 5000,
+                  "message": "Internal server error"
+                }
+                """;
+
+        accountDataApiWireMockServer.stubFor(
+                get(urlPathMatching("/accounts/" + publicSubjectId + "/authenticators/passkeys"))
+                        .willReturn(aResponse().withStatus(500).withBody(adapiResponse)));
+
+        // Act
+        var response =
+                makeRequest(
+                        Optional.empty(),
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        Map.of("publicSubjectId", publicSubjectId));
+
+        // Assert
+        assertThat(response, hasStatus(500));
+        assertThat(response.getBody(), equalTo(adapiResponse));
+    }
+}

--- a/ci/cloudformation/account-management/function/passkeys-delete-proxy.yaml
+++ b/ci/cloudformation/account-management/function/passkeys-delete-proxy.yaml
@@ -15,6 +15,20 @@ Resources:
             - "${env}"
             - env:
                 !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+          ACCOUNT_DATA_API_URI: !Sub
+            - "https://${ApiId}.execute-api.eu-west-2.amazonaws.com/${EnvOrSubEnv}"
+            - EnvOrSubEnv:
+                !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+              ApiId:
+                !FindInMap [
+                  EnvironmentConfiguration,
+                  !If [
+                    UseSubEnvironment,
+                    !Ref SubEnvironment,
+                    !Ref Environment,
+                  ],
+                  accountDataApiId,
+                ]
       LoggingConfig:
         LogGroup: !Ref PasskeysDeleteProxyFunctionLogGroup
       Policies:

--- a/ci/cloudformation/account-management/function/passkeys-retrieve-proxy.yaml
+++ b/ci/cloudformation/account-management/function/passkeys-retrieve-proxy.yaml
@@ -15,6 +15,20 @@ Resources:
             - "${env}"
             - env:
                 !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+          ACCOUNT_DATA_API_URI: !Sub
+            - "https://${ApiId}.execute-api.eu-west-2.amazonaws.com/${EnvOrSubEnv}"
+            - EnvOrSubEnv:
+                !If [UseSubEnvironment, !Ref SubEnvironment, !Ref Environment]
+              ApiId:
+                !FindInMap [
+                  EnvironmentConfiguration,
+                  !If [
+                    UseSubEnvironment,
+                    !Ref SubEnvironment,
+                    !Ref Environment,
+                  ],
+                  accountDataApiId,
+                ]
       LoggingConfig:
         LogGroup: !Ref PasskeysRetrieveProxyFunctionLogGroup
       Policies:

--- a/ci/cloudformation/account-management/parent.yaml
+++ b/ci/cloudformation/account-management/parent.yaml
@@ -303,6 +303,7 @@ Mappings:
       internationalSmsSendingEnabled: false
       testSigningKeyEnabled: true
       accessTokenJwksUrl: https://oidc.authdev3.dev.account.gov.uk/.well-known/jwks.json
+      accountDataApiId: rjlo8fsb55
     authdev2:
       accessTokenStoreTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/ff8d97e6-69d6-4ea1-81c0-0de8d8bcac85
       accountModifiersTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/a99e39a4-0a63-4816-b222-6e7c6c318b32
@@ -336,6 +337,7 @@ Mappings:
       internationalSmsSendingEnabled: false
       testSigningKeyEnabled: true
       accessTokenJwksUrl: https://oidc.authdev3.dev.account.gov.uk/.well-known/jwks.json
+      accountDataApiId: ez2ro7vca7
     authdev3:
       accessTokenStoreTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/8a67ba56-4eb2-4bfb-8254-5cc1c92a5db5
       accountModifiersTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/ce9680d3-953a-4b6a-9098-a0380d0afc70
@@ -369,6 +371,7 @@ Mappings:
       internationalSmsSendingEnabled: false
       testSigningKeyEnabled: true
       accessTokenJwksUrl: https://oidc.authdev3.dev.account.gov.uk/.well-known/jwks.json
+      accountDataApiId: 5ctgxqnq37
     dev:
       accessTokenStoreTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/f5e5d059-1581-4c5c-8d60-e168fd8a9a84
       accountModifiersTableEncryptionKey: arn:aws:kms:eu-west-2:653994557586:key/4b475855-e71a-43a5-a836-c6cb37e9cb22
@@ -409,6 +412,7 @@ Mappings:
       internationalSmsSendingEnabled: false
       testSigningKeyEnabled: true
       accessTokenJwksUrl: https://oidc.authdev3.dev.account.gov.uk/.well-known/jwks.json
+      accountDataApiId: 0aqzty84lj
     build:
       accessTokenStoreTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/e8fdebb6-2d33-4d0c-825c-2b5c874522d8
       accountModifiersTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/4932c4d3-bf86-4f39-a32c-b82faf9a2574
@@ -451,6 +455,7 @@ Mappings:
       internationalSmsSendingEnabled: false
       testSigningKeyEnabled: true
       accessTokenJwksUrl: https://oidc.build.account.gov.uk/.well-known/jwks.json
+      accountDataApiId: ac3znt5m23
     staging:
       accessTokenStoreTableEncryptionKey: arn:aws:kms:eu-west-2:758531536632:key/35cfcec1-e8f1-4ffc-950d-80e836c594ca
       accountModifiersTableEncryptionKey: arn:aws:kms:eu-west-2:758531536632:key/01f3d1a6-e66f-4eb7-a3d7-412437c8f01d
@@ -492,6 +497,7 @@ Mappings:
       internationalSmsSendingEnabled: false
       testSigningKeyEnabled: true
       accessTokenJwksUrl: https://oidc.staging.account.gov.uk/.well-known/jwks.json
+      accountDataApiId: 7xgl7lexy4
     integration:
       accessTokenStoreTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/11fdf47e-ce54-4d47-a9cf-7544489a112a
       accountModifiersTableEncryptionKey: arn:aws:kms:eu-west-2:761723964695:key/1e526227-051b-4078-ae10-46bda94e71c4
@@ -534,6 +540,7 @@ Mappings:
       internationalSmsSendingEnabled: false
       testSigningKeyEnabled: false
       accessTokenJwksUrl: https://oidc.integration.account.gov.uk/.well-known/jwks.json
+      accountDataApiId: hoidt6wujb
     production:
       accessTokenStoreTableEncryptionKey: arn:aws:kms:eu-west-2:172348255554:key/730472f0-c7ba-4bda-a411-08cdaa65fe8a
       accountModifiersTableEncryptionKey: arn:aws:kms:eu-west-2:172348255554:key/075774c2-b836-452f-9684-dcd742146f81
@@ -577,6 +584,7 @@ Mappings:
       legacyAccountDeletionTopicArn: arn:aws:sns:eu-west-2:172348255554:legacy-account-deletion-topic
       testSigningKeyEnabled: false
       accessTokenJwksUrl: https://oidc.account.gov.uk/.well-known/jwks.json
+      accountDataApiId: 0218o1p9tj
   LambdaConfiguration:
     account-recovery:
       RunbookLink: "https://govukverify.atlassian.net/l/cp/LfLKwP4s"

--- a/ci/cloudformation/auth/parent.yaml
+++ b/ci/cloudformation/auth/parent.yaml
@@ -239,8 +239,8 @@ Mappings:
       amcSfadRedirectUri: https://signin.authdev1.dev.account.gov.uk/sfad-callback
       amcTokenUri: https://amcstub.signin.authdev1.dev.account.gov.uk/token
       amcJourneyOutcomeUri: https://amcstub.signin.authdev1.dev.account.gov.uk/journeyoutcome
-      accountDataApiId: rjlo8fsb55
       amcClientId: auth_amc
+      accountDataApiId: rjlo8fsb55
       EvcsApiVpcEndpointId: ""
       enhancedAuthCodeProtectionEnabled: true
       amcCreatePasskeyRedirectUri: https://signin.authdev1.dev.account.gov.uk/create-passkey-callback
@@ -348,6 +348,7 @@ Mappings:
       amcTokenUri: https://amcstub.signin.authdev3.dev.account.gov.uk/token
       amcJourneyOutcomeUri: https://amcstub.signin.authdev3.dev.account.gov.uk/journeyoutcome
       amcClientId: auth_amc
+      accountDataApiId: 5ctgxqnq37
       EvcsApiVpcEndpointId: ""
       enhancedAuthCodeProtectionEnabled: true
       supportPasskeys: true

--- a/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/UnsuccessfulAccountDataApiResponseException.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/exceptions/UnsuccessfulAccountDataApiResponseException.java
@@ -1,0 +1,60 @@
+package uk.gov.di.authentication.shared.exceptions;
+
+import java.io.IOException;
+import java.net.http.HttpTimeoutException;
+
+import static java.lang.String.format;
+
+public class UnsuccessfulAccountDataApiResponseException extends Exception {
+
+    private final int httpCode;
+
+    public UnsuccessfulAccountDataApiResponseException(String message, int code) {
+        super(message);
+        this.httpCode = code;
+    }
+
+    public UnsuccessfulAccountDataApiResponseException(String message, Throwable cause) {
+        super(message, cause);
+        this.httpCode = 0;
+    }
+
+    public static UnsuccessfulAccountDataApiResponseException ioException(IOException e) {
+        return new UnsuccessfulAccountDataApiResponseException(
+                "Error when attempting to call Account Data API outbound endpoint", e);
+    }
+
+    public static UnsuccessfulAccountDataApiResponseException interruptedException(
+            InterruptedException e) {
+        return new UnsuccessfulAccountDataApiResponseException(
+                "Interrupted exception when attempting to call Account Data API outbound endpoint",
+                e);
+    }
+
+    public static UnsuccessfulAccountDataApiResponseException timeoutException(
+            Long timeout, HttpTimeoutException e) {
+
+        return new UnsuccessfulAccountDataApiResponseException(
+                format(
+                        "Timeout when calling Account Data API endpoint with timeout of %d",
+                        timeout),
+                e);
+    }
+
+    public static UnsuccessfulAccountDataApiResponseException httpResponseCodeException(
+            Integer statusCode, Object body) {
+        return new UnsuccessfulAccountDataApiResponseException(
+                format(
+                        "Error %s when attempting to call Account Data API outbound endpoint: %s",
+                        statusCode, body),
+                statusCode);
+    }
+
+    public static UnsuccessfulAccountDataApiResponseException parseException(Exception e) {
+        return new UnsuccessfulAccountDataApiResponseException("Error parsing HTTP response", e);
+    }
+
+    public int getHttpCode() {
+        return httpCode;
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/AccountDataApiService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/AccountDataApiService.java
@@ -1,0 +1,81 @@
+package uk.gov.di.authentication.shared.services;
+
+import uk.gov.di.authentication.shared.exceptions.UnsuccessfulAccountDataApiResponseException;
+import uk.gov.di.authentication.shared.helpers.HttpClientHelper;
+
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpTimeoutException;
+import java.time.Duration;
+
+import static uk.gov.di.authentication.shared.exceptions.UnsuccessfulAccountDataApiResponseException.interruptedException;
+import static uk.gov.di.authentication.shared.exceptions.UnsuccessfulAccountDataApiResponseException.ioException;
+import static uk.gov.di.authentication.shared.exceptions.UnsuccessfulAccountDataApiResponseException.timeoutException;
+import static uk.gov.di.authentication.shared.helpers.ConstructUriHelper.buildURI;
+
+public class AccountDataApiService {
+    private final HttpClient httpClient;
+    private final ConfigurationService configurationService;
+
+    public AccountDataApiService(ConfigurationService configurationService) {
+        this(HttpClientHelper.newInstrumentedHttpClient(), configurationService);
+    }
+
+    public AccountDataApiService(HttpClient httpClient, ConfigurationService configurationService) {
+        this.httpClient = httpClient;
+        this.configurationService = configurationService;
+    }
+
+    public HttpResponse<String> retrievePasskeys(String publicSubjectId)
+            throws UnsuccessfulAccountDataApiResponseException {
+        var request =
+                HttpRequest.newBuilder(
+                                buildURI(
+                                        configurationService.getAccountDataURI(),
+                                        "/accounts/"
+                                                + publicSubjectId
+                                                + "/authenticators/passkeys"))
+                        .GET()
+                        .timeout(
+                                Duration.ofMillis(
+                                        configurationService.getAccountDataApiCallTimeout()))
+                        .build();
+        return sendRequest(request);
+    }
+
+    public HttpResponse<String> deletePasskey(String publicSubjectId, String passkeyId)
+            throws UnsuccessfulAccountDataApiResponseException {
+        var request =
+                HttpRequest.newBuilder(
+                                buildURI(
+                                        configurationService.getAccountDataURI(),
+                                        "/accounts/"
+                                                + publicSubjectId
+                                                + "/authenticators/passkeys/"
+                                                + passkeyId))
+                        .DELETE()
+                        .timeout(
+                                Duration.ofMillis(
+                                        configurationService.getAccountDataApiCallTimeout()))
+                        .build();
+        return sendRequest(request);
+    }
+
+    private HttpResponse<String> sendRequest(HttpRequest request)
+            throws UnsuccessfulAccountDataApiResponseException {
+
+        try {
+            return httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        } catch (HttpTimeoutException e) {
+            throw timeoutException(
+                    configurationService.getAccountInterventionServiceCallTimeout(), e);
+        } catch (IOException e) {
+            throw ioException(e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw interruptedException(e);
+        }
+    }
+}

--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/ConfigurationService.java
@@ -917,6 +917,11 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return System.getenv("ACCOUNT_DATA_API_URI");
     }
 
+    public long getAccountDataApiCallTimeout() {
+        return Long.parseLong(
+                System.getenv().getOrDefault("ACCOUNT_DATA_API_CALL_TIMEOUT", "6000"));
+    }
+
     public URL getAmcJwksUrl() throws MalformedURLException {
         try {
             return new URL(System.getenv().getOrDefault("AMC_JWKS_URL", ""));

--- a/shared/src/test/java/uk/gov/di/authentication/shared/services/AccountDataApiServiceTest.java
+++ b/shared/src/test/java/uk/gov/di/authentication/shared/services/AccountDataApiServiceTest.java
@@ -1,0 +1,255 @@
+package uk.gov.di.authentication.shared.services;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import uk.gov.di.authentication.shared.exceptions.UnsuccessfulAccountDataApiResponseException;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class AccountDataApiServiceTest {
+    private AutoCloseable closeable;
+
+    @Mock private HttpClient httpClient;
+    @Mock private ConfigurationService configurationService;
+
+    private AccountDataApiService service;
+
+    @BeforeEach
+    void setUp() {
+        closeable = MockitoAnnotations.openMocks(this);
+        service = new AccountDataApiService(httpClient, configurationService);
+        when(configurationService.getAccountDataURI()).thenReturn("https://example.com");
+        when(configurationService.getAccountDataApiCallTimeout()).thenReturn(1000L);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        closeable.close();
+    }
+
+    @Nested
+    class RetrievePasskeys {
+        @Nested
+        class SuccessfulRequest {
+            @Test
+            void shouldBuildCorrectRequestUri()
+                    throws IOException,
+                            InterruptedException,
+                            UnsuccessfulAccountDataApiResponseException {
+                // Arrange
+                var httpRequestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
+                when(httpClient.send(any(), any())).thenReturn(null);
+
+                // Act
+                service.retrievePasskeys("testPublicSubjectId");
+
+                // Assert
+                verify(httpClient).send(httpRequestCaptor.capture(), any());
+                assertThat(
+                        httpRequestCaptor.getValue().uri(),
+                        equalTo(
+                                URI.create(
+                                        "https://example.com/accounts/testPublicSubjectId/authenticators/passkeys")));
+                assertThat(httpRequestCaptor.getValue().method(), equalTo("GET"));
+            }
+
+            @Test
+            void shouldReturnVerbatimHttpResponse()
+                    throws IOException,
+                            InterruptedException,
+                            UnsuccessfulAccountDataApiResponseException {
+                // Arrange
+                var mockHttpResponse = mock(HttpResponse.class);
+                when(mockHttpResponse.statusCode()).thenReturn(200);
+                when(mockHttpResponse.body()).thenReturn("{'test': true}");
+                when(httpClient.send(any(), any())).thenReturn(mockHttpResponse);
+
+                // Act
+                var resp = service.retrievePasskeys("testPublicSubjectId");
+
+                // Assert
+                assertThat(resp.statusCode(), equalTo(200));
+                assertThat(resp.body(), equalTo("{'test': true}"));
+            }
+        }
+
+        @Nested
+        class FailedRequest {
+            @Test
+            void shouldThrowWrappedExceptionIfHttpTimeoutExceptionEncountered()
+                    throws IOException, InterruptedException {
+                // Arrange
+                doThrow(new java.net.http.HttpTimeoutException("timed out"))
+                        .when(httpClient)
+                        .send(any(), any());
+
+                // Act & Assert
+                var exception =
+                        assertThrows(
+                                UnsuccessfulAccountDataApiResponseException.class,
+                                () -> service.retrievePasskeys("testPublicSubjectId"));
+                assertThat(exception.getMessage(), containsString("Timeout"));
+                assertThat(
+                        exception.getCause(), instanceOf(java.net.http.HttpTimeoutException.class));
+            }
+
+            @Test
+            void shouldThrowWrappedExceptionIfIOExceptionEncountered()
+                    throws IOException, InterruptedException {
+                // Arrange
+                doThrow(new IOException("connection failed")).when(httpClient).send(any(), any());
+
+                // Act & Assert
+                var exception =
+                        assertThrows(
+                                UnsuccessfulAccountDataApiResponseException.class,
+                                () -> service.retrievePasskeys("testPublicSubjectId"));
+                assertThat(exception.getMessage(), containsString("Error when attempting to call"));
+                assertThat(exception.getCause(), instanceOf(IOException.class));
+            }
+
+            @Test
+            void shouldThrowWrappedExceptionIfInterruptedExceptionEncountered()
+                    throws IOException, InterruptedException {
+                // Arrange
+                doThrow(new InterruptedException("interrupted"))
+                        .when(httpClient)
+                        .send(any(), any());
+
+                // Act & Assert
+                var exception =
+                        assertThrows(
+                                UnsuccessfulAccountDataApiResponseException.class,
+                                () -> service.retrievePasskeys("testPublicSubjectId"));
+                assertThat(exception.getMessage(), containsString("Interrupted exception"));
+                assertThat(exception.getCause(), instanceOf(InterruptedException.class));
+            }
+        }
+    }
+
+    @Nested
+    class DeletePasskey {
+        @Nested
+        class SuccessfulRequest {
+            @Test
+            void shouldBuildCorrectRequestUri()
+                    throws IOException,
+                            InterruptedException,
+                            UnsuccessfulAccountDataApiResponseException {
+                // Arrange
+                var httpRequestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
+                when(httpClient.send(any(), any())).thenReturn(null);
+
+                // Act
+                service.deletePasskey("testPublicSubjectId", "testPasskeyId");
+
+                // Assert
+                verify(httpClient).send(httpRequestCaptor.capture(), any());
+                assertThat(
+                        httpRequestCaptor.getValue().uri(),
+                        equalTo(
+                                URI.create(
+                                        "https://example.com/accounts/testPublicSubjectId/authenticators/passkeys/testPasskeyId")));
+                assertThat(httpRequestCaptor.getValue().method(), equalTo("DELETE"));
+            }
+
+            @Test
+            void shouldReturnVerbatimHttpResponse()
+                    throws IOException,
+                            InterruptedException,
+                            UnsuccessfulAccountDataApiResponseException {
+                // Arrange
+                var mockHttpResponse = mock(HttpResponse.class);
+                when(mockHttpResponse.statusCode()).thenReturn(200);
+                when(mockHttpResponse.body()).thenReturn("{'deleted': true}");
+                when(httpClient.send(any(), any())).thenReturn(mockHttpResponse);
+
+                // Act
+                var resp = service.deletePasskey("testPublicSubjectId", "testPasskeyId");
+
+                // Assert
+                assertThat(resp.statusCode(), equalTo(200));
+                assertThat(resp.body(), equalTo("{'deleted': true}"));
+            }
+        }
+
+        @Nested
+        class FailedRequest {
+            @Test
+            void shouldThrowWrappedExceptionIfHttpTimeoutExceptionEncountered()
+                    throws IOException, InterruptedException {
+                // Arrange
+                doThrow(new java.net.http.HttpTimeoutException("timed out"))
+                        .when(httpClient)
+                        .send(any(), any());
+
+                // Act & Assert
+                var exception =
+                        assertThrows(
+                                UnsuccessfulAccountDataApiResponseException.class,
+                                () ->
+                                        service.deletePasskey(
+                                                "testPublicSubjectId", "testPasskeyId"));
+                assertThat(exception.getMessage(), containsString("Timeout"));
+                assertThat(
+                        exception.getCause(), instanceOf(java.net.http.HttpTimeoutException.class));
+            }
+
+            @Test
+            void shouldThrowWrappedExceptionIfIOExceptionEncountered()
+                    throws IOException, InterruptedException {
+                // Arrange
+                doThrow(new IOException("connection failed")).when(httpClient).send(any(), any());
+
+                // Act & Assert
+                var exception =
+                        assertThrows(
+                                UnsuccessfulAccountDataApiResponseException.class,
+                                () ->
+                                        service.deletePasskey(
+                                                "testPublicSubjectId", "testPasskeyId"));
+                assertThat(exception.getMessage(), containsString("Error when attempting to call"));
+                assertThat(exception.getCause(), instanceOf(IOException.class));
+            }
+
+            @Test
+            void shouldThrowWrappedExceptionIfInterruptedExceptionEncountered()
+                    throws IOException, InterruptedException {
+                // Arrange
+                doThrow(new InterruptedException("interrupted"))
+                        .when(httpClient)
+                        .send(any(), any());
+
+                // Act & Assert
+                var exception =
+                        assertThrows(
+                                UnsuccessfulAccountDataApiResponseException.class,
+                                () ->
+                                        service.deletePasskey(
+                                                "testPublicSubjectId", "testPasskeyId"));
+                assertThat(exception.getMessage(), containsString("Interrupted exception"));
+                assertThat(exception.getCause(), instanceOf(InterruptedException.class));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What

Implements the Account Data API proxying endpoints within the Account Management API. These are quite dumb endpoints that simply forward through the request/response to the ADAPI.

Requires a bit more CloudFormation config to set the request URI.

I've also added WireMock to the account-management-integration-tests for the first time, to mock the ADAPI that's called. These tests allow us to check that the body was returned with no interference by the AMAPI.

## How to review

1. Code Review
1. Deploy to a dev environment using the most appropriate [GitHub dev deployment workflow](https://github.com/govuk-one-login/authentication-api/actions), or using the deployment scripts in this repo for the old account (e.g., `./deploy-authdevs.sh -c -b --all`).
1. Test calling the new endpoints to make sure they perform the actions you'd expect on the ADAPI.