### PR TITLE
ATO-2060 Turn on Snap Start for UserInfo Lambda

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -4199,17 +4199,8 @@ Resources:
       DeploymentPreference:
         Alarms:
           - Ref: UserInfoFunctionErrorAnomalyAlarm
-      ProvisionedConcurrencyConfig:
-        !If [
-          EnableProvisionedConcurrency,
-          ProvisionedConcurrentExecutions:
-            !FindInMap [
-              EnvironmentConfiguration,
-              !Ref Environment,
-              defaultProvisionedConcurrency,
-            ],
-          !Ref AWS::NoValue,
-        ]
+      SnapStart:
+        ApplyOn: PublishedVersions
       VpcConfig:
         SecurityGroupIds:
           - !Ref LambdaSecurityGroup


### PR DESCRIPTION
### Wider context of change

adding SnapStart to Java lambdas to reduce cold start time

### What’s changed

Add SnapStart to the UserInfo Lambda

### Manual testing

Tested in dev:
Start time without SnapStart: ~7s
Start time with SnapStart: ~1s

### Checklist

<!-- If any lambdas are accessing a resource for the first time, they must have additional permissions to do so.
This should be done in a separate PR.
-->

- [x] Lambdas have correct permissions for the resources they're accessing.

<!-- Be careful when making changes to code in 'shared' components where each team has a copy.
Check with counterparts to see if changes need to be made in the other team's code.
In particular pay attention to classes representing Session data where changes need to be applied on both sides to avoid deserialization errors.
-->

- [ ] Impact on orch and auth mutual dependencies has been checked.

<!-- Changes required to contract tests?
If there are changes to the API interaction between Orchestration and other services, the contract tests may need updating
-->

- [x] Changes have been made to contract tests or not required.

<!-- Changes required to the simulator?
If there are RP facing changes then this may need to be reflected in updates to [simulator](https://github.com/govuk-one-login/simulator).
-->

- [x] Changes have been made to the simulator or not required.

<!-- Changes required to the stubs?
eg. RP / IPV / SPOT / Auth stub
-->

- [x] Changes have been made to stubs or not required.

<!-- Deployed to authdev?
If this is a session split change, please check that it can be deployed to either authdev1 or authdev2. See [slack](https://gds.slack.com/archives/C060UE8NSP4/p1733137845652609).
-->

- [x] Successfully deployed to authdev or not required.

<!-- Run Authentication acceptance tests against sandpit?
As Orch code reaches production faster than Auth code, if this change could affect Auth, please run [Authentication acceptance tests](https://github.com/govuk-one-login/authentication-acceptance-tests) against sandpit.
-->

- [x] Successfully run Authentication acceptance tests against sandpit or not required.


