### PR TITLE
Bau: switch to record for send otp notification

### DIFF
--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/SendNotificationRequest.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/entity/SendNotificationRequest.java
@@ -5,62 +5,8 @@ import com.google.gson.annotations.SerializedName;
 import uk.gov.di.authentication.shared.entity.PriorityIdentifier;
 import uk.gov.di.authentication.shared.validation.Required;
 
-public class SendNotificationRequest {
-
-    @Expose
-    @SerializedName("notificationType")
-    @Required
-    private NotificationType notificationType;
-
-    @Expose
-    @SerializedName("phoneNumber")
-    private String phoneNumber;
-
-    @Expose
-    @SerializedName("priorityIdentifier")
-    PriorityIdentifier priorityIdentifier;
-
-    @Expose @Required private String email;
-
-    public SendNotificationRequest() {}
-
-    public SendNotificationRequest(
-            String email, NotificationType notificationType, String phoneNumber) {
-        this.email = email;
-        this.notificationType = notificationType;
-        this.phoneNumber = phoneNumber;
-    }
-
-    public String getEmail() {
-        return email;
-    }
-
-    public NotificationType getNotificationType() {
-        return notificationType;
-    }
-
-    public String getPhoneNumber() {
-        return phoneNumber;
-    }
-
-    public PriorityIdentifier getPriorityIdentifier() {
-        return priorityIdentifier;
-    }
-
-    @Override
-    public String toString() {
-        return "SendNotificationRequest{"
-                + "notificationType="
-                + notificationType
-                + ", phoneNumber='"
-                + phoneNumber
-                + '\''
-                + ", email='"
-                + email
-                + '\''
-                + ", priorityIdentifier='"
-                + priorityIdentifier
-                + '\''
-                + '}';
-    }
-}
+public record SendNotificationRequest(
+        @Expose @SerializedName("notificationType") @Required NotificationType notificationType,
+        @Expose @SerializedName("phoneNumber") String phoneNumber,
+        @Expose @SerializedName("priorityIdentifier") PriorityIdentifier priorityIdentifier,
+        @Expose @Required String email) {}

--- a/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
+++ b/account-management-api/src/main/java/uk/gov/di/accountmanagement/lambda/SendOtpNotificationHandler.java
@@ -171,7 +171,7 @@ public class SendOtpNotificationHandler
         try {
 
             boolean isTestUserRequest =
-                    testUserHelper.isTestJourney(sendNotificationRequest.getEmail());
+                    testUserHelper.isTestJourney(sendNotificationRequest.email());
 
             return Result.success(isTestUserRequest);
         } catch (Exception e) {
@@ -213,10 +213,10 @@ public class SendOtpNotificationHandler
         incrementUserSubmittedCredentialIfNotificationSetupJourney(
                 cloudwatchMetricsService,
                 JourneyType.ACCOUNT_MANAGEMENT,
-                sendNotificationRequest.getNotificationType().name(),
+                sendNotificationRequest.notificationType().name(),
                 configurationService.getEnvironment());
 
-        if (sendNotificationRequest.getNotificationType() == null) {
+        if (sendNotificationRequest.notificationType() == null) {
             return generateApiGatewayProxyErrorResponse(400, INVALID_NOTIFICATION_TYPE);
         }
 
@@ -224,7 +224,7 @@ public class SendOtpNotificationHandler
                 matchSupportedLanguage(
                         getUserLanguageFromRequestHeaders(headers, configurationService));
 
-        String email = sendNotificationRequest.getEmail();
+        String email = sendNotificationRequest.email();
 
         Optional<ErrorResponse> emailErrorResponse = ValidationHelper.validateEmailAddress(email);
 
@@ -232,7 +232,7 @@ public class SendOtpNotificationHandler
             return generateApiGatewayProxyErrorResponse(400, emailErrorResponse.get());
         }
 
-        switch (sendNotificationRequest.getNotificationType()) {
+        switch (sendNotificationRequest.notificationType()) {
             case VERIFY_EMAIL -> {
                 LOG.info("NotificationType is VERIFY_EMAIL");
 
@@ -262,7 +262,7 @@ public class SendOtpNotificationHandler
 
                 var response =
                         validatePhoneNumber(
-                                sendNotificationRequest.getPhoneNumber(),
+                                sendNotificationRequest.phoneNumber(),
                                 configurationService.getEnvironment(),
                                 false,
                                 configurationService.isAccountManagementInternationalSmsEnabled());
@@ -274,8 +274,7 @@ public class SendOtpNotificationHandler
                 String newPhoneNumber;
 
                 newPhoneNumber =
-                        PhoneNumberHelper.formatPhoneNumber(
-                                sendNotificationRequest.getPhoneNumber());
+                        PhoneNumberHelper.formatPhoneNumber(sendNotificationRequest.phoneNumber());
 
                 var inUseResult =
                         mfaMethodsService.isPhoneAlreadyInUseAsAVerifiedMfa(email, newPhoneNumber);
@@ -291,7 +290,7 @@ public class SendOtpNotificationHandler
 
                 return handleNotificationRequest(
                         isTestUserRequest,
-                        sendNotificationRequest.getPhoneNumber(),
+                        sendNotificationRequest.phoneNumber(),
                         sendNotificationRequest,
                         input,
                         context,
@@ -351,7 +350,7 @@ public class SendOtpNotificationHandler
             SupportedLanguage language)
             throws JsonException {
 
-        var notificationType = sendNotificationRequest.getNotificationType();
+        var notificationType = sendNotificationRequest.notificationType();
         String code =
                 isTestUserRequest
                         ? getOtpCodeForTestClient(notificationType)
@@ -364,17 +363,17 @@ public class SendOtpNotificationHandler
                         code,
                         language,
                         isTestUserRequest,
-                        sendNotificationRequest.getEmail());
+                        sendNotificationRequest.email());
 
         codeStorageService.saveOtpCode(
-                sendNotificationRequest.getEmail(),
+                sendNotificationRequest.email(),
                 code,
                 configurationService.getDefaultOtpCodeExpiry(),
-                sendNotificationRequest.getNotificationType());
+                sendNotificationRequest.notificationType());
 
         LOG.info(
                 "Sending message to SQS queue for notificationType: {}.  Is test user journey: {}",
-                sendNotificationRequest.getNotificationType(),
+                sendNotificationRequest.notificationType(),
                 isTestUserRequest);
 
         try {
@@ -396,9 +395,9 @@ public class SendOtpNotificationHandler
                                 .getAuthorizer()
                                 .getOrDefault("principalId", AuditService.UNKNOWN)
                                 .toString(),
-                        sendNotificationRequest.getEmail(),
+                        sendNotificationRequest.email(),
                         IpAddressHelper.extractIpAddress(input),
-                        sendNotificationRequest.getPhoneNumber(),
+                        sendNotificationRequest.phoneNumber(),
                         extractPersistentIdFromHeaders(input.getHeaders()),
                         AuditHelper.getTxmaAuditEncoded(input.getHeaders()),
                         new ArrayList<>());
@@ -407,15 +406,15 @@ public class SendOtpNotificationHandler
                 AccountManagementAuditableEvent.AUTH_SEND_OTP,
                 auditContext,
                 AUDIT_EVENT_COMPONENT_ID_AUTH,
-                pair("notification-type", sendNotificationRequest.getNotificationType()),
+                pair("notification-type", sendNotificationRequest.notificationType()),
                 pair("test-user", isTestUserRequest));
 
         if (notificationType == NotificationType.VERIFY_PHONE_NUMBER) {
             PriorityIdentifier priorityIdentifier;
-            if (Objects.isNull(sendNotificationRequest.getPriorityIdentifier())) {
+            if (Objects.isNull(sendNotificationRequest.priorityIdentifier())) {
                 priorityIdentifier = PriorityIdentifier.DEFAULT;
             } else {
-                priorityIdentifier = sendNotificationRequest.getPriorityIdentifier();
+                priorityIdentifier = sendNotificationRequest.priorityIdentifier();
             }
             auditService.submitAuditEvent(
                     AccountManagementAuditableEvent.AUTH_PHONE_CODE_SENT,

--- a/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/SendOtpNotificationIntegrationTest.java
+++ b/account-management-integration-tests/src/test/java/uk/gov/di/accountmanagement/api/SendOtpNotificationIntegrationTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import uk.gov.di.accountmanagement.entity.NotifyRequest;
-import uk.gov.di.accountmanagement.entity.SendNotificationRequest;
 import uk.gov.di.accountmanagement.lambda.SendOtpNotificationHandler;
 import uk.gov.di.accountmanagement.testsupport.helpers.NotificationAssertionHelper;
 import uk.gov.di.authentication.shared.entity.EmailCheckResultStatus;
@@ -75,6 +74,16 @@ class SendOtpNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTes
     @Nested
     class EmailVerification {
 
+        public static String verifyEmailRequestBody(String email) {
+            return """
+                    {
+                    "email": "%s",
+                    "notificationType": "VERIFY_EMAIL"
+                    }
+                    """
+                    .formatted(email);
+        }
+
         @Nested
         class UserReceivesVerificationEmail {
             @Test
@@ -93,9 +102,7 @@ class SendOtpNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTes
 
                 var response =
                         makeRequest(
-                                Optional.of(
-                                        new SendNotificationRequest(
-                                                TEST_NEW_EMAIL, VERIFY_EMAIL, TEST_PHONE_NUMBER)),
+                                Optional.of(verifyEmailRequestBody(TEST_NEW_EMAIL)),
                                 headers,
                                 Collections.emptyMap(),
                                 Collections.emptyMap(),
@@ -130,9 +137,7 @@ class SendOtpNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTes
 
                 var response =
                         makeRequest(
-                                Optional.of(
-                                        new SendNotificationRequest(
-                                                TEST_EMAIL, VERIFY_EMAIL, TEST_PHONE_NUMBER)),
+                                Optional.of(verifyEmailRequestBody(TEST_EMAIL)),
                                 headers,
                                 Collections.emptyMap(),
                                 Collections.emptyMap(),
@@ -154,6 +159,17 @@ class SendOtpNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTes
     @Nested
     class PhoneNumberVerification {
 
+        public static String requestWithPhoneNumberAndEmail(String phoneNumber, String email) {
+            return """
+                        {
+                            "email": "%s",
+                            "notificationType": "VERIFY_PHONE_NUMBER",
+                            "phoneNumber": "%s"
+                        }
+                        """
+                    .formatted(email, phoneNumber);
+        }
+
         @Nested
         class UserReceivesVerificationSms {
             @Test
@@ -167,10 +183,8 @@ class SendOtpNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTes
                 var response =
                         makeRequest(
                                 Optional.of(
-                                        new SendNotificationRequest(
-                                                TEST_EMAIL,
-                                                VERIFY_PHONE_NUMBER,
-                                                TEST_PHONE_NUMBER)),
+                                        requestWithPhoneNumberAndEmail(
+                                                TEST_PHONE_NUMBER, TEST_EMAIL)),
                                 headers,
                                 Collections.emptyMap(),
                                 Collections.emptyMap(),
@@ -217,10 +231,8 @@ class SendOtpNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTes
                 var response =
                         makeRequest(
                                 Optional.of(
-                                        new SendNotificationRequest(
-                                                nonExistentUserEmail,
-                                                VERIFY_PHONE_NUMBER,
-                                                TEST_PHONE_NUMBER)),
+                                        requestWithPhoneNumberAndEmail(
+                                                TEST_PHONE_NUMBER, nonExistentUserEmail)),
                                 headers,
                                 Collections.emptyMap(),
                                 Collections.emptyMap(),
@@ -243,8 +255,7 @@ class SendOtpNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTes
                 var response =
                         makeRequest(
                                 Optional.of(
-                                        new SendNotificationRequest(
-                                                TEST_EMAIL, VERIFY_PHONE_NUMBER, badPhoneNumber)),
+                                        requestWithPhoneNumberAndEmail(badPhoneNumber, TEST_EMAIL)),
                                 headers,
                                 Collections.emptyMap(),
                                 Collections.emptyMap(),
@@ -265,7 +276,8 @@ class SendOtpNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTes
             void shouldReturn400WhenNewPhoneNumberIsTheSameAsCurrentPhoneNumber()
                     throws Json.JsonException {
                 userStore.signUp(TEST_EMAIL, "password");
-                userStore.addVerifiedPhoneNumber(TEST_EMAIL, "+447755551084");
+                var phoneNumber = "+447755551084";
+                userStore.addVerifiedPhoneNumber(TEST_EMAIL, phoneNumber);
 
                 Map<String, String> headers = new HashMap<>();
                 headers.put(TXMA_AUDIT_ENCODED_HEADER, "ENCODED_DEVICE_DETAILS");
@@ -273,8 +285,7 @@ class SendOtpNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTes
                 var response =
                         makeRequest(
                                 Optional.of(
-                                        new SendNotificationRequest(
-                                                TEST_EMAIL, VERIFY_PHONE_NUMBER, "+447755551084")),
+                                        requestWithPhoneNumberAndEmail(phoneNumber, TEST_EMAIL)),
                                 headers,
                                 Collections.emptyMap(),
                                 Collections.emptyMap(),
@@ -302,10 +313,8 @@ class SendOtpNotificationIntegrationTest extends ApiGatewayHandlerIntegrationTes
                 var response =
                         makeRequest(
                                 Optional.of(
-                                        new SendNotificationRequest(
-                                                TEST_EMAIL,
-                                                VERIFY_PHONE_NUMBER,
-                                                INTERNATIONAL_MOBILE_NUMBER)),
+                                        requestWithPhoneNumberAndEmail(
+                                                INTERNATIONAL_MOBILE_NUMBER, TEST_EMAIL)),
                                 Collections.emptyMap(),
                                 Collections.emptyMap(),
                                 Collections.emptyMap(),


### PR DESCRIPTION
Switch to using a record to represent the request made to the account management api's send otp notification endpoint, to get rid of some boilerplate.

## How to review

1. Code Review
