### PR TITLE
BAU: Fix lower bound and simplify TOTP validation

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessor.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/validation/AuthAppCodeProcessor.java
@@ -187,7 +187,7 @@ public class AuthAppCodeProcessor extends MfaCodeProcessor {
             throw new IllegalArgumentException("Secret cannot be null.");
         }
 
-        if (codeToCheck <= 0 || codeToCheck >= (int) Math.pow(10, 6)) {
+        if (codeToCheck < 0 || codeToCheck >= 1_000_000) {
             return false;
         }
 


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

- Corrects logic to include `000000` as a valid TOTP value.
- Simplifies upper bound check

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to a dev environment using the most appropriate [GitHub dev deployment workflow](https://github.com/govuk-one-login/authentication-api/actions), or using the deployment scripts in this repo for the old account (e.g., `./deploy-authdevs.sh -c -b --all`).
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.dev.url/to/visit)
1. Sign in
1. Ensure `x` message appears in a modal
-->

1. Code Review
1. Check you are happy with the new bounds

## Checklist

- [x] Deployment of this PR will not break active user journeys **- No impact: Logic change includes `000000` in addition to the already supported codes.**
- [x] Impact on orch and auth mutual dependencies has been checked. **- N/A**
- [x] No changes required or changes have been made to stub-orchestration. **- N/A**
- [ ] A UCD review has been performed. **- N/A: Technical logic fix .**