### PR TITLE
BAU: Fix upper bound in six-digit code generation

### DIFF
--- a/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeGeneratorService.java
+++ b/shared/src/main/java/uk/gov/di/authentication/shared/services/CodeGeneratorService.java
@@ -11,7 +11,7 @@ public class CodeGeneratorService {
     private static final SecureRandom RANDOM = new SecureRandom();
 
     public String sixDigitCode() {
-        return format("%06d", RANDOM.nextInt(999999));
+        return format("%06d", RANDOM.nextInt(1_000_000));
     }
 
     public String twentyByteEncodedRandomCode() {


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

Corrects logic to include `999999` in code generation, ensuring the full range of 1,000,000 six-digit codes can be generated. The specified bound is exclusive - see [the docs](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/random/RandomGenerator.html#nextInt(int)) for more info.

At present `999998` is the "largest" OTP code that can be generated.

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to a dev environment using the most appropriate [GitHub dev deployment workflow](https://github.com/govuk-one-login/authentication-api/actions), or using the deployment scripts in this repo for the old account (e.g., `./deploy-authdevs.sh -c -b --all`).
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.dev.url/to/visit)
1. Sign in
1. Ensure `x` message appears in a modal
-->

1. Code Review
1. Check you are happy the bound is exclusive

## Checklist

- [x] Deployment of this PR will not break active user journeys **- No impact: Logic change affects new code generation only.**
- [x] Impact on orch and auth mutual dependencies has been checked. **- N/A**
- [x] No changes required or changes have been made to stub-orchestration. **- N/A**
- [ ] A UCD review has been performed. **- N/A: Technical logic fix .**