### PR TITLE
ATO-2469: validate stored old public key

### DIFF
--- a/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthenticationAuthorizationService.java
+++ b/oidc-api/src/main/java/uk/gov/di/authentication/oidc/services/AuthenticationAuthorizationService.java
@@ -384,7 +384,7 @@ public class AuthenticationAuthorizationService {
                 segmentedFunctionCall(
                         "isTokenSignatureValid",
                         () ->
-                                tokenValidationService.isTokenSignatureValid(
+                                tokenValidationService.isReauthTokenSignatureValid(
                                         authenticationRequest
                                                 .getCustomParameter("id_token_hint")
                                                 .get(0)));

--- a/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AuthenticationAuthorizationServiceTest.java
+++ b/oidc-api/src/test/java/uk/gov/di/authentication/oidc/services/AuthenticationAuthorizationServiceTest.java
@@ -257,7 +257,7 @@ class AuthenticationAuthorizationServiceTest {
                             ecSigningKey);
             var authRequest =
                     generateAuthRequestForReauthJourney(reauthToken.serialize(), AUTH_ONLY_VTR);
-            when(tokenValidationService.isTokenSignatureValid(anyString())).thenReturn(true);
+            when(tokenValidationService.isReauthTokenSignatureValid(anyString())).thenReturn(true);
 
             authService.generateAuthRedirectRequest(
                     SESSION_ID,

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/serialization/ECKeyAdapter.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/serialization/ECKeyAdapter.java
@@ -1,0 +1,42 @@
+package uk.gov.di.orchestration.shared.serialization;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import com.google.gson.TypeAdapter;
+import com.google.gson.internal.Streams;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import com.nimbusds.jose.jwk.ECKey;
+
+import java.io.IOException;
+import java.text.ParseException;
+
+public class ECKeyAdapter extends TypeAdapter<ECKey> {
+
+    @Override
+    public void write(JsonWriter out, ECKey value) throws IOException {
+        if (value == null) {
+            out.nullValue();
+            return;
+        }
+
+        String jsonString = value.toJSONObject().toString();
+        JsonElement jsonElement = JsonParser.parseString(jsonString);
+        Streams.write(jsonElement, out);
+    }
+
+    @Override
+    public ECKey read(JsonReader in) throws IOException {
+        JsonElement jsonElement = Streams.parse(in);
+
+        if (jsonElement.isJsonNull()) {
+            return null;
+        }
+
+        try {
+            return ECKey.parse(jsonElement.toString());
+        } catch (ParseException e) {
+            throw new IOException("Failed to parse JWK ECKey: " + e.getMessage(), e);
+        }
+    }
+}

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/serialization/Json.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/serialization/Json.java
@@ -2,12 +2,18 @@ package uk.gov.di.orchestration.shared.serialization;
 
 import uk.gov.di.orchestration.shared.validation.Validator;
 
+import java.lang.reflect.Type;
+
 public interface Json {
     <T> T readValueUnchecked(String jsonString, Class<T> clazz);
 
     <T> T readValue(String body, Class<T> klass) throws JsonException;
 
+    <T> T readValue(String body, Type typeOfT) throws JsonException;
+
     <T> T readValue(String body, Class<T> klass, Validator validator) throws JsonException;
+
+    <T> T readValue(String body, Type typeOfT, Validator validator) throws JsonException;
 
     String writeValueAsString(Object object) throws JsonException;
 

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/ConfigurationService.java
@@ -373,6 +373,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
         return System.getenv("NEXT_EXTERNAL_TOKEN_SIGNING_KEY_RSA_ALIAS_V2");
     }
 
+    public String getStoredOldTokenECPublicKeys() {
+        return System.getenv("STORED_OLD_ID_TOKEN_EC_PUBLIC_KEYS");
+    }
+
     public boolean isPublishNextExternalTokenSigningKeysEnabledV2() {
         return getFlagOrFalse("PUBLISH_NEXT_EXTERNAL_TOKEN_SIGNING_KEYS_V2");
     }
@@ -384,6 +388,10 @@ public class ConfigurationService implements BaseLambdaConfiguration, AuditPubli
 
     public boolean isUseNewV2TokenSigningKeysEnabled() {
         return getFlagOrFalse("USE_NEW_V2_TOKEN_SIGNING_KEYS");
+    }
+
+    public boolean isUseStoredOldIdTokenPublicKeysEnabled() {
+        return getFlagOrFalse("USE_STORED_OLD_ID_TOKEN_PUBLIC_KEYS");
     }
 
     public boolean isSingleFactorAccountDeletionEnabled() {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/JwksService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/JwksService.java
@@ -1,5 +1,6 @@
 package uk.gov.di.orchestration.shared.services;
 
+import com.google.gson.reflect.TypeToken;
 import com.nimbusds.jose.KeySourceException;
 import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jose.jwk.JWK;
@@ -13,12 +14,15 @@ import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
 import software.amazon.awssdk.services.kms.model.GetPublicKeyRequest;
 import software.amazon.awssdk.services.kms.model.GetPublicKeyResponse;
 import uk.gov.di.orchestration.shared.helpers.CryptoProviderHelper;
+import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.shared.utils.JwksUtils;
 
+import java.lang.reflect.Type;
 import java.net.URL;
 import java.security.PublicKey;
 import java.security.interfaces.ECPublicKey;
 import java.security.interfaces.RSAPublicKey;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -34,6 +38,7 @@ public class JwksService {
     private final KmsConnectionService kmsConnectionService;
     private static final Map<String, JWK> KEY_CACHE = new HashMap<>();
     private static final Logger LOG = LogManager.getLogger(JwksService.class);
+    private final Json objectMapper = SerializationService.getInstance();
 
     public JwksService(
             ConfigurationService configurationService, KmsConnectionService kmsConnectionService) {
@@ -49,6 +54,19 @@ public class JwksService {
     public JWK getPublicTokenRsaJwkWithOpaqueId() {
         LOG.info("Retrieving RSA public key");
         return getPublicJWKWithKeyId(configurationService.getExternalTokenSigningKeyRsaAlias());
+    }
+
+    public ArrayList<ECKey> getStoredOldPublicTokenJwksWithOpaqueId() {
+        try {
+            LOG.info("Retrieving stored EC public key");
+            Type listType = new TypeToken<ArrayList<ECKey>>() {}.getType();
+            return objectMapper.readValue(
+                    configurationService.getStoredOldTokenECPublicKeys(), listType);
+        } catch (Json.JsonException e) {
+            String error = "Error parsing stored EC public key: " + e.getMessage();
+            LOG.error(error);
+            throw new RuntimeException(error);
+        }
     }
 
     public JWK getNextPublicTokenJwkWithOpaqueIdV2() {

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/SerializationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/SerializationService.java
@@ -4,10 +4,12 @@ import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
+import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.oauth2.sdk.id.State;
 import com.nimbusds.oauth2.sdk.id.Subject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import uk.gov.di.orchestration.shared.serialization.ECKeyAdapter;
 import uk.gov.di.orchestration.shared.serialization.Json;
 import uk.gov.di.orchestration.shared.serialization.LocalDateTimeAdapter;
 import uk.gov.di.orchestration.shared.serialization.StateAdapter;
@@ -15,6 +17,7 @@ import uk.gov.di.orchestration.shared.serialization.SubjectAdapter;
 import uk.gov.di.orchestration.shared.validation.RequiredFieldValidator;
 import uk.gov.di.orchestration.shared.validation.Validator;
 
+import java.lang.reflect.Type;
 import java.time.LocalDateTime;
 
 import static java.util.Objects.isNull;
@@ -37,6 +40,7 @@ public class SerializationService implements Json {
                         .registerTypeAdapter(State.class, new StateAdapter())
                         .registerTypeAdapter(LocalDateTime.class, new LocalDateTimeAdapter())
                         .registerTypeAdapter(Subject.class, new SubjectAdapter())
+                        .registerTypeAdapter(ECKey.class, new ECKeyAdapter())
                         .create();
     }
 
@@ -55,6 +59,11 @@ public class SerializationService implements Json {
     }
 
     @Override
+    public <T> T readValue(String body, Type typeOfT) throws JsonException {
+        return readValue(body, typeOfT, defaultValidator);
+    }
+
+    @Override
     public <T> T readValue(String jsonString, Class<T> clazz, Validator validator)
             throws JsonException {
         try {
@@ -62,6 +71,31 @@ public class SerializationService implements Json {
                     segmentedFunctionCall(
                             "SerializationService::GSON::fromJson",
                             () -> gson.fromJson(jsonString, clazz));
+            var violations =
+                    segmentedFunctionCall(
+                            "SerializationService::validator::validate",
+                            () -> validator.validate(value));
+            if (violations.isEmpty()) {
+                return value;
+            }
+            violations.forEach(
+                    v -> LOG.warn("Json validation failed due to missing required field: {}", v));
+            throw new JsonException(
+                    "JSON validation error, missing required field(s): "
+                            + String.join(", ", violations));
+        } catch (JsonSyntaxException | IllegalArgumentException e) {
+            throw new JsonException(e);
+        }
+    }
+
+    @Override
+    public <T> T readValue(String jsonString, Type typeOfT, Validator validator)
+            throws JsonException {
+        try {
+            T value =
+                    segmentedFunctionCall(
+                            "SerializationService::GSON::fromJson",
+                            () -> gson.fromJson(jsonString, typeOfT));
             var violations =
                     segmentedFunctionCall(
                             "SerializationService::validator::validate",

--- a/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/TokenValidationService.java
+++ b/orchestration-shared/src/main/java/uk/gov/di/orchestration/shared/services/TokenValidationService.java
@@ -4,6 +4,7 @@ import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.crypto.ECDSAVerifier;
 import com.nimbusds.jose.crypto.RSASSAVerifier;
+import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.jwt.util.DateUtils;
@@ -16,6 +17,7 @@ import uk.gov.di.orchestration.shared.helpers.NowHelper;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 public class TokenValidationService {
 
@@ -95,6 +97,27 @@ public class TokenValidationService {
         }
     }
 
+    public boolean isReauthTokenSignatureValid(String tokenValue) {
+        try {
+            var jwt = SignedJWT.parse(tokenValue);
+
+            if (configuration.isPublishNextExternalTokenSigningKeysEnabledV2()) {
+                var newV2PublicKey = jwksService.getNextPublicTokenJwkWithOpaqueIdV2();
+                if (Objects.equals(jwt.getHeader().getKeyID(), newV2PublicKey.getKeyID())) {
+                    return jwt.verify(new ECDSAVerifier(newV2PublicKey.toECKey()));
+                } else {
+                    return validateWithOldECPublicKey(jwt);
+                }
+            } else {
+                return validateWithOldECPublicKey(jwt);
+            }
+
+        } catch (JOSEException | java.text.ParseException e) {
+            LOG.warn("Unable to validate Signature of Token", e);
+            return false;
+        }
+    }
+
     public boolean validateRefreshTokenScopes(
             List<String> clientScopes, List<String> refreshTokenScopes) {
         if (!clientScopes.containsAll(refreshTokenScopes)) {
@@ -106,5 +129,23 @@ public class TokenValidationService {
             return false;
         }
         return true;
+    }
+
+    private boolean validateWithOldECPublicKey(SignedJWT jwt) throws JOSEException {
+        var oldPublicKey = jwksService.getPublicTokenJwkWithOpaqueId();
+        if (configuration.isUseStoredOldIdTokenPublicKeysEnabled()) {
+            var oldStoredPublicKeys = jwksService.getStoredOldPublicTokenJwksWithOpaqueId();
+            Optional<ECKey> optionalPublicKey =
+                    oldStoredPublicKeys.stream()
+                            .filter(
+                                    key ->
+                                            Objects.equals(
+                                                    jwt.getHeader().getKeyID(), key.getKeyID()))
+                            .findFirst();
+            return optionalPublicKey.isPresent()
+                    && jwt.verify(new ECDSAVerifier(optionalPublicKey.get()));
+        } else {
+            return jwt.verify(new ECDSAVerifier(oldPublicKey.toECKey()));
+        }
     }
 }

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/SerializationServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/SerializationServiceTest.java
@@ -1,13 +1,24 @@
 package uk.gov.di.orchestration.shared.services;
 
 import com.google.gson.annotations.Expose;
+import com.google.gson.reflect.TypeToken;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.KeyType;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
+import static java.lang.String.format;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class SerializationServiceTest {
     private final SerializationService serializationService = SerializationService.getInstance();
@@ -58,6 +69,62 @@ class SerializationServiceTest {
             assertEquals(123, testObject.intField);
             assertEquals(List.of("def", "ghi"), testObject.stringListField);
         }
+
+        @Test
+        void shouldDeserialiseECKeyJson() throws Exception {
+            var testECKeyJsonString =
+                    "{"
+                            + "\"kty\": \"EC\","
+                            + "\"use\": \"sig\","
+                            + "\"crv\": \"P-256\","
+                            + "\"kid\": \"e44ca187e5f3fee60c2d772cc9743f1175899ddc53fcc1178587a2fbd8d20081\","
+                            + "\"x\": \"ccziorFA2LGN3Jdd8pAQNNLjYkTM5DqD2bXiHb62HF4\","
+                            + "\"y\": \"nd02oQv8Uz9mjy3-EUG6nzuzdhW4TwYh6RA94n8RAJc\","
+                            + "\"alg\": \"ES256\""
+                            + "}";
+
+            var testECKey = serializationService.readValue(testECKeyJsonString, ECKey.class);
+
+            assertEquals(
+                    "e44ca187e5f3fee60c2d772cc9743f1175899ddc53fcc1178587a2fbd8d20081",
+                    testECKey.getKeyID());
+            assertEquals("ES256", testECKey.getAlgorithm().toString());
+            assertEquals(KeyType.EC, testECKey.getKeyType());
+        }
+
+        @Test
+        void shouldDeserialiseECKeyJsonArray() throws Exception {
+            var testECKeyJsonString =
+                    "[{"
+                            + "\"kty\": \"EC\","
+                            + "\"use\": \"sig\","
+                            + "\"crv\": \"P-256\","
+                            + "\"kid\": \"e44ca187e5f3fee60c2d772cc9743f1175899ddc53fcc1178587a2fbd8d20081\","
+                            + "\"x\": \"ccziorFA2LGN3Jdd8pAQNNLjYkTM5DqD2bXiHb62HF4\","
+                            + "\"y\": \"nd02oQv8Uz9mjy3-EUG6nzuzdhW4TwYh6RA94n8RAJc\","
+                            + "\"alg\": \"ES256\""
+                            + "},"
+                            + "{"
+                            + "\"kty\": \"EC\","
+                            + "\"use\": \"sig\","
+                            + "\"crv\": \"P-256\","
+                            + "\"kid\": \"e44ca187e5f3fee60c2d772cc9743f1175899ddc53fcc1178587a2fbd8d20081\","
+                            + "\"x\": \"ccziorFA2LGN3Jdd8pAQNNLjYkTM5DqD2bXiHb62HF4\","
+                            + "\"y\": \"nd02oQv8Uz9mjy3-EUG6nzuzdhW4TwYh6RA94n8RAJc\","
+                            + "\"alg\": \"ES256\""
+                            + "}]";
+
+            Type listType = new TypeToken<ArrayList<ECKey>>() {}.getType();
+            ArrayList<ECKey> testECKey =
+                    serializationService.readValue(testECKeyJsonString, listType);
+
+            assertEquals(2, testECKey.size());
+            assertEquals(
+                    "e44ca187e5f3fee60c2d772cc9743f1175899ddc53fcc1178587a2fbd8d20081",
+                    testECKey.get(0).getKeyID());
+            assertEquals("ES256", testECKey.get(0).getAlgorithm().toString());
+            assertEquals(KeyType.EC, testECKey.get(0).getKeyType());
+        }
     }
 
     @Nested
@@ -88,6 +155,64 @@ class SerializationServiceTest {
                             + "\"string_list_field\":[\"def\",\"ghi\"]"
                             + "}";
             assertEquals(expectedJsonString, actualJsonString);
+        }
+
+        @Test
+        void shouldSerialiseECKeyJson() throws Exception {
+            var testECKey =
+                    new ECKeyGenerator(Curve.P_256)
+                            .keyID("testid123456789")
+                            .algorithm(JWSAlgorithm.ES256)
+                            .generate();
+
+            var testECKeyJsonString = serializationService.writeValueAsString(testECKey);
+
+            assertTrue(testECKeyJsonString.contains("\"kty\":\"EC\""));
+            assertTrue(testECKeyJsonString.contains("\"kid\":\"testid123456789\""));
+            assertTrue(testECKeyJsonString.contains("\"alg\":\"ES256\""));
+            assertTrue(testECKeyJsonString.contains("\"crv\":\"P-256\""));
+            assertTrue(
+                    testECKeyJsonString.contains(
+                            format("\"x\":\"%s\"", testECKey.getX().toString())));
+            assertTrue(
+                    testECKeyJsonString.contains(
+                            format("\"y\":\"%s\"", testECKey.getY().toString())));
+        }
+
+        @Test
+        void shouldSerialiseECKeyJsonArray() throws Exception {
+            var testECKey1 =
+                    new ECKeyGenerator(Curve.P_256)
+                            .keyID("testid123456789")
+                            .algorithm(JWSAlgorithm.ES256)
+                            .generate();
+            var testECKey2 =
+                    new ECKeyGenerator(Curve.P_256)
+                            .keyID("testid987654321")
+                            .algorithm(JWSAlgorithm.ES256)
+                            .generate();
+
+            var testECKeyJsonString =
+                    serializationService.writeValueAsString(Arrays.asList(testECKey1, testECKey2));
+
+            assertTrue(testECKeyJsonString.contains("\"kty\":\"EC\""));
+            assertTrue(testECKeyJsonString.contains("\"kid\":\"testid123456789\""));
+            assertTrue(testECKeyJsonString.contains("\"alg\":\"ES256\""));
+            assertTrue(testECKeyJsonString.contains("\"crv\":\"P-256\""));
+            assertTrue(
+                    testECKeyJsonString.contains(
+                            format("\"x\":\"%s\"", testECKey1.getX().toString())));
+            assertTrue(
+                    testECKeyJsonString.contains(
+                            format("\"y\":\"%s\"", testECKey1.getY().toString())));
+
+            assertTrue(testECKeyJsonString.contains("\"kid\":\"testid987654321\""));
+            assertTrue(
+                    testECKeyJsonString.contains(
+                            format("\"x\":\"%s\"", testECKey2.getX().toString())));
+            assertTrue(
+                    testECKeyJsonString.contains(
+                            format("\"y\":\"%s\"", testECKey2.getY().toString())));
         }
     }
 

--- a/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/TokenValidationServiceTest.java
+++ b/orchestration-shared/src/test/java/uk/gov/di/orchestration/shared/services/TokenValidationServiceTest.java
@@ -14,11 +14,14 @@ import com.nimbusds.oauth2.sdk.id.Subject;
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.oauth2.sdk.token.RefreshToken;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import uk.gov.di.orchestration.shared.helpers.NowHelper;
 import uk.gov.di.orchestration.sharedtest.helper.TokenGeneratorHelper;
 
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
@@ -40,6 +43,7 @@ class TokenValidationServiceTest {
     private static final String BASE_URL = "https://example.com";
     private static final String KEY_ID = "14342354354353";
     private static final String NEW_V2_KEY_ID = "14342334554354";
+    private static final String OLD_STORED_KEY_ID = "14442634554354";
     private static final String FAILED_KEY_ID = "14342354354355";
     private JWSSigner signer;
     private ECKey ecJWK;
@@ -85,6 +89,20 @@ class TokenValidationServiceTest {
                 .thenReturn(true);
 
         SignedJWT signedAccessToken = createCustomSignedAccessToken(ecSigner, NEW_V2_KEY_ID);
+        assertTrue(
+                tokenValidationService.isTokenSignatureValid(
+                        new BearerAccessToken(signedAccessToken.serialize()).getValue()));
+    }
+
+    @Test
+    void shouldSuccessfullyValidateAccessTokenWithOldKeyWhenKeyIdMatches() {
+        var newECKey = generateCustomECKeyPair(NEW_V2_KEY_ID);
+
+        when(jwksService.getNextPublicTokenJwkWithOpaqueIdV2()).thenReturn(newECKey);
+        when(configurationService.isPublishNextExternalTokenSigningKeysEnabledV2())
+                .thenReturn(true);
+
+        SignedJWT signedAccessToken = createSignedAccessToken(signer);
         assertTrue(
                 tokenValidationService.isTokenSignatureValid(
                         new BearerAccessToken(signedAccessToken.serialize()).getValue()));
@@ -139,11 +157,30 @@ class TokenValidationServiceTest {
     }
 
     @Test
-    void shouldFailToValidateRsaKeyAccessTokenIfKeyIdInvalid() throws JOSEException {
-        var wrongRSAKey = new RSAKeyGenerator(2048).generate();
-        var rsaSigner = new RSASSASigner(wrongRSAKey);
+    void shouldSuccessfullyValidateRsaSignedAccessTokenWithOldKeyWhenKeyIdMatches()
+            throws JOSEException {
         var rsaKey = generateCustomRsaKeyPair(KEY_ID);
         var newRSAKey = generateCustomRsaKeyPair(NEW_V2_KEY_ID);
+        var rsaSigner = new RSASSASigner(rsaKey);
+
+        when(configurationService.isRsaSigningAvailable()).thenReturn(true);
+        when(configurationService.isPublishNextExternalTokenSigningKeysEnabledV2())
+                .thenReturn(true);
+        when(jwksService.getPublicTokenRsaJwkWithOpaqueId()).thenReturn(rsaKey);
+        when(jwksService.getNextPublicTokenRsaJwkWithOpaqueIdV2()).thenReturn(newRSAKey);
+
+        SignedJWT signedAccessToken = createCustomSignedAccessToken(rsaSigner, KEY_ID);
+        assertTrue(
+                tokenValidationService.isTokenSignatureValid(
+                        new BearerAccessToken(signedAccessToken.serialize()).getValue()));
+    }
+
+    @Test
+    void shouldFailToValidateRsaKeyAccessTokenIfKeyIdInvalid() throws JOSEException {
+        var wrongRSAKey = generateCustomRsaKeyPair(FAILED_KEY_ID);
+        var rsaKey = generateCustomRsaKeyPair(KEY_ID);
+        var newRSAKey = generateCustomRsaKeyPair(NEW_V2_KEY_ID);
+        var rsaSigner = new RSASSASigner(wrongRSAKey);
 
         when(configurationService.isRsaSigningAvailable()).thenReturn(true);
         when(configurationService.isPublishNextExternalTokenSigningKeysEnabledV2())
@@ -155,6 +192,114 @@ class TokenValidationServiceTest {
         assertFalse(
                 tokenValidationService.isTokenSignatureValid(
                         new BearerAccessToken(signedAccessToken.serialize()).getValue()));
+    }
+
+    @Nested
+    class ReauthJourneys {
+        @Test
+        void shouldSuccessfullyValidateReauthIDToken() {
+            Date expiryDate = NowHelper.nowPlus(2, ChronoUnit.MINUTES);
+            SignedJWT signedIdToken = createSignedIdToken(expiryDate);
+            assertTrue(tokenValidationService.isTokenSignatureValid(signedIdToken.serialize()));
+        }
+
+        @Test
+        void shouldNotFailSignatureValidationIfReauthIDTokenHasExpired() {
+            Date expiryDate = NowHelper.nowMinus(2, ChronoUnit.MINUTES);
+            SignedJWT signedIdToken = createSignedIdToken(expiryDate);
+            assertTrue(tokenValidationService.isTokenSignatureValid(signedIdToken.serialize()));
+        }
+
+        @Test
+        void shouldSuccessfullyValidateNewECKeyV2ReauthIDToken() throws JOSEException {
+            Date expiryDate = NowHelper.nowPlus(2, ChronoUnit.MINUTES);
+            var newECKey = generateCustomECKeyPair(NEW_V2_KEY_ID);
+
+            when(jwksService.getNextPublicTokenJwkWithOpaqueIdV2()).thenReturn(newECKey);
+            when(configurationService.isPublishNextExternalTokenSigningKeysEnabledV2())
+                    .thenReturn(true);
+
+            SignedJWT signedIdToken = createCustomSignedIdToken(expiryDate, newECKey);
+            assertTrue(
+                    tokenValidationService.isTokenSignatureValid(
+                            new BearerAccessToken(signedIdToken.serialize()).getValue()));
+        }
+
+        @Test
+        void shouldSuccessfullyValidateReauthIDTokenWithOldKeyWhenKeyIdMatches() {
+            Date expiryDate = NowHelper.nowPlus(2, ChronoUnit.MINUTES);
+            var newECKey = generateCustomECKeyPair(NEW_V2_KEY_ID);
+
+            when(jwksService.getNextPublicTokenJwkWithOpaqueIdV2()).thenReturn(newECKey);
+            when(configurationService.isPublishNextExternalTokenSigningKeysEnabledV2())
+                    .thenReturn(true);
+
+            SignedJWT signedIdToken = createSignedIdToken(expiryDate);
+            assertTrue(
+                    tokenValidationService.isTokenSignatureValid(
+                            new BearerAccessToken(signedIdToken.serialize()).getValue()));
+        }
+
+        @Test
+        void shouldFailToValidateECKeyReauthIDTokenIfKeyIdInvalid() throws JOSEException {
+            Date expiryDate = NowHelper.nowPlus(2, ChronoUnit.MINUTES);
+            var newECKey = generateCustomECKeyPair(NEW_V2_KEY_ID);
+            var failedECKey = generateCustomECKeyPair(FAILED_KEY_ID);
+
+            when(jwksService.getNextPublicTokenJwkWithOpaqueIdV2()).thenReturn(newECKey);
+            when(configurationService.isPublishNextExternalTokenSigningKeysEnabledV2())
+                    .thenReturn(true);
+
+            SignedJWT signedIdToken = createCustomSignedIdToken(expiryDate, failedECKey);
+            assertFalse(
+                    tokenValidationService.isTokenSignatureValid(
+                            new BearerAccessToken(signedIdToken.serialize()).getValue()));
+        }
+
+        @Test
+        void shouldSuccessfullyValidateOldStoredECKeyReauthIDToken() throws JOSEException {
+            Date expiryDate = NowHelper.nowPlus(2, ChronoUnit.MINUTES);
+            var oldStoredECKey = generateCustomECKeyPair(OLD_STORED_KEY_ID);
+
+            when(jwksService.getStoredOldPublicTokenJwksWithOpaqueId())
+                    .thenReturn(new ArrayList<ECKey>(Arrays.asList(oldStoredECKey.toECKey())));
+            when(configurationService.isUseStoredOldIdTokenPublicKeysEnabled()).thenReturn(true);
+
+            SignedJWT signedIdToken = createCustomSignedIdToken(expiryDate, oldStoredECKey);
+            assertTrue(
+                    tokenValidationService.isReauthTokenSignatureValid(
+                            new BearerAccessToken(signedIdToken.serialize()).getValue()));
+        }
+
+        @Test
+        void shouldFailToValidateECKeyReauthIDTokenIfOldStoredPublicKeyIdInvalid()
+                throws JOSEException {
+            Date expiryDate = NowHelper.nowPlus(2, ChronoUnit.MINUTES);
+            var oldStoredECKey = generateCustomECKeyPair(OLD_STORED_KEY_ID);
+            var failedECKey = generateCustomECKeyPair(FAILED_KEY_ID);
+
+            when(jwksService.getStoredOldPublicTokenJwksWithOpaqueId())
+                    .thenReturn(new ArrayList<ECKey>(Arrays.asList(oldStoredECKey.toECKey())));
+            when(configurationService.isUseStoredOldIdTokenPublicKeysEnabled()).thenReturn(true);
+
+            SignedJWT signedIdToken = createCustomSignedIdToken(expiryDate, failedECKey);
+            assertFalse(
+                    tokenValidationService.isReauthTokenSignatureValid(
+                            new BearerAccessToken(signedIdToken.serialize()).getValue()));
+        }
+
+        @Test
+        void shouldFailToValidateECKeyReauthIDTokenIfNoOldStoredPublicKey() {
+            Date expiryDate = NowHelper.nowPlus(2, ChronoUnit.MINUTES);
+            when(jwksService.getStoredOldPublicTokenJwksWithOpaqueId())
+                    .thenReturn(new ArrayList<>());
+            when(configurationService.isUseStoredOldIdTokenPublicKeysEnabled()).thenReturn(true);
+
+            SignedJWT signedIdToken = createSignedIdToken(expiryDate);
+            assertFalse(
+                    tokenValidationService.isReauthTokenSignatureValid(
+                            new BearerAccessToken(signedIdToken.serialize()).getValue()));
+        }
     }
 
     @Test
@@ -222,14 +367,17 @@ class TokenValidationServiceTest {
                 CLIENT_ID, SUBJECT, BASE_URL, ecJWK, expiryDate);
     }
 
-    private SignedJWT createCustomSignedAccessToken(JWSSigner signer, String keyId) {
+    private SignedJWT createCustomSignedIdToken(Date expiryDate, ECKey ecKey) {
+        return TokenGeneratorHelper.generateIDToken(
+                CLIENT_ID, SUBJECT, BASE_URL, ecKey, expiryDate);
+    }
 
+    private SignedJWT createCustomSignedAccessToken(JWSSigner signer, String keyId) {
         return TokenGeneratorHelper.generateSignedToken(
                 CLIENT_ID, BASE_URL, SCOPES, signer, SUBJECT, keyId);
     }
 
     private SignedJWT createSignedAccessToken(JWSSigner signer) {
-
         return createCustomSignedAccessToken(signer, KEY_ID);
     }
 

--- a/template.yaml
+++ b/template.yaml
@@ -180,14 +180,6 @@ Mappings:
         "y": "nd02oQv8Uz9mjy3-EUG6nzuzdhW4TwYh6RA94n8RAJc",
         "alg": "ES256"
         }]'
-      oldIdTokenRSAPublicKeys: '[{
-        "kty": "RSA",
-        "e": "AQAB",
-        "use": "sig",
-        "kid": "646cbe13a3af45842a4a5b6c95e9cbc96e31b8fd393f0e971d54c58863ed34f2",
-        "alg": "RS256",
-        "n": "mUCN8SxuAHLa-oEqoKACK3aSd7Vlt4X6sIsVcVpvYix6FoHDHayj4Wj3q2isW3VR8b-Ej-_7u982GEklK5APvhwTI8EzrnObfBORppdqjB_yrqPMjIdRNtPKYa1EEG-acCbKYbdDundUPHRW7CAXZjREh1nthRsDJlxkkNYyqd4JEX3EkPaH5xEavUCbPLI4a4WTf63iuycWsXNTTyvUHFN8kelBq6gGzu4PY5u7eRXoc9IXuqV0sMwJOaXwveIP6X2k2I7PdF6TWG77IOU9y5QYrGrfmDwbxEboGJ3NMaLE2eNyAQ0GOEZ64_eveSa-hEJrRR7lzZe4Ty1R2WuGE2piTAt94vxz5FHwXrWZorB7I6y6ykau20_QCVcotI6htlp8JmGw-EzHRKwh4qDeje43tgfqQ0KbPysy-miK7AaUIi_ExwRWHxaRdwq5Hu08Y8-qNwqGggHI-g5go-fPobnk_uIUjm3TKjHGg06xCCRVmBiBgbfw2wvM0O4RdlZEDAsjEGPmfU7--LvxFHLoBskNBWzjuhNbOQNi3wuAX4b8IVZaD-94DLDXGldfaIUkuOSLz9Nero17GV7qgIQaKmf_bEgk_J1ZyT1M3eLGOaJzT2FousQf9QZTuGMeQDsK64uII_OVna5PqouMjLjSePWWsVltw7ooujB5Gvj9ojs"
-        }]'
     build:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       dynatraceLayerArn: arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_331_39_20260206-150338_with_collector_java_arm:1
@@ -223,14 +215,6 @@ Mappings:
         "x": "CzgXTqLUvx0P06QkOujQwTBSs8v47F3wl3eGLkvmC7E",
         "y": "7UOFJn9pipVDB1PlAbD57wk6a7RzjjyjIvJTbPGIfNw",
         "alg": "ES256"
-        }]'
-      oldIdTokenRSAPublicKeys: '[{
-        "kty": "RSA",
-        "e": "AQAB",
-        "use": "sig",
-        "kid": "4cc61ab001586d3c310a4ab672bbc78f73fe90b4258c7ccf5f54d0b629d0b8db",
-        "alg": "RS256",
-        "n": "ri1u9loetZ_j4J4YH4pUmE0-M0LCUK6eWIqfGOo5H5A629hvcnaH3NU0mbs0-e_0UTe3ASb82pP6SEOmqoqVl6dbcuhmBSQuAWCs3q7puQ7EyL5FoSCr_kf9Kizv6lTC9XW5VfMVzIYKuDCr2fmTqxZolu6gjejczGkq7sGTCjf_fpgc_AkagsjjRcNobhVz1IpROAmFNz5fLGmKewiKv7qX7D2Aqt8dWDMFuDq9kq8IbgeO2T88PntUps5QVRZsW1VXUAa1JaQ1Eq99a6Ji2KsDM0y_x-_2MBRSRcg2Z83FNZd8qvzhlAeW3IGC7GzYTRSfnuLURoSO1c-pQiEEXWoWrTTSLBegnmm_5ukN29uRfCu-hhHZWOuf_J08H9cc4J2M9BMMUi6dQw8slVnIlwt5hjSHvTJqK386C89WQiiRPF4sXqadfLedSdDG5DnincCZSjO061vMGI6v4UiygMY6BnVsb1wsuk7ABWXd2QfrtbFXMnW_Im4kKz2W7SPtTjApEy81LwTo-3eyTDQhRLl9k0Muu3fA0T9oXGPOn2ns6Xpth6gSV7bQWKPfpE5KteSe42VR4LVOwtPeFQURrzj7zSv7F4VESayQzoV0IEbuXlC0Q5sMJTjXRj6Gk8yxIXNGkz2QCN4rx_vXcnY3-m368XAGrwh8OAWXWc0H0yU"
         }]'
     staging:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
@@ -270,14 +254,6 @@ Mappings:
         "y": "KCkzB3M9l4tcDchHM8agucY05giwCvSuNTB0M-W3--Y",
         "alg": "ES256"
         }]'
-      oldIdTokenRSAPublicKeys: '[{
-        "kty": "RSA",
-        "e": "AQAB",
-        "use": "sig",
-        "kid": "c190f0cc30cd9667376607ce52d1e084a6856054dc4e599fbb30b49894730903",
-        "alg": "RS256",
-        "n": "srLfKCgyRr5XfngmCRAqnBS4TyEksaw49Jd1VKMeVZ79BuIdnezeZH3GENbfVkyJnpuKjmQcbnF2ANi_FZOIbt-sxcQZ_R28CBppBExUbahZ9jJW2DASCnYsu90cSqI342fjgGo_Qi0UbKXeSgsYtHI-GlHExC2wtfsro9_E6oZm27M6cqS040nNPJi8iXlVmdinAD-NdFvdacxsBpv6iBoDFCQf2rx_9MNWW3kOf8GTRzve0H0I4wIqjTPqCmTRyxSfRz-J9TJcECe2MUN8jy7X0p1jM0V4m67vUnZsCASqEV4fUDulzzSR3lc4qFRFGKDKh17a0jpGBbrh3YBIFCowX-Vln__5DasHtJKU4ZAc98Nmih23sGMpAF5KqKOjWiQVgDfzRAbZQtrHdRRuetji5uHOJM567zGSmrgr9hIVzsuS1d2F0fI5TwwXSh8iNyMcT0uWuuPOwS47S944BGUf3CmxOBK5v3uiYEJvDOlkc5940OzAAwijZt4Cd35d6FO19h03eC-Ht-W3qh9GaRaoa0DW_0vB7OAkr6D0PJPFotP8mu1Su5kYwTjWgV23btU-sNKF3qMHO6aljme9lwCgye-hDUXMPBbArKXNt0R5QkanypCFJQ1E2cqzm_ZOYIEq3k-oRJsYARMTDTWuqmG3cjGP7cANWV3Wvz8Ui60"
-        }]'
     integration:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       dynatraceLayerArn: arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_311_51_20250331-143707_with_collector_java:1
@@ -314,14 +290,6 @@ Mappings:
         "y": "QzrvsnDy3oY1yuz55voaAq9B1M5tfhgW3FBjh_n_F0U",
         "alg": "ES256"
         }]'
-      oldIdTokenRSAPublicKeys: '[{
-        "kty": "RSA",
-        "e": "AQAB",
-        "use": "sig",
-        "kid": "76e79bfc350137593e5bd992b202e248fc97e7a20988a5d4fbe9a0273e54844e",
-        "alg": "RS256",
-        "n": "lGac-hw2cW5_amtNiDI-Nq2dEXt1x0nwOEIEFd8NwtYz7ha1GzNwO2LyFEoOvqIAcG0NFCAxgjkKD5QwcsThGijvMOLG3dPRMjhyB2S4bCmlkwLpW8vY4sJjc4bItdfuBtUxDA0SWqepr5h95RAsg9UP1LToJecJJR_duMzN-Nutu9qwbpIJph8tFjOFp_T37bVFk4vYkWfX-d4-TOImOOD75G0kgYoAJLS2SRovQAkbJwC1bdn_N8yw7RL9WIqZCwzqMqANdo3dEgSb04XD_CUzL0Y2zU3onewH9PhaMfb11JhsuijH3zRA0dwignDHp7pBw8uMxYSqhoeVO6V0jz8vYo27LyySR1ZLMg13bPNrtMnEC-LlRtZpxkcDLm7bkO-mPjYLrhGpDy7fSdr-6b2rsHzE_YerkZA_RgX_Qv-dZueX5tq2VRZu66QJAgdprZrUx34QBitSAvHL4zcI_Qn2aNl93DR-bT8lrkwB6UBz7EghmQivrwK84BjPircDWdivT4GcEzRdP0ed6PmpAmerHaalyWpLUNoIgVXLa_Px07SweNzyb13QFbiEaJ8p1UFT05KzIRxO8p18g7gWpH8-6jfkZtTOtJJKseNRSyKHgUK5eO9kgvy9sRXmmflV6pl4AMOEwMf4gZpbKtnLh4NETdGg5oSXEuTiF2MjmXE"
-        }]'
     production:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
       dynatraceLayerArn: arn:aws:lambda:eu-west-2:216552277552:layer:Dynatrace_OneAgent_1_311_51_20250331-143707_with_collector_java:1
@@ -357,14 +325,6 @@ Mappings:
         "x": "qBwa5L5ZA33RortEjaQ8_lwrVd-EE2eVsgOC84VwyVQ",
         "y": "ONF88GoP9xQJtq8RRV6zquggcd7xtggzZ20yW-PljHE",
         "alg": "ES256"
-        }]'
-      oldIdTokenRSAPublicKeys: '[{
-        "kty": "RSA",
-        "e": "AQAB",
-        "use": "sig",
-        "kid": "9523e2842d6da6d5ab8cf860c9972edc4dd9931e78191863a423c8e0a3672edc",
-        "alg": "RS256",
-        "n": "szPJQdwSk6hfrForvDfxi8NUp64nN2svpQIY1yqO80FH7N-YLe0U5lBRAtMMDd0J0PeL5lqn11fIMMRZv0qgx6V5vTOZPALNMHIVvFFqqJISUi56975jzdMn5og-I35bgmNuupLwtmQQWezFoZK7Y21iNK21Iz82wLbfQf7vJiHbtq7eGtOEAzzayH_0OgEk0TyeULErMZy3_GN12njmNiBDxDw5hC8r3euoGCBVlC68Jc8Id7QSn7QMsakXWfnyboVQQtdzvbSfHFNf4jW6lqsb-3lMZxDOSBkPmrJTnGbFauJDXArnTk7YAprDnnoc_S5pXvwNZWJPX7IFugwGbqsFRwTPqWL8iWBc0JXsx02T5p6wf1ZEuyjNVZn4FMT_EHjYnFVIkaFhR9Ad3NZikHkNMDCf_1l8JOXiZ-l0BWqwfAiz9eiFAwM4LgdQviZmFdJZ7-A82lQwNzeqj8L4g5EB_DECWMVVD8YHXy7gs8FLfnuj9QRCDaConl0RkZfgoFeK8ayhbVhfQlDRTrDb9yrpK8RRS3vvfcImoj26gqWphMXcbEagfriTYLg5AZLzT1svraGnqS5cu6_XbDjzP-62tMRA_9-QSoCZqwBqjxd04cZZIanHJXBzVDNfcDFBFPwQ4Rt_ZifC8G0SvxleXXlRxeceq4rj3gNUYQugK4s"
         }]'
 
 Globals:

--- a/template.yaml
+++ b/template.yaml
@@ -141,6 +141,8 @@ Conditions:
   ProvisionNewApiGateway: !Equals [dev, !Ref Environment]
   ProvisionNewApiClientRegistryApiKey:
     !And [!Condition ProvisionNewApiGateway, !Condition IsNotProduction]
+  UseStoredOldIdTokenPublicKeys:
+    !Or [!Equals [dev, !Ref Environment], !Equals [build, !Ref Environment]]
 
 Mappings:
   EnvironmentConfiguration:
@@ -3950,6 +3952,16 @@ Resources:
             - PublishNextExternalTokenSigningKeysV2
             - !Ref OrchExternalTokenEcSigningKmsKeyAliasV2
             - !Ref AWS::NoValue
+          STORED_OLD_ID_TOKEN_EC_PUBLIC_KEYS:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !Ref Environment,
+              oldIdTokenECPublicKeys,
+            ]
+          USE_STORED_OLD_ID_TOKEN_PUBLIC_KEYS: !If
+            - UseStoredOldIdTokenPublicKeys
+            - true
+            - false
           IDENTITY_ENABLED: true
           INTERNAl_SECTOR_URI: !Sub
             - https://identity.${ServiceDomain}


### PR DESCRIPTION
### Wider context of change

We want to be able to continue with the auth/orch split but the old EC keys needs to be supported for verification for longer (for reauth). It turns out RSA keys aren't supported for reauth currently - which will be addressed in another ticket.

### What’s changed

- Remove old RSA keys
- Add Gson adapter for EC keys to support JSON - ECKey conversion
- Validate tokens with the old stored EC public key

### Manual testing

Disabled using new V2 key in dev and completed a journey successfully (also double checked logs to be sure)

### Checklist

- [x] Lambdas have correct permissions for the resources they're accessing. **N/A**
- [x] Impact on orch and auth mutual dependencies has been checked. **N/A**
- [x] Changes have been made to contract tests or not required. **N/A**
- [x] Changes have been made to the simulator or not required. **N/A**
- [x] Changes have been made to stubs or not required. **N/A**
- [x] Successfully deployed to authdev or not required.
- [x] Successfully run Authentication acceptance tests against sandpit or not required. **N/A**