### PR TITLE
BAU: add missing AMC_JWKS_URL to .env.local

### DIFF
--- a/local-running/.env.local
+++ b/local-running/.env.local
@@ -31,6 +31,7 @@ TRACING_ENABLED=false
 # that if the JWKS verification fails, the orch stub key will be used (which is
 # defined above!)
 AUTH_JWKS_URL=http://localhost/placeholder
+AMC_JWKS_URL=http://localhost/placeholder
 
 # Key aliases
 TOKEN_SIGNING_KEY_ALIAS=alias/local-token-signing-key


### PR DESCRIPTION
## What

We need to add the AMC_JWKS_URL env var in order to be able to use local running

## How to review

1. Code review
2. Check local running works from the frontend

