### PR TITLE
AUT-5307: Increase the bulk email send rate

### DIFF
--- a/ci/terraform/utils/production.tfvars
+++ b/ci/terraform/utils/production.tfvars
@@ -16,7 +16,7 @@ bulk_user_email_audience_load_pause_duration      = 300000
 bulk_user_email_send_schedule_enabled    = true
 bulk_user_email_send_schedule_expression = "cron(* 8-14 ? 3-4 2-6 2026)"
 bulk_user_email_email_sending_enabled    = true
-bulk_user_email_batch_size               = 48
+bulk_user_email_batch_size               = 96
 bulk_user_email_send_mode                = "PENDING"
 bulk_user_email_sender_type              = "INTERNATIONAL_NUMBERS_FORCED_MFA_RESET"
 


### PR DESCRIPTION
## What

<!-- Describe what you have changed and why -->

Increase the bulk email send rate by increasing the batch size.

Approved by product.

## How to review

<!-- Describe the steps required to review this PR.
For example:

1. Code Review
1. Deploy to a dev environment using the most appropriate [GitHub dev deployment workflow](https://github.com/govuk-one-login/authentication-api/actions), or using the deployment scripts in this repo for the old account (e.g., `./deploy-authdevs.sh -c -b --all`).
1. Ensure that resources `x`, `y` and `z` were not changed
1. Visit [some url](https://some.dev.url/to/visit)
1. Sign in
1. Ensure `x` message appears in a modal
-->

1. Code Review

## Checklist

<!-- Active user journey impact

It’s crucial that deploying this change to production doesn’t disrupt users with active sessions.

Existing sessions may contain data that this PR treats as invalid, potentially triggering errors. For example, if you remove support for an enum value that’s already stored in the database, casting the deprecated string back to an enum must handle any errors gracefully.

When deprecating session data, split the work into two PRs:

1. Remove all uses of the deprecated value.
2. After any sessions containing that data have expired, remove the value’s definition.
-->

- [x] Deployment of this PR will not break active user journeys

<!-- 🚨⚠️ Orchestration and Authentication mutual dependencies ⚠️ 🚨

Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.

In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [x] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to stub-orchestration?

If the contract between Orch and Auth has changed then this may need to be reflected in updates to [stub-orchestration](https://github.com/govuk-one-login/authentication-stubs/tree/main/orchestration-stub)

-->

- [x] No changes required or changes have been made to stub-orchestration.
