### PR TITLE
ATO-2258: Add hosted zone template for orchestration

### DIFF
--- a/ci/stack-orchestration/manual-stacks/domains/template.yaml
+++ b/ci/stack-orchestration/manual-stacks/domains/template.yaml
@@ -1,0 +1,302 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform:
+  - AWS::Serverless-2016-10-31
+
+Parameters:
+  Environment:
+    Type: String
+    Description: The name of the environment to deploy to
+    AllowedValues:
+      - dev
+      - build
+      - staging
+      - integration
+      - production
+  EndpointSuffix:
+    Description: >
+      (Optional) domain suffix i.e. -orch. Example output FQDN - oidc-orch.build.account.gov.uk
+    Type: String
+    Default: ""
+    AllowedPattern: "[a-z0-9-]*"
+    ConstraintDescription: >
+      must be a valid domain name, consists of lowercase letters, numbers and hyphens OR blank
+  DeployHostedZone:
+    Description: >
+      Deploy the Route53 hosted zone
+    Type: String
+    Default: "Yes"
+    AllowedValues:
+      - "Yes"
+      - "No"
+  DeployCertificate:
+    Description: >
+      Deploy domain certificate
+    Type: String
+    Default: "No"
+    AllowedValues:
+      - "Yes"
+      - "No"
+  DeploySubEnvDomains:
+    Description: >
+      (Optional) Deploy the sub-environment subdomains
+    Type: String
+    Default: "No"
+    AllowedValues:
+      - "Yes"
+      - "No"
+
+Conditions:
+  DeployDevSubDomains:
+    !And [
+      !Equals [!Ref Environment, dev],
+      !Equals [!Ref DeploySubEnvDomains, "Yes"],
+    ]
+  DeployCertificate: !And [!Equals [!Ref DeployCertificate, "Yes"]]
+
+Mappings:
+  EnvironmentConfiguration:
+    dev:
+      domainSuffix: dev.account.gov.uk
+    build:
+      domainSuffix: build.account.gov.uk
+    staging:
+      domainSuffix: staging.account.gov.uk
+    integration:
+      domainSuffix: integration.account.gov.uk
+    production:
+      domainSuffix: account.gov.uk
+
+Resources:
+  OidcHostedZone:
+    Type: AWS::Route53::HostedZone
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      Name: !Sub
+        - oidc${EndpointSuffix}.${DomainSuffix}
+        - DomainSuffix:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !Ref Environment,
+              domainSuffix,
+            ]
+
+  # Manually Create the NS records sets here as we want to adjust the
+  # TTL to 60 seconds from the default created by the public hosted zone
+  # See here: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/hosted-zones-migrating.html#:~:text=The%20typical%20TTL,something%20goes%20wrong.
+  OidcNSRecordSet:
+    Type: AWS::Route53::RecordSet
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      Name: !Sub
+        - oidc${EndpointSuffix}.${DomainSuffix}
+        - DomainSuffix:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !Ref Environment,
+              domainSuffix,
+            ]
+      Type: NS
+      HostedZoneId: !Ref OidcHostedZone
+      ResourceRecords: !GetAtt
+        - OidcHostedZone
+        - NameServers
+      TTL: "60"
+
+  OidcHostedZoneRootCertificate:
+    Condition: DeployCertificate
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Type: AWS::CertificateManager::Certificate
+    Properties:
+      DomainName: !Sub
+        - oidc${EndpointSuffix}.${DomainSuffix}
+        - DomainSuffix:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !Ref Environment,
+              domainSuffix,
+            ]
+      ValidationMethod: "DNS"
+      DomainValidationOptions:
+        - DomainName: !Sub
+            - oidc${EndpointSuffix}.${DomainSuffix}
+            - DomainSuffix:
+                !FindInMap [
+                  EnvironmentConfiguration,
+                  !Ref Environment,
+                  domainSuffix,
+                ]
+          HostedZoneId: !Ref OidcHostedZone
+      SubjectAlternativeNames: !If
+        - DeployDevSubDomains
+        - - !Sub
+            - orchdev1.oidc.${DomainSuffix}
+            - DomainSuffix:
+                !FindInMap [
+                  EnvironmentConfiguration,
+                  !Ref Environment,
+                  domainSuffix,
+                ]
+          - !Sub
+            - orchdev2.oidc.${DomainSuffix}
+            - DomainSuffix:
+                !FindInMap [
+                  EnvironmentConfiguration,
+                  !Ref Environment,
+                  domainSuffix,
+                ]
+          - !Sub
+            - orchdev3.oidc.${DomainSuffix}
+            - DomainSuffix:
+                !FindInMap [
+                  EnvironmentConfiguration,
+                  !Ref Environment,
+                  domainSuffix,
+                ]
+        - !Ref AWS::NoValue
+
+  Orchdev1HostedZone:
+    Condition: DeployDevSubDomains
+    Type: AWS::Route53::HostedZone
+    Properties:
+      Name: !Sub
+        - orchdev1.oidc.${DomainSuffix}
+        - DomainSuffix:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !Ref Environment,
+              domainSuffix,
+            ]
+
+  Orchdev1DelegationRecord:
+    Condition: DeployDevSubDomains
+    Type: AWS::Route53::RecordSet
+    Properties:
+      HostedZoneId: !Ref OidcHostedZone
+      Name: !Ref Orchdev1HostedZone
+      Type: NS
+      TTL: "3600"
+      ResourceRecords: !GetAtt
+        - Orchdev1HostedZone
+        - NameServers
+
+  Orchdev2HostedZone:
+    Condition: DeployDevSubDomains
+    Type: AWS::Route53::HostedZone
+    Properties:
+      Name: !Sub
+        - orchdev2.oidc.${DomainSuffix}
+        - DomainSuffix:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !Ref Environment,
+              domainSuffix,
+            ]
+
+  Orchdev2DelegationRecord:
+    Condition: DeployDevSubDomains
+    Type: AWS::Route53::RecordSet
+    Properties:
+      HostedZoneId: !Ref OidcHostedZone
+      Name: !Ref Orchdev2HostedZone
+      Type: NS
+      TTL: "3600"
+      ResourceRecords: !GetAtt
+        - Orchdev2HostedZone
+        - NameServers
+
+  Orchdev3HostedZone:
+    Condition: DeployDevSubDomains
+    Type: AWS::Route53::HostedZone
+    Properties:
+      Name: !Sub
+        - orchdev3.oidc.${DomainSuffix}
+        - DomainSuffix:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !Ref Environment,
+              domainSuffix,
+            ]
+
+  Orchdev3DelegationRecord:
+    Condition: DeployDevSubDomains
+    Type: AWS::Route53::RecordSet
+    Properties:
+      HostedZoneId: !Ref OidcHostedZone
+      Name: !Ref Orchdev3HostedZone
+      Type: NS
+      TTL: "3600"
+      ResourceRecords: !GetAtt
+        - Orchdev3HostedZone
+        - NameServers
+
+Outputs:
+  OidcHostedZoneId:
+    Description: "ID of the Hosted Zone for oidc domain"
+    Value: !Ref OidcHostedZone
+    Export:
+      Name: !Sub "${AWS::StackName}-OidcHostedZoneId"
+
+  OidcHostedZoneNameServers:
+    Description: "Name servers for the OIDC domain"
+    Value: !GetAtt
+      - OidcHostedZone
+      - NameServers
+    Export:
+      Name: !Sub "${AWS::StackName}-OidcHostedZoneNameServers"
+
+  CertificateArn:
+    Description: "The ARN of the ACM certificate"
+    Value: !Ref OidcHostedZoneRootCertificate
+    Export:
+      Name: !Sub "${AWS::StackName}-certificateArn"
+
+  OrchDev1HostedZoneId:
+    Condition: DeployDevSubDomains
+    Description: "ID of the Hosted Zone for orchdev1 domain"
+    Value: !Ref Orchdev1HostedZone
+    Export:
+      Name: !Sub "${AWS::StackName}-orchdev1-HostedZoneId"
+
+  OrchDev2HostedZoneId:
+    Condition: DeployDevSubDomains
+    Description: "ID of the Hosted Zone for orchdev2 domain"
+    Value: !Ref Orchdev2HostedZone
+    Export:
+      Name: !Sub "${AWS::StackName}-orchdev2-HostedZoneId"
+
+  OrchDev3HostedZoneId:
+    Condition: DeployDevSubDomains
+    Description: "ID of the Hosted Zone for orchdev3 domain"
+    Value: !Ref Orchdev3HostedZone
+    Export:
+      Name: !Sub "${AWS::StackName}-orchdev3-HostedZoneId"
+
+  OrchDev1HostedZoneNameServers:
+    Condition: DeployDevSubDomains
+    Description: "Name servers for the orchdev1 domain"
+    Value: !GetAtt
+      - Orchdev1HostedZone
+      - NameServers
+    Export:
+      Name: !Sub "${AWS::StackName}-orchdev1-HostedZoneNameServers"
+
+  OrchDev2HostedZoneNameServers:
+    Condition: DeployDevSubDomains
+    Description: "Name servers for the orchdev2 domain"
+    Value: !GetAtt
+      - Orchdev2HostedZone
+      - NameServers
+    Export:
+      Name: !Sub "${AWS::StackName}-orchdev2-HostedZoneNameServers"
+
+  OrchDev3HostedZoneNameServers:
+    Condition: DeployDevSubDomains
+    Description: "Name servers for the orchdev3 domain"
+    Value: !GetAtt
+      - Orchdev3HostedZone
+      - NameServers
+    Export:
+      Name: !Sub "${AWS::StackName}-orchdev3-HostedZoneNameServers"


### PR DESCRIPTION
### Wider context of change
We're planning on migrating the management of the oidc domain to our own AWS account, so this requires us to create a hosted zone for the domain. We're doing this in Cloudformation and this PR creates a template for that.

### What’s changed:
- Adds a hosted zone template containing a few feature:
  - Ability to conditionally deploy an ACM cert
  - Ability to conditionally deploy dev subdomains
  - Ability to add an suffix to differentiate the domain (e.g `oidc-orch.account.gov.uk`)

### Manual testing:

This one isn't deployed anywhere yet so not really much to test yet, but the commit message explains a bit of why I've set out things the way I have in the template 

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [ ] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [ ] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [ ] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [ ] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [ ] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [ ] Successfully run Authentication acceptance tests against sandpit or not required.

### Related PRs

<!-- Links to PRs in other repositories that are relevant to this PR.

This could be:
  - PRs that depend on this one
  - PRs this one depends on
  - If this work is being duplicated in other repos, other PRs
  - PRs which just provide context to this one.

Delete this section if not needed! -->
