### PR TITLE
AUT-5340: Generate ADAPI access tokens in generic way

### DIFF
--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/IPVReverificationFailureReason.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/IPVReverificationFailureReason.java
@@ -1,0 +1,15 @@
+package uk.gov.di.authentication.frontendapi;
+
+public enum IPVReverificationFailureReason {
+    JWT_CREATION_ERROR("jwt_creation_error");
+
+    private final String value;
+
+    IPVReverificationFailureReason(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/JwtFailureReason.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/JwtFailureReason.java
@@ -1,0 +1,22 @@
+package uk.gov.di.authentication.frontendapi.entity;
+
+public enum JwtFailureReason {
+    JWT_ENCODING_ERROR("jwt_encoding_error"),
+    UNKNOWN_JWT_SIGNING_ERROR("unknown_jwt_signing_error"),
+    TRANSCODING_ERROR("transcoding_error"),
+    SIGNING_ERROR("signing_error"),
+    KEY_RETRIEVAL_ERROR("key_retrieval_error"),
+    ENCRYPTION_ERROR("encryption_error"),
+    UNKNOWN_JWT_ENCRYPTING_ERROR("unknown_jwt_encrypting_error"),
+    JWKS_RETRIEVAL_ERROR("jwks_retrieval_error");
+
+    private final String value;
+
+    JwtFailureReason(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/amc/AMCAuthorizeFailureReason.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/amc/AMCAuthorizeFailureReason.java
@@ -1,6 +1,6 @@
 package uk.gov.di.authentication.frontendapi.entity.amc;
 
-public enum JwtFailureReason {
+public enum AMCAuthorizeFailureReason {
     JWT_ENCODING_ERROR("jwt_encoding_error"),
     UNKNOWN_JWT_SIGNING_ERROR("unknown_jwt_signing_error"),
     TRANSCODING_ERROR("transcoding_error"),
@@ -11,7 +11,7 @@ public enum JwtFailureReason {
 
     private final String value;
 
-    JwtFailureReason(String value) {
+    AMCAuthorizeFailureReason(String value) {
         this.value = value;
     }
 

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/amc/AccessTokenConfig.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/amc/AccessTokenConfig.java
@@ -1,4 +1,4 @@
 package uk.gov.di.authentication.frontendapi.entity.amc;
 
 public record AccessTokenConfig(
-        String accessTokenName, AMCDownstreamScope scope, String audience, String signingKey) {}
+        String accessTokenName, ExternalApiScope scope, String audience, String signingKey) {}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/amc/AccountDataScope.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/amc/AccountDataScope.java
@@ -1,6 +1,6 @@
 package uk.gov.di.authentication.frontendapi.entity.amc;
 
-public enum AccountDataScope implements AMCDownstreamScope {
+public enum AccountDataScope implements ExternalApiScope {
     PASSKEY_CREATE("passkey-create");
 
     private final String value;

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/amc/AccountManagementScope.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/amc/AccountManagementScope.java
@@ -1,6 +1,6 @@
 package uk.gov.di.authentication.frontendapi.entity.amc;
 
-public enum AccountManagementScope implements AMCDownstreamScope {
+public enum AccountManagementScope implements ExternalApiScope {
     ACCOUNT_DELETE("account-delete");
 
     private final String value;

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/amc/ExternalApiScope.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/entity/amc/ExternalApiScope.java
@@ -1,6 +1,6 @@
 package uk.gov.di.authentication.frontendapi.entity.amc;
 
-public interface AMCDownstreamScope {
+public interface ExternalApiScope {
 
     String getValue();
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/errormapper/AMCFailureHttpMapper.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/errormapper/AMCFailureHttpMapper.java
@@ -1,8 +1,8 @@
 package uk.gov.di.authentication.frontendapi.errormapper;
 
 import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import uk.gov.di.authentication.frontendapi.entity.amc.AMCAuthorizeFailureReason;
 import uk.gov.di.authentication.frontendapi.entity.amc.JourneyOutcomeError;
-import uk.gov.di.authentication.frontendapi.entity.amc.JwtFailureReason;
 import uk.gov.di.authentication.frontendapi.entity.amc.TokenResponseError;
 import uk.gov.di.authentication.shared.entity.ErrorResponse;
 
@@ -12,7 +12,7 @@ public class AMCFailureHttpMapper {
 
     private AMCFailureHttpMapper() {}
 
-    public static ErrorResponseWithStatus toHttpResponse(JwtFailureReason failureReason) {
+    public static ErrorResponseWithStatus toHttpResponse(AMCAuthorizeFailureReason failureReason) {
         return switch (failureReason) {
             case JWT_ENCODING_ERROR -> new ErrorResponseWithStatus(
                     400, ErrorResponse.AMC_JWT_ENCODING_ERROR);
@@ -56,7 +56,7 @@ public class AMCFailureHttpMapper {
     }
 
     public static APIGatewayProxyResponseEvent toApiGatewayProxyErrorResponse(
-            JwtFailureReason failureReason) {
+            AMCAuthorizeFailureReason failureReason) {
         var httpResponse = toHttpResponse(failureReason);
         return generateApiGatewayProxyErrorResponse(
                 httpResponse.statusCode(), httpResponse.errorResponse());

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AMCAuthorizeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/AMCAuthorizeHandler.java
@@ -16,10 +16,10 @@ import com.nimbusds.oauth2.sdk.id.State;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import uk.gov.di.authentication.frontendapi.entity.amc.AMCAuthorizationUrlAndCookie;
+import uk.gov.di.authentication.frontendapi.entity.amc.AMCAuthorizeFailureReason;
 import uk.gov.di.authentication.frontendapi.entity.amc.AMCAuthorizeRequest;
 import uk.gov.di.authentication.frontendapi.entity.amc.AMCAuthorizeResponse;
 import uk.gov.di.authentication.frontendapi.entity.amc.AccessTokenConfig;
-import uk.gov.di.authentication.frontendapi.entity.amc.JwtFailureReason;
 import uk.gov.di.authentication.frontendapi.entity.amc.TransportJWTConfig;
 import uk.gov.di.authentication.frontendapi.errormapper.AMCFailureHttpMapper;
 import uk.gov.di.authentication.frontendapi.services.AMCService;
@@ -126,7 +126,7 @@ public class AMCAuthorizeHandler extends BaseFrontendHandler<AMCAuthorizeRequest
         var state = new State();
         dynamoAmcStateService.store(state.getValue(), userContext.getClientSessionId());
 
-        Result<JwtFailureReason, AMCAuthorizationUrlAndCookie> result =
+        Result<AMCAuthorizeFailureReason, AMCAuthorizationUrlAndCookie> result =
                 getAMCPublicEncryptionKey()
                         .flatMap(
                                 publicEncryptionKey ->
@@ -153,7 +153,7 @@ public class AMCAuthorizeHandler extends BaseFrontendHandler<AMCAuthorizeRequest
                 });
     }
 
-    private Result<JwtFailureReason, RSAPublicKey> getAMCPublicEncryptionKey() {
+    private Result<AMCAuthorizeFailureReason, RSAPublicKey> getAMCPublicEncryptionKey() {
         LOG.info("Retrieving RSA encryption JWK from AMC JWKS endpoint for auth -> AMC encryption");
         try {
             return Result.success(
@@ -172,10 +172,10 @@ public class AMCAuthorizeHandler extends BaseFrontendHandler<AMCAuthorizeRequest
                             .toRSAPublicKey());
         } catch (KeySourceException e) {
             LOG.error("Could not retrieve JWKS", e);
-            return Result.failure(JwtFailureReason.JWKS_RETRIEVAL_ERROR);
+            return Result.failure(AMCAuthorizeFailureReason.JWKS_RETRIEVAL_ERROR);
         } catch (JOSEException e) {
             LOG.error("Could not parse JWK", e);
-            return Result.failure(JwtFailureReason.JWKS_RETRIEVAL_ERROR);
+            return Result.failure(AMCAuthorizeFailureReason.JWKS_RETRIEVAL_ERROR);
         }
     }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetAuthorizeHandler.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetAuthorizeHandler.java
@@ -128,6 +128,11 @@ public class MfaResetAuthorizeHandler extends BaseFrontendHandler<MfaResetReques
             var ipvReverificationRequestURI =
                     ipvReverificationService.buildIpvReverificationRedirectUri(
                             internalCommonSubjectId, clientSessionId, authenticationState);
+            if (ipvReverificationRequestURI.isFailure()) {
+                LOG.error("Error building the IPV reverification request.");
+                return generateApiGatewayProxyResponse(
+                        500, MFA_RESET_JAR_GENERATION_ERROR.getMessage());
+            }
 
             idReverificationStateService.store(
                     authenticationState.getValue(),
@@ -158,7 +163,7 @@ public class MfaResetAuthorizeHandler extends BaseFrontendHandler<MfaResetReques
             cloudwatchMetricsService.incrementMfaResetHandoffCount();
 
             return generateApiGatewayProxyResponse(
-                    200, new MfaResetResponse(ipvReverificationRequestURI));
+                    200, new MfaResetResponse(ipvReverificationRequestURI.getSuccess()));
         } catch (Json.JsonException | RuntimeException e) {
             LOG.error("Error building the IPV reverification request.", e);
             return generateApiGatewayProxyResponse(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/AMCService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/AMCService.java
@@ -8,7 +8,6 @@ import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import com.nimbusds.oauth2.sdk.AuthorizationCodeGrant;
 import com.nimbusds.oauth2.sdk.AuthorizationRequest;
 import com.nimbusds.oauth2.sdk.ResponseType;
-import com.nimbusds.oauth2.sdk.Scope;
 import com.nimbusds.oauth2.sdk.TokenRequest;
 import com.nimbusds.oauth2.sdk.auth.JWTAuthenticationClaimsSet;
 import com.nimbusds.oauth2.sdk.auth.PrivateKeyJWT;
@@ -21,13 +20,12 @@ import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.openid.connect.sdk.UserInfoRequest;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import software.amazon.awssdk.core.exception.SdkException;
+import uk.gov.di.authentication.frontendapi.entity.JwtFailureReason;
 import uk.gov.di.authentication.frontendapi.entity.amc.AMCAuthorizationUrlAndCookie;
-import uk.gov.di.authentication.frontendapi.entity.amc.AMCDownstreamScope;
+import uk.gov.di.authentication.frontendapi.entity.amc.AMCAuthorizeFailureReason;
 import uk.gov.di.authentication.frontendapi.entity.amc.AMCScope;
 import uk.gov.di.authentication.frontendapi.entity.amc.AccessTokenConfig;
 import uk.gov.di.authentication.frontendapi.entity.amc.JourneyOutcomeError;
-import uk.gov.di.authentication.frontendapi.entity.amc.JwtFailureReason;
 import uk.gov.di.authentication.frontendapi.exceptions.JwtServiceException;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.Result;
@@ -50,6 +48,7 @@ import static java.util.Collections.singletonList;
 
 public class AMCService {
     private final ConfigurationService configurationService;
+    private final ExternalApiAccessTokenService externalApiAccessTokenService;
     private final NowHelper.NowClock nowClock;
     private final JwtService jwtService;
     private static final Logger LOG = LogManager.getLogger(AMCService.class);
@@ -62,9 +61,11 @@ public class AMCService {
         this.configurationService = configurationService;
         this.nowClock = nowClock;
         this.jwtService = jwtService;
+        this.externalApiAccessTokenService =
+                new ExternalApiAccessTokenService(jwtService, configurationService);
     }
 
-    public Result<JwtFailureReason, AMCAuthorizationUrlAndCookie> buildAuthorizationResult(
+    public Result<AMCAuthorizeFailureReason, AMCAuthorizationUrlAndCookie> buildAuthorizationResult(
             String internalPairwiseSubject,
             AMCScope amcScope,
             AuthSessionItem authSessionItem,
@@ -101,19 +102,21 @@ public class AMCService {
                         });
     }
 
-    public Result<JwtFailureReason, TokenRequest> buildTokenRequest(
+    public Result<AMCAuthorizeFailureReason, TokenRequest> buildTokenRequest(
             String authCode, String usedRedirectUrl) {
         var clientAssertionJwt = buildClientAssertionJwt();
         var keyId = configurationService.getAuthToAMCTransportJWTSigningKey();
-        var signedJWTResult = signJWT(clientAssertionJwt.toJWTClaimsSet(), keyId);
-        return signedJWTResult.map(
-                signedJWT ->
-                        new TokenRequest(
-                                configurationService.getAMCTokenEndpointURI(),
-                                new PrivateKeyJWT(signedJWT),
-                                new AuthorizationCodeGrant(
-                                        new AuthorizationCode(authCode),
-                                        URI.create(usedRedirectUrl))));
+        var signedJWTResult = jwtService.signJWT(clientAssertionJwt.toJWTClaimsSet(), keyId);
+        return signedJWTResult
+                .mapFailure(this::mapSignJwtFailureReason)
+                .map(
+                        signedJWT ->
+                                new TokenRequest(
+                                        configurationService.getAMCTokenEndpointURI(),
+                                        new PrivateKeyJWT(signedJWT),
+                                        new AuthorizationCodeGrant(
+                                                new AuthorizationCode(authCode),
+                                                URI.create(usedRedirectUrl))));
     }
 
     public Result<JourneyOutcomeError, HTTPResponse> requestJourneyOutcome(
@@ -131,48 +134,33 @@ public class AMCService {
         }
     }
 
-    private Result<JwtFailureReason, SignedJWT> signJWT(JWTClaimsSet jwtClaims, String keyId) {
-        try {
-            return Result.success(jwtService.signJWT(jwtClaims, keyId));
-        } catch (JwtServiceException e) {
-            Throwable cause = e.getCause();
-            if (cause instanceof SdkException) {
-                return Result.failure(JwtFailureReason.SIGNING_ERROR);
-            } else if (cause instanceof ParseException) {
-                return Result.failure(JwtFailureReason.JWT_ENCODING_ERROR);
-            } else if (cause instanceof JOSEException) {
-                return Result.failure(JwtFailureReason.TRANSCODING_ERROR);
-            }
-            return Result.failure(JwtFailureReason.UNKNOWN_JWT_SIGNING_ERROR);
-        }
-    }
-
-    private Result<JwtFailureReason, EncryptedJWT> encryptJWT(
+    private Result<AMCAuthorizeFailureReason, EncryptedJWT> encryptJWT(
             SignedJWT signedJWT, RSAPublicKey publicEncryptionKey) {
         try {
             return Result.success(jwtService.encryptJWT(signedJWT, publicEncryptionKey));
         } catch (JwtServiceException e) {
             Throwable cause = e.getCause();
             if (cause instanceof JOSEException) {
-                return Result.failure(JwtFailureReason.ENCRYPTION_ERROR);
+                return Result.failure(AMCAuthorizeFailureReason.ENCRYPTION_ERROR);
             } else if (cause instanceof ParseException) {
-                return Result.failure(JwtFailureReason.JWT_ENCODING_ERROR);
+                return Result.failure(AMCAuthorizeFailureReason.JWT_ENCODING_ERROR);
             }
-            return Result.failure(JwtFailureReason.UNKNOWN_JWT_ENCRYPTING_ERROR);
+            return Result.failure(AMCAuthorizeFailureReason.UNKNOWN_JWT_ENCRYPTING_ERROR);
         }
     }
 
     private record EncryptedJWTAndAmcCookie(EncryptedJWT encryptedJWT, String amcCookie) {}
 
-    private Result<JwtFailureReason, EncryptedJWTAndAmcCookie> createTransportJWTAndAmcCookie(
-            String internalPairwiseSubject,
-            AMCScope amcScope,
-            String amcRedirectUri,
-            AuthSessionItem authSessionItem,
-            String publicSubject,
-            List<AccessTokenConfig> accessTokenConfigs,
-            RSAPublicKey publicEncryptionKey,
-            State state) {
+    private Result<AMCAuthorizeFailureReason, EncryptedJWTAndAmcCookie>
+            createTransportJWTAndAmcCookie(
+                    String internalPairwiseSubject,
+                    AMCScope amcScope,
+                    String amcRedirectUri,
+                    AuthSessionItem authSessionItem,
+                    String publicSubject,
+                    List<AccessTokenConfig> accessTokenConfigs,
+                    RSAPublicKey publicEncryptionKey,
+                    State state) {
         Date issueTime = nowClock.now();
         Date expiryDate = nowClock.nowPlus(CLIENT_ASSERTION_LIFETIME, ChronoUnit.MINUTES);
 
@@ -209,9 +197,12 @@ public class AMCService {
                                     (claimName, accessToken) ->
                                             claimsBuilder.claim(claimName, accessToken.getValue()));
 
-                            return signJWT(
-                                    claimsBuilder.build(),
-                                    configurationService.getAuthToAMCTransportJWTSigningKey());
+                            return jwtService
+                                    .signJWT(
+                                            claimsBuilder.build(),
+                                            configurationService
+                                                    .getAuthToAMCTransportJWTSigningKey())
+                                    .mapFailure(this::mapSignJwtFailureReason);
                         })
                 .flatMap(
                         signedJWT -> {
@@ -224,63 +215,35 @@ public class AMCService {
                         });
     }
 
-    private Result<JwtFailureReason, Map<String, BearerAccessToken>> createAccessTokenClaimsMap(
-            List<AccessTokenConfig> configs,
-            String internalPairwiseSubject,
-            AuthSessionItem authSessionItem,
-            Date issueTime,
-            Date expiryDate) {
+    private Result<AMCAuthorizeFailureReason, Map<String, BearerAccessToken>>
+            createAccessTokenClaimsMap(
+                    List<AccessTokenConfig> configs,
+                    String internalPairwiseSubject,
+                    AuthSessionItem authSessionItem,
+                    Date issueTime,
+                    Date expiryDate) {
         var accessTokens = new HashMap<String, BearerAccessToken>();
 
         for (AccessTokenConfig config : configs) {
             var result =
-                    createAccessToken(
+                    externalApiAccessTokenService.createSignedAccessToken(
                             internalPairwiseSubject,
                             config.scope(),
                             authSessionItem,
                             issueTime,
                             expiryDate,
                             config.audience(),
+                            configurationService.getAuthIssuerClaim(),
+                            configurationService.getAMCClientId(),
                             config.signingKey());
 
             if (result.isFailure()) {
-                return Result.failure(result.getFailure());
+                return Result.failure(mapSignJwtFailureReason(result.getFailure()));
             }
 
             accessTokens.put(config.accessTokenName(), result.getSuccess());
         }
         return Result.success(accessTokens);
-    }
-
-    private Result<JwtFailureReason, BearerAccessToken> createAccessToken(
-            String internalPairwiseSubject,
-            AMCDownstreamScope scope,
-            AuthSessionItem authSessionItem,
-            Date issueTime,
-            Date expiryDate,
-            String audience,
-            String signingKey) {
-        var claims =
-                new JWTClaimsSet.Builder()
-                        .claim("scope", scope.getValue())
-                        .issuer(configurationService.getAuthIssuerClaim())
-                        .audience(audience)
-                        .expirationTime(expiryDate)
-                        .issueTime(issueTime)
-                        .notBeforeTime(issueTime)
-                        .subject(internalPairwiseSubject)
-                        .claim("client_id", configurationService.getAMCClientId())
-                        .claim("sid", authSessionItem.getSessionId())
-                        .jwtID(UUID.randomUUID().toString())
-                        .build();
-
-        return signJWT(claims, signingKey)
-                .map(
-                        signedJWT ->
-                                new BearerAccessToken(
-                                        signedJWT.serialize(),
-                                        configurationService.getSessionExpiry(),
-                                        new Scope(scope.getValue())));
     }
 
     private JWTAuthenticationClaimsSet buildClientAssertionJwt() {
@@ -296,5 +259,18 @@ public class AMCService {
                 now,
                 now,
                 new JWTID());
+    }
+
+    private AMCAuthorizeFailureReason mapSignJwtFailureReason(JwtFailureReason jwtFailureReason) {
+        return switch (jwtFailureReason) {
+            case JWT_ENCODING_ERROR -> AMCAuthorizeFailureReason.JWT_ENCODING_ERROR;
+            case UNKNOWN_JWT_SIGNING_ERROR -> AMCAuthorizeFailureReason.UNKNOWN_JWT_SIGNING_ERROR;
+            case TRANSCODING_ERROR -> AMCAuthorizeFailureReason.TRANSCODING_ERROR;
+            case SIGNING_ERROR, KEY_RETRIEVAL_ERROR -> AMCAuthorizeFailureReason.SIGNING_ERROR;
+            case ENCRYPTION_ERROR -> AMCAuthorizeFailureReason.ENCRYPTION_ERROR;
+            case UNKNOWN_JWT_ENCRYPTING_ERROR -> AMCAuthorizeFailureReason
+                    .UNKNOWN_JWT_ENCRYPTING_ERROR;
+            case JWKS_RETRIEVAL_ERROR -> AMCAuthorizeFailureReason.JWKS_RETRIEVAL_ERROR;
+        };
     }
 }

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/ExternalApiAccessTokenService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/ExternalApiAccessTokenService.java
@@ -1,0 +1,59 @@
+package uk.gov.di.authentication.frontendapi.services;
+
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.oauth2.sdk.Scope;
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
+import uk.gov.di.authentication.frontendapi.entity.JwtFailureReason;
+import uk.gov.di.authentication.frontendapi.entity.amc.ExternalApiScope;
+import uk.gov.di.authentication.shared.entity.AuthSessionItem;
+import uk.gov.di.authentication.shared.entity.Result;
+import uk.gov.di.authentication.shared.services.ConfigurationService;
+
+import java.util.Date;
+import java.util.UUID;
+
+public class ExternalApiAccessTokenService {
+
+    private final JwtService jwtService;
+    private final ConfigurationService configurationService;
+
+    public ExternalApiAccessTokenService(
+            JwtService jwtService, ConfigurationService configurationService) {
+        this.jwtService = jwtService;
+        this.configurationService = configurationService;
+    }
+
+    public Result<JwtFailureReason, BearerAccessToken> createSignedAccessToken(
+            String internalPairwiseSubject,
+            ExternalApiScope scope,
+            AuthSessionItem authSessionItem,
+            Date issueTime,
+            Date expiryDate,
+            String audience,
+            String issuer,
+            String clientId,
+            String signingKey) {
+        var claims =
+                new JWTClaimsSet.Builder()
+                        .claim("scope", scope.getValue())
+                        .issuer(issuer)
+                        .audience(audience)
+                        .expirationTime(expiryDate)
+                        .issueTime(issueTime)
+                        .notBeforeTime(issueTime)
+                        .subject(internalPairwiseSubject)
+                        .claim("client_id", clientId)
+                        .claim("sid", authSessionItem.getSessionId())
+                        .jwtID(UUID.randomUUID().toString())
+                        .build();
+
+        return jwtService
+                .signJWT(claims, signingKey)
+                .map(
+                        signedJWT ->
+                                new BearerAccessToken(
+                                        signedJWT.serialize(),
+                                        configurationService.getSessionExpiry(),
+                                        new Scope(scope.getValue())));
+    }
+}

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/IPVReverificationService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/IPVReverificationService.java
@@ -11,7 +11,6 @@ import com.nimbusds.jose.jwk.source.JWKSourceBuilder;
 import com.nimbusds.jose.proc.SecurityContext;
 import com.nimbusds.jwt.EncryptedJWT;
 import com.nimbusds.jwt.JWTClaimsSet;
-import com.nimbusds.jwt.SignedJWT;
 import com.nimbusds.oauth2.sdk.AuthorizationRequest;
 import com.nimbusds.oauth2.sdk.ResponseType;
 import com.nimbusds.oauth2.sdk.id.ClientID;
@@ -22,8 +21,10 @@ import com.nimbusds.openid.connect.sdk.OIDCClaimsRequest;
 import com.nimbusds.openid.connect.sdk.claims.ClaimsSetRequest;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import uk.gov.di.authentication.frontendapi.IPVReverificationFailureReason;
 import uk.gov.di.authentication.frontendapi.exceptions.IPVReverificationServiceException;
 import uk.gov.di.authentication.frontendapi.exceptions.JwtServiceException;
+import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.exceptions.MissingEnvVariableException;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.helpers.NowHelper.NowClock;
@@ -120,42 +121,61 @@ public class IPVReverificationService {
         this.jwkSource = jwkSource;
     }
 
-    public String buildIpvReverificationRedirectUri(
+    public Result<IPVReverificationFailureReason, String> buildIpvReverificationRedirectUri(
             Subject subject, String clientSessionId, State state) throws JwtServiceException {
         ClaimsSetRequest claims = buildMfaResetClaimsRequest(subject);
-        EncryptedJWT requestJWT =
-                constructMfaResetAuthorizationJWT(state, subject, claims, clientSessionId);
 
-        AuthorizationRequest.Builder authRequestBuilder =
-                new AuthorizationRequest.Builder(
-                                new ResponseType(ResponseType.Value.CODE),
-                                new ClientID(configurationService.getIPVAuthorisationClientId()))
-                        .endpointURI(configurationService.getIPVAuthorisationURI())
-                        .requestObject(requestJWT);
-
-        AuthorizationRequest ipvAuthorisationRequest = authRequestBuilder.build();
-        String ipvReverificationRequestURI = ipvAuthorisationRequest.toURI().toString();
+        var ipvReverificationRequestURI =
+                constructMfaResetAuthorizationJWT(state, subject, claims, clientSessionId)
+                        .map(
+                                jwt ->
+                                        new AuthorizationRequest.Builder(
+                                                        new ResponseType(ResponseType.Value.CODE),
+                                                        new ClientID(
+                                                                configurationService
+                                                                        .getIPVAuthorisationClientId()))
+                                                .endpointURI(
+                                                        configurationService
+                                                                .getIPVAuthorisationURI())
+                                                .requestObject(jwt))
+                        .map(AuthorizationRequest.Builder::build)
+                        .map(ipvAuthRequest -> ipvAuthRequest.toURI().toString());
 
         LOG.info("IPV reverification JAR created, redirect URI {}", ipvReverificationRequestURI);
 
         return ipvReverificationRequestURI;
     }
 
-    private EncryptedJWT constructMfaResetAuthorizationJWT(
+    private Result<IPVReverificationFailureReason, EncryptedJWT> constructMfaResetAuthorizationJWT(
             State state, Subject subject, ClaimsSetRequest claims, String clientSessionId) {
         LOG.info("Generating MFA Reset request JWT");
+
         JWTClaimsSet mfaResetAuthorizationClaims =
                 createMfaResetAuthorizationClaims(state, subject, claims, clientSessionId);
 
-        SignedJWT signedJWT =
-                jwtService.signJWT(
+        return jwtService
+                .signJWT(
                         mfaResetAuthorizationClaims,
-                        configurationService.getMfaResetJarSigningKeyId());
-        LOG.info("Created Signed MFA Reset JWT");
-
-        EncryptedJWT encryptedJWT = jwtService.encryptJWT(signedJWT, getPublicKey());
-        LOG.info("Created encrypted MFA Reset request JWT");
-        return encryptedJWT;
+                        configurationService.getMfaResetJarSigningKeyId())
+                .map(
+                        jwt -> {
+                            LOG.info("Created Signed MFA Reset JWT");
+                            return jwtService.encryptJWT(jwt, getPublicKey());
+                        })
+                .fold(
+                        failure ->
+                                switch (failure) {
+                                    case JWT_ENCODING_ERROR,
+                                            UNKNOWN_JWT_SIGNING_ERROR,
+                                            TRANSCODING_ERROR,
+                                            SIGNING_ERROR,
+                                            ENCRYPTION_ERROR,
+                                            UNKNOWN_JWT_ENCRYPTING_ERROR,
+                                            JWKS_RETRIEVAL_ERROR,
+                                            KEY_RETRIEVAL_ERROR -> Result.failure(
+                                            IPVReverificationFailureReason.JWT_CREATION_ERROR);
+                                },
+                        Result::success);
     }
 
     private JWTClaimsSet createMfaResetAuthorizationClaims(

--- a/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/JwtService.java
+++ b/frontend-api/src/main/java/uk/gov/di/authentication/frontendapi/services/JwtService.java
@@ -24,7 +24,9 @@ import software.amazon.awssdk.services.kms.model.MessageType;
 import software.amazon.awssdk.services.kms.model.SignRequest;
 import software.amazon.awssdk.services.kms.model.SignResponse;
 import software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec;
+import uk.gov.di.authentication.frontendapi.entity.JwtFailureReason;
 import uk.gov.di.authentication.frontendapi.exceptions.JwtServiceException;
+import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.services.KmsConnectionService;
 
 import java.nio.charset.StandardCharsets;
@@ -42,7 +44,7 @@ public class JwtService {
         this.kmsConnectionService = kmsConnectionService;
     }
 
-    public SignedJWT signJWT(JWTClaimsSet jwtClaims, String keyId) throws JwtServiceException {
+    public Result<JwtFailureReason, SignedJWT> signJWT(JWTClaimsSet jwtClaims, String keyId) {
         String nonAliasKeyId;
         try {
             GetPublicKeyRequest getPublicKeyRequest =
@@ -50,7 +52,7 @@ public class JwtService {
             nonAliasKeyId = kmsConnectionService.getPublicKey(getPublicKeyRequest).keyId();
         } catch (SdkException e) {
             LOG.error("AWS SDK error when resolving key ID", e);
-            throw new JwtServiceException("AWS SDK error when resolving key ID", e);
+            return Result.failure(JwtFailureReason.KEY_RETRIEVAL_ERROR);
         }
 
         JWSHeader header =
@@ -78,7 +80,7 @@ public class JwtService {
             signResponse = kmsConnectionService.sign(signRequest);
         } catch (SdkException e) {
             LOG.error("AWS SDK error when signing JWT", e);
-            throw new JwtServiceException("AWS SDK error when signing JWT", e);
+            return Result.failure(JwtFailureReason.SIGNING_ERROR);
         }
 
         Base64URL signature;
@@ -89,14 +91,14 @@ public class JwtService {
             signature = Base64URL.encode(joseSignature);
         } catch (JOSEException e) {
             LOG.error("Failed to transcode KMS signature from DER to JOSE format", e);
-            throw new JwtServiceException("Failed to transcode signature", e);
+            return Result.failure(JwtFailureReason.TRANSCODING_ERROR);
         }
 
         try {
-            return new SignedJWT(encodedHeader, encodedClaims, signature);
+            return Result.success(new SignedJWT(encodedHeader, encodedClaims, signature));
         } catch (ParseException e) {
             LOG.error("Failed to construct final SignedJWT object", e);
-            throw new JwtServiceException("Failed to construct JWT", e);
+            return Result.failure(JwtFailureReason.JWT_ENCODING_ERROR);
         }
     }
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AMCAuthorizeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AMCAuthorizeHandlerTest.java
@@ -15,11 +15,11 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import uk.gov.di.authentication.frontendapi.entity.amc.AMCAuthorizationUrlAndCookie;
+import uk.gov.di.authentication.frontendapi.entity.amc.AMCAuthorizeFailureReason;
 import uk.gov.di.authentication.frontendapi.entity.amc.AMCAuthorizeRequest;
 import uk.gov.di.authentication.frontendapi.entity.amc.AMCAuthorizeResponse;
 import uk.gov.di.authentication.frontendapi.entity.amc.AMCJourneyType;
 import uk.gov.di.authentication.frontendapi.entity.amc.AMCScope;
-import uk.gov.di.authentication.frontendapi.entity.amc.JwtFailureReason;
 import uk.gov.di.authentication.frontendapi.errormapper.AMCFailureHttpMapper;
 import uk.gov.di.authentication.frontendapi.helpers.ApiGatewayProxyRequestHelper;
 import uk.gov.di.authentication.frontendapi.services.AMCService;
@@ -199,7 +199,7 @@ class AMCAuthorizeHandlerTest {
                         event, context, new AMCAuthorizeRequest(AMCJourneyType.SFAD), userContext);
 
         var httpResponse =
-                AMCFailureHttpMapper.toHttpResponse(JwtFailureReason.JWKS_RETRIEVAL_ERROR);
+                AMCFailureHttpMapper.toHttpResponse(AMCAuthorizeFailureReason.JWKS_RETRIEVAL_ERROR);
         assertEquals(httpResponse.statusCode(), result.getStatusCode());
         assertTrue(result.getBody().contains(httpResponse.errorResponse().getMessage()));
     }
@@ -220,14 +220,14 @@ class AMCAuthorizeHandlerTest {
                         event, context, new AMCAuthorizeRequest(AMCJourneyType.SFAD), userContext);
 
         var httpResponse =
-                AMCFailureHttpMapper.toHttpResponse(JwtFailureReason.JWKS_RETRIEVAL_ERROR);
+                AMCFailureHttpMapper.toHttpResponse(AMCAuthorizeFailureReason.JWKS_RETRIEVAL_ERROR);
         assertEquals(httpResponse.statusCode(), result.getStatusCode());
         assertTrue(result.getBody().contains(httpResponse.errorResponse().getMessage()));
     }
 
     @ParameterizedTest
-    @EnumSource(JwtFailureReason.class)
-    void shouldHandleAllFailureReasons(JwtFailureReason failureReason) {
+    @EnumSource(AMCAuthorizeFailureReason.class)
+    void shouldHandleAllFailureReasons(AMCAuthorizeFailureReason failureReason) {
         when(authenticationService.getUserProfileByEmailMaybe(EMAIL))
                 .thenReturn(Optional.of(userProfile));
         when(amcService.buildAuthorizationResult(

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AMCCallbackHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/AMCCallbackHandlerTest.java
@@ -10,9 +10,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import uk.gov.di.authentication.frontendapi.entity.amc.AMCAuthorizeFailureReason;
 import uk.gov.di.authentication.frontendapi.entity.amc.AMCCallbackRequest;
 import uk.gov.di.authentication.frontendapi.entity.amc.JourneyOutcomeError;
-import uk.gov.di.authentication.frontendapi.entity.amc.JwtFailureReason;
 import uk.gov.di.authentication.frontendapi.services.AMCService;
 import uk.gov.di.authentication.shared.entity.AMCState;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
@@ -246,7 +246,7 @@ class AMCCallbackHandlerTest {
     @Test
     void shouldReturn400WhenTokenResponseUnsuccessful() {
         when(AMC_SERVICE.buildTokenRequest(AUTH_CODE, USED_REDIRECT_URL))
-                .thenReturn(Result.failure(JwtFailureReason.JWT_ENCODING_ERROR));
+                .thenReturn(Result.failure(AMCAuthorizeFailureReason.JWT_ENCODING_ERROR));
 
         AMCCallbackRequest request = new AMCCallbackRequest(AUTH_CODE, STATE, USED_REDIRECT_URL);
 

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetAuthorizeHandlerTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/lambda/MfaResetAuthorizeHandlerTest.java
@@ -18,6 +18,7 @@ import uk.gov.di.authentication.frontendapi.helpers.ApiGatewayProxyRequestHelper
 import uk.gov.di.authentication.frontendapi.services.IPVReverificationService;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.JourneyType;
+import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.entity.UserProfile;
 import uk.gov.di.authentication.shared.services.AuditService;
 import uk.gov.di.authentication.shared.services.AuthSessionService;
@@ -139,7 +140,7 @@ class MfaResetAuthorizeHandlerTest {
                 objectMapper.writeValueAsString(new MfaResetResponse(TEST_REDIRECT_URI));
         when(ipvReverificationService.buildIpvReverificationRedirectUri(
                         eq(new Subject(INTERNAL_COMMON_SUBJECT_ID)), eq(CLIENT_SESSION_ID), any()))
-                .thenReturn(TEST_REDIRECT_URI);
+                .thenReturn(Result.success(TEST_REDIRECT_URI));
 
         var request = new MfaResetRequest(EMAIL, TEST_REDIRECT_URI);
 
@@ -167,6 +168,11 @@ class MfaResetAuthorizeHandlerTest {
 
     @Test
     void storesTheStateValuesForCrossBrowserIssue() {
+        final String TEST_REDIRECT_URI = "https://some.uri.gov.uk/authorize?request=x.y.z";
+        when(ipvReverificationService.buildIpvReverificationRedirectUri(
+                        eq(new Subject(INTERNAL_COMMON_SUBJECT_ID)), eq(CLIENT_SESSION_ID), any()))
+                .thenReturn(Result.success(TEST_REDIRECT_URI));
+
         handler.handleRequest(TEST_INVOKE_EVENT, context);
 
         ArgumentCaptor<State> authenticationStateCaptor = ArgumentCaptor.forClass(State.class);

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/AMCServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/AMCServiceTest.java
@@ -39,15 +39,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import software.amazon.awssdk.core.exception.SdkException;
-import software.amazon.awssdk.services.kms.model.KmsException;
-import uk.gov.di.authentication.frontendapi.entity.amc.AMCDownstreamScope;
+import uk.gov.di.authentication.frontendapi.entity.JwtFailureReason;
+import uk.gov.di.authentication.frontendapi.entity.amc.AMCAuthorizeFailureReason;
 import uk.gov.di.authentication.frontendapi.entity.amc.AMCScope;
 import uk.gov.di.authentication.frontendapi.entity.amc.AccessTokenConfig;
 import uk.gov.di.authentication.frontendapi.entity.amc.AccountDataScope;
 import uk.gov.di.authentication.frontendapi.entity.amc.AccountManagementScope;
+import uk.gov.di.authentication.frontendapi.entity.amc.ExternalApiScope;
 import uk.gov.di.authentication.frontendapi.entity.amc.JourneyOutcomeError;
-import uk.gov.di.authentication.frontendapi.entity.amc.JwtFailureReason;
 import uk.gov.di.authentication.frontendapi.exceptions.JwtServiceException;
 import uk.gov.di.authentication.shared.entity.AuthSessionItem;
 import uk.gov.di.authentication.shared.entity.Result;
@@ -257,10 +256,7 @@ class AMCServiceTest {
         @Test
         void shouldReturnFailureWhenKmsSigningFails() {
             when(jwtService.signJWT(any(JWTClaimsSet.class), any(String.class)))
-                    .thenThrow(
-                            new JwtServiceException(
-                                    "AWS SDK error when signing JWT",
-                                    SdkException.builder().message("KMS Unreachable").build()));
+                    .thenReturn(Result.failure(JwtFailureReason.SIGNING_ERROR));
 
             var result =
                     amcService.buildAuthorizationResult(
@@ -274,16 +270,14 @@ class AMCServiceTest {
                             STATE);
 
             assertTrue(result.isFailure());
-            assertEquals(JwtFailureReason.SIGNING_ERROR, result.getFailure());
+            assertEquals(AMCAuthorizeFailureReason.SIGNING_ERROR, result.getFailure());
         }
 
         @Test
         void shouldReturnFailureWhenSignatureTranscodingFails() {
 
             when(jwtService.signJWT(any(JWTClaimsSet.class), any(String.class)))
-                    .thenThrow(
-                            new JwtServiceException(
-                                    "Failed to transcode signature", new JOSEException("Invalid")));
+                    .thenReturn(Result.failure(JwtFailureReason.TRANSCODING_ERROR));
 
             var result =
                     amcService.buildAuthorizationResult(
@@ -297,7 +291,7 @@ class AMCServiceTest {
                             STATE);
 
             assertTrue(result.isFailure());
-            assertEquals(JwtFailureReason.TRANSCODING_ERROR, result.getFailure());
+            assertEquals(AMCAuthorizeFailureReason.TRANSCODING_ERROR, result.getFailure());
         }
 
         private static Stream<Arguments> jwtServiceErrorsToJwtFailureReason() {
@@ -306,20 +300,20 @@ class AMCServiceTest {
                             new JwtServiceException(
                                     "Encryption failed",
                                     new com.nimbusds.jose.JOSEException("Encryption error")),
-                            JwtFailureReason.ENCRYPTION_ERROR),
+                            AMCAuthorizeFailureReason.ENCRYPTION_ERROR),
                     Arguments.of(
                             new JwtServiceException("Unknown encryption error"),
-                            JwtFailureReason.UNKNOWN_JWT_ENCRYPTING_ERROR),
+                            AMCAuthorizeFailureReason.UNKNOWN_JWT_ENCRYPTING_ERROR),
                     Arguments.of(
                             new JwtServiceException(
                                     "Parse error", new java.text.ParseException("Invalid", 0)),
-                            JwtFailureReason.JWT_ENCODING_ERROR));
+                            AMCAuthorizeFailureReason.JWT_ENCODING_ERROR));
         }
 
         @ParameterizedTest
         @MethodSource("jwtServiceErrorsToJwtFailureReason")
         void shouldMapJwtServiceExceptionsToJwtFailureReason(
-                Exception encryptionException, JwtFailureReason expectedFailureReason) {
+                Exception encryptionException, AMCAuthorizeFailureReason expectedFailureReason) {
             when(jwtService.encryptJWT(any(), any())).thenThrow(encryptionException);
 
             AMCService serviceWithMockJwt =
@@ -340,22 +334,22 @@ class AMCServiceTest {
             assertEquals(expectedFailureReason, result.getFailure());
         }
 
-        private static Stream<Arguments> signingErrorsToJwtFailureReasons() {
+        private static Stream<Arguments> signingFailureReasonsToJwtFailureReasons() {
             return Stream.of(
                     Arguments.of(
-                            new JwtServiceException("Unknown error"),
-                            JwtFailureReason.UNKNOWN_JWT_SIGNING_ERROR),
+                            JwtFailureReason.UNKNOWN_JWT_SIGNING_ERROR,
+                            AMCAuthorizeFailureReason.UNKNOWN_JWT_SIGNING_ERROR),
                     Arguments.of(
-                            new JwtServiceException(
-                                    "Parse error", new java.text.ParseException("Invalid", 0)),
-                            JwtFailureReason.JWT_ENCODING_ERROR));
+                            JwtFailureReason.JWT_ENCODING_ERROR,
+                            AMCAuthorizeFailureReason.JWT_ENCODING_ERROR));
         }
 
         @ParameterizedTest
-        @MethodSource("signingErrorsToJwtFailureReasons")
-        void shouldMapJwtSigningErrorsToJwtFailureReason(
-                Exception signingException, JwtFailureReason expectedFailureReason) {
-            when(jwtService.signJWT(any(), any())).thenThrow(signingException);
+        @MethodSource("signingFailureReasonsToJwtFailureReasons")
+        void shouldMapJwtSigningFailureReasonsToJwtFailureReason(
+                JwtFailureReason signingFailureReason,
+                AMCAuthorizeFailureReason expectedFailureReason) {
+            when(jwtService.signJWT(any(), any())).thenReturn(Result.failure(signingFailureReason));
 
             AMCService serviceWithMockJwt =
                     new AMCService(configurationService, NOW_CLOCK, jwtService);
@@ -407,7 +401,7 @@ class AMCServiceTest {
         }
 
         private void assertAccessTokenClaims(
-                AMCDownstreamScope expectedScope,
+                ExternalApiScope expectedScope,
                 String expectedAudience,
                 JWTClaimsSet accessTokenClaims) {
             assertAll(
@@ -468,8 +462,7 @@ class AMCServiceTest {
 
             mockJwtSigning(Map.of(signingKeyPair.getKeyID(), signingKeyPair));
 
-            TokenRequest result =
-                    amcService.buildTokenRequest(AUTH_CODE, USED_REDIRECT_URL).getSuccess();
+            var result = amcService.buildTokenRequest(AUTH_CODE, USED_REDIRECT_URL).getSuccess();
 
             var authGrant = (AuthorizationCodeGrant) result.getAuthorizationGrant();
             assertEquals(AUTH_CODE, authGrant.getAuthorizationCode().toString());
@@ -501,16 +494,13 @@ class AMCServiceTest {
                     .thenReturn(invalidKeyAlias);
 
             when(jwtService.signJWT(any(JWTClaimsSet.class), eq(invalidKeyAlias)))
-                    .thenThrow(
-                            new JwtServiceException(
-                                    "AWS SDK error when signing JWT",
-                                    KmsException.create("Unable to sign", new RuntimeException())));
+                    .thenReturn(Result.failure(JwtFailureReason.SIGNING_ERROR));
 
-            Result<JwtFailureReason, TokenRequest> result =
+            Result<AMCAuthorizeFailureReason, TokenRequest> result =
                     amcService.buildTokenRequest(AUTH_CODE, USED_REDIRECT_URL);
 
             assertTrue(result.isFailure());
-            assertEquals(JwtFailureReason.SIGNING_ERROR, result.getFailure());
+            assertEquals(AMCAuthorizeFailureReason.SIGNING_ERROR, result.getFailure());
         }
     }
 
@@ -581,7 +571,7 @@ class AMCServiceTest {
                                                         .build(),
                                                 claims);
                                 signedJWT.sign(new ECDSASigner(key));
-                                return signedJWT;
+                                return Result.success(signedJWT);
                             } catch (JOSEException e) {
                                 throw new RuntimeException(e);
                             }

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/IPVReverificationServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/IPVReverificationServiceTest.java
@@ -37,6 +37,8 @@ import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import uk.gov.di.authentication.frontendapi.exceptions.IPVReverificationServiceException;
+import uk.gov.di.authentication.frontendapi.exceptions.JwtServiceException;
+import uk.gov.di.authentication.shared.entity.Result;
 import uk.gov.di.authentication.shared.exceptions.MissingEnvVariableException;
 import uk.gov.di.authentication.shared.helpers.IdGenerator;
 import uk.gov.di.authentication.shared.helpers.NowHelper;
@@ -142,7 +144,7 @@ class IPVReverificationServiceTest {
                         Base64URL.encode(testJwtClaims.toString()),
                         TEST_ENCODED_JWS_SIGNATURE);
         testEncryptedJwt = constructTestEncryptedJWT(testSignedJwt);
-        when(jwtService.signJWT(any(), any())).thenReturn(testSignedJwt);
+        when(jwtService.signJWT(any(), any())).thenReturn(Result.success(testSignedJwt));
         when(jwtService.encryptJWT(any(), any())).thenReturn(testEncryptedJwt);
         mockIdGen = Mockito.mockStatic(IdGenerator.class);
         mockIdGen.when(IdGenerator::generate).thenReturn(TEST_UUID);
@@ -179,9 +181,11 @@ class IPVReverificationServiceTest {
                             when(mock.getValue()).thenReturn(TEST_STATE_VALUE);
                         })) {
 
-            String redirectUri =
+            var redirectUriResult =
                     ipvReverificationService.buildIpvReverificationRedirectUri(
                             TEST_SUBJECT, TEST_CLIENT_SESSION_ID, STATE);
+
+            var redirectUri = redirectUriResult.getSuccess();
 
             RSAPublicKey expectedPublicKey =
                     new RSAKey.Builder(
@@ -222,9 +226,11 @@ class IPVReverificationServiceTest {
                 new IPVReverificationService(
                         configurationService, nowClock, jwtService, tokenService, jwkSource);
 
-        String redirectUri =
+        var redirectUriResult =
                 ipvReverificationService.buildIpvReverificationRedirectUri(
                         TEST_SUBJECT, TEST_CLIENT_SESSION_ID, STATE);
+
+        var redirectUri = redirectUriResult.getSuccess();
 
         RSAPublicKey expectedPublicKey =
                 new RSAKey.Builder(
@@ -257,6 +263,21 @@ class IPVReverificationServiceTest {
         assertEquals(
                 "Missing required environment variable: IPV_PUBLIC_ENCRYPTION_KEY",
                 exception.getMessage());
+    }
+
+    @Test
+    void shouldThrowEncryptJwtExceptionWhenEncryptJwtThrowsException() {
+        when(jwtService.encryptJWT(any(), any()))
+                .thenThrow(new JwtServiceException("JWT Service Exception"));
+
+        var exception =
+                assertThrows(
+                        JwtServiceException.class,
+                        () ->
+                                ipvReverificationService.buildIpvReverificationRedirectUri(
+                                        TEST_SUBJECT, TEST_CLIENT_SESSION_ID, STATE));
+
+        assertEquals("JWT Service Exception", exception.getMessage());
     }
 
     private JWTClaimsSet constructTestClaimSet() {

--- a/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/JwtServiceTest.java
+++ b/frontend-api/src/test/java/uk/gov/di/authentication/frontendapi/services/JwtServiceTest.java
@@ -23,7 +23,7 @@ import software.amazon.awssdk.services.kms.model.MessageType;
 import software.amazon.awssdk.services.kms.model.SignRequest;
 import software.amazon.awssdk.services.kms.model.SignResponse;
 import software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec;
-import uk.gov.di.authentication.frontendapi.exceptions.JwtServiceException;
+import uk.gov.di.authentication.frontendapi.entity.JwtFailureReason;
 import uk.gov.di.authentication.shared.services.KmsConnectionService;
 import uk.gov.di.authentication.sharedtest.helper.KeyPairHelper;
 
@@ -34,8 +34,7 @@ import java.security.interfaces.RSAPublicKey;
 import java.text.ParseException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -82,7 +81,7 @@ class JwtServiceTest {
     }
 
     @Test
-    void CallsKmsToGenerateSignatureAndReturnsJWS() throws ParseException {
+    void shouldCallKmsToGenerateSignatureAndReturnsJWS() throws ParseException {
         Base64URL encodedClaims = TEST_CLAIMS.toPayload().toBase64URL();
         SdkBytes expectedMessage =
                 SdkBytes.fromByteArray(
@@ -96,7 +95,7 @@ class JwtServiceTest {
                         .signingAlgorithm(SigningAlgorithmSpec.ECDSA_SHA_256)
                         .build();
 
-        SignedJWT signedJWT = jwtService.signJWT(TEST_CLAIMS, TEST_KEY_ID);
+        var signedJWT = jwtService.signJWT(TEST_CLAIMS, TEST_KEY_ID).getSuccess();
 
         verify(kmsConnectionService)
                 .getPublicKey(GetPublicKeyRequest.builder().keyId(TEST_KEY_ID).build());
@@ -124,52 +123,41 @@ class JwtServiceTest {
     }
 
     @Test
-    void shouldThrowJwtServiceExceptionWithSdkExceptionCauseWhenKmsSigningFails() {
+    void shouldReturnSigningErrorFailureReasonWhenKmsSigningFails() {
         when(kmsConnectionService.sign(any()))
                 .thenThrow(
                         software.amazon.awssdk.core.exception.SdkException.builder()
                                 .message("KMS unavailable")
                                 .build());
 
-        var exception =
-                org.junit.jupiter.api.Assertions.assertThrows(
-                        uk.gov.di.authentication.frontendapi.exceptions.JwtServiceException.class,
-                        () -> jwtService.signJWT(TEST_CLAIMS, TEST_KEY_ID));
+        var result = jwtService.signJWT(TEST_CLAIMS, TEST_KEY_ID);
 
-        assertEquals("AWS SDK error when signing JWT", exception.getMessage());
-        org.junit.jupiter.api.Assertions.assertInstanceOf(
-                software.amazon.awssdk.core.exception.SdkException.class, exception.getCause());
+        assertTrue(result.isFailure());
+        assertEquals(JwtFailureReason.SIGNING_ERROR, result.getFailure());
     }
 
     @Test
-    void shouldThrowJwtServiceExceptionWithSdkExceptionCauseWhenResolvingKeyIdFails() {
+    void shouldReturnKeyRetrievalErrorFailureReasonWhenResolvingKeyIdFails() {
         when(kmsConnectionService.getPublicKey(any(GetPublicKeyRequest.class)))
                 .thenThrow(SdkException.builder().message("KMS unavailable").build());
 
-        var exception =
-                assertThrows(
-                        JwtServiceException.class,
-                        () -> jwtService.signJWT(TEST_CLAIMS, TEST_KEY_ID));
+        var result = jwtService.signJWT(TEST_CLAIMS, TEST_KEY_ID);
 
-        assertEquals("AWS SDK error when resolving key ID", exception.getMessage());
-        assertInstanceOf(SdkException.class, exception.getCause());
+        assertTrue(result.isFailure());
+        assertEquals(JwtFailureReason.KEY_RETRIEVAL_ERROR, result.getFailure());
     }
 
     @Test
-    void shouldThrowJwtServiceExceptionWithJOSEExceptionCauseWhenTranscodingFails() {
+    void shouldReturnTranscodingErrorFailureReasonWhenTranscodingFails() {
         when(kmsConnectionService.sign(any()))
                 .thenReturn(
                         SignResponse.builder()
                                 .signature(SdkBytes.fromByteArray(new byte[] {0x00, 0x01}))
                                 .build());
 
-        var exception =
-                org.junit.jupiter.api.Assertions.assertThrows(
-                        uk.gov.di.authentication.frontendapi.exceptions.JwtServiceException.class,
-                        () -> jwtService.signJWT(TEST_CLAIMS, TEST_KEY_ID));
+        var result = jwtService.signJWT(TEST_CLAIMS, TEST_KEY_ID);
 
-        assertEquals("Failed to transcode signature", exception.getMessage());
-        org.junit.jupiter.api.Assertions.assertInstanceOf(
-                com.nimbusds.jose.JOSEException.class, exception.getCause());
+        assertTrue(result.isFailure());
+        assertEquals(JwtFailureReason.TRANSCODING_ERROR, result.getFailure());
     }
 }


### PR DESCRIPTION
## What

- Create a new ExternalApiAccessTokenService to create and sign access tokens.
- Refactor the signJwt method in JwtService to return a result. This means we no longer have to wrap calls to this service in try catches and can now map the failures to the callers failure type
- Refactor the AMCService to return an AMCAuthorizeFailureReason instead of JWTFailureReason. Decoupling these failures means that callers to the JwtService (which can return a JWTFailureReason), can decide what to do with the failures rather than have to each one explicitly 


## How to review

1. Code review
2. Deploy to dev env and run through the following journeys
  - MFA reset
  - Passkey create
  - Check they all work as expected


